### PR TITLE
cranelift: Implement `global_value` in interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/global_value.clif
+++ b/cranelift/filetests/filetests/runtests/global_value.clif
@@ -1,0 +1,23 @@
+test interpret
+test run
+target x86_64
+target s390x
+target aarch64
+
+; Store a value in the heap using `heap_addr` and load it using `global_value`
+function %store_load(i64 vmctx, i64, i32) -> i32 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0+0
+    heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, offset_guard 0, index_type i64
+
+block0(v0: i64, v1: i64, v2: i32):
+    v3 = heap_addr.i64 heap0, v1, 0
+    store.i32 v2, v3
+
+    v4 = global_value.i64 gv1
+    v5 = load.i32 v4
+    return v5
+}
+; heap: static, size=0x1000, ptr=vmctx+0, bound=vmctx+8
+; run: %store_load(0, 1) == 1
+; run: %store_load(0, -1) == -1

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -381,7 +381,13 @@ where
                 })
             })
         }
-        Opcode::GlobalValue => unimplemented!("GlobalValue"),
+        Opcode::GlobalValue => {
+            if let InstructionData::UnaryGlobalValue { global_value, .. } = inst {
+                assign_or_memtrap(state.resolve_global_value(global_value))
+            } else {
+                unreachable!()
+            }
+        }
         Opcode::SymbolValue => unimplemented!("SymbolValue"),
         Opcode::TlsValue => unimplemented!("TlsValue"),
         Opcode::HeapAddr => {


### PR DESCRIPTION
👋 Hey, This probably should have been implemented along with the heap resolution, but here it is.