### PR TITLE
Implement module imports into components

### DIFF
--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -130,6 +130,10 @@ indices! {
 
     /// Same as `RuntimeMemoryIndex` except for the `realloc` function.
     pub struct RuntimeReallocIndex(u32);
+
+    /// Index that represents an exported module from a component since that's
+    /// currently the only use for saving the entire module state at runtime.
+    pub struct RuntimeModuleIndex(u32);
 }
 
 // Reexport for convenience some core-wasm indices which are also used in the

--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -1,0 +1,272 @@
+use crate::component::instance::RuntimeImport;
+use crate::component::matching::TypeChecker;
+use crate::component::{Component, Instance, InstancePre};
+use crate::{AsContextMut, Engine, Module};
+use anyhow::{anyhow, bail, Context, Result};
+use std::collections::hash_map::{Entry, HashMap};
+use std::marker;
+use std::sync::Arc;
+use wasmtime_environ::PrimaryMap;
+
+/// A type used to instantiate [`Component`]s.
+///
+/// This type is used to both link components together as well as supply host
+/// functionality to components. Values are defined in a [`Linker`] by their
+/// import name and then components are instantiated with a [`Linker`] using the
+/// names provided for name resolution of the component's imports.
+pub struct Linker<T> {
+    engine: Engine,
+    strings: Strings,
+    map: NameMap,
+    allow_shadowing: bool,
+    _marker: marker::PhantomData<fn() -> T>,
+}
+
+#[derive(Default)]
+pub struct Strings {
+    string2idx: HashMap<Arc<str>, usize>,
+    strings: Vec<Arc<str>>,
+}
+
+/// Structure representing an "instance" being defined within a linker.
+///
+/// Instances do not need to be actual [`Instance`]s and instead are defined by
+/// a "bag of named items", so each [`LinkerInstance`] can further define items
+/// internally.
+pub struct LinkerInstance<'a, T> {
+    strings: &'a mut Strings,
+    map: &'a mut NameMap,
+    allow_shadowing: bool,
+    _marker: marker::PhantomData<fn() -> T>,
+}
+
+pub type NameMap = HashMap<usize, Definition>;
+
+#[derive(Clone)]
+pub enum Definition {
+    Instance(NameMap),
+    Module(Module),
+}
+
+impl<T> Linker<T> {
+    /// Creates a new linker for the [`Engine`] specified with no items defined
+    /// within it.
+    pub fn new(engine: &Engine) -> Linker<T> {
+        Linker {
+            engine: engine.clone(),
+            strings: Strings::default(),
+            map: NameMap::default(),
+            allow_shadowing: false,
+            _marker: marker::PhantomData,
+        }
+    }
+
+    /// Returns the [`Engine`] this is connected to.
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// Configures whether or not name-shadowing is allowed.
+    ///
+    /// By default name shadowing is not allowed and it's an error to redefine
+    /// the same name within a linker.
+    pub fn allow_shadowing(&mut self, allow: bool) -> &mut Self {
+        self.allow_shadowing = allow;
+        self
+    }
+
+    /// Returns the "root instance" of this linker, used to define names into
+    /// the root namespace.
+    pub fn root(&mut self) -> LinkerInstance<'_, T> {
+        LinkerInstance {
+            strings: &mut self.strings,
+            map: &mut self.map,
+            allow_shadowing: self.allow_shadowing,
+            _marker: self._marker,
+        }
+    }
+
+    /// Returns a builder for the named instance specified.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is already defined within the linker.
+    pub fn instance(&mut self, name: &str) -> Result<LinkerInstance<'_, T>> {
+        self.root().into_instance(name)
+    }
+
+    /// Performs a "pre-instantiation" to resolve the imports of the
+    /// [`Component`] specified with the items defined within this linker.
+    ///
+    /// This method will perform as much work as possible short of actually
+    /// instnatiating an instance. Internally this will use the names defined
+    /// within this linker to satisfy the imports of the [`Component`] provided.
+    /// Additionally this will perform type-checks against the component's
+    /// imports against all items defined within this linker.
+    ///
+    /// Note that unlike internally in components where subtyping at the
+    /// interface-types layer is supported this is not supported here. Items
+    /// defined in this linker must match the component's imports precisely.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this linker doesn't define a name that the
+    /// `component` imports or if a name defined doesn't match the type of the
+    /// item imported by the `component` provided.
+    pub fn instantiate_pre(&self, component: &Component) -> Result<InstancePre<T>> {
+        let cx = TypeChecker {
+            types: component.types(),
+            strings: &self.strings,
+        };
+
+        // Walk over the component's list of import names and use that to lookup
+        // the definition within this linker that it corresponds to. When found
+        // perform a typecheck against the component's expected type.
+        let env_component = component.env_component();
+        for (_idx, (name, ty)) in env_component.import_types.iter() {
+            let import = self
+                .strings
+                .lookup(name)
+                .and_then(|name| self.map.get(&name))
+                .ok_or_else(|| anyhow!("import `{name}` not defined"))?;
+            cx.definition(ty, import)
+                .with_context(|| format!("import `{name}` has the wrong type"))?;
+        }
+
+        // Now that all imports are known to be defined and satisfied by this
+        // linker a list of "flat" import items (aka no instances) is created
+        // using the import map within the component created at
+        // component-compile-time.
+        let mut imports = PrimaryMap::with_capacity(env_component.imports.len());
+        for (idx, (import, names)) in env_component.imports.iter() {
+            let (root, _) = &env_component.import_types[*import];
+            let root = self.strings.lookup(root).unwrap();
+
+            // This is the flattening process where we go from a definition
+            // optionally through a list of exported names to get to the final
+            // item.
+            let mut cur = &self.map[&root];
+            for name in names {
+                let name = self.strings.lookup(name).unwrap();
+                cur = match cur {
+                    Definition::Instance(map) => &map[&name],
+                    _ => unreachable!(),
+                };
+            }
+            let import = match cur {
+                Definition::Module(m) => RuntimeImport::Module(m.clone()),
+
+                // This is guaranteed by the compilation process that "leaf"
+                // runtime imports are never instances.
+                Definition::Instance(_) => unreachable!(),
+            };
+            let i = imports.push(import);
+            assert_eq!(i, idx);
+        }
+        Ok(unsafe { InstancePre::new_unchecked(component.clone(), imports) })
+    }
+
+    /// Instantiates the [`Component`] provided into the `store` specified.
+    ///
+    /// This function will use the items defined within this [`Linker`] to
+    /// satisfy the imports of the [`Component`] provided as necessary. For more
+    /// information about this see [`Linker::instantiate_pre`] as well.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this [`Linker`] doesn't define an import that
+    /// `component` requires or if it is of the wrong type. Additionally this
+    /// can return an error if something goes wrong during instantiation such as
+    /// a runtime trap or a runtime limit being exceeded.
+    pub fn instantiate(
+        &self,
+        store: impl AsContextMut<Data = T>,
+        component: &Component,
+    ) -> Result<Instance> {
+        self.instantiate_pre(component)?.instantiate(store)
+    }
+}
+
+impl<T> LinkerInstance<'_, T> {
+    fn as_mut(&mut self) -> LinkerInstance<'_, T> {
+        LinkerInstance {
+            strings: self.strings,
+            map: self.map,
+            allow_shadowing: self.allow_shadowing,
+            _marker: self._marker,
+        }
+    }
+
+    /// Defines a [`Module`] within this instance.
+    ///
+    /// This can be used to provide a core wasm [`Module`] as an import to a
+    /// component. The [`Module`] provided is saved within the linker for the
+    /// specified `name` in this instance.
+    pub fn module(&mut self, name: &str, module: &Module) -> Result<()> {
+        let name = self.strings.intern(name);
+        self.insert(name, Definition::Module(module.clone()))
+    }
+
+    /// Defines a nested instance within this instance.
+    ///
+    /// This can be used to describe arbitrarily nested levels of instances
+    /// within a linker to satisfy nested instance exports of components.
+    pub fn instance(&mut self, name: &str) -> Result<LinkerInstance<'_, T>> {
+        self.as_mut().into_instance(name)
+    }
+
+    /// Same as [`LinkerInstance::instance`] except with different liftime
+    /// parameters.
+    pub fn into_instance(mut self, name: &str) -> Result<Self> {
+        let name = self.strings.intern(name);
+        let item = Definition::Instance(NameMap::default());
+        let slot = match self.map.entry(name) {
+            Entry::Occupied(_) if !self.allow_shadowing => {
+                bail!("import of `{}` defined twice", self.strings.strings[name])
+            }
+            Entry::Occupied(o) => {
+                let slot = o.into_mut();
+                *slot = item;
+                slot
+            }
+            Entry::Vacant(v) => v.insert(item),
+        };
+        self.map = match slot {
+            Definition::Instance(map) => map,
+            _ => unreachable!(),
+        };
+        Ok(self)
+    }
+
+    fn insert(&mut self, key: usize, item: Definition) -> Result<()> {
+        match self.map.entry(key) {
+            Entry::Occupied(_) if !self.allow_shadowing => {
+                bail!("import of `{}` defined twice", self.strings.strings[key])
+            }
+            Entry::Occupied(mut e) => {
+                e.insert(item);
+            }
+            Entry::Vacant(v) => {
+                v.insert(item);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Strings {
+    fn intern(&mut self, string: &str) -> usize {
+        if let Some(idx) = self.string2idx.get(string) {
+            return *idx;
+        }
+        let string: Arc<str> = string.into();
+        let idx = self.strings.len();
+        self.strings.push(string.clone());
+        self.string2idx.insert(string, idx);
+        idx
+    }
+
+    pub fn lookup(&self, string: &str) -> Option<usize> {
+        self.string2idx.get(string).cloned()
+    }
+}

--- a/crates/wasmtime/src/component/matching.rs
+++ b/crates/wasmtime/src/component/matching.rs
@@ -1,0 +1,84 @@
+use crate::component::linker::{Definition, NameMap, Strings};
+use crate::types::matching;
+use crate::Module;
+use anyhow::{anyhow, bail, Context, Result};
+use wasmtime_environ::component::{ComponentInstanceType, ComponentTypes, ModuleType, TypeDef};
+
+pub struct TypeChecker<'a> {
+    pub types: &'a ComponentTypes,
+    pub strings: &'a Strings,
+}
+
+impl TypeChecker<'_> {
+    pub fn definition(&self, expected: &TypeDef, actual: &Definition) -> Result<()> {
+        match *expected {
+            TypeDef::Module(t) => match actual {
+                Definition::Module(actual) => self.module(&self.types[t], actual),
+                _ => bail!("expected module found {}", actual.desc()),
+            },
+            TypeDef::ComponentInstance(t) => match actual {
+                Definition::Instance(actual) => self.instance(&self.types[t], actual),
+                _ => bail!("expected instance found {}", actual.desc()),
+            },
+            TypeDef::Func(_) => bail!("expected func found {}", actual.desc()),
+            TypeDef::Component(_) => bail!("expected component found {}", actual.desc()),
+            TypeDef::Interface(_) => bail!("expected type found {}", actual.desc()),
+        }
+    }
+
+    fn module(&self, expected: &ModuleType, actual: &Module) -> Result<()> {
+        let actual_types = actual.types();
+        let actual = actual.env_module();
+
+        // Every export that is expected should be in the actual module we have
+        for (name, expected) in expected.exports.iter() {
+            let idx = actual
+                .exports
+                .get(name)
+                .ok_or_else(|| anyhow!("module export `{name}` not defined"))?;
+            let actual = actual.type_of(*idx);
+            matching::entity_ty(expected, self.types.module_types(), &actual, actual_types)
+                .with_context(|| format!("module export `{name}` has the wrong type"))?;
+        }
+
+        // Note the opposite order of checks here. Every import that the actual
+        // module expects should be imported by the expected module since the
+        // expected module has the set of items given to the actual module.
+        // Additionally the "matches" check is inverted here.
+        for (module, name, actual) in actual.imports() {
+            // TODO: shouldn't need a `.to_string()` here ideally
+            let expected = expected
+                .imports
+                .get(&(module.to_string(), name.to_string()))
+                .ok_or_else(|| anyhow!("module import `{module}::{name}` not defined"))?;
+            matching::entity_ty(&actual, actual_types, expected, self.types.module_types())
+                .with_context(|| format!("module import `{module}::{name}` has the wrong type"))?;
+        }
+        Ok(())
+    }
+
+    fn instance(&self, expected: &ComponentInstanceType, actual: &NameMap) -> Result<()> {
+        // Like modules, every export in the expected type must be present in
+        // the actual type. It's ok, though, to have extra exports in the actual
+        // type.
+        for (name, expected) in expected.exports.iter() {
+            let actual = self
+                .strings
+                .lookup(name)
+                .and_then(|name| actual.get(&name))
+                .ok_or_else(|| anyhow!("instance export `{name}` not defined"))?;
+            self.definition(expected, actual)
+                .with_context(|| format!("instance export `{name}` has the wrong type"))?;
+        }
+        Ok(())
+    }
+}
+
+impl Definition {
+    fn desc(&self) -> &'static str {
+        match self {
+            Definition::Module(_) => "module",
+            Definition::Instance(_) => "instance",
+        }
+    }
+}

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -6,10 +6,13 @@
 mod component;
 mod func;
 mod instance;
