### PR TITLE
s390x: use full vector register file for FP operations

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -109,10 +109,10 @@ fn get_intreg_for_arg(idx: usize) -> Option<Reg> {
 
 fn get_fltreg_for_arg(idx: usize) -> Option<Reg> {
     match idx {
-        0 => Some(regs::fpr(0)),
-        1 => Some(regs::fpr(2)),
-        2 => Some(regs::fpr(4)),
-        3 => Some(regs::fpr(6)),
+        0 => Some(regs::vr(0)),
+        1 => Some(regs::vr(2)),
+        2 => Some(regs::vr(4)),
+        3 => Some(regs::vr(6)),
         _ => None,
     }
 }
@@ -130,11 +130,11 @@ fn get_intreg_for_ret(idx: usize) -> Option<Reg> {
 
 fn get_fltreg_for_ret(idx: usize) -> Option<Reg> {
     match idx {
-        0 => Some(regs::fpr(0)),
+        0 => Some(regs::vr(0)),
         // ABI extension to support multi-value returns:
-        1 => Some(regs::fpr(2)),
-        2 => Some(regs::fpr(4)),
-        3 => Some(regs::fpr(6)),
+        1 => Some(regs::vr(2)),
+        2 => Some(regs::vr(4)),
+        3 => Some(regs::vr(6)),
         _ => None,
     }
 }
@@ -736,14 +736,30 @@ const fn clobbers() -> PRegSet {
         .with(gpr_preg(3))
         .with(gpr_preg(4))
         .with(gpr_preg(5))
-        .with(fpr_preg(0))
-        .with(fpr_preg(1))
-        .with(fpr_preg(2))
-        .with(fpr_preg(3))
-        .with(fpr_preg(4))
-        .with(fpr_preg(5))
-        .with(fpr_preg(6))
-        .with(fpr_preg(7))
+        .with(vr_preg(0))
+        .with(vr_preg(1))
+        .with(vr_preg(2))
+        .with(vr_preg(3))
+        .with(vr_preg(4))
+        .with(vr_preg(5))
+        .with(vr_preg(6))
+        .with(vr_preg(7))
+        .with(vr_preg(16))
+        .with(vr_preg(17))
+        .with(vr_preg(18))
+        .with(vr_preg(19))
+        .with(vr_preg(20))
+        .with(vr_preg(21))
+        .with(vr_preg(22))
+        .with(vr_preg(23))
+        .with(vr_preg(24))
+        .with(vr_preg(25))
+        .with(vr_preg(26))
+        .with(vr_preg(27))
+        .with(vr_preg(28))
+        .with(vr_preg(29))
+        .with(vr_preg(30))
+        .with(vr_preg(31))
 }
 
 const CLOBBERS: PRegSet = clobbers();

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -445,62 +445,68 @@
       (cond Cond)
       (imm i16))
 
-    ;; A 32-bit FPU move.
+    ;; A 32-bit FPU move possibly implemented as vector instruction.
     (FpuMove32
       (rd WritableReg)
       (rn Reg))
 
-    ;; A 64-bit FPU move.
+    ;; A 64-bit FPU move possibly implemented as vector instruction.
     (FpuMove64
       (rd WritableReg)
       (rn Reg))
 
-    ;; A 32-bit conditional move FPU instruction.
+    ;; A 32-bit conditional move FPU instruction, possibly as vector instruction.
     (FpuCMov32
       (rd WritableReg)
       (cond Cond)
       (rm Reg))
 
-    ;; A 64-bit conditional move FPU instruction.
+    ;; A 64-bit conditional move FPU instruction, possibly as vector instruction.
     (FpuCMov64
       (rd WritableReg)
       (cond Cond)
       (rm Reg))
 
-    ;; A 64-bit move instruction from GPR to FPR.
-    (MovToFpr
+    ;; A 32-bit move instruction from GPR to FPR or vector element.
+    (MovToFpr32
       (rd WritableReg)
       (rn Reg))
 
-    ;; A 64-bit move instruction from FPR to GPR.
-    (MovFromFpr
+    ;; A 64-bit move instruction from GPR to FPR or vector element.
+    (MovToFpr64
       (rd WritableReg)
       (rn Reg))
 
-    ;; 1-op FPU instruction.
+    ;; A 32-bit move instruction from FPR or vector element to GPR.
+    (MovFromFpr32
+      (rd WritableReg)
+      (rn Reg))
+
+    ;; A 64-bit move instruction from FPR or vector element to GPR.
+    (MovFromFpr64
+      (rd WritableReg)
+      (rn Reg))
+
+    ;; 1-op FPU instruction implemented as vector instruction with the W bit.
     (FpuRR
       (fpu_op FPUOp1)
       (rd WritableReg)
       (rn Reg))
 
-    ;; 2-op FPU instruction.
+    ;; 2-op FPU instruction implemented as vector instruction with the W bit.
     (FpuRRR
       (fpu_op FPUOp2)
       (rd WritableReg)
+      (rn Reg)
       (rm Reg))
 
-    ;; 3-op FPU instruction.
+    ;; 3-op FPU instruction implemented as vector instruction with the W bit.
     (FpuRRRR
       (fpu_op FPUOp3)
       (rd WritableReg)
       (rn Reg)
-      (rm Reg))
-
-    ;; FPU copy sign instruction.
-    (FpuCopysign
-      (rd WritableReg)
-      (rn Reg)
-      (rm Reg))
+      (rm Reg)
+      (ra Reg))
 
     ;; FPU comparison, single-precision (32 bit).
     (FpuCmp32
@@ -562,30 +568,19 @@
       (rd WritableReg)
       (const_data u64))
 
-    ;; Conversion FP -> integer.
-    (FpuToInt
-      (op FpuToIntOp)
-      (rd WritableReg)
-      (rn Reg))
-
-    ;; Conversion integer -> FP.
-    (IntToFpu
-      (op IntToFpuOp)
-      (rd WritableReg)
-      (rn Reg))
-
-    ;; Round to integer.
+    ;; 1-op FPU instruction with rounding mode.
     (FpuRound
-      (op FpuRoundMode)
+      (op FpuRoundOp)
+      (mode FpuRoundMode)
       (rd WritableReg)
       (rn Reg))
 
-    ;; 2-op FPU instruction implemented as vector instruction with the W bit.
-    (FpuVecRRR
-      (fpu_op FPUOp2)
+    ;; Vector select instruction.
+    (VecSelect
       (rd WritableReg)
       (rn Reg)
-      (rm Reg))
+      (rm Reg)
+      (ra Reg))
 
     ;; A machine call instruction.
     (Call
@@ -824,7 +819,6 @@
     (Sqrt32)
     (Sqrt64)
     (Cvt32To64)
-    (Cvt64To32)
 ))
 
 ;; A floating-point unit (FPU) operation with two args.
@@ -853,44 +847,32 @@
     (MSub64)
 ))
 
-;; A conversion from an FP to an integer value.
-(type FpuToIntOp
+;; A floating-point unit (FPU) operation with one arg, and rounding mode.
+(type FpuRoundOp
   (enum
-    (F32ToU32)
-    (F32ToI32)
-    (F32ToU64)
-    (F32ToI64)
-    (F64ToU32)
-    (F64ToI32)
-    (F64ToU64)
-    (F64ToI64)
+    (Cvt64To32)
+    (Round32)
+    (Round64)
+    (ToSInt32)
+    (ToSInt64)
+    (ToUInt32)
+    (ToUInt64)
+    (FromSInt32)
+    (FromSInt64)
+    (FromUInt32)
+    (FromUInt64)
 ))
 
-;; A conversion from an integer to an FP value.
-(type IntToFpuOp
-  (enum
-    (U32ToF32)
-    (I32ToF32)
-    (U32ToF64)
-    (I32ToF64)
-    (U64ToF32)
-    (I64ToF32)
-    (U64ToF64)
-    (I64ToF64)
-))
-
-;; Modes for FP rounding ops: round down (floor) or up (ceil), or toward zero
-;; (trunc), or to nearest, and for 32- or 64-bit FP values.
+;; Rounding modes for floating-point ops.
 (type FpuRoundMode
   (enum
-    (Minus32)
-    (Minus64)
-    (Plus32)
-    (Plus64)
-    (Zero32)
-    (Zero64)
-    (Nearest32)
-    (Nearest64)
+    (Current)
+    (ToNearest)
+    (ShorterPrecision)
+    (ToNearestTiesToEven)
+    (ToZero)
+    (ToPosInfinity)
+    (ToNegInfinity)
 ))
 
 
@@ -1608,22 +1590,15 @@
 ;; Helper for emitting `MInst.FpuRRR` instructions.
 (decl fpu_rrr (Type FPUOp2 Reg Reg) Reg)
 (rule (fpu_rrr ty op src1 src2)
-      (let ((dst WritableReg (copy_writable_reg ty src1))
-            (_ Unit (emit (MInst.FpuRRR op dst src2))))
+      (let ((dst WritableReg (temp_writable_reg ty))
+            (_ Unit (emit (MInst.FpuRRR op dst src1 src2))))
         dst))
 
 ;; Helper for emitting `MInst.FpuRRRR` instructions.
 (decl fpu_rrrr (Type FPUOp3 Reg Reg Reg) Reg)
 (rule (fpu_rrrr ty op src1 src2 src3)
-      (let ((dst WritableReg (copy_writable_reg ty src1))
-            (_ Unit (emit (MInst.FpuRRRR op dst src2 src3))))
-        dst))
-
-;; Helper for emitting `MInst.FpuCopysign` instructions.
-(decl fpu_copysign (Type Reg Reg) Reg)
-(rule (fpu_copysign ty src1 src2)
       (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.FpuCopysign dst src1 src2))))
+            (_ Unit (emit (MInst.FpuRRRR op dst src1 src2 src3))))
         dst))
 
 ;; Helper for emitting `MInst.FpuCmp32` instructions.
@@ -1636,46 +1611,39 @@
 (rule (fpu_cmp64 src1 src2)
       (ProducesFlags.ProducesFlagsSideEffect (MInst.FpuCmp64 src1 src2)))
 
-;; Helper for emitting `MInst.FpuToInt` instructions.
-(decl fpu_to_int (Type FpuToIntOp Reg) ProducesFlags)
-(rule (fpu_to_int ty op src)
-      (let ((dst WritableReg (temp_writable_reg ty)))
-        (ProducesFlags.ProducesFlagsReturnsReg (MInst.FpuToInt op dst src)
-                                               dst)))
-
-;; Helper for emitting `MInst.IntToFpu` instructions.
-(decl int_to_fpu (Type IntToFpuOp Reg) Reg)
-(rule (int_to_fpu ty op src)
-      (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.IntToFpu op dst src))))
-        dst))
-
 ;; Helper for emitting `MInst.FpuRound` instructions.
-(decl fpu_round (Type FpuRoundMode Reg) Reg)
-(rule (fpu_round ty mode src)
+(decl fpu_round (Type FpuRoundOp FpuRoundMode Reg) Reg)
+(rule (fpu_round ty op mode src)
       (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.FpuRound mode dst src))))
