### PR TITLE
x64: port `atomic_rmw` to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -430,11 +430,7 @@
        ;; problem.
        ;;
        ;; This instruction sequence has fixed register uses as follows:
-       ;;
-       ;; - %r9   (read) address
-       ;; - %r10  (read) second operand for `op`
-       ;; - %r11  (written) scratch reg; value afterwards has no meaning
-       ;; - %rax  (written) the old value at %r9
+       ;; - %rax  (written) the old value at `address`
        ;; - %rflags is written.  Do not assume anything about it after the
        ;;   instruction.
        (AtomicRmwSeq (ty Type) ;; I8, I16, I32, or I64
@@ -2926,9 +2922,6 @@
 (rule (x64_atomic_rmw_seq ty op address input)
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
-            ;; In a future iteration of this, the sequence itself could be
-            ;; encoded in ISLE and some of the specific register assignments
-            ;; (see `x64_get_operands` in `inst/mod.rs`) could be relaxed.
             (_ Unit (emit (MInst.AtomicRmwSeq ty op address input tmp dst))))
         dst))
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -415,10 +415,10 @@
        ;; The sequence consists of an initial "normal" load from `dst`, followed
        ;; by a loop which computes the new value and tries to compare-and-swap
        ;; ("CAS") it into `dst`, using the native instruction `lock
-       ;; cmpxchg{b,w,l,q}` .  The loop iterates until the CAS is successful.
-       ;; If there is no contention, there will be only one pass through the
-       ;; loop body.  The sequence does *not* perform any explicit memory fence
-       ;; instructions (mfence/sfence/lfence).
+       ;; cmpxchg{b,w,l,q}`.  The loop iterates until the CAS is successful. If
+       ;; there is no contention, there will be only one pass through the loop
+       ;; body.  The sequence does *not* perform any explicit memory fence
+       ;; instructions (`mfence`/`sfence`/`lfence`).
        ;;
        ;; Note that the transaction is atomic in the sense that, as observed by
        ;; some other thread, `dst` either has the initial or final value, but no
@@ -431,13 +431,14 @@
        ;;
        ;; This instruction sequence has fixed register uses as follows:
        ;;
-       ;; %r9   (read) address
-       ;; %r10  (read) second operand for `op`
-       ;; %r11  (written) scratch reg; value afterwards has no meaning
-       ;; %rax  (written) the old value at %r9
-       ;; %rflags is written.  Do not assume anything about it after the instruction.
+       ;; - %r9   (read) address
+       ;; - %r10  (read) second operand for `op`
+       ;; - %r11  (written) scratch reg; value afterwards has no meaning
+       ;; - %rax  (written) the old value at %r9
+       ;; - %rflags is written.  Do not assume anything about it after the
+       ;;   instruction.
        (AtomicRmwSeq (ty Type) ;; I8, I16, I32, or I64
-                     (op AtomicRmwOp)
+                     (op MachAtomicRmwOp)
                      (address Reg)
                      (operand Reg)
                      (temp WritableReg)
@@ -2921,6 +2922,22 @@
             (_ Unit (emit (MInst.LockCmpxchg ty replacement expected addr dst))))
         dst))
 
+(decl x64_atomic_rmw_seq (Type MachAtomicRmwOp Gpr Gpr) Gpr)
+(rule (x64_atomic_rmw_seq ty op address input)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (tmp WritableGpr (temp_writable_gpr))
+            ;; In a future iteration of this, the sequence itself could be
+            ;; encoded in ISLE and some of the specific register assignments
+            ;; (see `x64_get_operands` in `inst/mod.rs`) could be relaxed.
+            (_ Unit (emit (MInst.AtomicRmwSeq ty op address input tmp dst))))
+        dst))
+
+;; CLIF IR has one enumeration for atomic operations (`AtomicRmwOp`) while the
+;; mach backend has another (`MachAtomicRmwOp`)--this converts one to the other.
+(type MachAtomicRmwOp extern (enum))
+(decl atomic_rmw_op_to_mach_atomic_rmw_op (AtomicRmwOp) MachAtomicRmwOp)
+      (extern constructor atomic_rmw_op_to_mach_atomic_rmw_op atomic_rmw_op_to_mach_atomic_rmw_op)
+
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (convert Gpr InstOutput output_gpr)
@@ -2973,6 +2990,7 @@
 (convert SyntheticAmode XmmMem synthetic_amode_to_xmm_mem)
 
 (convert IntCC CC intcc_to_cc)
+(convert AtomicRmwOp MachAtomicRmwOp atomic_rmw_op_to_mach_atomic_rmw_op)
 
 (decl reg_to_xmm_mem (Reg) XmmMem)
 (rule (reg_to_xmm_mem r)
@@ -3012,3 +3030,5 @@
 (decl synthetic_amode_to_xmm_mem (SyntheticAmode) XmmMem)
 (rule (synthetic_amode_to_xmm_mem amode)
       (synthetic_amode_to_reg_mem amode))
+
+

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3023,5 +3023,3 @@
 (decl synthetic_amode_to_xmm_mem (SyntheticAmode) XmmMem)
 (rule (synthetic_amode_to_xmm_mem amode)
       (synthetic_amode_to_reg_mem amode))
-
-

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2936,7 +2936,7 @@
 ;; mach backend has another (`MachAtomicRmwOp`)--this converts one to the other.
 (type MachAtomicRmwOp extern (enum))
 (decl atomic_rmw_op_to_mach_atomic_rmw_op (AtomicRmwOp) MachAtomicRmwOp)
-      (extern constructor atomic_rmw_op_to_mach_atomic_rmw_op atomic_rmw_op_to_mach_atomic_rmw_op)
+(extern constructor atomic_rmw_op_to_mach_atomic_rmw_op atomic_rmw_op_to_mach_atomic_rmw_op)
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -430,12 +430,12 @@
        ;; problem.
        ;;
        ;; This instruction sequence has fixed register uses as follows:
-       ;; - %rax  (written) the old value at `address`
+       ;; - %rax  (written) the old value at `mem`
        ;; - %rflags is written.  Do not assume anything about it after the
        ;;   instruction.
        (AtomicRmwSeq (ty Type) ;; I8, I16, I32, or I64
                      (op MachAtomicRmwOp)
-                     (address Reg)
+                     (mem SyntheticAmode)
                      (operand Reg)
                      (temp WritableReg)
                      (dst_old WritableReg))
@@ -2918,11 +2918,11 @@
             (_ Unit (emit (MInst.LockCmpxchg ty replacement expected addr dst))))
         dst))
 
-(decl x64_atomic_rmw_seq (Type MachAtomicRmwOp Gpr Gpr) Gpr)
-(rule (x64_atomic_rmw_seq ty op address input)
+(decl x64_atomic_rmw_seq (Type MachAtomicRmwOp SyntheticAmode Gpr) Gpr)
+(rule (x64_atomic_rmw_seq ty op mem input)
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.AtomicRmwSeq ty op address input tmp dst))))
+            (_ Unit (emit (MInst.AtomicRmwSeq ty op mem input tmp dst))))
         dst))
 
 ;; CLIF IR has one enumeration for atomic operations (`AtomicRmwOp`) while the

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2618,6 +2618,7 @@ pub(crate) fn emit(
             temp,
             dst_old,
         } => {
+            // TODO: replace hardcoded registers with allocated registers.
             debug_assert_eq!(allocs.next(*address), regs::r9());
             debug_assert_eq!(allocs.next(*operand), regs::r10());
             debug_assert_eq!(allocs.next(temp.to_reg()), regs::r11());

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2624,13 +2624,13 @@ pub(crate) fn emit(
             debug_assert_eq!(dst_old.to_reg(), regs::rax());
             let mem = mem.finalize(state, sink).with_allocs(allocs);
 
-            // Emit this: mov{zbq,zwq,zlq,q}     (%r_address), %rax    // rax =
-            //    old value again: movq                   %rax, %r_temp
-            //   // rax = old value, r_temp = old value `op`q
-            //    %r_operand, %r_temp   // rax = old value, r_temp = new value
-            //    lock cmpxchg{b,w,l,q}  %r_temp, (%r_address) // try to store
-            //    new value jnz again // If this is taken, rax will have a
-            //    "revised" old value
+            // Emit this:
+            //    mov{zbq,zwq,zlq,q}     (%r_address), %rax    // rax = old value
+            //  again:
+            //    movq                   %rax, %r_temp         // rax = old value, r_temp = old value
+            //    `op`q                  %r_operand, %r_temp   // rax = old value, r_temp = new value
+            //    lock cmpxchg{b,w,l,q}  %r_temp, (%r_address) // try to store new value
+            //    jnz again // If this is taken, rax will have a "revised" old value
             //
             // Operand conventions: IN:  %r_address, %r_operand OUT: %rax (old
             //    value), %r_temp (trashed), %rflags (trashed)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4611,6 +4611,8 @@ fn test_x64_emit() {
         3,
     )
     .into();
+    // Use `r9` with a 0 offset.
+    let am3: SyntheticAmode = Amode::imm_reg(0, r9).into();
 
     // A general 8-bit case.
     insns.push((
@@ -4744,7 +4746,7 @@ fn test_x64_emit() {
         Inst::AtomicRmwSeq {
             ty: types::I8,
             op: inst_common::MachAtomicRmwOp::Or,
-            address: r9,
+            mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
@@ -4756,7 +4758,7 @@ fn test_x64_emit() {
         Inst::AtomicRmwSeq {
             ty: types::I16,
             op: inst_common::MachAtomicRmwOp::And,
-            address: r9,
+            mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
@@ -4768,7 +4770,7 @@ fn test_x64_emit() {
         Inst::AtomicRmwSeq {
             ty: types::I32,
             op: inst_common::MachAtomicRmwOp::Xchg,
-            address: r9,
+            mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
@@ -4780,7 +4782,7 @@ fn test_x64_emit() {
         Inst::AtomicRmwSeq {
             ty: types::I32,
             op: inst_common::MachAtomicRmwOp::Umin,
-            address: r9,
+            mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax
@@ -4792,7 +4794,7 @@ fn test_x64_emit() {
         Inst::AtomicRmwSeq {
             ty: types::I64,
             op: inst_common::MachAtomicRmwOp::Add,
-            address: r9,
+            mem: am3.clone(),
             operand: r10,
             temp: w_r11,
             dst_old: w_rax

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4743,7 +4743,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I8,
-            op: inst_common::AtomicRmwOp::Or,
+            op: inst_common::MachAtomicRmwOp::Or,
             address: r9,
             operand: r10,
             temp: w_r11,
@@ -4755,7 +4755,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I16,
-            op: inst_common::AtomicRmwOp::And,
+            op: inst_common::MachAtomicRmwOp::And,
             address: r9,
             operand: r10,
             temp: w_r11,
@@ -4767,7 +4767,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I32,
-            op: inst_common::AtomicRmwOp::Xchg,
+            op: inst_common::MachAtomicRmwOp::Xchg,
             address: r9,
             operand: r10,
             temp: w_r11,
@@ -4779,7 +4779,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I32,
-            op: inst_common::AtomicRmwOp::Umin,
+            op: inst_common::MachAtomicRmwOp::Umin,
             address: r9,
             operand: r10,
             temp: w_r11,
@@ -4791,7 +4791,7 @@ fn test_x64_emit() {
     insns.push((
         Inst::AtomicRmwSeq {
             ty: types::I64,
-            op: inst_common::AtomicRmwOp::Add,
+            op: inst_common::MachAtomicRmwOp::Add,
             address: r9,
             operand: r10,
             temp: w_r11,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2056,6 +2056,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             operand,
             temp,
             dst_old,
+            mem,
             ..
         } => {
             collector.reg_late_use(*operand);
@@ -2063,6 +2064,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             // This `fixed_def` is needed because `CMPXCHG` always uses this
             // register implicitly.
             collector.reg_fixed_def(*dst_old, regs::rax());
+            mem.get_operands(collector)
         }
 
         Inst::Ret { rets } => {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2059,10 +2059,11 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             dst_old,
             ..
         } => {
-            // TODO: replace hardcoded registers with allocated registers.
-            collector.reg_fixed_use(*address, regs::r9());
-            collector.reg_fixed_use(*operand, regs::r10());
+            collector.reg_late_use(*address);
+            collector.reg_late_use(*operand);
             collector.reg_early_def(*temp);
+            // This `fixed_def` is needed because `CMPXCHG` always uses this
+            // register implicitly.
             collector.reg_fixed_def(*dst_old, regs::rax());
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2053,13 +2053,11 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
         }
 
         Inst::AtomicRmwSeq {
-            address,
             operand,
             temp,
             dst_old,
             ..
         } => {
-            collector.reg_late_use(*address);
             collector.reg_late_use(*operand);
             collector.reg_early_def(*temp);
             // This `fixed_def` is needed because `CMPXCHG` always uses this

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2064,7 +2064,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             // This `fixed_def` is needed because `CMPXCHG` always uses this
             // register implicitly.
             collector.reg_fixed_def(*dst_old, regs::rax());
-            mem.get_operands(collector)
+            mem.get_operands_late(collector)
         }
 
         Inst::Ret { rets } => {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2060,8 +2060,8 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             ..
         } => {
             // TODO: replace hardcoded registers with allocated registers.
-            collector.reg_fixed_late_use(*address, regs::r9());
-            collector.reg_fixed_late_use(*operand, regs::r10());
+            collector.reg_fixed_use(*address, regs::r9());
+            collector.reg_fixed_use(*operand, regs::r10());
             collector.reg_fixed_def(*temp, regs::r11());
             collector.reg_fixed_def(*dst_old, regs::rax());
         }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2059,6 +2059,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             dst_old,
             ..
         } => {
+            // TODO: replace hardcoded registers with allocated registers.
             collector.reg_fixed_use(*address, regs::r9());
             collector.reg_fixed_use(*operand, regs::r10());
             collector.reg_fixed_def(*temp, regs::r11());

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2062,7 +2062,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             // TODO: replace hardcoded registers with allocated registers.
             collector.reg_fixed_use(*address, regs::r9());
             collector.reg_fixed_use(*operand, regs::r10());
-            collector.reg_fixed_def(*temp, regs::r11());
+            collector.reg_early_def(*temp);
             collector.reg_fixed_def(*dst_old, regs::rax());
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2060,8 +2060,8 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             ..
         } => {
             // TODO: replace hardcoded registers with allocated registers.
-            collector.reg_fixed_use(*address, regs::r9());
-            collector.reg_fixed_use(*operand, regs::r10());
+            collector.reg_fixed_late_use(*address, regs::r9());
+            collector.reg_fixed_late_use(*operand, regs::r10());
             collector.reg_fixed_def(*temp, regs::r11());
             collector.reg_fixed_def(*dst_old, regs::rax());
         }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2052,13 +2052,17 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             mem.get_operands(collector);
         }
 
-        Inst::AtomicRmwSeq { .. } => {
-            // FIXME: take vreg args, not fixed regs, and just use
-            // reg_fixed_use here.
-            collector.reg_use(regs::r9());
-            collector.reg_use(regs::r10());
-            collector.reg_def(Writable::from_reg(regs::r11()));
-            collector.reg_def(Writable::from_reg(regs::rax()));
+        Inst::AtomicRmwSeq {
+            address,
+            operand,
+            temp,
+            dst_old,
+            ..
+        } => {
+            collector.reg_fixed_use(*address, regs::r9());
+            collector.reg_fixed_use(*operand, regs::r10());
+            collector.reg_fixed_def(*temp, regs::r11());
+            collector.reg_fixed_def(*dst_old, regs::rax());
         }
 
         Inst::Ret { rets } => {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2851,3 +2851,20 @@
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_cas flags address expected replacement)))
       (x64_cmpxchg ty expected replacement (to_amode flags address (zero_offset))))
+
+;; Rules for `atomic_rmw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; This is a simple, general-case atomic update, based on a loop involving
+;; `cmpxchg`.  Note that we could do much better than this in the case where the
+;; old value at the location (that is to say, the SSA `Value` computed by this
+;; CLIF instruction) is not required.  In that case, we could instead implement
+;; this using a single `lock`-prefixed x64 read-modify-write instruction.  Also,
+;; even in the case where the old value is required, for the `add` and `sub`
+;; cases, we can use the single instruction `lock xadd`.  However, those
+;; improvements have been left for another day. TODO: filed as
+;; https://github.com/bytecodealliance/wasmtime/issues/2153.
+
+(rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
+                  (atomic_rmw flags op address input)))
+      ;; TODO: `flags` is unused--should it be?
+      (x64_atomic_rmw_seq ty op address input))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2866,5 +2866,4 @@
 
 (rule (lower (has_type (and (fits_in_64 ty) (ty_int _))
                   (atomic_rmw flags op address input)))
-      ;; TODO: `flags` is unused--should it be?
-      (x64_atomic_rmw_seq ty op address input))
+      (x64_atomic_rmw_seq ty op (to_amode flags address (zero_offset)) input))

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -44,14 +44,6 @@ fn is_bool_ty(ty: Type) -> bool {
     }
 }
 
