### PR TITLE
Disable the cranelift-fuzzgen fuzz targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -85,17 +85,22 @@ path = "fuzz_targets/compile-maybe-invalid.rs"
 test = false
 doc = false
 
-[[bin]]
-name = "cranelift-fuzzgen"
-path = "fuzz_targets/cranelift-fuzzgen.rs"
-test = false
-doc = false
+# FIXME: the cranelift-fuzzgen fuzz targets are temporarily disabled until
+# the crashes they're finding are fixed. One issue is #3347 but otherwise the
+# oss-fuzz bots are reporting a 100% crash rate with these fuzzers so there may
+# be more issues as well. It's recommended to locally run these fuzzers for a
+# few hours locally before re-enabling.
+# [[bin]]
+# name = "cranelift-fuzzgen"
+# path = "fuzz_targets/cranelift-fuzzgen.rs"
+# test = false
+# doc = false
 
-[[bin]]
-name = "cranelift-fuzzgen-verify"
-path = "fuzz_targets/cranelift-fuzzgen-verify.rs"
-test = false
-doc = false
+# [[bin]]
+# name = "cranelift-fuzzgen-verify"
+# path = "fuzz_targets/cranelift-fuzzgen-verify.rs"
+# test = false
+# doc = false
 
 [[bin]]
 name = "instantiate-many"


### PR DESCRIPTION
Consulting oss-fuzz it looks like these fuzz targets are crashing 100%
of the time partly due to #3347 I believe. Until that's fixed this hopes
to reclaim the time used on oss-fuzz for other fuzzers to make progress.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
