### PR TITLE
Cranelift: fix filetest now failing after merge to main.

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
@@ -9,8 +9,8 @@ block0(v0: f32, v1: f32):
     v3 = iconst.i32 1
     v4 = iconst.i32 0
     v5 = select v2, v3, v4
-    ; check: ucomiss %xmm0, %xmm1
-    ; nextln: cmovnzl %r8d, %eax, %eax
-    ; nextln: cmovpl  %r8d, %eax, %eax
+    ; check: ucomiss
+    ; nextln: cmovnzl
+    ; nextln: cmovpl
     return v5
 }


### PR DESCRIPTION
This test was added between the last CI run on #4088 and its merge to
main, and the changes in #4088 (use of constants directly in instruction
via load from constant pool, rather than from a register initialized by
a separate instruction) cause it to fail now.

This PR alters the test to be invariant to regalloc and argument
decisions during lowering, as the test is really checking (per the
comment) that we get two cmoves without an intervening move. As such, it
just matches the instruction opcodes, irrespective of the arguments.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
