### PR TITLE
Remove dependency on `more-asserts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,12 +1737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "more-asserts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3402,7 +3396,6 @@ dependencies = [
  "file-per-thread-logger",
  "filetime",
  "log",
- "more-asserts",
  "once_cell",
  "pretty_env_logger",
  "rustix",
@@ -3429,7 +3422,6 @@ dependencies = [
  "libc",
  "listenfd",
  "memchr",
- "more-asserts",
  "num_cpus",
  "once_cell",
  "rayon",
@@ -3492,7 +3484,6 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "more-asserts",
  "object",
  "target-lexicon",
  "thiserror",
@@ -3509,7 +3500,6 @@ dependencies = [
  "gimli",
  "indexmap",
  "log",
- "more-asserts",
  "object",
  "serde",
  "target-lexicon",
@@ -3620,7 +3610,6 @@ dependencies = [
  "mach",
  "memfd",
  "memoffset",
- "more-asserts",
  "rand 0.8.5",
  "rustix",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ rustix = { version = "0.35.6", features = ["mm", "param"] }
 wasmtime = { path = "crates/wasmtime", version = "0.40.0" }
 env_logger = "0.9.0"
 filecheck = "0.5.0"
-more-asserts = "0.2.1"
 tempfile = "3.1.0"
 test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { path = "crates/runtime" }

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -32,6 +32,5 @@ rustix = { version = "0.35.6", features = ["process"] }
 [dev-dependencies]
 filetime = "0.2.7"
 once_cell = "1.12.0"
-more-asserts = "0.2.1"
 pretty_env_logger = "0.4.0"
 tempfile = "3"

--- a/crates/cache/src/worker/tests.rs
+++ b/crates/cache/src/worker/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::config::tests::test_prolog;
-use more_asserts::{assert_ge, assert_gt, assert_lt};
 use std::iter::repeat;
 use std::process;
 // load_config! comes from crate::cache(::config::tests);
@@ -150,10 +149,7 @@ fn test_on_get_recompress_with_mod_file() {
     let scenarios = [(4, false), (7, true), (2, false)];
 
     let mut usages = start_stats.usages;
-    assert_lt!(
-        usages,
-        cache_config.optimized_compression_usage_counter_threshold()
-    );
+    assert!(usages < cache_config.optimized_compression_usage_counter_threshold());
     let mut tested_higher_opt_compr_lvl = false;
     for (times_used, lower_compr_lvl) in &scenarios {
         for _ in 0..*times_used {
@@ -180,19 +176,13 @@ fn test_on_get_recompress_with_mod_file() {
         assert_eq!(decoded_data, mod_data.as_bytes());
 
         if *lower_compr_lvl {
-            assert_ge!(
-                usages,
-                cache_config.optimized_compression_usage_counter_threshold()
-            );
+            assert!(usages >= cache_config.optimized_compression_usage_counter_threshold());
             tested_higher_opt_compr_lvl = true;
             stats.compression_level -= 1;
             assert!(write_stats_file(&stats_file, &stats));
         }
     }
-    assert_ge!(
-        usages,
-        cache_config.optimized_compression_usage_counter_threshold()
-    );
+    assert!(usages >= cache_config.optimized_compression_usage_counter_threshold());
     assert!(tested_higher_opt_compr_lvl);
 }
 
@@ -428,7 +418,7 @@ fn test_on_update_cleanup_limits_trash_locks() {
                 "past",
                 &Duration::from_secs(secs_ago),
             );
-            assert_gt!(secs_ago, 0);
+            assert!(secs_ago > 0);
             secs_ago -= 1;
         }
 

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -23,7 +23,6 @@ wasmparser = "0.87.0"
 target-lexicon = "0.12"
 gimli = { version = "0.26.0", default-features = false, features = ['read', 'std'] }
 object = { version = "0.29.0", default-features = false, features = ['write'] }
-more-asserts = "0.2.1"
 thiserror = "1.0.4"
 
 [features]

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -6,7 +6,6 @@ use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::ValueLabelsRanges;
 use cranelift_wasm::get_vmctx_value_label;
 use gimli::{self, write, Expression, Operation, Reader, ReaderOffset, X86_64};
-use more_asserts::{assert_le, assert_lt};
 use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -687,7 +686,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
             if range_start == range_end {
                 continue;
             }
-            assert_lt!(range_start, range_end);
+            assert!(range_start < range_end);
 
             // Find acceptable scope of ranges to intersect with.
             let i = match ranges.binary_search_by(|s| s.start.cmp(&range_start)) {
@@ -716,7 +715,7 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
                     tail.start = range_end;
                     ranges.insert(i + 1, tail);
                 }
-                assert_le!(ranges[i].end, range_end);
+                assert!(ranges[i].end <= range_end);
                 if range_start <= ranges[i].start {
                     ranges[i].label_location.insert(label, loc);
                     continue;

--- a/crates/cranelift/src/debug/transform/line_program.rs
+++ b/crates/cranelift/src/debug/transform/line_program.rs
@@ -6,7 +6,6 @@ use gimli::{
     write, DebugLine, DebugLineOffset, DebugLineStr, DebugStr, DebugStrOffsets,
     DebuggingInformationEntry, LineEncoding, Unit,
 };
-use more_asserts::assert_le;
 use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
 #[derive(Debug)]
@@ -93,7 +92,7 @@ where
     if let Ok(program) = program {
         let header = program.header();
         let file_index_base = if header.version() < 5 { 1 } else { 0 };
-        assert_le!(header.version(), 5, "not supported 6");
+        assert!(header.version() <= 5, "not supported 6");
         let line_encoding = LineEncoding {
             minimum_instruction_length: header.minimum_instruction_length(),
             maximum_operations_per_instruction: header.maximum_operations_per_instruction(),

--- a/crates/cranelift/src/debug/transform/range_info_builder.rs
+++ b/crates/cranelift/src/debug/transform/range_info_builder.rs
@@ -2,7 +2,6 @@ use super::address_transform::AddressTransform;
 use super::{DebugInputContext, Reader};
 use anyhow::Error;
 use gimli::{write, AttributeValue, DebuggingInformationEntry, RangeListsOffset, Unit};
-use more_asserts::assert_lt;
 use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
 pub(crate) enum RangeInfoBuilder {
@@ -206,7 +205,7 @@ impl RangeInfoBuilder {
         if let RangeInfoBuilder::Ranges(ranges) = self {
             let mut range_list = Vec::new();
             for (begin, end) in ranges {
-                assert_lt!(begin, end);
+                assert!(begin < end);
                 range_list.extend(addr_tr.translate_ranges(*begin, *end).map(|tr| {
                     write::Range::StartLength {
                         begin: tr.0,

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -19,7 +19,6 @@ indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
 serde = { version = "1.0.94", features = ["derive"] }
 log = { version = "0.4.8", default-features = false }
-more-asserts = "0.2.1"
 gimli = { version = "0.26.0", default-features = false, features = ['read'] }
 object = { version = "0.29.0", default-features = false, features = ['read_core', 'write_core', 'elf'] }
 target-lexicon = "0.12"

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -26,7 +26,6 @@ use crate::{
     GlobalIndex, MemoryIndex, Module, TableIndex,
 };
 use cranelift_entity::packed_option::ReservedValue;
-use more_asserts::assert_lt;
 use std::convert::TryFrom;
 use wasmtime_types::OwnedMemoryIndex;
 
@@ -671,7 +670,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMFunctionImport` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import(&self, index: FuncIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_functions);
+        assert!(index.as_u32() < self.num_imported_functions);
         self.vmctx_imported_functions_begin()
             + index.as_u32() * u32::from(self.size_of_vmfunction_import())
     }
