### PR TITLE
Narrow `allow(dead_code)` declarations

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -1,8 +1,5 @@
 //! AArch64 ISA definitions: instruction arguments.
 
-// Some variants are never constructed, but we still want them as options in the future.
-#![allow(dead_code)]
-
 use crate::ir::types::*;
 use crate::ir::Type;
 use crate::isa::aarch64::inst::*;
@@ -18,8 +15,11 @@ use std::string::String;
 #[repr(u8)]
 pub enum ShiftOp {
     LSL = 0b00,
+    #[allow(dead_code)]
     LSR = 0b01,
+    #[allow(dead_code)]
     ASR = 0b10,
+    #[allow(dead_code)]
     ROR = 0b11,
 }
 
@@ -92,6 +92,7 @@ pub enum ExtendOp {
     SXTB = 0b100,
     SXTH = 0b101,
     SXTW = 0b110,
+    #[allow(dead_code)]
     SXTX = 0b111,
 }
 
@@ -131,6 +132,7 @@ pub enum AMode {
     /// Register plus register offset.
     RegReg(Reg, Reg),
 
+    #[allow(dead_code)]
     /// Register plus register offset, scaled by type's size.
     RegScaled(Reg, Reg, Type),
 
@@ -186,25 +188,10 @@ impl AMode {
         AMode::UnsignedOffset(reg, UImm12Scaled::zero(I64))
     }
 
-    /// Memory reference using the sum of two registers as an address.
-    pub fn reg_plus_reg(reg1: Reg, reg2: Reg) -> AMode {
-        AMode::RegReg(reg1, reg2)
-    }
-
-    /// Memory reference using `reg1 + sizeof(ty) * reg2` as an address.
-    pub fn reg_plus_reg_scaled(reg1: Reg, reg2: Reg, ty: Type) -> AMode {
-        AMode::RegScaled(reg1, reg2, ty)
-    }
-
     /// Memory reference using `reg1 + sizeof(ty) * reg2` as an address, with `reg2` sign- or
     /// zero-extended as per `op`.
     pub fn reg_plus_reg_scaled_extended(reg1: Reg, reg2: Reg, ty: Type, op: ExtendOp) -> AMode {
         AMode::RegScaledExtended(reg1, reg2, ty, op)
-    }
-
-    /// Memory reference to a label: a global function or value, or data in the constant pool.
-    pub fn label(label: MemLabel) -> AMode {
-        AMode::Label(label)
     }
 
     /// Does the address resolve to just a register value, with no offset or
@@ -560,18 +547,12 @@ impl OperandSize {
     pub fn is32(self) -> bool {
         self == OperandSize::Size32
     }
+
     /// 64-bit case?
     pub fn is64(self) -> bool {
         self == OperandSize::Size64
     }
-    /// Convert from an `is32` boolean flag to an `OperandSize`.
-    pub fn from_is32(is32: bool) -> OperandSize {
-        if is32 {
-            OperandSize::Size32
-        } else {
-            OperandSize::Size64
-        }
-    }
+
     /// Convert from a needed width to the smallest size that fits.
     pub fn from_bits<I: Into<usize>>(bits: I) -> OperandSize {
         let bits: usize = bits.into();
@@ -642,14 +623,6 @@ impl ScalarSize {
             ScalarSize::Size32 => OperandSize::Size32,
             ScalarSize::Size64 => OperandSize::Size64,
             _ => panic!("Unexpected operand_size request for: {:?}", self),
-        }
-    }
-
-    /// Convert from an integer operand size.
-    pub fn from_operand_size(size: OperandSize) -> ScalarSize {
-        match size {
-            OperandSize::Size32 => ScalarSize::Size32,
-            OperandSize::Size64 => ScalarSize::Size64,
         }
     }
 
@@ -752,31 +725,6 @@ impl VectorSize {
             VectorSize::Size32x2 => false,
             VectorSize::Size32x4 => true,
             VectorSize::Size64x2 => true,
-        }
-    }
-
-    /// Produces a `VectorSize` with lanes twice as wide.  Note that if the resulting
-    /// size would exceed 128 bits, then the number of lanes is also halved, so as to
-    /// ensure that the result size is at most 128 bits.
-    pub fn widen(&self) -> VectorSize {
-        match self {
-            VectorSize::Size8x8 => VectorSize::Size16x8,
-            VectorSize::Size8x16 => VectorSize::Size16x8,
-            VectorSize::Size16x4 => VectorSize::Size32x4,
-            VectorSize::Size16x8 => VectorSize::Size32x4,
-            VectorSize::Size32x2 => VectorSize::Size64x2,
-            VectorSize::Size32x4 => VectorSize::Size64x2,
-            VectorSize::Size64x2 => unreachable!(),
-        }
-    }
-
-    /// Produces a `VectorSize` that has the same lane width, but half as many lanes.
-    pub fn halve(&self) -> VectorSize {
-        match self {
-            VectorSize::Size8x16 => VectorSize::Size8x8,
-            VectorSize::Size16x8 => VectorSize::Size16x4,
-            VectorSize::Size32x4 => VectorSize::Size32x2,
-            _ => *self,
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3,7 +3,6 @@
 use regalloc2::Allocation;
 
 use crate::binemit::{CodeOffset, Reloc, StackMap};
-use crate::ir::constant::ConstantData;
 use crate::ir::types::*;
 use crate::ir::{LibCall, MemFlags, TrapCode};
 use crate::isa::aarch64::inst::*;
@@ -86,12 +85,6 @@ pub fn mem_finalize(
 
         _ => (smallvec![], mem.clone()),
     }
-}
-
-/// Helper: get a ConstantData from a u64.
-pub fn u64_constant(bits: u64) -> ConstantData {
-    let data = bits.to_le_bytes();
-    ConstantData::from(&data[..])
 }
 
 //=============================================================================

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -7,6 +7,16 @@ use crate::settings;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
+#[cfg(test)]
+fn simm9_zero() -> SImm9 {
+    SImm9::maybe_from_i64(0).unwrap()
+}
+
+#[cfg(test)]
+fn simm7_scaled_zero(scale_ty: Type) -> SImm7Scaled {
+    SImm7Scaled::maybe_from_i64(0, scale_ty).unwrap()
+}
+
 #[test]
 fn test_aarch64_binemit() {
     let mut insns = Vec::<(Inst, &str, &str)>::new();
@@ -1333,7 +1343,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad8 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "41004038",
@@ -1360,7 +1370,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad8 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "41008038",
@@ -1414,7 +1424,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad16 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "41008078",
@@ -1441,7 +1451,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad32 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "410040B8",
@@ -1468,7 +1478,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::SLoad32 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "410080B8",
@@ -1495,7 +1505,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "410040F8",
@@ -1661,7 +1671,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store8 {
             rd: xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "41000038",
@@ -1679,7 +1689,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store16 {
             rd: xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "41000078",
@@ -1697,7 +1707,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store32 {
             rd: xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "410000B8",
@@ -1715,7 +1725,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::Store64 {
             rd: xreg(1),
-            mem: AMode::Unscaled(xreg(2), SImm9::zero()),
+            mem: AMode::Unscaled(xreg(2), simm9_zero()),
             flags: MemFlags::trusted(),
         },
         "410000F8",
@@ -1789,7 +1799,7 @@ fn test_aarch64_binemit() {
         Inst::StoreP64 {
             rt: xreg(8),
             rt2: xreg(9),
-            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
+            mem: PairAMode::SignedOffset(xreg(10), simm7_scaled_zero(I64)),
             flags: MemFlags::trusted(),
         },
         "482500A9",
@@ -1856,7 +1866,7 @@ fn test_aarch64_binemit() {
         Inst::LoadP64 {
             rt: writable_xreg(8),
             rt2: writable_xreg(9),
-            mem: PairAMode::SignedOffset(xreg(10), SImm7Scaled::zero(I64)),
+            mem: PairAMode::SignedOffset(xreg(10), simm7_scaled_zero(I64)),
             flags: MemFlags::trusted(),
         },
         "482540A9",
@@ -5934,7 +5944,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoadP64 {
             rt: writable_vreg(0),
             rt2: writable_vreg(31),
-            mem: PairAMode::SignedOffset(xreg(0), SImm7Scaled::zero(F64)),
+            mem: PairAMode::SignedOffset(xreg(0), simm7_scaled_zero(F64)),
             flags: MemFlags::trusted(),
         },
         "007C406D",
@@ -6015,7 +6025,7 @@ fn test_aarch64_binemit() {
         Inst::FpuLoadP128 {
             rt: writable_vreg(0),
             rt2: writable_vreg(17),
-            mem: PairAMode::SignedOffset(xreg(3), SImm7Scaled::zero(I8X16)),
+            mem: PairAMode::SignedOffset(xreg(3), simm7_scaled_zero(I8X16)),
             flags: MemFlags::trusted(),
         },
         "604440AD",

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -88,11 +88,6 @@ impl SImm7Scaled {
         }
     }
 
-    /// Create a zero immediate of this format.
-    pub fn zero(scale_ty: Type) -> SImm7Scaled {
-        SImm7Scaled { value: 0, scale_ty }
-    }
-
     /// Bits for encoding.
     pub fn bits(&self) -> u32 {
         let ty_bytes: i16 = self.scale_ty.bytes() as i16;
@@ -200,11 +195,6 @@ impl SImm9 {
         } else {
             None
         }
-    }
-
-    /// Create a zero immediate of this format.
-    pub fn zero() -> SImm9 {
-        SImm9 { value: 0 }
     }
 
     /// Bits for encoding.
@@ -548,37 +538,6 @@ impl ImmLogic {
         // For every ImmLogical immediate, the inverse can also be encoded.
         Self::maybe_from_u64(!self.value, self.size.to_ty()).unwrap()
     }
-
-    /// This provides a safe(ish) way to avoid the costs of `maybe_from_u64` when we want to
-    /// encode a constant that we know at compiler-build time.  It constructs an `ImmLogic` from
-    /// the fields `n`, `r`, `s` and `size`, but in a debug build, checks that `value_to_check`
-    /// corresponds to those four fields.  The intention is that, in a non-debug build, this
-    /// reduces to something small enough that it will be a candidate for inlining.
-    pub fn from_n_r_s(value_to_check: u64, n: bool, r: u8, s: u8, size: OperandSize) -> Self {
-        // Construct it from the components we got given.
-        let imml = Self {
-            value: value_to_check,
-            n,
-            r,
-            s,
-            size,
-        };
-
-        // In debug mode, check that `n`/`r`/`s` are correct, given `value` and `size`.
-        debug_assert!(match ImmLogic::maybe_from_u64(
-            value_to_check,
-            if size == OperandSize::Size64 {
-                I64
-            } else {
-                I32
-            }
-        ) {
-            None => false, // fail: `value` is unrepresentable
-            Some(imml_check) => imml_check == imml,
-        });
-
-        imml
-    }
 }
 
 /// An immediate for shift instructions.
@@ -658,11 +617,6 @@ impl MoveWideConst {
                 shift: shift_enc,
             })
         }
-    }
-
-    /// Returns the value that this constant represents.
-    pub fn value(&self) -> u64 {
-        (self.bits as u64) << (16 * self.shift)
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1,8 +1,5 @@
 //! This module defines aarch64-specific machine instruction types.
 
-// Some variants are not constructed, but we still want them as options in the future.
-#![allow(dead_code)]
-
 use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::types::{
     B1, B128, B16, B32, B64, B8, F32, F64, FFLAGS, I128, I16, I32, I64, I8, I8X16, IFLAGS, R32, R64,
@@ -2738,9 +2735,11 @@ pub enum LabelUse {
     /// 26-bit branch offset (unconditional branches). PC-rel, offset is imm << 2. Immediate is 26
     /// signed bits, in bits 25:0. Used by b, bl.
     Branch26,
+    #[allow(dead_code)]
     /// 19-bit offset for LDR (load literal). PC-rel, offset is imm << 2. Immediate is 19 signed bits,
     /// in bits 23:5.
     Ldr19,
+    #[allow(dead_code)]
     /// 21-bit offset for ADR (get address of label). PC-rel, offset is not shifted. Immediate is
     /// 21 signed bits, with high 19 bits in bits 23:5 and low 2 bits in bits 30:29.
     Adr21,

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -1,8 +1,5 @@
 //! S390x ISA definitions: instruction arguments.
 
-// Some variants are never constructed, but we still want them as options in the future.
-#![allow(dead_code)]
-
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::MemFlags;
 use crate::isa::s390x::inst::*;

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -4,6 +4,11 @@ use crate::isa::s390x::settings as s390x_settings;
 use crate::settings;
 use alloc::vec::Vec;
 
+#[cfg(test)]
+fn simm20_zero() -> SImm20 {
+    SImm20::maybe_from_i64(0).unwrap()
+}
+
 #[test]
 fn test_s390x_binemit() {
     let mut insns = Vec::<(Inst, &str, &str)>::new();
@@ -498,7 +503,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -512,7 +517,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -582,7 +587,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -652,7 +657,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -666,7 +671,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -736,7 +741,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -806,7 +811,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -820,7 +825,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -890,7 +895,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -932,7 +937,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -974,7 +979,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -1573,7 +1578,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -1612,7 +1617,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },
@@ -1726,7 +1731,7 @@ fn test_s390x_binemit() {
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
-                disp: SImm20::zero(),
+                disp: simm20_zero(),
                 flags: MemFlags::trusted(),
             },
         },

--- a/cranelift/codegen/src/isa/s390x/inst/imms.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/imms.rs
@@ -56,11 +56,6 @@ impl SImm20 {
         }
     }
 
-    /// Create a zero immediate of this format.
-    pub fn zero() -> SImm20 {
-        SImm20 { value: 0 }
-    }
-
     /// Bits for encoding.
     pub fn bits(&self) -> u32 {
         let encoded: u32 = self.value as u32;
@@ -130,11 +125,6 @@ impl UImm16Shifted {
             shift: self.shift,
         }
     }
-
-    /// Returns the value that this constant represents.
-    pub fn value(&self) -> u64 {
-        (self.bits as u64) << (16 * self.shift)
-    }
 }
 
 /// A 32-bit immediate with a {0,32}-bit shift.
@@ -179,30 +169,11 @@ impl UImm32Shifted {
         }
     }
 
-    pub fn from_uimm16shifted(value: UImm16Shifted) -> UImm32Shifted {
-        if value.shift % 2 == 0 {
-            UImm32Shifted {
-                bits: value.bits as u32,
-                shift: value.shift / 2,
-            }
-        } else {
-            UImm32Shifted {
-                bits: (value.bits as u32) << 16,
-                shift: value.shift / 2,
-            }
-        }
-    }
-
     pub fn negate_bits(&self) -> UImm32Shifted {
         UImm32Shifted {
             bits: !self.bits,
             shift: self.shift,
         }
-    }
-
-    /// Returns the value that this constant represents.
-    pub fn value(&self) -> u64 {
-        (self.bits as u64) << (32 * self.shift)
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1,8 +1,5 @@
 //! This module defines s390x-specific machine instruction types.
 
-// Some variants are not constructed, but we still want them as options in the future.
-#![allow(dead_code)]
-
 use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::{types, ExternalName, Opcode, Type};
 use crate::machinst::*;
@@ -2019,6 +2016,7 @@ impl Inst {
 /// Different forms of label references for different instruction formats.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LabelUse {
+    #[allow(dead_code)]
     /// RI-format branch.  16-bit signed offset.  PC-relative, offset is imm << 1.
     BranchRI,
     /// RIL-format branch.  32-bit signed offset.  PC-relative, offset is imm << 1.

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -11,26 +11,6 @@ use crate::settings;
 //=============================================================================
 // Registers, the Universe thereof, and printing
 
-#[rustfmt::skip]
-const GPR_INDICES: [u8; 16] = [
-    // r0 and r1 reserved
-    30, 31,
-    // r2 - r5 call-clobbered
-    16, 17, 18, 19,
-    // r6 - r14 call-saved (order reversed)
-    28, 27, 26, 25, 24, 23, 22, 21, 20,
-    // r15 (SP)
-    29,
-];
-
-#[rustfmt::skip]
-const FPR_INDICES: [u8; 16] = [
-    // f0 - f7 as pairs
-    0, 4, 1, 5, 2, 6, 3, 7,
-    // f8 - f15 as pairs
-    8, 12, 9, 13, 10, 14, 11, 15,
-];
-
 /// Get a reference to a GPR (integer register).
 pub fn gpr(num: u8) -> Reg {
     assert!(num < 16);


### PR DESCRIPTION
Having module wide `allow(dead_code)` may hide some code that's really
dead. In this commit I just narrowed the declarations to the specific
enum variants that were not used (as it seems reasonable to keep them
and their handling in all the matches, for future use). And the compiler
found more dead code that I think we can remove safely in the short
term.

With this, the only files annotated with a module-wide
`allow(dead_code)` are isle-generated files.