### PR TITLE
bench-api: configure WASI modules based on passed flags

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -31,6 +31,6 @@ cap-std = "0.26.0"
 wat = "1.0.45"
 
 [features]
-default = ["shuffling-allocator"]
+default = ["shuffling-allocator", "wasi-crypto", "wasi-nn"]
 wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -31,6 +31,6 @@ cap-std = "0.26.0"
 wat = "1.0.45"
 
 [features]
-default = ["shuffling-allocator", "wasi-crypto", "wasi-nn"]
+default = ["shuffling-allocator", "wasi-nn"]
 wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]


### PR DESCRIPTION
When benchmarking in Sightglass, @brianjjones has found it necessary to
enable the wasi-nn module. The current way to do so is to alter the
engine build script to pass `--features wasi-nn` so that this crate can
run code relying on these imports. This change allows the user to
instead pass the WASI modules using the engine flags added in #4096.
This could look something like the following in Sightglass:

```
sightglass-cli benchmark ... --engine-flags '--wasi-modules experimental-wasi-nn'
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
