### PR TITLE
cranelift: Support boolean arguments larger than `b1` in trampoline

### DIFF
--- a/cranelift/filetests/filetests/runtests/bextend.clif
+++ b/cranelift/filetests/filetests/runtests/bextend.clif
@@ -1,4 +1,8 @@
 test interpret
+test run
+target aarch64
+target x86_64
+target s390x
 
 function %bextend_b1_b8(b1) -> b8 {
 block0(v0: b1):

--- a/cranelift/filetests/filetests/runtests/breduce.clif
+++ b/cranelift/filetests/filetests/runtests/breduce.clif
@@ -1,4 +1,8 @@
 test interpret
+test run
+target aarch64
+target x86_64
+target s390x
 
 function %breduce_b8_b1(b8) -> b1 {
 block0(v0: b8):


### PR DESCRIPTION
Hey,

This PR adds support for scalar booleans larger than b1 as arguments to test functions.

This doesen't yet close #2237 since we are still missing the ability to return boolean vectors. See #3341 and #3384 for more details on that.