### PR TITLE
Accept `(tuple)` and `unit` as `()` in Rust

### DIFF
--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -62,6 +62,9 @@ fn typecheck() -> Result<()> {
             (func (export "thunk")
                 (canon.lift (func) (func $i "thunk"))
             )
+            (func (export "tuple-thunk")
+                (canon.lift (func (param (tuple)) (result (tuple))) (func $i "thunk"))
+            )
             (func (export "take-string")
                 (canon.lift (func (param string)) (into $i) (func $i "take-string"))
             )
@@ -88,6 +91,7 @@ fn typecheck() -> Result<()> {
     let mut store = Store::new(&engine, ());
     let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
     let thunk = instance.get_func(&mut store, "thunk").unwrap();
+    let tuple_thunk = instance.get_func(&mut store, "tuple-thunk").unwrap();
     let take_string = instance.get_func(&mut store, "take-string").unwrap();
     let take_two_args = instance.get_func(&mut store, "take-two-args").unwrap();
     let ret_tuple = instance.get_func(&mut store, "ret-tuple").unwrap();
@@ -97,6 +101,8 @@ fn typecheck() -> Result<()> {
     assert!(thunk.typed::<(), u32, _>(&store).is_err());
     assert!(thunk.typed::<(u32,), (), _>(&store).is_err());
     assert!(thunk.typed::<(), (), _>(&store).is_ok());
+    assert!(tuple_thunk.typed::<(), (), _>(&store).is_err());
+    assert!(tuple_thunk.typed::<((),), (), _>(&store).is_ok());
     assert!(take_string.typed::<(), (), _>(&store).is_err());
     assert!(take_string.typed::<(String,), (), _>(&store).is_ok());
     assert!(take_string.typed::<(&str,), (), _>(&store).is_ok());


### PR DESCRIPTION
This commit updates the implementation of `ComponentType for ()` to
typecheck both the empty tuple type in addition to the `unit` type in
the component model. This allows the usage of `()` when either of those
types are used. Currently this can work because we don't need to
currently support the answer of "what is the type of this host
function". Instead the only question that needs to be answered at
runtime is "does this host function match this type".

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
