### PR TITLE
Update lifting for integers and bools

### DIFF
--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -801,11 +801,7 @@ macro_rules! integers {
 
             #[inline]
             fn lift(_store: &StoreOpaque, _options: &Options, src: &Self::Lower) -> Result<Self> {
-                // Perform a lossless cast from our field storage to the
-                // destination type. Note that `try_from` here is load bearing
-                // which rejects conversions like `500u32` to `u8` because
-                // that's out-of-bounds for `u8`.
-                Ok($primitive::try_from(src.$get())?)
+                Ok(src.$get() as $primitive)
             }
 
             #[inline]
@@ -933,8 +929,7 @@ unsafe impl ComponentValue for bool {
     fn lift(_store: &StoreOpaque, _options: &Options, src: &Self::Lower) -> Result<Self> {
         match src.get_i32() {
             0 => Ok(false),
-            1 => Ok(true),
-            _ => bail!("invalid boolean value"),
+            _ => Ok(true),
         }
     }
 
@@ -942,8 +937,7 @@ unsafe impl ComponentValue for bool {
     fn load(_mem: &Memory<'_>, bytes: &[u8]) -> Result<Self> {
         match bytes[0] {
             0 => Ok(false),
-            1 => Ok(true),
-            _ => bail!("invalid boolean value"),
+            _ => Ok(true),
         }
     }
 }

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -372,15 +372,12 @@ fn integers() -> Result<()> {
         0
     );
 
-    // Returning -1 should fail for u8 and u16, but succeed for all other types.
-    let err = instance
-        .get_typed_func::<(), u8, _>(&mut store, "retm1-u8")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    // Returning -1 should reinterpret the bytes as defined by each type.
+    assert_eq!(
+        instance
+            .get_typed_func::<(), u8, _>(&mut store, "retm1-u8")?
+            .call(&mut store, ())?,
+        0xff
     );
     assert_eq!(
         instance
@@ -388,14 +385,11 @@ fn integers() -> Result<()> {
             .call(&mut store, ())?,
         -1
     );
-    let err = instance
-        .get_typed_func::<(), u16, _>(&mut store, "retm1-u16")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    assert_eq!(
+        instance
+            .get_typed_func::<(), u16, _>(&mut store, "retm1-u16")?
+            .call(&mut store, ())?,
+        0xffff
     );
     assert_eq!(
         instance
@@ -428,54 +422,43 @@ fn integers() -> Result<()> {
         -1
     );
 
-    // Returning 100000 should fail for small primitives but succeed for 32-bit.
-    let err = instance
-        .get_typed_func::<(), u8, _>(&mut store, "retbig-u8")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    // Returning 100000 should chop off bytes as necessary
+    let ret: u32 = 100000;
+    assert_eq!(
+        instance
+            .get_typed_func::<(), u8, _>(&mut store, "retbig-u8")?
+            .call(&mut store, ())?,
+        ret as u8,
     );
-    let err = instance
-        .get_typed_func::<(), i8, _>(&mut store, "retbig-s8")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    assert_eq!(
+        instance
+            .get_typed_func::<(), i8, _>(&mut store, "retbig-s8")?
+            .call(&mut store, ())?,
+        ret as i8,
     );
-    let err = instance
-        .get_typed_func::<(), u16, _>(&mut store, "retbig-u16")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    assert_eq!(
+        instance
+            .get_typed_func::<(), u16, _>(&mut store, "retbig-u16")?
+            .call(&mut store, ())?,
+        ret as u16,
     );
-    let err = instance
-        .get_typed_func::<(), i16, _>(&mut store, "retbig-s16")?
-        .call(&mut store, ())
-        .unwrap_err();
-    assert!(
-        err.to_string().contains("out of range integral type"),
-        "{}",
-        err
+    assert_eq!(
+        instance
+            .get_typed_func::<(), i16, _>(&mut store, "retbig-s16")?
+            .call(&mut store, ())?,
+        ret as i16,
     );
     assert_eq!(
         instance
             .get_typed_func::<(), u32, _>(&mut store, "retbig-u32")?
             .call(&mut store, ())?,
-        100000
+        ret,
     );
     assert_eq!(
         instance
             .get_typed_func::<(), i32, _>(&mut store, "retbig-s32")?
             .call(&mut store, ())?,
-        100000
+        ret as i32,
     );
 
     Ok(())
@@ -630,8 +613,7 @@ fn bools() -> Result<()> {
     assert_eq!(bool_to_u32.call(&mut store, (true,))?, 1);
     assert_eq!(u32_to_bool.call(&mut store, (0,))?, false);
     assert_eq!(u32_to_bool.call(&mut store, (1,))?, true);
-    let err = u32_to_bool.call(&mut store, (2,)).unwrap_err();
-    assert!(err.to_string().contains("invalid boolean"), "{}", err);
+    assert_eq!(u32_to_bool.call(&mut store, (2,))?, true);
 
     Ok(())
 }
@@ -1313,7 +1295,9 @@ fn char_bool_memory() -> Result<()> {
     let ret = func.call(&mut store, (1, '🍰' as u32))?;
     assert_eq!(ret, (true, '🍰'));
 
-    assert!(func.call(&mut store, (2, 'a' as u32)).is_err());
+    let ret = func.call(&mut store, (2, 'a' as u32))?;
+    assert_eq!(ret, (true, 'a'));
+
     assert!(func.call(&mut store, (0, 0xd800)).is_err());
 
     Ok(())


### PR DESCRIPTION
This commit updates lifting for integer types and boolean types to
account for WebAssembly/component-model#35 where extra bits are now
discarded instead of being validated as all zero.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