-/// This is target-word-size dependent.  And it excludes booleans and reftypes.
-fn is_valid_atomic_transaction_ty(ty: Type) -> bool {
-    match ty {
-        types::I8 | types::I16 | types::I32 | types::I64 => true,
-        _ => false,
-    }
-}
-
 /// Returns whether the given specified `input` is a result produced by an instruction with Opcode
 /// `op`.
 // TODO investigate failures with checking against the result index.

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -2136,54 +2136,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::AtomicRmw => {
-            // This is a simple, general-case atomic update, based on a loop involving
-            // `cmpxchg`.  Note that we could do much better than this in the case where the old
-            // value at the location (that is to say, the SSA `Value` computed by this CLIF
-            // instruction) is not required.  In that case, we could instead implement this
-            // using a single `lock`-prefixed x64 read-modify-write instruction.  Also, even in
-            // the case where the old value is required, for the `add` and `sub` cases, we can
-            // use the single instruction `lock xadd`.  However, those improvements have been
-            // left for another day.
-            // TODO: filed as https://github.com/bytecodealliance/wasmtime/issues/2153
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let mut addr = put_input_in_reg(ctx, inputs[0]);
-            let mut arg2 = put_input_in_reg(ctx, inputs[1]);
-            let ty_access = ty.unwrap();
-            assert!(is_valid_atomic_transaction_ty(ty_access));
-
-            // Make sure that both args are in virtual regs, since in effect we have to do a
-            // parallel copy to get them safely to the AtomicRmwSeq input regs, and that's not
-            // guaranteed safe if either is in a real reg.
-            addr = ctx.ensure_in_vreg(addr, types::I64);
-            arg2 = ctx.ensure_in_vreg(arg2, types::I64);
-
-            // Move the args to the preordained AtomicRMW input regs.  Note that `AtomicRmwSeq`
-            // operates at whatever width is specified by `ty`, so there's no need to
-            // zero-extend `arg2` in the case of `ty` being I8/I16/I32.
-            ctx.emit(Inst::gen_move(
-                Writable::from_reg(regs::r9()),
-                addr,
-                types::I64,
-            ));
-            ctx.emit(Inst::gen_move(
-                Writable::from_reg(regs::r10()),
-                arg2,
-                types::I64,
-            ));
-
-            // Now the AtomicRmwSeq (pseudo-) instruction itself
-            let op = inst_common::AtomicRmwOp::from(ctx.data(insn).atomic_rmw_op().unwrap());
-            ctx.emit(Inst::AtomicRmwSeq {
-                ty: ty_access,
-                op,
-                address: regs::r9(),
-                operand: regs::r10(),
-                temp: Writable::from_reg(regs::r11()),
-                dst_old: Writable::from_reg(regs::rax()),
-            });
-
-            // And finally, copy the preordained AtomicRmwSeq output reg to its destination.
-            ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
+            implemented_in_isle(ctx);
         }
 
         Opcode::AtomicCas => {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -2,7 +2,10 @@
 
 // Pull in the ISLE generated code.
 pub(crate) mod generated_code;
-use crate::machinst::{InputSourceInst, Reg, Writable};
+use crate::{
+    ir::AtomicRmwOp,
+    machinst::{InputSourceInst, Reg, Writable},
+};
 use generated_code::MInst;
 
 // Types that the generated ISLE code uses via `use super::*`.
@@ -23,7 +26,7 @@ use crate::{
         },
     },
     machinst::{
-        isle::*, AtomicRmwOp, InsnInput, InsnOutput, LowerCtx, VCodeConstant, VCodeConstantData,
+        isle::*, InsnInput, InsnOutput, LowerCtx, MachAtomicRmwOp, VCodeConstant, VCodeConstantData,
     },
 };
 use std::boxed::Box;
