### PR TITLE
[RFC] Dynamic Vector Support

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -218,7 +218,9 @@ fn get_isle_compilations(
                 inputs: vec![
                     prelude_isle.clone(),
                     src_isa_aarch64.join("inst.isle"),
+                    src_isa_aarch64.join("inst_neon.isle"),
                     src_isa_aarch64.join("lower.isle"),
+                    src_isa_aarch64.join("lower_dynamic_neon.isle"),
                 ],
                 untracked_inputs: vec![clif_isle.clone()],
             },

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -688,6 +688,7 @@ pub(crate) fn gen_typesets_table(type_sets: &UniqueTable<TypeSet>, fmt: &mut For
             fmt.indent(|fmt| {
                 fmt.comment(typeset_to_string(ts));
                 gen_bitset(&ts.lanes, "lanes", 16, fmt);
+                gen_bitset(&ts.dynamic_lanes, "dynamic_lanes", 16, fmt);
                 gen_bitset(&ts.ints, "ints", 8, fmt);
                 gen_bitset(&ts.floats, "floats", 8, fmt);
                 gen_bitset(&ts.bools, "bools", 8, fmt);

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -119,7 +119,7 @@ fn gen_to_and_from_str(name: &str, values: &[&'static str], fmt: &mut Formatter)
     });
     fmtln!(fmt, "}");
 
-    fmtln!(fmt, "impl str::FromStr for {} {{", name);
+    fmtln!(fmt, "impl core::str::FromStr for {} {{", name);
     fmt.indent(|fmt| {
         fmtln!(fmt, "type Err = ();");
         fmtln!(fmt, "fn from_str(s: &str) -> Result<Self, Self::Err> {");

--- a/cranelift/codegen/meta/src/shared/entities.rs
+++ b/cranelift/codegen/meta/src/shared/entities.rs
@@ -18,6 +18,9 @@ pub(crate) struct EntityRefs {
     /// A reference to a stack slot declared in the function preamble.
     pub(crate) stack_slot: OperandKind,
 
+    /// A reference to a dynamic_stack slot declared in the function preamble.
+    pub(crate) dynamic_stack_slot: OperandKind,
+
     /// A reference to a global value.
     pub(crate) global_value: OperandKind,
 
@@ -51,6 +54,12 @@ impl EntityRefs {
                 "a basic block in the same function.",
             ),
             stack_slot: new("stack_slot", "ir::StackSlot", "A stack slot"),
+
+            dynamic_stack_slot: new(
+                "dynamic_stack_slot",
+                "ir::DynamicStackSlot",
+                "A dynamic stack slot",
+            ),
 
             global_value: new("global_value", "ir::GlobalValue", "A global value."),
 

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -34,6 +34,8 @@ pub(crate) struct Formats {
     pub(crate) shuffle: Rc<InstructionFormat>,
     pub(crate) stack_load: Rc<InstructionFormat>,
     pub(crate) stack_store: Rc<InstructionFormat>,
+    pub(crate) dynamic_stack_load: Rc<InstructionFormat>,
+    pub(crate) dynamic_stack_store: Rc<InstructionFormat>,
     pub(crate) store: Rc<InstructionFormat>,
     pub(crate) store_no_offset: Rc<InstructionFormat>,
     pub(crate) table_addr: Rc<InstructionFormat>,
@@ -228,6 +230,15 @@ impl Formats {
                 .value()
                 .imm(&entities.stack_slot)
                 .imm(&imm.offset32)
+                .build(),
+
+            dynamic_stack_load: Builder::new("DynamicStackLoad")
+                .imm(&entities.dynamic_stack_slot)
+                .build(),
+
+            dynamic_stack_store: Builder::new("DynamicStackStore")
+                .value()
+                .imm(&entities.dynamic_stack_slot)
                 .build(),
 
             // Accessing a WebAssembly heap.

--- a/cranelift/codegen/shared/src/constants.rs
+++ b/cranelift/codegen/shared/src/constants.rs
@@ -8,9 +8,12 @@
 // 0x70-0x7d: Lane types
 // 0x7e-0x7f: Reference types
 // 0x80-0xff: Vector types
+// 0x100-0x17f: Dynamic Vector types
 //
 // Vector types are encoded with the lane type in the low 4 bits and log2(lanes)
-// in the high 4 bits, giving a range of 2-256 lanes.
+// in the next highest 4 bits, giving a range of 2-256 lanes.
+
+// Dynamic vector types are encoded similarily.
 
 /// Start of the lane types.
 pub const LANE_BASE: u16 = 0x70;
@@ -20,3 +23,6 @@ pub const REFERENCE_BASE: u16 = 0x7E;
 
 /// Start of the 2-lane vector types.
 pub const VECTOR_BASE: u16 = 0x80;
+
+/// Start of the dynamic vector types.
+pub const DYNAMIC_VECTOR_BASE: u16 = 0x100;

--- a/cranelift/codegen/src/ir/dynamic_type.rs
+++ b/cranelift/codegen/src/ir/dynamic_type.rs
@@ -1,0 +1,38 @@
+//! Dynamic IR types
+
+use crate::ir::entities::DynamicType;
+use crate::ir::GlobalValue;
+use crate::ir::PrimaryMap;
+use crate::ir::Type;
+
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
+/// A dynamic type object which has a base vector type and a scaling factor.
+#[derive(Clone)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct DynamicTypeData {
+    /// Base vector type, this is the minimum size of the type.
+    pub base_vector_ty: Type,
+    /// The dynamic scaling factor of the base vector type.
+    pub dynamic_scale: GlobalValue,
+}
+
+impl DynamicTypeData {
+    /// Create a new dynamic type.
+    pub fn new(base_vector_ty: Type, dynamic_scale: GlobalValue) -> Self {
+        assert!(base_vector_ty.is_vector());
+        Self {
+            base_vector_ty,
+            dynamic_scale,
+        }
+    }
+
+    /// Convert 'base_vector_ty' into a concrete dynamic vector type.
+    pub fn concrete(&self) -> Option<Type> {
+        self.base_vector_ty.vector_to_dynamic()
+    }
+}
+
+/// All allocated dynamic types.
+pub type DynamicTypes = PrimaryMap<DynamicType, DynamicTypeData>;

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -135,6 +135,44 @@ impl StackSlot {
     }
 }
 
+/// An opaque reference to a dynamic stack slot.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct DynamicStackSlot(u32);
+entity_impl!(DynamicStackSlot, "dss");
+
+impl DynamicStackSlot {
+    /// Create a new stack slot reference from its number.
+    ///
+    /// This method is for use by the parser.
+    pub fn with_number(n: u32) -> Option<Self> {
+        if n < u32::MAX {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+}
+
+/// An opaque reference to a dynamic type.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct DynamicType(u32);
+entity_impl!(DynamicType, "dt");
+
+impl DynamicType {
+    /// Create a new dynamic type reference from its number.
+    ///
+    /// This method is for use by the parser.
+    pub fn with_number(n: u32) -> Option<Self> {
+        if n < u32::MAX {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+}
+
 /// An opaque reference to a global value.
 ///
 /// A `GlobalValue` is a [`Value`](Value) that will be live across the entire
@@ -389,6 +427,10 @@ pub enum AnyEntity {
     Value(Value),
     /// A stack slot.
     StackSlot(StackSlot),
+    /// A dynamic stack slot.
+    DynamicStackSlot(DynamicStackSlot),
+    /// A dynamic type
+    DynamicType(DynamicType),
     /// A Global value.
     GlobalValue(GlobalValue),
     /// A jump table.
@@ -415,6 +457,8 @@ impl fmt::Display for AnyEntity {
             Self::Inst(r) => r.fmt(f),
             Self::Value(r) => r.fmt(f),
             Self::StackSlot(r) => r.fmt(f),
+            Self::DynamicStackSlot(r) => r.fmt(f),
+            Self::DynamicType(r) => r.fmt(f),
             Self::GlobalValue(r) => r.fmt(f),
             Self::JumpTable(r) => r.fmt(f),
             Self::Constant(r) => r.fmt(f),
@@ -454,6 +498,18 @@ impl From<Value> for AnyEntity {
 impl From<StackSlot> for AnyEntity {
     fn from(r: StackSlot) -> Self {
         Self::StackSlot(r)
+    }
+}
+
+impl From<DynamicStackSlot> for AnyEntity {
+    fn from(r: DynamicStackSlot) -> Self {
+        Self::DynamicStackSlot(r)
+    }
+}
+
+impl From<DynamicType> for AnyEntity {
+    fn from(r: DynamicType) -> Self {
+        Self::DynamicType(r)
     }
 }
 

--- a/cranelift/codegen/src/ir/globalvalue.rs
+++ b/cranelift/codegen/src/ir/globalvalue.rs
@@ -76,6 +76,13 @@ pub enum GlobalValueData {
         /// Does this symbol refer to a thread local storage value?
         tls: bool,
     },
+
+    /// Value is a multiple of how many instances of `vector_type` will fit in
+    /// a target vector register.
+    DynScaleTargetConst {
+        /// Base vector type.
+        vector_type: Type,
+    },
 }
 
 impl GlobalValueData {
@@ -92,6 +99,7 @@ impl GlobalValueData {
         match *self {
             Self::VMContext { .. } | Self::Symbol { .. } => isa.pointer_type(),
             Self::IAddImm { global_type, .. } | Self::Load { global_type, .. } => global_type,
+            Self::DynScaleTargetConst { .. } => isa.pointer_type(),
         }
     }
 
@@ -153,6 +161,9 @@ impl fmt::Display for GlobalValueData {
                     write!(f, "{}", offset)?;
                 }
                 Ok(())
+            }
+            Self::DynScaleTargetConst { vector_type } => {
+                write!(f, "dyn_scale_target_const.{}", vector_type)
             }
         }
     }

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -5,6 +5,7 @@ mod builder;
 pub mod condcodes;
 pub mod constant;
 pub mod dfg;
+pub mod dynamic_type;
 pub mod entities;
 mod extfunc;
 mod extname;
@@ -33,9 +34,10 @@ pub use crate::ir::builder::{
 };
 pub use crate::ir::constant::{ConstantData, ConstantPool};
 pub use crate::ir::dfg::{DataFlowGraph, ValueDef};
+pub use crate::ir::dynamic_type::{DynamicTypeData, DynamicTypes};
 pub use crate::ir::entities::{
-    Block, Constant, FuncRef, GlobalValue, Heap, Immediate, Inst, JumpTable, SigRef, StackSlot,
-    Table, Value,
+    Block, Constant, DynamicStackSlot, DynamicType, FuncRef, GlobalValue, Heap, Immediate, Inst,
+    JumpTable, SigRef, StackSlot, Table, Value,
 };
 pub use crate::ir::extfunc::{
     AbiParam, ArgumentExtension, ArgumentPurpose, ExtFuncData, Signature,
@@ -53,7 +55,9 @@ pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::{Endianness, MemFlags};
 pub use crate::ir::progpoint::{ExpandedProgramPoint, ProgramOrder, ProgramPoint};
 pub use crate::ir::sourceloc::SourceLoc;
-pub use crate::ir::stackslot::{StackSlotData, StackSlotKind, StackSlots};
+pub use crate::ir::stackslot::{
+    DynamicStackSlotData, DynamicStackSlots, StackSlotData, StackSlotKind, StackSlots,
+};
 pub use crate::ir::table::TableData;
 pub use crate::ir::trapcode::TrapCode;
 pub use crate::ir::types::Type;

--- a/cranelift/codegen/src/ir/stackslot.rs
+++ b/cranelift/codegen/src/ir/stackslot.rs
@@ -4,9 +4,17 @@
 //!
 
 use crate::entity::PrimaryMap;
+use crate::ir::entities::{DynamicStackSlot, DynamicType};
 use crate::ir::StackSlot;
 use core::fmt;
 use core::str::FromStr;
+
+/// imports only needed for testing.
+#[allow(unused_imports)]
+use crate::ir::{DynamicTypeData, GlobalValueData};
+
+#[allow(unused_imports)]
+use crate::ir::types::*;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -25,6 +33,9 @@ pub enum StackSlotKind {
     /// An explicit stack slot. This is a chunk of stack memory for use by the `stack_load`
     /// and `stack_store` instructions.
     ExplicitSlot,
+    /// An explicit stack slot for dynamic vector types. This is a chunk of stack memory
+    /// for use by the `dynamic_stack_load` and `dynamic_stack_store` instructions.
+    ExplicitDynamicSlot,
 }
 
 impl FromStr for StackSlotKind {
@@ -34,6 +45,7 @@ impl FromStr for StackSlotKind {
         use self::StackSlotKind::*;
         match s {
             "explicit_slot" => Ok(ExplicitSlot),
+            "explicit_dynamic_slot" => Ok(ExplicitDynamicSlot),
             _ => Err(()),
         }
     }
@@ -44,6 +56,7 @@ impl fmt::Display for StackSlotKind {
         use self::StackSlotKind::*;
         f.write_str(match *self {
             ExplicitSlot => "explicit_slot",
+            ExplicitDynamicSlot => "explicit_dynamic_slot",
         })
     }
 }
@@ -68,11 +81,15 @@ impl StackSlotData {
     /// Get the alignment in bytes of this stack slot given the stack pointer alignment.
     pub fn alignment(&self, max_align: StackSize) -> StackSize {
         debug_assert!(max_align.is_power_of_two());
-        // We want to find the largest power of two that divides both `self.size` and `max_align`.
-        // That is the same as isolating the rightmost bit in `x`.
-        let x = self.size | max_align;
-        // C.f. Hacker's delight.
-        x & x.wrapping_neg()
+        if self.kind == StackSlotKind::ExplicitDynamicSlot {
+            max_align
+        } else {
+            // We want to find the largest power of two that divides both `self.size` and `max_align`.
+            // That is the same as isolating the rightmost bit in `x`.
+            let x = self.size | max_align;
+            // C.f. Hacker's delight.
+            x & x.wrapping_neg()
+        }
     }
 }
 
@@ -82,8 +99,42 @@ impl fmt::Display for StackSlotData {
     }
 }
 
+/// Contents of a dynamic stack slot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct DynamicStackSlotData {
+    /// The kind of stack slot.
+    pub kind: StackSlotKind,
+
+    /// The type of this slot.
+    pub dyn_ty: DynamicType,
+}
+
+impl DynamicStackSlotData {
+    /// Create a stack slot with the specified byte size.
+    pub fn new(kind: StackSlotKind, dyn_ty: DynamicType) -> Self {
+        assert!(kind == StackSlotKind::ExplicitDynamicSlot);
+        Self { kind, dyn_ty }
+    }
+
+    /// Get the alignment in bytes of this stack slot given the stack pointer alignment.
+    pub fn alignment(&self, max_align: StackSize) -> StackSize {
+        debug_assert!(max_align.is_power_of_two());
+        max_align
+    }
+}
+
+impl fmt::Display for DynamicStackSlotData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} {}", self.kind, self.dyn_ty)
+    }
+}
+
 /// All allocated stack slots.
 pub type StackSlots = PrimaryMap<StackSlot, StackSlotData>;
+
+/// All allocated dynamic stack slots.
+pub type DynamicStackSlots = PrimaryMap<DynamicStackSlot, DynamicStackSlotData>;
 
 #[cfg(test)]
 mod tests {
@@ -95,16 +146,56 @@ mod tests {
     fn stack_slot() {
         let mut func = Function::new();
 
-        let ss0 = func.create_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 4));
-        let ss1 = func.create_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 8));
+        let ss0 = func.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 4));
+        let ss1 = func.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 8));
         assert_eq!(ss0.to_string(), "ss0");
         assert_eq!(ss1.to_string(), "ss1");
 
-        assert_eq!(func.stack_slots[ss0].size, 4);
-        assert_eq!(func.stack_slots[ss1].size, 8);
+        assert_eq!(func.sized_stack_slots[ss0].size, 4);
+        assert_eq!(func.sized_stack_slots[ss1].size, 8);
 
-        assert_eq!(func.stack_slots[ss0].to_string(), "explicit_slot 4");
-        assert_eq!(func.stack_slots[ss1].to_string(), "explicit_slot 8");
+        assert_eq!(func.sized_stack_slots[ss0].to_string(), "explicit_slot 4");
+        assert_eq!(func.sized_stack_slots[ss1].to_string(), "explicit_slot 8");
+    }
+
+    #[test]
+    fn dynamic_stack_slot() {
+        let mut func = Function::new();
+
+        let int_vector_ty = I32X4;
+        let fp_vector_ty = F64X2;
+        let scale0 = GlobalValueData::DynScaleTargetConst {
+            vector_type: int_vector_ty,
+        };
+        let scale1 = GlobalValueData::DynScaleTargetConst {
+            vector_type: fp_vector_ty,
+        };
+        let gv0 = func.create_global_value(scale0);
+        let gv1 = func.create_global_value(scale1);
+        let dtd0 = DynamicTypeData::new(int_vector_ty, gv0);
+        let dtd1 = DynamicTypeData::new(fp_vector_ty, gv1);
+        let dt0 = func.dfg.make_dynamic_ty(dtd0);
+        let dt1 = func.dfg.make_dynamic_ty(dtd1);
+
+        let dss0 = func.create_dynamic_stack_slot(DynamicStackSlotData::new(
+            StackSlotKind::ExplicitDynamicSlot,
+            dt0,
+        ));
+        let dss1 = func.create_dynamic_stack_slot(DynamicStackSlotData::new(
+            StackSlotKind::ExplicitDynamicSlot,
+            dt1,
+        ));
+        assert_eq!(dss0.to_string(), "dss0");
+        assert_eq!(dss1.to_string(), "dss1");
+
+        assert_eq!(
+            func.dynamic_stack_slots[dss0].to_string(),
+            "explicit_dynamic_slot dt0"
+        );
+        assert_eq!(
+            func.dynamic_stack_slots[dss1].to_string(),
+            "explicit_dynamic_slot dt1"
+        );
     }
 
     #[test]

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -919,6 +919,17 @@
     (Size64x2)
 ))
 