@@ -679,7 +678,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableImport` index `index`.
     #[inline]
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_tables);
+        assert!(index.as_u32() < self.num_imported_tables);
         self.vmctx_imported_tables_begin()
             + index.as_u32() * u32::from(self.size_of_vmtable_import())
     }
@@ -687,7 +686,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMMemoryImport` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_import(&self, index: MemoryIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_memories);
+        assert!(index.as_u32() < self.num_imported_memories);
         self.vmctx_imported_memories_begin()
             + index.as_u32() * u32::from(self.size_of_vmmemory_import())
     }
@@ -695,7 +694,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMGlobalImport` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_import(&self, index: GlobalIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_imported_globals);
+        assert!(index.as_u32() < self.num_imported_globals);
         self.vmctx_imported_globals_begin()
             + index.as_u32() * u32::from(self.size_of_vmglobal_import())
     }
@@ -703,21 +702,21 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to `VMTableDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmtable_definition(&self, index: DefinedTableIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_tables);
+        assert!(index.as_u32() < self.num_defined_tables);
         self.vmctx_tables_begin() + index.as_u32() * u32::from(self.size_of_vmtable_definition())
     }
 
     /// Return the offset to the `*mut VMMemoryDefinition` at index `index`.
     #[inline]
     pub fn vmctx_vmmemory_pointer(&self, index: DefinedMemoryIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_memories);
