### PR TITLE
Add rerun-if-changed to fiber/build.rs

### DIFF
--- a/crates/fiber/build.rs
+++ b/crates/fiber/build.rs
@@ -5,13 +5,16 @@ fn main() {
     let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     if os == "windows" {
+        println!("cargo:rerun-if-changed=src/windows.c");
         build.file("src/windows.c");
     } else if arch == "s390x" {
+        println!("cargo:rerun-if-changed=src/unix/s390x.S");
         build.file("src/unix/s390x.S");
     } else {
         // assume that this is included via inline assembly in the crate itself,
         // and the crate will otherwise have a `compile_error!` for unsupported
         // platforms.
+        println!("cargo:rerun-if-changed=build.rs");
         return;
     }
     build.define(&format!("CFG_TARGET_OS_{}", os), None);


### PR DESCRIPTION
Not having rerun-if-changed leads to including nanosecond-precision
mtimes in fingerprints and unnecessary rebuilds in docker [1].

[1] https://github.com/rust-lang/cargo/blob/0.63.1/src/cargo/core/compiler/fingerprint.rs#L1491



- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.

This is a trivial fix.

- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.

- [ ] This PR contains test cases, if meaningful.

This is a build issue.

- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

The list of suggested reviewers is empty.
`git log build.rs` points to @alexcrichton.