+(type DynamicVectorSize extern
+  (enum
+    (Size8x8xN)
+    (Size8x16xN)
+    (Size16x4xN)
+    (Size16x8xN)
+    (Size32x2xN)
+    (Size32x4xN)
+    (Size64x2xN)
+))
+
 ;; Helper for calculating the `VectorSize` corresponding to a type
 (decl vector_size (Type) VectorSize)
 (rule (vector_size (multi_lane 8 8)) (VectorSize.Size8x8))
@@ -928,6 +939,13 @@
 (rule (vector_size (multi_lane 32 2)) (VectorSize.Size32x2))
 (rule (vector_size (multi_lane 32 4)) (VectorSize.Size32x4))
 (rule (vector_size (multi_lane 64 2)) (VectorSize.Size64x2))
+(rule (vector_size (dynamic_lane 8 8)) (VectorSize.Size8x8))
+(rule (vector_size (dynamic_lane 8 16)) (VectorSize.Size8x16))
+(rule (vector_size (dynamic_lane 16 4)) (VectorSize.Size16x4))
+(rule (vector_size (dynamic_lane 16 8)) (VectorSize.Size16x8))
+(rule (vector_size (dynamic_lane 32 2)) (VectorSize.Size32x2))
+(rule (vector_size (dynamic_lane 32 4)) (VectorSize.Size32x4))
+(rule (vector_size (dynamic_lane 64 2)) (VectorSize.Size64x2))
 
 ;; A floating-point unit (FPU) operation with one arg.
 (type FPUOp1

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -706,12 +706,9 @@ impl VectorSize {
     /// Get the scalar operand size that corresponds to a lane of a vector with a certain size.
     pub fn lane_size(&self) -> ScalarSize {
         match self {
-            VectorSize::Size8x8 => ScalarSize::Size8,
-            VectorSize::Size8x16 => ScalarSize::Size8,
-            VectorSize::Size16x4 => ScalarSize::Size16,
-            VectorSize::Size16x8 => ScalarSize::Size16,
-            VectorSize::Size32x2 => ScalarSize::Size32,
-            VectorSize::Size32x4 => ScalarSize::Size32,
+            VectorSize::Size8x8 | VectorSize::Size8x16 => ScalarSize::Size8,
+            VectorSize::Size16x4 | VectorSize::Size16x8 => ScalarSize::Size16,
+            VectorSize::Size32x2 | VectorSize::Size32x4 => ScalarSize::Size32,
             VectorSize::Size64x2 => ScalarSize::Size64,
         }
     }
@@ -741,5 +738,20 @@ impl VectorSize {
         };
 
         (q, size)
+    }
+}
+
+pub(crate) fn dynamic_to_fixed(ty: Type) -> Type {
+    match ty {
+        I8X8XN => I8X8,
+        I8X16XN => I8X16,
+        I16X4XN => I16X4,
+        I16X8XN => I16X8,
+        I32X2XN => I32X2,
+        I32X4XN => I32X4,
+        I64X2XN => I64X2,
+        F32X4XN => F32X4,
+        F64X2XN => F64X2,
+        _ => unreachable!("unhandled type: {}", ty),
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -89,12 +89,12 @@ pub fn mem_finalize(
 //=============================================================================
 // Instructions and subcomponents: emission
 
-fn machreg_to_gpr(m: Reg) -> u32 {
+pub(crate) fn machreg_to_gpr(m: Reg) -> u32 {
     assert_eq!(m.class(), RegClass::Int);
     u32::try_from(m.to_real_reg().unwrap().hw_enc() & 31).unwrap()
 }
 
-fn machreg_to_vec(m: Reg) -> u32 {
+pub(crate) fn machreg_to_vec(m: Reg) -> u32 {
     assert_eq!(m.class(), RegClass::Float);
     u32::try_from(m.to_real_reg().unwrap().hw_enc()).unwrap()
 }
@@ -2259,7 +2259,7 @@ impl MachInstEmit for Inst {
                     VectorSize::Size16x8 => 0b00010,
                     VectorSize::Size32x4 => 0b00100,
                     VectorSize::Size64x2 => 0b01000,
-                    _ => unimplemented!(),
+                    _ => unimplemented!("Unexpected VectorSize: {:?}", size),
                 };
                 sink.put4(
                     0b010_01110000_00000_000011_00000_00000

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1194,6 +1194,7 @@ impl MachInst for Inst {
                 assert!(ty.bits() <= 128);
                 Ok((&[RegClass::Float], &[I8X16]))
             }
+            _ if ty.is_dynamic_vector() => Ok((&[RegClass::Float], &[I8X16])),
             IFLAGS | FFLAGS => Ok((&[RegClass::Int], &[I64])),
             _ => Err(CodegenError::Unsupported(format!(
                 "Unexpected SSA-value type: {}",

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -332,12 +332,9 @@ pub fn show_vreg_element(reg: Reg, idx: u8, size: VectorSize) -> String {
     assert_eq!(RegClass::Float, reg.class());
     let s = show_reg(reg);
     let suffix = match size {
-        VectorSize::Size8x8 => ".b",
-        VectorSize::Size8x16 => ".b",
-        VectorSize::Size16x4 => ".h",
-        VectorSize::Size16x8 => ".h",
-        VectorSize::Size32x2 => ".s",
-        VectorSize::Size32x4 => ".s",
+        VectorSize::Size8x8 | VectorSize::Size8x16 => ".b",
+        VectorSize::Size16x4 | VectorSize::Size16x8 => ".h",
+        VectorSize::Size32x2 | VectorSize::Size32x4 => ".s",
         VectorSize::Size64x2 => ".d",
     };
     format!("{}{}[{}]", s, suffix, idx)

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -117,7 +117,7 @@ mod tests {
         pos.ins().return_(&[]);
 
         if let Some(stack_slot) = stack_slot {
-            func.stack_slots.push(stack_slot);
+            func.sized_stack_slots.push(stack_slot);
         }
 
         func

--- a/cranelift/codegen/src/isa/aarch64/inst_neon.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst_neon.isle
@@ -1,0 +1,8 @@
+
+;; Move helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(decl fpu_move_128 (Reg) Reg)
+(rule (fpu_move_128 src)
+      (let ((dst WritableReg (temp_writable_reg $I8X16))
+            (_ Unit (emit (MInst.FpuMove128 dst src))))
+        (writable_reg_to_reg dst)))
+

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -81,6 +81,9 @@
 (rule (lower (has_type ty @ (multi_lane _ _) (iadd x y)))
       (add_vec x y (vector_size ty)))
 
+(rule (lower (has_type ty @ (dynamic_lane _ _) (iadd x y)))
+      (value_reg (vec_rrr (VecALUOp.Add) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
 ;; `i128`
 (rule (lower (has_type $I128 (iadd x y)))
       (let
@@ -157,6 +160,8 @@
 ;; vectors
 (rule (lower (has_type ty @ (multi_lane _ _) (isub x y)))
       (sub_vec x y (vector_size ty)))
+(rule (lower (has_type ty @ (dynamic_lane _ _) (isub x y)))
+      (value_reg (sub_vec (put_in_reg x) (put_in_reg y) (vector_size ty))))
 
 ;; `i128`
 (rule (lower (has_type $I128 (isub x y)))
@@ -243,6 +248,10 @@
 ;; Case for i8x16, i16x8, and i32x4.
 (rule (lower (has_type (ty_vec128 ty @ (not_i64x2)) (imul x y)))
       (mul x y (vector_size ty)))
+
+;; Case for 'dynamic' i8x16, i16x8, and i32x4.
+(rule (lower (has_type ty @ (dynamic_lane _ _) (imul x y)))
+      (value_reg (vec_rrr (VecALUOp.Mul) (put_in_reg x) (put_in_reg y) (vector_size ty))))
 
 ;; Special lowering for i64x2.
 ;;

--- a/cranelift/codegen/src/isa/aarch64/lower_dynamic_neon.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower_dynamic_neon.isle
@@ -1,0 +1,30 @@
+
+;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (has_type ty @ (dynamic_lane _ _) (iadd x y)))
+      (value_reg (vec_rrr (VecALUOp.Add) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
+;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (has_type ty @ (dynamic_lane _ _) (isub x y)))
+      (value_reg (vec_rrr (VecALUOp.Sub) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
+;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (has_type (lane_fits_in_32 ty @ (dynamic_lane _ _)) (imul x y)))
+      (value_reg (vec_rrr (VecALUOp.Mul) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
+;;;; Rules for `fsub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (has_type ty @ (dynamic_lane _ _) (fadd x y)))
+      (value_reg (vec_rrr (VecALUOp.Fadd) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
+;;;; Rules for `fsub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (has_type ty @ (dynamic_lane _ _) (fsub x y)))
+      (value_reg (vec_rrr (VecALUOp.Fsub) (put_in_reg x) (put_in_reg y) (vector_size ty))))
+
+;;; Rules for `dynamic_stack_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (dynamic_stack_addr stack_slot))
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (abi_dynamic_stackslot_addr dst stack_slot))))
+        (value_reg dst)))
+
+;;; Rules for `extract_vector` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule (lower (extract_vector x 0))
+      (value_reg (fpu_move_128 (put_in_reg x))))

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -1,7 +1,7 @@
 //! ARM 64-bit Instruction Set Architecture.
 
 use crate::ir::condcodes::IntCC;
-use crate::ir::Function;
+use crate::ir::{Function, Type};
 use crate::isa::aarch64::settings as aarch64_settings;
 use crate::isa::{Builder as IsaBuilder, TargetIsa};
 use crate::machinst::{
@@ -57,7 +57,7 @@ impl AArch64Backend {
         flags: shared_settings::Flags,
     ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
         let emit_info = EmitInfo::new(flags.clone());
-        let abi = Box::new(abi::AArch64ABICallee::new(func, flags, self.isa_flags())?);
+        let abi = Box::new(abi::AArch64ABICallee::new(func, self)?);
         compile::compile::<AArch64Backend>(func, self, abi, &self.machine_env, emit_info)
     }
 }
@@ -76,7 +76,8 @@ impl TargetIsa for AArch64Backend {
         let frame_size = emit_result.frame_size;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer.finish();
-        let stackslot_offsets = emit_result.stackslot_offsets;
+        let sized_stackslot_offsets = emit_result.sized_stackslot_offsets;
+        let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
             log::debug!("disassembly:\n{}", disasm);
@@ -87,7 +88,8 @@ impl TargetIsa for AArch64Backend {
             frame_size,
             disasm: emit_result.disasm,
             value_labels_ranges,
-            stackslot_offsets,
+            sized_stackslot_offsets,
+            dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
         })
@@ -107,6 +109,10 @@ impl TargetIsa for AArch64Backend {
 
     fn isa_flags(&self) -> Vec<shared_settings::Value> {
         self.isa_flags.iter().collect()
+    }
+
+    fn dynamic_vector_bytes(&self, _dyn_ty: Type) -> u32 {
+        16
     }
 
     fn unsigned_add_overflow_condition(&self) -> IntCC {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -196,7 +196,7 @@ pub struct TargetFrontendConfig {
 impl TargetFrontendConfig {
     /// Get the pointer type of this target.
     pub fn pointer_type(self) -> ir::Type {
-        ir::Type::int(u16::from(self.pointer_bits())).unwrap()
+        ir::Type::int(self.pointer_bits() as u16).unwrap()
     }
 
     /// Get the width of pointers on this target, in units of bits.
@@ -225,6 +225,9 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
     /// Get the ISA-dependent flag values that were used to make this trait object.
     fn isa_flags(&self) -> Vec<settings::Value>;
+
+    /// Get the ISA-dependent maximum vector register size, in bytes.
+    fn dynamic_vector_bytes(&self, dynamic_ty: ir::Type) -> u32;
 
     /// Compile the given function.
     fn compile_function(
@@ -311,7 +314,7 @@ impl<'a> dyn TargetIsa + 'a {
 
     /// Get the pointer type of this ISA.
     pub fn pointer_type(&self) -> ir::Type {
-        ir::Type::int(u16::from(self.pointer_bits())).unwrap()
+        ir::Type::int(self.pointer_bits() as u16).unwrap()
     }
 
     /// Get the width of pointers on this ISA.

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -61,6 +61,7 @@ use crate::ir;
 use crate::ir::condcodes::IntCC;
 use crate::ir::types;
 use crate::ir::MemFlags;
+use crate::ir::Signature;
 use crate::ir::Type;
 use crate::isa;
 use crate::isa::s390x::inst::*;
@@ -556,6 +557,7 @@ impl ABIMachineSpec for S390xMachineDeps {
 
     fn gen_clobber_restore(
         call_conv: isa::CallConv,
+        _: &Signature,
         _: &settings::Flags,
         clobbers: &[Writable<RealReg>],
         fixed_frame_storage_size: u32,
@@ -633,7 +635,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         unimplemented!("StructArgs not implemented for S390X yet");
     }
 
-    fn get_number_of_spillslots_for_value(rc: RegClass) -> u32 {
+    fn get_number_of_spillslots_for_value(rc: RegClass, _vector_scale: u32) -> u32 {
         // We allocate in terms of 8-byte slots.
         match rc {
             RegClass::Int => 1,
@@ -665,6 +667,7 @@ impl ABIMachineSpec for S390xMachineDeps {
     fn get_clobbered_callee_saves(
         call_conv: isa::CallConv,
         flags: &settings::Flags,
+        _sig: &Signature,
         regs: &[Writable<RealReg>],
     ) -> Vec<Writable<RealReg>> {
         assert!(
@@ -688,7 +691,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         _is_leaf: bool,
         _stack_args_size: u32,
         _num_clobbered_callee_saves: usize,
-        _fixed_frame_storage_size: u32,
+        _frame_storage_size: u32,
     ) -> bool {
         // The call frame set-up is handled by gen_clobber_save().
         false

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1158,9 +1158,6 @@
 
 ;; Helpers for stack-slot addresses ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl abi_stackslot_addr (WritableReg StackSlot Offset32) MInst)
-(extern constructor abi_stackslot_addr abi_stackslot_addr)
-
 (decl stack_addr_impl (Type StackSlot Offset32) Reg)
 (rule (stack_addr_impl ty stack_slot offset)
       (let ((dst WritableReg (temp_writable_reg ty))

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -148,7 +148,7 @@ mod tests {
         pos.ins().return_(&[]);
 
         if let Some(stack_slot) = stack_slot {
-            func.stack_slots.push(stack_slot);
+            func.sized_stack_slots.push(stack_slot);
         }
 
         func
@@ -206,7 +206,7 @@ mod tests {
         pos.ins().return_(&[]);
 
         if let Some(stack_slot) = stack_slot {
-            func.stack_slots.push(stack_slot);
+            func.sized_stack_slots.push(stack_slot);
         }
 
         func

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -2301,7 +2301,7 @@
 (decl lower_call_ret_arg (ABISig) InstOutput)
 (rule (lower_call_ret_arg (abi_no_ret_arg)) (output_none))
 (rule (lower_call_ret_arg abi @ (abi_ret_arg (abi_arg_only_slot slot)))
-      (let ((ret_arg Reg (load_addr (memarg_stack_off (abi_stack_arg_space abi) 0)))
+      (let ((ret_arg Reg (load_addr (memarg_stack_off (abi_sized_stack_arg_space abi) 0)))
             (_ Unit (copy_reg_to_arg_slot 0 slot ret_arg)))
         (output_none)))
 
@@ -2309,7 +2309,7 @@
 (decl lower_call_rets (ABISig Range InstOutputBuilder) InstOutput)
 (rule (lower_call_rets abi (range_empty) builder) (output_builder_finish builder))
 (rule (lower_call_rets abi (range_unwrap head tail) builder)
-      (let ((ret ValueRegs (copy_from_arg (abi_stack_arg_space abi) (abi_get_ret abi head)))
+      (let ((ret ValueRegs (copy_from_arg (abi_sized_stack_arg_space abi) (abi_get_ret abi head)))
             (_ Unit (output_builder_push builder ret)))
         (lower_call_rets abi tail builder)))
 

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -197,7 +197,11 @@ impl LowerBackend for S390xBackend {
             | Opcode::SqmulRoundSat
             | Opcode::FvpromoteLow
             | Opcode::Fvdemote
-            | Opcode::IaddPairwise => {
+            | Opcode::IaddPairwise
+            | Opcode::DynamicStackLoad
+            | Opcode::DynamicStackStore
+            | Opcode::DynamicStackAddr
+            | Opcode::ExtractVector => {
                 unreachable!(
                     "TODO: not yet implemented in ISLE: inst = `{}`, type = `{:?}`",
                     ctx.dfg().display_inst(ir_inst),

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -16,7 +16,7 @@ use crate::settings::Flags;
 use crate::{
     ir::{
         condcodes::*, immediates::*, types::*, AtomicRmwOp, Endianness, Inst, InstructionData,
-        MemFlags, Opcode, StackSlot, TrapCode, Value, ValueList,
+        MemFlags, Opcode, TrapCode, Value, ValueList,
     },
     isa::unwind::UnwindInst,
     machinst::{InsnOutput, LowerCtx, VCodeConstant, VCodeConstantData},
@@ -77,7 +77,7 @@ where
     }
 
     fn abi_accumulate_outgoing_args_size(&mut self, abi: &ABISig) -> Unit {
-        let off = abi.stack_arg_space() + abi.stack_ret_space();
+        let off = abi.sized_stack_arg_space() + abi.sized_stack_ret_space();
         self.lower_ctx
             .abi()
             .accumulate_outgoing_args_size(off as u32);
@@ -529,17 +529,6 @@ where
         } else {
             None
         }
-    }
-
-    #[inline]
-    fn abi_stackslot_addr(
-        &mut self,
-        dst: WritableReg,
-        stack_slot: StackSlot,
-        offset: Offset32,
-    ) -> MInst {
-        let offset = u32::try_from(i32::from(offset)).unwrap();
-        self.lower_ctx.abi().stackslot_addr(stack_slot, offset, dst)
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -144,7 +144,7 @@ mod tests {
         pos.ins().return_(&[]);
 
         if let Some(stack_slot) = stack_slot {
-            func.stack_slots.push(stack_slot);
+            func.sized_stack_slots.push(stack_slot);
         }
 
         func

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2169,6 +2169,8 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             });
         }
 
+        Opcode::DynamicStackAddr => unimplemented!("DynamicStackAddr"),
+
         Opcode::StackAddr => {
             let (stack_slot, offset) = match *ctx.data(insn) {
                 InstructionData::StackLoad {
@@ -2180,9 +2182,9 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             };
             let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let offset: i32 = offset.into();
-            let inst = ctx
-                .abi()
-                .stackslot_addr(stack_slot, u32::try_from(offset).unwrap(), dst);
+            let inst =
+                ctx.abi()
+                    .sized_stackslot_addr(stack_slot, u32::try_from(offset).unwrap(), dst);
             ctx.emit(inst);
         }
 
@@ -2908,7 +2910,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         // Unimplemented opcodes below. These are not currently used by Wasm
         // lowering or other known embeddings, but should be either supported or
-        // removed eventually.
+        // removed eventually
+        Opcode::ExtractVector => {
+            unimplemented!("ExtractVector not supported");
+        }
+
         Opcode::Cls => unimplemented!("Cls not supported"),
 
         Opcode::Fma => unimplemented!("Fma not supported"),
@@ -2965,7 +2971,10 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             panic!("ALU+imm and ALU+carry ops should not appear here!");
         }
 
-        Opcode::StackLoad | Opcode::StackStore => {
+        Opcode::StackLoad
+        | Opcode::StackStore
+        | Opcode::DynamicStackStore
+        | Opcode::DynamicStackLoad => {
             panic!("Direct stack memory access not supported; should have been legalized");
         }
 

--- a/cranelift/codegen/src/legalizer/globalvalue.rs
+++ b/cranelift/codegen/src/legalizer/globalvalue.rs
@@ -28,7 +28,21 @@ pub fn expand_global_value(
             readonly,
         } => load_addr(inst, func, base, offset, global_type, readonly, isa),
         ir::GlobalValueData::Symbol { tls, .. } => symbol(inst, func, global_value, isa, tls),
+        ir::GlobalValueData::DynScaleTargetConst { vector_type } => {
+            const_vector_scale(inst, func, vector_type, isa)
+        }
     }
+}
+
+fn const_vector_scale(inst: ir::Inst, func: &mut ir::Function, ty: ir::Type, isa: &dyn TargetIsa) {
+    assert!(ty.bytes() <= 16);
+
+    // Use a minimum of 128-bits for the base type.
+    let base_bytes = std::cmp::max(ty.bytes(), 16);
+    let scale = (isa.dynamic_vector_bytes(ty) / base_bytes) as i64;
+    assert!(scale > 0);
+    let pos = FuncCursor::new(func).at_inst(inst);
+    pos.func.dfg.replace(inst).iconst(isa.pointer_type(), scale);
 }
 
 /// Expand a `global_value` instruction for a vmctx global.

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -45,7 +45,7 @@
 //! ```
 
 use crate::binemit::{Addend, CodeInfo, CodeOffset, Reloc, StackMap};
-use crate::ir::{SourceLoc, StackSlot, Type};
+use crate::ir::{DynamicStackSlot, SourceLoc, StackSlot, Type};
 use crate::result::CodegenResult;
 use crate::settings::Flags;
 use crate::value_label::ValueLabelsRanges;
@@ -282,7 +282,9 @@ pub struct MachCompileResult {
     /// Debug info: value labels to registers/stackslots at code offsets.
     pub value_labels_ranges: ValueLabelsRanges,
     /// Debug info: stackslots to stack pointer offsets.
-    pub stackslot_offsets: PrimaryMap<StackSlot, u32>,
+    pub sized_stackslot_offsets: PrimaryMap<StackSlot, u32>,
+    /// Debug info: stackslots to stack pointer offsets.
+    pub dynamic_stackslot_offsets: PrimaryMap<DynamicStackSlot, u32>,
     /// Basic-block layout info: block start offsets.
     ///
     /// This info is generated only if the `machine_code_cfg_info`

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -19,7 +19,9 @@
 
 use crate::fx::FxHashMap;
 use crate::fx::FxHashSet;
-use crate::ir::{self, types, Constant, ConstantData, LabelValueLoc, SourceLoc, ValueLabel};
+use crate::ir::{
+    self, types, Constant, ConstantData, DynamicStackSlot, LabelValueLoc, SourceLoc, ValueLabel,
+};
 use crate::machinst::*;
 use crate::timing;
 use crate::ValueLocRange;
@@ -207,8 +209,11 @@ pub struct EmitResult<I: VCodeInst> {
     /// epilogue(s), and makes use of the regalloc results.
     pub disasm: Option<String>,
 
-    /// Offsets of stackslots.
-    pub stackslot_offsets: PrimaryMap<StackSlot, u32>,
+    /// Offsets of sized stackslots.
+    pub sized_stackslot_offsets: PrimaryMap<StackSlot, u32>,
+
+    /// Offsets of dynamic stackslots.
+    pub dynamic_stackslot_offsets: PrimaryMap<DynamicStackSlot, u32>,
 
     /// Value-labels information (debug metadata).
     pub value_labels_ranges: ValueLabelsRanges,
@@ -1038,7 +1043,8 @@ impl<I: VCodeInst> VCode<I> {
             inst_offsets,
             func_body_len,
             disasm: if want_disasm { Some(disasm) } else { None },
-            stackslot_offsets: self.abi.stackslot_offsets().clone(),
+            sized_stackslot_offsets: self.abi.sized_stackslot_offsets().clone(),
+            dynamic_stackslot_offsets: self.abi.dynamic_stackslot_offsets().clone(),
             value_labels_ranges,
             frame_size,
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -256,6 +256,8 @@
 (extern const $F32X4 Type)
 (extern const $F64X2 Type)
 
+(extern const $I32X4XN Type)
+
 ;; Get the bit width of a given type.
 (decl pure ty_bits (Type) u8)
 (extern constructor ty_bits ty_bits)
@@ -289,6 +291,10 @@
 ;; An extractor that only matches types that can fit in 32 bits.
 (decl fits_in_32 (Type) Type)
 (extern extractor fits_in_32 fits_in_32)
+
+;; An extractor that only matches types that can fit in 32 bits.
+(decl lane_fits_in_32 (Type) Type)
+(extern extractor lane_fits_in_32 lane_fits_in_32)
 
 ;; An extractor that only matches types that can fit in 64 bits.
 (decl fits_in_64 (Type) Type)
@@ -432,6 +438,21 @@
 ;; type. Will only match when there is more than one lane.
 (decl multi_lane (u32 u32) Type)
 (extern extractor multi_lane multi_lane)
+
+;; Match a dynamic-lane type, extracting (# bits per lane) from the given
+;; type.
+(decl dynamic_lane (u32 u32) Type)
+(extern extractor dynamic_lane dynamic_lane)
+
+;; Match a dynamic-lane integer type, extracting (# bits per lane) from the given
+;; type.
+(decl dynamic_int_lane (u32) Type)
+(extern extractor dynamic_int_lane dynamic_int_lane)
+
+;; Match a dynamic-lane floating point type, extracting (# bits per lane)
+;; from the given type.
+(decl dynamic_fp_lane (u32) Type)
+(extern extractor dynamic_fp_lane dynamic_fp_lane)
 
 ;; Match the instruction that defines the given value, if any.
 (decl def_inst (Inst) Value)
@@ -727,12 +748,20 @@
 (extern extractor abi_no_ret_arg abi_no_ret_arg)
 
 ;; Size of the argument area.
-(decl abi_stack_arg_space (ABISig) i64)
-(extern constructor abi_stack_arg_space abi_stack_arg_space)
+(decl abi_sized_stack_arg_space (ABISig) i64)
+(extern constructor abi_sized_stack_arg_space abi_sized_stack_arg_space)
 
 ;; Size of the return-value area.
-(decl abi_stack_ret_space (ABISig) i64)
-(extern constructor abi_stack_ret_space abi_stack_ret_space)
+(decl abi_sized_stack_ret_space (ABISig) i64)
+(extern constructor abi_sized_stack_ret_space abi_sized_stack_ret_space)
+
+;; StackSlot addr
+(decl abi_stackslot_addr (WritableReg StackSlot Offset32) MInst)
+(extern constructor abi_stackslot_addr abi_stackslot_addr)
+
+;; DynamicStackSlot addr
+(decl abi_dynamic_stackslot_addr (WritableReg DynamicStackSlot) MInst)
+(extern constructor abi_dynamic_stackslot_addr abi_dynamic_stackslot_addr)
 
 ;; Extractor to detect the special case where an argument or
 ;; return value only requires a single slot to be passed.

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -65,8 +65,8 @@ use crate::ir;
 use crate::ir::entities::AnyEntity;
 use crate::ir::instructions::{BranchInfo, CallInfo, InstructionFormat, ResolvedConstraint};
 use crate::ir::{
-    types, ArgumentPurpose, Block, Constant, FuncRef, Function, GlobalValue, Inst, JumpTable,
-    Opcode, SigRef, StackSlot, Type, Value, ValueDef, ValueList,
+    types, ArgumentPurpose, Block, Constant, DynamicStackSlot, FuncRef, Function, GlobalValue,
+    Inst, JumpTable, Opcode, SigRef, StackSlot, Type, Value, ValueDef, ValueList,
 };
 use crate::isa::TargetIsa;
 use crate::iterators::IteratorExtras;
@@ -681,6 +681,14 @@ impl<'a> Verifier<'a> {
             StackLoad { stack_slot, .. } | StackStore { stack_slot, .. } => {
                 self.verify_stack_slot(inst, stack_slot, errors)?;
             }
+            DynamicStackLoad {
+                dynamic_stack_slot, ..
+            }
+            | DynamicStackStore {
+                dynamic_stack_slot, ..
+            } => {
+                self.verify_dynamic_stack_slot(inst, dynamic_stack_slot, errors)?;
+            }
             UnaryGlobalValue { global_value, .. } => {
                 self.verify_global_value(inst, global_value, errors)?;
             }
@@ -819,11 +827,28 @@ impl<'a> Verifier<'a> {
         ss: StackSlot,
         errors: &mut VerifierErrors,
     ) -> VerifierStepResult<()> {
-        if !self.func.stack_slots.is_valid(ss) {
+        if !self.func.sized_stack_slots.is_valid(ss) {
             errors.nonfatal((
                 inst,
                 self.context(inst),
                 format!("invalid stack slot {}", ss),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn verify_dynamic_stack_slot(
+        &self,
+        inst: Inst,
+        ss: DynamicStackSlot,
+        errors: &mut VerifierErrors,
+    ) -> VerifierStepResult<()> {
+        if !self.func.dynamic_stack_slots.is_valid(ss) {
+            errors.nonfatal((
+                inst,
+                self.context(inst),
+                format!("invalid dynamic stack slot {}", ss),
             ))
         } else {
             Ok(())

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
@@ -1,0 +1,164 @@
+test compile
+target aarch64
+
+function %snarrow_i16x8(i16) -> i8x16 {
+  gv0 = dyn_scale_target_const.i16x8
+  gv1 = dyn_scale_target_const.i8x16
+  dt0 = i16x8*gv0
+  dt1 = i8x16*gv0
+
+block0(v0: i16):
+  v1 = splat.dt0 v0
+  v2 = snarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.8h, w0
+; nextln: sqxtn v0.8b, v2.8h
+; nextln: sqxtn2 v0.16b, v2.8h
+; nextln: ret
+
+function %snarrow_i32x4(i32) -> i16x8 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i16x8
+  dt0 = i32x4*gv0
+  dt1 = i16x8*gv0
+
+block0(v0: i32):
+  v1 = splat.dt0 v0
+  v2 = snarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.4s, w0
+; nextln: sqxtn v0.4h, v2.4s
+; nextln: sqxtn2 v0.8h, v2.4s
+; nextln: ret
+
+function %snarrow_i64x2(i64) -> i32x4 {
+  gv0 = dyn_scale_target_const.i64x2
+  gv1 = dyn_scale_target_const.i32x4
+  dt0 = i64x2*gv0
+  dt1 = i32x4*gv0
+
+block0(v0: i64):
+  v1 = splat.dt0 v0
+  v2 = snarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.2d, x0
+; nextln: sqxtn v0.2s, v2.2d
+; nextln: sqxtn2 v0.4s, v2.2d
+; nextln: ret
+
+function %unarrow_i16x8(i16) -> i8x16 {
+  gv0 = dyn_scale_target_const.i16x8
+  gv1 = dyn_scale_target_const.i8x16
+  dt0 = i16x8*gv0
+  dt1 = i8x16*gv0
+
+block0(v0: i16):
+  v1 = splat.dt0 v0
+  v2 = unarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.8h, w0
+; nextln: sqxtun v0.8b, v2.8h
+; nextln: sqxtun2 v0.16b, v2.8h
+; nextln: ret
+
+function %unarrow_i32x4(i32) -> i16x8 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i16x8
+  dt0 = i32x4*gv0
+  dt1 = i16x8*gv0
+
+block0(v0: i32):
+  v1 = splat.dt0 v0
+  v2 = unarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.4s, w0
+; nextln: sqxtun v0.4h, v2.4s
+; nextln: sqxtun2 v0.8h, v2.4s
+; nextln: ret
+
+function %unarrow_i64x2(i64) -> i32x4 {
+  gv0 = dyn_scale_target_const.i64x2
+  gv1 = dyn_scale_target_const.i32x4
+  dt0 = i64x2*gv0
+  dt1 = i32x4*gv0
+
+block0(v0: i64):
+  v1 = splat.dt0 v0
+  v2 = unarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.2d, x0
+; nextln: sqxtun v0.2s, v2.2d
+; nextln: sqxtun2 v0.4s, v2.2d
+; nextln: ret
+
+function %uunarrow_i16x8(i16) -> i8x16 {
+  gv0 = dyn_scale_target_const.i16x8
+  gv1 = dyn_scale_target_const.i8x16
+  dt0 = i16x8*gv0
+  dt1 = i8x16*gv0
+
+block0(v0: i16):
+  v1 = splat.dt0 v0
+  v2 = uunarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.8h, w0
+; nextln: uqxtn v0.8b, v2.8h
+; nextln: uqxtn2 v0.16b, v2.8h
+; nextln: ret
+
+function %uunarrow_i32x4(i32) -> i16x8 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i16x8
+  dt0 = i32x4*gv0
+  dt1 = i16x8*gv0
+
+block0(v0: i32):
+  v1 = splat.dt0 v0
+  v2 = uunarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.4s, w0
+; nextln: uqxtn v0.4h, v2.4s
+; nextln: uqxtn2 v0.8h, v2.4s
+; nextln: ret
+
+function %uunarrow_i64x2(i64) -> i32x4 {
+  gv0 = dyn_scale_target_const.i64x2
+  gv1 = dyn_scale_target_const.i32x4
+  dt0 = i64x2*gv0
+  dt1 = i32x4*gv0
+
+block0(v0: i64):
+  v1 = splat.dt0 v0
+  v2 = uunarrow.dt0 v1, v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.2d, x0
+; nextln: uqxtn v0.2s, v2.2d
+; nextln: uqxtn2 v0.4s, v2.2d
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
@@ -1,0 +1,104 @@
+test compile
+target aarch64
+
+function %i8x16_splat_add(i8, i8) -> i8x16 {
+  gv0 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv0
+
+block0(v0: i8, v1: i8):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.16b, w0
+; nextln: dup v6.16b, w1
+; nextln: add v0.16b, v4.16b, v6.16b
+; nextln: ret
+
+function %i16x8_splat_add(i16, i16) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv0
+
+block0(v0: i16, v1: i16):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.8h, w0
+; nextln: dup v6.8h, w1
+; nextln: add v0.8h, v4.8h, v6.8h
+; nextln: ret
+
+function %i32x4_splat_mul(i32, i32) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+
+block0(v0: i32, v1: i32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = imul v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.4s, w0
+; nextln: dup v6.4s, w1
+; nextln: mul v0.4s, v4.4s, v6.4s
+; nextln: ret
+
+function %i64x2_splat_sub(i64, i64) -> i64x2 {
+  gv0 = dyn_scale_target_const.i64x2
+  dt0 = i64x2*gv0
+
+block0(v0: i64, v1: i64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = isub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.2d, x0
+; nextln: dup v6.2d, x1
+; nextln: sub v0.2d, v4.2d, v6.2d
+; nextln: ret
+
+function %f32x4_splat_add(f32, f32) -> f32x4 {
+  gv0 = dyn_scale_target_const.f32x4
+  dt0 = f32x4*gv0
+
+block0(v0: f32, v1: f32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.4s, v0.s[0]
+; nextln: dup v6.4s, v1.s[0]
+; nextln: fadd v0.4s, v4.4s, v6.4s
+; nextln: ret
+
+function %f64x2_splat_sub(f64, f64) -> f64x2 {
+  gv0 = dyn_scale_target_const.f64x2
+  dt0 = f64x2*gv0
+
+block0(v0: f64, v1: f64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fsub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+
+; check:  dup v4.2d, v0.d[0]
+; nextln: dup v6.2d, v1.d[0]
+; nextln: fsub v0.2d, v4.2d, v6.2d
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
@@ -1,0 +1,104 @@
+test compile
+target aarch64
+
+function %swidenhigh_i8x16(i8) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  gv1 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv1
+  dt1 = i16x8*gv0
+
+block0(v0: i8):
+  v1 = splat.dt0 v0
+  v2 = swiden_high v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.16b, w0
+; nextln: sxtl2 v0.8h, v2.16b
+; nextln: ret
+
+function %swidenhigh_i16x8(i16) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv1
+  dt1 = i32x4*gv0
+
+block0(v0: i16):
+  v1 = splat.dt0 v0
+  v2 = swiden_high v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.8h, w0
+; nextln: sxtl2 v0.4s, v2.8h
+; nextln: ret
+
+function %swidenhigh_i32x4(i32) -> i64x2 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i64x2
+  dt0 = i64x2*gv1
+  dt1 = i32x4*gv0
+
+block0(v0: i32):
+  v1 = splat.dt1 v0
+  v2 = swiden_high v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.4s, w0
+; nextln: sxtl2 v0.2d, v2.4s
+; nextln: ret
+
+function %swidenlow_i8x16(i8) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  gv1 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv1
+  dt1 = i16x8*gv0
+
+block0(v0: i8):
+  v1 = splat.dt0 v0
+  v2 = swiden_low v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.16b, w0
+; nextln: sxtl v0.8h, v2.8b
+; nextln: ret
+
+function %swidenlow_i16x8(i16) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv1
+  dt1 = i32x4*gv0
+
+block0(v0: i16):
+  v1 = splat.dt0 v0
+  v2 = swiden_low v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.8h, w0
+; nextln: sxtl v0.4s, v2.4h
+; nextln: ret
+
+function %swidenlow_i32x4(i32) -> i64x2 {
+  gv0 = dyn_scale_target_const.i32x4
+  gv1 = dyn_scale_target_const.i64x2
+  dt0 = i64x2*gv1
+  dt1 = i32x4*gv0
+
+block0(v0: i32):
+  v1 = splat.dt1 v0
+  v2 = swiden_low v1
+  v3 = extract_vector v2, 0
+  return v3
+}
+
+; check: dup v2.4s, w0
+; nextln: sxtl v0.2d, v2.2s
+; nextln: ret

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -1,0 +1,129 @@
+test compile precise-output
+target aarch64
+
+function %store_scale() {
+  gv0 = dyn_scale_target_const.i32x4
+  ss0 = explicit_slot 8
+
+block0:
+  v0 = global_value.i64 gv0
+  stack_store.i64 v0, ss0
+  return
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   mov x0, sp
+;   movz x2, #1
+;   str x2, [x0]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %store_scale_lt_128() {
+  gv0 = dyn_scale_target_const.i16x4
+  ss0 = explicit_slot 8
+
+block0:
+  v0 = global_value.i64 gv0
+  stack_store.i64 v0, ss0
+  return
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   mov x0, sp
+;   movz x2, #1
+;   str x2, [x0]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %store_explicit(i32) {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+  dss0 = explicit_dynamic_slot dt0
+
+block0(v0: i32):
+  v1 = splat.dt0 v0
+  dynamic_stack_store.dt0 v1, dss0
+  return
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   dup v2.4s, w0
+;   mov x4, sp
+;   str q2, [x4]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %load_explicit() -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+  dss0 = explicit_dynamic_slot dt0
+
+block0:
+  v0 = dynamic_stack_load.dt0 dss0
+  v1 = extract_vector.dt0 v0, 0
+  return v1
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   mov x3, sp
+;   ldr q0, [x3]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %store_implicit(i32) {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+  dss0 = explicit_dynamic_slot dt0
+
+block0(v0: i32):
+  v1 = splat.dt0 v0
+  dynamic_stack_store v1, dss0
+  return
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   dup v2.4s, w0
+;   mov x4, sp
+;   str q2, [x4]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %addr() -> i64 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+  dss0 = explicit_dynamic_slot dt0
+
+block0:
+  v0 = dynamic_stack_addr.i64 dss0
+  return v0
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   mov x0, sp
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/dynamic-simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/dynamic-simd-arithmetic.clif
@@ -1,0 +1,197 @@
+test run
+target aarch64
+
+function %i8x16_splat_add(i8, i8) -> i8x16 {
+  gv0 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv0
+
+block0(v0: i8, v1: i8):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i8x16_splat_add(1, 3) == [4 4 4 4 4 4 4 4 4 4 4 4 4 4 4 4]
+
+function %i16x8_splat_add(i16, i16) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv0
+
+block0(v0: i16, v1: i16):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i16x8_splat_add(255, 254) == [509 509 509 509 509 509 509 509]
+
+function %i32x4_splat_add(i32, i32) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+
+block0(v0: i32, v1: i32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i32sv_splat_add(1234, 8765) == [9999 9999 9999 9999]
+
+function %i64x2_splat_add(i64, i64) -> i64x2 {
+  gv0 = dyn_scale_target_const.i64x2
+  dt0 = i64x2*gv0
+
+block0(v0: i64, v1: i64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = iadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i64x2_splat_add(4321, 8765) == [13086 13086]
+
+function %i8x16_splat_sub(i8, i8) -> i8x16 {
+  gv0 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv0
+
+block0(v0: i8, v1: i8):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = isub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i8x16_splat_sub(127, 126) == [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+
+function %i16x8_splat_sub(i16, i16) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv0
+
+block0(v0: i16, v1: i16):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = isub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i16x8_splat_sub(12345, 6789) == [5556 5556 5556 5556 5556 5556 5556 5556]
+
+function %i32x4_splat_sub(i32, i32) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+
+block0(v0: i32, v1: i32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = isub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i32x4_splat_sub(1, 3) == [-2 -2 -2 -2]
+
+function %i64x2_splat_sub(i64, i64) -> i64x2 {
+  gv0 = dyn_scale_target_const.i64x2
+  dt0 = i64x2*gv0
+
+block0(v0: i64, v1: i64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = isub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i64x2_splat_sub(255, 65535) == [-65280 -65280]
+
+function %i8x16_splat_mul(i8, i8) -> i8x16 {
+  gv0 = dyn_scale_target_const.i8x16
+  dt0 = i8x16*gv0
+
+block0(v0: i8, v1: i8):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = imul v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i8x16_splat_mul(15, 15) == [225 225 225 225 225 225 225 225 225 225 225 225 225 225 225 225]
+
+function %i16x8_splat_mul(i16, i16) -> i16x8 {
+  gv0 = dyn_scale_target_const.i16x8
+  dt0 = i16x8*gv0
+
+block0(v0: i16, v1: i16):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = imul v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i16x8_splat_mul(135, 246) == [33210 33210 33210 33210 33210 33210 33210 33210]
+
+function %i32x4_splat_mul(i32, i32) -> i32x4 {
+  gv0 = dyn_scale_target_const.i32x4
+  dt0 = i32x4*gv0
+
+block0(v0: i32, v1: i32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = imul v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %i32x4_splat_mul(2, 3) == [6 6 6 6]
+
+function %f32x4_splat_add(f32, f32) -> f32x4 {
+  gv0 = dyn_scale_target_const.f32x4
+  dt0 = f32x4*gv0
+
+block0(v0: f32, v1: f32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %f32x4_splat_add(0x1.2, 0x3.4) == [0x4.6 0x4.6 0x4.6 0x4.6]
+
+function %f64x2_splat_add(f64, f64) -> f64x2 {
+  gv0 = dyn_scale_target_const.f64x2
+  dt0 = f64x2*gv0
+
+block0(v0: f64, v1: f64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fadd v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %f64x2_splat_add(0x1.0, 0x2.0) == [0x3.0 0x3.0]
+
+function %f32x4_splat_sub(f32, f32) -> f32x4 {
+  gv0 = dyn_scale_target_const.f32x4
+  dt0 = f32x4*gv0
+
+block0(v0: f32, v1: f32):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fsub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %f32x4_splat_sub(0x1.2, 0x3.4) == [-0x2.2 -0x2.2 -0x2.2 -0x2.2]
+
+function %f64x2_splat_sub(f64, f64) -> f64x2 {
+  gv0 = dyn_scale_target_const.f64x2
+  dt0 = f64x2*gv0
+
+block0(v0: f64, v1: f64):
+  v2 = splat.dt0 v0
+  v3 = splat.dt0 v1
+  v4 = fsub v2, v3
+  v5 = extract_vector v4, 0
+  return v5
+}
+; run: %f64x2_splat_sub(0x1.0, 0x3.0) == [-0x2.0 -0x2.0]

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -6,10 +6,11 @@ use cranelift_codegen::entity::{EntitySet, SecondaryMap};
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{
-    types, AbiParam, Block, DataFlowGraph, ExtFuncData, ExternalName, FuncRef, Function,
-    GlobalValue, GlobalValueData, Heap, HeapData, Inst, InstBuilder, InstBuilderBase,
-    InstructionData, JumpTable, JumpTableData, LibCall, MemFlags, SigRef, Signature, StackSlot,
-    StackSlotData, Type, Value, ValueLabel, ValueLabelAssignments, ValueLabelStart,
+    types, AbiParam, Block, DataFlowGraph, DynamicStackSlot, DynamicStackSlotData, ExtFuncData,
+    ExternalName, FuncRef, Function, GlobalValue, GlobalValueData, Heap, HeapData, Inst,
+    InstBuilder, InstBuilderBase, InstructionData, JumpTable, JumpTableData, LibCall, MemFlags,
+    SigRef, Signature, StackSlot, StackSlotData, Type, Value, ValueLabel, ValueLabelAssignments,
+    ValueLabelStart,
 };
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_codegen::packed_option::PackedOption;
@@ -370,10 +371,16 @@ impl<'a> FunctionBuilder<'a> {
         self.func.create_jump_table(data)
     }
 
-    /// Creates a stack slot in the function, to be used by `stack_load`, `stack_store` and
+    /// Creates a sized stack slot in the function, to be used by `stack_load`, `stack_store` and
     /// `stack_addr` instructions.
-    pub fn create_stack_slot(&mut self, data: StackSlotData) -> StackSlot {
-        self.func.create_stack_slot(data)
+    pub fn create_sized_stack_slot(&mut self, data: StackSlotData) -> StackSlot {
+        self.func.create_sized_stack_slot(data)
+    }
+
+    /// Creates a dynamic stack slot in the function, to be used by `dynamic_stack_load`,
+    /// `dynamic_stack_store` and `dynamic_stack_addr` instructions.
+    pub fn create_dynamic_stack_slot(&mut self, data: DynamicStackSlotData) -> DynamicStackSlot {
+        self.func.create_dynamic_stack_slot(data)
     }
 
     /// Adds a signature which can later be used to declare an external function import.

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -381,6 +381,9 @@ where
                 })
             })
         }
+        Opcode::DynamicStackAddr => unimplemented!("DynamicStackSlot"),
+        Opcode::DynamicStackLoad => unimplemented!("DynamicStackLoad"),
+        Opcode::DynamicStackStore => unimplemented!("DynamicStackStore"),
         Opcode::GlobalValue => {
             if let InstructionData::UnaryGlobalValue { global_value, .. } = inst {
                 assign_or_memtrap(state.resolve_global_value(global_value))
@@ -995,6 +998,9 @@ where
             assign(vectorizelanes(&new_vec, ctrl_ty)?)
         }
         Opcode::IaddPairwise => assign(binary_pairwise(arg(0)?, arg(1)?, ctrl_ty, Value::add)?),
+        Opcode::ExtractVector => {
+            unimplemented!("ExtractVector not supported");
+        }
     })
 }
 

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -15,40 +15,43 @@ use std::u16;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Token<'a> {
     Comment(&'a str),
-    LPar,                 // '('
-    RPar,                 // ')'
-    LBrace,               // '{'
-    RBrace,               // '}'
-    LBracket,             // '['
-    RBracket,             // ']'
-    Minus,                // '-'
-    Plus,                 // '+'
-    Comma,                // ','
-    Dot,                  // '.'
-    Colon,                // ':'
-    Equal,                // '='
-    Not,                  // '!'
-    Arrow,                // '->'
-    Float(&'a str),       // Floating point immediate
-    Integer(&'a str),     // Integer immediate
-    Type(types::Type),    // i32, f32, b32x4, ...
-    Value(Value),         // v12, v7
-    Block(Block),         // block3
-    Cold,                 // cold (flag on block)
-    StackSlot(u32),       // ss3
-    GlobalValue(u32),     // gv3
-    Heap(u32),            // heap2
-    Table(u32),           // table2
-    JumpTable(u32),       // jt2
-    Constant(u32),        // const2
-    FuncRef(u32),         // fn2
-    SigRef(u32),          // sig2
-    UserRef(u32),         // u345
-    Name(&'a str),        // %9arbitrary_alphanum, %x3, %0, %function ...
-    String(&'a str),      // "arbitrary quoted string with no escape" ...
-    HexSequence(&'a str), // #89AF
-    Identifier(&'a str),  // Unrecognized identifier (opcode, enumerator, ...)
-    SourceLoc(&'a str),   // @00c7
+    LPar,                  // '('
+    RPar,                  // ')'
+    LBrace,                // '{'
+    RBrace,                // '}'
+    LBracket,              // '['
+    RBracket,              // ']'
+    Minus,                 // '-'
+    Plus,                  // '+'
+    Multiply,              // '*'
+    Comma,                 // ','
+    Dot,                   // '.'
+    Colon,                 // ':'
+    Equal,                 // '='
+    Not,                   // '!'
+    Arrow,                 // '->'
+    Float(&'a str),        // Floating point immediate
+    Integer(&'a str),      // Integer immediate
+    Type(types::Type),     // i32, f32, b32x4, ...
+    DynamicType(u32),      // dt5
+    Value(Value),          // v12, v7
+    Block(Block),          // block3
+    Cold,                  // cold (flag on block)
+    StackSlot(u32),        // ss3
+    DynamicStackSlot(u32), // dss4
+    GlobalValue(u32),      // gv3
+    Heap(u32),             // heap2
+    Table(u32),            // table2
+    JumpTable(u32),        // jt2
+    Constant(u32),         // const2
+    FuncRef(u32),          // fn2
+    SigRef(u32),           // sig2
+    UserRef(u32),          // u345
+    Name(&'a str),         // %9arbitrary_alphanum, %x3, %0, %function ...
+    String(&'a str),       // "arbitrary quoted string with no escape" ...
+    HexSequence(&'a str),  // #89AF
+    Identifier(&'a str),   // Unrecognized identifier (opcode, enumerator, ...)
+    SourceLoc(&'a str),    // @00c7
 }
 
 /// A `Token` with an associated location.
@@ -341,6 +344,8 @@ impl<'a> Lexer<'a> {
             "v" => Value::with_number(number).map(Token::Value),
             "block" => Block::with_number(number).map(Token::Block),
             "ss" => Some(Token::StackSlot(number)),
+            "dss" => Some(Token::DynamicStackSlot(number)),
+            "dt" => Some(Token::DynamicType(number)),
             "gv" => Some(Token::GlobalValue(number)),
             "heap" => Some(Token::Heap(number)),
             "table" => Some(Token::Table(number)),
@@ -482,6 +487,7 @@ impl<'a> Lexer<'a> {
                 Some('=') => Some(self.scan_char(Token::Equal)),
                 Some('!') => Some(self.scan_char(Token::Not)),
                 Some('+') => Some(self.scan_number()),
+                Some('*') => Some(self.scan_char(Token::Multiply)),
                 Some('-') => {
                     if self.looking_at("->") {
                         Some(self.scan_chars(2, Token::Arrow))

--- a/cranelift/reader/src/sourcemap.rs
+++ b/cranelift/reader/src/sourcemap.rs
@@ -8,9 +8,10 @@
 
 use crate::error::{Location, ParseResult};
 use crate::lexer::split_entity_name;
-use cranelift_codegen::ir::entities::AnyEntity;
+use cranelift_codegen::ir::entities::{AnyEntity, DynamicType};
 use cranelift_codegen::ir::{
-    Block, Constant, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot, Table, Value,
+    Block, Constant, DynamicStackSlot, FuncRef, GlobalValue, Heap, JumpTable, SigRef, StackSlot,
+    Table, Value,
 };
 use std::collections::HashMap;
 
@@ -36,6 +37,11 @@ impl SourceMap {
     /// Look up a stack slot entity.
     pub fn contains_ss(&self, ss: StackSlot) -> bool {
         self.locations.contains_key(&ss.into())
+    }
+
+    /// Look up a dynamic stack slot entity.
+    pub fn contains_dss(&self, dss: DynamicStackSlot) -> bool {
+        self.locations.contains_key(&dss.into())
     }
 
     /// Look up a global value entity.
@@ -170,6 +176,16 @@ impl SourceMap {
 
     /// Define the stack slot `entity`.
     pub fn def_ss(&mut self, entity: StackSlot, loc: Location) -> ParseResult<()> {
+        self.def_entity(entity.into(), loc)
+    }
+
+    /// Define the dynamic stack slot `entity`.
+    pub fn def_dss(&mut self, entity: DynamicStackSlot, loc: Location) -> ParseResult<()> {
+        self.def_entity(entity.into(), loc)
+    }
+
+    /// Define the dynamic type `entity`.
+    pub fn def_dt(&mut self, entity: DynamicType, loc: Location) -> ParseResult<()> {
         self.def_entity(entity.into(), loc)
     }
 

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -575,7 +575,7 @@ impl Mutator for RemoveUnusedEntities {
 
                 let mut stack_slots = StackSlots::new();
 
-                for (stack_slot, stack_slot_data) in func.stack_slots.clone().iter() {
+                for (stack_slot, stack_slot_data) in func.sized_stack_slots.clone().iter() {
                     if let Some(stack_slot_usage) = stack_slot_usage_map.get(&stack_slot) {
                         let new_stack_slot = stack_slots.push(stack_slot_data.clone());
                         for &inst in stack_slot_usage {
@@ -591,7 +591,7 @@ impl Mutator for RemoveUnusedEntities {
                     }
                 }
 
-                func.stack_slots = stack_slots;
+                func.sized_stack_slots = stack_slots;
 
                 "Remove unused stack slots"
             }
@@ -617,9 +617,9 @@ impl Mutator for RemoveUnusedEntities {
                         // These can create cyclic references, which cause complications. Just skip
                         // the global value removal for now.
                         // FIXME Handle them in a better way.
-                        GlobalValueData::Load { .. } | GlobalValueData::IAddImm { .. } => {
-                            return None
-                        }
+                        GlobalValueData::Load { .. }
+                        | GlobalValueData::IAddImm { .. }
+                        | GlobalValueData::DynScaleTargetConst { .. } => return None,
                     }
                 }
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -264,7 +264,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let length = u32::try_from(code_buf.len()).unwrap();
 
-        let stack_slots = std::mem::take(&mut context.func.stack_slots);
+        let sized_stack_slots = std::mem::take(&mut context.func.sized_stack_slots);
 
         self.save_context(CompilerContext {
             func_translator,
@@ -275,7 +275,7 @@ impl wasmtime_environ::Compiler for Compiler {
             body: code_buf,
             relocations: func_relocs,
             value_labels_ranges: ranges.unwrap_or(Default::default()),
-            stack_slots,
+            sized_stack_slots,
             unwind_info,
             traps,
             info: FunctionInfo {
@@ -613,7 +613,7 @@ impl Compiler {
         let values_vec_byte_size = u32::try_from(value_size * values_vec_len).unwrap();
         let values_vec_len = u32::try_from(values_vec_len).unwrap();
 
-        let ss = builder.func.create_stack_slot(ir::StackSlotData::new(
+        let ss = builder.func.create_sized_stack_slot(ir::StackSlotData::new(
             ir::StackSlotKind::ExplicitSlot,
             values_vec_byte_size,
         ));
@@ -712,7 +712,7 @@ impl Compiler {
             body: code_buf,
             unwind_info,
             relocations: Vec::new(),
-            stack_slots: Default::default(),
+            sized_stack_slots: Default::default(),
             value_labels_ranges: Default::default(),
             info: Default::default(),
             address_map: Default::default(),

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -17,7 +17,7 @@ use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 pub struct FunctionFrameInfo<'a> {
     pub value_ranges: &'a ValueLabelsRanges,
     pub memory_offset: ModuleMemoryOffset,
-    pub stack_slots: &'a StackSlots,
+    pub sized_stack_slots: &'a StackSlots,
 }
 
 impl<'a> FunctionFrameInfo<'a> {
@@ -1207,11 +1207,11 @@ mod tests {
         use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
         let addr_tr = create_mock_address_transform();
-        let stack_slots = StackSlots::new();
+        let sized_stack_slots = StackSlots::new();
         let (value_ranges, value_labels) = create_mock_value_ranges();
         let fi = FunctionFrameInfo {
             memory_offset: ModuleMemoryOffset::None,
-            stack_slots: &stack_slots,
+            sized_stack_slots: &sized_stack_slots,
             value_ranges: &value_ranges,
         };
 

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -178,7 +178,7 @@ where
         let frame_info = FunctionFrameInfo {
             value_ranges: &func.value_labels_ranges,
             memory_offset: memory_offset.clone(),
-            stack_slots: &func.stack_slots,
+            sized_stack_slots: &func.sized_stack_slots,
         };
         Some(frame_info)
     } else {

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -42,8 +42,9 @@ pub struct CompiledFunction {
 
     relocations: Vec<Relocation>,
     value_labels_ranges: cranelift_codegen::ValueLabelsRanges,
-    stack_slots: ir::StackSlots,
+    sized_stack_slots: ir::StackSlots,
 
+    // TODO: Add dynamic_stack_slots?
     info: FunctionInfo,
 }
 


### PR DESCRIPTION
Introduce a new concept in the IR that allows a producer to create
dynamic vector types. An IR function can now contain global value(s)
that represent a dynamic scaling factor, for a given fixed-width
vector type. A dynamic type is then created by 'multiplying' the
corresponding global value with a fixed-width type. These new types
can be used just like the existing types and the type system has a
set of hard-coded dynamic types, such as I32X4XN, which the user
defined types map onto. The dynamic types are also used explicitly
to create dynamic stack slots, which have no set size like their
existing counterparts. New IR instructions are added to access these
new stack entities.

Currently, during codegen, the dynamic scaling factor has to be
lowered to a constant so the dynamic slots do eventually have a
compile-time known size, as do spill slots.

The current lowering for aarch64 just targets Neon, using a dynamic
scale of 1.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