+mod linker;
+mod matching;
 mod store;
 pub use self::component::Component;
 pub use self::func::{ComponentParams, ComponentValue, Func, Op, TypedFunc, WasmList, WasmStr};
-pub use self::instance::Instance;
+pub use self::instance::{Instance, InstancePre};
+pub use self::linker::Linker;
 
 // These items are expected to be used by an eventual
 // `#[derive(ComponentValue)]`, they are not part of Wasmtime's API stability

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -1,7 +1,7 @@
 use crate::linker::Definition;
 use crate::store::StoreOpaque;
 use crate::{signatures::SignatureCollection, Engine, Extern};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
     EntityType, Global, Memory, ModuleTypes, SignatureIndex, Table, WasmFuncType, WasmType,
 };
@@ -16,82 +16,23 @@ pub struct MatchCx<'a> {
 
 impl MatchCx<'_> {
     pub fn global(&self, expected: &Global, actual: &crate::Global) -> Result<()> {
-        self.global_ty(expected, actual.wasmtime_ty(self.store.store_data()))
-    }
-
-    fn global_ty(&self, expected: &Global, actual: &Global) -> Result<()> {
-        match_ty(expected.wasm_ty, actual.wasm_ty, "global")?;
-        match_bool(
-            expected.mutability,
-            actual.mutability,
-            "global",
-            "mutable",
-            "immutable",
-        )?;
-        Ok(())
+        global_ty(expected, actual.wasmtime_ty(self.store.store_data()))
     }
 
     pub fn table(&self, expected: &Table, actual: &crate::Table) -> Result<()> {
-        self.table_ty(
+        table_ty(
             expected,
             actual.wasmtime_ty(self.store.store_data()),
             Some(actual.internal_size(self.store)),
         )
-    }
-
-    fn table_ty(
-        &self,
-        expected: &Table,
-        actual: &Table,
-        actual_runtime_size: Option<u32>,
-    ) -> Result<()> {
-        match_ty(expected.wasm_ty, actual.wasm_ty, "table")?;
-        match_limits(
-            expected.minimum.into(),
-            expected.maximum.map(|i| i.into()),
-            actual_runtime_size.unwrap_or(actual.minimum).into(),
-            actual.maximum.map(|i| i.into()),
-            "table",
-        )?;
-        Ok(())
     }
 
     pub fn memory(&self, expected: &Memory, actual: &crate::Memory) -> Result<()> {
-        self.memory_ty(
+        memory_ty(
             expected,
             actual.wasmtime_ty(self.store.store_data()),
             Some(actual.internal_size(self.store)),
         )
-    }
-
-    fn memory_ty(
-        &self,
-        expected: &Memory,
-        actual: &Memory,
-        actual_runtime_size: Option<u64>,
-    ) -> Result<()> {
-        match_bool(
-            expected.shared,
-            actual.shared,
-            "memory",
-            "shared",
-            "non-shared",
-        )?;
-        match_bool(
-            expected.memory64,
-            actual.memory64,
-            "memory",
-            "64-bit",
-            "32-bit",
-        )?;
-        match_limits(
-            expected.minimum,
-            expected.maximum,
-            actual_runtime_size.unwrap_or(actual.minimum),
-            actual.maximum,
-            "memory",
-        )?;
-        Ok(())
     }
 
     pub fn func(&self, expected: SignatureIndex, actual: &crate::Func) -> Result<()> {
@@ -130,27 +71,7 @@ impl MatchCx<'_> {
             }
         };
 
-        let render = |ty: &WasmFuncType| {
-            let params = ty
-                .params()
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let returns = ty
-                .returns()
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("`({}) -> ({})`", params, returns)
-        };
-        bail!(
-            "{}: expected func of type {}, found func of type {}",
-            msg,
-            render(expected),
-            render(&actual)
-        )
+        Err(func_ty_mismatch(msg, expected, &actual))
     }
 
     /// Validates that the `expected` type matches the type of `actual`