+            (_ Unit (emit (MInst.FpuRound op mode dst src))))
         dst))
 
-;; Helper for emitting `MInst.FpuVecRRR` instructions.
-(decl fpuvec_rrr (Type FPUOp2 Reg Reg) Reg)
-(rule (fpuvec_rrr ty op src1 src2)
-      (let ((dst WritableReg (temp_writable_reg ty))
-            (_ Unit (emit (MInst.FpuVecRRR op dst src1 src2))))
+;; Helper for emitting `MInst.MovToFpr32` instructions.
+(decl mov_to_fpr32 (Reg) Reg)
+(rule (mov_to_fpr32 src)
+      (let ((dst WritableReg (temp_writable_reg $F32))
+            (_ Unit (emit (MInst.MovToFpr32 dst src))))
         dst))
 
-;; Helper for emitting `MInst.MovToFpr` instructions.
-(decl mov_to_fpr (Reg) Reg)
-(rule (mov_to_fpr src)
+;; Helper for emitting `MInst.MovToFpr64` instructions.
+(decl mov_to_fpr64 (Reg) Reg)
+(rule (mov_to_fpr64 src)
       (let ((dst WritableReg (temp_writable_reg $F64))
-            (_ Unit (emit (MInst.MovToFpr dst src))))
+            (_ Unit (emit (MInst.MovToFpr64 dst src))))
         dst))
 
-;; Helper for emitting `MInst.MovFromFpr` instructions.
-(decl mov_from_fpr (Reg) Reg)
-(rule (mov_from_fpr src)
+;; Helper for emitting `MInst.MovFromFpr32` instructions.
+(decl mov_from_fpr32 (Reg) Reg)
+(rule (mov_from_fpr32 src)
+      (let ((dst WritableReg (temp_writable_reg $I32))
+            (_ Unit (emit (MInst.MovFromFpr32 dst src))))
+        dst))
+
+;; Helper for emitting `MInst.MovFromFpr64` instructions.
+(decl mov_from_fpr64 (Reg) Reg)
+(rule (mov_from_fpr64 src)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.MovFromFpr dst src))))
+            (_ Unit (emit (MInst.MovFromFpr64 dst src))))
         dst))
 
 ;; Helper for emitting `MInst.FpuLoad32` instructions.
@@ -1725,6 +1693,13 @@
 (decl fpu_storerev64 (Reg MemArg) SideEffectNoResult)
 (rule (fpu_storerev64 src addr)
       (SideEffectNoResult.Inst (MInst.FpuStoreRev64 src addr)))
+
+;; Helper for emitting `MInst.VecSelect` instructions.
+(decl vec_select (Type Reg Reg Reg) Reg)
+(rule (vec_select ty src1 src2 src3)
+      (let ((dst WritableReg (temp_writable_reg ty))
+            (_ Unit (emit (MInst.VecSelect dst src1 src2 src3))))
+        dst))
 
 ;; Helper for emitting `MInst.LoadExtNameFar` instructions.
 (decl load_ext_name_far (ExternalName i64) Reg)
@@ -2046,6 +2021,13 @@
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit_imm ty dst n)))
         dst))
+
+;; Variant used for negative constants.
+(decl imm32 (Type i32) Reg)
+(rule (imm32 $I64 n)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.Mov64SImm32 dst n))))
+        (writable_reg_to_reg dst)))
 
 ;; Place an immediate into the low half of a register pair.
 ;; The high half is taken from the input.
@@ -2651,6 +2633,50 @@
         dst))
 
 
+;; Helpers for generating saturating integer instructions ;;;;;;;;;;;;;;;;;;;;;;
+
+(decl uint_sat_reg (Type Type Reg) Reg)
+(rule (uint_sat_reg ty ty reg) reg)
+(rule (uint_sat_reg $I8 (ty_32_or_64 ty) reg)
+      (with_flags_reg (icmpu_uimm32 ty reg 256)
+        (cmov_imm ty (intcc_as_cond (IntCC.UnsignedGreaterThan)) 255 reg)))
+(rule (uint_sat_reg $I16 (ty_32_or_64 ty) reg)
+      (with_flags_reg (icmpu_uimm32 ty reg 65535)
+        (cmov_imm ty (intcc_as_cond (IntCC.UnsignedGreaterThan)) -1 reg)))
+(rule (uint_sat_reg $I32 $I64 reg)
+      (let ((bound Reg (imm $I64 4294967295))
+            (cond ProducesBool
+              (bool (icmpu_reg $I64 reg bound)
+                    (intcc_as_cond (IntCC.UnsignedGreaterThan)))))
+        (select_bool_reg $I64 cond bound reg)))
+
+(decl sint_sat_reg (Type Type Reg) Reg)
+(rule (sint_sat_reg ty ty reg) reg)
+(rule (sint_sat_reg $I8 (ty_32_or_64 ty) reg)
+      (let ((ub Reg (with_flags_reg (icmps_simm16 ty reg 127)
+                      (cmov_imm ty
+                        (intcc_as_cond (IntCC.SignedGreaterThan)) 127 reg))))
+        (with_flags_reg (icmps_simm16 ty ub -128)
+          (cmov_imm ty (intcc_as_cond (IntCC.SignedLessThan)) -128 ub))))
+(rule (sint_sat_reg $I16 (ty_32_or_64 ty) reg)
+      (let ((ub Reg (with_flags_reg (icmps_simm16 ty reg 32767)
+                      (cmov_imm ty
+                        (intcc_as_cond (IntCC.SignedGreaterThan)) 32767 reg))))
+        (with_flags_reg (icmps_simm16 ty ub -32768)
+          (cmov_imm ty (intcc_as_cond (IntCC.SignedLessThan)) -32768 ub))))
+(rule (sint_sat_reg $I32 $I64 reg)
+      (let ((u_bound Reg (imm32 $I64 2147483647))
+            (u_cond ProducesBool
+              (bool (icmps_reg $I64 reg u_bound)
+                    (intcc_as_cond (IntCC.SignedGreaterThan))))
+            (ub Reg (select_bool_reg $I64 u_cond u_bound reg))
+            (l_bound Reg (imm32 $I64 -2147483648))
+            (l_cond ProducesBool
+              (bool (icmps_reg $I64 ub l_bound)
+                    (intcc_as_cond (IntCC.SignedLessThan)))))
+        (select_bool_reg $I64 l_cond l_bound ub)))
+
+
 ;; Helpers for generating `add` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl aluop_add (Type) ALUOp)
@@ -3151,7 +3177,7 @@
 (rule (fpuop2_min $F64) (FPUOp2.Min64))
 
 (decl fmin_reg (Type Reg Reg) Reg)
-(rule (fmin_reg ty x y) (fpuvec_rrr ty (fpuop2_min ty) x y))
+(rule (fmin_reg ty x y) (fpu_rrr ty (fpuop2_min ty) x y))
 
 
 ;; Helpers for generating `fmax` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3161,7 +3187,7 @@
 (rule (fpuop2_max $F64) (FPUOp2.Max64))
 
 (decl fmax_reg (Type Reg Reg) Reg)
-(rule (fmax_reg ty x y) (fpuvec_rrr ty (fpuop2_max ty) x y))
+(rule (fmax_reg ty x y) (fpu_rrr ty (fpuop2_max ty) x y))
 
 
 ;; Helpers for generating `fma` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3171,7 +3197,7 @@
 (rule (fpuop3_fma $F64) (FPUOp3.MAdd64))
 
 (decl fma_reg (Type Reg Reg Reg) Reg)
-(rule (fma_reg ty x y acc) (fpu_rrrr ty (fpuop3_fma ty) acc x y))
+(rule (fma_reg ty x y acc) (fpu_rrrr ty (fpuop3_fma ty) x y acc))
 
 
 ;; Helpers for generating `sqrt` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3204,124 +3230,136 @@
 (rule (fabs_reg ty x) (fpu_rr ty (fpuop1_abs ty) x))
 
 
-;; Helpers for generating `ceil` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers for generating `ceil`, `floor`, `trunc`, `nearest`  instructions ;;;;
 
-(decl fpuroundmode_ceil (Type) FpuRoundMode)
-(rule (fpuroundmode_ceil $F32) (FpuRoundMode.Plus32))
-(rule (fpuroundmode_ceil $F64) (FpuRoundMode.Plus64))
+(decl fpuroundop_round (Type) FpuRoundOp)
+(rule (fpuroundop_round $F32) (FpuRoundOp.Round32))
+(rule (fpuroundop_round $F64) (FpuRoundOp.Round64))
 
 (decl ceil_reg (Type Reg) Reg)
-(rule (ceil_reg ty x) (fpu_round ty (fpuroundmode_ceil ty) x))
-
-
-;; Helpers for generating `floor` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl fpuroundmode_floor (Type) FpuRoundMode)
-(rule (fpuroundmode_floor $F32) (FpuRoundMode.Minus32))
-(rule (fpuroundmode_floor $F64) (FpuRoundMode.Minus64))
+(rule (ceil_reg ty x) (fpu_round ty (fpuroundop_round ty)
+                                    (FpuRoundMode.ToPosInfinity) x))
 
 (decl floor_reg (Type Reg) Reg)
-(rule (floor_reg ty x) (fpu_round ty (fpuroundmode_floor ty) x))
-
-
-;; Helpers for generating `trunc` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl fpuroundmode_trunc (Type) FpuRoundMode)
-(rule (fpuroundmode_trunc $F32) (FpuRoundMode.Zero32))
-(rule (fpuroundmode_trunc $F64) (FpuRoundMode.Zero64))
+(rule (floor_reg ty x) (fpu_round ty (fpuroundop_round ty)
+                                     (FpuRoundMode.ToNegInfinity) x))
 
 (decl trunc_reg (Type Reg) Reg)
-(rule (trunc_reg ty x) (fpu_round ty (fpuroundmode_trunc ty) x))
-
-
-;; Helpers for generating `nearest` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl fpuroundmode_nearest (Type) FpuRoundMode)
-(rule (fpuroundmode_nearest $F32) (FpuRoundMode.Nearest32))
-(rule (fpuroundmode_nearest $F64) (FpuRoundMode.Nearest64))
+(rule (trunc_reg ty x) (fpu_round ty (fpuroundop_round ty)
+                                     (FpuRoundMode.ToZero) x))
 
 (decl nearest_reg (Type Reg) Reg)
-(rule (nearest_reg ty x) (fpu_round ty (fpuroundmode_nearest ty) x))
+(rule (nearest_reg ty x) (fpu_round ty (fpuroundop_round ty)
+                                       (FpuRoundMode.ToNearestTiesToEven) x))
 
 
 ;; Helpers for generating `fpromote` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fpuop1_promote (Type Type) FPUOp1)
-(rule (fpuop1_promote $F64 $F32) (FPUOp1.Cvt32To64))
-
 (decl fpromote_reg (Type Type Reg) Reg)
