### PR TITLE
x64: Fix codegen for the `i8x16.swizzle` instruction

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2558,17 +2558,18 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::xmm_load_const(constant, zero_mask, ty));
 
             // Use the `zero_mask` on a writable `swizzle_mask`.
-            let swizzle_mask = Writable::from_reg(swizzle_mask);
+            let swizzle_mask_tmp = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
+            ctx.emit(Inst::gen_move(swizzle_mask_tmp, swizzle_mask, ty));
             ctx.emit(Inst::xmm_rm_r(
                 SseOpcode::Paddusb,
                 RegMem::from(zero_mask),
-                swizzle_mask,
+                swizzle_mask_tmp,
             ));
 
             // Shuffle `dst` using the fixed-up `swizzle_mask`.
             ctx.emit(Inst::xmm_rm_r(
                 SseOpcode::Pshufb,
-                RegMem::from(swizzle_mask),
+                RegMem::from(swizzle_mask_tmp),
                 dst,
             ));
         }


### PR DESCRIPTION
This commit fixes a mistake in the `Swizzle` opcode implementation in
the x64 backend of Cranelift. Previously an input register was casted to
a writable register and then modified, which I believe instructions are
not supposed to do. This was discovered as part of my investigation
into #4315.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
