### PR TITLE
Fix panics in the C API related to trap frames

### DIFF
--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -64,13 +64,7 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t>> {
-    if raw
-        .trap
-        .trace()
-        .expect("backtraces are always enabled")
-        .len()
-        > 0
-    {
+    if raw.trap.trace().unwrap_or(&[]).len() > 0 {
         Some(Box::new(wasm_frame_t {
             trap: raw.trap.clone(),
             idx: 0,
@@ -84,11 +78,7 @@ pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_trace(raw: &wasm_trap_t, out: &mut wasm_frame_vec_t) {
-    let vec = (0..raw
-        .trap
-        .trace()
-        .expect("backtraces are always enabled")
-        .len())
+    let vec = (0..raw.trap.trace().unwrap_or(&[]).len())
         .map(|idx| {
             Some(Box::new(wasm_frame_t {
                 trap: raw.trap.clone(),

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -288,7 +288,6 @@ impl Config {
     ///
     /// When disabled, wasm backtrace details are ignored, and [`crate::Trap::trace()`]
     /// will always return `None`.
-
     pub fn wasm_backtrace(&mut self, enable: bool) -> &mut Self {
         self.wasm_backtrace = enable;
         #[cfg(compiler)]

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -295,6 +295,14 @@ impl Trap {
 
     /// Returns a list of function frames in WebAssembly code that led to this
     /// trap happening.
+    ///
+    /// This function return an `Option` of a list of frames to indicate that
+    /// wasm frames are not always available. Frames will never be available if
+    /// backtraces are disabled via
+    /// [`Config::wasm_backtrace`](crate::Config::wasm_backtrace). Frames will
+    /// also not be available for freshly-created traps. WebAssembly frames are
+    /// currently only captured when the trap reaches wasm itself to get raised
+    /// across a wasm boundary.
     pub fn trace(&self) -> Option<&[FrameInfo]> {
         self.inner
             .backtrace


### PR DESCRIPTION
The `wasmtime-cpp` test suite uncovered an issue where asking for the
frames of a trap would fail immediately after the trap was created. In
addition to fixing this issue I've also updated the documentation of
`Trap::frames` to indicate when it returns `None`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