-(rule (fpromote_reg dst_ty src_ty x)
-      (fpu_rr dst_ty (fpuop1_promote dst_ty src_ty) x))
+(rule (fpromote_reg ty ty x) x)
+(rule (fpromote_reg $F64 $F32 x)
+      (fpu_rr $F64 (FPUOp1.Cvt32To64) x))
 
 
 ;; Helpers for generating `fdemote` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fpuop1_demote (Type Type) FPUOp1)
-(rule (fpuop1_demote $F32 $F64) (FPUOp1.Cvt64To32))
-
-(decl fdemote_reg (Type Type Reg) Reg)
-(rule (fdemote_reg dst_ty src_ty x)
-      (fpu_rr dst_ty (fpuop1_demote dst_ty src_ty) x))
+(decl fdemote_reg (Type Type FpuRoundMode Reg) Reg)
+(rule (fdemote_reg ty ty mode x) x)
+(rule (fdemote_reg $F32 $F64 mode x)
+      (fpu_round $F32 (FpuRoundOp.Cvt64To32) mode x))
 
 
 ;; Helpers for generating `fcvt_from_uint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl uint_to_fpu_op (Type Type) IntToFpuOp)
-(rule (uint_to_fpu_op $F32 $I32) (IntToFpuOp.U32ToF32))
-(rule (uint_to_fpu_op $F64 $I32) (IntToFpuOp.U32ToF64))
-(rule (uint_to_fpu_op $F32 $I64) (IntToFpuOp.U64ToF32))
-(rule (uint_to_fpu_op $F64 $I64) (IntToFpuOp.U64ToF64))
+(decl uint_to_fpu_op (Type) FpuRoundOp)
+(rule (uint_to_fpu_op $F32) (FpuRoundOp.FromUInt32))
+(rule (uint_to_fpu_op $F64) (FpuRoundOp.FromUInt64))
 
-(decl fcvt_from_uint_reg (Type Type Reg) Reg)
-(rule (fcvt_from_uint_reg dst_ty src_ty x)
-      (int_to_fpu dst_ty (uint_to_fpu_op dst_ty src_ty) x))
+(decl fcvt_from_uint_reg (Type FpuRoundMode Reg) Reg)
+(rule (fcvt_from_uint_reg ty mode x)
+      (fpu_round ty (uint_to_fpu_op ty) mode x))
 
 
 ;; Helpers for generating `fcvt_from_sint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl sint_to_fpu_op (Type Type) IntToFpuOp)
-(rule (sint_to_fpu_op $F32 $I32) (IntToFpuOp.I32ToF32))
-(rule (sint_to_fpu_op $F64 $I32) (IntToFpuOp.I32ToF64))
-(rule (sint_to_fpu_op $F32 $I64) (IntToFpuOp.I64ToF32))
-(rule (sint_to_fpu_op $F64 $I64) (IntToFpuOp.I64ToF64))
+(decl sint_to_fpu_op (Type) FpuRoundOp)
+(rule (sint_to_fpu_op $F32) (FpuRoundOp.FromSInt32))
+(rule (sint_to_fpu_op $F64) (FpuRoundOp.FromSInt64))
 
