### PR TITLE
[Doc] Note where to find start of memory when debugging

### DIFF
--- a/docs/examples-debugging.md
+++ b/docs/examples-debugging.md
@@ -35,4 +35,4 @@ If you run into trouble, the following discussions might help:
   (lldb) p __vmctx->set()
   (lldb) p *foo
   ```
-  
+- The address of the start of instance memory can be found in `__vmctx->memory`


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

This PR adds a note in the debugging docs about how to get the process address of the start of linear memory when debugging. This is useful when needing to inspect the value referred to by a pointer. It wasn't immediately obvious to me how to figure out the location of the start of linear memory until I attempted to auto-complete `__vmctx->` in my debugger. Including this in the docs would make it more obvious.

I have not opened an issue to discuss this since this seems like a very minor change.

I do not know who to assign to this PR from the core maintainer team at this time.