### PR TITLE
Migrate from `winapi` to `windows-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
  "wasmtime-runtime",
  "wasmtime-wasi",
  "wat",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3401,7 +3401,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
- "winapi",
+ "windows-sys",
  "zstd",
 ]
 
@@ -3442,7 +3442,7 @@ dependencies = [
  "wasmtime-wast",
  "wast 42.0.0",
  "wat",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3503,7 +3503,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "rustix",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3569,7 +3569,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-runtime",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3603,7 +3603,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ async-trait = "0.1"
 wat = "1.0.43"
 once_cell = "1.9.0"
 rayon = "1.5.0"
+
+[target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.36.0", features = ["Win32_System_Memory"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ tracing-subscriber = "0.3.1"
 wast = "42.0.0"
 criterion = "0.3.4"
 num_cpus = "1.13.0"
-winapi = { version = "0.3.9", features = ['memoryapi'] }
 memchr = "2.4"
 async-trait = "0.1"
 wat = "1.0.43"
 once_cell = "1.9.0"
 rayon = "1.5.0"
+windows-sys = { version = "0.36.0", features = ["Win32_System_Memory"] }
 
 [build-dependencies]
 anyhow = "1.0.19"

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -20,8 +20,11 @@ sha2 = "0.9.0"
 toml = "0.5.5"
 zstd = { version = "0.11.1", default-features = false }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3.7"
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+  "Win32_System_Threading",
+]
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 rustix = { version = "0.35.6", features = ["process"] }

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -230,8 +230,7 @@ impl WorkerThread {
 
     #[cfg(target_os = "windows")]
     fn lower_thread_priority() {
-        use winapi::um::processthreadsapi::{GetCurrentThread, SetThreadPriority};
-        use winapi::um::winbase::THREAD_MODE_BACKGROUND_BEGIN;
+        use windows_sys::Win32::System::Threading::*;
 
         // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadpriority
         // https://docs.microsoft.com/en-us/windows/win32/procthread/scheduling-priorities

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -19,11 +19,11 @@ cfg-if = "1.0"
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.35.6", features = ["mm", "param"] }
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3.9"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.1"
 features = [
-  "fibersapi",
-  "winbase",
+  "Win32_System_Threading",
+  "Win32_Foundation",
 ]
 
 [build-dependencies]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -29,8 +29,11 @@ rustc-demangle = "0.1.16"
 cpp_demangle = "0.3.2"
 log = "0.4.8"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", features = ["winnt", "impl-default"] }
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+  "Win32_System_Diagnostics_Debug",
+]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { version = "0.35.6", features = ["process"] }

--- a/crates/jit/src/unwind/winx64.rs
+++ b/crates/jit/src/unwind/winx64.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{bail, Result};
 use std::mem;
-use winapi::um::winnt;
+use windows_sys::Win32::System::Diagnostics::Debug::*;
 
 /// Represents a registry of function unwind information for Windows x64 ABI.
 pub struct UnwindRegistration {
@@ -16,9 +16,9 @@ impl UnwindRegistration {
         unwind_len: usize,
     ) -> Result<UnwindRegistration> {
         assert!(unwind_info as usize % 4 == 0);
-        let unit_len = mem::size_of::<winnt::RUNTIME_FUNCTION>();
+        let unit_len = mem::size_of::<IMAGE_RUNTIME_FUNCTION_ENTRY>();
         assert!(unwind_len % unit_len == 0);
-        if winnt::RtlAddFunctionTable(
+        if RtlAddFunctionTable(
             unwind_info as *mut _,
             (unwind_len / unit_len) as u32,
             base_address as u64,
@@ -40,7 +40,7 @@ impl UnwindRegistration {
 impl Drop for UnwindRegistration {
     fn drop(&mut self) {
         unsafe {
-            winnt::RtlDeleteFunctionTable(self.functions as _);
+            RtlDeleteFunctionTable(self.functions as _);
         }
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -33,8 +33,15 @@ mach = "0.3.2"
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.35.6", features = ["mm"] }
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.7", features = ["winbase", "memoryapi", "errhandlingapi", "handleapi"] }
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+  "Win32_System_Kernel",
+  "Win32_System_Memory",
+  "Win32_System_Diagnostics_Debug",
+  "Win32_Storage_FileSystem",
+  "Win32_Security",
+]
 
 [build-dependencies]
 cc = "1.0"

--- a/crates/runtime/src/instance/allocator/pooling/windows.rs
+++ b/crates/runtime/src/instance/allocator/pooling/windows.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Result};
-use winapi::um::memoryapi::{VirtualAlloc, VirtualFree};
-use winapi::um::winnt::{MEM_COMMIT, MEM_DECOMMIT, PAGE_READWRITE};
+use windows_sys::Win32::System::Memory::*;
 
 pub fn commit(addr: *mut u8, len: usize) -> Result<()> {
     if len == 0 {

--- a/crates/runtime/src/traphandlers/windows.rs
+++ b/crates/runtime/src/traphandlers/windows.rs
@@ -1,13 +1,11 @@
 use crate::traphandlers::{tls, wasmtime_longjmp};
 use std::io;
-use winapi::um::errhandlingapi::*;
-use winapi::um::minwinbase::*;
-use winapi::um::winnt::*;
-use winapi::vc::excpt::*;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::System::Diagnostics::Debug::*;
+use windows_sys::Win32::System::Kernel::*;
 
 /// Function which may handle custom signals while processing traps.
-pub type SignalHandler<'a> =
-    dyn Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool + Send + Sync + 'a;
+pub type SignalHandler<'a> = dyn Fn(*mut EXCEPTION_POINTERS) -> bool + Send + Sync + 'a;
 
 pub unsafe fn platform_init() {
     // our trap handler needs to go first, so that we can recover from
@@ -21,7 +19,7 @@ pub unsafe fn platform_init() {
     }
 }
 
-unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS) -> LONG {
+unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINTERS) -> i32 {
     // Check the kind of exception, since we only handle a subset within
     // wasm code. If anything else happens we want to defer to whatever
     // the rest of the system wants to do for this exception.
@@ -31,7 +29,7 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
         && record.ExceptionCode != EXCEPTION_INT_DIVIDE_BY_ZERO
         && record.ExceptionCode != EXCEPTION_INT_OVERFLOW
     {
-        return EXCEPTION_CONTINUE_SEARCH;
+        return ExceptionContinueSearch;
     }
 
     // FIXME: this is what the previous C++ did to make sure that TLS
@@ -43,7 +41,7 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
     // Rust.
     //
     // if (!NtCurrentTeb()->Reserved1[sThreadLocalArrayPointerIndex]) {
-    //     return EXCEPTION_CONTINUE_SEARCH;
+    //     return ExceptionContinueSearch;
     // }
 
     // This is basically the same as the unix version above, only with a
@@ -51,7 +49,7 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
     tls::with(|info| {
         let info = match info {
             Some(info) => info,
-            None => return EXCEPTION_CONTINUE_SEARCH,
+            None => return ExceptionContinueSearch,
         };
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "x86_64")] {
@@ -64,9 +62,9 @@ unsafe extern "system" fn exception_handler(exception_info: PEXCEPTION_POINTERS)
         }
         let jmp_buf = info.jmp_buf_if_trap(ip, |handler| handler(exception_info));
         if jmp_buf.is_null() {
-            EXCEPTION_CONTINUE_SEARCH
+            ExceptionContinueSearch
         } else if jmp_buf as usize == 1 {
-            EXCEPTION_CONTINUE_EXECUTION
+            ExceptionContinueExecution
         } else {
             info.capture_backtrace(ip);
             wasmtime_longjmp(jmp_buf)

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -39,8 +39,11 @@ object = { version = "0.28", default-features = false, features = ['read_core', 
 async-trait = { version = "0.1.51", optional = true }
 once_cell = "1.12"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3.7"
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+  "Win32_System_Diagnostics_Debug",
+]
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/wasmtime/src/windows.rs
+++ b/crates/wasmtime/src/windows.rs
@@ -10,6 +10,7 @@
 //! available on Windows.
 
 use crate::{AsContextMut, Store};
+use windows_sys::Win32::System::Diagnostics::Debug::EXCEPTION_POINTERS;
 
 /// Extensions for the [`Store`] type only available on Windows.
 pub trait StoreExt {
@@ -18,13 +19,13 @@ pub trait StoreExt {
     /// TODO: needs more documentation.
     unsafe fn set_signal_handler<H>(&mut self, handler: H)
     where
-        H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool + Send + Sync;
+        H: 'static + Fn(*mut EXCEPTION_POINTERS) -> bool + Send + Sync;
 }
 
 impl<T> StoreExt for Store<T> {
     unsafe fn set_signal_handler<H>(&mut self, handler: H)
     where
-        H: 'static + Fn(winapi::um::winnt::PEXCEPTION_POINTERS) -> bool + Send + Sync,
+        H: 'static + Fn(*mut EXCEPTION_POINTERS) -> bool + Send + Sync,
     {
         self.as_context_mut()
             .0

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -266,8 +266,7 @@ unsafe fn assert_faults(ptr: *mut u8) {
     }
     #[cfg(windows)]
     {
-        use winapi::um::memoryapi::*;
-        use winapi::um::winnt::*;
+        use windows_sys::Win32::System::Memory::*;
 
         let mut info = std::mem::MaybeUninit::uninit();
         let r = VirtualQuery(


### PR DESCRIPTION
I believe that Microsoft itself is supporting the development of
`windows-sys` and it's also used by `cap-std` now so this switches
Wasmtime's dependencies on Windows APIs from the `winapi` crate to the
`windows-sys` crate. We still have `winapi` in our dependency graph but
that may get phased out over time.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
