### PR TITLE
Use a `StoreOpaque` during backtraces for metadata

### DIFF
--- a/benches/thread_eager_init.rs
+++ b/benches/thread_eager_init.rs
@@ -78,7 +78,7 @@ fn lazy_thread_instantiate(engine: Engine, module: Module) -> Duration {
 fn eager_thread_instantiate(engine: Engine, module: Module) -> (Duration, Duration) {
     thread::spawn(move || {
         let init_start = Instant::now();
-        Engine::tls_eager_initialize().expect("eager init");
+        Engine::tls_eager_initialize();
         let init_duration = init_start.elapsed();
 
         (init_duration, duration_of_call(&engine, &module))

--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -33,7 +33,7 @@
 
 #![allow(non_snake_case)]
 
-use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
+use crate::traphandlers::{tls, wasmtime_longjmp};
 use mach::exception_types::*;
 use mach::kern_return::*;
 use mach::mach_init::*;
@@ -410,7 +410,7 @@ unsafe extern "C" fn unwind(wasm_pc: *const u8) -> ! {
 /// task-level port which is where we'd expected things like breakpad/crashpad
 /// exception handlers to get registered.
 #[cold]
-pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
+pub fn lazy_per_thread_init() {
     unsafe {
         assert!(WASMTIME_PORT != MACH_PORT_NULL);
         let this_thread = mach_thread_self();
@@ -424,5 +424,4 @@ pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
         mach_port_deallocate(mach_task_self(), this_thread);
         assert_eq!(kret, KERN_SUCCESS, "failed to set thread exception port");
     }
-    Ok(())
 }

--- a/crates/runtime/src/traphandlers/windows.rs
+++ b/crates/runtime/src/traphandlers/windows.rs
@@ -1,4 +1,4 @@
-use crate::traphandlers::{tls, wasmtime_longjmp, Trap};
+use crate::traphandlers::{tls, wasmtime_longjmp};
 use std::io;
 use winapi::um::errhandlingapi::*;
 use winapi::um::minwinbase::*;
@@ -74,7 +74,6 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
     })
 }
 
-pub fn lazy_per_thread_init() -> Result<(), Box<Trap>> {
+pub fn lazy_per_thread_init() {
     // Unused on Windows
-    Ok(())
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -1,5 +1,5 @@
 use crate::signatures::SignatureRegistry;
-use crate::{Config, Trap};
+use crate::Config;
 use anyhow::Result;
 use once_cell::sync::OnceCell;
 #[cfg(feature = "parallel-compilation")]
@@ -71,7 +71,7 @@ impl Engine {
         // Ensure that wasmtime_runtime's signal handlers are configured. This
         // is the per-program initialization required for handling traps, such
         // as configuring signals, vectored exception handlers, etc.
-        wasmtime_runtime::init_traps(crate::module::GlobalModuleRegistry::is_wasm_trap_pc);
+        wasmtime_runtime::init_traps(crate::module::is_wasm_trap_pc);
         debug_builtins::ensure_exported();
 
         let registry = SignatureRegistry::new();
@@ -117,8 +117,8 @@ impl Engine {
     /// on calls into WebAssembly. This is provided for use cases where the
     /// latency of WebAssembly calls are extra-important, which is not
     /// necessarily true of all embeddings.
-    pub fn tls_eager_initialize() -> Result<(), Trap> {
-        wasmtime_runtime::tls_eager_initialize().map_err(Trap::from_runtime_box)
+    pub fn tls_eager_initialize() {
+        wasmtime_runtime::tls_eager_initialize();
     }
 
     /// Returns the configuration settings that this engine is using.

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1241,7 +1241,7 @@ pub(crate) fn invoke_wasm_and_catch_traps<T>(
         );
         exit_wasm(store, exit);
         store.0.call_hook(CallHook::ReturningFromWasm)?;
-        result.map_err(Trap::from_runtime_box)
+        result.map_err(|t| Trap::from_runtime_box(store.0, t))
     }
 }
 

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -413,7 +413,7 @@ pub use crate::instance::{Instance, InstancePre};
 pub use crate::limits::*;
 pub use crate::linker::*;
 pub use crate::memory::*;
-pub use crate::module::{FrameInfo, FrameSymbol, Module};
+pub use crate::module::Module;
 pub use crate::r#ref::ExternRef;
 #[cfg(feature = "async")]
 pub use crate::store::CallHookHandler;

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -25,7 +25,7 @@ use wasmtime_runtime::{
 mod registry;
 mod serialization;
 
-pub use registry::{FrameInfo, FrameSymbol, GlobalModuleRegistry, ModuleRegistry};
+pub use registry::{is_wasm_trap_pc, ModuleRegistry};
 pub use serialization::SerializedModule;
 
 /// A compiled WebAssembly module, ready to be instantiated.
@@ -511,7 +511,7 @@ impl Module {
         // into the global registry of modules so we can resolve traps
         // appropriately. Note that the corresponding `unregister` happens below
         // in `Drop for ModuleInner`.
-        registry::register(engine, &module);
+        registry::register(&module);
 
         Ok(Self {
             inner: Arc::new(ModuleInner {

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1160,6 +1160,11 @@ impl StoreOpaque {
     }
 
     #[inline]
+    pub(crate) fn modules(&self) -> &ModuleRegistry {
+        &self.modules
+    }
+
+    #[inline]
     pub(crate) fn modules_mut(&mut self) -> &mut ModuleRegistry {
         &mut self.modules
     }
@@ -1767,9 +1772,9 @@ impl AsyncCx {
                 Poll::Pending => {}
             }
 
-            let before = wasmtime_runtime::TlsRestore::take().map_err(Trap::from_runtime_box)?;
+            let before = wasmtime_runtime::TlsRestore::take();
             let res = (*suspend).suspend(());
-            before.replace().map_err(Trap::from_runtime_box)?;
+            before.replace();
             res?;
         }
     }

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -1,9 +1,9 @@
-use crate::module::GlobalModuleRegistry;
-use crate::FrameInfo;
+use crate::store::StoreOpaque;
+use crate::Module;
 use once_cell::sync::OnceCell;
 use std::fmt;
 use std::sync::Arc;
-use wasmtime_environ::TrapCode as EnvTrapCode;
+use wasmtime_environ::{EntityRef, FilePos, TrapCode as EnvTrapCode};
 use wasmtime_jit::{demangle_function_name, demangle_function_name_or_index};
 use wasmtime_runtime::Backtrace;
 
@@ -136,44 +136,44 @@ pub(crate) struct TrapBacktrace {
 }
 
 impl TrapBacktrace {
-    pub fn new(native_trace: Backtrace, trap_pc: Option<usize>) -> Self {
+    pub fn new(store: &StoreOpaque, native_trace: Backtrace, trap_pc: Option<usize>) -> Self {
         let mut wasm_trace = Vec::<FrameInfo>::new();
         let mut hint_wasm_backtrace_details_env = false;
+        let wasm_backtrace_details_env_used =
+            store.engine().config().wasm_backtrace_details_env_used;
 
-        GlobalModuleRegistry::with(|registry| {
-            for frame in native_trace.frames() {
-                let pc = frame.ip() as usize;
-                if pc == 0 {
-                    continue;
-                }
-                // Note that we need to be careful about the pc we pass in
-                // here to lookup frame information. This program counter is
-                // used to translate back to an original source location in
-                // the origin wasm module. If this pc is the exact pc that
-                // the trap happened at, then we look up that pc precisely.
-                // Otherwise backtrace information typically points at the
-                // pc *after* the call instruction (because otherwise it's
-                // likely a call instruction on the stack). In that case we
-                // want to lookup information for the previous instruction
-                // (the call instruction) so we subtract one as the lookup.
-                let pc_to_lookup = if Some(pc) == trap_pc { pc } else { pc - 1 };
-                if let Some((info, has_unparsed_debuginfo, wasm_backtrace_details_env_used)) =
-                    registry.lookup_frame_info(pc_to_lookup)
-                {
-                    wasm_trace.push(info);
+        for frame in native_trace.frames() {
+            let pc = frame.ip() as usize;
+            if pc == 0 {
+                continue;
+            }
+            // Note that we need to be careful about the pc we pass in
+            // here to lookup frame information. This program counter is
+            // used to translate back to an original source location in
+            // the origin wasm module. If this pc is the exact pc that
+            // the trap happened at, then we look up that pc precisely.
+            // Otherwise backtrace information typically points at the
+            // pc *after* the call instruction (because otherwise it's
+            // likely a call instruction on the stack). In that case we
+            // want to lookup information for the previous instruction
+            // (the call instruction) so we subtract one as the lookup.
+            let pc_to_lookup = if Some(pc) == trap_pc { pc } else { pc - 1 };
+            if let Some((info, module)) = store.modules().lookup_frame_info(pc_to_lookup) {
+                wasm_trace.push(info);
 
-                    // If this frame has unparsed debug information and the
-                    // store's configuration indicates that we were
-                    // respecting the environment variable of whether to
-                    // do this then we will print out a helpful note in
-                    // `Display` to indicate that more detailed information
-                    // in a trap may be available.
-                    if has_unparsed_debuginfo && wasm_backtrace_details_env_used {
-                        hint_wasm_backtrace_details_env = true;
-                    }
+                // If this frame has unparsed debug information and the
+                // store's configuration indicates that we were
+                // respecting the environment variable of whether to
+                // do this then we will print out a helpful note in
+                // `Display` to indicate that more detailed information
+                // in a trap may be available.
+                let has_unparsed_debuginfo = module.compiled_module().has_unparsed_debuginfo();
+                if has_unparsed_debuginfo && wasm_backtrace_details_env_used {
+                    hint_wasm_backtrace_details_env = true;
                 }
             }
-        });
+        }
+
         Self {
             wasm_trace,
             native_trace,
@@ -212,38 +212,35 @@ impl Trap {
     }
 
     #[cold] // see Trap::new
-    pub(crate) fn from_runtime_box(runtime_trap: Box<wasmtime_runtime::Trap>) -> Self {
-        Self::from_runtime(*runtime_trap)
+    pub(crate) fn from_runtime_box(
+        store: &StoreOpaque,
+        runtime_trap: Box<wasmtime_runtime::Trap>,
+    ) -> Self {
+        Self::from_runtime(store, *runtime_trap)
     }
 
     #[cold] // see Trap::new
-    pub(crate) fn from_runtime(runtime_trap: wasmtime_runtime::Trap) -> Self {
+    pub(crate) fn from_runtime(store: &StoreOpaque, runtime_trap: wasmtime_runtime::Trap) -> Self {
         let wasmtime_runtime::Trap { reason, backtrace } = runtime_trap;
         match reason {
             wasmtime_runtime::TrapReason::User(error) => {
                 let trap = Trap::from(error);
                 if let Some(backtrace) = backtrace {
-                    trap.record_backtrace(TrapBacktrace::new(backtrace, None));
+                    trap.record_backtrace(TrapBacktrace::new(store, backtrace, None));
                 }
                 trap
             }
             wasmtime_runtime::TrapReason::Jit(pc) => {
-                let code = GlobalModuleRegistry::with(|modules| {
-                    modules
-                        .lookup_trap_code(pc)
-                        .unwrap_or(EnvTrapCode::StackOverflow)
-                });
-                let backtrace = backtrace.map(|bt| TrapBacktrace::new(bt, Some(pc)));
+                let code = store
+                    .modules()
+                    .lookup_trap_code(pc)
+                    .unwrap_or(EnvTrapCode::StackOverflow);
+                let backtrace = backtrace.map(|bt| TrapBacktrace::new(store, bt, Some(pc)));
                 Trap::new_wasm(code, backtrace)
             }
             wasmtime_runtime::TrapReason::Wasm(trap_code) => {
-                let backtrace = backtrace.map(|bt| TrapBacktrace::new(bt, None));
+                let backtrace = backtrace.map(|bt| TrapBacktrace::new(store, bt, None));
                 Trap::new_wasm(trap_code, backtrace)
-            }
-            wasmtime_runtime::TrapReason::OOM => {
-                let reason = TrapReason::Message("out of memory".to_string());
-                let backtrace = backtrace.map(|bt| TrapBacktrace::new(bt, None));
-                Trap::new_with_trace(reason, backtrace)
             }
         }
     }
@@ -440,5 +437,226 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Trap {
             let reason = TrapReason::Error(e.into());
             Trap::new_with_trace(reason, None)
         }
+    }
+}
+
+/// Description of a frame in a backtrace for a [`Trap`].
+///
+/// Whenever a WebAssembly trap occurs an instance of [`Trap`] is created. Each
+/// [`Trap`] has a backtrace of the WebAssembly frames that led to the trap, and
+/// each frame is described by this structure.
+///
+/// [`Trap`]: crate::Trap
+#[derive(Debug)]
+pub struct FrameInfo {
+    module_name: Option<String>,
+    func_index: u32,
+    func_name: Option<String>,
+    func_start: FilePos,
+    instr: Option<FilePos>,
+    symbols: Vec<FrameSymbol>,
+}
+
+impl FrameInfo {
+    /// Fetches frame information about a program counter in a backtrace.
+    ///
+    /// Returns an object if this `pc` is known to this module, or returns `None`
+    /// if no information can be found.
+    pub(crate) fn new(module: &Module, text_offset: usize) -> Option<FrameInfo> {
+        let module = module.compiled_module();
+        let (index, _func_offset) = module.func_by_text_offset(text_offset)?;
+        let info = module.func_info(index);
+        let instr = wasmtime_environ::lookup_file_pos(module.address_map_data(), text_offset);
+
+        // In debug mode for now assert that we found a mapping for `pc` within
+        // the function, because otherwise something is buggy along the way and
+        // not accounting for all the instructions. This isn't super critical
+        // though so we can omit this check in release mode.
+        //
+        // Note that if the module doesn't even have an address map due to
+        // compilation settings then it's expected that `instr` is `None`.
+        debug_assert!(
+            instr.is_some() || !module.has_address_map(),
+            "failed to find instruction for {:#x}",
+            text_offset
+        );
+
+        // Use our wasm-relative pc to symbolize this frame. If there's a
+        // symbolication context (dwarf debug info) available then we can try to
+        // look this up there.
+        //
+        // Note that dwarf pcs are code-section-relative, hence the subtraction
+        // from the location of `instr`. Also note that all errors are ignored
+        // here for now since technically wasm modules can always have any
+        // custom section contents.
+        let mut symbols = Vec::new();
+
+        if let Some(s) = &module.symbolize_context().ok().and_then(|c| c) {
+            if let Some(offset) = instr.and_then(|i| i.file_offset()) {
+                let to_lookup = u64::from(offset) - s.code_section_offset();
+                if let Ok(mut frames) = s.addr2line().find_frames(to_lookup) {
+                    while let Ok(Some(frame)) = frames.next() {
+                        symbols.push(FrameSymbol {
+                            name: frame
+                                .function
+                                .as_ref()
+                                .and_then(|l| l.raw_name().ok())
+                                .map(|s| s.to_string()),
+                            file: frame
+                                .location
+                                .as_ref()
+                                .and_then(|l| l.file)
+                                .map(|s| s.to_string()),
+                            line: frame.location.as_ref().and_then(|l| l.line),
+                            column: frame.location.as_ref().and_then(|l| l.column),
+                        });
+                    }
+                }
+            }
+        }
+
+        let index = module.module().func_index(index);
+
+        Some(FrameInfo {
+            module_name: module.module().name.clone(),
+            func_index: index.index() as u32,
+            func_name: module.func_name(index).map(|s| s.to_string()),
+            instr,
+            func_start: info.start_srcloc,
+            symbols,
+        })
+    }
+
+    /// Returns the WebAssembly function index for this frame.
+    ///
+    /// This function index is the index in the function index space of the
+    /// WebAssembly module that this frame comes from.
+    pub fn func_index(&self) -> u32 {
+        self.func_index
+    }
+
+    /// Returns the identifer of the module that this frame is for.
+    ///
+    /// Module identifiers are present in the `name` section of a WebAssembly
+    /// binary, but this may not return the exact item in the `name` section.
+    /// Module names can be overwritten at construction time or perhaps inferred
+    /// from file names. The primary purpose of this function is to assist in
+    /// debugging and therefore may be tweaked over time.
+    ///
+    /// This function returns `None` when no name can be found or inferred.
+    pub fn module_name(&self) -> Option<&str> {
+        self.module_name.as_deref()
+    }
+
+    /// Returns a descriptive name of the function for this frame, if one is
+    /// available.
+    ///
+    /// The name of this function may come from the `name` section of the
+    /// WebAssembly binary, or wasmtime may try to infer a better name for it if
+    /// not available, for example the name of the export if it's exported.
+    ///
+    /// This return value is primarily used for debugging and human-readable
+    /// purposes for things like traps. Note that the exact return value may be
+    /// tweaked over time here and isn't guaranteed to be something in
+    /// particular about a wasm module due to its primary purpose of assisting
+    /// in debugging.
+    ///
+    /// This function returns `None` when no name could be inferred.
+    pub fn func_name(&self) -> Option<&str> {
+        self.func_name.as_deref()
+    }
+
+    /// Returns the offset within the original wasm module this frame's program
+    /// counter was at.
+    ///
+    /// The offset here is the offset from the beginning of the original wasm
+    /// module to the instruction that this frame points to.
+    ///
+    /// Note that `None` may be returned if the original module was not
+    /// compiled with mapping information to yield this information. This is
+    /// controlled by the
+    /// [`Config::generate_address_map`](crate::Config::generate_address_map)
+    /// configuration option.
+    pub fn module_offset(&self) -> Option<usize> {
+        Some(self.instr?.file_offset()? as usize)
+    }
+
+    /// Returns the offset from the original wasm module's function to this
+    /// frame's program counter.
+    ///
+    /// The offset here is the offset from the beginning of the defining
+    /// function of this frame (within the wasm module) to the instruction this
+    /// frame points to.
+    ///
+    /// Note that `None` may be returned if the original module was not
+    /// compiled with mapping information to yield this information. This is
+    /// controlled by the
+    /// [`Config::generate_address_map`](crate::Config::generate_address_map)
+    /// configuration option.
+    pub fn func_offset(&self) -> Option<usize> {
+        let instr_offset = self.instr?.file_offset()?;
+        Some((instr_offset - self.func_start.file_offset()?) as usize)
+    }
+
+    /// Returns the debug symbols found, if any, for this function frame.
+    ///
+    /// When a wasm program is compiled with DWARF debug information then this
+    /// function may be populated to return symbols which contain extra debug
+    /// information about a frame including the filename and line number. If no
+    /// debug information was found or if it was malformed then this will return
+    /// an empty array.
+    pub fn symbols(&self) -> &[FrameSymbol] {
+        &self.symbols
+    }
+}
+
+/// Debug information for a symbol that is attached to a [`FrameInfo`].
+///
+/// When DWARF debug information is present in a wasm file then this structure
+/// can be found on a [`FrameInfo`] and can be used to learn about filenames,
+/// line numbers, etc, which are the origin of a function in a stack trace.
+#[derive(Debug)]
+pub struct FrameSymbol {
+    name: Option<String>,
+    file: Option<String>,
+    line: Option<u32>,
+    column: Option<u32>,
+}
+
+impl FrameSymbol {
+    /// Returns the function name associated with this symbol.
+    ///
+    /// Note that this may not be present with malformed debug information, or
+    /// the debug information may not include it. Also note that the symbol is
+    /// frequently mangled, so you might need to run some form of demangling
+    /// over it.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Returns the source code filename this symbol was defined in.
+    ///
+    /// Note that this may not be present with malformed debug information, or
+    /// the debug information may not include it.
+    pub fn file(&self) -> Option<&str> {
+        self.file.as_deref()
+    }
+
+    /// Returns the 1-indexed source code line number this symbol was defined
+    /// on.
+    ///
+    /// Note that this may not be present with malformed debug information, or
+    /// the debug information may not include it.
+    pub fn line(&self) -> Option<u32> {
+        self.line
+    }
+
+    /// Returns the 1-indexed source code column number this symbol was defined
+    /// on.
+    ///
+    /// Note that this may not be present with malformed debug information, or
+    /// the debug information may not include it.
+    pub fn column(&self) -> Option<u32> {
+        self.column
     }
 }


### PR DESCRIPTION
Previous to this commit Wasmtime would use the `GlobalModuleRegistry`
when learning information about a trap such as its trap code, the
symbols for each frame, etc. This has a downside though of holding a
global read-write lock for the duration of this operation which hinders
registration of new modules in parallel. In addition there was a fair
amount of internal duplication between this "global module registry" and
the store-local module registry. Finally relying on global state for
information like this gets a bit more brittle over time as it seems best
to scope global queries to precisely what's necessary rather than
holding extra information.

With the refactoring in wasm backtraces done in #4183 it's now possible
to always have a `StoreOpaque` reference when a backtrace is collected
for symbolication and otherwise Trap-identification purposes. This
commit adds a `StoreOpaque` parameter to the `Trap::from_runtime`
constructor and then plumbs that everywhere. Note that while doing this
I changed the internal `traphandlers::lazy_per_thread_init` function to
no longer return a `Result` and instead just `panic!` on Unix if memory
couldn't be allocated for a stack. This removed quite a lot of
error-handling code for a case that's expected to quite rarely happen.
If necessary in the future we can add a fallible initialization point
but this feels like a better default balance for the code here.

With a `StoreOpaque` in use when a trap is being symbolicated that means
we have a `ModuleRegistry` which can be used for queries and such. This
meant that the `GlobalModuleRegistry` state could largely be dismantled
and moved to per-`Store` state (within the `ModuleRegistry`, mostly just
moving methods around).

The final state is that the global rwlock is not exclusively scoped
around insertions/deletions/`is_wasm_trap_pc` which is just a lookup and
atomic add. Otherwise symbolication for a backtrace exclusively uses
store-local state now (as intended).

The original motivation for this commit was that frame information
lookup and pieces were looking to get somewhat complicated with the
addition of components which are a new vector of traps coming out of
Cranelift-generated code. My hope is that by having a `Store` around for
more operations it's easier to plumb all this through.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
