### PR TITLE
CRANELIFT_FUZZGEN_DEBUG flag to see what fuzzgen does

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -496,6 +496,10 @@ where
         builder.seal_all_blocks();
         builder.finalize();
 
+        if std::env::var_os("CRANELIFT_FUZZGEN_DEBUG").filter(|s| !s.is_empty()).is_some() {
+            eprintln!("cranelift-fuzzgen generated:\n{:?}\n", &func);
+        }
+
         Ok(func)
     }
 }


### PR DESCRIPTION
While investigating #3347 I couldn't find another way to see what CLIF was being generated for a given fuzzer input.

I'm assuming that checking for the existence of an environment variable is significantly faster than all the other work that fuzzgen does, so that this doesn't impact how much fuzz testing we can do with a given CPU time budget.