### PR TITLE
Remove unused `SourceLoc` in many `Mach` data structures

### DIFF
--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -200,7 +200,7 @@ fn bench_instantiation(c: &mut Criterion) {
 }
 
 fn strategies() -> impl Iterator<Item = InstanceAllocationStrategy> {
-    std::array::IntoIter::new([
+    [
         InstanceAllocationStrategy::OnDemand,
         InstanceAllocationStrategy::Pooling {
             strategy: Default::default(),
@@ -209,7 +209,8 @@ fn strategies() -> impl Iterator<Item = InstanceAllocationStrategy> {
                 ..Default::default()
             },
         },
-    ])
+    ]
+    .into_iter()
 }
 
 criterion_group!(benches, bench_instantiation);

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -2760,10 +2760,10 @@ impl MachInstEmit for Inst {
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(4), s);
                 }
-                let loc = state.cur_srcloc();
-                sink.add_reloc(loc, Reloc::Arm64Call, &info.dest, 0);
+                sink.add_reloc(Reloc::Arm64Call, &info.dest, 0);
                 sink.put4(enc_jump26(0b100101, 0));
                 if info.opcode.is_call() {
+                    let loc = state.cur_srcloc();
                     sink.add_call_site(loc, info.opcode);
                 }
             }
@@ -2773,8 +2773,8 @@ impl MachInstEmit for Inst {
                 }
                 let rn = allocs.next(info.rn);
                 sink.put4(0b1101011_0001_11111_000000_00000_00000 | (machreg_to_gpr(rn) << 5));
-                let loc = state.cur_srcloc();
                 if info.opcode.is_call() {
+                    let loc = state.cur_srcloc();
                     sink.add_call_site(loc, info.opcode);
                 }
             }
@@ -2958,8 +2958,7 @@ impl MachInstEmit for Inst {
                     dest: BranchTarget::ResolvedOffset(12),
                 };
                 inst.emit(&[], sink, emit_info, state);
