### PR TITLE
Tweak CLI fallback to the `run` command

### DIFF
--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -59,11 +59,10 @@ impl Wasmtime {
 fn main() -> Result<()> {
     Wasmtime::try_parse()
         .unwrap_or_else(|e| match e.kind() {
-            ErrorKind::DisplayHelp
-            | ErrorKind::DisplayVersion
-            | ErrorKind::MissingSubcommand
-            | ErrorKind::MissingRequiredArgument => e.exit(),
-            _ => Wasmtime::Run(RunCommand::parse()),
+            ErrorKind::UnrecognizedSubcommand | ErrorKind::UnknownArgument => {
+                Wasmtime::Run(RunCommand::parse())
+            }
+            _ => e.exit(),
         })
         .execute()
 }


### PR DESCRIPTION
I ran across a case in Wasmtime today where a poor error message came
out of the CLI. For example before this commit you would get:

    $ cargo run wast --wasm-features component-model foo.wast
    error: Invalid value "wast" for '<MODULE>': module name cannot be the same as a subcommand

and now after this commit you get:

    $ cargo run wast --wasm-features component-model foo.wast
    error: Invalid value "component-model" for '--wasm-features <FEATURE,FEATURE,...>': unsupported WebAssembly feature 'component-model'

I believe this was an accidental regression from #4082 since Wasmtime
0.36.0 produces the error message as expected.

I opted to invert the conditional logic for falling back to the `run`
subcommand. Instead of having a small set of error kinds that print the
first-level error a small set of error kinds are now used to fall back
to the `run` subcommand by default. My hope is that as `ErrorKind` is
extended over time with various sorts of errors of parsing argumenst
this'll be more robust because most of the time we want the CLI
invocation to print out the normal CLI error, it's only in a select few
cases that using `run` is likely to succeed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
