### PR TITLE
Upgrade to regalloc2 v0.2.3 to get bugfix from bytecodealliance/regalloc2#60.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d37148700dbb38f994cd99a1431613057f37ed934d7e4d799b7ab758c482461"
+checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
 dependencies = [
  "fxhash",
  "log",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,18 @@
 --------------------------------------------------------------------------------
 
+## 0.38.1
+
+Released 2022-06-27.
+
+### Fixed.
+
+* A register allocator bug was fixed that could affect direct users of
+  Cranelift who use struct-return (`sret`) arguments. The bug had to do with
+  the handling of physical register constraints in the function prologue. No
+  impact should be possible for users of Cranelift via the Wasm frontend,
+  including Wasmtime.
+  [regalloc2#60](https://github.com/bytecodealliance/regalloc2/pull/60)
+
 ## 0.38.0
 
 Released 2022-06-21.

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
-regalloc2 = { version = "0.2.2", features = ["checker"] }
+regalloc2 = { version = "0.2.3", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary


### PR DESCRIPTION
One of several changes for a 0.38.1 point release: upgrade to pull in an RA2 bugfix. Subsequently we'll want to pull in #4317, #4318 and #4332 as well.