### PR TITLE
Wasmtime: disable unwind_info unless needed

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1423,6 +1423,10 @@ impl Config {
             {
                 bail!("compiler option 'unwind_info' must be enabled when either 'backtraces' or 'reference types' are enabled");
             }
+        } else {
+            self.compiler_config
+                .settings
+                .insert("unwind_info".to_string(), "false".to_string());
         }
         if self.features.reference_types {
             if !self

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -345,7 +345,6 @@ impl Engine {
             // can affect the way the generated code performs or behaves at
             // runtime.
             "avoid_div_traps" => *value == FlagValue::Bool(true),
-            "unwind_info" => *value == FlagValue::Bool(true),
             "libcall_call_conv" => *value == FlagValue::Enum("isa_default".into()),
 
             // Features wasmtime doesn't use should all be disabled, since
@@ -381,6 +380,7 @@ impl Engine {
             | "enable_verifier"
             | "regalloc_checker"
             | "is_pic"
+            | "unwind_info"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
             | "opt_level" // opt level doesn't change semantics

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -519,8 +519,10 @@ impl Default for Engine {
 #[cfg(test)]
 mod tests {
     use crate::{Config, Engine, Module, OptLevel};
+
     use anyhow::Result;
     use tempfile::TempDir;
+    use wasmtime_environ::FlagValue;
 
     #[test]
     fn cache_accounts_for_opt_level() -> Result<()> {
@@ -584,5 +586,21 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    #[cfg(compiler)]
+    fn test_disable_backtraces() {
+        let engine = Engine::new(
+            Config::new()
+                .wasm_backtrace(false)
+                .wasm_reference_types(false),
+        )
+        .expect("failed to construct engine");
+        assert_eq!(
+            engine.compiler().flags().get("unwind_info"),
+            Some(&FlagValue::Bool(false)),
+            "unwind info should be disabled unless needed"
+        );
     }
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -368,6 +368,16 @@ impl Engine {
                 }
             }
 
+            // If reference types or backtraces are enabled, we need unwind info. Otherwise, we
+            // don't care.
+            "unwind_info" => {
+                if self.config().wasm_backtrace || self.config().features.reference_types {
+                    *value == FlagValue::Bool(true)
+                } else {
+                    return Ok(())
+                }
+            }
+
             // These settings don't affect the interface or functionality of
             // the module itself, so their configuration values shouldn't
             // matter.
@@ -380,7 +390,6 @@ impl Engine {
             | "enable_verifier"
             | "regalloc_checker"
             | "is_pic"
-            | "unwind_info"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
             | "opt_level" // opt level doesn't change semantics


### PR DESCRIPTION
Disable the "unwind_info" cranelift feature unless backtraces (or reference types) are enabled. Maintaining unwind info in deeply recursive modules can get expensive.

fixes #4350