-                let srcloc = state.cur_srcloc();
-                sink.add_reloc(srcloc, Reloc::Abs8, name, offset);
+                sink.add_reloc(Reloc::Abs8, name, offset);
                 if emit_info.0.emit_all_ones_funcaddrs() {
                     sink.put8(u64::max_value());
                 } else {
@@ -3073,16 +3072,15 @@ impl MachInstEmit for Inst {
                 // See: https://gcc.godbolt.org/z/KhMh5Gvra
 
                 // adrp x0, <label>
-                sink.add_reloc(state.cur_srcloc(), Reloc::Aarch64TlsGdAdrPage21, symbol, 0);
+                sink.add_reloc(Reloc::Aarch64TlsGdAdrPage21, symbol, 0);
                 sink.put4(0x90000000);
 
                 // add x0, x0, <label>
-                sink.add_reloc(state.cur_srcloc(), Reloc::Aarch64TlsGdAddLo12Nc, symbol, 0);
+                sink.add_reloc(Reloc::Aarch64TlsGdAddLo12Nc, symbol, 0);
                 sink.put4(0x91000000);
 
                 // bl __tls_get_addr
                 sink.add_reloc(
-                    state.cur_srcloc(),
                     Reloc::Arm64Call,
                     &ExternalName::LibCall(LibCall::ElfTlsGetAddr),
                     0,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -964,7 +964,7 @@ impl MachInstEmit for Inst {
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -1084,7 +1084,7 @@ impl MachInstEmit for Inst {
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual store instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -1161,7 +1161,7 @@ impl MachInstEmit for Inst {
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual store instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
                 match &mem {
                     &PairAMode::SignedOffset(reg, simm7) => {
@@ -1193,7 +1193,7 @@ impl MachInstEmit for Inst {
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -1233,7 +1233,7 @@ impl MachInstEmit for Inst {
 
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 let opc = match self {
@@ -1279,7 +1279,7 @@ impl MachInstEmit for Inst {
 
                 if srcloc != SourceLoc::default() && !flags.notrap() {
                     // Register the offset at which the actual store instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 let opc = match self {
@@ -1413,7 +1413,7 @@ impl MachInstEmit for Inst {
                 sink.bind_label(again_label);
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
                 sink.put4(enc_ldaxr(ty, x27wr, x25)); // ldaxr x27, [x25]
                 let size = OperandSize::from_ty(ty);
@@ -1537,7 +1537,7 @@ impl MachInstEmit for Inst {
 
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
                 if op == AtomicRMWLoopOp::Xchg {
                     sink.put4(enc_stlxr(ty, x24wr, x26, x25)); // stlxr w24, x26, [x25]
@@ -1599,7 +1599,7 @@ impl MachInstEmit for Inst {
                 sink.bind_label(again_label);
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
                 // ldaxr x27, [x25]
                 sink.put4(enc_ldaxr(ty, x27wr, x25));
@@ -1626,7 +1626,7 @@ impl MachInstEmit for Inst {
 
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
                 sink.put4(enc_stlxr(ty, x24wr, x28, x25)); // stlxr w24, x28, [x25]
 
@@ -2627,7 +2627,7 @@ impl MachInstEmit for Inst {
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 sink.put4(enc_ldst_vec(q, size, rn, rd));
@@ -2830,8 +2830,7 @@ impl MachInstEmit for Inst {
                 sink.put4(0xd4200000);
             }
             &Inst::Udf { trap_code } => {
-                let srcloc = state.cur_srcloc();
-                sink.add_trap(srcloc, trap_code);
+                sink.add_trap(trap_code);
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(4), s);
                 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -2763,8 +2763,7 @@ impl MachInstEmit for Inst {
                 sink.add_reloc(Reloc::Arm64Call, &info.dest, 0);
                 sink.put4(enc_jump26(0b100101, 0));
                 if info.opcode.is_call() {
-                    let loc = state.cur_srcloc();
-                    sink.add_call_site(loc, info.opcode);
+                    sink.add_call_site(info.opcode);
                 }
             }
             &Inst::CallInd { ref info } => {
@@ -2774,8 +2773,7 @@ impl MachInstEmit for Inst {
                 let rn = allocs.next(info.rn);
                 sink.put4(0b1101011_0001_11111_000000_00000_00000 | (machreg_to_gpr(rn) << 5));
                 if info.opcode.is_call() {
-                    let loc = state.cur_srcloc();
-                    sink.add_call_site(loc, info.opcode);
+                    sink.add_call_site(info.opcode);
                 }
             }
             &Inst::CondBr {

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -2185,8 +2185,7 @@ impl MachInstEmit for Inst {
                     0,
                 );
                 if info.opcode.is_call() {
-                    let srcloc = state.cur_srcloc();
-                    sink.add_call_site(srcloc, info.opcode);
+                    sink.add_call_site(info.opcode);
                 }
             }
             &Inst::CallInd { link, ref info } => {
@@ -2194,13 +2193,12 @@ impl MachInstEmit for Inst {
                 let rn = allocs.next(info.rn);
 
                 let opcode = 0x0d; // BASR
-                let srcloc = state.cur_srcloc();
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(2), s);
                 }
                 put(sink, &enc_rr(opcode, link.to_reg(), rn));
                 if info.opcode.is_call() {
-                    sink.add_call_site(srcloc, info.opcode);
+                    sink.add_call_site(info.opcode);
                 }
             }
             &Inst::Ret { link, .. } => {

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -133,7 +133,7 @@ pub fn mem_emit(
     if add_trap && mem.can_trap() {
         let srcloc = state.cur_srcloc();
         if srcloc != SourceLoc::default() {
-            sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+            sink.add_trap(TrapCode::HeapOutOfBounds);
         }
     }
 
@@ -201,7 +201,7 @@ pub fn mem_rs_emit(
     if add_trap && mem.can_trap() {
         let srcloc = state.cur_srcloc();
         if srcloc != SourceLoc::default() {
-            sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+            sink.add_trap(TrapCode::HeapOutOfBounds);
         }
     }
 
@@ -243,7 +243,7 @@ pub fn mem_imm8_emit(
     if add_trap && mem.can_trap() {
         let srcloc = state.cur_srcloc();
         if srcloc != SourceLoc::default() {
-            sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+            sink.add_trap(TrapCode::HeapOutOfBounds);
         }
     }
 
@@ -281,7 +281,7 @@ pub fn mem_imm16_emit(
     if add_trap && mem.can_trap() {
         let srcloc = state.cur_srcloc();
         if srcloc != SourceLoc::default() {
-            sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+            sink.add_trap(TrapCode::HeapOutOfBounds);
         }
     }
 
@@ -847,12 +847,12 @@ fn put(sink: &mut MachBuffer<Inst>, enc: &[u8]) {
 }
 
 /// Emit encoding to sink, adding a trap on the last byte.
-fn put_with_trap(sink: &mut MachBuffer<Inst>, enc: &[u8], srcloc: SourceLoc, trap_code: TrapCode) {
+fn put_with_trap(sink: &mut MachBuffer<Inst>, enc: &[u8], trap_code: TrapCode) {
     let len = enc.len();
     for i in 0..len - 1 {
         sink.put1(enc[i]);
     }
-    sink.add_trap(srcloc, trap_code);
+    sink.add_trap(trap_code);
     sink.put1(enc[len - 1]);
 }
 
@@ -1201,33 +1201,29 @@ impl MachInstEmit for Inst {
                 let rn = allocs.next(rn);
 
                 let opcode = 0xb91d; // DSGFR
-                let srcloc = state.cur_srcloc();
                 let trap_code = TrapCode::IntegerDivisionByZero;
-                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), srcloc, trap_code);
+                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), trap_code);
             }
             &Inst::SDivMod64 { rn } => {
                 let rn = allocs.next(rn);
 
                 let opcode = 0xb90d; // DSGR
-                let srcloc = state.cur_srcloc();
                 let trap_code = TrapCode::IntegerDivisionByZero;
-                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), srcloc, trap_code);
+                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), trap_code);
             }
             &Inst::UDivMod32 { rn } => {
                 let rn = allocs.next(rn);
 
                 let opcode = 0xb997; // DLR
-                let srcloc = state.cur_srcloc();
                 let trap_code = TrapCode::IntegerDivisionByZero;
-                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), srcloc, trap_code);
+                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), trap_code);
             }
             &Inst::UDivMod64 { rn } => {
                 let rn = allocs.next(rn);
 
                 let opcode = 0xb987; // DLGR
-                let srcloc = state.cur_srcloc();
                 let trap_code = TrapCode::IntegerDivisionByZero;
-                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), srcloc, trap_code);
+                put_with_trap(sink, &enc_rre(opcode, gpr(0), rn), trap_code);
             }
             &Inst::Flogr { rn } => {
                 let rn = allocs.next(rn);
@@ -1488,11 +1484,9 @@ impl MachInstEmit for Inst {
                     CmpOp::CmpL64 => 0xb961, // CLGRT
                     _ => unreachable!(),
                 };
-                let srcloc = state.cur_srcloc();
                 put_with_trap(
                     sink,
                     &enc_rrf_cde(opcode, rn, rm, cond.bits(), 0),
-                    srcloc,
                     trap_code,
                 );
             }
@@ -1510,11 +1504,9 @@ impl MachInstEmit for Inst {
                     CmpOp::CmpS64 => 0xec70, // CGIT
                     _ => unreachable!(),
                 };
-                let srcloc = state.cur_srcloc();
                 put_with_trap(
                     sink,
                     &enc_rie_a(opcode, rn, imm as u16, cond.bits()),
-                    srcloc,
                     trap_code,
                 );
             }
@@ -1532,13 +1524,7 @@ impl MachInstEmit for Inst {
                     CmpOp::CmpL64 => 0xec71, // CLGIT
                     _ => unreachable!(),
                 };
-                let srcloc = state.cur_srcloc();
-                put_with_trap(
-                    sink,
-                    &enc_rie_a(opcode, rn, imm, cond.bits()),
-                    srcloc,
-                    trap_code,
-                );
+                put_with_trap(sink, &enc_rie_a(opcode, rn, imm, cond.bits()), trap_code);
             }
 
             &Inst::AtomicRmw {
@@ -1695,7 +1681,7 @@ impl MachInstEmit for Inst {
 
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && mem.can_trap() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -1778,7 +1764,7 @@ impl MachInstEmit for Inst {
 
                 let srcloc = state.cur_srcloc();
                 if srcloc != SourceLoc::default() && mem.can_trap() {
-                    sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+                    sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
                 match &mem {
@@ -2277,8 +2263,7 @@ impl MachInstEmit for Inst {
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(2), s);
                 }
-                let srcloc = state.cur_srcloc();
-                put_with_trap(sink, &enc_e(0x0000), srcloc, trap_code);
+                put_with_trap(sink, &enc_e(0x0000), trap_code);
             }
             &Inst::TrapIf { cond, trap_code } => {
                 // Branch over trap if condition is false.
@@ -2288,8 +2273,7 @@ impl MachInstEmit for Inst {
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(2), s);
                 }
-                let srcloc = state.cur_srcloc();
-                put_with_trap(sink, &enc_e(0x0000), srcloc, trap_code);
+                put_with_trap(sink, &enc_e(0x0000), trap_code);
             }
             &Inst::JTSequence { ridx, ref targets } => {
                 let ridx = allocs.next(ridx);

--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -13,7 +13,7 @@ use crate::{
     ir::TrapCode,
     isa::x64::inst::{
         args::{Amode, OperandSize},
-        regs, EmitInfo, EmitState, Inst, LabelUse,
+        regs, EmitInfo, Inst, LabelUse,
     },
     machinst::MachBuffer,
 };
@@ -276,7 +276,6 @@ impl Default for LegacyPrefixes {
 /// indicate a 64-bit operation.
 pub(crate) fn emit_std_enc_mem(
     sink: &mut MachBuffer<Inst>,
-    state: &EmitState,
     info: &EmitInfo,
     prefixes: LegacyPrefixes,
     opcodes: u32,
@@ -290,10 +289,9 @@ pub(crate) fn emit_std_enc_mem(
     // 64-bit integer registers, because they are part of an address
     // expression.  But `enc_g` can be derived from a register of any class.
 
-    let srcloc = state.cur_srcloc();
     let can_trap = mem_e.can_trap();
     if can_trap {
-        sink.add_trap(srcloc, TrapCode::HeapOutOfBounds);
+        sink.add_trap(TrapCode::HeapOutOfBounds);
     }
 
     prefixes.emit(sink);
@@ -303,7 +301,7 @@ pub(crate) fn emit_std_enc_mem(
             // If this is an access based off of RSP, it may trap with a stack overflow if it's the
             // first touch of a new stack page.
             if *base == regs::rsp() && !can_trap && info.flags.enable_probestack() {
-                sink.add_trap(srcloc, TrapCode::StackOverflow);
+                sink.add_trap(TrapCode::StackOverflow);
             }
 
             // First, the REX byte.
@@ -369,7 +367,7 @@ pub(crate) fn emit_std_enc_mem(
             // If this is an access based off of RSP, it may trap with a stack overflow if it's the
             // first touch of a new stack page.
             if *reg_base == regs::rsp() && !can_trap && info.flags.enable_probestack() {
-                sink.add_trap(srcloc, TrapCode::StackOverflow);
+                sink.add_trap(TrapCode::StackOverflow);
             }
 
             let enc_base = int_reg_enc(*reg_base);
@@ -466,7 +464,6 @@ pub(crate) fn emit_std_enc_enc(
 
 pub(crate) fn emit_std_reg_mem(
     sink: &mut MachBuffer<Inst>,
-    state: &EmitState,
     info: &EmitInfo,
     prefixes: LegacyPrefixes,
     opcodes: u32,
@@ -479,7 +476,6 @@ pub(crate) fn emit_std_reg_mem(
     let enc_g = reg_enc(reg_g);
     emit_std_enc_mem(
         sink,
-        state,
         info,
         prefixes,
         opcodes,

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1208,8 +1208,7 @@ pub(crate) fn emit(
             emit_reloc(sink, Reloc::X86CallPCRel4, &dest, -4);
             sink.put4(0);
             if opcode.is_call() {
-                let loc = state.cur_srcloc();
-                sink.add_call_site(loc, *opcode);
+                sink.add_call_site(*opcode);
             }
         }
 
@@ -1253,8 +1252,7 @@ pub(crate) fn emit(
                 sink.add_stack_map(StackMapExtent::StartedAtOffset(start_offset), s);
             }
             if opcode.is_call() {
-                let loc = state.cur_srcloc();
-                sink.add_call_site(loc, *opcode);
+                sink.add_call_site(*opcode);
             }
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -601,9 +601,7 @@ impl Inst {
     }
 
     pub(crate) fn trap(trap_code: TrapCode) -> Inst {
-        Inst::Ud2 {
-            trap_code: trap_code,
-        }
+        Inst::Ud2 { trap_code }
     }
 
     pub(crate) fn setcc(cc: CC, dst: Writable<Reg>) -> Inst {
@@ -2431,10 +2429,6 @@ impl EmitState {
 
     fn clear_post_insn(&mut self) {
         self.stack_map = None;
-    }
-
-    pub(crate) fn cur_srcloc(&self) -> SourceLoc {
-        self.cur_srcloc
     }
 }
 

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1231,13 +1231,7 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// Add an external relocation at the current offset.
-    pub fn add_reloc(
-        &mut self,
-        srcloc: SourceLoc,
-        kind: Reloc,
-        name: &ExternalName,
-        addend: Addend,
-    ) {
+    pub fn add_reloc(&mut self, kind: Reloc, name: &ExternalName, addend: Addend) {
         let name = name.clone();
         // FIXME(#3277): This should use `I::LabelUse::from_reloc` to optionally
         // generate a label-use statement to track whether an island is possibly
@@ -1274,7 +1268,6 @@ impl<I: VCodeInst> MachBuffer<I> {
         // actually result in any memory unsafety or anything like that.
         self.relocs.push(MachReloc {
             offset: self.data.len() as CodeOffset,
-            srcloc,
             kind,
             name,
             addend,
@@ -1446,8 +1439,6 @@ pub struct MachReloc {
     /// The offset at which the relocation applies, *relative to the
     /// containing section*.
     pub offset: CodeOffset,
-    /// The original source location.
-    pub srcloc: SourceLoc,
     /// The kind of relocation.
     pub kind: Reloc,
     /// The external symbol / name to which this relocation refers.
@@ -1992,19 +1983,9 @@ mod test {
         buf.add_trap(SourceLoc::default(), TrapCode::IntegerOverflow);
         buf.add_trap(SourceLoc::default(), TrapCode::IntegerDivisionByZero);
         buf.add_call_site(SourceLoc::default(), Opcode::Call);
-        buf.add_reloc(
-            SourceLoc::default(),
-            Reloc::Abs4,
-            &ExternalName::user(0, 0),
-            0,
-        );
+        buf.add_reloc(Reloc::Abs4, &ExternalName::user(0, 0), 0);
         buf.put1(3);
-        buf.add_reloc(
-            SourceLoc::default(),
-            Reloc::Abs8,
-            &ExternalName::user(1, 1),
-            1,
-        );
+        buf.add_reloc(Reloc::Abs8, &ExternalName::user(1, 1), 1);
         buf.put1(4);
 
         let buf = buf.finish();

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1283,14 +1283,13 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// Add a call-site record at the current offset.
-    pub fn add_call_site(&mut self, srcloc: SourceLoc, opcode: Opcode) {
+    pub fn add_call_site(&mut self, opcode: Opcode) {
         debug_assert!(
             opcode.is_call(),
             "adding call site info for a non-call instruction."
         );
         self.call_sites.push(MachCallSite {
             ret_addr: self.data.len() as CodeOffset,
-            srcloc,
             opcode,
         });
     }
@@ -1461,8 +1460,6 @@ pub struct MachTrap {
 pub struct MachCallSite {
     /// The offset of the call's return address, *relative to the containing section*.
     pub ret_addr: CodeOffset,
-    /// The original source location.
-    pub srcloc: SourceLoc,
     /// The call's opcode.
     pub opcode: Opcode,
 }
@@ -1979,7 +1976,7 @@ mod test {
         buf.put1(2);
         buf.add_trap(TrapCode::IntegerOverflow);
         buf.add_trap(TrapCode::IntegerDivisionByZero);
-        buf.add_call_site(SourceLoc::default(), Opcode::Call);
+        buf.add_call_site(Opcode::Call);
         buf.add_reloc(Reloc::Abs4, &ExternalName::user(0, 0), 0);
         buf.put1(3);
         buf.add_reloc(Reloc::Abs8, &ExternalName::user(1, 1), 1);

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1275,10 +1275,9 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// Add a trap record at the current offset.
-    pub fn add_trap(&mut self, srcloc: SourceLoc, code: TrapCode) {
+    pub fn add_trap(&mut self, code: TrapCode) {
         self.traps.push(MachTrap {
             offset: self.data.len() as CodeOffset,
-            srcloc,
             code,
         });
     }
@@ -1453,8 +1452,6 @@ pub struct MachTrap {
     /// The offset at which the trap instruction occurs, *relative to the
     /// containing section*.
     pub offset: CodeOffset,
-    /// The original source location.
-    pub srcloc: SourceLoc,
     /// The trap code.
     pub code: TrapCode,
 }
@@ -1978,10 +1975,10 @@ mod test {
 
         buf.bind_label(label(0));
         buf.put1(1);
-        buf.add_trap(SourceLoc::default(), TrapCode::HeapOutOfBounds);
+        buf.add_trap(TrapCode::HeapOutOfBounds);
         buf.put1(2);
-        buf.add_trap(SourceLoc::default(), TrapCode::IntegerOverflow);
-        buf.add_trap(SourceLoc::default(), TrapCode::IntegerDivisionByZero);
+        buf.add_trap(TrapCode::IntegerOverflow);
+        buf.add_trap(TrapCode::IntegerDivisionByZero);
         buf.add_call_site(SourceLoc::default(), Opcode::Call);
         buf.add_reloc(Reloc::Abs4, &ExternalName::user(0, 0), 0);
         buf.put1(3);

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -22,7 +22,6 @@ impl CompiledBlob {
         for &MachReloc {
             kind,
             offset,
-            srcloc: _,
             ref name,
             addend,
         } in &self.relocs

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -2,7 +2,7 @@
 
 use cranelift_codegen::binemit::{Addend, CodeOffset, Reloc};
 use cranelift_codegen::entity::PrimaryMap;
-use cranelift_codegen::ir::{self, SourceLoc};
+use cranelift_codegen::ir;
 use cranelift_codegen::MachReloc;
 use std::borrow::ToOwned;
 use std::boxed::Box;
@@ -66,7 +66,6 @@ impl DataDescription {
             .map(move |&(offset, id)| MachReloc {
                 kind: pointer_reloc,
                 offset,
-                srcloc: SourceLoc::default(),
                 name: self.function_decls[id].clone(),
                 addend: 0,
             });
@@ -76,7 +75,6 @@ impl DataDescription {
             .map(move |&(offset, id, addend)| MachReloc {
                 kind: pointer_reloc,
                 offset,
-                srcloc: SourceLoc::default(),
                 name: self.data_decls[id].clone(),
                 addend,
             });

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -9,7 +9,6 @@ pub fn print_relocs(relocs: &[MachReloc]) -> String {
     for &MachReloc {
         kind,
         offset,
-        srcloc: _,
         ref name,
         addend,
     } in relocs

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -25,12 +25,7 @@ pub fn print_relocs(relocs: &[MachReloc]) -> String {
 
 pub fn print_traps(traps: &[MachTrap]) -> String {
     let mut text = String::new();
-    for &MachTrap {
-        offset,
-        srcloc: _,
-        code,
-    } in traps
-    {
+    for &MachTrap { offset, code } in traps {
         writeln!(text, "trap: {} at {}", code, offset).unwrap();
     }
     text

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -657,7 +657,6 @@ fn collect_address_maps(
 fn mach_reloc_to_reloc(reloc: &MachReloc) -> Relocation {
     let &MachReloc {
         offset,
-        srcloc: _,
         kind,
         ref name,
         addend,

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -678,11 +678,7 @@ fn mach_reloc_to_reloc(reloc: &MachReloc) -> Relocation {
 }
 
 fn mach_trap_to_trap(trap: &MachTrap) -> TrapInformation {
-    let &MachTrap {
-        offset,
-        srcloc: _,
-        code,
-    } = trap;
+    let &MachTrap { offset, code } = trap;
     TrapInformation {
         code_offset: offset,
         trap_code: match code {


### PR DESCRIPTION
These fields aren't used anywhere in the code base, and I think that a consumer could rely on `MachSrcLoc` instead. I thought it would be needed by the Spidermonkey backend, but it's a bit outdated (using a CL version predating the Mach stuff). I've received confirmation from the Spidermonkey folks that they're fine investigating the work necessary to adjust to these changes, so opening this PR as an incremental step towards #4155.