### PR TITLE
Update differential fuzzing configuration

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -272,29 +272,38 @@ impl Config {
         let config = &mut self.module_config.config;
 
         config.allow_start_export = false;
+
         // Make sure there's a type available for the function.
         config.min_types = 1;
-        config.max_types = 1;
+        config.max_types = config.max_types.max(1);
 
-        // Generate one and only one function
+        // Generate at least one function
         config.min_funcs = 1;
-        config.max_funcs = 1;
+        config.max_funcs = config.max_funcs.max(1);
 
-        // Give the function a memory, but keep it small
-        config.min_memories = 1;
+        // Allow a memory to be generated, but don't let it get too large.
+        // Additionally require the maximum size to guarantee that the growth
+        // behavior is consisten across engines.
         config.max_memories = 1;
-        config.max_memory_pages = 1;
+        config.max_memory_pages = 10;
         config.memory_max_size_required = true;
 
-        // While reference types are disabled below, only allow one table
+        // If tables are generated make sure they don't get too large to avoid
+        // hidding any engine-specific limit. Additionally ensure that the
+        // maximum size is required to guarantee consistent growth across
+        // engines.
+        //
+        // Note that while reference types are disabled below, only allow one
+        // table.
         config.max_tables = 1;
+        config.max_table_elements = 1_000;
+        config.table_max_size_required = true;
 
         // Don't allow any imports
         config.max_imports = 0;
 
         // Try to get the function and the memory exported
-        config.min_exports = 2;
-        config.max_exports = 4;
+        config.export_everything = true;
 
         // NaN is canonicalized at the wasm level for differential fuzzing so we
         // can paper over NaN differences between engines.
@@ -317,9 +326,10 @@ impl Config {
         {
             // One single-page memory
             limits.memories = 1;
-            limits.memory_pages = 1;
+            limits.memory_pages = 10;
 
             limits.tables = 1;
+            limits.table_elements = 1_000;
 
             match &mut self.wasmtime.memory_config {
                 MemoryConfig::Normal(config) => {

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -283,13 +283,13 @@ impl Config {
 
         // Allow a memory to be generated, but don't let it get too large.
         // Additionally require the maximum size to guarantee that the growth
-        // behavior is consisten across engines.
+        // behavior is consistent across engines.
         config.max_memories = 1;
         config.max_memory_pages = 10;
         config.memory_max_size_required = true;
 
         // If tables are generated make sure they don't get too large to avoid
-        // hidding any engine-specific limit. Additionally ensure that the
+        // hitting any engine-specific limit. Additionally ensure that the
         // maximum size is required to guarantee consistent growth across
         // engines.
         //


### PR DESCRIPTION
This uses some new features of `wasm-smith` and additionally tweaks the
existing fuzz configuration:

* More than one function is now allowed to be generated. There's no
  particular reason to limit differential execution to just one and we
  may want to explore other interesting module shapes.

* More than one function type is now allowed to possibly allow more
  interesting `block` types.

* Memories are now allowed to grow beyond one page, but still say small
  by staying underneath 10 pages.

* Tables are now always limited in their growth to ensure consistent
  behavior across engines (e.g. with the pooling allocator vs v8).

* The `export_everything` feature is used instead of specifying a
  min/max number of exports.

The `wasmi` differential fuzzer was updated to still work if memory is
exported, but otherwise the v8 differential fuzzer already worked if a
function was exported but a memory wasn't. Both fuzzers continue to
execute only the first exported function.

Also notable from this update is that the `SwarmConfig` from
`wasm-smith` will now include an arbitrary `allowed_instructions`
configuration which may help explore the space of interesting modules
more effectively.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
