### PR TITLE
Release Wasmtime 0.37.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 0.37.0
 
-Unreleased.
+Released 2022-05-20.
 
 ### Added
 

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -200,7 +200,7 @@ fn libcall_function() {
 
 #[test]
 #[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"function\\u{0}with\\u{0}nul\\u{0}bytes\" has a null byte, which is disallowed"
+    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"function\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
 )]
 fn reject_nul_byte_symbol_for_func() {
     let flag_builder = settings::builder();
@@ -224,7 +224,7 @@ fn reject_nul_byte_symbol_for_func() {
 
 #[test]
 #[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"data\\u{0}with\\u{0}nul\\u{0}bytes\" has a null byte, which is disallowed"
+    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"data\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
 )]
 fn reject_nul_byte_symbol_for_data() {
     let flag_builder = settings::builder();

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -265,7 +265,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
 
         // Translate the `wasmtime_val_t` results into the `results` space
         for (i, result) in out_results.iter().enumerate() {
-            results[i] = unsafe { result.to_val() };
+            results[i] = result.to_val();
         }
 
         // Move our `vals` storage back into the store now that we no longer


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is
intended to notify maintainers that it's time to release Wasmtime
0.37.0. The [release branch][branch] was created roughly two weeks ago
and it's now time for it to be published and released.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-0.37.0