-(decl fcvt_from_sint_reg (Type Type Reg) Reg)
-(rule (fcvt_from_sint_reg dst_ty src_ty x)
-      (int_to_fpu dst_ty (sint_to_fpu_op dst_ty src_ty) x))
+(decl fcvt_from_sint_reg (Type FpuRoundMode Reg) Reg)
+(rule (fcvt_from_sint_reg ty mode x)
+      (fpu_round ty (sint_to_fpu_op ty) mode x))
+
+
+;; Helpers for generating `fcvt_to_[us]int` instructions ;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl fcvt_flt_ty (Type Type) Type)
+(rule (fcvt_flt_ty (fits_in_32 ty) (and (vxrs_ext2_enabled) $F32)) $F32)
+(rule (fcvt_flt_ty (fits_in_64 ty) $F32) $F64)
+(rule (fcvt_flt_ty (fits_in_64 ty) $F64) $F64)
+
+(decl fcvt_int_ty (Type Type) Type)
+(rule (fcvt_int_ty (fits_in_32 ty) (and (vxrs_ext2_enabled) $F32)) $I32)
+(rule (fcvt_int_ty (fits_in_64 ty) $F32) $I64)
+(rule (fcvt_int_ty (fits_in_64 ty) $F64) $I64)
 
 
 ;; Helpers for generating `fcvt_to_uint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fpu_to_uint_op (Type Type) FpuToIntOp)
-(rule (fpu_to_uint_op $I32 $F32) (FpuToIntOp.F32ToU32))
-(rule (fpu_to_uint_op $I32 $F64) (FpuToIntOp.F64ToU32))
-(rule (fpu_to_uint_op $I64 $F32) (FpuToIntOp.F32ToU64))
-(rule (fpu_to_uint_op $I64 $F64) (FpuToIntOp.F64ToU64))
+(decl fcvt_to_uint_reg (Type FpuRoundMode Reg) Reg)
+(rule (fcvt_to_uint_reg $F32 mode x)
+      (mov_from_fpr32 (fpu_round $F32 (FpuRoundOp.ToUInt32) mode x)))
+(rule (fcvt_to_uint_reg $F64 mode x)
+      (mov_from_fpr64 (fpu_round $F64 (FpuRoundOp.ToUInt64) mode x)))
 
-(decl fcvt_to_uint_reg_with_flags (Type Type Reg) ProducesFlags)
-(rule (fcvt_to_uint_reg_with_flags dst_ty src_ty x)
-      (fpu_to_int dst_ty (fpu_to_uint_op dst_ty src_ty) x))
+(decl fcvt_to_uint_ub (Type Type) Reg)
+(rule (fcvt_to_uint_ub $F32 dst_ty)
+      (imm $F32 (fcvt_to_uint_ub32 (ty_bits dst_ty))))
+(rule (fcvt_to_uint_ub $F64 dst_ty)
+      (imm $F64 (fcvt_to_uint_ub64 (ty_bits dst_ty))))
 
-(decl fcvt_to_uint_reg (Type Type Reg) Reg)
-(rule (fcvt_to_uint_reg dst_ty src_ty x)
-      (drop_flags (fcvt_to_uint_reg_with_flags dst_ty src_ty x)))
+(decl fcvt_to_uint_lb (Type) Reg)
+(rule (fcvt_to_uint_lb $F32) (imm $F32 (fcvt_to_uint_lb32)))
+(rule (fcvt_to_uint_lb $F64) (imm $F64 (fcvt_to_uint_lb64)))
+
+(decl fcvt_to_uint_ub32 (u8) u64)
+(extern constructor fcvt_to_uint_ub32 fcvt_to_uint_ub32)
+(decl fcvt_to_uint_lb32 () u64)
+(extern constructor fcvt_to_uint_lb32 fcvt_to_uint_lb32)
+(decl fcvt_to_uint_ub64 (u8) u64)
+(extern constructor fcvt_to_uint_ub64 fcvt_to_uint_ub64)
+(decl fcvt_to_uint_lb64 () u64)
+(extern constructor fcvt_to_uint_lb64 fcvt_to_uint_lb64)
 
 
 ;; Helpers for generating `fcvt_to_sint` instructions ;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl fpu_to_sint_op (Type Type) FpuToIntOp)
-(rule (fpu_to_sint_op $I32 $F32) (FpuToIntOp.F32ToI32))
-(rule (fpu_to_sint_op $I32 $F64) (FpuToIntOp.F64ToI32))
-(rule (fpu_to_sint_op $I64 $F32) (FpuToIntOp.F32ToI64))
-(rule (fpu_to_sint_op $I64 $F64) (FpuToIntOp.F64ToI64))
+(decl fcvt_to_sint_reg (Type FpuRoundMode Reg) Reg)
+(rule (fcvt_to_sint_reg $F32 mode x)
+      (mov_from_fpr32 (fpu_round $F32 (FpuRoundOp.ToSInt32) mode x)))
+(rule (fcvt_to_sint_reg $F64 mode x)
+      (mov_from_fpr64 (fpu_round $F64 (FpuRoundOp.ToSInt64) mode x)))
 
-(decl fcvt_to_sint_reg_with_flags (Type Type Reg) ProducesFlags)
-(rule (fcvt_to_sint_reg_with_flags dst_ty src_ty x)
-      (fpu_to_int dst_ty (fpu_to_sint_op dst_ty src_ty) x))
+(decl fcvt_to_sint_ub (Type Type) Reg)
+(rule (fcvt_to_sint_ub $F32 dst_ty)
+      (imm $F32 (fcvt_to_sint_ub32 (ty_bits dst_ty))))
+(rule (fcvt_to_sint_ub $F64 dst_ty)
+      (imm $F64 (fcvt_to_sint_ub64 (ty_bits dst_ty))))
 
-(decl fcvt_to_sint_reg (Type Type Reg) Reg)
-(rule (fcvt_to_sint_reg dst_ty src_ty x)
-      (drop_flags (fcvt_to_sint_reg_with_flags dst_ty src_ty x)))
+(decl fcvt_to_sint_lb (Type Type) Reg)
+(rule (fcvt_to_sint_lb $F32 dst_ty)
+      (imm $F32 (fcvt_to_sint_lb32 (ty_bits dst_ty))))
+(rule (fcvt_to_sint_lb $F64 dst_ty)
+      (imm $F64 (fcvt_to_sint_lb64 (ty_bits dst_ty))))
+
+(decl fcvt_to_sint_ub32 (u8) u64)
+(extern constructor fcvt_to_sint_ub32 fcvt_to_sint_ub32)
+(decl fcvt_to_sint_lb32 (u8) u64)
+(extern constructor fcvt_to_sint_lb32 fcvt_to_sint_lb32)
+(decl fcvt_to_sint_ub64 (u8) u64)
+(extern constructor fcvt_to_sint_ub64 fcvt_to_sint_ub64)
+(decl fcvt_to_sint_lb64 (u8) u64)
+(extern constructor fcvt_to_sint_lb64 fcvt_to_sint_lb64)
 
 
 ;; Helpers for generating signed `icmp` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -6886,451 +6886,627 @@ fn test_s390x_binemit() {
 
     insns.push((
         Inst::FpuMove32 {
-            rd: writable_fpr(8),
-            rn: fpr(4),
+            rd: writable_vr(8),
+            rn: vr(4),
         },
         "3884",
         "ler %f8, %f4",
     ));
     insns.push((
+        Inst::FpuMove32 {
+            rd: writable_vr(8),
+            rn: vr(20),
+        },
+        "E78400000456",
+        "vlr %v8, %v20",
+    ));
+    insns.push((
         Inst::FpuMove64 {
-            rd: writable_fpr(8),
-            rn: fpr(4),
+            rd: writable_vr(8),
+            rn: vr(4),
         },
         "2884",
         "ldr %f8, %f4",
     ));
     insns.push((
+        Inst::FpuMove64 {
+            rd: writable_vr(8),
+            rn: vr(20),
+        },
+        "E78400000456",
+        "vlr %v8, %v20",
+    ));
+    insns.push((
         Inst::FpuCMov32 {
-            rd: writable_fpr(8),
-            rm: fpr(4),
+            rd: writable_vr(8),
+            rm: vr(4),
             cond: Cond::from_mask(1),
         },
         "A7E400033884",
         "jno 6 ; ler %f8, %f4",
     ));
     insns.push((
+        Inst::FpuCMov32 {
+            rd: writable_vr(8),
+            rm: vr(20),
+            cond: Cond::from_mask(1),
+        },
+        "A7E40005E78400000456",
+        "jno 10 ; vlr %v8, %v20",
+    ));
+    insns.push((
         Inst::FpuCMov64 {
-            rd: writable_fpr(8),
-            rm: fpr(4),
+            rd: writable_vr(8),
+            rm: vr(4),
             cond: Cond::from_mask(1),
         },
         "A7E400032884",
         "jno 6 ; ldr %f8, %f4",
     ));
+    insns.push((
+        Inst::FpuCMov64 {
+            rd: writable_vr(8),
+            rm: vr(20),
+            cond: Cond::from_mask(1),
+        },
+        "A7E40005E78400000456",
+        "jno 10 ; vlr %v8, %v20",
+    ));
 
     insns.push((
-        Inst::MovToFpr {
-            rd: writable_fpr(8),
+        Inst::MovToFpr64 {
+            rd: writable_vr(8),
             rn: gpr(4),
         },
         "B3C10084",
         "ldgr %f8, %r4",
     ));
     insns.push((
-        Inst::MovFromFpr {
+        Inst::MovToFpr64 {
+            rd: writable_vr(24),
+            rn: gpr(4),
+        },
+        "E78400003822",
+        "vlvgg %v24, %r4, 0",
+    ));
+    insns.push((
+        Inst::MovToFpr32 {
+            rd: writable_vr(8),
+            rn: gpr(4),
+        },
+        "E78400002022",
+        "vlvgf %v8, %r4, 0",
+    ));
+    insns.push((
+        Inst::MovToFpr32 {
+            rd: writable_vr(24),
+            rn: gpr(4),
+        },
+        "E78400002822",
+        "vlvgf %v24, %r4, 0",
+    ));
+    insns.push((
+        Inst::MovFromFpr64 {
             rd: writable_gpr(8),
-            rn: fpr(4),
+            rn: vr(4),
         },
         "B3CD0084",
         "lgdr %r8, %f4",
+    ));
+    insns.push((
+        Inst::MovFromFpr64 {
+            rd: writable_gpr(8),
+            rn: vr(20),
+        },
+        "E78400003421",
+        "vlgvg %r8, %v20, 0",
+    ));
+    insns.push((
+        Inst::MovFromFpr32 {
+            rd: writable_gpr(8),
+            rn: vr(4),
+        },
+        "E78400002021",
+        "vlgvf %r8, %v4, 0",
+    ));
+    insns.push((
+        Inst::MovFromFpr32 {
+            rd: writable_gpr(8),
+            rn: vr(20),
+        },
+        "E78400002421",
+        "vlgvf %r8, %v20, 0",
     ));
 
     insns.push((
         Inst::FpuRR {
             fpu_op: FPUOp1::Abs32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B300008C",
         "lpebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Abs32,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C002828CC",
+        "wflpsb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Abs64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B310008C",
         "lpdbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Abs64,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C002838CC",
+        "wflpdb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Neg32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B303008C",
         "lcebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Neg32,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000828CC",
+        "wflcsb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Neg64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B313008C",
         "lcdbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Neg64,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000838CC",
+        "wflcdb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::NegAbs32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B301008C",
         "lnebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::NegAbs32,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828CC",
+        "wflnsb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::NegAbs64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B311008C",
         "lndbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::NegAbs64,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838CC",
+        "wflndb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Sqrt32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B314008C",
         "sqebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Sqrt32,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000828CE",
+        "wfsqsb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Sqrt64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B315008C",
         "sqdbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
+            fpu_op: FPUOp1::Sqrt64,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C000838CE",
+        "wfsqdb %v24, %f12",
+    ));
+    insns.push((
+        Inst::FpuRR {
             fpu_op: FPUOp1::Cvt32To64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B304008C",
         "ldebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRR {
-            fpu_op: FPUOp1::Cvt64To32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
+            fpu_op: FPUOp1::Cvt32To64,
+            rd: writable_vr(24),
+            rn: vr(12),
         },
-        "B344008C",
-        "ledbr %f8, %f12",
+        "E78C000828C4",
+        "wldeb %v24, %f12",
     ));
 
     insns.push((
         Inst::FpuRRR {
             fpu_op: FPUOp2::Add32,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B30A008C",
         "aebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Add32,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00828E3",
+        "wfasb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Add64,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B31A008C",
         "adbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Add64,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00838E3",
+        "wfadb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Sub32,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B30B008C",
         "sebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Sub32,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00828E2",
+        "wfssb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Sub64,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B31B008C",
         "sdbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Sub64,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00838E2",
+        "wfsdb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Mul32,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B317008C",
         "meebr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Mul32,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00828E7",
+        "wfmsb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Mul64,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B31C008C",
         "mdbr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Mul64,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00838E7",
+        "wfmdb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Div32,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B30D008C",
         "debr %f8, %f12",
     ));
     insns.push((
         Inst::FpuRRR {
+            fpu_op: FPUOp2::Div32,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00828E5",
+        "wfdsb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
             fpu_op: FPUOp2::Div64,
-            rd: writable_fpr(8),
-            rm: fpr(12),
+            rd: writable_vr(8),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B31D008C",
         "ddbr %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Div64,
+            rd: writable_vr(20),
+            rn: vr(8),
+            rm: vr(12),
+        },
+        "E748C00838E5",
+        "wfddb %v20, %f8, %f12",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Max32,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+        },
+        "E746801820EF",
+        "wfmaxsb %f4, %f6, %f8, 1",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Max64,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(24),
+        },
+        "E746801832EF",
+        "wfmaxdb %f4, %f6, %v24, 1",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Min32,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+        },
+        "E746801820EE",
+        "wfminsb %f4, %f6, %f8, 1",
+    ));
+    insns.push((
+        Inst::FpuRRR {
+            fpu_op: FPUOp2::Min64,
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+        },
+        "E746801830EE",
+        "wfmindb %f4, %f6, %f8, 1",
     ));
 
     insns.push((
         Inst::FpuRRRR {
             fpu_op: FPUOp3::MAdd32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            rm: fpr(13),
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(8),
         },
         "B30E80CD",
         "maebr %f8, %f12, %f13",
     ));
     insns.push((
         Inst::FpuRRRR {
+            fpu_op: FPUOp3::MAdd32,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
+        },
+        "E78CD208418F",
+        "wfmasb %f8, %f12, %f13, %v20",
+    ));
+    insns.push((
+        Inst::FpuRRRR {
             fpu_op: FPUOp3::MAdd64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            rm: fpr(13),
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(8),
         },
         "B31E80CD",
         "madbr %f8, %f12, %f13",
     ));
     insns.push((
         Inst::FpuRRRR {
+            fpu_op: FPUOp3::MAdd64,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
+        },
+        "E78CD308418F",
+        "wfmadb %f8, %f12, %f13, %v20",
+    ));
+    insns.push((
+        Inst::FpuRRRR {
             fpu_op: FPUOp3::MSub32,
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            rm: fpr(13),
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(8),
         },
         "B30F80CD",
         "msebr %f8, %f12, %f13",
     ));
     insns.push((
         Inst::FpuRRRR {
+            fpu_op: FPUOp3::MSub32,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
+        },
+        "E78CD208418E",
+        "wfmssb %f8, %f12, %f13, %v20",
+    ));
+    insns.push((
+        Inst::FpuRRRR {
             fpu_op: FPUOp3::MSub64,
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            rm: fpr(13),
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(8),
         },
         "B31F80CD",
         "msdbr %f8, %f12, %f13",
     ));
-
     insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F32ToU32,
-            rd: writable_gpr(1),
-            rn: fpr(4),
+        Inst::FpuRRRR {
+            fpu_op: FPUOp3::MSub64,
+            rd: writable_vr(8),
+            rn: vr(12),
+            rm: vr(13),
+            ra: vr(20),
         },
-        "B39C5014",
-        "clfebr %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F32ToU64,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3AC5014",
-        "clgebr %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F32ToI32,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3985014",
-        "cfebra %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F32ToI64,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3A85014",
-        "cgebra %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F64ToU32,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B39D5014",
-        "clfdbr %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F64ToU64,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3AD5014",
-        "clgdbr %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F64ToI32,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3995014",
-        "cfdbra %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuToInt {
-            op: FpuToIntOp::F64ToI64,
-            rd: writable_gpr(1),
-            rn: fpr(4),
-        },
-        "B3A95014",
-        "cgdbra %r1, 5, %f4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::U32ToF32,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3900014",
-        "celfbr %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::I32ToF32,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3940014",
-        "cefbra %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::U32ToF64,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3910014",
-        "cdlfbr %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::I32ToF64,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3950014",
-        "cdfbra %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::U64ToF32,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3A00014",
-        "celgbr %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::I64ToF32,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3A40014",
-        "cegbra %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::U64ToF64,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3A10014",
-        "cdlgbr %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::IntToFpu {
-            op: IntToFpuOp::I64ToF64,
-            rd: writable_fpr(1),
-            rn: gpr(4),
-        },
-        "B3A50014",
-        "cdgbra %f1, 0, %r4, 0",
-    ));
-
-    insns.push((
-        Inst::FpuCopysign {
-            rd: writable_fpr(4),
-            rn: fpr(8),
-            rm: fpr(12),
-        },
-        "B372C048",
-        "cpsdr %f4, %f12, %f8",
+        "E78CD308418E",
+        "wfmsdb %f8, %f12, %f13, %v20",
     ));
 
     insns.push((
         Inst::FpuCmp32 {
-            rn: fpr(8),
-            rm: fpr(12),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B309008C",
         "cebr %f8, %f12",
     ));
     insns.push((
+        Inst::FpuCmp32 {
+            rn: vr(24),
+            rm: vr(12),
+        },
+        "E78C000028CB",
+        "wfcsb %v24, %f12",
+    ));
+    insns.push((
         Inst::FpuCmp64 {
-            rn: fpr(8),
-            rm: fpr(12),
+            rn: vr(8),
+            rm: vr(12),
         },
         "B319008C",
         "cdbr %f8, %f12",
     ));
+    insns.push((
+        Inst::FpuCmp64 {
+            rn: vr(24),
+            rm: vr(12),
+        },
+        "E78C000038CB",
+        "wfcdb %v24, %f12",
+    ));
 
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7343,7 +7519,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7356,7 +7532,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7369,7 +7545,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7382,7 +7558,33 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E71020000803",
+        "vlef %v17, 0(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad32 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102FFF0803",
+        "vlef %v17, 4095(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad32 {
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7395,7 +7597,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7408,7 +7610,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7421,7 +7623,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7433,8 +7635,34 @@ fn test_s390x_binemit() {
         "ley %f1, 524287(%r2,%r3)",
     ));
     insns.push((
+        Inst::FpuLoad32 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E71230000803",
+        "vlef %v17, 0(%r2,%r3), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad32 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123FFF0803",
+        "vlef %v17, 4095(%r2,%r3), 0",
+    ));
+    insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7447,7 +7675,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7460,7 +7688,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7473,7 +7701,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7486,7 +7714,33 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E71020000802",
+        "vleg %v17, 0(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad64 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102FFF0802",
+        "vleg %v17, 4095(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad64 {
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7499,7 +7753,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7512,7 +7766,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7525,7 +7779,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoad64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7537,8 +7791,34 @@ fn test_s390x_binemit() {
         "ldy %f1, 524287(%r2,%r3)",
     ));
     insns.push((
+        Inst::FpuLoad64 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E71230000802",
+        "vleg %v17, 0(%r2,%r3), 0",
+    ));
+    insns.push((
+        Inst::FpuLoad64 {
+            rd: writable_vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123FFF0802",
+        "vleg %v17, 4095(%r2,%r3), 0",
+    ));
+    insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7551,7 +7831,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7564,7 +7844,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7577,7 +7857,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7590,7 +7870,33 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102000080B",
+        "vstef %v17, 0(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuStore32 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102FFF080B",
+        "vstef %v17, 4095(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuStore32 {
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7603,7 +7909,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7616,7 +7922,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7629,7 +7935,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7641,8 +7947,34 @@ fn test_s390x_binemit() {
         "stey %f1, 524287(%r2,%r3)",
     ));
     insns.push((
+        Inst::FpuStore32 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123000080B",
+        "vstef %v17, 0(%r2,%r3), 0",
+    ));
+    insns.push((
+        Inst::FpuStore32 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123FFF080B",
+        "vstef %v17, 4095(%r2,%r3), 0",
+    ));
+    insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7655,7 +7987,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7668,7 +8000,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7681,7 +8013,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7694,7 +8026,33 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102000080A",
+        "vsteg %v17, 0(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuStore64 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(2),
+                index: zero_reg(),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7102FFF080A",
+        "vsteg %v17, 4095(%r2), 0",
+    ));
+    insns.push((
+        Inst::FpuStore64 {
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7707,7 +8065,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7720,7 +8078,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7733,7 +8091,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStore64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7744,10 +8102,36 @@ fn test_s390x_binemit() {
         "ED123FFF7F67",
         "stdy %f1, 524287(%r2,%r3)",
     ));
+    insns.push((
+        Inst::FpuStore64 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::zero(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123000080A",
+        "vsteg %v17, 0(%r2,%r3), 0",
+    ));
+    insns.push((
+        Inst::FpuStore64 {
+            rd: vr(17),
+            mem: MemArg::BXD12 {
+                base: gpr(3),
+                index: gpr(2),
+                disp: UImm12::maybe_from_u64(4095).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+        },
+        "E7123FFF080A",
+        "vsteg %v17, 4095(%r2,%r3), 0",
+    ));
 
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7760,7 +8144,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7773,7 +8157,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7786,7 +8170,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7799,7 +8183,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7812,7 +8196,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7825,7 +8209,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7838,7 +8222,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev32 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7851,7 +8235,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7864,7 +8248,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7877,7 +8261,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7890,7 +8274,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7903,7 +8287,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7916,7 +8300,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7929,7 +8313,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7942,7 +8326,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuLoadRev64 {
-            rd: writable_fpr(1),
+            rd: writable_vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -7955,7 +8339,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7968,7 +8352,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7981,7 +8365,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -7994,7 +8378,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -8007,7 +8391,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8020,7 +8404,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8033,7 +8417,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8046,7 +8430,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev32 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8059,7 +8443,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -8072,7 +8456,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -8085,7 +8469,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -8098,7 +8482,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(2),
                 index: zero_reg(),
@@ -8111,7 +8495,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8124,7 +8508,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD12 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8137,7 +8521,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8150,7 +8534,7 @@ fn test_s390x_binemit() {
     ));
     insns.push((
         Inst::FpuStoreRev64 {
-            rd: fpr(1),
+            rd: vr(1),
             mem: MemArg::BXD20 {
                 base: gpr(3),
                 index: gpr(2),
@@ -8164,133 +8548,297 @@ fn test_s390x_binemit() {
 
     insns.push((
         Inst::LoadFpuConst32 {
-            rd: writable_fpr(8),
+            rd: writable_vr(8),
             const_data: 1.0_f32.to_bits(),
         },
         "A71500043F80000078801000",
         "bras %r1, 8 ; data.f32 1 ; le %f8, 0(%r1)",
     ));
     insns.push((
+        Inst::LoadFpuConst32 {
+            rd: writable_vr(24),
+            const_data: 1.0_f32.to_bits(),
+        },
+        "A71500043F800000E78010000803",
+        "bras %r1, 8 ; data.f32 1 ; vlef %v24, 0(%r1), 0",
+    ));
+    insns.push((
         Inst::LoadFpuConst64 {
-            rd: writable_fpr(8),
+            rd: writable_vr(8),
             const_data: 1.0_f64.to_bits(),
         },
         "A71500063FF000000000000068801000",
         "bras %r1, 12 ; data.f64 1 ; ld %f8, 0(%r1)",
     ));
+    insns.push((
+        Inst::LoadFpuConst64 {
+            rd: writable_vr(24),
+            const_data: 1.0_f64.to_bits(),
+        },
+        "A71500063FF0000000000000E78010000802",
+        "bras %r1, 12 ; data.f64 1 ; vleg %v24, 0(%r1), 0",
+    ));
 
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Minus32,
+            op: FpuRoundOp::Cvt64To32,
+            mode: FpuRoundMode::Current,
+            rd: writable_vr(8),
+            rn: vr(12),
+        },
+        "B344008C",
+        "ledbra %f8, %f12, 0",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Cvt64To32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C5",
+        "wledb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Round32,
+            mode: FpuRoundMode::ToNegInfinity,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B357708C",
         "fiebr %f8, %f12, 7",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Minus64,
+            op: FpuRoundOp::Round64,
+            mode: FpuRoundMode::ToNegInfinity,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B35F708C",
         "fidbr %f8, %f12, 7",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Plus32,
+            op: FpuRoundOp::Round32,
+            mode: FpuRoundMode::ToPosInfinity,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B357608C",
         "fiebr %f8, %f12, 6",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Plus64,
+            op: FpuRoundOp::Round64,
+            mode: FpuRoundMode::ToPosInfinity,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B35F608C",
         "fidbr %f8, %f12, 6",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Zero32,
+            op: FpuRoundOp::Round32,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B357508C",
         "fiebr %f8, %f12, 5",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Zero64,
+            op: FpuRoundOp::Round64,
+            mode: FpuRoundMode::ToZero,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B35F508C",
         "fidbr %f8, %f12, 5",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Nearest32,
+            op: FpuRoundOp::Round32,
+            mode: FpuRoundMode::ToNearestTiesToEven,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B357408C",
         "fiebr %f8, %f12, 4",
     ));
     insns.push((
         Inst::FpuRound {
-            rd: writable_fpr(8),
-            rn: fpr(12),
-            op: FpuRoundMode::Nearest64,
+            op: FpuRoundOp::Round64,
+            mode: FpuRoundMode::ToNearestTiesToEven,
+            rd: writable_vr(8),
+            rn: vr(12),
         },
         "B35F408C",
         "fidbr %f8, %f12, 4",
     ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Round32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828C7",
+        "wfisb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::Round64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C7",
+        "wfidb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::ToSInt32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828C2",
+        "wcfeb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::ToSInt64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C2",
+        "wcgdb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::ToUInt32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828C0",
+        "wclfeb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::ToUInt64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C0",
+        "wclgdb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::FromSInt32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828C3",
+        "wcefb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::FromSInt64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C3",
+        "wcdgb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::FromUInt32,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001828C1",
+        "wcelfb %v24, %f12, 0, 1",
+    ));
+    insns.push((
+        Inst::FpuRound {
+            op: FpuRoundOp::FromUInt64,
+            mode: FpuRoundMode::ToNearest,
+            rd: writable_vr(24),
+            rn: vr(12),
+        },
+        "E78C001838C1",
+        "wcdlgb %v24, %f12, 0, 1",
+    ));
 
     insns.push((
-        Inst::FpuVecRRR {
-            fpu_op: FPUOp2::Max32,
-            rd: writable_fpr(4),
-            rn: fpr(6),
-            rm: fpr(8),
+        Inst::VecSelect {
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+            ra: vr(10),
         },
-        "E746801820EF",
-        "wfmaxsb %f4, %f6, %f8, 1",
+        "E7468000A08D",
+        "vsel %v4, %v6, %v8, %v10",
     ));
     insns.push((
-        Inst::FpuVecRRR {
-            fpu_op: FPUOp2::Max64,
-            rd: writable_fpr(4),
-            rn: fpr(6),
-            rm: fpr(8),
+        Inst::VecSelect {
+            rd: writable_vr(20),
+            rn: vr(6),
+            rm: vr(8),
+            ra: vr(10),
         },
-        "E746801830EF",
-        "wfmaxdb %f4, %f6, %f8, 1",
+        "E7468000A88D",
+        "vsel %v20, %v6, %v8, %v10",
     ));
     insns.push((
-        Inst::FpuVecRRR {
-            fpu_op: FPUOp2::Min32,
-            rd: writable_fpr(4),
-            rn: fpr(6),
-            rm: fpr(8),
+        Inst::VecSelect {
+            rd: writable_vr(4),
+            rn: vr(22),
+            rm: vr(8),
+            ra: vr(10),
         },
-        "E746801820EE",
-        "wfminsb %f4, %f6, %f8, 1",
+        "E7468000A48D",
+        "vsel %v4, %v22, %v8, %v10",
     ));
     insns.push((
-        Inst::FpuVecRRR {
-            fpu_op: FPUOp2::Min64,
-            rd: writable_fpr(4),
-            rn: fpr(6),
-            rm: fpr(8),
+        Inst::VecSelect {
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(24),
+            ra: vr(10),
         },
-        "E746801830EE",
-        "wfmindb %f4, %f6, %f8, 1",
+        "E7468000A28D",
+        "vsel %v4, %v6, %v24, %v10",
+    ));
+    insns.push((
+        Inst::VecSelect {
+            rd: writable_vr(4),
+            rn: vr(6),
+            rm: vr(8),
+            ra: vr(26),
+        },
+        "E7468000A18D",
+        "vsel %v4, %v6, %v8, %v26",
+    ));
+    insns.push((
+        Inst::VecSelect {
+            rd: writable_vr(20),
+            rn: vr(22),
+            rm: vr(24),
+            ra: vr(26),
+        },
+        "E7468000AF8D",
+        "vsel %v20, %v22, %v24, %v26",
     ));
 
     let flags = settings::Flags::new(settings::builder());

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -45,7 +45,7 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
         Register(14),
         Register(15),
     ];
-    const FPR_MAP: [gimli::Register; 16] = [
+    const VR_MAP: [gimli::Register; 32] = [
         Register(16),
         Register(20),
         Register(17),
@@ -62,11 +62,27 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
         Register(30),
         Register(27),
         Register(31),
+        Register(68),
+        Register(72),
+        Register(69),
+        Register(73),
+        Register(70),
+        Register(74),
+        Register(71),
+        Register(75),
+        Register(76),
+        Register(80),
+        Register(77),
+        Register(81),
+        Register(78),
+        Register(82),
+        Register(79),
+        Register(83),
     ];
 
     match reg.class() {
         RegClass::Int => Ok(GPR_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
-        RegClass::Float => Ok(FPR_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
+        RegClass::Float => Ok(VR_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -963,8 +963,10 @@
 ;;;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Copysign of two registers.
-(rule (lower (has_type ty (fcopysign x y)))
-      (fpu_copysign ty x y))
+(rule (lower (has_type $F32 (fcopysign x y)))
+      (vec_select $F32 x y (imm $F32 2147483647)))
+(rule (lower (has_type $F64 (fcopysign x y)))
+      (vec_select $F64 x y (imm $F64 9223372036854775807)))
 
 
 ;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1034,120 +1036,148 @@
 
 ;; Demote a register.
 (rule (lower (has_type dst_ty (fdemote x @ (value_type src_ty))))
-      (fdemote_reg dst_ty src_ty x))
+      (fdemote_reg dst_ty src_ty (FpuRoundMode.Current) x))
 
 
 ;;;; Rules for `fcvt_from_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Convert an unsigned integer value in a register to floating-point.
