### PR TITLE
Speed up CI a bit: run only component-model tests under `component-model` feature.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,7 +300,7 @@ jobs:
 
     # Test the component-model related functionality which is gated behind a
     # compile-time feature
-    - run: cargo test --features component-model
+    - run: cargo test --test all --features component-model component_model
 
   # Build and test the wasi-nn module.
   test_wasi_nn:


### PR DESCRIPTION
Right now the CI test job runs `cargo test --features component-model`
and runs all tests with this feature enabled, which takes a bit of time,
especially on our emulation-based targets. This seems to have become the
critical path, at least in some CI jobs I've been watching. This PR
restricts these runs to only component-model-specific tests when the
feature is enabled.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