@@ -186,6 +107,117 @@ impl MatchCx<'_> {
             },
         }
     }
+}
+
+pub fn entity_ty(
+    expected: &EntityType,
+    expected_types: &ModuleTypes,
+    actual: &EntityType,
+    actual_types: &ModuleTypes,
+) -> Result<()> {
+    match expected {
+        EntityType::Memory(expected) => match actual {
+            EntityType::Memory(actual) => memory_ty(expected, actual, None),
+            _ => bail!("expected memory found {}", entity_desc(actual)),
+        },
+        EntityType::Global(expected) => match actual {
+            EntityType::Global(actual) => global_ty(expected, actual),
+            _ => bail!("expected global found {}", entity_desc(actual)),
+        },
+        EntityType::Table(expected) => match actual {
+            EntityType::Table(actual) => table_ty(expected, actual, None),
+            _ => bail!("expected table found {}", entity_desc(actual)),
+        },
+        EntityType::Function(expected) => match actual {
+            EntityType::Function(actual) => {
+                let expected = &expected_types[*expected];
+                let actual = &actual_types[*actual];
+                if expected == actual {
+                    Ok(())
+                } else {
+                    Err(func_ty_mismatch(
+                        "function types incompaible",
+                        expected,
+                        actual,
+                    ))
+                }
+            }
+            _ => bail!("expected func found {}", entity_desc(actual)),
+        },
+        EntityType::Tag(_) => unimplemented!(),
+    }
+}
+
+fn func_ty_mismatch(msg: &str, expected: &WasmFuncType, actual: &WasmFuncType) -> anyhow::Error {
+    let render = |ty: &WasmFuncType| {
+        let params = ty
+            .params()
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let returns = ty
+            .returns()
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("`({}) -> ({})`", params, returns)
+    };
+    anyhow!(
+        "{msg}: expected func of type {}, found func of type {}",
+        render(expected),
+        render(actual)
+    )
+}
+
+fn global_ty(expected: &Global, actual: &Global) -> Result<()> {
+    match_ty(expected.wasm_ty, actual.wasm_ty, "global")?;
+    match_bool(
+        expected.mutability,
+        actual.mutability,
+        "global",
+        "mutable",
+        "immutable",
+    )?;
+    Ok(())
+}
+
+fn table_ty(expected: &Table, actual: &Table, actual_runtime_size: Option<u32>) -> Result<()> {
+    match_ty(expected.wasm_ty, actual.wasm_ty, "table")?;
+    match_limits(
+        expected.minimum.into(),
+        expected.maximum.map(|i| i.into()),
+        actual_runtime_size.unwrap_or(actual.minimum).into(),
+        actual.maximum.map(|i| i.into()),
+        "table",
+    )?;
+    Ok(())
+}
+
+fn memory_ty(expected: &Memory, actual: &Memory, actual_runtime_size: Option<u64>) -> Result<()> {
+    match_bool(
+        expected.shared,
+        actual.shared,
+        "memory",
+        "shared",
+        "non-shared",
+    )?;
+    match_bool(
+        expected.memory64,
+        actual.memory64,
+        "memory",
+        "64-bit",
+        "32-bit",
+    )?;
+    match_limits(
+        expected.minimum,
+        expected.maximum,
+        actual_runtime_size.unwrap_or(actual.minimum),
+        actual.maximum,
+        "memory",
+    )?;
+    Ok(())
 }
 
 fn match_ty(expected: WasmType, actual: WasmType, desc: &str) -> Result<()> {

--- a/crates/wasmtime/src/types/matching.rs
+++ b/crates/wasmtime/src/types/matching.rs
@@ -109,6 +109,7 @@ impl MatchCx<'_> {
     }
 }
 
