### PR TITLE
ISLE: provide locations in errors in basic non-miette mode.

### DIFF
--- a/cranelift/isle/isle/src/error_miette.rs
+++ b/cranelift/isle/isle/src/error_miette.rs
@@ -8,7 +8,7 @@ use miette::{SourceCode, SourceSpan};
 
 impl From<Span> for SourceSpan {
     fn from(span: Span) -> Self {
-        SourceSpan::new(span.from.into(), span.to.into())
+        SourceSpan::new(span.from.offset.into(), span.to.offset.into())
     }
 }
 

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -45,11 +45,16 @@ pub struct Pos {
 impl Pos {
     /// Print this source position as `file.isle:12:34`.
     pub fn pretty_print(&self, filenames: &[Arc<str>]) -> String {
-        format!("{}:{}:{}", filenames[self.file], self.line, self.col)
+        self.pretty_print_with_filename(&filenames[self.file])
     }
     /// Print this source position as `file.isle line 12`.
     pub fn pretty_print_line(&self, filenames: &[Arc<str>]) -> String {
         format!("{} line {}", filenames[self.file], self.line)
+    }
+    /// As above for `pretty_print`, but with the specific filename
+    /// already provided.
+    pub fn pretty_print_with_filename(&self, filename: &str) -> String {
+        format!("{}:{}:{}", filename, self.line, self.col)
     }
 }
 
@@ -167,7 +172,7 @@ impl<'a> Lexer<'a> {
                 self.filenames[pos.file].clone(),
                 self.file_texts[pos.file].clone(),
             ),
-            span: Span::new_single(self.pos().offset),
+            span: Span::new_single(self.pos()),
         }
     }
 

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -39,7 +39,7 @@ impl<'a> Parser<'a> {
                 self.lexer.filenames[pos.file].clone(),
                 self.lexer.file_texts[pos.file].clone(),
             ),
-            span: Span::new_single(pos.offset),
+            span: Span::new_single(pos),
         }
     }
 

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -727,7 +727,7 @@ impl TypeEnv {
                 self.filenames[pos.file].clone(),
                 self.file_texts[pos.file].clone(),
             ),
-            span: Span::new_single(pos.offset),
+            span: Span::new_single(pos),
         };
         log!("{}", e);
         e


### PR DESCRIPTION
In #4143 we made ISLE compilation part of the normal build flow again,
to avoid the issues with the checked-in source. To make this acceptably
fast, we cut down dependencies of the ISLE compiler, so the "fancy"
error printing is now optional. When not included, it just prints error
messages to stderr in a list. However, this did not include file
locations. It might be nice to have this without enabling the "fancy
printing" and waiting for that to build.

Fortunately most of the plumbing for this was already present (we had it
at one point before switching to miette). This PR adds back locations to
the basic error output. It now looks like:

```
  Error building ISLE files: ISLE errors:

  src/isa/aarch64/inst.isle:1:1: parse error: Unexpected token Symbol("asdf")
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
