### PR TITLE
Make `ValRaw` fields private

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -160,7 +160,7 @@ fn bench_host_to_wasm<Params, Results>(
         let untyped = instance.get_func(&mut *store, name).unwrap();
         let params = typed_params.to_vals();
         let results = typed_results.to_vals();
-        let mut space = vec![ValRaw { i32: 0 }; params.len().max(results.len())];
+        let mut space = vec![ValRaw::i32(0); params.len().max(results.len())];
         b.iter(|| unsafe {
             for (i, param) in params.iter().enumerate() {
                 space[i] = param.to_raw(&mut *store);

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -794,7 +794,7 @@ pub union ValRaw {
     /// or unsigned. The Rust type `i32` is simply chosen for convenience.
     ///
     /// This value is always stored in a little-endian format.
-    pub i32: i32,
+    i32: i32,
 
     /// A WebAssembly `i64` value.
     ///
@@ -803,7 +803,7 @@ pub union ValRaw {
     /// or unsigned. The Rust type `i64` is simply chosen for convenience.
     ///
     /// This value is always stored in a little-endian format.
-    pub i64: i64,
+    i64: i64,
 
     /// A WebAssembly `f32` value.
     ///
@@ -813,7 +813,7 @@ pub union ValRaw {
     /// `u32` value is the return value of `f32::to_bits` in Rust.
     ///
     /// This value is always stored in a little-endian format.
-    pub f32: u32,
+    f32: u32,
 
     /// A WebAssembly `f64` value.
     ///
@@ -823,7 +823,7 @@ pub union ValRaw {
     /// `u64` value is the return value of `f64::to_bits` in Rust.
     ///
     /// This value is always stored in a little-endian format.
-    pub f64: u64,
+    f64: u64,
 
     /// A WebAssembly `v128` value.
     ///
@@ -833,7 +833,7 @@ pub union ValRaw {
     /// underlying bits is left up to the instructions which consume this value.
     ///
     /// This value is always stored in a little-endian format.
-    pub v128: u128,
+    v128: u128,
 
     /// A WebAssembly `funcref` value.
     ///
@@ -843,7 +843,7 @@ pub union ValRaw {
     /// carefully calling the correct functions throughout the runtime.
     ///
     /// This value is always stored in a little-endian format.
-    pub funcref: usize,
+    funcref: usize,
 
     /// A WebAssembly `externref` value.
     ///
@@ -853,7 +853,119 @@ pub union ValRaw {
     /// carefully calling the correct functions throughout the runtime.
     ///
     /// This value is always stored in a little-endian format.
-    pub externref: usize,
+    externref: usize,
+}
+
+impl ValRaw {
+    /// Creates a WebAssembly `i32` value
+    #[inline]
+    pub fn i32(i: i32) -> ValRaw {
+        ValRaw { i32: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `i64` value
+    #[inline]
+    pub fn i64(i: i64) -> ValRaw {
+        ValRaw { i64: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `i32` value
+    #[inline]
+    pub fn u32(i: u32) -> ValRaw {
+        ValRaw::i32(i as i32)
+    }
+
+    /// Creates a WebAssembly `i64` value
+    #[inline]
+    pub fn u64(i: u64) -> ValRaw {
+        ValRaw::i64(i as i64)
+    }
+
+    /// Creates a WebAssembly `f32` value
+    #[inline]
+    pub fn f32(i: u32) -> ValRaw {
+        ValRaw { f32: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `f64` value
+    #[inline]
+    pub fn f64(i: u64) -> ValRaw {
+        ValRaw { f64: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `v128` value
+    #[inline]
+    pub fn v128(i: u128) -> ValRaw {
+        ValRaw { v128: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `funcref` value
+    #[inline]
+    pub fn funcref(i: usize) -> ValRaw {
+        ValRaw { funcref: i.to_le() }
+    }
+
+    /// Creates a WebAssembly `externref` value
+    #[inline]
+    pub fn externref(i: usize) -> ValRaw {
+        ValRaw {
+            externref: i.to_le(),
+        }
+    }
+
+    /// Gets the WebAssembly `i32` value
+    #[inline]
+    pub fn get_i32(&self) -> i32 {
+        unsafe { i32::from_le(self.i32) }
+    }
+
+    /// Gets the WebAssembly `i64` value
+    #[inline]
+    pub fn get_i64(&self) -> i64 {
+        unsafe { i64::from_le(self.i64) }
+    }
+
+    /// Gets the WebAssembly `i32` value
+    #[inline]
+    pub fn get_u32(&self) -> u32 {
+        self.get_i32() as u32
+    }
+
+    /// Gets the WebAssembly `i64` value
+    #[inline]
+    pub fn get_u64(&self) -> u64 {
+        self.get_i64() as u64
+    }
+
+    /// Gets the WebAssembly `f32` value
+    #[inline]
+    pub fn get_f32(&self) -> u32 {
+        unsafe { u32::from_le(self.f32) }
+    }
+
+    /// Gets the WebAssembly `f64` value
+    #[inline]
+    pub fn get_f64(&self) -> u64 {
+        unsafe { u64::from_le(self.f64) }
+    }
+
+    /// Gets the WebAssembly `v128` value
+    #[inline]
+    pub fn get_v128(&self) -> u128 {
+        unsafe { u128::from_le(self.v128) }
+    }
+
+    /// Gets the WebAssembly `funcref` value
+    #[inline]
+    pub fn get_funcref(&self) -> usize {
+        unsafe { usize::from_le(self.funcref) }
+    }
+
+    /// Gets the WebAssembly `externref` value
+    #[inline]
+    pub fn get_externref(&self) -> usize {
+        unsafe { usize::from_le(self.externref) }
+    }
 }
 
 /// Trampoline function pointer type.

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -966,7 +966,7 @@ impl Func {
         // Store the argument values into `values_vec`.
         let mut values_vec = store.0.take_wasm_val_raw_storage();
         debug_assert!(values_vec.is_empty());
-        values_vec.resize_with(values_vec_size, || ValRaw { i32: 0 });
+        values_vec.resize_with(values_vec_size, || ValRaw::i32(0));
         for (arg, slot) in params.iter().cloned().zip(&mut values_vec) {
             unsafe {
                 *slot = arg.to_raw(&mut *store);

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -103,28 +103,24 @@ impl Val {
     /// [`Func::to_raw`] are unsafe.
     pub unsafe fn to_raw(&self, store: impl AsContextMut) -> ValRaw {
         match self {
-            Val::I32(i) => ValRaw { i32: i.to_le() },
-            Val::I64(i) => ValRaw { i64: i.to_le() },
-            Val::F32(u) => ValRaw { f32: u.to_le() },
-            Val::F64(u) => ValRaw { f64: u.to_le() },
-            Val::V128(b) => ValRaw { v128: b.to_le() },
+            Val::I32(i) => ValRaw::i32(*i),
+            Val::I64(i) => ValRaw::i64(*i),
+            Val::F32(u) => ValRaw::f32(*u),
+            Val::F64(u) => ValRaw::f64(*u),
+            Val::V128(b) => ValRaw::v128(*b),
             Val::ExternRef(e) => {
                 let externref = match e {
                     Some(e) => e.to_raw(store),
                     None => 0,
                 };
-                ValRaw {
-                    externref: externref.to_le(),
-                }
+                ValRaw::externref(externref)
             }
             Val::FuncRef(f) => {
                 let funcref = match f {
                     Some(f) => f.to_raw(store),
                     None => 0,
                 };
-                ValRaw {
-                    funcref: funcref.to_le(),
-                }
+                ValRaw::funcref(funcref)
             }
         }
     }
@@ -138,15 +134,13 @@ impl Val {
     /// otherwise that `raw` should have the type `ty` specified.
     pub unsafe fn from_raw(store: impl AsContextMut, raw: ValRaw, ty: ValType) -> Val {
         match ty {
-            ValType::I32 => Val::I32(i32::from_le(raw.i32)),
-            ValType::I64 => Val::I64(i64::from_le(raw.i64)),
-            ValType::F32 => Val::F32(u32::from_le(raw.f32)),
-            ValType::F64 => Val::F64(u64::from_le(raw.f64)),
-            ValType::V128 => Val::V128(u128::from_le(raw.v128)),
-            ValType::ExternRef => {
-                Val::ExternRef(ExternRef::from_raw(usize::from_le(raw.externref)))
-            }
-            ValType::FuncRef => Val::FuncRef(Func::from_raw(store, usize::from_le(raw.funcref))),
+            ValType::I32 => Val::I32(raw.get_i32()),
+            ValType::I64 => Val::I64(raw.get_i64()),
+            ValType::F32 => Val::F32(raw.get_f32()),
+            ValType::F64 => Val::F64(raw.get_f64()),
+            ValType::V128 => Val::V128(raw.get_v128()),
+            ValType::ExternRef => Val::ExternRef(ExternRef::from_raw(raw.get_externref())),
+            ValType::FuncRef => Val::FuncRef(Func::from_raw(store, raw.get_funcref())),
         }
     }
 

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -52,10 +52,10 @@ fn call_wrapped_func() -> Result<(), Error> {
             |caller: Caller<State>, space| {
                 verify(caller.data());
 
-                assert_eq!((*space.add(0)).i32, 1i32.to_le());
-                assert_eq!((*space.add(1)).i64, 2i64.to_le());
-                assert_eq!((*space.add(2)).f32, 3.0f32.to_bits().to_le());
-                assert_eq!((*space.add(3)).f64, 4.0f64.to_bits().to_le());
+                assert_eq!((*space.add(0)).get_i32(), 1i32);
+                assert_eq!((*space.add(1)).get_i64(), 2i64);
+                assert_eq!((*space.add(2)).get_f32(), 3.0f32.to_bits());
+                assert_eq!((*space.add(3)).get_f64(), 4.0f64.to_bits());
                 Ok(())
             },
         )


### PR DESCRIPTION
Force accessing to go through constructors and accessors to localize the
knowledge about little-endian-ness. This is spawned since I made a
mistake in #4039 about endianness.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
