### PR TITLE
Cranelift: update to latest regalloc2 for better clobber and splitting handling.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
+checksum = "dd4159f16b35683a517cc0318997f8fbe89523ed03526c90e267bed6d66ced36"
 dependencies = [
  "fxhash",
  "log",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
-regalloc2 = { version = "0.2.3", features = ["checker"] }
+regalloc2 = { version = "0.3.0", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -14,7 +14,7 @@ use crate::settings;
 use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use regalloc2::VReg;
+use regalloc2::{PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
 
 // We use a generic implementation that factors out AArch64 and x64 ABI commonalities, because
@@ -1062,8 +1062,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn gen_call(
         dest: &CallDest,
-        uses: Vec<Reg>,
-        defs: Vec<Writable<Reg>>,
+        uses: SmallVec<[Reg; 8]>,
+        defs: SmallVec<[Writable<Reg>; 8]>,
+        clobbers: PRegSet,
         opcode: ir::Opcode,
         tmp: Writable<Reg>,
         callee_conv: isa::CallConv,
@@ -1076,6 +1077,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     dest: name.clone(),
                     uses,
                     defs,
+                    clobbers,
                     opcode,
                     caller_callconv: caller_conv,
                     callee_callconv: callee_conv,
@@ -1092,6 +1094,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                         rn: tmp.to_reg(),
                         uses,
                         defs,
+                        clobbers,
                         opcode,
                         caller_callconv: caller_conv,
                         callee_callconv: callee_conv,
@@ -1103,6 +1106,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                     rn: *reg,
                     uses,
                     defs,
+                    clobbers,
                     opcode,
                     caller_callconv: caller_conv,
                     callee_callconv: callee_conv,
@@ -1131,8 +1135,9 @@ impl ABIMachineSpec for AArch64MachineDeps {
         insts.push(Inst::Call {
             info: Box::new(CallInfo {
                 dest: ExternalName::LibCall(LibCall::Memcpy),
-                uses: vec![arg0.to_reg(), arg1.to_reg(), arg2.to_reg()],
-                defs: Self::get_regs_clobbered_by_call(call_conv),
+                uses: smallvec![arg0.to_reg(), arg1.to_reg(), arg2.to_reg()],
+                defs: smallvec![],
+                clobbers: Self::get_regs_clobbered_by_call(call_conv),
                 opcode: Opcode::Call,
                 caller_callconv: call_conv,
                 callee_callconv: call_conv,
@@ -1159,21 +1164,19 @@ impl ABIMachineSpec for AArch64MachineDeps {
         s.nominal_sp_to_fp
     }
 
-    fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> Vec<Writable<Reg>> {
-        let mut caller_saved = Vec::new();
-        for i in 0..29 {
-            let x = writable_xreg(i);
-            if is_reg_clobbered_by_call(call_conv_of_callee, x.to_reg().to_real_reg().unwrap()) {
-                caller_saved.push(x);
+    fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
+        let mut clobbers = DEFAULT_AAPCS_CLOBBERS;
+
+        if call_conv_of_callee.extends_baldrdash() {
+            // Every X-register except for x16, x17, x18 is
+            // caller-saved (clobbered by a call).
+            for i in 19..=28 {
+                clobbers.add(xreg_preg(i));
             }
+            clobbers.add(vreg_preg(31));
         }
-        for i in 0..32 {
-            let v = writable_vreg(i);
-            if is_reg_clobbered_by_call(call_conv_of_callee, v.to_reg().to_real_reg().unwrap()) {
-                caller_saved.push(v);
-            }
-        }
-        caller_saved
+
+        clobbers
     }
 
     fn get_ext_mode(
@@ -1290,47 +1293,74 @@ fn get_regs_restored_in_epilogue(
     (int_saves, vec_saves)
 }
 
-fn is_reg_clobbered_by_call(call_conv_of_callee: isa::CallConv, r: RealReg) -> bool {
-    if call_conv_of_callee.extends_baldrdash() {
-        match r.class() {
-            RegClass::Int => {
-                let enc = r.hw_enc() & 31;
-                if !BALDRDASH_JIT_CALLEE_SAVED_GPR[enc as usize] {
-                    return true;
-                }
-                // Otherwise, fall through to preserve native's ABI caller-saved.
-            }
-            RegClass::Float => {
-                let enc = r.hw_enc() & 31;
-                if !BALDRDASH_JIT_CALLEE_SAVED_FPU[enc as usize] {
-                    return true;
-                }
-                // Otherwise, fall through to preserve native's ABI caller-saved.
-            }
-        };
-    }
-
-    match r.class() {
-        RegClass::Int => {
-            // x0 - x17 inclusive are caller-saves.
-            r.hw_enc() <= 17
-        }
-        RegClass::Float => {
-            // v0 - v7 inclusive and v16 - v31 inclusive are caller-saves. The
-            // upper 64 bits of v8 - v15 inclusive are also caller-saves.
-            // However, because we cannot currently represent partial registers
-            // to regalloc.rs, we indicate here that every vector register is
-            // caller-save. Because this function is used at *callsites*,
-            // approximating in this direction (save more than necessary) is
-            // conservative and thus safe.
-            //
-            // Note that we set the 'not included in clobber set' flag in the
-            // regalloc.rs API when a call instruction's callee has the same ABI
-            // as the caller (the current function body); this is safe (anything
-            // clobbered by callee can be clobbered by caller as well) and
-            // avoids unnecessary saves of v8-v15 in the prologue even though we
-            // include them as defs here.
-            true
-        }
-    }
+const fn default_aapcs_clobbers() -> PRegSet {
+    PRegSet::empty()
+        // x0 - x17 inclusive are caller-saves.
+        .with(xreg_preg(0))
+        .with(xreg_preg(1))
+        .with(xreg_preg(2))
+        .with(xreg_preg(3))
+        .with(xreg_preg(4))
+        .with(xreg_preg(5))
+        .with(xreg_preg(6))
+        .with(xreg_preg(7))
+        .with(xreg_preg(8))
+        .with(xreg_preg(9))
+        .with(xreg_preg(10))
+        .with(xreg_preg(11))
+        .with(xreg_preg(12))
+        .with(xreg_preg(13))
+        .with(xreg_preg(14))
+        .with(xreg_preg(15))
+        .with(xreg_preg(16))
+        .with(xreg_preg(17))
+        // v0 - v7 inclusive and v16 - v31 inclusive are
+        // caller-saves. The upper 64 bits of v8 - v15 inclusive are
+        // also caller-saves.  However, because we cannot currently
+        // represent partial registers to regalloc2, we indicate here
+        // that every vector register is caller-save. Because this
+        // function is used at *callsites*, approximating in this
+        // direction (save more than necessary) is conservative and
+        // thus safe.
+        //
+        // Note that we exclude clobbers from a call instruction when
+        // a call instruction's callee has the same ABI as the caller
+        // (the current function body); this is safe (anything
+        // clobbered by callee can be clobbered by caller as well) and
+        // avoids unnecessary saves of v8-v15 in the prologue even
+        // though we include them as defs here.
+        .with(vreg_preg(0))
+        .with(vreg_preg(1))
+        .with(vreg_preg(2))
+        .with(vreg_preg(3))
+        .with(vreg_preg(4))
+        .with(vreg_preg(5))
+        .with(vreg_preg(6))
+        .with(vreg_preg(7))
+        .with(vreg_preg(8))
+        .with(vreg_preg(9))
+        .with(vreg_preg(10))
+        .with(vreg_preg(11))
+        .with(vreg_preg(12))
+        .with(vreg_preg(13))
+        .with(vreg_preg(14))
+        .with(vreg_preg(15))
+        .with(vreg_preg(16))
+        .with(vreg_preg(17))
+        .with(vreg_preg(18))
+        .with(vreg_preg(19))
+        .with(vreg_preg(20))
+        .with(vreg_preg(21))
+        .with(vreg_preg(22))
+        .with(vreg_preg(23))
+        .with(vreg_preg(24))
+        .with(vreg_preg(25))
+        .with(vreg_preg(26))
+        .with(vreg_preg(27))
+        .with(vreg_preg(28))
+        .with(vreg_preg(29))
+        .with(vreg_preg(30))
+        .with(vreg_preg(31))
 }
+
+const DEFAULT_AAPCS_CLOBBERS: PRegSet = default_aapcs_clobbers();

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -5286,8 +5286,9 @@ fn test_aarch64_binemit() {
         Inst::Call {
             info: Box::new(CallInfo {
                 dest: ExternalName::testcase("test0"),
-                uses: Vec::new(),
-                defs: Vec::new(),
+                uses: smallvec![],
+                defs: smallvec![],
+                clobbers: PRegSet::empty(),
                 opcode: Opcode::Call,
                 caller_callconv: CallConv::SystemV,
                 callee_callconv: CallConv::SystemV,
@@ -5301,8 +5302,9 @@ fn test_aarch64_binemit() {
         Inst::CallInd {
             info: Box::new(CallIndInfo {
                 rn: xreg(10),
-                uses: Vec::new(),
-                defs: Vec::new(),
+                uses: smallvec![],
+                defs: smallvec![],
+                clobbers: PRegSet::empty(),
                 opcode: Opcode::CallIndirect,
                 caller_callconv: CallConv::SystemV,
                 callee_callconv: CallConv::SystemV,

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -24,9 +24,13 @@ pub const PINNED_REG: u8 = 21;
 /// Get a reference to an X-register (integer register). Do not use
 /// this for xsp / xzr; we have two special registers for those.
 pub fn xreg(num: u8) -> Reg {
+    Reg::from(xreg_preg(num))
+}
+
+/// Get the given X-register as a PReg.
+pub(crate) const fn xreg_preg(num: u8) -> PReg {
     assert!(num < 31);
-    let preg = PReg::new(num as usize, RegClass::Int);
-    Reg::from(VReg::new(preg.index(), RegClass::Int))
+    PReg::new(num as usize, RegClass::Int)
 }
 
 /// Get a writable reference to an X-register.
@@ -36,9 +40,13 @@ pub fn writable_xreg(num: u8) -> Writable<Reg> {
 
 /// Get a reference to a V-register (vector/FP register).
 pub fn vreg(num: u8) -> Reg {
+    Reg::from(vreg_preg(num))
+}
+
+/// Get the given V-register as a PReg.
+pub(crate) const fn vreg_preg(num: u8) -> PReg {
     assert!(num < 32);
-    let preg = PReg::new(num as usize, RegClass::Float);
-    Reg::from(VReg::new(preg.index(), RegClass::Float))
+    PReg::new(num as usize, RegClass::Float)
 }
 
 /// Get a writable reference to a V-register.

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -6804,8 +6804,9 @@ fn test_s390x_binemit() {
             link: writable_gpr(14),
             info: Box::new(CallInfo {
                 dest: ExternalName::testcase("test0"),
-                uses: Vec::new(),
-                defs: Vec::new(),
+                uses: smallvec![],
+                defs: smallvec![],
+                clobbers: PRegSet::empty(),
                 opcode: Opcode::Call,
             }),
         },
@@ -6818,8 +6819,9 @@ fn test_s390x_binemit() {
             link: writable_gpr(14),
             info: Box::new(CallIndInfo {
                 rn: gpr(1),
-                uses: Vec::new(),
-                defs: Vec::new(),
+                uses: smallvec![],
+                defs: smallvec![],
+                clobbers: PRegSet::empty(),
                 opcode: Opcode::CallIndirect,
             }),
         },

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -13,9 +13,13 @@ use crate::settings;
 
 /// Get a reference to a GPR (integer register).
 pub fn gpr(num: u8) -> Reg {
-    assert!(num < 16);
-    let preg = PReg::new(num as usize, RegClass::Int);
+    let preg = gpr_preg(num);
     Reg::from(VReg::new(preg.index(), RegClass::Int))
+}
+
+pub(crate) const fn gpr_preg(num: u8) -> PReg {
+    assert!(num < 16);
+    PReg::new(num as usize, RegClass::Int)
 }
 
 /// Get a writable reference to a GPR.
@@ -25,12 +29,17 @@ pub fn writable_gpr(num: u8) -> Writable<Reg> {
 
 /// Get a reference to a FPR (floating-point register).
 pub fn fpr(num: u8) -> Reg {
-    assert!(num < 16);
-    let preg = PReg::new(num as usize, RegClass::Float);
+    let preg = fpr_preg(num);
     Reg::from(VReg::new(preg.index(), RegClass::Float))
 }
 
-/// Get a writable reference to a V-register.
+pub(crate) const fn fpr_preg(num: u8) -> PReg {
+    assert!(num < 16);
+    PReg::new(num as usize, RegClass::Float)
+}
+
+/// Get a writable reference to a FPR.
+#[allow(dead_code)] // used by tests.
 pub fn writable_fpr(num: u8) -> Writable<Reg> {
     Writable::from_reg(fpr(num))
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -315,15 +315,11 @@
 
        ;; Direct call: call simm32.
        (CallKnown (dest ExternalName)
-                  (uses VecReg)
-                  (defs VecWritableReg)
-                  (opcode Opcode))
+                  (info BoxCallInfo))
 
        ;; Indirect call: callq (reg mem)
        (CallUnknown (dest RegMem)
-                    (uses VecReg)
-                    (defs VecWritableReg)
-                    (opcode Opcode))
+                    (info BoxCallInfo))
 
        ;; Return.
        (Ret (rets VecReg))
@@ -501,6 +497,8 @@
       (enum MFence
             LFence
             SFence))
+
+(type BoxCallInfo extern (enum))
 
 ;; Get the `OperandSize` for a given `Type`, rounding smaller types up to 32 bits.
 (decl operand_size_of_type_32_64 (Type) OperandSize)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -3572,8 +3572,9 @@ fn test_x64_emit() {
                 namespace: 0,
                 index: 0,
             },
-            Vec::new(),
-            Vec::new(),
+            smallvec![],
+            smallvec![],
+            PRegSet::default(),
             Opcode::Call,
         ),
         "E800000000",
@@ -3583,7 +3584,13 @@ fn test_x64_emit() {
     // ========================================================
     // CallUnknown
     fn call_unknown(rm: RegMem) -> Inst {
-        Inst::call_unknown(rm, Vec::new(), Vec::new(), Opcode::CallIndirect)
+        Inst::call_unknown(
+            rm,
+            smallvec![],
+            smallvec![],
+            PRegSet::default(),
+            Opcode::CallIndirect,
+        )
     }
 
     insns.push((call_unknown(RegMem::reg(rbp)), "FFD5", "call    *%rbp"));

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -33,8 +33,11 @@ pub const ENC_R15: u8 = 15;
 // Constructors for Regs.
 
 fn gpr(enc: u8) -> Reg {
-    let preg = PReg::new(enc as usize, RegClass::Int);
+    let preg = gpr_preg(enc);
     Reg::from(VReg::new(preg.index(), RegClass::Int))
+}
+pub(crate) const fn gpr_preg(enc: u8) -> PReg {
+    PReg::new(enc as usize, RegClass::Int)
 }
 
 pub(crate) fn rsi() -> Reg {
@@ -96,8 +99,12 @@ pub(crate) fn pinned_reg() -> Reg {
 }
 
 fn fpr(enc: u8) -> Reg {
-    let preg = PReg::new(enc as usize, RegClass::Float);
+    let preg = fpr_preg(enc);
     Reg::from(VReg::new(preg.index(), RegClass::Float))
+}
+
+pub(crate) const fn fpr_preg(enc: u8) -> PReg {
+    PReg::new(enc as usize, RegClass::Float)
 }
 
 pub(crate) fn xmm0() -> Reg {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -18,7 +18,7 @@ use crate::{
         settings::Flags,
         unwind::UnwindInst,
         x64::{
-            inst::{args::*, regs},
+            inst::{args::*, regs, CallInfo},
             settings::Flags as IsaFlags,
         },
     },
@@ -26,7 +26,10 @@ use crate::{
         isle::*, AtomicRmwOp, InsnInput, InsnOutput, LowerCtx, VCodeConstant, VCodeConstantData,
     },
 };
+use std::boxed::Box;
 use std::convert::TryFrom;
+
+type BoxCallInfo = Box<CallInfo>;
 
 pub struct SinkableLoad {
     inst: Inst,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -16,7 +16,6 @@ pub type ValueArray2 = [Value; 2];
 pub type ValueArray3 = [Value; 3];
 pub type WritableReg = Writable<Reg>;
 pub type VecReg = Vec<Reg>;
-pub type VecWritableReg = Vec<WritableReg>;
 pub type ValueRegs = crate::machinst::ValueRegs<Reg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;


### PR DESCRIPTION
- Handle call instructions' clobbers with the clobbers API, using RA2's
  clobbers bitmask (bytecodealliance/regalloc2#58) rather than clobbers
  list;

- Pull in changes from bytecodealliance/regalloc2#59 for much more sane
  edge-case behavior w.r.t. liverange splitting.

Currently refers to local path for RA2 so will fail CI; I will update
this once RA2 PRs 58 and 59 are merged, version-bumped and released.

Fixes #4291.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
