### PR TITLE
Mark return value as define instead of clobber for TLS pseudoinstructions

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1032,9 +1032,10 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
         &Inst::VirtualSPOffsetAdj { .. } => {}
 
         &Inst::ElfTlsGetAddr { .. } => {
-            collector.reg_clobbers(AArch64MachineDeps::get_regs_clobbered_by_call(
-                CallConv::SystemV,
-            ));
+            collector.reg_def(Writable::from_reg(regs::xreg(0)));
+            let mut clobbers = AArch64MachineDeps::get_regs_clobbered_by_call(CallConv::SystemV);
+            clobbers.remove(regs::xreg_preg(0));
+            collector.reg_clobbers(clobbers);
         }
         &Inst::Unwind { .. } => {}
         &Inst::EmitIsland { .. } => {}
@@ -2723,7 +2724,7 @@ impl Inst {
             &Inst::EmitIsland { needed_space } => format!("emit_island {}", needed_space),
 
             &Inst::ElfTlsGetAddr { ref symbol } => {
-                format!("elf_tls_get_addr {}", symbol)
+                format!("x0 = elf_tls_get_addr {}", symbol)
             }
             &Inst::Unwind { ref inst } => {
                 format!("unwind {:?}", inst)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4840,7 +4840,7 @@ fn test_x64_emit() {
             },
         },
         "66488D3D00000000666648E800000000",
-        "elf_tls_get_addr User { namespace: 0, index: 0 }",
+        "%rax = elf_tls_get_addr User { namespace: 0, index: 0 }",
     ));
 
     insns.push((
@@ -4851,7 +4851,7 @@ fn test_x64_emit() {
             },
         },
         "488B3D00000000FF17",
-        "macho_tls_get_addr User { namespace: 0, index: 0 }",
+        "%rax = macho_tls_get_addr User { namespace: 0, index: 0 }",
     ));
 
     // ========================================================

--- a/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
@@ -19,7 +19,7 @@ block0(v0: i32):
 ;   stp d8, d9, [sp, #-16]!
 ; block0:
 ;   mov x25, x0
-;   elf_tls_get_addr u1:0
+;   x0 = elf_tls_get_addr u1:0
 ;   mov x1, x0
 ;   mov x0, x25
 ;   ldp d8, d9, [sp], #16

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -13,7 +13,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   elf_tls_get_addr User { namespace: 1, index: 0 }
+;   %rax = elf_tls_get_addr User { namespace: 1, index: 0 }
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
This fixes a regalloc verifier error when using thread local storage. See for example https://github.com/bjorn3/rustc_codegen_cranelift/runs/7104918392?check_suite_focus=true.

Thanks @cfallin for helping with debugging and fixing this.