-(rule (lower (has_type dst_ty (fcvt_from_uint x @ (value_type src_ty))))
-      (fcvt_from_uint_reg dst_ty (ty_ext32 src_ty)
-                          (put_in_reg_zext32 x)))
+;; Convert a 32-bit or smaller unsigned integer to $F32 (z15 instruction).
+(rule (lower (has_type $F32
+        (fcvt_from_uint x @ (value_type (and (vxrs_ext2_enabled) (fits_in_32 ty))))))
+      (fcvt_from_uint_reg $F32 (FpuRoundMode.ToNearestTiesToEven)
+                          (mov_to_fpr32 (put_in_reg_zext32 x))))
+
+;; Convert a 64-bit or smaller unsigned integer to $F32, via an intermediate $F64.
+(rule (lower (has_type $F32 (fcvt_from_uint x @ (value_type (fits_in_64 ty)))))
+      (fdemote_reg $F32 $F64 (FpuRoundMode.ToNearestTiesToEven)
+                   (fcvt_from_uint_reg $F64 (FpuRoundMode.ShorterPrecision)
+                                       (mov_to_fpr64 (put_in_reg_zext64 x)))))
+
+;; Convert a 64-bit or smaller unsigned integer to $F64.
+(rule (lower (has_type $F64 (fcvt_from_uint x @ (value_type (fits_in_64 ty)))))
+      (fcvt_from_uint_reg $F64 (FpuRoundMode.ToNearestTiesToEven)
+                          (mov_to_fpr64 (put_in_reg_zext64 x))))
 
 
 ;;;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Convert a signed integer value in a register to floating-point.
