### PR TITLE
aarch64: Implement `bint` in ISLE

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1109,6 +1109,21 @@
 (rule (lower (has_type ty (cls x)))
       (a64_cls ty x))
 
+;;;; Rules for `bint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Booleans are stored as all-zeroes (0) or all-ones (-1). We AND
+;; out the LSB to give a 0 / 1-valued integer result.
+
+(rule (lower (has_type $I128 (bint x)))
+      (let ((val ValueRegs x)
+            (in_lo Reg (value_regs_get val 0))
+            (dst_lo Reg (and_imm $I32 in_lo (u64_into_imm_logic $I32 1)))
+            (dst_hi Reg (imm $I64 0)))
+        (value_regs dst_lo dst_hi)))
+
+(rule (lower (bint x))
+      (and_imm $I32 x (u64_into_imm_logic $I32 1)))
+
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; The implementation of `popcnt` for scalar types is done by moving the value

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -481,33 +481,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         }
 
-        Opcode::Bint => {
-            let ty = ty.unwrap();
-
-            if ty.is_vector() {
-                return Err(CodegenError::Unsupported(format!(
-                    "Bint: Unsupported type: {:?}",
-                    ty
-                )));
-            }
-
-            // Booleans are stored as all-zeroes (0) or all-ones (-1). We AND
-            // out the LSB to give a 0 / 1-valued integer result.
-            let input = put_input_in_regs(ctx, inputs[0]);
-            let output = get_output_reg(ctx, outputs[0]);
-
-            ctx.emit(Inst::AluRRImmLogic {
-                alu_op: ALUOp::And,
-                size: OperandSize::Size32,
-                rd: output.regs()[0],
-                rn: input.regs()[0],
-                imml: ImmLogic::maybe_from_u64(1, I32).unwrap(),
-            });
-
-            if ty_bits(ty) > 64 {
-                lower_constant_u64(ctx, output.regs()[1], 0);
-            }
-        }
+        Opcode::Bint => implemented_in_isle(ctx),
 
         Opcode::Bitcast => {
             let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();


### PR DESCRIPTION
👋  Hey, This moves the `bint` instruction into isle rules for aarch64