### PR TITLE
fuzz: allow generating shared memories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0ed86e26ccdda3c178e557f8f2874e277c8d4f29c88e3c3320c58db12840ed"
+checksum = "c85cf25be85aac46356216b4662eb5768347046449a45c938ae1443b788665bb"
 dependencies = [
  "arbitrary",
  "flagset",

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -20,7 +20,7 @@ wasmprinter = "0.2.36"
 wasmtime = { path = "../wasmtime" }
 wasmtime-wast = { path = "../wast" }
 wasm-encoder = "0.13.0"
-wasm-smith = "0.11.0"
+wasm-smith = "0.11.1"
 wasm-mutate = "0.2.4"
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
 wasmi = "0.7.0"

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -343,7 +343,6 @@ impl Config {
     pub fn set_spectest_compliant(&mut self) {
         let config = &mut self.module_config.config;
         config.memory64_enabled = false;
-        config.simd_enabled = false;
         config.bulk_memory_enabled = true;
         config.reference_types_enabled = true;
         config.multi_value_enabled = true;
@@ -633,6 +632,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         // these are all unconditionally turned off even with
         // `SwarmConfig::arbitrary`.
         config.memory64_enabled = u.arbitrary()?;
+        config.threads_enabled = u.arbitrary()?;
 
         Ok(ModuleConfig { config })
     }

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -441,8 +441,16 @@ impl Config {
             }
         }
 
-        // If threads are enabled, we might generate shared memory; shared
-        // memory is less amenable to different memory configurations.
+        // Vary the memory configuration, but only if threads are not enabled.
+        // When the threads proposal is enabled we might generate shared memory,
+        // which is less amenable to different memory configurations:
+        // - shared memories are required to be "static" so fuzzing the various
+        //   memory configurations will mostly result in uninteresting errors.
+        //   The interesting part about shared memories is the runtime so we
+        //   don't fuzz non-default settings.
+        // - shared memories are required to be aligned which means that the
+        //   `CustomUnaligned` variant isn't actually safe to use with a shared
+        //   memory.
         if !self.module_config.config.threads_enabled {
             match &self.wasmtime.memory_config {
                 MemoryConfig::Normal(memory_config) => {

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -163,6 +163,11 @@ impl<'a> Arbitrary<'a> for Config {
             ..
         } = &config.wasmtime.strategy
         {
+            // If the pooling allocator is used, do not allow shared memory to
+            // be created. FIXME: see
+            // https://github.com/bytecodealliance/wasmtime/issues/4244.
+            config.module_config.config.threads_enabled = false;
+
             // Force the use of a normal memory config when using the pooling allocator and
             // limit the static memory maximum to be the same as the pooling allocator's memory
             // page limit.
@@ -639,7 +644,9 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         // these are all unconditionally turned off even with
         // `SwarmConfig::arbitrary`.
         config.memory64_enabled = u.arbitrary()?;
-        // FIXME: to allow threads and memory64 to coexist, see
+
+        // Allow the threads proposal if memory64 is not already enabled. FIXME:
+        // to allow threads and memory64 to coexist, see
         // https://github.com/bytecodealliance/wasmtime/issues/4267.
         config.threads_enabled = !config.memory64_enabled && u.arbitrary()?;
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -43,7 +43,7 @@ At the time of writing, we have the following fuzz targets:
   the same results as the `wasmi` interpreter.
 * `instantiate`: Generate a Wasm module and Wasmtime configuration and attempt
   to compile and instantiate with them.
-* `instantiate`: Generate many Wasm modules and attempt to compile and
+* `instantiate-many`: Generate many Wasm modules and attempt to compile and
   instantiate them concurrently.
 * `spectests`: Pick a random spec test and run it with a generated
   configuration.

--- a/fuzz/fuzz_targets/differential_v8.rs
+++ b/fuzz/fuzz_targets/differential_v8.rs
@@ -17,9 +17,12 @@ fn run(data: &[u8]) -> Result<()> {
     config.set_differential_config();
 
     // Enable features that v8 has implemented
-    config.module_config.config.simd_enabled = true;
-    config.module_config.config.bulk_memory_enabled = true;
-    config.module_config.config.reference_types_enabled = true;
+    config.module_config.config.simd_enabled = u.arbitrary()?;
+    config.module_config.config.bulk_memory_enabled = u.arbitrary()?;
+    config.module_config.config.reference_types_enabled = u.arbitrary()?;
+    // FIXME: to enable fuzzing with the threads proposal, see
+    // https://github.com/bytecodealliance/wasmtime/issues/4268.
+    // config.module_config.config.threads_enabled = u.arbitrary()?;
 
     // Allow multiple tables, as set_differential_config() assumes reference
     // types are disabled and therefore sets max_tables to 1


### PR DESCRIPTION
`wasm-smith` v0.11 has support for generating shared memories when the
`threads_enabled` configuration flag is set. This change turns on that
flag occasionally.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
