### PR TITLE
Update to openvino 0.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,15 +442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "component-macro-test"
 version = "0.1.0"
 dependencies = [
@@ -1899,9 +1890,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openvino"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61670c4f1f1fbd3889b97d3772462f6f81d959859a9031c5603850b5dfe93a61"
+checksum = "d9627908ea4af5766040aa191c8607479af7f70b45fdf6e999b450069fea851a"
 dependencies = [
  "openvino-sys",
  "thiserror",
@@ -1909,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-finder"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a50d2e3f93a32f4b384583c1623f15eec4268a299ff86228b04c475744b5c6"
+checksum = "213893e484dcf3db4af79d498a955f7c4c209d06e7020779cda68fca779c2578"
 dependencies = [
  "cfg-if",
  "log",
@@ -1919,14 +1910,14 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35a2728ef9dd1663ed6640fbe329d7c5f334f5867796d4f6840a921b1f40604"
+checksum = "e2ba37c26ad2591acc48abee5350d65daa263bf0ab7a79d2ab6999d4b20130ec"
 dependencies = [
- "cmake",
- "lazy_static",
  "libloading",
+ "once_cell",
  "openvino-finder",
+ "pretty_env_logger",
 ]
 
 [[package]]

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 wiggle = { path = "../wiggle", version = "=0.40.0" }
 
 # These dependencies are necessary for the wasi-nn implementation:
-openvino = { version = "0.3.3", features = ["runtime-linking"] }
+openvino = { version = "0.4.1", features = ["runtime-linking"] }
 thiserror = "1.0"
 
 [build-dependencies]

--- a/crates/wasi-nn/src/openvino.rs
+++ b/crates/wasi-nn/src/openvino.rs
@@ -87,10 +87,10 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
         // should not have to default to NHWC.
         let desc = TensorDesc::new(Layout::NHWC, &dimensions, precision);
         let data = tensor.data.as_slice()?;
-        let blob = openvino::Blob::new(desc, &data)?;
+        let blob = openvino::Blob::new(&desc, &data)?;
 
         // Actually assign the blob to the request.
-        self.1.set_blob(&input_name, blob)?;
+        self.1.set_blob(&input_name, &blob)?;
         Ok(())
     }
 


### PR DESCRIPTION
This eliminates one more dependency on lazy_static.

In the openvino API, a few parameters were changed from being passed by
value to being passed by reference.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
