### PR TITLE
implement wasmtime::component::flags! per #4308

### DIFF
--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -2,7 +2,10 @@ use proc_macro2::{Literal, TokenStream, TokenTree};
 use quote::{format_ident, quote};
 use std::collections::HashSet;
 use std::fmt;
-use syn::{parse_macro_input, parse_quote, Data, DeriveInput, Error, Result};
+use std::ops::Deref;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{braced, parse_macro_input, parse_quote, Data, DeriveInput, Error, Result, Token};
 
 #[derive(Debug, Copy, Clone)]
 enum VariantStyle {
@@ -200,11 +203,17 @@ struct VariantCase<'a> {
 }
 
 trait Expander {
-    fn expand_record(&self, input: &DeriveInput, fields: &syn::FieldsNamed) -> Result<TokenStream>;
+    fn expand_record(
+        &self,
+        name: &syn::Ident,
+        generics: &syn::Generics,
+        fields: &[&syn::Field],
+    ) -> Result<TokenStream>;
 
     fn expand_variant(
         &self,
-        input: &DeriveInput,
+        name: &syn::Ident,
+        generics: &syn::Generics,
         discriminant_size: DiscriminantSize,
         cases: &[VariantCase],
         style: VariantStyle,
@@ -231,7 +240,11 @@ fn expand_record(expander: &dyn Expander, input: &DeriveInput) -> Result<TokenSt
     };
 
     match &body.fields {
-        syn::Fields::Named(fields) => expander.expand_record(input, fields),
+        syn::Fields::Named(fields) => expander.expand_record(
+            &input.ident,
+            &input.generics,
+            &fields.named.iter().collect::<Vec<_>>(),
+        ),
 
         syn::Fields::Unnamed(_) | syn::Fields::Unit => Err(Error::new(
             name.span(),
@@ -312,7 +325,109 @@ fn expand_variant(
         )
         .collect::<Result<Vec<_>>>()?;
 
-    expander.expand_variant(input, discriminant_size, &cases, style)
+    expander.expand_variant(
+        &input.ident,
+        &input.generics,
+        discriminant_size,
+        &cases,
+        style,
+    )
+}
+
+fn expand_record_for_component_type(
+    name: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &[&syn::Field],
+    typecheck: TokenStream,
+    typecheck_argument: TokenStream,
+) -> Result<TokenStream> {
+    let internal = quote!(wasmtime::component::__internal);
+
+    let mut lower_generic_params = TokenStream::new();
+    let mut lower_generic_args = TokenStream::new();
+    let mut lower_field_declarations = TokenStream::new();
+    let mut sizes = TokenStream::new();
+    let mut unique_types = HashSet::new();
+
+    for (index, syn::Field { ident, ty, .. }) in fields.iter().enumerate() {
+        let generic = format_ident!("T{}", index);
+
+        lower_generic_params.extend(quote!(#generic: Copy,));
+        lower_generic_args.extend(quote!(<#ty as wasmtime::component::ComponentType>::Lower,));
+
+        lower_field_declarations.extend(quote!(#ident: #generic,));
+
+        sizes.extend(quote!(
+            size = #internal::align_to(size, <#ty as wasmtime::component::ComponentType>::ALIGN32);
+            size += <#ty as wasmtime::component::ComponentType>::SIZE32;
+        ));
+
+        unique_types.insert(ty);
+    }
+
+    let alignments = unique_types
+        .into_iter()
+        .map(|ty| {
+            let align = quote!(<#ty as wasmtime::component::ComponentType>::ALIGN32);
+            quote!(if #align > align {
+                align = #align;
+            })
+        })
+        .collect::<TokenStream>();
+
+    let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::ComponentType));
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let lower = format_ident!("Lower{}", name);
+
+    // You may wonder why we make the types of all the fields of the #lower struct generic.  This is to work
+    // around the lack of [perfect derive support in
+    // rustc](https://smallcultfollowing.com/babysteps//blog/2022/04/12/implied-bounds-and-perfect-derive/#what-is-perfect-derive)
+    // as of this writing.
+    //
+    // If the struct we're deriving a `ComponentType` impl for has any generic parameters, then #lower needs
+    // generic parameters too.  And if we just copy the parameters and bounds from the impl to #lower, then the
+    // `#[derive(Clone, Copy)]` will fail unless the original generics were declared with those bounds, which
+    // we don't want to require.
+    //
+    // Alternatively, we could just pass the `Lower` associated type of each generic type as arguments to
+    // #lower, but that would require distinguishing between generic and concrete types when generating
+    // #lower_field_declarations, which would require some form of symbol resolution.  That doesn't seem worth
+    // the trouble.
+
+    let expanded = quote! {
+        #[doc(hidden)]
+        #[derive(Clone, Copy)]
+        #[repr(C)]
+        pub struct #lower <#lower_generic_params> {
+            #lower_field_declarations
+        }
+
+        unsafe impl #impl_generics wasmtime::component::ComponentType for #name #ty_generics #where_clause {
+            type Lower = #lower <#lower_generic_args>;
+
+            const SIZE32: usize = {
+                let mut size = 0;
+                #sizes
+                size
+            };
+
+            const ALIGN32: u32 = {
+                let mut align = 1;
+                #alignments
+                align
+            };
+
+            #[inline]
+            fn typecheck(
+                ty: &#internal::InterfaceType,
+                types: &#internal::ComponentTypes,
+            ) -> #internal::anyhow::Result<()> {
+                #internal::#typecheck(ty, types, &[#typecheck_argument])
+            }
+        }
+    };
+
+    Ok(quote!(const _: () = { #expanded };))
 }
 
 #[proc_macro_derive(Lift, attributes(component))]
@@ -325,13 +440,18 @@ pub fn lift(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 struct LiftExpander;
 
 impl Expander for LiftExpander {
-    fn expand_record(&self, input: &DeriveInput, fields: &syn::FieldsNamed) -> Result<TokenStream> {
+    fn expand_record(
+        &self,
+        name: &syn::Ident,
+        generics: &syn::Generics,
+        fields: &[&syn::Field],
+    ) -> Result<TokenStream> {
         let internal = quote!(wasmtime::component::__internal);
 
         let mut lifts = TokenStream::new();
         let mut loads = TokenStream::new();
 
-        for syn::Field { ident, ty, .. } in &fields.named {
+        for syn::Field { ident, ty, .. } in fields {
             lifts.extend(quote!(#ident: <#ty as wasmtime::component::Lift>::lift(
                 store, options, &src.#ident
             )?,));
@@ -344,8 +464,7 @@ impl Expander for LiftExpander {
             )?,));
         }
 
-        let name = &input.ident;
-        let generics = add_trait_bounds(&input.generics, parse_quote!(wasmtime::component::Lift));
+        let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::Lift));
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let expanded = quote! {
@@ -381,7 +500,8 @@ impl Expander for LiftExpander {
 
     fn expand_variant(
         &self,
-        input: &DeriveInput,
+        name: &syn::Ident,
+        generics: &syn::Generics,
         discriminant_size: DiscriminantSize,
         cases: &[VariantCase],
         _style: VariantStyle,
@@ -415,8 +535,7 @@ impl Expander for LiftExpander {
             }
         }
 
-        let name = &input.ident;
-        let generics = add_trait_bounds(&input.generics, parse_quote!(wasmtime::component::Lift));
+        let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::Lift));
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let from_bytes = match discriminant_size {
@@ -469,13 +588,18 @@ pub fn lower(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 struct LowerExpander;
 
 impl Expander for LowerExpander {
-    fn expand_record(&self, input: &DeriveInput, fields: &syn::FieldsNamed) -> Result<TokenStream> {
+    fn expand_record(
+        &self,
+        name: &syn::Ident,
+        generics: &syn::Generics,
+        fields: &[&syn::Field],
+    ) -> Result<TokenStream> {
         let internal = quote!(wasmtime::component::__internal);
 
         let mut lowers = TokenStream::new();
         let mut stores = TokenStream::new();
 
-        for syn::Field { ident, ty, .. } in &fields.named {
+        for syn::Field { ident, ty, .. } in fields {
             lowers.extend(quote!(wasmtime::component::Lower::lower(
                 &self.#ident, store, options, #internal::map_maybe_uninit!(dst.#ident)
             )?;));
@@ -485,8 +609,7 @@ impl Expander for LowerExpander {
             )?;));
         }
 
-        let name = &input.ident;
-        let generics = add_trait_bounds(&input.generics, parse_quote!(wasmtime::component::Lower));
+        let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::Lower));
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let expanded = quote! {
@@ -520,7 +643,8 @@ impl Expander for LowerExpander {
 
     fn expand_variant(
         &self,
-        input: &DeriveInput,
+        name: &syn::Ident,
+        generics: &syn::Generics,
         discriminant_size: DiscriminantSize,
         cases: &[VariantCase],
         _style: VariantStyle,
@@ -565,8 +689,7 @@ impl Expander for LowerExpander {
             }));
         }
 
-        let name = &input.ident;
-        let generics = add_trait_bounds(&input.generics, parse_quote!(wasmtime::component::Lower));
+        let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::Lower));
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let expanded = quote! {
@@ -621,116 +744,38 @@ pub fn component_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 struct ComponentTypeExpander;
 
 impl Expander for ComponentTypeExpander {
-    fn expand_record(&self, input: &DeriveInput, fields: &syn::FieldsNamed) -> Result<TokenStream> {
-        let internal = quote!(wasmtime::component::__internal);
+    fn expand_record(
+        &self,
+        name: &syn::Ident,
+        generics: &syn::Generics,
+        fields: &[&syn::Field],
+    ) -> Result<TokenStream> {
+        expand_record_for_component_type(
+            name,
+            generics,
+            fields,
+            quote!(typecheck_record),
+            fields
+                .iter()
+                .map(
+                    |syn::Field {
+                         attrs, ident, ty, ..
+                     }| {
+                        let name = find_rename(attrs)?.unwrap_or_else(|| {
+                            Literal::string(&ident.as_ref().unwrap().to_string())
+                        });
 
-        let mut field_names_and_checks = TokenStream::new();
-        let mut lower_generic_params = TokenStream::new();
-        let mut lower_generic_args = TokenStream::new();
-        let mut lower_field_declarations = TokenStream::new();
-        let mut sizes = TokenStream::new();
-        let mut unique_types = HashSet::new();
-
-        for (
-            index,
-            syn::Field {
-                attrs, ident, ty, ..
-            },
-        ) in fields.named.iter().enumerate()
-        {
-            let name = find_rename(attrs)?
-                .unwrap_or_else(|| Literal::string(&ident.as_ref().unwrap().to_string()));
-
-            let generic = format_ident!("T{}", index);
-
-            lower_generic_params.extend(quote!(#generic: Copy,));
-            lower_generic_args.extend(quote!(<#ty as wasmtime::component::ComponentType>::Lower,));
-
-            lower_field_declarations.extend(quote!(#ident: #generic,));
-
-            field_names_and_checks
-                .extend(quote!((#name, <#ty as wasmtime::component::ComponentType>::typecheck),));
-
-            sizes.extend(quote!(
-                size = #internal::align_to(size, <#ty as wasmtime::component::ComponentType>::ALIGN32);
-                size += <#ty as wasmtime::component::ComponentType>::SIZE32;
-            ));
-
-            unique_types.insert(ty);
-        }
-
-        let alignments = unique_types
-            .into_iter()
-            .map(|ty| {
-                let align = quote!(<#ty as wasmtime::component::ComponentType>::ALIGN32);
-                quote!(if #align > align {
-                    align = #align;
-                })
-            })
-            .collect::<TokenStream>();
-
-        let name = &input.ident;
-        let generics = add_trait_bounds(
-            &input.generics,
-            parse_quote!(wasmtime::component::ComponentType),
-        );
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-        let lower = format_ident!("Lower{}", name);
-
-        // You may wonder why we make the types of all the fields of the #lower struct generic.  This is to work
-        // around the lack of [perfect derive support in
-        // rustc](https://smallcultfollowing.com/babysteps//blog/2022/04/12/implied-bounds-and-perfect-derive/#what-is-perfect-derive)
-        // as of this writing.
-        //
-        // If the struct we're deriving a `ComponentType` impl for has any generic parameters, then #lower needs
-        // generic parameters too.  And if we just copy the parameters and bounds from the impl to #lower, then the
-        // `#[derive(Clone, Copy)]` will fail unless the original generics were declared with those bounds, which
-        // we don't want to require.
-        //
-        // Alternatively, we could just pass the `Lower` associated type of each generic type as arguments to
-        // #lower, but that would require distinguishing between generic and concrete types when generating
-        // #lower_field_declarations, which would require some form of symbol resolution.  That doesn't seem worth
-        // the trouble.
-
-        let expanded = quote! {
-            #[doc(hidden)]
-            #[derive(Clone, Copy)]
-            #[repr(C)]
-            pub struct #lower <#lower_generic_params> {
-                #lower_field_declarations
-            }
-
-            unsafe impl #impl_generics wasmtime::component::ComponentType for #name #ty_generics #where_clause {
-                type Lower = #lower <#lower_generic_args>;
-
-                const SIZE32: usize = {
-                    let mut size = 0;
-                    #sizes
-                    size
-                };
-
-                const ALIGN32: u32 = {
-                    let mut align = 1;
-                    #alignments
-                    align
-                };
-
-                #[inline]
-                fn typecheck(
-                    ty: &#internal::InterfaceType,
-                    types: &#internal::ComponentTypes,
-                ) -> #internal::anyhow::Result<()> {
-                    #internal::typecheck_record(ty, types, &[#field_names_and_checks])
-                }
-            }
-        };
-
-        Ok(quote!(const _: () = { #expanded };))
+                        Ok(quote!((#name, <#ty as wasmtime::component::ComponentType>::typecheck),))
+                    },
+                )
+                .collect::<Result<_>>()?,
+        )
     }
 
     fn expand_variant(
         &self,
-        input: &DeriveInput,
+        name: &syn::Ident,
+        generics: &syn::Generics,
         discriminant_size: DiscriminantSize,
         cases: &[VariantCase],
         style: VariantStyle,
@@ -822,11 +867,7 @@ impl Expander for ComponentTypeExpander {
             VariantStyle::Enum => quote!(typecheck_enum),
         };
 
-        let name = &input.ident;
-        let generics = add_trait_bounds(
-            &input.generics,
-            parse_quote!(wasmtime::component::ComponentType),
-        );
+        let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::ComponentType));
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let lower = format_ident!("Lower{}", name);
         let lower_payload = format_ident!("LowerPayload{}", name);
@@ -884,4 +925,432 @@ impl Expander for ComponentTypeExpander {
 
         Ok(quote!(const _: () = { #expanded };))
     }
+}
+
+#[derive(Debug)]
+struct Flag {
+    rename: Option<String>,
+    name: String,
+}
+
+impl Parse for Flag {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let attributes = syn::Attribute::parse_outer(input)?;
+
+        let rename = find_rename(&attributes)?
+            .map(|literal| {
+                let s = literal.to_string();
+
+                s.strip_prefix('"')
+                    .and_then(|s| s.strip_suffix('"'))
+                    .map(|s| s.to_owned())
+                    .ok_or_else(|| Error::new(literal.span(), "expected string literal"))
+            })
+            .transpose()?;
+
+        input.parse::<Token![const]>()?;
+        let name = input.parse::<syn::Ident>()?.to_string();
+
+        Ok(Self { rename, name })
+    }
+}
+
+#[derive(Debug)]
+struct Flags {
+    derive_lift: bool,
+    derive_lower: bool,
+    name: String,
+    flags: Vec<Flag>,
+}
+
+impl Parse for Flags {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let attributes = syn::Attribute::parse_outer(input)?;
+
+        let attribute = if attributes.len() == 1 {
+            attributes.into_iter().next().unwrap()
+        } else {
+            return Err(input.error("expected a single derive attribute"));
+        };
+
+        let syntax_error = || {
+            Err(input
+                .error("expected `#[derive(...)]` attribute containing `Lift`, `Lower` or both"))
+        };
+
+        if let Some(ident) = attribute.path.get_ident() {
+            if "derive" != &ident.to_string() {
+                return syntax_error();
+            }
+        } else {
+            return syntax_error();
+        }
+
+        let traits = if let [TokenTree::Group(group)] =
+            &attribute.tokens.into_iter().collect::<Vec<_>>()[..]
+        {
+            match &group.stream().into_iter().collect::<Vec<_>>()[..] {
+                [TokenTree::Ident(a), TokenTree::Punct(punct), TokenTree::Ident(b)]
+                    if ',' == punct.as_char() =>
+                {
+                    vec![a.to_string(), b.to_string()]
+                }
+                [TokenTree::Ident(a)] => {
+                    vec![a.to_string()]
+                }
+                _ => return syntax_error(),
+            }
+        } else {
+            return syntax_error();
+        };
+
+        let mut derive_lift = false;
+        let mut derive_lower = false;
+        for tr in traits {
+            match tr.deref() {
+                "Lift" => derive_lift = true,
+                "Lower" => derive_lower = true,
+                _ => return syntax_error(),
+            }
+        }
+
+        let keyword = input.parse::<syn::Ident>()?;
+
+        if "flags" != &keyword.to_string() {
+            return Err(Error::new(keyword.span(), "expected `flags` keyword"));
+        }
+
+        let name = input.parse::<syn::Ident>()?.to_string();
+
+        let content;
+        braced!(content in input);
+
+        let flags = content
+            .parse_terminated::<_, Token![;]>(Flag::parse)?
+            .into_iter()
+            .collect();
+
+        Ok(Self {
+            derive_lift,
+            derive_lower,
+            name,
+            flags,
+        })
+    }
+}
+
+enum FlagsSize {
+    /// Flags can fit in a u8
+    Size1,
+    /// Flags can fit in a u16
+    Size2,
+    /// Flags can fit in a specified number of u32 fields
+    Size4Plus(usize),
+}
+
+fn ceiling_divide(n: usize, d: usize) -> usize {
+    (n + d - 1) / d
+}
+
+#[proc_macro]
+pub fn flags(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand_flags(&parse_macro_input!(input as Flags))
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+fn expand_flags(flags: &Flags) -> Result<TokenStream> {
+    let size = if flags.flags.len() <= 8 {
+        FlagsSize::Size1
+    } else if flags.flags.len() <= 16 {
+        FlagsSize::Size2
+    } else {
+        FlagsSize::Size4Plus(ceiling_divide(flags.flags.len(), 32))
+    };
+
+    let ty;
+    let eq;
+
+    match size {
+        FlagsSize::Size1 => {
+            ty = quote!(u8);
+
+            let mut mask = 0u8;
+            for index in 0..flags.flags.len() {
+                mask |= 1 << index;
+            }
+
+            eq = quote!((self.__inner0 & #mask).eq(&(rhs.__inner0 & #mask)));
+        }
+        FlagsSize::Size2 => {
+            ty = quote!(u16);
+
+            let mut mask = 0u16;
+            for index in 0..flags.flags.len() {
+                mask |= 1 << index;
+            }
+
+            eq = quote!((self.__inner0 & #mask).eq(&(rhs.__inner0 & #mask)));
+        }
+        FlagsSize::Size4Plus(n) => {
+            ty = quote!(u32);
+
+            let comparisons = (0..n)
+                .map(|index| {
+                    let field = format_ident!("__inner{}", index);
+
+                    if index == n - 1 {
+                        let mut mask = 0u32;
+                        for index in (n * 32)..flags.flags.len() {
+                            mask |= 1 << index;
+                        }
+
+                        quote!((self.#field & #mask).eq(&(rhs.#field & #mask)) &&)
+                    } else {
+                        quote!(self.#field.eq(&rhs.#field) &&)
+                    }
+                })
+                .collect::<TokenStream>();
+
+            eq = quote!(#comparisons true);
+        }
+    }
+
+    let count;
+    let mut as_array;
+    let mut bitor;
+    let mut bitor_assign;
+    let mut bitand;
+    let mut bitand_assign;
+    let mut bitxor;
+    let mut bitxor_assign;
+    let mut not;
+
+    match size {
+        FlagsSize::Size1 | FlagsSize::Size2 => {
+            count = 1;
+            as_array = quote!([self.__inner0 as u32]);
+            bitor = quote!(Self {
+                __inner0: self.__inner0.bitor(rhs.__inner0)
+            });
+            bitor_assign = quote!(self.__inner0.bitor_assign(rhs.__inner0));
+            bitand = quote!(Self {
+                __inner0: self.__inner0.bitand(rhs.__inner0)
+            });
+            bitand_assign = quote!(self.__inner0.bitand_assign(rhs.__inner0));
+            bitxor = quote!(Self {
+                __inner0: self.__inner0.bitxor(rhs.__inner0)
+            });
+            bitxor_assign = quote!(self.__inner0.bitxor_assign(rhs.__inner0));
+            not = quote!(Self {
+                __inner0: self.__inner0.not()
+            });
+        }
+        FlagsSize::Size4Plus(n) => {
+            count = n;
+            as_array = TokenStream::new();
+            bitor = TokenStream::new();
+            bitor_assign = TokenStream::new();
+            bitand = TokenStream::new();
+            bitand_assign = TokenStream::new();
+            bitxor = TokenStream::new();
+            bitxor_assign = TokenStream::new();
+            not = TokenStream::new();
+
+            for index in 0..n {
+                let field = format_ident!("__inner{}", index);
+
+                as_array.extend(quote!(self.#field,));
+                bitor.extend(quote!(#field: self.#field.bitor(rhs.#field),));
+                bitor_assign.extend(quote!(self.#field.bitor_assign(rhs.#field);));
+                bitand.extend(quote!(#field: self.#field.bitand(rhs.#field),));
+                bitand_assign.extend(quote!(self.#field.bitand_assign(rhs.#field);));
+                bitxor.extend(quote!(#field: self.#field.bitxor(rhs.#field),));
+                bitxor_assign.extend(quote!(self.#field.bitxor_assign(rhs.#field);));
+                not.extend(quote!(#field: self.#field.not(),));
+            }
+
+            as_array = quote!([#as_array]);
+            bitor = quote!(Self { #bitor });
+            bitand = quote!(Self { #bitand });
+            bitxor = quote!(Self { #bitxor });
+            not = quote!(Self { #not });
+        }
+    };
+
+    let name = format_ident!("{}", flags.name);
+
+    let mut constants = TokenStream::new();
+    let mut rust_names = TokenStream::new();
+    let mut component_names = TokenStream::new();
+
+    for (index, Flag { name, rename }) in flags.flags.iter().enumerate() {
+        rust_names.extend(quote!(#name,));
+
+        let component_name = rename.as_ref().unwrap_or(name);
+        component_names.extend(quote!(#component_name,));
+
+        let fields = match size {
+            FlagsSize::Size1 => {
+                let init = 1_u8 << index;
+                quote!(__inner0: #init)
+            }
+            FlagsSize::Size2 => {
+                let init = 1_u16 << index;
+                quote!(__inner0: #init)
+            }
+            FlagsSize::Size4Plus(n) => (0..n)
+                .map(|i| {
+                    let field = format_ident!("__inner{}", i);
+
+                    let init = if index / 32 == i {
+                        1_u32 << (index % 32)
+                    } else {
+                        0
+                    };
+
+                    quote!(#field: #init,)
+                })
+                .collect::<TokenStream>(),
+        };
+
+        let name = format_ident!("{}", name);
+
+        constants.extend(quote!(const #name: Self = Self { #fields };));
+    }
+
+    let generics = syn::Generics {
+        lt_token: None,
+        params: Punctuated::new(),
+        gt_token: None,
+        where_clause: None,
+    };
+
+    let fields = {
+        let ty = syn::parse2::<syn::Type>(ty.clone())?;
+
+        (0..count)
+            .map(|index| syn::Field {
+                attrs: Vec::new(),
+                vis: syn::Visibility::Inherited,
+                ident: Some(format_ident!("__inner{}", index)),
+                colon_token: None,
+                ty: ty.clone(),
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let fields = fields.iter().collect::<Vec<_>>();
+
+    let component_type_impl = expand_record_for_component_type(
+        &name,
+        &generics,
+        &fields,
+        quote!(typecheck_flags),
+        component_names,
+    )?;
+
+    let lower_impl = if flags.derive_lower {
+        LowerExpander.expand_record(&name, &generics, &fields)?
+    } else {
+        TokenStream::new()
+    };
+
+    let lift_impl = if flags.derive_lift {
+        LiftExpander.expand_record(&name, &generics, &fields)?
+    } else {
+        TokenStream::new()
+    };
+
+    let internal = quote!(wasmtime::component::__internal);
+
+    let fields = fields
+        .iter()
+        .map(|syn::Field { ident, .. }| quote!(#[doc(hidden)] #ident: #ty,))
+        .collect::<TokenStream>();
+
+    let expanded = quote! {
+        #[derive(Copy, Clone, Default)]
+        struct #name { #fields }
+
+        impl #name {
+            #constants
+
+            fn as_array(&self) -> [u32; #count] {
+                #as_array
+            }
+        }
+
+        impl std::cmp::PartialEq for #name {
+            fn eq(&self, rhs: &#name) -> bool {
+                #eq
+            }
+        }
+
+        impl std::cmp::Eq for #name { }
+
+        impl std::fmt::Debug for #name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                #internal::format_flags(&self.as_array(), &[#rust_names], f)
+            }
+        }
+
+        impl std::ops::BitOr for #name {
+            type Output = #name;
+
+            fn bitor(self, rhs: #name) -> #name {
+                #bitor
+            }
+        }
+
+        impl std::ops::BitOrAssign for #name {
+            fn bitor_assign(&mut self, rhs: #name) {
+                #bitor_assign
+            }
+        }
+
+        impl std::ops::BitAnd for #name {
+            type Output = #name;
+
+            fn bitand(self, rhs: #name) -> #name {
+                #bitand
+            }
+        }
+
+        impl std::ops::BitAndAssign for #name {
+            fn bitand_assign(&mut self, rhs: #name) {
+                #bitand_assign
+            }
+        }
+
+        impl std::ops::BitXor for #name {
+            type Output = #name;
+
+            fn bitxor(self, rhs: #name) -> #name {
+                #bitxor
+            }
+        }
+
+        impl std::ops::BitXorAssign for #name {
+            fn bitxor_assign(&mut self, rhs: #name) {
+                #bitxor_assign
+            }
+        }
+
+        impl std::ops::Not for #name {
+            type Output = #name;
+
+            fn not(self) -> #name {
+                #not
+            }
+        }
+
+        #component_type_impl
+
+        #lower_impl
+
+        #lift_impl
+    };
+
+    Ok(expanded)
 }

--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -1101,7 +1101,7 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
 
                     if index == n - 1 {
                         let mut mask = 0u32;
-                        for index in (n * 32)..flags.flags.len() {
+                        for index in 0..(flags.flags.len() - (index * 32)) {
                             mask |= 1 << index;
                         }
 

--- a/crates/misc/component-macro-test/src/lib.rs
+++ b/crates/misc/component-macro-test/src/lib.rs
@@ -68,8 +68,7 @@ fn expand_flags_test(test: &FlagsTest) -> Result<TokenStream> {
 
     let expanded = quote! {
         wasmtime::component::flags! {
-            #[derive(Lift, Lower)]
-            flags #name {
+            #name {
                 #flags
             }
         }

--- a/crates/misc/component-macro-test/src/lib.rs
+++ b/crates/misc/component-macro-test/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
-use syn::parse_macro_input;
+use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::{parse_macro_input, Error, Result, Token};
 
 #[proc_macro_attribute]
 pub fn add_variants(
@@ -31,4 +32,48 @@ fn expand_variants(count: &syn::LitInt, mut ty: syn::ItemEnum) -> syn::Result<To
         .collect();
 
     Ok(quote!(#ty))
+}
+
+#[derive(Debug)]
+struct FlagsTest {
+    name: String,
+    flag_count: usize,
+}
+
+impl Parse for FlagsTest {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let name = input.parse::<syn::Ident>()?.to_string();
+        input.parse::<Token![,]>()?;
+        let flag_count = input.parse::<syn::LitInt>()?.base10_parse()?;
+
+        Ok(Self { name, flag_count })
+    }
+}
+
+#[proc_macro]
+pub fn flags_test(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand_flags_test(&parse_macro_input!(input as FlagsTest))
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
+
+fn expand_flags_test(test: &FlagsTest) -> Result<TokenStream> {
+    let name = format_ident!("{}", test.name);
+    let flags = (0..test.flag_count)
+        .map(|index| {
+            let name = format_ident!("F{}", index);
+            quote!(const #name;)
+        })
+        .collect::<TokenStream>();
+
+    let expanded = quote! {
+        wasmtime::component::flags! {
+            #[derive(Lift, Lower)]
+            flags #name {
+                #flags
+            }
+        }
+    };
+
+    Ok(expanded)
 }

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -5,6 +5,7 @@ use crate::store::StoreOpaque;
 use crate::{AsContext, AsContextMut, StoreContext, StoreContextMut, ValRaw};
 use anyhow::{bail, Context, Result};
 use std::borrow::Cow;
+use std::fmt;
 use std::marker;
 use std::mem::{self, MaybeUninit};
 use std::str;
@@ -1579,6 +1580,54 @@ pub fn typecheck_union(
         }
         other => bail!("expected `union` found `{}`", desc(other)),
     }
+}
+
+/// Verify that the given wasm type is a flags type with the expected flags in the right order and with the right
+/// names.
+pub fn typecheck_flags(
+    ty: &InterfaceType,
+    types: &ComponentTypes,
+    expected: &[&str],
+) -> Result<()> {
+    match ty {
+        InterfaceType::Flags(index) => {
+            let names = &types[*index].names;
+
+            if names.len() != expected.len() {
+                bail!(
+                    "expected flags type with {} names, found {} names",
+                    expected.len(),
+                    names.len()
+                );
+            }
+
+            for (name, expected) in names.iter().zip(expected) {
+                if name != expected {
+                    bail!("expected flag named {}, found {}", expected, name);
+                }
+            }
+
+            Ok(())
+        }
+        other => bail!("expected `flags` found `{}`", desc(other)),
+    }
+}
+
+/// Format the specified bitflags using the specified names for debugging
+pub fn format_flags(bits: &[u32], names: &[&str], f: &mut fmt::Formatter) -> fmt::Result {
+    let mut wrote = false;
+    for (index, name) in names.iter().enumerate() {
+        if ((bits[index / 32] >> (index % 32)) & 1) != 0 {
+            if wrote {
+                f.write_str("|")?;
+            } else {
+                wrote = true;
+            }
+
+            f.write_str(name)?;
+        }
+    }
+    Ok(())
 }
 
 unsafe impl<T> ComponentType for Option<T>

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -1615,6 +1615,7 @@ pub fn typecheck_flags(
 
 /// Format the specified bitflags using the specified names for debugging
 pub fn format_flags(bits: &[u32], names: &[&str], f: &mut fmt::Formatter) -> fmt::Result {
+    f.write_str("(")?;
     let mut wrote = false;
     for (index, name) in names.iter().enumerate() {
         if ((bits[index / 32] >> (index % 32)) & 1) != 0 {
@@ -1627,7 +1628,7 @@ pub fn format_flags(bits: &[u32], names: &[&str], f: &mut fmt::Formatter) -> fmt
             f.write_str(name)?;
         }
     }
-    Ok(())
+    f.write_str(")")
 }
 
 unsafe impl<T> ComponentType for Option<T>

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -16,7 +16,7 @@ pub use self::func::{
 };
 pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
-pub use wasmtime_component_macro::{ComponentType, Lift, Lower};
+pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 
 // These items are expected to be used by an eventual
 // `#[derive(ComponentType)]`, they are not part of Wasmtime's API stability
@@ -24,8 +24,8 @@ pub use wasmtime_component_macro::{ComponentType, Lift, Lower};
 #[doc(hidden)]
 pub mod __internal {
     pub use super::func::{
-        align_to, next_field, typecheck_enum, typecheck_record, typecheck_union, typecheck_variant,
-        MaybeUninitExt, Memory, MemoryMut, Options,
+        align_to, format_flags, next_field, typecheck_enum, typecheck_flags, typecheck_record,
+        typecheck_union, typecheck_variant, MaybeUninitExt, Memory, MemoryMut, Options,
     };
     pub use crate::map_maybe_uninit;
     pub use crate::store::StoreOpaque;

--- a/tests/all/component_model/macros.rs
+++ b/tests/all/component_model/macros.rs
@@ -600,6 +600,63 @@ fn flags() -> Result<()> {
         .get_typed_func::<(Foo,), Foo, _>(&mut store, "echo")
         .is_err());
 
+    // Happy path redux, with large flag count (exactly 8)
+
+    flags_test!(Foo8Exact, 8);
+
+    assert_eq!(
+        Foo8Exact::default(),
+        (Foo8Exact::F0 | Foo8Exact::F6) & Foo8Exact::F7
+    );
+    assert_eq!(
+        Foo8Exact::F6,
+        (Foo8Exact::F0 | Foo8Exact::F6) & Foo8Exact::F6
+    );
+    assert_eq!(
+        Foo8Exact::F0,
+        (Foo8Exact::F0 | Foo8Exact::F6) & Foo8Exact::F0
+    );
+    assert_eq!(Foo8Exact::F0 | Foo8Exact::F6, Foo8Exact::F0 ^ Foo8Exact::F6);
+    assert_eq!(Foo8Exact::default(), Foo8Exact::F0 ^ Foo8Exact::F0);
+    assert_eq!(
+        Foo8Exact::F1
+            | Foo8Exact::F2
+            | Foo8Exact::F3
+            | Foo8Exact::F4
+            | Foo8Exact::F5
+            | Foo8Exact::F6
+            | Foo8Exact::F7,
+        !Foo8Exact::F0
+    );
+
+    let component = Component::new(
+        &engine,
+        make_echo_component(
+            &format!(
+                r#"(type $Foo (flags {}))"#,
+                (0..8)
+                    .map(|index| format!(r#""F{}""#, index))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            4,
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(Foo8Exact,), Foo8Exact, _>(&mut store, "echo")?;
+
+    for &input in &[
+        Foo8Exact::F0,
+        Foo8Exact::F1,
+        Foo8Exact::F5,
+        Foo8Exact::F6,
+        Foo8Exact::F7,
+    ] {
+        let output = func.call_and_post_return(&mut store, (input,))?;
+
+        assert_eq!(input, output);
+    }
+
     // Happy path redux, with large flag count (more than 8)
 
     flags_test!(Foo16, 9);
@@ -643,6 +700,60 @@ fn flags() -> Result<()> {
         assert_eq!(input, output);
     }
 
+    // Happy path redux, with large flag count (exactly 16)
+
+    flags_test!(Foo16Exact, 16);
+
+    assert_eq!(
+        Foo16Exact::default(),
+        (Foo16Exact::F0 | Foo16Exact::F14) & Foo16Exact::F5
+    );
+    assert_eq!(
+        Foo16Exact::F14,
+        (Foo16Exact::F0 | Foo16Exact::F14) & Foo16Exact::F14
+    );
+    assert_eq!(
+        Foo16Exact::F0,
+        (Foo16Exact::F0 | Foo16Exact::F14) & Foo16Exact::F0
+    );
+    assert_eq!(
+        Foo16Exact::F0 | Foo16Exact::F14,
+        Foo16Exact::F0 ^ Foo16Exact::F14
+    );
+    assert_eq!(Foo16Exact::default(), Foo16Exact::F0 ^ Foo16Exact::F0);
+    assert_eq!(
+        Foo16Exact::F0 | Foo16Exact::F15,
+        !((!Foo16Exact::F0) & (!Foo16Exact::F15))
+    );
+
+    let component = Component::new(
+        &engine,
+        make_echo_component(
+            &format!(
+                r#"(type $Foo (flags {}))"#,
+                (0..16)
+                    .map(|index| format!(r#""F{}""#, index))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            4,
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(Foo16Exact,), Foo16Exact, _>(&mut store, "echo")?;
+
+    for &input in &[
+        Foo16Exact::F0,
+        Foo16Exact::F1,
+        Foo16Exact::F13,
+        Foo16Exact::F14,
+        Foo16Exact::F15,
+    ] {
+        let output = func.call_and_post_return(&mut store, (input,))?;
+
+        assert_eq!(input, output);
+    }
+
     // Happy path redux, with large flag count (more than 16)
 
     flags_test!(Foo32, 17);
@@ -671,6 +782,60 @@ fn flags() -> Result<()> {
     let func = instance.get_typed_func::<(Foo32,), Foo32, _>(&mut store, "echo")?;
 
     for &input in &[Foo32::F0, Foo32::F1, Foo32::F14, Foo32::F15, Foo32::F16] {
+        let output = func.call_and_post_return(&mut store, (input,))?;
+
+        assert_eq!(input, output);
+    }
+
+    // Happy path redux, with large flag count (exactly 32)
+
+    flags_test!(Foo32Exact, 32);
+
+    assert_eq!(
+        Foo32Exact::default(),
+        (Foo32Exact::F0 | Foo32Exact::F30) & Foo32Exact::F31
+    );
+    assert_eq!(
+        Foo32Exact::F30,
+        (Foo32Exact::F0 | Foo32Exact::F30) & Foo32Exact::F30
+    );
+    assert_eq!(
+        Foo32Exact::F0,
+        (Foo32Exact::F0 | Foo32Exact::F30) & Foo32Exact::F0
+    );
+    assert_eq!(
+        Foo32Exact::F0 | Foo32Exact::F30,
+        Foo32Exact::F0 ^ Foo32Exact::F30
+    );
+    assert_eq!(Foo32Exact::default(), Foo32Exact::F0 ^ Foo32Exact::F0);
+    assert_eq!(
+        Foo32Exact::F0 | Foo32Exact::F15,
+        !((!Foo32Exact::F0) & (!Foo32Exact::F15))
+    );
+
+    let component = Component::new(
+        &engine,
+        make_echo_component(
+            &format!(
+                r#"(type $Foo (flags {}))"#,
+                (0..32)
+                    .map(|index| format!(r#""F{}""#, index))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+            4,
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(Foo32Exact,), Foo32Exact, _>(&mut store, "echo")?;
+
+    for &input in &[
+        Foo32Exact::F0,
+        Foo32Exact::F1,
+        Foo32Exact::F29,
+        Foo32Exact::F30,
+        Foo32Exact::F31,
+    ] {
         let output = func.call_and_post_return(&mut store, (input,))?;
 
         assert_eq!(input, output);

--- a/tests/all/component_model/macros.rs
+++ b/tests/all/component_model/macros.rs
@@ -605,6 +605,23 @@ fn flags() -> Result<()> {
 
     flags_test!(Foo16, 9);
 
+    assert_eq!(Foo16::default(), (Foo16::F0 | Foo16::F7) & Foo16::F8);
+    assert_eq!(Foo16::F7, (Foo16::F0 | Foo16::F7) & Foo16::F7);
+    assert_eq!(Foo16::F0, (Foo16::F0 | Foo16::F7) & Foo16::F0);
+    assert_eq!(Foo16::F0 | Foo16::F7, Foo16::F0 ^ Foo16::F7);
+    assert_eq!(Foo16::default(), Foo16::F0 ^ Foo16::F0);
+    assert_eq!(
+        Foo16::F1
+            | Foo16::F2
+            | Foo16::F3
+            | Foo16::F4
+            | Foo16::F5
+            | Foo16::F6
+            | Foo16::F7
+            | Foo16::F8,
+        !Foo16::F0
+    );
+
     let component = Component::new(
         &engine,
         make_echo_component(
@@ -630,6 +647,13 @@ fn flags() -> Result<()> {
     // Happy path redux, with large flag count (more than 16)
 
     flags_test!(Foo32, 17);
+
+    assert_eq!(Foo32::default(), (Foo32::F0 | Foo32::F15) & Foo32::F16);
+    assert_eq!(Foo32::F15, (Foo32::F0 | Foo32::F15) & Foo32::F15);
+    assert_eq!(Foo32::F0, (Foo32::F0 | Foo32::F15) & Foo32::F0);
+    assert_eq!(Foo32::F0 | Foo32::F15, Foo32::F0 ^ Foo32::F15);
+    assert_eq!(Foo32::default(), Foo32::F0 ^ Foo32::F0);
+    assert_eq!(Foo32::F0 | Foo32::F16, !((!Foo32::F0) & (!Foo32::F16)));
 
     let component = Component::new(
         &engine,
@@ -657,6 +681,13 @@ fn flags() -> Result<()> {
 
     flags_test!(Foo64, 33);
 
+    assert_eq!(Foo64::default(), (Foo64::F0 | Foo64::F31) & Foo64::F32);
+    assert_eq!(Foo64::F31, (Foo64::F0 | Foo64::F31) & Foo64::F31);
+    assert_eq!(Foo64::F0, (Foo64::F0 | Foo64::F31) & Foo64::F0);
+    assert_eq!(Foo64::F0 | Foo64::F31, Foo64::F0 ^ Foo64::F31);
+    assert_eq!(Foo64::default(), Foo64::F0 ^ Foo64::F0);
+    assert_eq!(Foo64::F0 | Foo64::F32, !((!Foo64::F0) & (!Foo64::F32)));
+
     let component = Component::new(
         &engine,
         make_echo_component(
@@ -682,6 +713,13 @@ fn flags() -> Result<()> {
     // Happy path redux, with large flag count (more than 64)
 
     flags_test!(Foo96, 65);
+
+    assert_eq!(Foo96::default(), (Foo96::F0 | Foo96::F63) & Foo96::F64);
+    assert_eq!(Foo96::F63, (Foo96::F0 | Foo96::F63) & Foo96::F63);
+    assert_eq!(Foo96::F0, (Foo96::F0 | Foo96::F63) & Foo96::F0);
+    assert_eq!(Foo96::F0 | Foo96::F63, Foo96::F0 ^ Foo96::F63);
+    assert_eq!(Foo96::default(), Foo96::F0 ^ Foo96::F0);
+    assert_eq!(Foo96::F0 | Foo96::F64, !((!Foo96::F0) & (!Foo96::F64)));
 
     let component = Component::new(
         &engine,

--- a/tests/all/component_model/macros.rs
+++ b/tests/all/component_model/macros.rs
@@ -520,8 +520,7 @@ fn enum_derive() -> Result<()> {
 #[test]
 fn flags() -> Result<()> {
     wasmtime::component::flags! {
-        #[derive(Lift, Lower)]
-        flags Foo {
+        Foo {
             #[component(name = "foo-bar-baz")]
             const A;
             const B;


### PR DESCRIPTION
This is the last macro needed to complete #4308.  It supports generating a Rust
type that represents a `flags` component type, analogous to how the [bitflags
crate](https://crates.io/crates/bitflags) operates.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
