### PR TITLE
x64: Fix codegen for the `select` instruction with v128

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -168,7 +168,7 @@
               (dst WritableGpr))
 
        ;; XMM conditional move; overwrites the destination register.
-       (XmmCmove (size OperandSize)
+       (XmmCmove (ty Type)
                  (cc CC)
                  (consequent XmmMem)
                  (alternative Xmm)
@@ -1896,10 +1896,9 @@
 
 (decl cmove_xmm (Type CC XmmMem Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (size OperandSize (operand_size_of_type_32_64 ty)))
+      (let ((dst WritableXmm (temp_writable_xmm)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
-         (MInst.XmmCmove size cc consequent alternative dst)
+         (MInst.XmmCmove ty cc consequent alternative dst)
          dst)))
 
 ;; Helper for creating `cmove` instructions directly from values. This allows us
@@ -1952,9 +1951,8 @@
 (rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
       (let ((dst WritableXmm (temp_writable_xmm))
             (tmp WritableXmm (temp_writable_xmm))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (cmove1 MInst (MInst.XmmCmove size cc1 consequent alternative tmp))
-            (cmove2 MInst (MInst.XmmCmove size cc2 consequent tmp dst)))
+            (cmove1 MInst (MInst.XmmCmove ty cc1 consequent alternative tmp))
+            (cmove2 MInst (MInst.XmmCmove ty cc2 consequent tmp dst)))
         (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
          cmove1
          cmove2

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2271,11 +2271,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 debug_assert!(ty == types::F32 || ty == types::F64);
                 emit_moves(ctx, dst, rhs, ty);
                 ctx.emit(Inst::xmm_cmove(
-                    if ty == types::F64 {
-                        OperandSize::Size64
-                    } else {
-                        OperandSize::Size32
-                    },
+                    ty,
                     cc,
                     RegMem::reg(lhs.only_reg().unwrap()),
                     dst.only_reg().unwrap(),

--- a/tests/misc_testsuite/simd/v128-select.wast
+++ b/tests/misc_testsuite/simd/v128-select.wast
@@ -1,0 +1,19 @@
+(module
+  (func (export "select") (param v128 v128 i32) (result v128)
+    local.get 0
+    local.get 1
+    local.get 2
+    select)
+)
+
+(assert_return (invoke "select"
+                       (v128.const i64x2 1 1)
+                       (v128.const i64x2 2 2)
+                       (i32.const 0))
+               (v128.const i64x2 2 2))
+
+(assert_return (invoke "select"
+                       (v128.const i64x2 1 1)
+                       (v128.const i64x2 2 2)
+                       (i32.const 1))
+               (v128.const i64x2 1 1))


### PR DESCRIPTION
This commit fixes a bug in the previous codegen for the `select`
instruction when the operations of the `select` were of the `v128` type.
Previously teh `XmmCmove` instruction only stored an `OperandSize` of 32
or 64 for a 64 or 32-bit move, but this was also used for these 128-bit
types which meant that when used the wrong move instruction was
generated. The fix applied here is to store the whole `Type` being moved
so the 128-bit variant can be selected as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
