### PR TITLE
Add a method to Linker and flag to wasmtime-cli to trap unknown import funcs

### DIFF
--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -2,8 +2,8 @@ use crate::func::HostFunc;
 use crate::instance::InstancePre;
 use crate::store::StoreOpaque;
 use crate::{
-    AsContextMut, Caller, Engine, Extern, Func, FuncType, ImportType, Instance, IntoFunc, Module,
-    StoreContextMut, Trap, Val, ValRaw,
+    AsContextMut, Caller, Engine, Extern, ExternType, Func, FuncType, ImportType, Instance,
+    IntoFunc, Module, StoreContextMut, Trap, Val, ValRaw,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use log::warn;
@@ -235,6 +235,46 @@ impl<T> Linker<T> {
     pub fn allow_unknown_exports(&mut self, allow: bool) -> &mut Self {
         self.allow_unknown_exports = allow;
         self
+    }
+
+    /// Implement any imports of the given [`Module`] with a function which traps.
+    ///
+    /// By default a [`Linker`] will error when unknown imports are encountered
+    /// in a command module while using [`Linker::module`]. Use this function
+    /// when
+    ///
+    /// This method can be used to allow unknown imports from command modules.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use wasmtime::*;
+    /// # fn main() -> anyhow::Result<()> {
+    /// # let engine = Engine::default();
+    /// # let module = Module::new(&engine, "(module (import \"unknown\" \"import\" (func)))")?;
+    /// # let mut store = Store::new(&engine, ());
+    /// let mut linker = Linker::new(&engine);
+    /// linker.define_unknown_imports_as_traps(&module)?;
+    /// linker.instantiate(&mut store, &module)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn define_unknown_imports_as_traps(&mut self, module: &Module) -> anyhow::Result<()> {
+        for import in module.imports() {
+            if self._get_by_import(&import).is_err() {
+                if let ExternType::Func(func_ty) = import.ty() {
+                    let err_msg = format!(
+                        "unknown import: `{}::{}` has not been defined",
+                        import.module(),
+                        import.name(),
+                    );
+                    self.func_new(import.module(), import.name(), func_ty, move |_, _, _| {
+                        Err(Trap::new(err_msg.clone()))
+                    })?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Defines a new item in this [`Linker`].


### PR DESCRIPTION

Sometimes users have a Command module which imports functions unknown to
the wasmtime-cli, but does not call them at runtime. This PR provides a
convenience method on Linker to define all unknown import functions in
a given Module as a trivial implementation which traps, and hooks this
up to a new cli flag --trap-unknown-imports.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
