### PR TITLE
Improve error message for failed function compiles

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -374,9 +374,21 @@ impl Module {
         let functions = functions.into_iter().collect::<Vec<_>>();
         let funcs = engine
             .run_maybe_parallel(functions, |(index, func)| {
+                let offset = func.body.range().start;
                 engine
                     .compiler()
                     .compile_function(&translation, index, func, tunables, types)
+                    .with_context(|| {
+                        let index = translation.module.func_index(index);
+                        let name = match translation.debuginfo.name_section.func_names.get(&index) {
+                            Some(name) => format!(" (`{}`) ", name),
+                            None => String::new(),
+                        };
+                        let index = index.as_u32();
+                        format!(
+                            "failed to compile wasm function {index}{name}at offset {offset:#x}"
+                        )
+                    })
             })?
             .into_iter()
             .collect();

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -381,12 +381,12 @@ impl Module {
                     .with_context(|| {
                         let index = translation.module.func_index(index);
                         let name = match translation.debuginfo.name_section.func_names.get(&index) {
-                            Some(name) => format!(" (`{}`) ", name),
+                            Some(name) => format!(" (`{}`)", name),
                             None => String::new(),
                         };
                         let index = index.as_u32();
                         format!(
-                            "failed to compile wasm function {index}{name}at offset {offset:#x}"
+                            "failed to compile wasm function {index}{name} at offset {offset:#x}"
                         )
                     })
             })?


### PR DESCRIPTION
Add in the wasm function index, the name if specified, and the function
offset in the original file to assist in debugging failed function compiles.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
