### PR TITLE
Backport simd fixes to 0.38.0

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -168,7 +168,7 @@
               (dst WritableGpr))
 
        ;; XMM conditional move; overwrites the destination register.
-       (XmmCmove (size OperandSize)
+       (XmmCmove (ty Type)
                  (cc CC)
                  (consequent XmmMem)
                  (alternative Xmm)
@@ -1876,10 +1876,9 @@
 
 (decl cmove_xmm (Type CC XmmMem Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (size OperandSize (operand_size_of_type_32_64 ty)))
+      (let ((dst WritableXmm (temp_writable_xmm)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
-         (MInst.XmmCmove size cc consequent alternative dst)
+         (MInst.XmmCmove ty cc consequent alternative dst)
          dst)))
 
 ;; Helper for creating `cmove` instructions directly from values. This allows us
@@ -1932,9 +1931,8 @@
 (rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
       (let ((dst WritableXmm (temp_writable_xmm))
             (tmp WritableXmm (temp_writable_xmm))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (cmove1 MInst (MInst.XmmCmove size cc1 consequent alternative tmp))
-            (cmove2 MInst (MInst.XmmCmove size cc2 consequent tmp dst)))
+            (cmove1 MInst (MInst.XmmCmove ty cc1 consequent alternative tmp))
+            (cmove2 MInst (MInst.XmmCmove ty cc2 consequent tmp dst)))
         (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
          cmove1
          cmove2

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2315,11 +2315,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 debug_assert!(ty == types::F32 || ty == types::F64);
                 emit_moves(ctx, dst, rhs, ty);
                 ctx.emit(Inst::xmm_cmove(
-                    if ty == types::F64 {
-                        OperandSize::Size64
-                    } else {
-                        OperandSize::Size32
-                    },
+                    ty,
                     cc,
                     RegMem::reg(lhs.only_reg().unwrap()),
                     dst.only_reg().unwrap(),

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2602,17 +2602,18 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             ctx.emit(Inst::xmm_load_const(constant, zero_mask, ty));
 
             // Use the `zero_mask` on a writable `swizzle_mask`.
-            let swizzle_mask = Writable::from_reg(swizzle_mask);
+            let swizzle_mask_tmp = ctx.alloc_tmp(types::I8X16).only_reg().unwrap();
+            ctx.emit(Inst::gen_move(swizzle_mask_tmp, swizzle_mask, ty));
             ctx.emit(Inst::xmm_rm_r(
                 SseOpcode::Paddusb,
                 RegMem::from(zero_mask),
-                swizzle_mask,
+                swizzle_mask_tmp,
             ));
 
             // Shuffle `dst` using the fixed-up `swizzle_mask`.
             ctx.emit(Inst::xmm_rm_r(
                 SseOpcode::Pshufb,
-                RegMem::from(swizzle_mask),
+                RegMem::from(swizzle_mask_tmp),
                 dst,
             ));
         }

--- a/tests/misc_testsuite/simd/v128-select.wast
+++ b/tests/misc_testsuite/simd/v128-select.wast
@@ -1,0 +1,19 @@
+(module
+  (func (export "select") (param v128 v128 i32) (result v128)
+    local.get 0
+    local.get 1
+    local.get 2
+    select)
+)
+
+(assert_return (invoke "select"
+                       (v128.const i64x2 1 1)
+                       (v128.const i64x2 2 2)
+                       (i32.const 0))
+               (v128.const i64x2 2 2))
+
+(assert_return (invoke "select"
+                       (v128.const i64x2 1 1)
+                       (v128.const i64x2 2 2)
+                       (i32.const 1))
+               (v128.const i64x2 1 1))


### PR DESCRIPTION
This backports #4318 and #4317 to the 0.38.0 branch for a pending and upcoming 0.38.1 release.