### PR TITLE
Run a callback when the interruption epoch is reached

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -360,23 +360,27 @@ impl Config {
     ///
     /// The [`Store`](crate::Store) tracks the deadline, and controls
     /// what happens when the deadline is reached during
-    /// execution. Two behaviors are possible:
+    /// execution. Several behaviors are possible:
     ///
     /// - Trap if code is executing when the epoch deadline is
     ///   met. See
     ///   [`Store::epoch_deadline_trap`](crate::Store::epoch_deadline_trap).
     ///
+    /// - Call an arbitrary function. This function may chose to trap or
+    ///   increment the epoch. See
+    ///   [`Store::epoch_deadline_callback`](crate::Store::epoch_deadline_callback).
+    ///
     /// - Yield to the executor loop, then resume when the future is
     ///   next polled. See
     ///   [`Store::epoch_deadline_async_yield_and_update`](crate::Store::epoch_deadline_async_yield_and_update).
     ///
-    /// The first is the default; set the second for the timeslicing
-    /// behavior described above.
+    /// Trapping is the default. The yielding behaviour may be used for
+    /// the timeslicing behavior described above.
     ///
-    /// This feature is available with or without async
-    /// support. However, without async support, only the trapping
-    /// behavior is available. In this mode, epoch-based interruption
-    /// can serve as a simple external-interruption mechanism.
+    /// This feature is available with or without async support.
+    /// However, without async support, the timeslicing behaviour is
+    /// not available. This means epoch-based interruption can only
+    /// serve as a simple external-interruption mechanism.
     ///
     /// An initial deadline can be set before executing code by
     /// calling
@@ -404,6 +408,7 @@ impl Config {
     /// - [`Engine::increment_epoch`](crate::Engine::increment_epoch)
     /// - [`Store::set_epoch_deadline`](crate::Store::set_epoch_deadline)
     /// - [`Store::epoch_deadline_trap`](crate::Store::epoch_deadline_trap)
+    /// - [`Store::epoch_deadline_callback`](crate::Store::epoch_deadline_callback)
     /// - [`Store::epoch_deadline_async_yield_and_update`](crate::Store::epoch_deadline_async_yield_and_update)
     pub fn epoch_interruption(&mut self, enable: bool) -> &mut Self {
         self.tunables.epoch_interruption = enable;

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -202,6 +202,7 @@ pub struct StoreInner<T> {
 
     limiter: Option<ResourceLimiterInner<T>>,
     call_hook: Option<CallHookInner<T>>,
+    epoch_deadline_behavior: EpochDeadline<T>,
     // for comments about `ManuallyDrop`, see `Store::into_data`
     data: ManuallyDrop<T>,
 }
@@ -296,7 +297,6 @@ pub struct StoreOpaque {
     #[cfg(feature = "async")]
     async_state: AsyncState,
     out_of_gas_behavior: OutOfGas,
-    epoch_deadline_behavior: EpochDeadline,
     /// Indexed data within this `Store`, used to store information about
     /// globals, functions, memories, etc.
     ///
@@ -426,10 +426,11 @@ enum OutOfGas {
 
 /// What to do when the engine epoch reaches the deadline for a Store
 /// during execution of a function using that store.
-#[derive(Copy, Clone)]
-enum EpochDeadline {
+enum EpochDeadline<T> {
     /// Return early with a trap.
     Trap,
+    /// Call a custom deadline handler.
+    Callback(Box<dyn FnMut(&mut T) -> Result<u64> + Send + Sync>),
     /// Extend the deadline by the specified number of ticks after
     /// yielding to the async executor loop.
     #[cfg(feature = "async")]
@@ -491,7 +492,6 @@ impl<T> Store<T> {
                     current_poll_cx: UnsafeCell::new(ptr::null_mut()),
                 },
                 out_of_gas_behavior: OutOfGas::Trap,
-                epoch_deadline_behavior: EpochDeadline::Trap,
                 store_data: ManuallyDrop::new(StoreData::new()),
                 default_callee,
                 hostcall_val_storage: Vec::new(),
@@ -500,6 +500,7 @@ impl<T> Store<T> {
             },
             limiter: None,
             call_hook: None,
+            epoch_deadline_behavior: EpochDeadline::Trap,
             data: ManuallyDrop::new(data),
         });
 
@@ -842,7 +843,8 @@ impl<T> Store<T> {
     ///
     /// This behavior is the default if the store is not otherwise
     /// configured via
-    /// [`epoch_deadline_trap()`](Store::epoch_deadline_trap) or
+    /// [`epoch_deadline_trap()`](Store::epoch_deadline_trap),
+    /// [`epoch_deadline_callback()`](Store::epoch_deadline_callback) or
     /// [`epoch_deadline_async_yield_and_update()`](Store::epoch_deadline_async_yield_and_update).
     ///
     /// This setting is intended to allow for coarse-grained
@@ -855,6 +857,33 @@ impl<T> Store<T> {
     /// for an introduction to epoch-based interruption.
     pub fn epoch_deadline_trap(&mut self) {
         self.inner.epoch_deadline_trap();
+    }
+
+    /// Configures epoch-deadline expiration to invoke a custom callback
+    /// function.
+    ///
+    /// When epoch-interruption-instrumented code is executed on this
+    /// store and the epoch deadline is reached before completion, the
+    /// provided callback function is invoked.
+    ///
+    /// This function should return a positive `delta`, which is used to
+    /// update the new epoch, setting it to the current epoch plus
+    /// `delta` ticks. Alternatively, the callback may return an error,
+    /// which will terminate execution.
+    ///
+    /// This setting is intended to allow for coarse-grained
+    /// interruption, but not a deterministic deadline of a fixed,
+    /// finite interval. For deterministic interruption, see the
+    /// "fuel" mechanism instead.
+    ///
+    /// See documentation on
+    /// [`Config::epoch_interruption()`](crate::Config::epoch_interruption)
+    /// for an introduction to epoch-based interruption.
+    pub fn epoch_deadline_callback(
+        &mut self,
+        callback: impl FnMut(&mut T) -> Result<u64> + Send + Sync + 'static,
+    ) {
+        self.inner.epoch_deadline_callback(Box::new(callback));
     }
 
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
@@ -1351,22 +1380,6 @@ impl StoreOpaque {
         }
     }
 
-    fn epoch_deadline_trap(&mut self) {
-        self.epoch_deadline_behavior = EpochDeadline::Trap;
-    }
-
-    fn epoch_deadline_async_yield_and_update(&mut self, delta: u64) {
-        assert!(
-            self.async_support(),
-            "cannot use `epoch_deadline_async_yield_and_update` without enabling async support in the config"
-        );
-        #[cfg(feature = "async")]
-        {
-            self.epoch_deadline_behavior = EpochDeadline::YieldAndExtendDeadline { delta };
-        }
-        drop(delta); // suppress warning in non-async build
-    }
-
     #[inline]
     pub fn signal_handler(&self) -> Option<*const SignalHandler<'static>> {
         let handler = self.signal_handler.as_ref()?;
@@ -1855,8 +1868,8 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
     }
 
     fn new_epoch(&mut self) -> Result<u64, anyhow::Error> {
-        return match &self.epoch_deadline_behavior {
-            &EpochDeadline::Trap => {
+        return match &mut self.epoch_deadline_behavior {
+            &mut EpochDeadline::Trap => {
                 let trap = Trap::new_wasm(
                     None,
                     wasmtime_environ::TrapCode::Interrupt,
@@ -1864,8 +1877,17 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
                 );
                 Err(anyhow::Error::from(trap))
             }
+            EpochDeadline::Callback(callback) => match callback(&mut self.data) {
+                Ok(delta) => {
+                    // Set a new deadline and return the new epoch deadline so
+                    // the Wasm code doesn't have to reload it.
+                    self.set_epoch_deadline(delta);
+                    Ok(self.get_epoch_deadline())
+                }
+                Err(e) => Err(e),
+            },
             #[cfg(feature = "async")]
-            &EpochDeadline::YieldAndExtendDeadline { delta } => {
+            &mut EpochDeadline::YieldAndExtendDeadline { delta } => {
                 // Do the async yield. May return a trap if future was
                 // canceled while we're yielded.
                 self.async_yield_impl()?;
@@ -1893,6 +1915,29 @@ impl<T> StoreInner<T> {
         // return into it.
         let epoch_deadline = unsafe { (*self.vmruntime_limits()).epoch_deadline.get_mut() };
         *epoch_deadline = self.engine().current_epoch() + delta;
+    }
+
+    fn epoch_deadline_trap(&mut self) {
+        self.epoch_deadline_behavior = EpochDeadline::Trap;
+    }
+
+    fn epoch_deadline_callback(
+        &mut self,
+        callback: Box<dyn FnMut(&mut T) -> Result<u64> + Send + Sync>,
+    ) {
+        self.epoch_deadline_behavior = EpochDeadline::Callback(callback);
+    }
+
+    fn epoch_deadline_async_yield_and_update(&mut self, delta: u64) {
+        assert!(
+            self.async_support(),
+            "cannot use `epoch_deadline_async_yield_and_update` without enabling async support in the config"
+        );
+        #[cfg(feature = "async")]
+        {
+            self.epoch_deadline_behavior = EpochDeadline::YieldAndExtendDeadline { delta };
+        }
+        drop(delta); // suppress warning in non-async build
     }
 
     fn get_epoch_deadline(&self) -> u64 {


### PR DESCRIPTION
Adds Store::epoch_deadline_callback. This accepts a callback which, when invoked, can mutate the store's contents. The callback can either return an error (in which case we trap) or return a delta which we'll use to set the new epoch deadline.

As discussed with @alexcrichton on Zulip. I'm not very happy with the tests here - happy to improve those if people have ideas.

It might be desirable to reimplement the trap and yield behaviours in terms of this callback. Happy to do that if preferred.