### PR TITLE
Convert `isplit` / `iconcat` to ISLE (AArch64)

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -107,6 +107,20 @@
 (rule (lower (has_type vec_i128_ty (swizzle rn rm)))
       (vec_tbl rn rm #f))
 
+;;;; Rules for `isplit` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $I64 (isplit x)))
+      (let
+          ((x_regs ValueRegs x)
+           (x_lo ValueRegs (value_regs_get x_regs 0))
+           (x_hi ValueRegs (value_regs_get x_regs 1)))
+        (output_pair x_lo x_hi)))
+
+;;;; Rules for `iconcat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $I128 (iconcat lo hi)))
+      (output (value_regs lo hi)))
+
 ;;;; Rules for `iadd_pairwise` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I16X8 (iadd_pairwise (swiden_low x) (swiden_high y))))

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1212,47 +1212,9 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
         Opcode::Swizzle => implemented_in_isle(ctx),
 
-        Opcode::Isplit => {
-            let input_ty = ctx.input_ty(insn, 0);
+        Opcode::Isplit => implemented_in_isle(ctx),
 
-            if input_ty != I128 {
-                return Err(CodegenError::Unsupported(format!(
-                    "Isplit: Unsupported type: {:?}",
-                    input_ty
-                )));
-            }
-
-            assert_eq!(ctx.output_ty(insn, 0), I64);
-            assert_eq!(ctx.output_ty(insn, 1), I64);
-
-            let src_regs = put_input_in_regs(ctx, inputs[0]);
-            let dst_lo = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let dst_hi = get_output_reg(ctx, outputs[1]).only_reg().unwrap();
-
-            ctx.emit(Inst::gen_move(dst_lo, src_regs.regs()[0], I64));
-            ctx.emit(Inst::gen_move(dst_hi, src_regs.regs()[1], I64));
-        }
-
-        Opcode::Iconcat => {
-            let ty = ty.unwrap();
-
-            if ty != I128 {
-                return Err(CodegenError::Unsupported(format!(
-                    "Iconcat: Unsupported type: {:?}",
-                    ty
-                )));
-            }
-
-            assert_eq!(ctx.input_ty(insn, 0), I64);
-            assert_eq!(ctx.input_ty(insn, 1), I64);
-
-            let src_lo = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let src_hi = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-            let dst = get_output_reg(ctx, outputs[0]);
-
-            ctx.emit(Inst::gen_move(dst.regs()[0], src_lo, I64));
-            ctx.emit(Inst::gen_move(dst.regs()[1], src_hi, I64));
-        }
+        Opcode::Iconcat => implemented_in_isle(ctx),
 
         Opcode::Imax | Opcode::Umax | Opcode::Umin | Opcode::Imin => implemented_in_isle(ctx),
 

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -317,12 +317,12 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   mov x9, x0
+;   mov x7, x0
 ;   movz x0, #42
-;   mov x1, x9
+;   mov x1, x7
 ;   movz x2, #42
-;   ldr x14, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
-;   blr x14
+;   ldr x10, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
+;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
 
@@ -349,11 +349,12 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
+;   mov x7, x0
 ;   movz x3, #42
-;   mov x2, x0
 ;   movz x0, #42
-;   ldr x14, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
-;   blr x14
+;   mov x2, x7
+;   ldr x10, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
+;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
 
@@ -380,11 +381,12 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
+;   mov x7, x0
 ;   movz x2, #42
-;   mov x1, x0
 ;   movz x0, #42
-;   ldr x14, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
-;   blr x14
+;   mov x1, x7
+;   ldr x10, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
+;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
 


### PR DESCRIPTION
Converted the existing implementations for `isplit` and `iconcat` for
AArch64 to ISLE.

Copyright (c) 2022 Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
