### PR TITLE
enable multi-value in spec intepreter fuzzing

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/build.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/build.rs
@@ -12,7 +12,7 @@ const OCAML_DIR: &'static str = "ocaml";
 const SPEC_DIR: &'static str = "ocaml/spec";
 const SPEC_REPOSITORY: &'static str = "https://github.com/conrad-watt/spec";
 const SPEC_REPOSITORY_BRANCH: &'static str = "wasmtime_fuzzing";
-const SPEC_REPOSITORY_REV: &'static str = "5395f07394eac9383b99ae04bb1fb34a77394555";
+const SPEC_REPOSITORY_REV: &'static str = "7208af3bdb33fbf357ca5755e4edf2b35147ae95";
 
 fn main() {
     if cfg!(feature = "build-libinterpret") {

--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
@@ -61,7 +61,7 @@ let interpret_exn module_bytes opt_params =
   let fuel = Z.of_string "4611686018427387904" in
   let max_call_depth = Z.of_string "300" in
   (match run_fuzz (nat_of_integer fuel) (nat_of_integer max_call_depth) (make_empty_store_m ()) m_isa [] opt_params_ () with
-  | (s', RValue vs_isa') -> List.map convert_from_wasm (List.rev vs_isa')
+  | (s', RValue vs_isa') -> List.rev_map convert_from_wasm vs_isa'
   | (s', RTrap str) -> raise (Eval.Trap (Source.no_region, "(Isabelle) trap: " ^ str))
   | (s', (RCrash (Error_exhaustion str))) -> raise (Eval.Exhaustion (Source.no_region, "(Isabelle) call stack exhausted"))
   | (s', (RCrash (Error_invalid str))) -> raise (Eval.Crash (Source.no_region, "(Isabelle) error: " ^ str))

--- a/fuzz/fuzz_targets/differential_spec.rs
+++ b/fuzz/fuzz_targets/differential_spec.rs
@@ -22,7 +22,6 @@ fn run(data: &[u8]) -> Result<()> {
     config.set_differential_config();
 
     // Enable features that the spec interpreter has implemented
-    config.module_config.config.multi_value_enabled = false;
     config.module_config.config.simd_enabled = true;
 
     // TODO: this is a best-effort attempt to avoid errors caused by the


### PR DESCRIPTION
Apologies for submitting another PR so soon after my previous one, but this turned out to work pretty quickly.