### PR TITLE
cranelift: Implement scalar `ireduce` on interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/i128-ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/i128-ireduce.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 set enable_llvm_abi_extensions=true
 target aarch64

--- a/cranelift/filetests/filetests/runtests/ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/ireduce.clif
@@ -1,0 +1,58 @@
+test interpret
+test run
+target aarch64
+target x86_64
+
+function %ireduce_i16_i8(i16) -> i8 {
+block0(v0: i16):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i16_i8(0xFF00) == 0x00
+; run: %ireduce_i16_i8(0x0042) == 0x42
+; run: %ireduce_i16_i8(0xFFFF) == 0xFF
+
+function %ireduce_i32_i8(i32) -> i8 {
+block0(v0: i32):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i32_i8(0xFFFFFF00) == 0x00
+; run: %ireduce_i32_i8(0x00000042) == 0x42
+; run: %ireduce_i32_i8(0xFFFFFFFF) == 0xFF
+
+function %ireduce_i32_i16(i32) -> i16 {
+block0(v0: i32):
+  v1 = ireduce.i16 v0
+  return v1
+}
+; run: %ireduce_i32_i16(0xFFFF0000) == 0x0000
+; run: %ireduce_i32_i16(0x00004242) == 0x4242
+; run: %ireduce_i32_i16(0xFFFFFFFF) == 0xFFFF
+
+function %ireduce_i64_i8(i64) -> i8 {
+block0(v0: i64):
+  v1 = ireduce.i8 v0
+  return v1
+}
+; run: %ireduce_i64_i8(0xFFFFFFFF_FFFFFF00) == 0x00
+; run: %ireduce_i64_i8(0x00000000_00000042) == 0x42
+; run: %ireduce_i64_i8(0xFFFFFFFF_FFFFFFFF) == 0xFF
+
+function %ireduce_i64_i16(i64) -> i16 {
+block0(v0: i64):
+  v1 = ireduce.i16 v0
+  return v1
+}
+; run: %ireduce_i64_i16(0xFFFFFFFF_FFFF0000) == 0x0000
+; run: %ireduce_i64_i16(0x00000000_00004242) == 0x4242
+; run: %ireduce_i64_i16(0xFFFFFFFF_FFFFFFFF) == 0xFFFF
+
+function %ireduce_i64_i32(i64) -> i32 {
+block0(v0: i64):
+  v1 = ireduce.i32 v0
+  return v1
+}
+; run: %ireduce_i64_i32(0xFFFFFFFF_00000000) == 0x00000000
+; run: %ireduce_i64_i32(0x00000000_42424242) == 0x42424242
+; run: %ireduce_i64_i32(0xFFFFFFFF_FFFFFFFF) == 0xFFFFFFFF

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -715,10 +715,13 @@ where
         | Opcode::RawBitcast
         | Opcode::ScalarToVector
         | Opcode::Breduce
-        | Opcode::Bextend
-        | Opcode::Ireduce => assign(Value::convert(
+        | Opcode::Bextend => assign(Value::convert(
             arg(0)?,
             ValueConversionKind::Exact(ctrl_ty),
+        )?),
+        Opcode::Ireduce => assign(Value::convert(
+            arg(0)?,
+            ValueConversionKind::Truncate(ctrl_ty),
         )?),
         Opcode::Bint => {
             let bool = arg(0)?.into_bool()?;


### PR DESCRIPTION
Hey, This implements `ireduce` on the interpreter. It ignores the SIMD version of the instruction because the interpreter isn't really ready for non 128 bit vectors.