### PR TITLE
Fix a "trampoline missing" panic with components

### DIFF
--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -210,6 +210,7 @@ impl<'a> Instantiator<'a> {
         imports: &'a PrimaryMap<RuntimeImportIndex, RuntimeImport>,
     ) -> Instantiator<'a> {
         let env_component = component.env_component();
+        store.modules_mut().register_component(component);
         Instantiator {
             component,
             imports,

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -242,7 +242,7 @@ impl Instance {
 
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
-        store.modules_mut().register(module);
+        store.modules_mut().register_module(module);
 
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an

--- a/crates/wasmtime/src/signatures.rs
+++ b/crates/wasmtime/src/signatures.rs
@@ -19,7 +19,7 @@ use wasmtime_runtime::{VMSharedSignatureIndex, VMTrampoline};
 pub struct SignatureCollection {
     registry: Arc<RwLock<SignatureRegistryInner>>,
     signatures: PrimaryMap<SignatureIndex, VMSharedSignatureIndex>,
-    trampolines: HashMap<VMSharedSignatureIndex, (usize, VMTrampoline)>,
+    trampolines: HashMap<VMSharedSignatureIndex, VMTrampoline>,
 }
 
 impl SignatureCollection {
@@ -59,9 +59,7 @@ impl SignatureCollection {
 
     /// Gets a trampoline for a registered signature.
     pub fn trampoline(&self, index: VMSharedSignatureIndex) -> Option<VMTrampoline> {
-        self.trampolines
-            .get(&index)
-            .map(|(_, trampoline)| *trampoline)
+        self.trampolines.get(&index).copied()
     }
 }
 
@@ -93,7 +91,7 @@ impl SignatureRegistryInner {
         trampolines: impl Iterator<Item = (SignatureIndex, VMTrampoline)>,
     ) -> (
         PrimaryMap<SignatureIndex, VMSharedSignatureIndex>,
-        HashMap<VMSharedSignatureIndex, (usize, VMTrampoline)>,
+        HashMap<VMSharedSignatureIndex, VMTrampoline>,
     ) {
         let mut sigs = PrimaryMap::default();
         let mut map = HashMap::default();
@@ -104,7 +102,7 @@ impl SignatureRegistryInner {
         }
 
         for (index, trampoline) in trampolines {
-            map.insert(sigs[index], (1, trampoline));
+            map.insert(sigs[index], trampoline);
         }
 
         (sigs, map)
@@ -165,8 +163,8 @@ impl SignatureRegistryInner {
         } else {
             // Otherwise, use the trampolines map, which has reference counts related
             // to the stored index
-            for (index, (count, _)) in collection.trampolines.iter() {
-                self.unregister_entry(*index, *count);
+            for (index, _) in collection.trampolines.iter() {
+                self.unregister_entry(*index, 1);
             }
         }
     }


### PR DESCRIPTION
One test case I wrote recently was to import a lowered function into a
wasm module and then immediately export it. This previously didn't work
because trampoline lookup would fail as the original
`VMCallerCheckedAnyfunc` function pointer points into the
`trampoline_obj` of a component which wasn't registered with the
`ModuleRegistry`. This plumbs through the necessary configuration to get
that all hooked up.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