@@ -564,6 +567,11 @@ where
     #[inline]
     fn zero_offset(&mut self) -> Offset32 {
         Offset32::new(0)
+    }
+
+    #[inline]
+    fn atomic_rmw_op_to_mach_atomic_rmw_op(&mut self, op: &AtomicRmwOp) -> MachAtomicRmwOp {
+        MachAtomicRmwOp::from(*op)
     }
 }
 

--- a/cranelift/codegen/src/machinst/inst_common.rs
+++ b/cranelift/codegen/src/machinst/inst_common.rs
@@ -45,11 +45,10 @@ pub(crate) fn insn_outputs<I: VCodeInst, C: LowerCtx<I = I>>(
 //============================================================================
 // Atomic instructions.
 
-/// Atomic memory update operations.  As of 21 Aug 2020 these are used for the aarch64 and x64
-/// targets.
+/// Atomic memory update operations.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum AtomicRmwOp {
+pub enum MachAtomicRmwOp {
     /// Add
     Add,
     /// Sub
@@ -74,21 +73,22 @@ pub enum AtomicRmwOp {
     Smax,
 }
 
-impl AtomicRmwOp {
-    /// Converts an `ir::AtomicRmwOp` to the corresponding `inst_common::AtomicRmwOp`.
+impl MachAtomicRmwOp {
+    /// Converts an `ir::AtomicRmwOp` to the corresponding
+    /// `inst_common::AtomicRmwOp`.
     pub fn from(ir_op: ir::AtomicRmwOp) -> Self {
         match ir_op {
-            ir::AtomicRmwOp::Add => AtomicRmwOp::Add,
-            ir::AtomicRmwOp::Sub => AtomicRmwOp::Sub,
-            ir::AtomicRmwOp::And => AtomicRmwOp::And,
-            ir::AtomicRmwOp::Nand => AtomicRmwOp::Nand,
-            ir::AtomicRmwOp::Or => AtomicRmwOp::Or,
-            ir::AtomicRmwOp::Xor => AtomicRmwOp::Xor,
-            ir::AtomicRmwOp::Xchg => AtomicRmwOp::Xchg,
-            ir::AtomicRmwOp::Umin => AtomicRmwOp::Umin,
-            ir::AtomicRmwOp::Umax => AtomicRmwOp::Umax,
-            ir::AtomicRmwOp::Smin => AtomicRmwOp::Smin,
-            ir::AtomicRmwOp::Smax => AtomicRmwOp::Smax,
+            ir::AtomicRmwOp::Add => MachAtomicRmwOp::Add,
+            ir::AtomicRmwOp::Sub => MachAtomicRmwOp::Sub,
+            ir::AtomicRmwOp::And => MachAtomicRmwOp::And,
+            ir::AtomicRmwOp::Nand => MachAtomicRmwOp::Nand,
+            ir::AtomicRmwOp::Or => MachAtomicRmwOp::Or,
+            ir::AtomicRmwOp::Xor => MachAtomicRmwOp::Xor,
+            ir::AtomicRmwOp::Xchg => MachAtomicRmwOp::Xchg,
+            ir::AtomicRmwOp::Umin => MachAtomicRmwOp::Umin,
+            ir::AtomicRmwOp::Umax => MachAtomicRmwOp::Umax,
+            ir::AtomicRmwOp::Smin => MachAtomicRmwOp::Smin,
+            ir::AtomicRmwOp::Smax => MachAtomicRmwOp::Smax,
         }
     }
 }

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -328,6 +328,11 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
         self.add_operand(Operand::reg_use(reg.into()));
     }
 
+    /// Add a register use, at the end of the instruction (`After` position).
+    pub fn reg_late_use(&mut self, reg: Reg) {
+        self.add_operand(Operand::reg_use_at_end(reg.into()));
+    }
+
     /// Add multiple register uses.
     pub fn reg_uses(&mut self, regs: &[Reg]) {
         for &reg in regs {

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -364,6 +364,19 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
         self.add_operand(Operand::reg_fixed_use(reg.into(), rreg.into()));
     }
 
+    /// Add a register "fixed use", which ties a vreg to a particular
+    /// RealReg at the "late" point of the instruction.
+    pub fn reg_fixed_late_use(&mut self, reg: Reg, rreg: Reg) {
+        let rreg = rreg.to_real_reg().expect("fixed reg is not a RealReg");
+        let operand = Operand::new(
+            reg.into(),
+            regalloc2::OperandConstraint::FixedReg(rreg.into()),
+            regalloc2::OperandKind::Use,
+            regalloc2::OperandPos::Late,
+        );
+        self.add_operand(operand);
+    }
+
     /// Add a register "fixed def", which ties a vreg to a particular
     /// RealReg at this point.
     pub fn reg_fixed_def(&mut self, reg: Writable<Reg>, rreg: Reg) {

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -364,19 +364,6 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
         self.add_operand(Operand::reg_fixed_use(reg.into(), rreg.into()));
     }
 
-    /// Add a register "fixed use", which ties a vreg to a particular
-    /// RealReg at the "late" point of the instruction.
-    pub fn reg_fixed_late_use(&mut self, reg: Reg, rreg: Reg) {
-        let rreg = rreg.to_real_reg().expect("fixed reg is not a RealReg");
-        let operand = Operand::new(
-            reg.into(),
-            regalloc2::OperandConstraint::FixedReg(rreg.into()),
-            regalloc2::OperandKind::Use,
-            regalloc2::OperandPos::Late,
-        );
-        self.add_operand(operand);
-    }
-
     /// Add a register "fixed def", which ties a vreg to a particular
     /// RealReg at this point.
     pub fn reg_fixed_def(&mut self, reg: Writable<Reg>, rreg: Reg) {


### PR DESCRIPTION
This change ports `atomic_rmw` to ISLE for the x64 backend. It does not
change the lowering in any way, though it seems possible that the fixed
regs need not be as fixed and that there are opportunities for single
instruction lowerings. It does rename `inst_common::AtomicRmwOp` to
`MachAtomicRmwOp` to disambiguate with the IR enum with the same name.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
