### PR TITLE
Disable reference types in v8 fuzzing

### DIFF
--- a/fuzz/fuzz_targets/differential_v8.rs
+++ b/fuzz/fuzz_targets/differential_v8.rs
@@ -19,7 +19,16 @@ fn run(data: &[u8]) -> Result<()> {
     // Enable features that v8 has implemented
     config.module_config.config.simd_enabled = u.arbitrary()?;
     config.module_config.config.bulk_memory_enabled = u.arbitrary()?;
-    config.module_config.config.reference_types_enabled = u.arbitrary()?;
+
+    // FIXME: reference types are disabled for now as we seemingly keep finding
+    // a segfault in v8. This is found relatively quickly locally and keeps
+    // getting found by oss-fuzz and currently we don't think that there's
+    // really much we can do about it. For the time being disable reference
+    // types entirely. An example bug is
+    // https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45662
+    //
+    // config.module_config.config.reference_types_enabled = u.arbitrary()?;
+
     // FIXME: to enable fuzzing with the threads proposal, see
     // https://github.com/bytecodealliance/wasmtime/issues/4268.
     // config.module_config.config.threads_enabled = u.arbitrary()?;


### PR DESCRIPTION
OSS-fuzz long-ago discovered https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45662
which we currently believe to be a bug in v8. I originally thought it
was going to be fixed with https://bugs.chromium.org/p/v8/issues/detail?id=12722
but that no longer appears to be the case now that the `v8` crate has
caught up and it still isn't fixed. Personally I've sort of lost an
appetite for continuing to debug these issues so I figure it's best to
just disable reference types with v8 for now and exercise the rest of
the engine, e.g. simd.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
