### PR TITLE
Upgrade to regalloc2 v0.2.3 to get bugfix from bytecodealliance/regalloc2#60.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d37148700dbb38f994cd99a1431613057f37ed934d7e4d799b7ab758c482461"
+checksum = "4a8d23b35d7177df3b9d31ed8a9ab4bf625c668be77a319d4f5efd4a5257701c"
 dependencies = [
  "fxhash",
  "log",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -24,6 +24,21 @@ Unreleased.
 
 --------------------------------------------------------------------------------
 
+## 0.38.1
+
+Released 2022-06-27.
+
+### Fixed.
+
+* A register allocator bug was fixed that could affect direct users of
+  Cranelift who use struct-return (`sret`) arguments. The bug had to do with
+  the handling of physical register constraints in the function prologue. No
+  impact should be possible for users of Cranelift via the Wasm frontend,
+  including Wasmtime.
+  [regalloc2#60](https://github.com/bytecodealliance/regalloc2/pull/60)
+
+--------------------------------------------------------------------------------
+
 ## 0.38.0
 
 Released 2022-06-21

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
 smallvec = { version = "1.6.1" }
-regalloc2 = { version = "0.2.2", features = ["checker"] }
+regalloc2 = { version = "0.2.3", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -72,20 +72,20 @@ block3(v7: r64, v8: r64):
 ;   ldr x3, 8 ; b 12 ; data TestCase { length: 1, ascii: [102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
 ;   blr x3
 ;   mov x9, sp
-;   ldr x10, [sp, #8]
-;   str x10, [x9]
+;   ldr x11, [sp, #8]
+;   str x11, [x9]
 ;   and w7, w0, #1
 ;   cbz x7, label1 ; b label3
 ; block1:
 ;   b label2
 ; block2:
-;   mov x1, x10
+;   mov x1, x11
 ;   ldr x0, [sp, #16]
 ;   b label5
 ; block3:
 ;   b label4
 ; block4:
-;   mov x0, x10
+;   mov x0, x11
 ;   ldr x1, [sp, #16]
 ;   b label5
 ; block5:

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -74,21 +74,21 @@ block3(v7: r64, v8: r64):
 ;   bras %r1, 12 ; data %f + 0 ; lg %r5, 0(%r1)
 ;   basr %r14, %r5
 ;   la %r3, 160(%r15)
-;   lg %r4, 168(%r15)
-;   stg %r4, 0(%r3)
-;   llcr %r5, %r2
-;   chi %r5, 0
+;   lg %r5, 168(%r15)
+;   stg %r5, 0(%r3)
+;   llcr %r4, %r2
+;   chi %r4, 0
 ;   jgnlh label1 ; jg label3
 ; block1:
 ;   jg label2
 ; block2:
-;   lgr %r3, %r4
+;   lgr %r3, %r5
 ;   lg %r2, 176(%r15)
 ;   jg label5
 ; block3:
 ;   jg label4
 ; block4:
-;   lgr %r2, %r4
+;   lgr %r2, %r5
 ;   lg %r3, 176(%r15)
 ;   jg label5
 ; block5:


### PR DESCRIPTION
This is a reverse-cherrypick of the point-release-branch changes in #4333.