### PR TITLE
Update release date of Wasmtime 0.37.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,7 +12,7 @@ Unreleased.
 
 ## 0.37.0
 
-Unreleased.
+Released 2022-05-20
 
 ### Added
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is updating
the release date of Wasmtime 0.37.0 to today. This PR's base branch
is `main` and a second PR will be coming to perform the actual
release which will be targeted at `release-0.37.0`.

[process]: https://docs.wasmtime.dev/contributing-release-process.html
