### PR TITLE
Change some `VMContext` pointers to `()` pointers

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -10,7 +10,7 @@ use crate::traphandlers::Trap;
 use crate::vmcontext::{
     VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionImport,
     VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMRuntimeLimits,
-    VMTableDefinition, VMTableImport,
+    VMTableDefinition, VMTableImport, VMCONTEXT_MAGIC,
 };
 use crate::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, Imports, ModuleRuntimeInfo, Store,
@@ -488,7 +488,11 @@ impl Instance {
                 (self.runtime_info.image_base()
                     + self.runtime_info.function_info(def_index).start as usize)
                     as *mut _,
-                self.vmctx_ptr(),
+                // Note that `*mut VMContext` is erased here to `*mut ()`. The
+                // origin function pointer, coming from our own image, knows
+                // that it's still `VMContext but in general callers are
+                // unable to know this.
+                self.vmctx_ptr() as *mut (),
             )
         } else {
             let import = self.imported_function(index);
@@ -878,6 +882,8 @@ impl Instance {
     /// function.
     unsafe fn initialize_vmctx(&mut self, module: &Module, store: StorePtr, imports: Imports) {
         assert!(std::ptr::eq(module, self.module().as_ref()));
+
+        *self.vmctx_plus_offset(self.offsets.vmctx_magic()) = VMCONTEXT_MAGIC;
 
         if let Some(store) = store.as_raw() {
             *self.runtime_limits() = (*store).vmruntime_limits();

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -9,8 +9,8 @@ use crate::table::{Table, TableElement, TableElementType};
 use crate::traphandlers::Trap;
 use crate::vmcontext::{
     VMBuiltinFunctionsArray, VMCallerCheckedAnyfunc, VMContext, VMFunctionImport,
-    VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMRuntimeLimits,
-    VMTableDefinition, VMTableImport, VMCONTEXT_MAGIC,
+    VMGlobalDefinition, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext,
+    VMRuntimeLimits, VMTableDefinition, VMTableImport, VMCONTEXT_MAGIC,
 };
 use crate::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, Imports, ModuleRuntimeInfo, Store,
@@ -488,11 +488,7 @@ impl Instance {
                 (self.runtime_info.image_base()
                     + self.runtime_info.function_info(def_index).start as usize)
                     as *mut _,
-                // Note that `*mut VMContext` is erased here to `*mut ()`. The
-                // origin function pointer, coming from our own image, knows
-                // that it's still `VMContext but in general callers are
-                // unable to know this.
-                self.vmctx_ptr() as *mut (),
+                VMOpaqueContext::from_vmcontext(self.vmctx_ptr()),
             )
         } else {
             let import = self.imported_function(index);

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -65,8 +65,9 @@ pub use crate::traphandlers::{
 };
 pub use crate::vmcontext::{
     VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
-    VMGlobalImport, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport, VMRuntimeLimits,
-    VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline, ValRaw,
+    VMGlobalImport, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport, VMOpaqueContext,
+    VMRuntimeLimits, VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline,
+    ValRaw,
 };
 
 mod module_id;

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -773,7 +773,7 @@ impl VMContext {
         // static offset is asserted in `VMOffsets::from` and needs to be kept
         // in sync with this line for this debug assertion to work.
         //
-        // Also note that this magic is only ever in valid in the presence of
+        // Also note that this magic is only ever invalid in the presence of
         // bugs, meaning we don't actually read the magic and act differently
         // at runtime depending what it is, so this is a debug assertion as
         // opposed to a regular assertion.
@@ -1016,10 +1016,9 @@ impl ValRaw {
 /// * `*mut VMOpaqueContext` - this a contextual pointer defined within the
 ///   context of the receiving function pointer. For now this is always `*mut
 ///   VMContext` but with the component model it may be the case that this is a
-///   different type of pointer. The type of pointer depends third function
-///   pointer argument itself.
+///   different type of pointer.
 ///
-/// * `*mut VMContext` - this is teh "caller" context, which at this time is
+/// * `*mut VMContext` - this is the "caller" context, which at this time is
 ///   always unconditionally core wasm (even in the component model). This
 ///   contextual pointer cannot be `NULL` and provides information necessary to
 ///   resolve the caller's context for the `Caller` API in Wasmtime.

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use wasmtime_environ::FuncIndex;
 use wasmtime_runtime::{
     raise_user_trap, ExportFunction, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
-    VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMSharedSignatureIndex,
-    VMTrampoline,
+    VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMOpaqueContext,
+    VMSharedSignatureIndex, VMTrampoline,
 };
 
 /// A WebAssembly function which can be called.
@@ -1852,7 +1852,7 @@ macro_rules! impl_into_func {
                 /// by Cranelift, since Cranelift is generating raw function
                 /// calls directly to this function.
                 unsafe extern "C" fn wasm_to_host_shim<T, F, $($args,)* R>(
-                    vmctx: *mut (),
+                    vmctx: *mut VMOpaqueContext,
                     caller_vmctx: *mut VMContext,
                     $( $args: $args::Abi, )*
                     retptr: R::Retptr,
@@ -1875,12 +1875,7 @@ macro_rules! impl_into_func {
                     // should be part of this block, and the long-jmp-ing
                     // happens after the block in handling `CallResult`.
                     let result = Caller::with(caller_vmctx, |mut caller| {
-                        // The general type for the first context argument is
-                        // `*mut ()` but within the context of this function we
-                        // know that this is `VMContext` due to the compilation
-                        // of this function. Note that this is debug-asserted in
-                        // `host_state()` with the `VMCONTEXT_MAGIC` value.
-                        let vmctx = vmctx as *mut VMContext;
+                        let vmctx = VMContext::from_opaque(vmctx);
                         let state = (*vmctx).host_state();
                         // Double-check ourselves in debug mode, but we control
                         // the `Any` here so an unsafe downcast should also
@@ -1946,7 +1941,7 @@ macro_rules! impl_into_func {
                 /// calls the given function pointer, and then stores the result
                 /// back into the `args` array.
                 unsafe extern "C" fn host_trampoline<$($args,)* R>(
-                    callee_vmctx: *mut (),
+                    callee_vmctx: *mut VMOpaqueContext,
                     caller_vmctx: *mut VMContext,
                     ptr: *const VMFunctionBody,
                     args: *mut ValRaw,
@@ -1958,7 +1953,7 @@ macro_rules! impl_into_func {
                     let ptr = mem::transmute::<
                         *const VMFunctionBody,
                         unsafe extern "C" fn(
-                            *mut (),
+                            *mut VMOpaqueContext,
                             *mut VMContext,
                             $( $args::Abi, )*
                             R::Retptr,

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -464,7 +464,7 @@ pub unsafe trait WasmParams: Send {
     #[doc(hidden)]
     unsafe fn invoke<R: WasmResults>(
         func: *const VMFunctionBody,
-        vmctx1: *mut VMContext,
+        vmctx1: *mut (),
         vmctx2: *mut VMContext,
         abi: Self::Abi,
     ) -> R::ResultAbi;
@@ -494,7 +494,7 @@ where
 
     unsafe fn invoke<R: WasmResults>(
         func: *const VMFunctionBody,
-        vmctx1: *mut VMContext,
+        vmctx1: *mut (),
         vmctx2: *mut VMContext,
         abi: Self::Abi,
     ) -> R::ResultAbi {
@@ -554,14 +554,14 @@ macro_rules! impl_wasm_params {
 
             unsafe fn invoke<R: WasmResults>(
                 func: *const VMFunctionBody,
-                vmctx1: *mut VMContext,
+                vmctx1: *mut (),
                 vmctx2: *mut VMContext,
                 abi: Self::Abi,
             ) -> R::ResultAbi {
                 let fnptr = mem::transmute::<
                     *const VMFunctionBody,
                     unsafe extern "C" fn(
-                        *mut VMContext,
+                        *mut (),
                         *mut VMContext,
                         $($t::Abi,)*
                         <R::ResultAbi as HostAbi>::Retptr,

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -5,7 +5,9 @@ use anyhow::{bail, Result};
 use std::marker;
 use std::mem::{self, MaybeUninit};
 use std::ptr;
-use wasmtime_runtime::{VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMSharedSignatureIndex};
+use wasmtime_runtime::{
+    VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMOpaqueContext, VMSharedSignatureIndex,
+};
 
 /// A statically typed WebAssembly function.
 ///
@@ -464,7 +466,7 @@ pub unsafe trait WasmParams: Send {
     #[doc(hidden)]
     unsafe fn invoke<R: WasmResults>(
         func: *const VMFunctionBody,
-        vmctx1: *mut (),
+        vmctx1: *mut VMOpaqueContext,
         vmctx2: *mut VMContext,
         abi: Self::Abi,
     ) -> R::ResultAbi;
@@ -494,7 +496,7 @@ where
 
     unsafe fn invoke<R: WasmResults>(
         func: *const VMFunctionBody,
-        vmctx1: *mut (),
+        vmctx1: *mut VMOpaqueContext,
         vmctx2: *mut VMContext,
         abi: Self::Abi,
     ) -> R::ResultAbi {
@@ -554,14 +556,14 @@ macro_rules! impl_wasm_params {
 
             unsafe fn invoke<R: WasmResults>(
                 func: *const VMFunctionBody,
-                vmctx1: *mut (),
+                vmctx1: *mut VMOpaqueContext,
                 vmctx2: *mut VMContext,
                 abi: Self::Abi,
             ) -> R::ResultAbi {
                 let fnptr = mem::transmute::<
                     *const VMFunctionBody,
                     unsafe extern "C" fn(
-                        *mut (),
+                        *mut VMOpaqueContext,
                         *mut VMContext,
                         $($t::Abi,)*
                         <R::ResultAbi as HostAbi>::Retptr,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use wasmtime_environ::{EntityType, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap, TableIndex};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstantiationError, StorePtr, VMContext, VMFunctionBody,
-    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMTableImport,
+    VMFunctionImport, VMGlobalImport, VMMemoryImport, VMOpaqueContext, VMTableImport,
 };
 
 /// An instantiated WebAssembly module.
@@ -343,9 +343,12 @@ impl Instance {
         let vmctx = instance.vmctx_ptr();
         unsafe {
             super::func::invoke_wasm_and_catch_traps(store, |_default_callee| {
-                mem::transmute::<*const VMFunctionBody, unsafe extern "C" fn(*mut (), *mut VMContext)>(
-                    f.anyfunc.as_ref().func_ptr.as_ptr(),
-                )(f.anyfunc.as_ref().vmctx, vmctx)
+                mem::transmute::<
+                    *const VMFunctionBody,
+                    unsafe extern "C" fn(*mut VMOpaqueContext, *mut VMContext),
+                >(f.anyfunc.as_ref().func_ptr.as_ptr())(
+                    f.anyfunc.as_ref().vmctx, vmctx
+                )
             })?;
         }
         Ok(())

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -343,12 +343,9 @@ impl Instance {
         let vmctx = instance.vmctx_ptr();
         unsafe {
             super::func::invoke_wasm_and_catch_traps(store, |_default_callee| {
-                mem::transmute::<
-                    *const VMFunctionBody,
-                    unsafe extern "C" fn(*mut VMContext, *mut VMContext),
-                >(f.anyfunc.as_ref().func_ptr.as_ptr())(
-                    f.anyfunc.as_ref().vmctx, vmctx
-                )
+                mem::transmute::<*const VMFunctionBody, unsafe extern "C" fn(*mut (), *mut VMContext)>(
+                    f.anyfunc.as_ref().func_ptr.as_ptr(),
+                )(f.anyfunc.as_ref().vmctx, vmctx)
             })?;
         }
         Ok(())

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -12,8 +12,8 @@ use wasmtime_environ::{
 use wasmtime_jit::{CodeMemory, ProfilingAgent};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
-    OnDemandInstanceAllocator, StorePtr, VMContext, VMFunctionBody, VMSharedSignatureIndex,
-    VMTrampoline,
+    OnDemandInstanceAllocator, StorePtr, VMContext, VMFunctionBody, VMOpaqueContext,
+    VMSharedSignatureIndex, VMTrampoline,
 };
 
 struct TrampolineState<F> {
@@ -23,7 +23,7 @@ struct TrampolineState<F> {
 }
 
 unsafe extern "C" fn stub_fn<F>(
-    vmctx: *mut (),
+    vmctx: *mut VMOpaqueContext,
     caller_vmctx: *mut VMContext,
     values_vec: *mut ValRaw,
 ) where
@@ -43,11 +43,7 @@ unsafe extern "C" fn stub_fn<F>(
     // have any. To prevent leaks we avoid having any local destructors by
     // avoiding local variables.
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        // The general type for the first context argument is `*mut ()` but
-        // within the context of this function we know that this is `VMContext`
-        // due to the compilation of this function. Note that this is
-        // debug-asserted in `host_state()` with the `VMCONTEXT_MAGIC` value.
-        let vmctx = vmctx as *mut VMContext;
+        let vmctx = VMContext::from_opaque(vmctx);
         // Double-check ourselves in debug mode, but we control
         // the `Any` here so an unsafe downcast should also
         // work.

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -23,7 +23,7 @@ struct TrampolineState<F> {
 }
 
 unsafe extern "C" fn stub_fn<F>(
-    vmctx: *mut VMContext,
+    vmctx: *mut (),
     caller_vmctx: *mut VMContext,
     values_vec: *mut ValRaw,
 ) where
@@ -43,6 +43,11 @@ unsafe extern "C" fn stub_fn<F>(
     // have any. To prevent leaks we avoid having any local destructors by
     // avoiding local variables.
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        // The general type for the first context argument is `*mut ()` but
+        // within the context of this function we know that this is `VMContext`
+        // due to the compilation of this function. Note that this is
+        // debug-asserted in `host_state()` with the `VMCONTEXT_MAGIC` value.
+        let vmctx = vmctx as *mut VMContext;
         // Double-check ourselves in debug mode, but we control
         // the `Any` here so an unsafe downcast should also
         // work.

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -630,11 +630,10 @@ fn instance_too_large() -> Result<()> {
 
     let engine = Engine::new(&config)?;
     let expected = "\
-instance allocation for this module requires 304 bytes which exceeds the \
+instance allocation for this module requires 320 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 78.95% - 240 bytes - instance state management
- * 5.26% - 16 bytes - jit store state
+ * 80.00% - 256 bytes - instance state management
 ";
     match Module::new(&engine, "(module)") {
         Ok(_) => panic!("should have failed to compile"),
@@ -648,11 +647,11 @@ configured maximum of 16 bytes; breakdown of allocation requirement:
     lots_of_globals.push_str(")");
 
     let expected = "\
-instance allocation for this module requires 1904 bytes which exceeds the \
+instance allocation for this module requires 1920 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 12.61% - 240 bytes - instance state management
- * 84.03% - 1600 bytes - defined globals
+ * 13.33% - 256 bytes - instance state management
+ * 83.33% - 1600 bytes - defined globals
 ";
     match Module::new(&engine, &lots_of_globals) {
         Ok(_) => panic!("should have failed to compile"),


### PR DESCRIPTION
This commit is motivated by my work on the component model
implementation for imported functions. Currently all context pointers in
wasm are `*mut VMContext` but with the component model my plan is to
make some pointers instead along the lines of `*mut VMComponentContext`.
In doing this though one worry I have is breaking what has otherwise
been a core invariant of Wasmtime for quite some time, subtly
introducing bugs by accident.

To help assuage my worry I've opted here to erase knowledge of
`*mut VMContext` where possible. Instead where applicable a context
pointer is simply known as `*mut ()` and the embedder doesn't actually
know anything about this context beyond the value of the pointer. This
will help prevent Wasmtime from accidentally ever trying to interpret
this context pointer as an actual `VMContext` when it might instead be a
`VMComponentContext`.

Overall this was a pretty smooth transition. The main change here is
that the `VMTrampoline` (now sporting more docs) has its first argument
changed to `*mut ()`. The second argument, the caller context, is still
configured as `*mut VMContext` though because all functions are always
called from wasm still. Eventually for component-to-component calls I
think we'll probably "fake" the second argument as the same as the first
argument, losing track of the original caller, as an intentional way of
isolating components from each other.

Along the way there are a few host locations which do actually assume
that the first argument is indeed a `VMContext`. These are valid
assumptions that are upheld from a correct implementation, but I opted
to add a "magic" field to `VMContext` to assert this in debug mode. This
new "magic" field is inintialized during normal vmcontext initialization
and it's checked whenever a `VMContext` is reinterpreted as an
`Instance` (but only in debug mode). My hope here is to catch any future
accidental mistakes, if ever.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
