### PR TITLE
Fix the documentation build in the component model

### DIFF
--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -127,30 +127,26 @@ impl Func {
     ///
     /// This function will perform a type-check at runtime that the [`Func`]
     /// takes `Params` as parameters and returns `Return`. If the type-check
-    /// passes then a [`TypedFunc`] will be returned which can be used to invoke
-    /// the function in an efficient, statically-typed, and ergonomic manner.
+    /// passes then a [`TypedFunc`] will be returned which can be used to
+    /// invoke the function in an efficient, statically-typed, and ergonomic
+    /// manner.
     ///
     /// The `Params` type parameter here is a tuple of the parameters to the
     /// function. A function which takes no arguments should use `()`, a
-    /// function with one argument should use `(T,)`, etc.
+    /// function with one argument should use `(T,)`, etc. Note that all
+    /// `Params` must also implement the [`Lower`] trait since they're going tin
+    /// to wasm.
     ///
     /// The `Return` type parameter is the return value of this function. A
     /// return value of `()` means that there's no return (similar to a Rust
-    /// unit return) and otherwise a type `T` can be specified.
+    /// unit return) and otherwise a type `T` can be specified. Note that the
+    /// `Return` must also implement the [`Lift`] trait since it's coming from
+    /// wasm.
     ///
-    /// Types specified here are mainly those that implement the
-    /// [`ComponentValue`] trait. This trait is implemented for built-in types
-    /// to Rust such as integer primitives, floats, `Option<T>`, `Result<T, E>`,
-    /// strings, and `Vec<T>`. As parameters you'll be passing native Rust
-    /// types.
-    ///
-    /// For the `Return` type parameter many types need to be wrapped in a
-    /// [`Value<T>`]. For example functions which return a string should use the
-    /// `Return` type parameter as `Value<String>` instead of a bare `String`.
-    /// The usage of [`Value`] indicates that a type is stored in linear memory.
-    //
-    // FIXME: Having to remember when to use `Value<T>` vs `T` is going to trip
-    // people up using this API. It's not clear, though, how to fix that.
+    /// Types specified here must implement the [`ComponentType`] trait. This
+    /// trait is implemented for built-in types to Rust such as integer
+    /// primitives, floats, `Option<T>`, `Result<T, E>`, strings, `Vec<T>`, and
+    /// more. As parameters you'll be passing native Rust types.
     ///
     /// # Errors
     ///

--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -17,7 +17,7 @@ use wasmtime_runtime::{VMCallerCheckedAnyfunc, VMMemoryDefinition, VMOpaqueConte
 /// component.
 ///
 /// For more information see the
-/// [`Linker::func_wrap`](crate::component::Linker::func_wrap) documentation.
+/// [`func_wrap`](crate::component::LinkerInstance::func_wrap) documentation.
 pub trait IntoComponentFunc<T, Params, Return> {
     /// Host entrypoint from a cranelift-generated trampoline.
     ///

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -382,7 +382,8 @@ impl<'a> Instantiator<'a> {
 /// This structure represents an efficient form of instantiation where import
 /// type-checking and import lookup has all been resolved by the time that this
 /// type is created. This type is primarily created through the
-/// [`Linker::instance_pre`](crate::component::Linker::instance_pre) method.
+/// [`Linker::instantiate_pre`](crate::component::Linker::instantiate_pre)
+/// method.
 pub struct InstancePre<T> {
     component: Component,
     imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,

--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -210,7 +210,7 @@ impl<T> LinkerInstance<'_, T> {
     ///
     /// The [`IntoComponentFunc`] trait is implemented for functions whose
     /// arguments and return values implement the
-    /// [`ComponentValue`](crate::component::ComponentValue) trait. Additionally
+    /// [`ComponentType`](crate::component::ComponentType) trait. Additionally
     /// the `func` may take a [`StoreContextMut`](crate::StoreContextMut) as its
     /// first parameter.
     ///

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -15,7 +15,7 @@ pub use self::func::{
     WasmStr,
 };
 pub use self::instance::{Instance, InstancePre};
-pub use self::linker::Linker;
+pub use self::linker::{Linker, LinkerInstance};
 
 // These items are expected to be used by an eventual
 // `#[derive(ComponentValue)]`, they are not part of Wasmtime's API stability


### PR DESCRIPTION
Currently `cargo doc` fails for a number of broken links and this commit
fixes all of them. Currently I don't think it's worth adding this to CI
because we don't actually generate docs for the component model anywhere
yet. When the component model support is compiled in by default I think
it would make sense to implement that.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
