### PR TITLE
Fix failing cranelift-object tests in Rust 1.60 and older: make panic message match more generic.

### DIFF
--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -199,9 +199,7 @@ fn libcall_function() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"function\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
-)]
+#[should_panic(expected = "has a null byte, which is disallowed")]
 fn reject_nul_byte_symbol_for_func() {
     let flag_builder = settings::builder();
     let isa_builder = cranelift_codegen::isa::lookup_by_name("x86_64-unknown-linux-gnu").unwrap();
@@ -223,9 +221,7 @@ fn reject_nul_byte_symbol_for_func() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Result::unwrap()` on an `Err` value: Backend(Symbol \"data\\0with\\0nul\\0bytes\" has a null byte, which is disallowed"
-)]
+#[should_panic(expected = "has a null byte, which is disallowed")]
 fn reject_nul_byte_symbol_for_data() {
     let flag_builder = settings::builder();
     let isa_builder = cranelift_codegen::isa::lookup_by_name("x86_64-unknown-linux-gnu").unwrap();


### PR DESCRIPTION
Rust 1.61 changed the way `Debug` output looks for strings with null
bytes in them. Tests currently pass in Rust 1.61 but not with prior versions.
Generally we only support latest stable Rust but here it seems worthwhile
to fix a brittle specific-error-string match. This makes the expectations more
generic while still capturing the important part ("has a null byte").

Fixes #4210.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
