### PR TITLE
Update may_enter flag handling in components

### DIFF
--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -154,10 +154,6 @@ where
         bail!("cannot leave component instance");
     }
 
-    // While we're lifting and lowering this instance cannot be reentered, so
-    // unset the flag here. This is also reset back to `true` on exit.
-    let _reset_may_enter = unset_and_reset_on_drop(flags, VMComponentFlags::set_may_enter);
-
     // There's a 2x2 matrix of whether parameters and results are stored on the
     // stack or on the heap. Each of the 4 branches here have a different
     // representation of the storage of arguments/returns which is represented
@@ -168,13 +164,12 @@ where
     // trivially DCE'd by LLVM. Perhaps one day with enough const programming in
     // Rust we can make monomorphizations of this function codegen only one
     // branch, but today is not that day.
-    let reset_may_leave;
     if Params::flatten_count() <= MAX_STACK_PARAMS {
         if Return::flatten_count() <= MAX_STACK_RESULTS {
             let storage = cast_storage::<ReturnStack<Params::Lower, Return::Lower>>(storage);
             let params = Params::lift(cx.0, &options, &storage.assume_init_ref().args)?;
             let ret = closure(cx.as_context_mut(), params)?;
-            reset_may_leave = unset_and_reset_on_drop(flags, VMComponentFlags::set_may_leave);
+            (*flags).set_may_leave(false);
             ret.lower(&mut cx, &options, map_maybe_uninit!(storage.ret))?;
         } else {
             let storage = cast_storage::<ReturnPointer<Params::Lower>>(storage).assume_init_ref();
@@ -182,7 +177,7 @@ where
             let ret = closure(cx.as_context_mut(), params)?;
             let mut memory = MemoryMut::new(cx.as_context_mut(), &options);
             let ptr = validate_inbounds::<Return>(memory.as_slice_mut(), &storage.retptr)?;
-            reset_may_leave = unset_and_reset_on_drop(flags, VMComponentFlags::set_may_leave);
+            (*flags).set_may_leave(false);
             ret.store(&mut memory, ptr)?;
         }
     } else {
@@ -193,7 +188,7 @@ where
                 validate_inbounds::<Params>(memory.as_slice(), &storage.assume_init_ref().args)?;
             let params = Params::load(&memory, &memory.as_slice()[ptr..][..Params::size()])?;
             let ret = closure(cx.as_context_mut(), params)?;
-            reset_may_leave = unset_and_reset_on_drop(flags, VMComponentFlags::set_may_leave);
+            (*flags).set_may_leave(false);
             ret.lower(&mut cx, &options, map_maybe_uninit!(storage.ret))?;
         } else {
             let storage = cast_storage::<ReturnPointer<ValRaw>>(storage).assume_init_ref();
@@ -202,32 +197,14 @@ where
             let ret = closure(cx.as_context_mut(), params)?;
             let mut memory = MemoryMut::new(cx.as_context_mut(), &options);
             let ptr = validate_inbounds::<Return>(memory.as_slice_mut(), &storage.retptr)?;
-            reset_may_leave = unset_and_reset_on_drop(flags, VMComponentFlags::set_may_leave);
+            (*flags).set_may_leave(false);
             ret.store(&mut memory, ptr)?;
         }
     }
 
-    drop(reset_may_leave);
+    (*flags).set_may_leave(true);
 
     return Ok(());
-
-    unsafe fn unset_and_reset_on_drop(
-        slot: *mut VMComponentFlags,
-        set: fn(&mut VMComponentFlags, bool),
-    ) -> impl Drop {
-        set(&mut *slot, false);
-        return Reset(slot, set);
-
-        struct Reset(*mut VMComponentFlags, fn(&mut VMComponentFlags, bool));
-
-        impl Drop for Reset {
-            fn drop(&mut self) {
-                unsafe {
-                    (self.1)(&mut *self.0, true);
-                }
-            }
-        }
-    }
 }
 
 fn validate_inbounds<T: ComponentType>(memory: &[u8], ptr: &ValRaw) -> Result<usize> {

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -221,11 +221,11 @@ fn attempt_to_leave_during_malloc() -> Result<()> {
         })?;
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = linker.instantiate(&mut store, &component)?;
 
     // Assert that during a host import if we return values to wasm that a trap
     // happens if we try to leave the instance.
-    let trap = instance
+    let trap = linker
+        .instantiate(&mut store, &component)?
         .get_typed_func::<(), (), _>(&mut store, "run")?
         .call(&mut store, ())
         .unwrap_err()
@@ -261,7 +261,8 @@ fn attempt_to_leave_during_malloc() -> Result<()> {
     // In addition to the above trap also ensure that when we enter a wasm
     // component if we try to leave while lowering then that's also a dynamic
     // trap.
-    let trap = instance
+    let trap = linker
+        .instantiate(&mut store, &component)?
         .get_typed_func::<(&str,), (), _>(&mut store, "take-string")?
         .call(&mut store, ("x",))
         .unwrap_err()
@@ -599,14 +600,15 @@ fn bad_import_alignment() -> Result<()> {
     )?;
     let component = Component::new(&engine, component)?;
     let mut store = Store::new(&engine, ());
-    let instance = linker.instantiate(&mut store, &component)?;
-    let trap = instance
+    let trap = linker
+        .instantiate(&mut store, &component)?
         .get_typed_func::<(), (), _>(&mut store, "unaligned-retptr")?
         .call(&mut store, ())
         .unwrap_err()
         .downcast::<Trap>()?;
     assert!(trap.to_string().contains("pointer not aligned"), "{}", trap);
-    let trap = instance
+    let trap = linker
+        .instantiate(&mut store, &component)?
         .get_typed_func::<(), (), _>(&mut store, "unaligned-argptr")?
         .call(&mut store, ())
         .unwrap_err()


### PR DESCRIPTION
This commit updates the management of the `may_enter` flag in line with
WebAssembly/component-model#57. Namely the `may_enter` flag is now
exclusively managed in the `canon lift` function (which is
`TypedFunc::call`) and is only unset after post-return completes
successfully. This implements semantics where if any trap happens for
any reason (lifting, lowering, execution, imports, etc) then the
instance is considered permanently poisoned and can no longer be
entered.

Tests needed many updates to create new instances where previously the
same instance was reused after it had an erroneous state.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
