### PR TITLE
Upgrade to regalloc2 0.1.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec1c2e4f4b879982653d243d9561d9f49004ce15a47e9682ad1f6d53a06aac0"
+checksum = "904196c12c9f55d3aea578613219f493ced8e05b3d0c6a42d11cb4142d8b4879"
 dependencies = [
  "fxhash",
  "log",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
-regalloc2 = { version = "0.1.2", features = ["checker"] }
+regalloc2 = { version = "0.1.3", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -67,28 +67,25 @@ block3(v7: r64, v8: r64):
 ;   mov fp, sp
 ;   sub sp, sp, #32
 ; block0:
-;   mov x4, x1
-;   mov x2, x0
+;   str x1, [sp, #16]
+;   str x0, [sp, #8]
 ;   ldr x3, 8 ; b 12 ; data TestCase { length: 1, ascii: [102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
-;   str x2, [sp, #8]
-;   str x4, [sp, #16]
 ;   blr x3
-;   ldr x2, [sp, #8]
 ;   mov x9, sp
-;   mov x12, x2
-;   str x12, [x9]
+;   ldr x10, [sp, #8]
+;   str x10, [x9]
 ;   and w7, w0, #1
 ;   cbz x7, label1 ; b label3
 ; block1:
 ;   b label2
 ; block2:
-;   mov x1, x12
+;   mov x1, x10
 ;   ldr x0, [sp, #16]
 ;   b label5
 ; block3:
 ;   b label4
 ; block4:
-;   mov x0, x12
+;   mov x0, x10
 ;   ldr x1, [sp, #16]
 ;   b label5
 ; block5:

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -69,27 +69,26 @@ block3(v7: r64, v8: r64):
 ;   aghi %r15, -184
 ;   virtual_sp_offset_adjust 160
 ; block0:
-;   lgr %r4, %r3
-;   lgr %r3, %r2
+;   stg %r3, 176(%r15)
+;   stg %r2, 168(%r15)
 ;   bras %r1, 12 ; data %f + 0 ; lg %r5, 0(%r1)
-;   stg %r3, 168(%r15)
-;   stg %r4, 176(%r15)
 ;   basr %r14, %r5
-;   lg %r3, 168(%r15)
-;   la %r4, 160(%r15)
-;   stg %r3, 0(%r4)
-;   llcr %r4, %r2
-;   chi %r4, 0
+;   la %r3, 160(%r15)
+;   lg %r4, 168(%r15)
+;   stg %r4, 0(%r3)
+;   llcr %r5, %r2
+;   chi %r5, 0
 ;   jgnlh label1 ; jg label3
 ; block1:
 ;   jg label2
 ; block2:
+;   lgr %r3, %r4
 ;   lg %r2, 176(%r15)
 ;   jg label5
 ; block3:
 ;   jg label4
 ; block4:
-;   lgr %r2, %r3
+;   lgr %r2, %r4
 ;   lg %r3, 176(%r15)
 ;   jg label5
 ; block5:


### PR DESCRIPTION
This pulls in bytecodealliance/regalloc2#49, which slightly improves
codegen in some cases where a safepoint (for reference-typed values)
occurs in the same liverange as a register-constrained use. For
example, in bytecodealliance/wasmtime#3785, an extra move instruction
appeared and a callee-save register was used (necessitating a more
expensive prologue) because of suboptimal splitting heuristics, which
this PR fixes. The updated RA2 heuristics appear to have no measured
downsides in existing benchmarks and improve the manually-observed
codegen issue.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