+        assert!(index.as_u32() < self.num_defined_memories);
         self.vmctx_memories_begin() + index.as_u32() * u32::from(self.size_of_vmmemory_pointer())
     }
 
     /// Return the offset to the owned `VMMemoryDefinition` at index `index`.
     #[inline]
     pub fn vmctx_vmmemory_definition(&self, index: OwnedMemoryIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_owned_memories);
+        assert!(index.as_u32() < self.num_owned_memories);
         self.vmctx_owned_memories_begin()
             + index.as_u32() * u32::from(self.size_of_vmmemory_definition())
     }
@@ -725,7 +724,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to the `VMGlobalDefinition` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_definition(&self, index: DefinedGlobalIndex) -> u32 {
-        assert_lt!(index.as_u32(), self.num_defined_globals);
+        assert!(index.as_u32() < self.num_defined_globals);
         self.vmctx_globals_begin()
             + index.as_u32() * u32::from(self.ptr.size_of_vmglobal_definition())
     }
@@ -735,7 +734,7 @@ impl<P: PtrSize> VMOffsets<P> {
     #[inline]
     pub fn vmctx_anyfunc(&self, index: AnyfuncIndex) -> u32 {
         assert!(!index.is_reserved_value());
-        assert_lt!(index.as_u32(), self.num_escaped_funcs);
+        assert!(index.as_u32() < self.num_escaped_funcs);
         self.vmctx_anyfuncs_begin()
             + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
     }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,7 +19,6 @@ log = "0.4.8"
 memoffset = "0.6.0"
 indexmap = "1.0.2"
 thiserror = "1.0.4"
-more-asserts = "0.2.1"
 cfg-if = "1.0"
 backtrace = { version = "0.3.61" }
 rand = "0.8.3"

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use anyhow::Error;
 use memoffset::offset_of;
-use more_asserts::assert_lt;
 use std::alloc::Layout;
 use std::any::Any;
 use std::convert::TryFrom;
@@ -364,7 +363,7 @@ impl Instance {
             )
             .unwrap(),
         );
-        assert_lt!(index.index(), self.tables.len());
+        assert!(index.index() < self.tables.len());
         index
     }
 

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -9,7 +9,6 @@ use crate::MemoryImageSlot;
 use crate::Store;
 use anyhow::Error;
 use anyhow::{bail, format_err, Result};
-use more_asserts::{assert_ge, assert_le};
 use std::convert::TryFrom;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
