### PR TITLE
Upgrade to regalloc2 version 0.2.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e5ed49768d554b34463e467c27af849a7335c051d3ac402c4755f8366c6e0b"
+checksum = "dac38642b54866528dc69ab1d8d041cd13f5546a928b911004ab52611be66b3d"
 dependencies = [
  "fxhash",
  "log",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
-regalloc2 = { version = "0.2.0", features = ["checker"] }
+regalloc2 = { version = "0.2.1", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -115,13 +115,15 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   movq    %rdi, %r9
 ;   imulq   %r9, %rcx, %r9
-;   movq    %rdi, %rax
 ;   imulq   %rsi, %rdx, %rsi
-;   addq    %r9, %rsi, %r9
+;   movq    %r9, %r8
+;   addq    %r8, %rsi, %r8
+;   movq    %r8, %r9
+;   movq    %rdi, %rax
 ;   mul     %rax, %rdx, %rax, %rdx
-;   movq    %r9, %rdi
-;   addq    %rdi, %rdx, %rdi
-;   movq    %rdi, %r9
+;   movq    %r9, %r11
+;   addq    %r11, %rdx, %r11
+;   movq    %r11, %r9
 ;   movq    %r9, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
This resolves an edge-case where mul.i128 with an input that continues
to be live after the instruction could cause an invalid regalloc
constraint (basically, the regalloc did not previously support an
instruction use and def both being constrained to the same physical reg;
and the "mul" variant used for mul.i128 on x64 was the only instance of
such operands in Cranelift).

Causes two extra move instructions in the mul.i128 filetest, but that's
the price to pay for the slightly more general (works in all cases)
handling of the constraints.

See bytecodealliance/regalloc2#53 for the original bug report.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
