### PR TITLE
Cranelift: fix use of pinned reg with SysV calling convention.

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -719,8 +719,14 @@ impl ABIMachineSpec for S390xMachineDeps {
 
     fn get_clobbered_callee_saves(
         call_conv: isa::CallConv,
+        flags: &settings::Flags,
         regs: &[Writable<RealReg>],
     ) -> Vec<Writable<RealReg>> {
+        assert!(
+            !flags.enable_pinned_reg(),
+            "Pinned register not supported on s390x"
+        );
+
         let mut regs: Vec<Writable<RealReg>> = regs
             .iter()
             .cloned()

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -428,6 +428,7 @@ pub trait ABIMachineSpec {
     /// contains the registers in a sorted order.
     fn get_clobbered_callee_saves(
         call_conv: isa::CallConv,
+        flags: &settings::Flags,
         regs: &[Writable<RealReg>],
     ) -> Vec<Writable<RealReg>>;
 
@@ -1224,7 +1225,8 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
         }
         let mask = M::stack_align(self.call_conv) - 1;
         let total_stacksize = (total_stacksize + mask) & !mask; // 16-align the stack.
-        let clobbered_callee_saves = M::get_clobbered_callee_saves(self.call_conv, &self.clobbered);
+        let clobbered_callee_saves =
+            M::get_clobbered_callee_saves(self.call_conv, &self.flags, &self.clobbered);
         let mut insts = smallvec![];
 
         if !self.call_conv.extends_baldrdash() {

--- a/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
@@ -1,0 +1,16 @@
+test compile precise-output
+set enable_pinned_reg=true
+target aarch64
+
+function %f0() {
+block0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 1
+    set_pinned_reg v2
+    return
+}
+
+; block0:
+;   add x21, x21, #1
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -1,0 +1,36 @@
+test compile precise-output
+set enable_pinned_reg=true
+target x86_64
+
+function %f0() {
+block0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 1
+    set_pinned_reg v2
+    return
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addq    %r15, $1, %r15
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f1() windows_fastcall {
+block0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 1
+    set_pinned_reg v2
+    return
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addq    %r15, $1, %r15
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+


### PR DESCRIPTION
Previously, the pinned register (enabled by the `enable_pinned_reg`
Cranelift setting and used via the `get_pinned_reg` and `set_pinned_reg`
CLIF ops) was only used when Cranelift was embedded in SpiderMonkey, in
order to support a pinned heap register. SpiderMonkey has its own
calling convention in Cranelift (named after the integration layer,
"Baldrdash").

However, the feature is more general, and should be usable with the
default system calling convention too, e.g. SysV or Windows Fastcall.

This PR fixes the ABI code to properly treat the pinned register as a
globally allocated register -- and hence an implicit input and output to
every function, not saved/restored in the prologue/epilogue -- for SysV
on x86-64 and aarch64, and Fastcall on x86-64.

Fixes #4170.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
