### PR TITLE
Avoid spurious build script runs

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -166,6 +166,7 @@ struct IsleCompilations {
 struct IsleCompilation {
     output: std::path::PathBuf,
     inputs: Vec<std::path::PathBuf>,
+    untracked_inputs: Vec<std::path::PathBuf>,
 }
 
 /// Construct the list of compilations (transformations from ISLE
@@ -205,31 +206,31 @@ fn get_isle_compilations(
             IsleCompilation {
                 output: out_dir.join("isle_x64.rs"),
                 inputs: vec![
-                    clif_isle.clone(),
                     prelude_isle.clone(),
                     src_isa_x64.join("inst.isle"),
                     src_isa_x64.join("lower.isle"),
                 ],
+                untracked_inputs: vec![clif_isle.clone()],
             },
             // The aarch64 instruction selector.
             IsleCompilation {
                 output: out_dir.join("isle_aarch64.rs"),
                 inputs: vec![
-                    clif_isle.clone(),
                     prelude_isle.clone(),
                     src_isa_aarch64.join("inst.isle"),
                     src_isa_aarch64.join("lower.isle"),
                 ],
+                untracked_inputs: vec![clif_isle.clone()],
             },
             // The s390x instruction selector.
             IsleCompilation {
                 output: out_dir.join("isle_s390x.rs"),
                 inputs: vec![
-                    clif_isle.clone(),
                     prelude_isle.clone(),
                     src_isa_s390x.join("inst.isle"),
                     src_isa_s390x.join("lower.isle"),
                 ],
+                untracked_inputs: vec![clif_isle.clone()],
             },
         ],
     })
@@ -279,7 +280,12 @@ fn run_compilation(
     println!("Rebuilding {}", compilation.output.display());
 
     let code = (|| {
-        let lexer = isle::lexer::Lexer::from_files(&compilation.inputs[..])?;
+        let lexer = isle::lexer::Lexer::from_files(
+            compilation
+                .inputs
+                .iter()
+                .chain(compilation.untracked_inputs.iter()),
+        )?;
         let defs = isle::parser::parse(lexer)?;
 
         let mut options = isle::codegen::CodegenOptions::default();

--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -277,7 +277,7 @@ fn run_compilation(
 ) -> Result<(), Box<dyn std::error::Error + 'static>> {
     use cranelift_isle as isle;
 
-    println!("Rebuilding {}", compilation.output.display());
+    eprintln!("Rebuilding {}", compilation.output.display());
 
     let code = (|| {
         let lexer = isle::lexer::Lexer::from_files(
@@ -361,7 +361,7 @@ fn run_compilation(
         code
     });
 
-    println!(
+    eprintln!(
         "Writing ISLE-generated Rust code to {}",
         compilation.output.display()
     );

--- a/cranelift/codegen/meta/src/srcgen.rs
+++ b/cranelift/codegen/meta/src/srcgen.rs
@@ -100,7 +100,7 @@ impl Formatter {
         let path_str = format!("{}/{}", directory, filename.as_ref());
 
         let path = path::Path::new(&path_str);
-        println!("Writing generated file: {}", path.display());
+        eprintln!("Writing generated file: {}", path.display());
         let mut f = fs::File::create(path)?;
 
         for l in self.lines.iter().map(|l| l.as_bytes()) {


### PR DESCRIPTION
The second commit is not strictly necessary, but the first commit prevents the cranelift-codegen build script from unnecessarily running in some cases.