### PR TITLE
docs: Remove regalloc entry from documentation index

### DIFF
--- a/cranelift/docs/index.md
+++ b/cranelift/docs/index.md
@@ -11,9 +11,6 @@
  - [Cranelift compared to LLVM](compare-llvm.md)
    LLVM and Cranelift have similarities and differences.
 
- - [Cranelift's register allocator](regalloc.md)
-   This page document Cranelift's current register allocator.
-   
 ## Cranelift crate documentation:
 
  - [cranelift](https://docs.rs/cranelift)


### PR DESCRIPTION
This is a follow up to https://github.com/bytecodealliance/wasmtime/pull/4013 in which the
outdated regalloc documentation was removed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
