### PR TITLE
Backport #4239 (to_amode fix) to release-0.38 branch.

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -981,7 +981,16 @@
 
 ;; Finally, define the toplevel `to_amode`.
 (rule (to_amode flags base offset)
-      (amode_add (amode_initial flags offset) base))
+      (amode_finalize (amode_add (amode_initial flags offset) base)))
+
+;; If an amode has no registers at all and only offsets (a constant
+;; value), we need to "finalize" it by sticking in a zero'd reg in
+;; place of the (invalid_reg) produced by (amode_initial).
+(decl amode_finalize (Amode) Amode)
+(rule 1 (amode_finalize (Amode.ImmReg off (invalid_reg) flags))
+      (Amode.ImmReg off (imm $I64 0) flags))
+(rule 0 (amode_finalize amode)
+      amode)
 
 ;; Offsetting an Amode. Used when we need to do consecutive
 ;; loads/stores to adjacent addresses.

--- a/cranelift/filetests/filetests/isa/x64/atomic_cas_const_addr.clif
+++ b/cranelift/filetests/filetests/isa/x64/atomic_cas_const_addr.clif
@@ -1,0 +1,23 @@
+;; See https://github.com/bytecodealliance/wasmtime/issues/4234.
+;;
+;; We just want to verify that this can be compiled successfully.
+
+test compile
+target x86_64
+
+function u0:31() -> i32, i32 system_v {
+                                block0:
+                                    v0 = iconst.i64 0
+                                    v1 = iconst.i32 0
+                                    v2 = iconst.i32 0
+@0004                               v28 = bconst.b1 false
+@0005                               brnz v28, block25
+                                    jump block1
+
+                                block1:
+@0005                               trap unreachable
+
+                                block25:
+@0035                               v85 = atomic_cas.i32 v0, v1, v2
+@0036                               trap user0
+}


### PR DESCRIPTION
This is a cherry-pick of "x64 backend: fix `to_amode` with constant address (no registers). (#4239)"

If an address expression is given to `to_amode` that is completely
constant (no registers at all), then it will produce an `Amode` that has
the resulting constant as an offset, and `(invalid_reg)` as the base.
This is a side-effect of the way we build up the amode step-by-step --
we're waiting to see a register and plug it into the base field. If we
never get a reg though, we need to generate a constant zero into a
register and use that as the base. This PR adds a `finalize_amode`
helper to do just that.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
