### PR TITLE
Adds VTune profiling strategy to the C-API

### DIFF
--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -35,6 +35,7 @@ pub enum wasmtime_opt_level_t {
 pub enum wasmtime_profiling_strategy_t {
     WASMTIME_PROFILING_STRATEGY_NONE,
     WASMTIME_PROFILING_STRATEGY_JITDUMP,
+    WASMTIME_PROFILING_STRATEGY_VTUNE,
 }
 
 #[no_mangle]
@@ -150,6 +151,7 @@ pub extern "C" fn wasmtime_config_profiler_set(
     let result = c.config.profiler(match strategy {
         WASMTIME_PROFILING_STRATEGY_NONE => ProfilingStrategy::None,
         WASMTIME_PROFILING_STRATEGY_JITDUMP => ProfilingStrategy::JitDump,
+        WASMTIME_PROFILING_STRATEGY_VTUNE => ProfilingStrategy::VTune,
     });
     handle_result(result, |_cfg| {})
 }


### PR DESCRIPTION
C-API currently only includes the jitdump strategy intended for use with
perf. This adds the vtune strategy for use with Intel VTune Profiler.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
