### PR TITLE
Do one `add_seals` call, rather than one per flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,11 +1631,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6627dc657574b49d6ad27105ed671822be56e0d2547d413bfbf3e8d8fa92e7a"
+checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
- "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "1.0"
 backtrace = { version = "0.3.61" }
 rand = "0.8.3"
 anyhow = "1.0.38"
-memfd = { version = "0.4.1", optional = true }
+memfd = { version = "0.6.1", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"

--- a/crates/runtime/src/cow.rs
+++ b/crates/runtime/src/cow.rs
@@ -162,10 +162,12 @@ impl MemoryImage {
                 // extra-super-sure that it never changes, and because
                 // this costs very little, we use the kernel's "seal" API
                 // to make the memfd image permanently read-only.
-                memfd.add_seal(memfd::FileSeal::SealGrow)?;
-                memfd.add_seal(memfd::FileSeal::SealShrink)?;
-                memfd.add_seal(memfd::FileSeal::SealWrite)?;
-                memfd.add_seal(memfd::FileSeal::SealSeal)?;
+                memfd.add_seals(&[
+                    memfd::FileSeal::SealGrow,
+                    memfd::FileSeal::SealShrink,
+                    memfd::FileSeal::SealWrite,
+                    memfd::FileSeal::SealSeal,
+                ])?;
 
                 Ok(Some(MemoryImage {
                     fd: FdSource::Memfd(memfd),


### PR DESCRIPTION
When setting up a copy on write image, we add several seals, to prevent
the image from being resized or modified. Set all the seals in a single
call, rather than doing one call per seal.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
