### PR TITLE
Fix a mistake in the language reference

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -359,7 +359,7 @@ For a simple example, consider the following rules:
 ```
 
 This set of rules will rewrite `(A (B (D 42)))` to `(C (D 42))`, then
-to `(E 42)` (via the first and third rules respectively).
+to `(E 42)` (via the first and second rules respectively).
 
 How is this useful? First, rewriting one term to another (here, `C` at
 the top level) that in turn appears in the left-hand side of other


### PR DESCRIPTION
It is clear that the third rule does not contribute to the rewriting of the expression `(A (B (D 42)))` to `(C (D 42))` to `(E 42)`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
