### PR TITLE
Ensure `simd` is enabled for spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -346,6 +346,7 @@ impl Config {
         config.bulk_memory_enabled = true;
         config.reference_types_enabled = true;
         config.multi_value_enabled = true;
+        config.simd_enabled = true;
         config.max_memories = 1;
         config.max_tables = 5;
 


### PR DESCRIPTION
This is required now that the simd specification has been merged into
the upstream specification, so to run the spec tests this must always be
enabled instead of being left to the whims of the fuzzer about whether
to enable it or not.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
