### PR TITLE
cranelift-frontend: Allow jump table reuse

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -85,16 +85,11 @@ path = "fuzz_targets/compile-maybe-invalid.rs"
 test = false
 doc = false
 
-# FIXME: the cranelift-fuzzgen fuzz targets are temporarily disabled until
-# the crashes they're finding are fixed. One issue is #3347 but otherwise the
-# oss-fuzz bots are reporting a 100% crash rate with these fuzzers so there may
-# be more issues as well. It's recommended to locally run these fuzzers for a
-# few hours locally before re-enabling.
-# [[bin]]
-# name = "cranelift-fuzzgen"
-# path = "fuzz_targets/cranelift-fuzzgen.rs"
-# test = false
-# doc = false
+[[bin]]
+name = "cranelift-fuzzgen"
+path = "fuzz_targets/cranelift-fuzzgen.rs"
+test = false
+doc = false
 
 [[bin]]
 name = "instantiate-many"


### PR DESCRIPTION
This fixes #3347; see that issue for more context.

I'm also proposing to re-enable the `cranelift-fuzzgen` fuzz target with this PR. I've been running it for about 1.5 hours without finding any bugs. I figure I'll leave it running until the end of my day and merge this PR then, assuming that folks approve this change and I don't see any bugs in that time.