### PR TITLE
Split the `ComponentValue` trait into... components

### DIFF
--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -196,8 +196,8 @@ impl Func {
     /// ```
     pub fn typed<Params, Return, S>(&self, store: S) -> Result<TypedFunc<Params, Return>>
     where
-        Params: ComponentParams,
-        Return: ComponentValue,
+        Params: ComponentParams + Lower,
+        Return: Lift,
         S: AsContext,
     {
         self.typecheck::<Params, Return>(store.as_context().0)?;
@@ -206,16 +206,15 @@ impl Func {
 
     fn typecheck<Params, Return>(&self, store: &StoreOpaque) -> Result<()>
     where
-        Params: ComponentParams,
-        Return: ComponentValue,
+        Params: ComponentParams + Lower,
+        Return: Lift,
     {
         let data = &store[self.0];
         let ty = &data.types[data.ty];
 
-        Params::typecheck(&ty.params, &data.types, Op::Lower)
+        Params::typecheck_params(&ty.params, &data.types)
             .context("type mismatch with parameters")?;
-        Return::typecheck(&ty.result, &data.types, Op::Lift)
-            .context("type mismatch with result")?;
+        Return::typecheck(&ty.result, &data.types).context("type mismatch with result")?;
 
         Ok(())
     }

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -1,5 +1,5 @@
 use crate::component::func::HostFunc;
-use crate::component::{Component, ComponentParams, ComponentValue, Func, TypedFunc};
+use crate::component::{Component, ComponentParams, Func, Lift, Lower, TypedFunc};
 use crate::instance::OwnedImports;
 use crate::store::{StoreOpaque, Stored};
 use crate::{AsContextMut, Module, StoreContext, StoreContextMut};
@@ -86,8 +86,8 @@ impl Instance {
         name: &str,
     ) -> Result<TypedFunc<Params, Results>>
     where
-        Params: ComponentParams,
-        Results: ComponentValue,
+        Params: ComponentParams + Lower,
+        Results: Lift,
         S: AsContextMut,
     {
         let f = self

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -11,7 +11,8 @@ mod matching;
 mod store;
 pub use self::component::Component;
 pub use self::func::{
-    ComponentParams, ComponentValue, Func, IntoComponentFunc, Op, TypedFunc, WasmList, WasmStr,
+    ComponentParams, ComponentType, Func, IntoComponentFunc, Lift, Lower, TypedFunc, WasmList,
+    WasmStr,
 };
 pub use self::instance::{Instance, InstancePre};
 pub use self::linker::Linker;

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -158,10 +158,6 @@ fn typecheck() -> Result<()> {
     assert!(thunk.typed::<(u32,), (), _>(&store).is_err());
     assert!(thunk.typed::<(), (), _>(&store).is_ok());
     assert!(take_string.typed::<(), (), _>(&store).is_err());
-    assert!(take_string.typed::<(), String, _>(&store).is_err());
-    assert!(take_string
-        .typed::<(String, String), String, _>(&store)
-        .is_err());
     assert!(take_string.typed::<(String,), (), _>(&store).is_ok());
     assert!(take_string.typed::<(&str,), (), _>(&store).is_ok());
     assert!(take_string.typed::<(&[u8],), (), _>(&store).is_err());
@@ -175,11 +171,7 @@ fn typecheck() -> Result<()> {
     assert!(ret_tuple1.typed::<(), (u32,), _>(&store).is_ok());
     assert!(ret_tuple1.typed::<(), u32, _>(&store).is_err());
     assert!(ret_string.typed::<(), (), _>(&store).is_err());
-    assert!(ret_string.typed::<(), String, _>(&store).is_err());
-    assert!(ret_string.typed::<(), &str, _>(&store).is_err());
     assert!(ret_string.typed::<(), WasmStr, _>(&store).is_ok());
-    assert!(ret_list_u8.typed::<(), &[u8], _>(&store).is_err());
-    assert!(ret_list_u8.typed::<(), Vec<u8>, _>(&store).is_err());
     assert!(ret_list_u8.typed::<(), WasmList<u16>, _>(&store).is_err());
     assert!(ret_list_u8.typed::<(), WasmList<i8>, _>(&store).is_err());
     assert!(ret_list_u8.typed::<(), WasmList<u8>, _>(&store).is_ok());


### PR DESCRIPTION
This commit splits the current `ComponentValue` trait into three
separate traits:

* `ComponentType` - contains size/align/typecheck information in
  addition to the "lower" representation.
* `Lift` - only contains `lift` and `load`
* `Lower` - only contains `lower` and `store`

When describing the original implementation of host functions to Nick he
immediately pointed out this superior solution to the traits involved
with Wasmtime's support for typed parameters/returns in exported and
imported functions. Instead of having dynamic errors at runtime for
things like "you can't lift a `String`" that's instead a static
compile-time error now.

While I was doing this split I also refactored the `ComponentParams`
trait a bit to have `ComponentType` as a supertrait instead of a subtype
which made its implementations a bit more compact. Additionally its impl
blocks were folded into the existing tuple impl blocks.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
