### PR TITLE
Change wasm-to-host trampolines to take the values_vec size

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -314,15 +314,15 @@ fn wasm_to_host(c: &mut Criterion) {
             let ty = FuncType::new([ValType::I32, ValType::I64], [ValType::F32]);
             unchecked
                 .func_new_unchecked("", "nop-params-and-results", ty, |mut caller, space| {
-                    match Val::from_raw(&mut caller, *space, ValType::I32) {
+                    match Val::from_raw(&mut caller, space[0], ValType::I32) {
                         Val::I32(0) => {}
                         _ => unreachable!(),
                     }
-                    match Val::from_raw(&mut caller, *space.add(1), ValType::I64) {
+                    match Val::from_raw(&mut caller, space[1], ValType::I64) {
                         Val::I64(0) => {}
                         _ => unreachable!(),
                     }
-                    *space = Val::F32(0).to_raw(&mut caller);
+                    space[0] = Val::F32(0).to_raw(&mut caller);
                     Ok(())
                 })
                 .unwrap();

--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -121,7 +121,8 @@ WASM_API_EXTERN void wasmtime_func_new(
 typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
     void *env,
     wasmtime_caller_t* caller,
-    wasmtime_val_raw_t *args_and_results);
+    wasmtime_val_raw_t *args_and_results,
+    size_t num_args_and_results);
 
 /**
  * \brief Creates a new host function in the same manner of #wasmtime_func_new,

--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -101,6 +101,8 @@ WASM_API_EXTERN void wasmtime_func_new(
  *        array depends on the function type that the host function is created
  *        with, but it will be the maximum of the number of parameters and
  *        number of results.
+ * \param num_args_and_results the size of the `args_and_results` parameter in
+ *        units of #wasmtime_val_raw_t.
  *
  * This callback can optionally return a #wasm_trap_t indicating that a trap
  * should be raised in WebAssembly. It's expected that in this case the caller

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -324,7 +324,7 @@ impl<T> Linker<T> {
         module: &str,
         name: &str,
         ty: FuncType,
-        func: impl Fn(Caller<'_, T>, *mut ValRaw) -> Result<(), Trap> + Send + Sync + 'static,
+        func: impl Fn(Caller<'_, T>, &mut [ValRaw]) -> Result<(), Trap> + Send + Sync + 'static,
     ) -> Result<&mut Self> {
         let func = HostFunc::new_unchecked(&self.engine, ty, func);
         let key = self.import_key(module, Some(name));

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -52,10 +52,10 @@ fn call_wrapped_func() -> Result<(), Error> {
             |caller: Caller<State>, space| {
                 verify(caller.data());
 
-                assert_eq!((*space.add(0)).get_i32(), 1i32);
-                assert_eq!((*space.add(1)).get_i64(), 2i64);
-                assert_eq!((*space.add(2)).get_f32(), 3.0f32.to_bits());
-                assert_eq!((*space.add(3)).get_f64(), 4.0f64.to_bits());
+                assert_eq!(space[0].get_i32(), 1i32);
+                assert_eq!(space[1].get_i64(), 2i64);
+                assert_eq!(space[2].get_f32(), 3.0f32.to_bits());
+                assert_eq!(space[3].get_f64(), 4.0f64.to_bits());
                 Ok(())
             },
         )


### PR DESCRIPTION
This commit changes the ABI of wasm-to-host trampolines, which are
only used right now for functions created with `Func::new`, to pass
along the size of the `values_vec` argument. Previously the trampoline
simply received `*mut ValRaw` and assumed that it was the appropriate
size. By receiving a size as well we can thread through `&mut [ValRaw]`
internally instead of `*mut ValRaw`.

The original motivation for this is that I'm planning to leverage these
trampolines for the component model for host-defined functions. Out of
an abundance of caution of making sure that everything lines up I wanted
to be able to write down asserts about the size received at runtime
compared to the size expected. This overall led me to the desire to
thread this size parameter through on the assumption that it would not
impact performance all that much.

I ran two benchmarks locally from the `call.rs` benchmark and got:

* `sync/no-hook/wasm-to-host - nop - unchecked` - no change
* `sync/no-hook/wasm-to-host - nop-params-and-results - unchecked` - 5%
  slower

This is what I roughly expected in that if nothing actually reads the
new parameter (e.g. no arguments) then threading through the parameter
is effectively otherwise free. Otherwise though accesses to the `ValRaw`
storage is now bounds-checked internally in Wasmtime instead of assuming
it's valid, leading to the 5% slowdown (~9.6ns to ~10.3ns). If this
becomes a peformance bottleneck for a particular use case then we should
be fine to remove the bounds checking here or otherwise only bounds
check in debug mode, otherwise I plan on leaving this as-is.

Of particular note this also changes the C API for `*_unchecked`
functions where the C callback now receives the size of the array as
well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