+#[cfg_attr(not(feature = "component-model"), allow(dead_code))]
 pub fn entity_ty(
     expected: &EntityType,
     expected_types: &ModuleTypes,

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -89,7 +89,7 @@ fn thunks() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     instance
         .get_typed_func::<(), (), _>(&mut store, "thunk")?
         .call(&mut store, ())?;
@@ -146,7 +146,7 @@ fn typecheck() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let thunk = instance.get_func(&mut store, "thunk").unwrap();
     let take_string = instance.get_func(&mut store, "take-string").unwrap();
     let take_two_args = instance.get_func(&mut store, "take-two-args").unwrap();
@@ -252,7 +252,7 @@ fn integers() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
 
     // Passing in 100 is valid for all primitives
     instance
@@ -502,7 +502,7 @@ fn type_layers() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
 
     instance
         .get_typed_func::<(Box<u32>,), (), _>(&mut store, "take-u32")?
@@ -565,7 +565,7 @@ fn floats() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let f32_to_u32 = instance.get_typed_func::<(f32,), u32, _>(&mut store, "f32-to-u32")?;
     let f64_to_u64 = instance.get_typed_func::<(f64,), u64, _>(&mut store, "f64-to-u64")?;
     let u32_to_f32 = instance.get_typed_func::<(u32,), f32, _>(&mut store, "u32-to-f32")?;
@@ -622,7 +622,7 @@ fn bools() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let u32_to_bool = instance.get_typed_func::<(u32,), bool, _>(&mut store, "u32-to-bool")?;
     let bool_to_u32 = instance.get_typed_func::<(bool,), u32, _>(&mut store, "bool-to-u32")?;
 
@@ -657,7 +657,7 @@ fn chars() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let u32_to_char = instance.get_typed_func::<(u32,), char, _>(&mut store, "u32-to-char")?;
     let char_to_u32 = instance.get_typed_func::<(char,), u32, _>(&mut store, "char-to-u32")?;
 
@@ -729,7 +729,7 @@ fn tuple_result() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
 
     let input = (-1, 100, 3.0, 100.0);
     let output = instance
@@ -812,7 +812,7 @@ fn strings() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let list8_to_str =
         instance.get_typed_func::<(&[u8],), WasmStr, _>(&mut store, "list8-to-str")?;
     let str_to_list8 =
@@ -936,7 +936,7 @@ fn many_parameters() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let func = instance.get_typed_func::<(
         i8,
         u64,
@@ -1138,7 +1138,7 @@ fn some_traps() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
 
     // This should fail when calling the allocator function for the argument
     let err = instance
@@ -1304,7 +1304,7 @@ fn char_bool_memory() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let func = instance.get_typed_func::<(u32, u32), (bool, char), _>(&mut store, "ret-tuple")?;
 
     let ret = func.call(&mut store, (0, 'a' as u32))?;
@@ -1362,7 +1362,7 @@ fn string_list_oob() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let ret_list_u8 = instance.get_typed_func::<(), WasmList<u8>, _>(&mut store, "ret-list-u8")?;
     let ret_string = instance.get_typed_func::<(), WasmStr, _>(&mut store, "ret-string")?;
 
@@ -1426,7 +1426,7 @@ fn tuples() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let foo = instance.get_typed_func::<((i32, f64), (i8,)), (u16,), _>(&mut store, "foo")?;
     assert_eq!(foo.call(&mut store, ((0, 1.0), (2,)))?, (3,));
 
@@ -1546,7 +1546,7 @@ fn option() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let option_unit_to_u32 =
         instance.get_typed_func::<(Option<()>,), u32, _>(&mut store, "option-unit-to-u32")?;
     assert_eq!(option_unit_to_u32.call(&mut store, (None,))?, 0);
@@ -1711,7 +1711,7 @@ fn expected() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let take_expected_unit =
         instance.get_typed_func::<(Result<(), ()>,), u32, _>(&mut store, "take-expected-unit")?;
     assert_eq!(take_expected_unit.call(&mut store, (Ok(()),))?, 0);
@@ -1813,7 +1813,7 @@ fn fancy_list() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = Instance::new(&mut store, &component)?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
 
     let func = instance
         .get_typed_func::<(&[(Option<u8>, Result<(), &str>)],), (u32, u32, WasmList<u8>), _>(

--- a/tests/misc_testsuite/component-model/linking.wast
+++ b/tests/misc_testsuite/component-model/linking.wast
@@ -1,0 +1,18 @@
+(assert_unlinkable
+  (component
+    (import "undefined-name" (module))
+  )
+  "import `undefined-name` not defined")
+(component $i)
+(component
+  (import "i" (instance))
+)
+(assert_unlinkable
+  (component (import "i" (module)))
+  "expected module found instance")
+(assert_unlinkable
+  (component (import "i" (func)))
+  "expected func found instance")
+(assert_unlinkable
+  (component (import "i" (instance (export "x" (func)))))
+  "export `x` not defined")

--- a/tests/misc_testsuite/component-model/modules.wast
+++ b/tests/misc_testsuite/component-model/modules.wast
@@ -1,0 +1,477 @@
+(component $foo
+  (module (export "a-module"))
+)
+
+;; the above instance can be imported into this component
+(component
+  (import "foo" (instance
+    (export "a-module" (module))
+  ))
+)
+
+;; specifying extra imports is ok
+(component
+  (import "foo" (instance
+    (export "a-module" (module
+      (import "foo" "bar" (func))
+    ))
+  ))
+)
+
+;; specifying extra exports is not ok
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "a-module" (module
+        (export "the-export" (func))
+      ))
+    ))
+  )
+  "module export `the-export` not defined")
+
+(component $foo
+  (module (export "a-module")
+    (import "env" "something" (func))
+  )
+)
+
+;; imports must be specified
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "a-module" (module))
+    ))
+  )
+  "module import `env::something` not defined")
+
+(component
+  (import "foo" (instance
+    (export "a-module" (module
+      (import "env" "something" (func))
+    ))
+  ))
+)
+
+;; extra imports still ok
+(component
+  (import "foo" (instance
+    (export "a-module" (module
+      (import "env" "something" (func))
+      (import "env" "other" (global i32))
+    ))
+  ))
+)
+
+(component $foo
+  (module (export "a-module")
+    (func (export "f"))
+  )
+)
+
+;; dropping exports is ok
+(component
+  (import "foo" (instance
+    (export "a-module" (module))
+  ))
+)
+
+(component
+  (import "foo" (instance
+    (export "a-module" (module
+      (export "f" (func))
+    ))
+  ))
+)
+
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "a-module" (module
+        (export "f" (func (param i32)))
+      ))
+    ))
+  )
+  "expected func of type `(i32) -> ()`, found func of type `() -> ()`")
+
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "a-module" (module
+        (export "f" (global i32))
+      ))
+    ))
+  )
+  "expected global found func")
+
+(component $foo
+  (module (export "m")
+    (func (export "f"))
+    (table (export "t") 1 funcref)
+    (memory (export "m") 1)
+    (global (export "g") i32 i32.const 0)
+  )
+)
+
+;; wrong class of item
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "f" (global i32))))
+    ))
+  )
+  "expected global found func")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "t" (func))))
+    ))
+  )
+  "expected func found table")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "m" (func))))
+    ))
+  )
+  "expected func found memory")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "g" (func))))
+    ))
+  )
+  "expected func found global")
+
+;; wrong item type
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "f" (func (param i32)))))
+    ))
+  )
+  "export `f` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "t" (table 1 externref))))
+    ))
+  )
+  "export `t` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "t" (table 2 funcref))))
+    ))
+  )
+  "export `t` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "m" (memory 2))))
+    ))
+  )
+  "export `m` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "g" (global f32))))
+    ))
+  )
+  "export `g` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (export "g" (global (mut i32)))))
+    ))
+  )
+  "export `g` has the wrong type")
+
+;; subtyping ok
+(component
+  (import "foo" (instance
+    (export "m" (module
+      (export "t" (table 0 funcref))
+      (export "m" (memory 0))
+    ))
+  ))
+)
+
+(component $foo
+  (module (export "f") (func (import "" "")))
+  (module (export "t") (table (import "" "") 1 funcref))
+  (module (export "m") (memory (import "" "") 1))
+  (module (export "g") (global (import "" "") i32))
+)
+
+;; wrong class of item
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "f" (module (import "" "" (global i32))))
+    ))
+  )
+  "expected func found global")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "t" (module (import "" "" (func))))
+    ))
+  )
+  "expected table found func")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (import "" "" (func))))
+    ))
+  )
+  "expected memory found func")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "g" (module (import "" "" (func))))
+    ))
+  )
+  "expected global found func")
+
+;; wrong item type
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "f" (module (import "" "" (func (param i32)))))
+    ))
+  )
+  "module import `::` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "t" (module (import "" "" (table 1 externref))))
+    ))
+  )
+  "module import `::` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "t" (module (import "" "" (table 0 funcref))))
+    ))
+  )
+  "module import `::` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "m" (module (import "" "" (memory 0))))
+    ))
+  )
+  "module import `::` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "g" (module (import "" "" (global f32))))
+    ))
+  )
+  "module import `::` has the wrong type")
+(assert_unlinkable
+  (component
+    (import "foo" (instance
+      (export "g" (module (import "" "" (global (mut i32)))))
+    ))
+  )
+  "module import `::` has the wrong type")
+
+;; subtyping ok, but in the opposite direction of imports
+(component
+  (import "foo" (instance
+    (export "t" (module (import "" "" (table 2 funcref))))
+    (export "m" (module (import "" "" (memory 2))))
+  ))
+)
+
+;; An instance can reexport a module, define a module, and everything can be
+;; used by something else
+(component $src
+  (module (export "m")
+    (global (export "g") i32 i32.const 2)
+  )
+)
+
+(component $reexport
+  (module $m1
+    (global (export "g") i32 i32.const 1)
+  )
+  (import "src" (instance $src
+    (export "m" (module (export "g" (global i32))))
+  ))
+
+  (module $m3
+    (global (export "g") i32 i32.const 3)
+  )
+
+  (export "m1" (module $m1))
+  (export "m2" (module $src "m"))
+  (export "m3" (module $m3))
+)
+
+(component
+  (type $modulety (module (export "g" (global i32))))
+  (import "reexport" (instance $reexport
+    (export "m1" (module (type $modulety)))
+    (export "m2" (module (type $modulety)))
+    (export "m3" (module (type $modulety)))
+  ))
+
+  (module $assert_ok
+    (import "m1" "g" (global $m1 i32))
+    (import "m2" "g" (global $m2 i32))
+    (import "m3" "g" (global $m3 i32))
+
+    (func $assert_ok
+      block
+        global.get $m1
+        i32.const 1
+        i32.eq
+        br_if 0
+        unreachable
+      end
+      block
+        global.get $m2
+        i32.const 2
+        i32.eq
+        br_if 0
+        unreachable
+      end
+      block
+        global.get $m3
+        i32.const 3
+        i32.eq
+        br_if 0
+        unreachable
+      end
+    )
+
+    (start $assert_ok)
+  )
+
+  (instance $m1 (instantiate (module $reexport "m1")))
+  (instance $m2 (instantiate (module $reexport "m2")))
+  (instance $m3 (instantiate (module $reexport "m3")))
+
+  (instance (instantiate (module $assert_ok)
+    (with "m1" (instance $m1))
+    (with "m2" (instance $m2))
+    (with "m3" (instance $m3))
+  ))
+)
+
+;; order of imports and exports can be shuffled between definition site and
+;; use-site
+(component $provider
+  (module (export "m")
+    (import "" "1" (global $i1 i32))
+    (import "" "2" (global $i2 i32))
+    (import "" "3" (global $i3 i32))
+    (import "" "4" (global $i4 i32))
+
+    (global $g1 i32 i32.const 100)
+    (global $g2 i32 i32.const 101)
+    (global $g3 i32 i32.const 102)
+    (global $g4 i32 i32.const 103)
+
+    (func $assert_imports
+      (block
+        global.get $i1
+        i32.const 1
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $i2
+        i32.const 2
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $i3
+        i32.const 3
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $i4
+        i32.const 4
+        i32.eq
+        br_if 0
+        unreachable)
+    )
+
+    (start $assert_imports)
+
+    (export "g1" (global $g1))
+    (export "g2" (global $g2))
+    (export "g3" (global $g3))
+    (export "g4" (global $g4))
+  )
+)
+
+(component
+  (import "provider" (instance $provider
+    (export "m" (module
+      (import "" "4" (global i32))
+      (import "" "3" (global i32))
+      (import "" "2" (global i32))
+      (import "" "1" (global i32))
+
+      (export "g4" (global i32))
+      (export "g3" (global i32))
+      (export "g2" (global i32))
+      (export "g1" (global i32))
+    ))
+  ))
+
+  (module $imports
+    (global (export "1") i32 (i32.const 1))
+    (global (export "3") i32 (i32.const 3))
+    (global (export "2") i32 (i32.const 2))
+    (global (export "4") i32 (i32.const 4))
+  )
+  (instance $imports (instantiate (module $imports)))
+  (instance $m (instantiate (module $provider "m")
+    (with "" (instance $imports))
+  ))
+
+  (module $import_globals
+    (import "" "g4" (global $g4 i32))
+    (import "" "g3" (global $g3 i32))
+    (import "" "g2" (global $g2 i32))
+    (import "" "g1" (global $g1 i32))
+
+    (func $assert_imports
+      (block
+        global.get $g1
+        i32.const 100
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $g2
+        i32.const 101
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $g3
+        i32.const 102
+        i32.eq
+        br_if 0
+        unreachable)
+      (block
+        global.get $g4
+        i32.const 103
+        i32.eq
+        br_if 0
+        unreachable)
+    )
+
+    (start $assert_imports)
+  )
+
+  (instance (instantiate (module $import_globals) (with "" (instance $m))))
+)


### PR DESCRIPTION
As a step towards implementing function imports into a component this
commit implements importing modules into a component. This fills out
missing pieces of functionality such as exporting modules as well. The
previous translation code had initial support for translating imported
modules but some of the AST type information was restructured with
feedback from this implementation, namely splitting the
`InstantiateModule` initializer into separate upvar/import variants to
clarify that the item orderings for imports are resolved differently at
runtime.

Much of this commit is also adding infrastructure for any imports at all
into a component. For example a `Linker` type (analagous to
`wasmtime::Linker`) was added here as well. For now this type is quite
limited due to the inability to define host functions (it can only work
with instances and instances-of-modules) but it's enough to start
writing `*.wast` tests which exercise lots of module-related functionality.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