-(rule (lower (has_type dst_ty (fcvt_from_sint x @ (value_type src_ty))))
-      (fcvt_from_sint_reg dst_ty (ty_ext32 src_ty)
-                          (put_in_reg_sext32 x)))
+;; Convert a 32-bit or smaller signed integer to $F32 (z15 instruction).
+(rule (lower (has_type $F32
+        (fcvt_from_sint x @ (value_type (and (vxrs_ext2_enabled) (fits_in_32 ty))))))
+      (fcvt_from_sint_reg $F32 (FpuRoundMode.ToNearestTiesToEven)
+                          (mov_to_fpr32 (put_in_reg_sext32 x))))
+
+;; Convert a 64-bit or smaller signed integer to $F32, via an intermediate $F64.
+(rule (lower (has_type $F32 (fcvt_from_sint x @ (value_type (fits_in_64 ty)))))
+      (fdemote_reg $F32 $F64 (FpuRoundMode.ToNearestTiesToEven)
+                   (fcvt_from_sint_reg $F64 (FpuRoundMode.ShorterPrecision)
+                                       (mov_to_fpr64 (put_in_reg_sext64 x)))))
+
+;; Convert a 64-bit or smaller signed integer to $F64.
+(rule (lower (has_type $F64 (fcvt_from_sint x @ (value_type (fits_in_64 ty)))))
+      (fcvt_from_sint_reg $F64 (FpuRoundMode.ToNearestTiesToEven)
+                          (mov_to_fpr64 (put_in_reg_sext64 x))))
 
 
 ;;;; Rules for `fcvt_to_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert a floating-point value in a register to an unsigned integer value.
 ;; Traps if the input cannot be represented in the output type.
-;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
-(rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_uint x @ (value_type src_ty))))
-      (let ((src Reg x)
+(rule (lower (has_type dst_ty (fcvt_to_uint x @ (value_type src_ty))))
+      (let ((src Reg (put_in_reg x))
             ;; First, check whether the input is a NaN, and trap if so.
-            (_ Reg (trap_if (fcmp_reg src_ty src src)
-                            (floatcc_as_cond (FloatCC.Unordered))
-                            (trap_code_bad_conversion_to_integer)))
-            ;; Perform the conversion.  If this sets CC 3, we have a
-            ;; "special case".  Since we already exluded the case where
-            ;; the input was a NaN, the only other option is that the
-            ;; conversion overflowed the target type.
-            (dst Reg (trap_if (fcvt_to_uint_reg_with_flags dst_ty src_ty src)
-                              (floatcc_as_cond (FloatCC.Unordered))
-                              (trap_code_integer_overflow))))
-        dst))
+            (_1 Reg (trap_if (fcmp_reg src_ty src src)
+                             (floatcc_as_cond (FloatCC.Unordered))
+                             (trap_code_bad_conversion_to_integer)))
+            ;; Now check whether the input is out of range for the target type.
+            (_2 Reg (trap_if (fcmp_reg src_ty src (fcvt_to_uint_ub src_ty dst_ty))
+                             (floatcc_as_cond (FloatCC.GreaterThanOrEqual))
+                             (trap_code_integer_overflow)))
+            (_3 Reg (trap_if (fcmp_reg src_ty src (fcvt_to_uint_lb src_ty))
+                             (floatcc_as_cond (FloatCC.LessThanOrEqual))
+                             (trap_code_integer_overflow)))
+            ;; Perform the conversion using the larger type size.
+            (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (src_ext Reg (fpromote_reg flt_ty src_ty src)))
+        (fcvt_to_uint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
 
 
 ;;;; Rules for `fcvt_to_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert a floating-point value in a register to a signed integer value.
 ;; Traps if the input cannot be represented in the output type.
