### PR TITLE
Refactor binary-compatible-builds for releases

### DIFF
--- a/.github/actions/binary-compatible-builds/action.yml
+++ b/.github/actions/binary-compatible-builds/action.yml
@@ -4,3 +4,7 @@ description: 'Set up a CentOS 6 container to build releases in'
 runs:
   using: node12
   main: 'main.js'
+inputs:
+  name:
+    required: true
+    description: "Name of the build"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [main, refactor-docker-builds]
     tags-ignore: [dev]
     paths-ignore:
       - 'meetings/**'
@@ -376,29 +376,17 @@ jobs:
         - build: aarch64-linux
           os: ubuntu-latest
           target: aarch64-unknown-linux-gnu
-          gcc_package: gcc-aarch64-linux-gnu
-          gcc: aarch64-linux-gnu-gcc
         - build: s390x-linux
           os: ubuntu-latest
           target: s390x-unknown-linux-gnu
-          gcc_package: gcc-s390x-linux-gnu
-          gcc: s390x-linux-gnu-gcc
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
     - uses: ./.github/actions/binary-compatible-builds
-      if: matrix.target == ''
-
-    - name: Install cross-compilation tools
-      run: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }}
-        upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
-        echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
-      if: matrix.target != '' && matrix.os == 'ubuntu-latest'
+      with:
+        name: ${{ matrix.build }}
     - run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [main, refactor-docker-builds]
+    branches: [main]
     tags-ignore: [dev]
     paths-ignore:
       - 'meetings/**'

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates
+
+ENV PATH=$PATH:/rust/bin
+ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -y && apt-get install -y gcc gcc-s390x-linux-gnu ca-certificates
+
+ENV PATH=$PATH:/rust/bin
+ENV CARGO_BUILD_TARGET=s390x-unknown-linux-gnu
+ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+
+RUN yum install -y git gcc
+
+ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
I was poking around this yesterday and noticed a few things that could
be improved for our release builds:

* The centos container for the x86_64 builds contained a bunch of extra
  tooling we no longer need such as python3 and a C++ compiler. Along
  with custom toolchain things this could all get removed since the C we
  include now is quite simple.

* The aarch64 and s390x cross-compiled builds had relatively high glibc
  version requirements compared to the x86_64 build. This was because we
  don't use a container to build the cross-compiled binaries. I added
  containers here along the lines of the x86_64 build to use an older
  glibc to build the release binary to lower our version requirement.
  This lower the aarch64 version requirement from glibc 2.28 to 2.17.
  Additionally the s390x requirement dropped from 2.28 to 2.16.

* To make the containers a bit easier to read/write I added
  `Dockerfile`s for them in a new `ci/docker` directory instead of
  hardcoding install commands in JS.

This isn't intended to be a really big change or anything for anyone,
but it's intended to keep our Linux-based builds consistent at least as
best we can.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
