### PR TITLE
Add Cranelift meeting agendas for rest of 2022.

### DIFF
--- a/meetings/cranelift/2022/cranelift-06-06.md
+++ b/meetings/cranelift/2022/cranelift-06-06.md
@@ -1,0 +1,20 @@
+# June 6 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-06-13.md
+++ b/meetings/cranelift/2022/cranelift-06-13.md
@@ -1,0 +1,20 @@
+# June 13 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-06-27.md
+++ b/meetings/cranelift/2022/cranelift-06-27.md
@@ -1,0 +1,20 @@
+# June 27 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-07-11.md
+++ b/meetings/cranelift/2022/cranelift-07-11.md
@@ -1,0 +1,20 @@
+# July 11 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-07-25.md
+++ b/meetings/cranelift/2022/cranelift-07-25.md
@@ -1,0 +1,20 @@
+# July 25 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-08-08.md
+++ b/meetings/cranelift/2022/cranelift-08-08.md
@@ -1,0 +1,20 @@
+# August 8 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-08-22.md
+++ b/meetings/cranelift/2022/cranelift-08-22.md
@@ -1,0 +1,20 @@
+# August 22 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-09-12.md
+++ b/meetings/cranelift/2022/cranelift-09-12.md
@@ -1,0 +1,20 @@
+# September 12 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-09-19.md
+++ b/meetings/cranelift/2022/cranelift-09-19.md
@@ -1,0 +1,20 @@
+# September 19 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-10-03.md
+++ b/meetings/cranelift/2022/cranelift-10-03.md
@@ -1,0 +1,20 @@
+# October 3 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-10-17.md
+++ b/meetings/cranelift/2022/cranelift-10-17.md
@@ -1,0 +1,20 @@
+# October 17 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-10-31.md
+++ b/meetings/cranelift/2022/cranelift-10-31.md
@@ -1,0 +1,20 @@
+# October 31 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-11-14.md
+++ b/meetings/cranelift/2022/cranelift-11-14.md
@@ -1,0 +1,20 @@
+# November 14 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-11-28.md
+++ b/meetings/cranelift/2022/cranelift-11-28.md
@@ -1,0 +1,20 @@
+# November 28 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes

--- a/meetings/cranelift/2022/cranelift-12-12.md
+++ b/meetings/cranelift/2022/cranelift-12-12.md
@@ -1,0 +1,20 @@
+# December 12 project call
+
+**See the [instructions](../README.md) for details on how to attend**
+
+## Agenda
+1. Opening, welcome and roll call
+    1. Note: meeting notes linked in the invite.
+    1. Please help add your name to the meeting notes.
+    1. Please help take notes.
+    1. Thanks!
+1. Announcements
+    1. _Submit a PR to add your announcement here_
+1. Other agenda items
+    1. _Submit a PR to add your item here_
+
+## Notes
+
+### Attendees
+
+### Notes


### PR DESCRIPTION
As per discussion today, when we have a holiday (affecting any regular
attendee), we will push the meeting by a week. This does mean we
sometimes have meetings in contiguous weeks, but given the number of
topics we usually have to discuss, erring on the side of more discussion
time (rather than just canceling) is probably not a bad thing.

For the rest of this calendar year, given an otherwise regular
biweekly-on-Mondays cadence, the holiday conflicts I am aware of are: US
Memorial Day (falls on Mon May 28, pushed meeting to Mon Jun 6); US
Labor Day (falls on Mon Sept 5, pushed to Mon Sept 12). If there are any
other holidays in the below dates, I'm happy to update further!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
