### PR TITLE
Upgrade listenfd to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
  "cap-std",
  "rand 0.8.5",
  "rustix",
- "uuid 1.0.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1579,12 +1579,12 @@ checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
 
 [[package]]
 name = "listenfd"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e514e2cb8a9624701346ea3e694c1766d76778e343e537d873c1c366e79a7"
+checksum = "14e4fcc00ff6731d94b70e16e71f43bda62883461f31230742e3bc6dddf12988"
 dependencies = [
  "libc",
- "uuid 0.8.2",
+ "uuid",
  "winapi",
 ]
 
@@ -2998,12 +2998,6 @@ dependencies = [
  "generic-array",
  "subtle",
 ]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ target-lexicon = { version = "0.12.0", default-features = false }
 libc = "0.2.60"
 humantime = "2.0.0"
 lazy_static = "1.4.0"
-listenfd = "0.3.5"
+listenfd = "1.0.0"
 
 [target.'cfg(unix)'.dependencies]
 rustix = "0.33.7"

--- a/deny.toml
+++ b/deny.toml
@@ -40,9 +40,4 @@ skip-tree = [
     # This is somewhat unmaintained at this point and seems to pull in an old
     # version of `env_logger`, so ignore it.
     { name = "pretty_env_logger", depth = 20 },
-
-    # This crate depends on an old version of the `uuid` crate: `wasmtime-cli ->
-    # listenfd -> uuid`. Once `listenfd` upgrades to `uuid` v1.0.0, this can be
-    # removed.
-    { name = "listenfd", depth = 20 },
 ]


### PR DESCRIPTION
Previously, `listenfd` depended on an old version of the `uuid` crate
which caused cargo deny failures.
https://github.com/mitsuhiko/listenfd/pull/13 upgrades the `uuid`
dependency and a new version of `listenfd` is published. This change
moves to the latest version of `listenfd`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
