### PR TITLE
Implement a first-class error for reexported component functions

### DIFF
--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -141,7 +141,9 @@ pub(super) fn run(
                 ComponentFuncDef::Lifted { ty, func, options } => {
                     Export::LiftedFunction { ty, func, options }
                 }
-                ComponentFuncDef::Import(_) => unimplemented!("reexporting a function import"),
+                ComponentFuncDef::Import(_) => {
+                    bail!("component export `{name}` is a reexport of an imported function which is not implemented")
+                }
             },
 
             ComponentItemDef::Instance(_) => unimplemented!("exporting an instance to the host"),

--- a/tests/misc_testsuite/component-model/import.wast
+++ b/tests/misc_testsuite/component-model/import.wast
@@ -1,0 +1,5 @@
+(assert_invalid
+  (component
+    (import "host-return-two" (func $f (result u32)))
+    (export "x" (func $f)))
+  "component export `x` is a reexport of an imported function which is not implemented")


### PR DESCRIPTION
Currently I don't know how we can reasonably implement this. Given all
the signatures of how we call functions and how functions are called on
the host there's no real feasible way that I know of to hook these two
up "seamlessly". This means that a component which reexports an imported
function can't be run in Wasmtime.

One of the main reasons for this is that when calling a component
function Wasmtime wants to lower arguments first and then have them
lifted when the host is called. With a reexport though there's not
actually anything to lower into so we'd sort of need something similar
to a table on the side or maybe a linear memory and that seems like it'd
get quite complicated quite quickly for not really all that much
benefit. As-such for now this simply returns a first-class error (rather
than the current panic) in situations like this.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
