### PR TITLE
Fix compilation of wasmtime-fiber on arm macOS

### DIFF
--- a/crates/fiber/src/unix/aarch64.rs
+++ b/crates/fiber/src/unix/aarch64.rs
@@ -20,15 +20,19 @@
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "macos")] {
-        macro_rules! cfi_window_save { () => (); }
-        macro_rules! pacia1716 { () => (); }
-        macro_rules! paciasp { () => (); }
-        macro_rules! autiasp { () => (); }
+        macro_rules! cfi_window_save { () => (""); }
+        macro_rules! pacia1716 { () => (""); }
+        macro_rules! paciasp { () => (""); }
+        macro_rules! autiasp { () => (""); }
+        macro_rules! sym_adrp { ($s:tt) => (concat!("_", $s, "@PAGE")); }
+        macro_rules! sym_add { ($s:tt) => (concat!("_", $s, "@PAGEOFF")); }
     } else {
         macro_rules! cfi_window_save { () => (".cfi_window_save\n"); }
         macro_rules! pacia1716 { () => ("pacia1716\n"); }
         macro_rules! paciasp { () => ("paciasp\n"); }
         macro_rules! autiasp { () => ("autiasp\n"); }
+        macro_rules! sym_adrp { ($s:tt) => (concat!($s, "")); }
+        macro_rules! sym_add { ($s:tt) => (concat!(":lo12:", $s)); }
     }
 }
 
@@ -112,7 +116,8 @@ asm_func!(
         .cfi_startproc
         hint #34 // bti c
         sub x16, x0, #16
-        adr x17, ", asm_sym!("wasmtime_fiber_start"), "
+        adrp x17, ", sym_adrp!("wasmtime_fiber_start"), "
+        add x17, x17, ", sym_add!("wasmtime_fiber_start"), "
     ",
     pacia1716!(),
     "


### PR DESCRIPTION
Turns out that `adr` doesn't work in inline assembly within LLVM on
arm macOS, or at least not how we were using it. This switches instead
to an `adrp` and `add` pair which seems to convince the linker that the
relocations should all fit. The same pattern is used on Linux as well
only it has different syntax (so much for a portable assembler) for
consistency. Performance isn't really an issue here so there's no need
to go out of our way to get the single-instruction operand working.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
