### PR TITLE
Update the wasm-tools family of crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,18 +3220,18 @@ checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35138d119147af92d7e44ae0f052f6496ee5f38e7c0cad3e0338befdb8f3753"
+checksum = "2b47b995b096a689358ca9de6c727b94351b95b390dbbf6b7021c22797d36caa"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e5f369abe36f3dca16811234da3550d72075c6b1365173811118307478f51d"
+checksum = "afc948447bea01d54509cb4a6ccbeb7e572c42c4c84f778d286b7633a1c49e86"
 dependencies = [
  "egg",
  "log",
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b4138c138f975e29dbd3ceea3a8d3ea2bb43f71abd4b236640d0cb14cb8ef7"
+checksum = "bb87569c81c298836d88405a28a68e8dfcd43b75220a4b4522831a63921b7dbc"
 dependencies = [
  "arbitrary",
  "flagset",
@@ -3290,18 +3290,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.84.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dc97c22bb5ce49a47b745bed8812d30206eff5ef3af31424f2c1820c0974b2"
+checksum = "570460c58b21e9150d2df0eaaedbb7816c34bcec009ae0dcc976e40ba81463e7"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b72b3c96567183a4eca151040b5f61735b2d53e7cadd4242dbb61cd9011d865"
+checksum = "ea454634a2a7888d053f7723a26a76024e4f705cf86f7b4d38d5f15b79369c31"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3430,7 +3430,6 @@ dependencies = [
  "test-programs",
  "tokio",
  "tracing-subscriber",
- "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3441,7 +3440,7 @@ dependencies = [
  "wasmtime-wasi-crypto",
  "wasmtime-wasi-nn",
  "wasmtime-wast",
- "wast 40.0.0",
+ "wast 41.0.0",
  "wat",
  "winapi",
 ]
@@ -3655,7 +3654,7 @@ version = "0.38.0"
 dependencies = [
  "anyhow",
  "wasmtime",
- "wast 40.0.0",
+ "wast 41.0.0",
 ]
 
 [[package]]
@@ -3669,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "40.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
+checksum = "f882898b8b817cc4edc16aa3692fdc087b356edc8cc0c2164f5b5181e31c3870"
 dependencies = [
  "leb128",
  "memchr",
@@ -3680,11 +3679,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0401b6395ce0db91629a75b29597ccb66ea29950af9fc859f1bb3a736609c76e"
+checksum = "48b3b9b3e39e66c7fd3f8be785e74444d216260f491e93369e317ed6482ff80f"
 dependencies = [
- "wast 40.0.0",
+ "wast 41.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
 libc = "0.2.60"
 humantime = "2.0.0"
-wasmparser = "0.84.0"
 lazy_static = "1.4.0"
 listenfd = "0.3.5"
 
@@ -53,7 +52,7 @@ test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { path = "crates/runtime" }
 tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.1"
-wast = "40.0.0"
+wast = "41.0.0"
 criterion = "0.3.4"
 num_cpus = "1.13.0"
 winapi = { version = "0.3.9", features = ['memoryapi'] }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["webassembly", "wasm"]
 edition = "2021"
 
 [dependencies]
-wasmparser = { version = "0.84.0", default-features = false }
+wasmparser = { version = "0.85.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.85.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.85.0" }
 cranelift-frontend = { path = "../frontend", version = "0.85.0", default-features = false }

--- a/cranelift/wasm/src/module_translator.rs
+++ b/cranelift/wasm/src/module_translator.rs
@@ -107,13 +107,8 @@ pub fn translate_module<'data>(
                 environ.reserve_passive_data(count)?;
             }
 
-            Payload::CustomSection {
-                name: "name",
-                data,
-                data_offset,
-                range: _,
-            } => {
-                let result = NameSectionReader::new(data, data_offset)
+            Payload::CustomSection(s) if s.name() == "name" => {
+                let result = NameSectionReader::new(s.data(), s.data_offset())
                     .map_err(|e| e.into())
                     .and_then(|s| parse_name_section(s, environ));
                 if let Err(e) = result {
@@ -121,7 +116,7 @@ pub fn translate_module<'data>(
                 }
             }
 
-            Payload::CustomSection { name, data, .. } => environ.custom_section(name, data)?,
+            Payload::CustomSection(s) => environ.custom_section(s.name(), s.data())?,
 
             other => {
                 validator.payload(&other)?;

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-codegen = { path = "../../cranelift/codegen", version = "0.85.0" }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.85.0" }
 cranelift-entity = { path = "../../cranelift/entity", version = "0.85.0" }
 cranelift-native = { path = "../../cranelift/native", version = "0.85.0" }
-wasmparser = "0.84.0"
+wasmparser = "0.85.0"
 target-lexicon = "0.12"
 gimli = { version = "0.26.0", default-features = false, features = ['read', 'std'] }
 object = { version = "0.28.0", default-features = false, features = ['write'] }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 anyhow = "1.0"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.85.0" }
 wasmtime-types = { path = "../types", version = "0.38.0" }
-wasmparser = "0.84.0"
+wasmparser = "0.85.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -15,13 +15,13 @@ log = "0.4.8"
 rayon = "1.2.1"
 target-lexicon = "0.12.3"
 tempfile = "3.3.0"
-wasmparser = "0.84.0"
-wasmprinter = "0.2.34"
+wasmparser = "0.85.0"
+wasmprinter = "0.2.35"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
-wasm-encoder = "0.11.0"
-wasm-smith = "0.10.0"
-wasm-mutate = "0.2.2"
+wasm-encoder = "0.12.0"
+wasm-smith = "0.10.1"
+wasm-mutate = "0.2.3"
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
 wasmi = "0.7.0"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.85.0", features = ['enable-serde'] }
 serde = { version = "1.0.94", features = ["derive"] }
 thiserror = "1.0.4"
-wasmparser = { version = "0.84.0", default-features = false }
+wasmparser = { version = "0.85.0", default-features = false }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -20,14 +20,14 @@ wasmtime-cache = { path = "../cache", version = "=0.38.0", optional = true }
 wasmtime-fiber = { path = "../fiber", version = "=0.38.0", optional = true }
 wasmtime-cranelift = { path = "../cranelift", version = "=0.38.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
-wasmparser = "0.84.0"
+wasmparser = "0.85.0"
 anyhow = "1.0.19"
 region = "2.2.0"
 libc = "0.2"
 cfg-if = "1.0"
 backtrace = { version = "0.3.61", optional = true }
 log = "0.4.8"
-wat = { version = "1.0.42", optional = true }
+wat = { version = "1.0.43", optional = true }
 serde = { version = "1.0.94", features = ["derive"] }
 bincode = "1.2.1"
 indexmap = "1.6"

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -389,7 +389,7 @@ impl Table {
     ///         (table (import \"\" \"\") 2 funcref)
     ///         (func $f (result i32)
     ///             i32.const 10)
-    ///         (elem (i32.const 0) (func $f))
+    ///         (elem (i32.const 0) $f)
     ///     )"
     /// )?;
     ///

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.19"
 wasmtime = { path = "../wasmtime", version = "0.38.0", default-features = false, features = ['cranelift'] }
-wast = "40.0.0"
+wast = "41.0.0"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -291,8 +291,11 @@ impl<T> WastContext<T> {
                 mut module,
                 message,
             } => {
-                let bytes = module.encode()?;
-                let err = match self.module(None, &bytes) {
+                let err = match module
+                    .encode()
+                    .map_err(|e| e.into())
+                    .and_then(|bytes| self.module(None, &bytes))
+                {
                     Ok(()) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -4,16 +4,18 @@ use std::fmt::{Display, LowerHex};
 use std::path::Path;
 use std::str;
 use wasmtime::*;
+use wast::core::{Expression, HeapType};
 use wast::lexer::Lexer;
-use wast::Wat;
+use wast::parser::{self, ParseBuffer};
+use wast::token::{Float32, Float64};
 use wast::{
-    parser::{self, ParseBuffer},
-    HeapType,
+    AssertExpression, NanPattern, QuoteWat, V128Pattern, Wast, WastDirective, WastExecute,
+    WastInvoke,
 };
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
-fn runtime_value(v: &wast::Expression<'_>) -> Result<Val> {
-    use wast::Instruction::*;
+fn runtime_value(v: &Expression<'_>) -> Result<Val> {
+    use wast::core::Instruction::*;
 
     if v.instrs.len() != 1 {
         bail!("too many instructions in {:?}", v);
@@ -101,10 +103,10 @@ impl<T> WastContext<T> {
     }
 
     /// Perform the action portion of a command.
-    fn perform_execute(&mut self, exec: wast::WastExecute<'_>) -> Result<Outcome> {
+    fn perform_execute(&mut self, exec: WastExecute<'_>) -> Result<Outcome> {
         match exec {
-            wast::WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
-            wast::WastExecute::Module(mut module) => {
+            WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
+            WastExecute::Wat(mut module) => {
                 let binary = module.encode()?;
                 let result = self.instantiate(&binary)?;
                 Ok(match result {
@@ -112,11 +114,11 @@ impl<T> WastContext<T> {
                     Outcome::Trap(e) => Outcome::Trap(e),
                 })
             }
-            wast::WastExecute::Get { module, global } => self.get(module.map(|s| s.name()), global),
+            WastExecute::Get { module, global } => self.get(module.map(|s| s.name()), global),
         }
     }
 
-    fn perform_invoke(&mut self, exec: wast::WastInvoke<'_>) -> Result<Outcome> {
+    fn perform_invoke(&mut self, exec: WastInvoke<'_>) -> Result<Outcome> {
         let values = exec
             .args
             .iter()
@@ -181,7 +183,7 @@ impl<T> WastContext<T> {
         Ok(Outcome::Ok(vec![global.get(&mut self.store)]))
     }
 
-    fn assert_return(&self, result: Outcome, results: &[wast::AssertExpression]) -> Result<()> {
+    fn assert_return(&self, result: Outcome, results: &[AssertExpression]) -> Result<()> {
         let values = result.into_result()?;
         for (i, (v, e)) in values.iter().zip(results).enumerate() {
             match_val(v, e).with_context(|| format!("result {} didn't match", i))?;
@@ -219,11 +221,15 @@ impl<T> WastContext<T> {
         let mut lexer = Lexer::new(wast);
         lexer.allow_confusing_unicode(filename.ends_with("names.wast"));
         let buf = ParseBuffer::new_with_lexer(lexer).map_err(adjust_wast)?;
-        let ast = parser::parse::<wast::Wast>(&buf).map_err(adjust_wast)?;
+        let ast = parser::parse::<Wast>(&buf).map_err(adjust_wast)?;
 
         for directive in ast.directives {
             let sp = directive.span();
-            self.run_directive(directive, &adjust_wast)
+            self.run_directive(directive)
+                .map_err(|e| match e.downcast() {
+                    Ok(err) => adjust_wast(err).into(),
+                    Err(e) => e,
+                })
                 .with_context(|| {
                     let (line, col) = sp.linecol_in(wast);
                     format!("failed directive on {}:{}:{}", filename, line + 1, col)
@@ -232,31 +238,19 @@ impl<T> WastContext<T> {
         Ok(())
     }
 
-    fn run_directive(
-        &mut self,
-        directive: wast::WastDirective,
-        adjust: impl Fn(wast::Error) -> wast::Error,
-    ) -> Result<()> {
-        use wast::WastDirective::*;
+    fn run_directive(&mut self, directive: WastDirective) -> Result<()> {
+        use WastDirective::*;
 
         match directive {
-            Module(mut module) => {
-                let binary = module.encode().map_err(adjust)?;
-                self.module(module.id.map(|s| s.name()), &binary)?;
-            }
-            QuoteModule { span: _, source } => {
-                let mut module = String::new();
-                for src in source {
-                    module.push_str(str::from_utf8(src)?);
-                    module.push_str(" ");
-                }
-                let buf = ParseBuffer::new(&module)?;
-                let mut wat = parser::parse::<Wat>(&buf).map_err(|mut e| {
-                    e.set_text(&module);
-                    e
-                })?;
-                let binary = wat.module.encode()?;
-                self.module(wat.module.id.map(|s| s.name()), &binary)?;
+            Wat(mut module) => {
+                let binary = module.encode()?;
+                let name = match &module {
+                    QuoteWat::Wat(wast::Wat::Module(m)) => m.id,
+                    QuoteWat::Wat(wast::Wat::Component(c)) => c.id,
+                    QuoteWat::QuoteModule(..) => None,
+                    QuoteWat::QuoteComponent(..) => None,
+                };
+                self.module(name.map(|s| s.name()), &binary)?;
             }
             Register {
                 span: _,
@@ -294,15 +288,9 @@ impl<T> WastContext<T> {
             }
             AssertInvalid {
                 span: _,
-                module,
+                mut module,
                 message,
             } => {
-                let mut module = match module {
-                    wast::QuoteModule::Module(m) => m,
-                    // This is a `*.wat` parser test which we're not
-                    // interested in.
-                    wast::QuoteModule::Quote(_) => return Ok(()),
-                };
                 let bytes = module.encode()?;
                 let err = match self.module(None, &bytes) {
                     Ok(()) => bail!("expected module to fail to build"),
@@ -318,18 +306,15 @@ impl<T> WastContext<T> {
                 }
             }
             AssertMalformed {
-                module,
+                mut module,
                 span: _,
                 message: _,
             } => {
-                let mut module = match module {
-                    wast::QuoteModule::Module(m) => m,
-                    // This is a `*.wat` parser test which we're not
-                    // interested in.
-                    wast::QuoteModule::Quote(_) => return Ok(()),
-                };
-                let bytes = module.encode().map_err(adjust)?;
-                if let Ok(_) = self.module(None, &bytes) {
+                let result = module
+                    .encode()
+                    .map_err(|e| e.into())
+                    .and_then(|bytes| self.module(None, &bytes));
+                if result.is_ok() {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
@@ -338,7 +323,7 @@ impl<T> WastContext<T> {
                 mut module,
                 message,
             } => {
-                let bytes = module.encode().map_err(adjust)?;
+                let bytes = module.encode()?;
                 let err = match self.module(None, &bytes) {
                     Ok(()) => bail!("expected module to fail to link"),
                     Err(e) => e,
@@ -373,6 +358,11 @@ fn is_matching_assert_invalid_error_message(expected: &str, actual: &str) -> boo
         || (expected.contains("out of bounds") && actual.contains("does not fit"))
         // slight difference in error messages
         || (expected.contains("unknown elem segment") && actual.contains("unknown element segment"))
+        // The same test here is asserted to have one error message in
+        // `memory.wast` and a different error message in
+        // `memory64/memory.wast`, so we equate these two error messages to get
+        // the memory64 tests to pass.
+        || (expected.contains("memory size must be at most 65536 pages") && actual.contains("invalid u32 number"))
 }
 
 fn extract_lane_as_i8(bytes: u128, lane: usize) -> i8 {
@@ -391,16 +381,16 @@ fn extract_lane_as_i64(bytes: u128, lane: usize) -> i64 {
     (bytes >> (lane * 64)) as i64
 }
 
-fn match_val(actual: &Val, expected: &wast::AssertExpression) -> Result<()> {
+fn match_val(actual: &Val, expected: &AssertExpression) -> Result<()> {
     match (actual, expected) {
-        (Val::I32(a), wast::AssertExpression::I32(b)) => match_int(a, b),
-        (Val::I64(a), wast::AssertExpression::I64(b)) => match_int(a, b),
+        (Val::I32(a), AssertExpression::I32(b)) => match_int(a, b),
+        (Val::I64(a), AssertExpression::I64(b)) => match_int(a, b),
         // Note that these float comparisons are comparing bits, not float
         // values, so we're testing for bit-for-bit equivalence
-        (Val::F32(a), wast::AssertExpression::F32(b)) => match_f32(*a, b),
-        (Val::F64(a), wast::AssertExpression::F64(b)) => match_f64(*a, b),
-        (Val::V128(a), wast::AssertExpression::V128(b)) => match_v128(*a, b),
-        (Val::ExternRef(x), wast::AssertExpression::RefNull(Some(HeapType::Extern))) => {
+        (Val::F32(a), AssertExpression::F32(b)) => match_f32(*a, b),
+        (Val::F64(a), AssertExpression::F64(b)) => match_f64(*a, b),
+        (Val::V128(a), AssertExpression::V128(b)) => match_v128(*a, b),
+        (Val::ExternRef(x), AssertExpression::RefNull(Some(HeapType::Extern))) => {
             if let Some(x) = x {
                 let x = x
                     .data()
@@ -411,7 +401,7 @@ fn match_val(actual: &Val, expected: &wast::AssertExpression) -> Result<()> {
                 Ok(())
             }
         }
-        (Val::ExternRef(x), wast::AssertExpression::RefExtern(y)) => {
+        (Val::ExternRef(x), AssertExpression::RefExtern(y)) => {
             if let Some(x) = x {
                 let x = x
                     .data()
@@ -426,7 +416,7 @@ fn match_val(actual: &Val, expected: &wast::AssertExpression) -> Result<()> {
                 bail!("expected non-null externref, found null")
             }
         }
-        (Val::FuncRef(x), wast::AssertExpression::RefNull(_)) => {
+        (Val::FuncRef(x), AssertExpression::RefNull(_)) => {
             if x.is_none() {
                 Ok(())
             } else {
@@ -457,7 +447,7 @@ where
     }
 }
 
-fn match_f32(actual: u32, expected: &wast::NanPattern<wast::Float32>) -> Result<()> {
+fn match_f32(actual: u32, expected: &NanPattern<Float32>) -> Result<()> {
     match expected {
         // Check if an f32 (as u32 bits to avoid possible quieting when moving values in registers, e.g.
         // https://developer.arm.com/documentation/ddi0344/i/neon-and-vfp-programmers-model/modes-of-operation/default-nan-mode?lang=en)
@@ -466,7 +456,7 @@ fn match_f32(actual: u32, expected: &wast::NanPattern<wast::Float32>) -> Result<
         //  - the 8-bit exponent is set to all 1s
         //  - the MSB of the payload is set to 1 (a quieted NaN) and all others to 0.
         // See https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        wast::NanPattern::CanonicalNan => {
+        NanPattern::CanonicalNan => {
             let canon_nan = 0x7fc0_0000;
             if (actual & 0x7fff_ffff) == canon_nan {
                 Ok(())
@@ -487,7 +477,7 @@ fn match_f32(actual: u32, expected: &wast::NanPattern<wast::Float32>) -> Result<
         // set to 1, but one or more of the remaining payload bits MAY BE set to
         // 1 (a canonical NaN specifies all 0s). See
         // https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        wast::NanPattern::ArithmeticNan => {
+        NanPattern::ArithmeticNan => {
             const AF32_NAN: u32 = 0x7f80_0000;
             let is_nan = actual & AF32_NAN == AF32_NAN;
             const AF32_PAYLOAD_MSB: u32 = 0x0040_0000;
@@ -505,7 +495,7 @@ fn match_f32(actual: u32, expected: &wast::NanPattern<wast::Float32>) -> Result<
                 )
             }
         }
-        wast::NanPattern::Value(expected_value) => {
+        NanPattern::Value(expected_value) => {
             if actual == expected_value.bits {
                 Ok(())
             } else {
@@ -522,7 +512,7 @@ fn match_f32(actual: u32, expected: &wast::NanPattern<wast::Float32>) -> Result<
     }
 }
 
-fn match_f64(actual: u64, expected: &wast::NanPattern<wast::Float64>) -> Result<()> {
+fn match_f64(actual: u64, expected: &NanPattern<Float64>) -> Result<()> {
     match expected {
         // Check if an f64 (as u64 bits to avoid possible quieting when moving values in registers, e.g.
         // https://developer.arm.com/documentation/ddi0344/i/neon-and-vfp-programmers-model/modes-of-operation/default-nan-mode?lang=en)
@@ -531,7 +521,7 @@ fn match_f64(actual: u64, expected: &wast::NanPattern<wast::Float64>) -> Result<
         //  - the 11-bit exponent is set to all 1s
         //  - the MSB of the payload is set to 1 (a quieted NaN) and all others to 0.
         // See https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        wast::NanPattern::CanonicalNan => {
+        NanPattern::CanonicalNan => {
             let canon_nan = 0x7ff8_0000_0000_0000;
             if (actual & 0x7fff_ffff_ffff_ffff) == canon_nan {
                 Ok(())
@@ -551,7 +541,7 @@ fn match_f64(actual: u64, expected: &wast::NanPattern<wast::Float64>) -> Result<
         // canonical NaN including that the payload MSB is set to 1, but one or more of the remaining
         // payload bits MAY BE set to 1 (a canonical NaN specifies all 0s). See
         // https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        wast::NanPattern::ArithmeticNan => {
+        NanPattern::ArithmeticNan => {
             const AF64_NAN: u64 = 0x7ff0_0000_0000_0000;
             let is_nan = actual & AF64_NAN == AF64_NAN;
             const AF64_PAYLOAD_MSB: u64 = 0x0008_0000_0000_0000;
@@ -569,7 +559,7 @@ fn match_f64(actual: u64, expected: &wast::NanPattern<wast::Float64>) -> Result<
                 )
             }
         }
-        wast::NanPattern::Value(expected_value) => {
+        NanPattern::Value(expected_value) => {
             if actual == expected_value.bits {
                 Ok(())
             } else {
@@ -586,9 +576,9 @@ fn match_f64(actual: u64, expected: &wast::NanPattern<wast::Float64>) -> Result<
     }
 }
 
-fn match_v128(actual: u128, expected: &wast::V128Pattern) -> Result<()> {
+fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
     match expected {
-        wast::V128Pattern::I8x16(expected) => {
+        V128Pattern::I8x16(expected) => {
             let actual = [
                 extract_lane_as_i8(actual, 0),
                 extract_lane_as_i8(actual, 1),
@@ -620,7 +610,7 @@ fn match_v128(actual: u128, expected: &wast::V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        wast::V128Pattern::I16x8(expected) => {
+        V128Pattern::I16x8(expected) => {
             let actual = [
                 extract_lane_as_i16(actual, 0),
                 extract_lane_as_i16(actual, 1),
@@ -644,7 +634,7 @@ fn match_v128(actual: u128, expected: &wast::V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        wast::V128Pattern::I32x4(expected) => {
+        V128Pattern::I32x4(expected) => {
             let actual = [
                 extract_lane_as_i32(actual, 0),
                 extract_lane_as_i32(actual, 1),
@@ -664,7 +654,7 @@ fn match_v128(actual: u128, expected: &wast::V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        wast::V128Pattern::I64x2(expected) => {
+        V128Pattern::I64x2(expected) => {
             let actual = [
                 extract_lane_as_i64(actual, 0),
                 extract_lane_as_i64(actual, 1),
@@ -682,14 +672,14 @@ fn match_v128(actual: u128, expected: &wast::V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        wast::V128Pattern::F32x4(expected) => {
+        V128Pattern::F32x4(expected) => {
             for (i, expected) in expected.iter().enumerate() {
                 let a = extract_lane_as_i32(actual, i) as u32;
                 match_f32(a, expected).with_context(|| format!("difference in lane {}", i))?;
             }
             Ok(())
         }
-        wast::V128Pattern::F64x2(expected) => {
+        V128Pattern::F64x2(expected) => {
             for (i, expected) in expected.iter().enumerate() {
                 let a = extract_lane_as_i64(actual, i) as u64;
                 match_f64(a, expected).with_context(|| format!("difference in lane {}", i))?;

--- a/examples/multimemory.wat
+++ b/examples/multimemory.wat
@@ -5,22 +5,22 @@
   (func (export "size0") (result i32) (memory.size 0))
   (func (export "load0") (param i32) (result i32)
     local.get 0
-    i32.load8_s (memory 0)
+    i32.load8_s 0
   )
   (func (export "store0") (param i32 i32)
     local.get 0
     local.get 1
-    i32.store8 (memory 0)
+    i32.store8 0
   )
   (func (export "size1") (result i32) (memory.size 1))
   (func (export "load1") (param i32) (result i32)
     local.get 0
-    i32.load8_s (memory 1)
+    i32.load8_s 1
   )
   (func (export "store1") (param i32 i32)
     local.get 0
     local.get 1
-    i32.store8 (memory 1)
+    i32.store8 1
   )
 
   (data (memory 0) (i32.const 0x1000) "\01\02\03\04")

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1,13 +1,14 @@
 use anyhow::Result;
 use wasmtime::*;
 use wast::parser::{self, Parse, ParseBuffer, Parser};
+use wast::token::Span;
 
 mod kw {
     wast::custom_keyword!(assert_fuel);
 }
 
 struct FuelWast<'a> {
-    assertions: Vec<(wast::Span, u64, wast::Module<'a>)>,
+    assertions: Vec<(Span, u64, wast::core::Module<'a>)>,
 }
 
 impl<'a> Parse<'a> for FuelWast<'a> {

--- a/tests/misc_testsuite/multi-memory/simple.wast
+++ b/tests/misc_testsuite/multi-memory/simple.wast
@@ -5,20 +5,20 @@
   (func (export "store1") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store (memory $m1))
+      i64.store $m1)
 
   (func (export "store2") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store (memory $m2))
+      i64.store $m2)
 
   (func (export "load1") (param i32) (result i64)
       local.get 0
-      i64.load (memory $m1))
+      i64.load $m1)
 
   (func (export "load2") (param i32) (result i64)
       local.get 0
-      i64.load (memory $m2))
+      i64.load $m2)
 )
 
 (invoke "store1" (i32.const 0) (i64.const 1))
@@ -64,20 +64,20 @@
   (func (export "store1") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store (memory $m1))
+      i64.store $m1)
 
   (func (export "store2") (param i32 i64)
       local.get 0
       local.get 1
-      i64.store (memory $m2))
+      i64.store $m2)
 
   (func (export "load1") (param i32) (result i64)
       local.get 0
-      i64.load (memory $m1))
+      i64.load $m1)
 
   (func (export "load2") (param i32) (result i64)
       local.get 0
-      i64.load (memory $m2))
+      i64.load $m2)
 )
 
 (invoke "store1" (i32.const 0) (i64.const 1))
@@ -92,11 +92,11 @@
 
   (func (export "grow1") (param i32) (result i32)
       local.get 0
-      memory.grow (memory $m1))
+      memory.grow $m1)
 
   (func (export "grow2") (param i32) (result i32)
       local.get 0
-      memory.grow (memory $m2))
+      memory.grow $m2)
 
   (func (export "size1") (result i32) memory.size $m1)
   (func (export "size2") (result i32) memory.size $m2)
@@ -128,7 +128,7 @@
       i32.const 4
       memory.init $m2 $d
       i32.const 1
-      i32.load (memory $m2))
+      i32.load $m2)
 
   (data $d "\01\00\00\00" "\02\00\00\00")
 )
@@ -154,7 +154,7 @@
       i32.const 2
       memory.fill $m2
       i32.const 1
-      i32.load (memory $m2))
+      i32.load $m2)
 )
 
 (assert_return (invoke "fill1") (i32.const 0x01010101))


### PR DESCRIPTION
This commit updates these crates as used by Wasmtime for the recently
published versions to pull in changes necessary to support the component
model. I've split this out from #4005 to make it clear what's impacted
here and #4005 can simply rebase on top of this to pick up the necessary
changes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
