### PR TITLE
Fix CI for Rust 1.61.0

### DIFF
--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -200,7 +200,7 @@ fn libcall_function() {
 
 #[test]
 #[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"function\\u{0}with\\u{0}nul\\u{0}bytes\" has a null byte, which is disallowed"
+    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"function\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
 )]
 fn reject_nul_byte_symbol_for_func() {
     let flag_builder = settings::builder();
@@ -224,7 +224,7 @@ fn reject_nul_byte_symbol_for_func() {
 
 #[test]
 #[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"data\\u{0}with\\u{0}nul\\u{0}bytes\" has a null byte, which is disallowed"
+    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"data\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
 )]
 fn reject_nul_byte_symbol_for_data() {
     let flag_builder = settings::builder();

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -265,7 +265,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
 
         // Translate the `wasmtime_val_t` results into the `results` space
         for (i, result) in out_results.iter().enumerate() {
-            results[i] = unsafe { result.to_val() };
+            results[i] = result.to_val();
         }
 
         // Move our `vals` storage back into the store now that we no longer


### PR DESCRIPTION
A new version of rustc was released this morning and we have a few small
breakages on our CI which need fixing:

* A new warning was coming out of the c-api crate about an unneeded
  `unsafe` block.
* The panic message of a task in `cranelift-object` needed updating
  since the standard library changed how it formats strings with the nul
  byte.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