-;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
-(rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_sint x @ (value_type src_ty))))
-      (let ((src Reg x)
+(rule (lower (has_type dst_ty (fcvt_to_sint x @ (value_type src_ty))))
+      (let ((src Reg (put_in_reg x))
             ;; First, check whether the input is a NaN, and trap if so.
-            (_ Reg (trap_if (fcmp_reg src_ty src src)
-                            (floatcc_as_cond (FloatCC.Unordered))
-                            (trap_code_bad_conversion_to_integer)))
-            ;; Perform the conversion.  If this sets CC 3, we have a
-            ;; "special case".  Since we already exluded the case where
-            ;; the input was a NaN, the only other option is that the
-            ;; conversion overflowed the target type.
-            (dst Reg (trap_if (fcvt_to_sint_reg_with_flags dst_ty src_ty src)
-                              (floatcc_as_cond (FloatCC.Unordered))
-                              (trap_code_integer_overflow))))
-        dst))
+            (_1 Reg (trap_if (fcmp_reg src_ty src src)
+                             (floatcc_as_cond (FloatCC.Unordered))
+                             (trap_code_bad_conversion_to_integer)))
+            ;; Now check whether the input is out of range for the target type.
+            (_2 Reg (trap_if (fcmp_reg src_ty src (fcvt_to_sint_ub src_ty dst_ty))
+                             (floatcc_as_cond (FloatCC.GreaterThanOrEqual))
+                             (trap_code_integer_overflow)))
+            (_3 Reg (trap_if (fcmp_reg src_ty src (fcvt_to_sint_lb src_ty dst_ty))
+                             (floatcc_as_cond (FloatCC.LessThanOrEqual))
+                             (trap_code_integer_overflow)))
+            ;; Perform the conversion using the larger type size.
+            (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (src_ext Reg (fpromote_reg flt_ty src_ty src)))
+        ;; Perform the conversion.
+        (fcvt_to_sint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
 
 
 ;;;; Rules for `fcvt_to_uint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert a floating-point value in a register to an unsigned integer value.
-;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
-(rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_uint_sat x @ (value_type src_ty))))
-      (let ((src Reg x)
-            (dst Reg (fcvt_to_uint_reg dst_ty src_ty src))
-            ;; In most special cases, the Z instruction already yields the
-            ;; result expected by Cranelift semantics.  The only exception
-            ;; it the case where the input was a NaN.  We explicitly check
-            ;; for that and force the output to 0 in that case.
-            (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
-                                     (cmov_imm dst_ty
-                                               (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
-        sat))
+(rule (lower (has_type dst_ty (fcvt_to_uint_sat x @ (value_type src_ty))))
+      (let ((src Reg (put_in_reg x))
+            ;; Perform the conversion using the larger type size.
+            (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (int_ty Type (fcvt_int_ty dst_ty src_ty))
+            (src_ext Reg (fpromote_reg flt_ty src_ty src))
+            (dst Reg (fcvt_to_uint_reg flt_ty (FpuRoundMode.ToZero) src_ext)))
+        ;; Clamp the output to the destination type bounds.
+        (uint_sat_reg dst_ty int_ty dst)))
 
 
 ;;;; Rules for `fcvt_to_sint_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Convert a floating-point value in a register to a signed integer value.
-;; FIXME: Add support for 8-/16-bit destination types (needs overflow check).
-(rule (lower (has_type (ty_32_or_64 dst_ty) (fcvt_to_sint_sat x @ (value_type src_ty))))
-      (let ((src Reg x)
-            (dst Reg (fcvt_to_sint_reg dst_ty src_ty src))
+(rule (lower (has_type dst_ty (fcvt_to_sint_sat x @ (value_type src_ty))))
+      (let ((src Reg (put_in_reg x))
+            ;; Perform the conversion using the larger type size.
+            (flt_ty Type (fcvt_flt_ty dst_ty src_ty))
+            (int_ty Type (fcvt_int_ty dst_ty src_ty))
+            (src_ext Reg (fpromote_reg flt_ty src_ty src))
+            (dst Reg (fcvt_to_sint_reg flt_ty (FpuRoundMode.ToZero) src_ext))
             ;; In most special cases, the Z instruction already yields the
             ;; result expected by Cranelift semantics.  The only exception
             ;; it the case where the input was a NaN.  We explicitly check
             ;; for that and force the output to 0 in that case.
             (sat Reg (with_flags_reg (fcmp_reg src_ty src src)
-                                     (cmov_imm dst_ty
-                                               (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
-        sat))
+                                     (cmov_imm int_ty
+                                       (floatcc_as_cond (FloatCC.Unordered)) 0 dst))))
+        ;; Clamp the output to the destination type bounds.
+        (sint_sat_reg dst_ty int_ty sat)))
 
 
 ;;;; Rules for `bitcast` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Reinterpret a 64-bit integer value as floating-point.
 (rule (lower (has_type $F64 (bitcast x @ (value_type $I64))))
-      (mov_to_fpr x))
+      (mov_to_fpr64 x))
 
 ;; Reinterpret a 64-bit floating-point value as integer.
 (rule (lower (has_type $I64 (bitcast x @ (value_type $F64))))
-      (mov_from_fpr x))
+      (mov_from_fpr64 x))
 
 ;; Reinterpret a 32-bit integer value as floating-point (via $I64).
-;; Note that a 32-bit float is located in the high bits of the GPR.
 (rule (lower (has_type $F32 (bitcast x @ (value_type $I32))))
-      (mov_to_fpr (lshl_imm $I64 x 32)))
+      (mov_to_fpr32 x))
 
 ;; Reinterpret a 32-bit floating-point value as integer (via $I64).
-;; Note that a 32-bit float is located in the high bits of the GPR.
 (rule (lower (has_type $I32 (bitcast x @ (value_type $F32))))
-      (lshr_imm $I64 (mov_from_fpr x) 32))
+      (mov_from_fpr32 x))
 
 
 ;;;; Rules for `stack_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1232,7 +1262,7 @@
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F32)
                        (load flags @ (littleendian) addr offset)))
       (let ((gpr Reg (loadrev32 (lower_address flags addr offset))))
-        (mov_to_fpr (lshl_imm $I64 gpr 32))))
+        (mov_to_fpr32 gpr)))
 
 ;; Load 64-bit big-endian floating-point values.
 (rule (lower (has_type $F64 (load flags @ (bigendian) addr offset)))
@@ -1247,7 +1277,7 @@
 (rule (lower (has_type (and (vxrs_ext2_disabled) $F64)
                             (load flags @ (littleendian) addr offset)))
       (let ((gpr Reg (loadrev64 (lower_address flags addr offset))))
-        (mov_to_fpr gpr)))
+        (mov_to_fpr64 gpr)))
 
 
 ;;;; Rules for `uload8` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1390,7 +1420,7 @@
 ;; Store 32-bit little-endian floating-point type (via GPR on z14).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F32 (vxrs_ext2_disabled))) addr offset))
-      (let ((gpr Reg (lshr_imm $I64 (mov_from_fpr (put_in_reg val)) 32)))
+      (let ((gpr Reg (mov_from_fpr32 (put_in_reg val))))
         (side_effect (storerev32 gpr (lower_address flags addr offset)))))
 
 ;; Store 64-bit big-endian floating-point type.
@@ -1408,7 +1438,7 @@
 ;; Store 64-bit little-endian floating-point type (via GPR on z14).
 (rule (lower (store flags @ (littleendian)
                     val @ (value_type (and $F64 (vxrs_ext2_disabled))) addr offset))
-      (let ((gpr Reg (mov_from_fpr (put_in_reg val))))
+      (let ((gpr Reg (mov_from_fpr64 (put_in_reg val))))
         (side_effect (storerev64 gpr (lower_address flags addr offset)))))
 
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -426,6 +426,48 @@ where
     }
 
     #[inline]
+    fn fcvt_to_uint_ub32(&mut self, size: u8) -> u64 {
+        (2.0_f32).powi(size.into()).to_bits() as u64
+    }
+
+    #[inline]
+    fn fcvt_to_uint_lb32(&mut self) -> u64 {
+        (-1.0_f32).to_bits() as u64
+    }
+
+    #[inline]
+    fn fcvt_to_uint_ub64(&mut self, size: u8) -> u64 {
+        (2.0_f64).powi(size.into()).to_bits()
+    }
+
+    #[inline]
+    fn fcvt_to_uint_lb64(&mut self) -> u64 {
+        (-1.0_f64).to_bits()
+    }
+
+    #[inline]
+    fn fcvt_to_sint_ub32(&mut self, size: u8) -> u64 {
+        (2.0_f32).powi((size - 1).into()).to_bits() as u64
+    }
+
+    #[inline]
+    fn fcvt_to_sint_lb32(&mut self, size: u8) -> u64 {
+        let lb = (-2.0_f32).powi((size - 1).into());
+        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits()) as u64
+    }
+
+    #[inline]
+    fn fcvt_to_sint_ub64(&mut self, size: u8) -> u64 {
+        (2.0_f64).powi((size - 1).into()).to_bits()
+    }
+
+    #[inline]
+    fn fcvt_to_sint_lb64(&mut self, size: u8) -> u64 {
+        let lb = (-2.0_f64).powi((size - 1).into());
+        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
+    }
+
+    #[inline]
     fn littleendian(&mut self, flags: MemFlags) -> Option<()> {
         let endianness = flags.endianness(Endianness::Big);
         if endianness == Endianness::Little {

--- a/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
@@ -1,374 +1,5 @@
 test compile precise-output
-target s390x
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; F32CONST/F64CONST
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-; FIXME: should use FZERO instruction
-; FIXME: should use out-of-line literal pool
-
-function %f32const_zero() -> f32 {
-block0:
-  v1 = f32const 0x0.0
-  return v1
-}
-
-; block0:
-;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
-;   br %r14
-
-function %f64const_zero() -> f64 {
-block0:
-  v1 = f64const 0x0.0
-  return v1
-}
-
-; block0:
-;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
-;   br %r14
-
-function %f32const_one() -> f32 {
-block0:
-  v1 = f32const 0x1.0
-  return v1
-}
-
-; block0:
-;   bras %r1, 8 ; data.f32 1 ; le %f0, 0(%r1)
-;   br %r14
-
-function %f64const_one() -> f64 {
-block0:
-  v1 = f64const 0x1.0
-  return v1
-}
-
-; block0:
-;   bras %r1, 12 ; data.f64 1 ; ld %f0, 0(%r1)
-;   br %r14
-
-function %fadd_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fadd v0, v1
-  return v2
-}
-
-; block0:
-;   aebr %f0, %f2
-;   br %r14
-
-function %fadd_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fadd v0, v1
-  return v2
-}
-
-; block0:
-;   adbr %f0, %f2
-;   br %r14
-
-function %fsub_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fsub v0, v1
-  return v2
-}
-
-; block0:
-;   sebr %f0, %f2
-;   br %r14
-
-function %fsub_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fsub v0, v1
-  return v2
-}
-
-; block0:
-;   sdbr %f0, %f2
-;   br %r14
-
-function %fmul_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fmul v0, v1
-  return v2
-}
-
-; block0:
-;   meebr %f0, %f2
-;   br %r14
-
-function %fmul_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fmul v0, v1
-  return v2
-}
-
-; block0:
-;   mdbr %f0, %f2
-;   br %r14
-
-function %fdiv_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fdiv v0, v1
-  return v2
-}
-
-; block0:
-;   debr %f0, %f2
-;   br %r14
-
-function %fdiv_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fdiv v0, v1
-  return v2
-}
-
-; block0:
-;   ddbr %f0, %f2
-;   br %r14
-
-function %fmin_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fmin v0, v1
-  return v2
-}
-
-; block0:
-;   wfminsb %f0, %f0, %f2, 1
-;   br %r14
-
-function %fmin_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fmin v0, v1
-  return v2
-}
-
-; block0:
-;   wfmindb %f0, %f0, %f2, 1
-;   br %r14
-
-function %fmax_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fmax v0, v1
-  return v2
-}
-
-; block0:
-;   wfmaxsb %f0, %f0, %f2, 1
-;   br %r14
-
-function %fmax_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fmax v0, v1
-  return v2
-}
-
-; block0:
-;   wfmaxdb %f0, %f0, %f2, 1
-;   br %r14
-
-function %sqrt_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = sqrt v0
-  return v1
-}
-
-; block0:
-;   sqebr %f0, %f0
-;   br %r14
-
-function %sqrt_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = sqrt v0
-  return v1
-}
-
-; block0:
-;   sqdbr %f0, %f0
-;   br %r14
-
-function %fabs_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = fabs v0
-  return v1
-}
-
-; block0:
-;   lpebr %f0, %f0
-;   br %r14
-
-function %fabs_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = fabs v0
-  return v1
-}
-
-; block0:
-;   lpdbr %f0, %f0
-;   br %r14
-
-function %fneg_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = fneg v0
-  return v1
-}
-
-; block0:
-;   lcebr %f0, %f0
-;   br %r14
-
-function %fneg_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = fneg v0
-  return v1
-}
-
-; block0:
-;   lcdbr %f0, %f0
-;   br %r14
-
-function %fpromote_f32(f32) -> f64 {
-block0(v0: f32):
-  v1 = fpromote.f64 v0
-  return v1
-}
-
-; block0:
-;   ldebr %f0, %f0
-;   br %r14
-
-function %fdemote_f64(f64) -> f32 {
-block0(v0: f64):
-  v1 = fdemote.f32 v0
-  return v1
-}
-
-; block0:
-;   ledbra %f0, %f0, 0
-;   br %r14
-
-function %ceil_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = ceil v0
-  return v1
-}
-
-; block0:
-;   fiebr %f0, %f0, 6
-;   br %r14
-
-function %ceil_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = ceil v0
-  return v1
-}
-
-; block0:
-;   fidbr %f0, %f0, 6
-;   br %r14
-
-function %floor_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = floor v0
-  return v1
-}
-
-; block0:
-;   fiebr %f0, %f0, 7
-;   br %r14
-
-function %floor_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = floor v0
-  return v1
-}
-
-; block0:
-;   fidbr %f0, %f0, 7
-;   br %r14
-
-function %trunc_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = trunc v0
-  return v1
-}
-
-; block0:
-;   fiebr %f0, %f0, 5
-;   br %r14
-
-function %trunc_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = trunc v0
-  return v1
-}
-
-; block0:
-;   fidbr %f0, %f0, 5
-;   br %r14
-
-function %nearest_f32(f32) -> f32 {
-block0(v0: f32):
-  v1 = nearest v0
-  return v1
-}
-
-; block0:
-;   fiebr %f0, %f0, 4
-;   br %r14
-
-function %nearest_f64(f64) -> f64 {
-block0(v0: f64):
-  v1 = nearest v0
-  return v1
-}
-
-; block0:
-;   fidbr %f0, %f0, 4
-;   br %r14
-
-function %fma_f32(f32, f32, f32) -> f32 {
-block0(v0: f32, v1: f32, v2: f32):
-  v3 = fma v0, v1, v2
-  return v3
-}
-
-; block0:
-;   wfmasb %f0, %f0, %f2, %f4
-;   br %r14
-
-function %fma_f64(f64, f64, f64) -> f64 {
-block0(v0: f64, v1: f64, v2: f64):
-  v3 = fma v0, v1, v2
-  return v3
-}
-
-; block0:
-;   wfmadb %f0, %f0, %f2, %f4
-;   br %r14
-
-function %fcopysign_f32(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-  v2 = fcopysign v0, v1
-  return v2
-}
-
-; block0:
-;   bras %r1, 8 ; data.f32 NaN ; le %f5, 0(%r1)
-;   vsel %v0, %v0, %v2, %v5
-;   br %r14
-
-function %fcopysign_f64(f64, f64) -> f64 {
-block0(v0: f64, v1: f64):
-  v2 = fcopysign v0, v1
-  return v2
-}
-
-; block0:
-;   bras %r1, 12 ; data.f64 NaN ; ld %f5, 0(%r1)
-;   vsel %v0, %v0, %v2, %v5
-;   br %r14
+target s390x arch13
 
 function %fcvt_to_uint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -385,9 +16,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wclgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wclfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_sint_f32_i8(f32) -> i8 {
@@ -405,9 +35,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -129 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wcgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wcfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_uint_f32_i16(f32) -> i16 {
@@ -425,9 +54,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wclgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wclfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_sint_f32_i16(f32) -> i16 {
@@ -445,9 +73,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -32769 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wcgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wcfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_uint_f32_i32(f32) -> i32 {
@@ -465,9 +92,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wclgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wclfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_sint_f32_i32(f32) -> i32 {
@@ -485,9 +111,8 @@ block0(v0: f32):
 ;   bras %r1, 8 ; data.f32 -2147484000 ; vlef %v17, 0(%r1), 0
 ;   wfcsb %f0, %v17
 ;   jnle 6 ; trap
-;   wldeb %v21, %f0
-;   wcgdb %v23, %v21, 0, 5
-;   vlgvg %r2, %v23, 0
+;   wcfeb %v21, %f0, 0, 5
+;   vlgvf %r2, %v21, 0
 ;   br %r14
 
 function %fcvt_to_uint_f32_i64(f32) -> i64 {
@@ -689,10 +314,9 @@ block0(v0: i8):
 }
 
 ; block0:
-;   llgcr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdlgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   llcr %r5, %r2
+;   vlvgf %v5, %r5, 0
+;   wcelfb %f0, %f5, 0, 4
 ;   br %r14
 
 function %fcvt_from_sint_i8_f32(i8) -> f32 {
@@ -702,10 +326,9 @@ block0(v0: i8):
 }
 
 ; block0:
-;   lgbr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   lbr %r5, %r2
+;   vlvgf %v5, %r5, 0
+;   wcefb %f0, %f5, 0, 4
 ;   br %r14
 
 function %fcvt_from_uint_i16_f32(i16) -> f32 {
@@ -715,10 +338,9 @@ block0(v0: i16):
 }
 
 ; block0:
-;   llghr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdlgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   llhr %r5, %r2
+;   vlvgf %v5, %r5, 0
+;   wcelfb %f0, %f5, 0, 4
 ;   br %r14
 
 function %fcvt_from_sint_i16_f32(i16) -> f32 {
@@ -728,10 +350,9 @@ block0(v0: i16):
 }
 
 ; block0:
-;   lghr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   lhr %r5, %r2
+;   vlvgf %v5, %r5, 0
+;   wcefb %f0, %f5, 0, 4
 ;   br %r14
 
 function %fcvt_from_uint_i32_f32(i32) -> f32 {
@@ -741,10 +362,8 @@ block0(v0: i32):
 }
 
 ; block0:
-;   llgfr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdlgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   vlvgf %v3, %r2, 0
+;   wcelfb %f0, %f3, 0, 4
 ;   br %r14
 
 function %fcvt_from_sint_i32_f32(i32) -> f32 {
@@ -754,10 +373,8 @@ block0(v0: i32):
 }
 
 ; block0:
-;   lgfr %r5, %r2
-;   ldgr %f5, %r5
-;   wcdgb %f7, %f5, 0, 3
-;   ledbra %f0, %f7, 4
+;   vlvgf %v3, %r2, 0
+;   wcefb %f0, %f3, 0, 4
 ;   br %r14
 
 function %fcvt_from_uint_i64_f32(i64) -> f32 {
@@ -885,12 +502,11 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wclgdb %f5, %f3, 0, 5
-;   lgdr %r5, %f5
-;   lgr %r2, %r5
-;   clgfi %r5, 256
-;   locghih %r2, 255
+;   wclfeb %f3, %f0, 0, 5
+;   vlgvf %r3, %v3, 0
+;   lgr %r2, %r3
+;   clfi %r3, 256
+;   lochih %r2, 255
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32_i8(f32) -> i8 {
@@ -900,17 +516,16 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wcgdb %f5, %f3, 0, 5
-;   lgdr %r5, %f5
+;   wcfeb %f3, %f0, 0, 5
+;   vlgvf %r3, %v3, 0
 ;   cebr %f0, %f0
-;   locghio %r5, 0
-;   lgr %r4, %r5
-;   cghi %r5, 127
-;   locghih %r4, 127
+;   lochio %r3, 0
+;   lgr %r4, %r3
+;   chi %r3, 127
+;   lochih %r4, 127
 ;   lgr %r2, %r4
-;   cghi %r4, -128
-;   locghil %r2, -128
+;   chi %r4, -128
+;   lochil %r2, -128
 ;   br %r14
 
 function %fcvt_to_uint_sat_f32_i16(f32) -> i16 {
@@ -920,12 +535,11 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wclgdb %f5, %f3, 0, 5
-;   lgdr %r5, %f5
-;   lgr %r2, %r5
-;   clgfi %r5, 65535
-;   locghih %r2, -1
+;   wclfeb %f3, %f0, 0, 5
+;   vlgvf %r3, %v3, 0
+;   lgr %r2, %r3
+;   clfi %r3, 65535
+;   lochih %r2, -1
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32_i16(f32) -> i16 {
@@ -935,17 +549,16 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wcgdb %f5, %f3, 0, 5
-;   lgdr %r5, %f5
+;   wcfeb %f3, %f0, 0, 5
+;   vlgvf %r3, %v3, 0
 ;   cebr %f0, %f0
-;   locghio %r5, 0
-;   lgr %r4, %r5
-;   cghi %r5, 32767
-;   locghih %r4, 32767
+;   lochio %r3, 0
+;   lgr %r4, %r3
+;   chi %r3, 32767
+;   lochih %r4, 32767
 ;   lgr %r2, %r4
-;   cghi %r4, -32768
-;   locghil %r2, -32768
+;   chi %r4, -32768
+;   lochil %r2, -32768
 ;   br %r14
 
 function %fcvt_to_uint_sat_f32_i32(f32) -> i32 {
@@ -955,12 +568,8 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wclgdb %f5, %f3, 0, 5
-;   lgdr %r2, %f5
-;   llilf %r3, 4294967295
-;   clgr %r2, %r3
-;   locgrh %r2, %r3
+;   wclfeb %f3, %f0, 0, 5
+;   vlgvf %r2, %v3, 0
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32_i32(f32) -> i32 {
@@ -970,17 +579,10 @@ block0(v0: f32):
 }
 
 ; block0:
-;   ldebr %f3, %f0
-;   wcgdb %f5, %f3, 0, 5
-;   lgdr %r2, %f5
+;   wcfeb %f3, %f0, 0, 5
+;   vlgvf %r2, %v3, 0
 ;   cebr %f0, %f0
-;   locghio %r2, 0
-;   lgfi %r3, 2147483647
-;   cgr %r2, %r3
-;   locgrh %r2, %r3
-;   lgfi %r5, -2147483648
-;   cgr %r2, %r5
-;   locgrl %r2, %r5
+;   lochio %r2, 0
 ;   br %r14
 
 function %fcvt_to_uint_sat_f32_i64(f32) -> i64 {
@@ -1130,45 +732,5 @@ block0(v0: f64):
 ;   lgdr %r2, %f3
 ;   cdbr %f0, %f0
 ;   locghio %r2, 0
-;   br %r14
-
-function %bitcast_i64_f64(i64) -> f64 {
-block0(v0: i64):
-  v1 = bitcast.f64 v0
-  return v1
-}
-
-; block0:
-;   ldgr %f0, %r2
-;   br %r14
-
-function %bitcast_f64_i64(f64) -> i64 {
-block0(v0: f64):
-  v1 = bitcast.i64 v0
-  return v1
-}
-
-; block0:
-;   lgdr %r2, %f0
-;   br %r14
-
-function %bitcast_i32_f32(i32) -> f32 {
-block0(v0: i32):
-  v1 = bitcast.f32 v0
-  return v1
-}
-
-; block0:
-;   vlvgf %v0, %r2, 0
-;   br %r14
-
-function %bitcast_f32_i32(f32) -> i32 {
-block0(v0: f32):
-  v1 = bitcast.i32 v0
-  return v1
-}
-
-; block0:
-;   vlgvf %r2, %v0, 0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/fpmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem.clif
@@ -40,8 +40,7 @@ block0(v0: i64):
 
 ; block0:
 ;   lrv %r5, 0(%r2)
-;   sllg %r3, %r5, 32
-;   ldgr %f0, %r3
+;   vlvgf %v0, %r5, 0
 ;   br %r14
 
 function %store_f64(f64, i64) {
@@ -82,8 +81,7 @@ block0(v0: f32, v1: i64):
 }
 
 ; block0:
-;   lgdr %r3, %f0
-;   srlg %r4, %r3, 32
-;   strv %r4, 0(%r2)
+;   vlgvf %r3, %v0, 0
+;   strv %r3, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -76,9 +76,9 @@ block1:
 ;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
 ;   bras %r1, 12 ; data.f64 2 ; ld %f4, 0(%r1)
 ;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
-;   bras %r1, 12 ; data.f64 4 ; ld %f5, 0(%r1)
-;   bras %r1, 12 ; data.f64 5 ; ld %f7, 0(%r1)
-;   std %f5, 0(%r2)
-;   std %f7, 8(%r2)
+;   bras %r1, 12 ; data.f64 4 ; vleg %v28, 0(%r1), 0
+;   bras %r1, 12 ; data.f64 5 ; vleg %v31, 0(%r1), 0
+;   vsteg %v28, 0(%r2), 0
+;   vsteg %v31, 8(%r2), 0
 ;   br %r14
 


### PR DESCRIPTION
This defines the full set of 32 128-bit vector registers on s390x.
(Note that the VRs overlap the existing FPRs.)  In addition, this
adds support to use all 32 vector registers to implement floating-
point operations, by using vector floating-point instructions with
the 'W' bit set to operate only on the first element.

This part of the vector instruction set mostly matches the old FP
instruction set, with two exceptions:

- There is no vector version of the COPY SIGN instruction.  Instead,
  now use a VECTOR SELECT with an appropriate bit mask to implement
  the fcopysign operation.

- There are no vector version of the float <-> int conversion
  instructions where source and target differ in bit size.  Use
  appropriate multiple conversion steps instead.  This also requires
  use of explicit checking to implement correct overflow handling.
  As a side effect, this version now also implements the i8 / i16
  variants of all conversions, which had been missing so far.

For all operations except those two above, we continue to use the
old FP instruction if applicable (i.e. if all operands happen to
have been allocated to the original FP register set), and use the
vector instruction otherwise.

CC @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
