### PR TITLE
Disable tests for `wasmtime-bench-api`

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -11,8 +11,9 @@ publish = false
 
 [lib]
 name = "wasmtime_bench_api"
-crate-type = ["rlib", "cdylib"]
-# The rlib is only included here so that `cargo test` will run.
+crate-type = ["cdylib"]
+test = false
+doctest = false
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Additionally remove the `rlib` crate type so it's possible to build the
API with LTO options if configured (otherwise Cargo ignores LTO
configuration with an `rlib` output since it would hit an error in
rustc)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
