### PR TITLE
Add source tarballs to our releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -407,6 +407,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    # On one builder produce the source tarball since there's no need to produce
+    # it everywhere
+    - run: ./ci/build-src-tarball.sh
+      if: matrix.build == 'x86_64-linux'
     - uses: ./.github/actions/install-rust
     - uses: ./.github/actions/binary-compatible-builds
       with:

--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -ex
+
+# Determine the name of the tarball
+tag=dev
+if [[ $GITHUB_REF == refs/tags/v* ]]; then
+  tag=${GITHUB_REF:10}
+fi
+pkgname=wasmtime-$tag-src
+rm -rf /tmp/$pkgname
+mkdir /tmp/$pkgname
+
+# Vendor all crates.io dependencies since this is supposed to be an
+# offline-only-compatible tarball
+mkdir /tmp/$pkgname/.cargo
+cargo vendor > /tmp/$pkgname/.cargo/config.toml
+
+# Copy over everything in-tree to the destination
+cp -r * /tmp/$pkgname
+
+# Create the tarball from the destination
+mkdir -p dist
+tar -czf dist/$pkgname.tar.gz -C /tmp $pkgname

--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -8,15 +8,13 @@ if [[ $GITHUB_REF == refs/tags/v* ]]; then
   tag=${GITHUB_REF#refs/tags/}
 fi
 pkgname=wasmtime-$tag-src
-rm -rf /tmp/$pkgname
-mkdir /tmp/$pkgname
 
 # Vendor all crates.io dependencies since this is supposed to be an
 # offline-only-compatible tarball
-mkdir /tmp/$pkgname/.cargo
-cargo vendor > /tmp/$pkgname/.cargo/config.toml
+mkdir .cargo
+cargo vendor > .cargo/config.toml
 
 # Create the tarball from the destination
-tar -czf /tmp/$pkgname.tar.gz --transform "s/^\./$pkgname/S" --exclude-vcs .
+tar -czf /tmp/$pkgname.tar.gz --transform "s/^\./$pkgname/S" --exclude=.git .
 mkdir -p dist
 mv /tmp/$pkgname.tar.gz dist/

--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -5,7 +5,7 @@ set -ex
 # Determine the name of the tarball
 tag=dev
 if [[ $GITHUB_REF == refs/tags/v* ]]; then
-  tag=${GITHUB_REF:10}
+  tag=${GITHUB_REF#refs/tags/}
 fi
 pkgname=wasmtime-$tag-src
 rm -rf /tmp/$pkgname
@@ -16,9 +16,7 @@ mkdir /tmp/$pkgname
 mkdir /tmp/$pkgname/.cargo
 cargo vendor > /tmp/$pkgname/.cargo/config.toml
 
-# Copy over everything in-tree to the destination
-cp -r * /tmp/$pkgname
-
 # Create the tarball from the destination
+tar -czf /tmp/$pkgname.tar.gz --transform "s/^\./$pkgname/S" --exclude-vcs .
 mkdir -p dist
-tar -czf dist/$pkgname.tar.gz -C /tmp $pkgname
+mv /tmp/$pkgname.tar.gz dist/


### PR DESCRIPTION
This commit adds a small script to create a source tarball as part of
the release process. This goes further than requested by #3808 by
vendoring all Rust dependencies as well to be more in line with
"download the source once then build somewhere without a network".
Vendoring the Rust dependencies makes the tarball pretty beefy (67M
compressed, 500M uncompressed). Unfortunately most of this size comes
from vendored crates such as v8, pqcrypto-kyber, winapi, capstone-sys,
plotters, and web-sys. Only `winapi` in this list is actually needed for
`wasmtime`-the-binary and only on Windows as well but for now this is
the state of things related to `cargo vendor`. If this becomes an issue
we could specifically remove the bulky contents of crates in the
`vendor` directory such as `v8` since it's only used for fuzzing.

Closes #3808

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
