### PR TITLE
x64: port some atomics to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2866,6 +2866,12 @@
 (rule (x64_xor_mem ty addr val)
       (alu_rm ty (AluRmiROpcode.Xor) addr val))
 
+;;;; Atomics ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl x64_mfence () SideEffectNoResult)
+(rule (x64_mfence)
+      (SideEffectNoResult.Inst (MInst.Fence (FenceKind.MFence))))
+
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (convert Gpr InstOutput output_gpr)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -988,6 +988,10 @@
 (decl amode_offset (Amode u32) Amode)
 (extern constructor amode_offset amode_offset)
 
+;; Return a zero offset as an `Offset32`.
+(decl zero_offset () Offset32)
+(extern constructor zero_offset zero_offset)
+
 ;; Shift kinds.
 
 (type ShiftKind extern

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2781,3 +2781,8 @@
       (let ((_ RegMemImm (sink_load sink)))
         (side_effect
          (x64_xor_mem ty (to_amode flags addr offset) src2))))
+
+;; Rules for `fence` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (fence))
+      (side_effect (x64_mfence)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2786,3 +2786,17 @@
 
 (rule (lower (fence))
       (side_effect (x64_mfence)))
+
+;; Rules for `atomic_load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; This is a normal load. The x86-TSO memory model provides sufficient
+;; sequencing to satisfy the CLIF synchronisation requirements for `AtomicLoad`
+;; without the need for any fence instructions.
+;;
+;; As described in the `atomic_load` documentation, this lowering is only valid
+;; for I8, I16, I32, and I64. The sub-64-bit types are zero extended, as with a
+;; normal load.
+(rule (lower (has_type $I64 (atomic_load flags address)))
+      (x64_mov (to_amode flags address (zero_offset))))
+(rule (lower (has_type (and (fits_in_32 ty) (ty_int _)) (atomic_load flags address)))
+      (x64_movzx (ext_mode (ty_bits_u16 ty) 64) (to_amode flags address (zero_offset))))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2800,3 +2800,15 @@
       (x64_mov (to_amode flags address (zero_offset))))
 (rule (lower (has_type (and (fits_in_32 ty) (ty_int _)) (atomic_load flags address)))
       (x64_movzx (ext_mode (ty_bits_u16 ty) 64) (to_amode flags address (zero_offset))))
+
+;; Rules for `atomic_store` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; This is a normal store followed by an `mfence` instruction. As described in
+;; the `atomic_load` documentation, this lowering is only valid for I8, I16,
+;; I32, and I64.
+(rule (lower (atomic_store flags
+                           value @ (value_type (and (fits_in_64 ty) (ty_int _)))
+                           address))
+      (side_effect (side_effect_concat
+       (x64_movrm ty (to_amode flags address (zero_offset)) value)
+       (x64_mfence))))

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2238,16 +2238,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::AtomicStore => {
-            // This is a normal store, followed by an `mfence` instruction.
-            let data = put_input_in_reg(ctx, inputs[0]);
-            let addr = lower_to_amode(ctx, inputs[1], 0);
-            let ty_access = ctx.input_ty(insn, 0);
-            assert!(is_valid_atomic_transaction_ty(ty_access));
-
-            ctx.emit(Inst::store(ty_access, data, addr));
-            ctx.emit(Inst::Fence {
-                kind: FenceKind::MFence,
-            });
+            implemented_in_isle(ctx);
         }
 
         Opcode::Fence => {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2234,27 +2234,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::AtomicLoad => {
-            // This is a normal load.  The x86-TSO memory model provides sufficient sequencing
-            // to satisfy the CLIF synchronisation requirements for `AtomicLoad` without the
-            // need for any fence instructions.
-            let data = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let addr = lower_to_amode(ctx, inputs[0], 0);
-            let ty_access = ty.unwrap();
-            assert!(is_valid_atomic_transaction_ty(ty_access));
-
-            let rm = RegMem::mem(addr);
-            if ty_access == types::I64 {
-                ctx.emit(Inst::mov64_rm_r(rm, data));
-            } else {
-                let ext_mode = ExtMode::new(ty_access.bits(), 64).unwrap_or_else(|| {
-                    panic!(
-                        "invalid extension during AtomicLoad: {} -> {}",
-                        ty_access.bits(),
-                        64
-                    )
-                });
-                ctx.emit(Inst::movzx_rm_r(ext_mode, rm, data));
-            }
+            implemented_in_isle(ctx);
         }
 
         Opcode::AtomicStore => {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2271,9 +2271,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Fence => {
-            ctx.emit(Inst::Fence {
-                kind: FenceKind::MFence,
-            });
+            implemented_in_isle(ctx);
         }
 
         Opcode::FuncAddr => {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -542,6 +542,11 @@ where
     fn amode_offset(&mut self, addr: &Amode, offset: u32) -> Amode {
         addr.offset(offset)
     }
+
+    #[inline]
+    fn zero_offset(&mut self) -> Offset32 {
+        Offset32::new(0)
+    }
 }
 
 // Since x64 doesn't have 8x16 shifts and we must use a 16x8 shift instead, we

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -301,6 +301,11 @@ macro_rules! isle_prelude_methods {
         }
 
         #[inline]
+        fn ty_int(&mut self, ty: Type) -> Option<Type> {
+            ty.is_int().then(|| ty)
+        }
+
+        #[inline]
         fn ty_scalar_float(&mut self, ty: Type) -> Option<Type> {
             match ty {
                 F32 | F64 => Some(ty),

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -318,6 +318,10 @@
 (decl ty_int_bool_128 (Type) Type)
 (extern extractor ty_int_bool_128 ty_int_bool_128)
 
+;; An extractor that only matches integers.
+(decl ty_int (Type) Type)
+(extern extractor ty_int ty_int)
+
 ;; An extractor that only matches scalar floating-point types--F32 or F64.
 (decl ty_scalar_float (Type) Type)
 (extern extractor ty_scalar_float ty_scalar_float)


### PR DESCRIPTION
These commits port `fence`, `atomic_load`, and `atomic_store` over to ISLE for the x64 backend.