### PR TITLE
fuzzgen: Generate stack load/store instructions

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -18,6 +18,12 @@ pub struct Config {
     pub block_signature_params: RangeInclusive<usize>,
     pub jump_tables_per_function: RangeInclusive<usize>,
     pub jump_table_entries: RangeInclusive<usize>,
+
+    /// Stack slots.
+    /// The combination of these two determines stack usage per function
+    pub static_stack_slots_per_function: RangeInclusive<usize>,
+    /// Size in bytes
+    pub static_stack_slot_size: RangeInclusive<usize>,
 }
 
 impl Default for Config {
@@ -32,6 +38,8 @@ impl Default for Config {
             block_signature_params: 0..=16,
             jump_tables_per_function: 0..=4,
             jump_table_entries: 0..=16,
+            static_stack_slots_per_function: 0..=8,
+            static_stack_slot_size: 0..=128,
         }
     }
 }


### PR DESCRIPTION
👋 Hey,

This PR adds stack slots and stack loads and stores to the functions generated by fuzzgen. We use only the specialized instructions `stack_store`/`stack_load` and not the more general combo of `stack_addr` + `store`/`load`.

This also generates random stack slots, that are zero initialized on the first block of the function to prevent reading uninitialized memory.

This has run overnight on a (not very fast) x86 server, and so far hasn't found any issues.

cc: @cfallin @jameysharp 