@@ -214,7 +213,7 @@ impl MmapMemory {
             // of the two is, the `maximum` given or the `bound` specified for
             // this memory.
             MemoryStyle::Static { bound } => {
-                assert_ge!(bound, plan.memory.minimum);
+                assert!(bound >= plan.memory.minimum);
                 let bound_bytes =
                     usize::try_from(bound.checked_mul(WASM_PAGE_SIZE_U64).unwrap()).unwrap();
                 maximum = Some(bound_bytes.min(maximum.unwrap_or(usize::MAX)));
@@ -662,7 +661,7 @@ impl Memory {
         } else {
             WASM32_MAX_PAGES
         };
-        assert_le!(plan.memory.minimum, absolute_max);
+        assert!(plan.memory.minimum <= absolute_max);
         assert!(plan.memory.maximum.is_none() || plan.memory.maximum.unwrap() <= absolute_max);
 
         // This is the absolute possible maximum that the module can try to

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -3,7 +3,6 @@
 
 use anyhow::anyhow;
 use anyhow::{Context, Result};
-use more_asserts::assert_le;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::ops::Range;
@@ -160,7 +159,7 @@ impl Mmap {
     #[cfg(not(target_os = "windows"))]
     pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
         let page_size = crate::page_size();
-        assert_le!(accessible_size, mapping_size);
+        assert!(accessible_size <= mapping_size);
         assert_eq!(mapping_size & (page_size - 1), 0);
         assert_eq!(accessible_size & (page_size - 1), 0);
 
@@ -228,7 +227,7 @@ impl Mmap {
         }
 
         let page_size = crate::page_size();
-        assert_le!(accessible_size, mapping_size);
+        assert!(accessible_size <= mapping_size);
         assert_eq!(mapping_size & (page_size - 1), 0);
         assert_eq!(accessible_size & (page_size - 1), 0);
 
@@ -284,8 +283,8 @@ impl Mmap {
         let page_size = crate::page_size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
-        assert_le!(len, self.len);
-        assert_le!(start, self.len - len);
+        assert!(len <= self.len);
+        assert!(start <= self.len - len);
 
         // Commit the accessible size.
         let ptr = self.ptr as *mut u8;
@@ -313,8 +312,8 @@ impl Mmap {
         let page_size = crate::page_size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
-        assert_le!(len, self.len);
-        assert_le!(start, self.len - len);
+        assert!(len <= self.len);
+        assert!(start <= self.len - len);
 
         // Commit the accessible size.
         let ptr = self.ptr as *const u8;

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -332,17 +332,16 @@ pub struct VMGlobalDefinition {
 mod test_vmglobal_definition {
     use super::VMGlobalDefinition;
     use crate::externref::VMExternRef;
-    use more_asserts::assert_ge;
     use std::mem::{align_of, size_of};
     use wasmtime_environ::{Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vmglobal_definition_alignment() {
-        assert_ge!(align_of::<VMGlobalDefinition>(), align_of::<i32>());
-        assert_ge!(align_of::<VMGlobalDefinition>(), align_of::<i64>());
-        assert_ge!(align_of::<VMGlobalDefinition>(), align_of::<f32>());
-        assert_ge!(align_of::<VMGlobalDefinition>(), align_of::<f64>());
-        assert_ge!(align_of::<VMGlobalDefinition>(), align_of::<[u8; 16]>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<i32>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<i64>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<f32>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<f64>());
+        assert!(align_of::<VMGlobalDefinition>() >= align_of::<[u8; 16]>());
     }
 
     #[test]

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -48,6 +48,7 @@ mod wasi_tests {
     fn build_tests(testsuite: &str, out_dir: &Path) -> io::Result<()> {
         let mut cmd = Command::new("cargo");
         cmd.env("CARGO_PROFILE_RELEASE_DEBUG", "1");
+        cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
         cmd.args(&[
             "build",
             "--release",

--- a/crates/test-programs/wasi-tests/Cargo.lock
+++ b/crates/test-programs/wasi-tests/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
-name = "more-asserts"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
-
-[[package]]
 name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,7 +25,6 @@ name = "wasi-tests"
 version = "0.19.0"
 dependencies = [
  "libc",
- "more-asserts",
  "once_cell",
  "wasi",
 ]

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 libc = "0.2.65"
 wasi = "0.10.2"
-more-asserts = "0.2.1"
 once_cell = "1.12.0"
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/clock_time_get.rs
@@ -1,5 +1,3 @@
-use more_asserts::assert_le;
-
 unsafe fn test_clock_time_get() {
     // Test that clock_time_get succeeds. Even in environments where it's not
     // desirable to expose high-precision timers, it should still succeed.
@@ -10,7 +8,7 @@ unsafe fn test_clock_time_get() {
         wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("precision 0 should work");
 
     let time = wasi::clock_time_get(wasi::CLOCKID_MONOTONIC, 0).expect("re-fetch time should work");
-    assert_le!(first_time, time, "CLOCK_MONOTONIC should be monotonic");
+    assert!(first_time <= time, "CLOCK_MONOTONIC should be monotonic");
 }
 
 fn main() {

--- a/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
+++ b/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
@@ -1,11 +1,10 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
 unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
     let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
 
-    assert_gt!(dir_fd, pre_fd, "dir_fd number");
+    assert!(dir_fd > pre_fd, "dir_fd number");
 
     // Try to close a preopened directory handle.
     assert_errno!(

--- a/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
+++ b/crates/test-programs/wasi-tests/src/bin/dangling_fd.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{open_scratch_directory, TESTCONFIG};
 
@@ -9,9 +8,8 @@ unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
         let fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).unwrap();
         wasi::fd_close(fd).unwrap();
         let file_fd = wasi::path_open(dir_fd, 0, "file", 0, 0, 0, 0).expect("failed to open");
-        assert_gt!(
-            file_fd,
-            libc::STDERR_FILENO as wasi::Fd,
+        assert!(
+            file_fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",
         );
         wasi::path_unlink_file(dir_fd, "file").expect("failed to unlink");
@@ -22,9 +20,8 @@ unsafe fn test_dangling_fd(dir_fd: wasi::Fd) {
         wasi::path_create_directory(dir_fd, "subdir").expect("failed to create dir");
         let subdir_fd = wasi::path_open(dir_fd, 0, "subdir", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect("failed to open dir");
-        assert_gt!(
-            subdir_fd,
-            libc::STDERR_FILENO as wasi::Fd,
+        assert!(
+            subdir_fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",
         );
         wasi::path_remove_directory(dir_fd, "subdir").expect("failed to remove dir 2");

--- a/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
+++ b/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
@@ -17,9 +16,8 @@ unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
         0,
     )
     .expect("failed to open file");
-    assert_gt!(
-        fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_advise.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_advise.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{open_scratch_directory, TESTCONFIG};
 
@@ -19,9 +18,8 @@ unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
         0,
     )
     .expect("failed to open file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_filestat_set.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
 
@@ -18,9 +17,8 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
         0,
     )
     .expect("failed to create file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, mem, process, slice, str};
 use wasi_tests::open_scratch_directory;
 
@@ -107,9 +106,8 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         0,
     )
     .expect("failed to create file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 
@@ -165,9 +163,8 @@ unsafe fn test_fd_readdir_lots(dir_fd: wasi::Fd) {
             0,
         )
         .expect("failed to create file");
-        assert_gt!(
-            file_fd,
-            libc::STDERR_FILENO as wasi::Fd,
+        assert!(
+            file_fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",
         );
         wasi::fd_close(file_fd).expect("closing a file");

--- a/crates/test-programs/wasi-tests/src/bin/file_allocate.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_allocate.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{open_scratch_directory, TESTCONFIG};
 
@@ -17,9 +16,8 @@ unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
@@ -14,9 +13,8 @@ unsafe fn test_file_seek_tell(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/file_unbuffered_write.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_unbuffered_write.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
 
@@ -14,18 +13,16 @@ unsafe fn test_file_unbuffered_write(dir_fd: wasi::Fd) {
         0,
     )
     .expect("create and open file for reading");
-    assert_gt!(
-        fd_read,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd_read > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 
     // Open the same file but for writing
     let fd_write = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_WRITE, 0, 0)
         .expect("opening file for writing");
-    assert_gt!(
-        fd_write,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd_write > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
+++ b/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, create_file, open_scratch_directory};
 
@@ -31,9 +30,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
         0,
     )
     .expect("opening a file with \"..\" in the path");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(file_fd).expect("closing a file");
@@ -68,9 +66,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open the directory with a trailing slash.
     file_fd = wasi::path_open(dir_fd, 0, "dir/nested/", 0, 0, 0, 0)
         .expect("opening a directory with a trailing slash");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(file_fd).expect("closing a file");
@@ -78,9 +75,8 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open the directory with trailing slashes.
     file_fd = wasi::path_open(dir_fd, 0, "dir/nested///", 0, 0, 0, 0)
         .expect("opening a directory with trailing slashes");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(file_fd).expect("closing a file");

--- a/crates/test-programs/wasi-tests/src/bin/isatty.rs
+++ b/crates/test-programs/wasi-tests/src/bin/isatty.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
 
@@ -6,9 +5,8 @@ unsafe fn test_isatty(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory and test if it's a tty.
     let file_fd =
         wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0).expect("opening a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     assert_eq!(

--- a/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
+++ b/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
@@ -38,9 +37,8 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a symlink as a directory");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(file_fd).expect("closing a file");

--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory, TESTCONFIG};
 
@@ -28,9 +27,8 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
         fdflags,
     )
     .expect("opening a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/path_link.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_link.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, create_file, open_scratch_directory, TESTCONFIG};
 
@@ -12,9 +11,8 @@ const TEST_RIGHTS: wasi::Rights = wasi::RIGHTS_FD_READ
 unsafe fn create_or_open(dir_fd: wasi::Fd, name: &str, flags: wasi::Oflags) -> wasi::Fd {
     let file_fd = wasi::path_open(dir_fd, 0, name, flags, TEST_RIGHTS, TEST_RIGHTS, 0)
         .unwrap_or_else(|_| panic!("opening '{}'", name));
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     file_fd
@@ -23,9 +21,8 @@ unsafe fn create_or_open(dir_fd: wasi::Fd, name: &str, flags: wasi::Oflags) -> w
 unsafe fn open_link(dir_fd: wasi::Fd, name: &str) -> wasi::Fd {
     let file_fd = wasi::path_open(dir_fd, 0, name, 0, TEST_RIGHTS, TEST_RIGHTS, 0)
         .unwrap_or_else(|_| panic!("opening a link '{}'", name));
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     file_fd

--- a/crates/test-programs/wasi-tests/src/bin/path_rename.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_rename.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, create_file, open_scratch_directory, TESTCONFIG};
 
@@ -21,9 +20,8 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     // Check that target directory exists
     let mut fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
         .expect("opening renamed path as a directory");
-    assert_gt!(
-        fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 
@@ -51,9 +49,8 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
         // Check that target directory exists
         fd = wasi::path_open(dir_fd, 0, "target", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
             .expect("opening renamed path as a directory");
-        assert_gt!(
-            fd,
-            libc::STDERR_FILENO as wasi::Fd,
+        assert!(
+            fd > libc::STDERR_FILENO as wasi::Fd,
             "file descriptor range check",
         );
 
@@ -117,9 +114,8 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 
     // Check that target file exists
     fd = wasi::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
-    assert_gt!(
-        fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 
@@ -143,9 +139,8 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 
     // Check that target file exists
     fd = wasi::path_open(dir_fd, 0, "target", 0, 0, 0, 0).expect("opening renamed path");
-    assert_gt!(
-        fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_files.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_files.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, mem::MaybeUninit, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
@@ -16,7 +15,9 @@ unsafe fn poll_oneoff_impl(r#in: &[wasi::Subscription]) -> Result<Vec<wasi::Even
 
 /// Repeatedly call `poll_oneoff` until all the subcriptions in `in` have
 /// seen their events occur.
-unsafe fn poll_oneoff_with_retry(r#in: &[wasi::Subscription]) -> Result<Vec<wasi::Event>, wasi::Error> {
+unsafe fn poll_oneoff_with_retry(
+    r#in: &[wasi::Subscription],
+) -> Result<Vec<wasi::Event>, wasi::Error> {
     let mut subscriptions = r#in.to_vec();
     let mut events = Vec::new();
     while !subscriptions.is_empty() {
@@ -24,7 +25,11 @@ unsafe fn poll_oneoff_with_retry(r#in: &[wasi::Subscription]) -> Result<Vec<wasi
         out.resize_with(subscriptions.len(), || {
             MaybeUninit::<wasi::Event>::zeroed().assume_init()
         });
-        let size = wasi::poll_oneoff(subscriptions.as_ptr(), out.as_mut_ptr(), subscriptions.len())?;
+        let size = wasi::poll_oneoff(
+            subscriptions.as_ptr(),
+            out.as_mut_ptr(),
+            subscriptions.len(),
+        )?;
         out.truncate(size);
 
         // Append the events from this `poll` to the result.
@@ -204,9 +209,8 @@ unsafe fn test_fd_readwrite_valid_fd(dir_fd: wasi::Fd) {
     )
     .expect("opening a readable file");
 
-    assert_gt!(
-        readable_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        readable_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     // Create a file in the scratch directory.
@@ -220,9 +224,8 @@ unsafe fn test_fd_readwrite_valid_fd(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a writable file");
-    assert_gt!(
-        writable_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        writable_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/renumber.rs
+++ b/crates/test-programs/wasi-tests/src/bin/renumber.rs
@@ -1,11 +1,10 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::{assert_errno, open_scratch_directory};
 
 unsafe fn test_renumber(dir_fd: wasi::Fd) {
     let pre_fd: wasi::Fd = (libc::STDERR_FILENO + 1) as wasi::Fd;
 
-    assert_gt!(dir_fd, pre_fd, "dir_fd number");
+    assert!(dir_fd > pre_fd, "dir_fd number");
 
     // Create a file in the scratch directory.
     let fd_from = wasi::path_open(
@@ -18,9 +17,8 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a file");
-    assert_gt!(
-        fd_from,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd_from > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 
@@ -39,9 +37,8 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a file");
-    assert_gt!(
-        fd_to,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        fd_to > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
 
@@ -22,9 +21,8 @@ unsafe fn create_symlink_to_file(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a symlink as a directory");
-    assert_gt!(
-        target_file_via_symlink,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        target_file_via_symlink > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(target_file_via_symlink).expect("close the symlink file");
@@ -52,9 +50,8 @@ unsafe fn create_symlink_to_directory(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a symlink as a directory");
-    assert_gt!(
-        target_dir_via_symlink,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        target_dir_via_symlink > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(target_dir_via_symlink).expect("closing a file");

--- a/crates/test-programs/wasi-tests/src/bin/symlink_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_filestat.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 use std::{env, process};
 use wasi_tests::open_scratch_directory;
 
@@ -21,9 +20,8 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
         0,
     )
     .expect("opening a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
 

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -1,4 +1,3 @@
-use more_asserts::assert_gt;
 pub mod config;
 use once_cell::sync::Lazy;
 
@@ -43,9 +42,8 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
 pub unsafe fn create_file(dir_fd: wasi::Fd, filename: &str) {
     let file_fd =
         wasi::path_open(dir_fd, 0, filename, wasi::OFLAGS_CREAT, 0, 0, 0).expect("creating a file");
-    assert_gt!(
-        file_fd,
-        libc::STDERR_FILENO as wasi::Fd,
+    assert!(
+        file_fd > libc::STDERR_FILENO as wasi::Fd,
         "file descriptor range check",
     );
     wasi::fd_close(file_fd).expect("closing a file");

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -591,10 +591,6 @@ criteria = "safe-to-deploy"
 version = "0.3.7"
 criteria = "safe-to-deploy"
 
-[[exemptions.more-asserts]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.ntapi]]
 version = "0.3.7"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
In my recent adventures to do a bit of gardening on our dependencies I
noticed that there's a new major version for the `more-asserts` crate.
Instead of updating to this though I've opted to instead remove the
dependency since I don't think we heavily lean on this crate and
otherwise one-off prints are probably sufficient to avoid the need for
pulling in a whole crate for this.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
