### PR TITLE
support dynamic function calls in component model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "wasmparser",
  "wasmtime-cache",
  "wasmtime-component-macro",
+ "wasmtime-component-util",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -3480,7 +3481,12 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "wasmtime-component-util",
 ]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "0.40.0"
 
 [[package]]
 name = "wasmtime-cranelift"

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
+wasmtime-component-util = { path = "../component-util", version = "=0.40.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/component-util/Cargo.toml
+++ b/crates/component-util/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wasmtime-component-util"
+version = "0.40.0"
+authors = ["The Wasmtime Project Developers"]
+description = "Utility types and functions to support the component model in Wasmtime"
+license = "Apache-2.0 WITH LLVM-exception"
+repository = "https://github.com/bytecodealliance/wasmtime"
+documentation = "https://docs.rs/wasmtime-component-util/"
+categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
+edition = "2021"

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -1,0 +1,75 @@
+/// Represents the possible sizes in bytes of the discriminant of a variant type in the component model
+#[derive(Debug, Copy, Clone)]
+pub enum DiscriminantSize {
+    /// 8-bit discriminant
+    Size1,
+    /// 16-bit discriminant
+    Size2,
+    /// 32-bit discriminant
+    Size4,
+}
+
+impl DiscriminantSize {
+    /// Calculate the size of discriminant needed to represent a variant with the specified number of cases.
+    pub fn from_count(count: usize) -> Option<Self> {
+        if count <= 0xFF {
+            Some(Self::Size1)
+        } else if count <= 0xFFFF {
+            Some(Self::Size2)
+        } else if count <= 0xFFFF_FFFF {
+            Some(Self::Size4)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<DiscriminantSize> for u32 {
+    /// Size of the discriminant as a `u32`
+    fn from(size: DiscriminantSize) -> u32 {
+        match size {
+            DiscriminantSize::Size1 => 1,
+            DiscriminantSize::Size2 => 2,
+            DiscriminantSize::Size4 => 4,
+        }
+    }
+}
+
+impl From<DiscriminantSize> for usize {
+    /// Size of the discriminant as a `usize`
+    fn from(size: DiscriminantSize) -> usize {
+        match size {
+            DiscriminantSize::Size1 => 1,
+            DiscriminantSize::Size2 => 2,
+            DiscriminantSize::Size4 => 4,
+        }
+    }
+}
+
+/// Represents the number of bytes required to store a flags value in the component model
+pub enum FlagsSize {
+    /// Flags can fit in a u8
+    Size1,
+    /// Flags can fit in a u16
+    Size2,
+    /// Flags can fit in a specified number of u32 fields
+    Size4Plus(usize),
+}
+
+impl FlagsSize {
+    /// Calculate the size needed to represent a value with the specified number of flags.
+    pub fn from_count(count: usize) -> FlagsSize {
+        if count <= 8 {
+            FlagsSize::Size1
+        } else if count <= 16 {
+            FlagsSize::Size2
+        } else {
+            FlagsSize::Size4Plus(ceiling_divide(count, 32))
+        }
+    }
+}
+
+/// Divide `n` by `d`, rounding up in the case of a non-zero remainder.
+fn ceiling_divide(n: usize, d: usize) -> usize {
+    (n + d - 1) / d
+}

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -20,6 +20,7 @@ wasmtime-cache = { path = "../cache", version = "=0.40.0", optional = true }
 wasmtime-fiber = { path = "../fiber", version = "=0.40.0", optional = true }
 wasmtime-cranelift = { path = "../cranelift", version = "=0.40.0", optional = true }
 wasmtime-component-macro = { path = "../component-macro", version = "=0.40.0", optional = true }
+wasmtime-component-util = { path = "../component-util", version = "=0.40.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
 wasmparser = "0.87.0"
 anyhow = "1.0.19"
@@ -115,4 +116,5 @@ component-model = [
   "wasmtime-cranelift?/component-model",
   "wasmtime-runtime/component-model",
   "dep:wasmtime-component-macro",
+  "dep:wasmtime-component-util",
 ]

--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -1,8 +1,10 @@
 use crate::component::instance::{Instance, InstanceData};
+use crate::component::types::{SizeAndAlignment, Type};
+use crate::component::values::Val;
 use crate::store::{StoreOpaque, Stored};
-use crate::{AsContext, ValRaw};
-use anyhow::{Context, Result};
-use std::mem::MaybeUninit;
+use crate::{AsContext, AsContextMut, StoreContextMut, ValRaw};
+use anyhow::{bail, Context, Result};
+use std::mem::{self, MaybeUninit};
 use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmtime_environ::component::{
@@ -10,8 +12,8 @@ use wasmtime_environ::component::{
 };
 use wasmtime_runtime::{Export, ExportFunction, VMTrampoline};
 
-const MAX_STACK_PARAMS: usize = 16;
-const MAX_STACK_RESULTS: usize = 1;
+pub(crate) const MAX_STACK_PARAMS: usize = 16;
+pub(crate) const MAX_STACK_RESULTS: usize = 1;
 
 /// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
 /// is a field projection within `T`.
@@ -71,6 +73,12 @@ mod typed;
 pub use self::host::*;
 pub use self::options::*;
 pub use self::typed::*;
+
+#[repr(C)]
+union ParamsAndResults<Params: Copy, Return: Copy> {
+    params: Params,
+    ret: Return,
+}
 
 /// A WebAssembly component function.
 //
@@ -240,5 +248,349 @@ impl Func {
         Return::typecheck(&ty.result, &data.types).context("type mismatch with result")?;
 
         Ok(())
+    }
+
+    /// Get the parameter types for this function.
+    pub fn params(&self, store: impl AsContext) -> Box<[Type]> {
+        let data = &store.as_context()[self.0];
+        data.types[data.ty]
+            .params
+            .iter()
+            .map(|(_, ty)| Type::from(ty, &data.types))
+            .collect()
+    }
+
+    /// Invokes this function with the `params` given and returns the result.
+    ///
+    /// The `params` here must match the type signature of this `Func`, or this will return an error. If a trap
+    /// occurs while executing this function, then an error will also be returned.
+    // TODO: say more -- most of the docs for `TypedFunc::call` apply here, too
+    pub fn call(&self, mut store: impl AsContextMut, args: &[Val]) -> Result<Val> {
+        let store = &mut store.as_context_mut();
+
+        let params;
+        let result;
+
+        {
+            let data = &store[self.0];
+            let ty = &data.types[data.ty];
+
+            if ty.params.len() != args.len() {
+                bail!(
+                    "expected {} argument(s), got {}",
+                    ty.params.len(),
+                    args.len()
+                );
+            }
+
+            params = ty
+                .params
+                .iter()
+                .zip(args)
+                .map(|((_, ty), arg)| {
+                    let ty = Type::from(ty, &data.types);
+
+                    ty.check(arg).context("type mismatch with parameters")?;
+
+                    Ok(ty)
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            result = Type::from(&ty.result, &data.types);
+        }
+
+        let param_count = params.iter().map(|ty| ty.flatten_count()).sum::<usize>();
+        let result_count = result.flatten_count();
+
+        self.call_raw(
+            store,
+            args,
+            |store, options, args, dst: &mut MaybeUninit<[ValRaw; MAX_STACK_PARAMS]>| {
+                if param_count > MAX_STACK_PARAMS {
+                    self.store_args(store, &options, &params, args, dst)
+                } else {
+                    args.iter()
+                        .try_for_each(|arg| arg.lower(store, &options, dst, 0))
+                }
+            },
+            |store, options, src: &[ValRaw; MAX_STACK_RESULTS]| {
+                if result_count > MAX_STACK_RESULTS {
+                    Self::load_result(
+                        store,
+                        &Memory::new(store, &options),
+                        &result,
+                        &mut src.iter(),
+                    )
+                } else {
+                    result.lift(store, &options, &mut src.iter())
+                }
+            },
+        )
+    }
+
+    /// Invokes the underlying wasm function, lowering arguments and lifting the
+    /// result.
+    ///
+    /// The `lower` function and `lift` function provided here are what actually
+    /// do the lowering and lifting. The `LowerParams` and `LowerReturn` types
+    /// are what will be allocated on the stack for this function call. They
+    /// should be appropriately sized for the lowering/lifting operation
+    /// happening.
+    fn call_raw<T, Params: ?Sized, Return, LowerParams, LowerReturn>(
+        &self,
+        store: &mut StoreContextMut<'_, T>,
+        params: &Params,
+        lower: impl FnOnce(
+            &mut StoreContextMut<'_, T>,
+            &Options,
+            &Params,
+            &mut MaybeUninit<LowerParams>,
+        ) -> Result<()>,
+        lift: impl FnOnce(&StoreOpaque, &Options, &LowerReturn) -> Result<Return>,
+    ) -> Result<Return>
+    where
+        LowerParams: Copy,
+        LowerReturn: Copy,
+    {
+        let FuncData {
+            trampoline,
+            export,
+            options,
+            instance,
+            component_instance,
+            ..
+        } = store.0[self.0];
+
+        let space = &mut MaybeUninit::<ParamsAndResults<LowerParams, LowerReturn>>::uninit();
+
+        // Double-check the size/alignemnt of `space`, just in case.
+        //
+        // Note that this alone is not enough to guarantee the validity of the
+        // `unsafe` block below, but it's definitely required. In any case LLVM
+        // should be able to trivially see through these assertions and remove
+        // them in release mode.
+        let val_size = mem::size_of::<ValRaw>();
+        let val_align = mem::align_of::<ValRaw>();
+        assert!(mem::size_of_val(space) % val_size == 0);
+        assert!(mem::size_of_val(map_maybe_uninit!(space.params)) % val_size == 0);
+        assert!(mem::size_of_val(map_maybe_uninit!(space.ret)) % val_size == 0);
+        assert!(mem::align_of_val(space) == val_align);
+        assert!(mem::align_of_val(map_maybe_uninit!(space.params)) == val_align);
+        assert!(mem::align_of_val(map_maybe_uninit!(space.ret)) == val_align);
+
+        let instance = store.0[instance.0].as_ref().unwrap().instance();
+        let flags = instance.flags(component_instance);
+
+        unsafe {
+            // Test the "may enter" flag which is a "lock" on this instance.
+            // This is immediately set to `false` afterwards and note that
+            // there's no on-cleanup setting this flag back to true. That's an
+            // intentional design aspect where if anything goes wrong internally
+            // from this point on the instance is considered "poisoned" and can
+            // never be entered again. The only time this flag is set to `true`
+            // again is after post-return logic has completed successfully.
+            if !(*flags).may_enter() {
+                bail!("cannot reenter component instance");
+            }
+            (*flags).set_may_enter(false);
+
+            debug_assert!((*flags).may_leave());
+            (*flags).set_may_leave(false);
+            let result = lower(store, &options, params, map_maybe_uninit!(space.params));
+            (*flags).set_may_leave(true);
+            result?;
+
+            // This is unsafe as we are providing the guarantee that all the
+            // inputs are valid. The various pointers passed in for the function
+            // are all valid since they're coming from our store, and the
+            // `params_and_results` should have the correct layout for the core
+            // wasm function we're calling. Note that this latter point relies
+            // on the correctness of this module and `ComponentType`
+            // implementations, hence `ComponentType` being an `unsafe` trait.
+            crate::Func::call_unchecked_raw(
+                store,
+                export.anyfunc,
+                trampoline,
+                space.as_mut_ptr().cast(),
+            )?;
+
+            // Note that `.assume_init_ref()` here is unsafe but we're relying
+            // on the correctness of the structure of `LowerReturn` and the
+            // type-checking performed to acquire the `TypedFunc` to make this
+            // safe. It should be the case that `LowerReturn` is the exact
+            // representation of the return value when interpreted as
+            // `[ValRaw]`, and additionally they should have the correct types
+            // for the function we just called (which filled in the return
+            // values).
+            let ret = map_maybe_uninit!(space.ret).assume_init_ref();
+
+            // Lift the result into the host while managing post-return state
+            // here as well.
+            //
+            // After a successful lift the return value of the function, which
+            // is currently required to be 0 or 1 values according to the
+            // canonical ABI, is saved within the `Store`'s `FuncData`. This'll
+            // later get used in post-return.
+            (*flags).set_needs_post_return(true);
+            let val = lift(store.0, &options, ret)?;
+            let ret_slice = cast_storage(ret);
+            let data = &mut store.0[self.0];
+            assert!(data.post_return_arg.is_none());
+            match ret_slice.len() {
+                0 => data.post_return_arg = Some(ValRaw::i32(0)),
+                1 => data.post_return_arg = Some(ret_slice[0]),
+                _ => unreachable!(),
+            }
+            return Ok(val);
+        }
+
+        unsafe fn cast_storage<T>(storage: &T) -> &[ValRaw] {
+            assert!(std::mem::size_of_val(storage) % std::mem::size_of::<ValRaw>() == 0);
+            assert!(std::mem::align_of_val(storage) == std::mem::align_of::<ValRaw>());
+
+            std::slice::from_raw_parts(
+                (storage as *const T).cast(),
+                mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
+            )
+        }
+    }
+
+    /// Invokes the `post-return` canonical ABI option, if specified, after a
+    /// [`Func::call`] has finished.
+    ///
+    /// For some more information on when to use this function see the
+    /// documentation for post-return in the [`Func::call`] method.
+    /// Otherwise though this function is a required method call after a
+    /// [`Func::call`] completes successfully. After the embedder has
+    /// finished processing the return value then this function must be invoked.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error in the case of a WebAssembly trap
+    /// happening during the execution of the `post-return` function, if
+    /// specified.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it's not called under the correct
+    /// conditions. This can only be called after a previous invocation of
+    /// [`Func::call`] completes successfully, and this function can only
+    /// be called for the same [`Func`] that was `call`'d.
+    ///
+    /// If this function is called when [`Func::call`] was not previously
+    /// called, then it will panic. If a different [`Func`] for the same
+    /// component instance was invoked then this function will also panic
+    /// because the `post-return` needs to happen for the other function.
+    pub fn post_return(&self, mut store: impl AsContextMut) -> Result<()> {
+        let mut store = store.as_context_mut();
+        let data = &mut store.0[self.0];
+        let instance = data.instance;
+        let post_return = data.post_return;
+        let component_instance = data.component_instance;
+        let post_return_arg = data.post_return_arg.take();
+        let instance = store.0[instance.0].as_ref().unwrap().instance();
+        let flags = instance.flags(component_instance);
+
+        unsafe {
+            // First assert that the instance is in a "needs post return" state.
+            // This will ensure that the previous action on the instance was a
+            // function call above. This flag is only set after a component
+            // function returns so this also can't be called (as expected)
+            // during a host import for example.
+            //
+            // Note, though, that this assert is not sufficient because it just
+            // means some function on this instance needs its post-return
+            // called. We need a precise post-return for a particular function
+            // which is the second assert here (the `.expect`). That will assert
+            // that this function itself needs to have its post-return called.
+            //
+            // The theory at least is that these two asserts ensure component
+            // model semantics are upheld where the host properly calls
+            // `post_return` on the right function despite the call being a
+            // separate step in the API.
+            assert!(
+                (*flags).needs_post_return(),
+                "post_return can only be called after a function has previously been called",
+            );
+            let post_return_arg = post_return_arg.expect("calling post_return on wrong function");
+
+            // This is a sanity-check assert which shouldn't ever trip.
+            assert!(!(*flags).may_enter());
+
+            // Unset the "needs post return" flag now that post-return is being
+            // processed. This will cause future invocations of this method to
+            // panic, even if the function call below traps.
+            (*flags).set_needs_post_return(false);
+
+            // If the function actually had a `post-return` configured in its
+            // canonical options that's executed here.
+            //
+            // Note that if this traps (returns an error) this function
+            // intentionally leaves the instance in a "poisoned" state where it
+            // can no longer be entered because `may_enter` is `false`.
+            if let Some((func, trampoline)) = post_return {
+                crate::Func::call_unchecked_raw(
+                    &mut store,
+                    func.anyfunc,
+                    trampoline,
+                    &post_return_arg as *const ValRaw as *mut ValRaw,
+                )?;
+            }
+
+            // And finally if everything completed successfully then the "may
+            // enter" flag is set to `true` again here which enables further use
+            // of the component.
+            (*flags).set_may_enter(true);
+        }
+        Ok(())
+    }
+
+    fn store_args<T>(
+        &self,
+        store: &mut StoreContextMut<'_, T>,
+        options: &Options,
+        params: &[Type],
+        args: &[Val],
+        dst: &mut MaybeUninit<[ValRaw; MAX_STACK_PARAMS]>,
+    ) -> Result<()> {
+        let mut size = 0;
+        let mut alignment = 1;
+        for ty in params {
+            alignment = alignment.max(ty.size_and_alignment().alignment);
+            ty.next_field(&mut size);
+        }
+
+        let mut memory = MemoryMut::new(store.as_context_mut(), options);
+        let ptr = memory.realloc(0, 0, alignment, size)?;
+        let mut offset = ptr;
+        for (ty, arg) in params.iter().zip(args) {
+            arg.store(&mut memory, ty.next_field(&mut offset))?;
+        }
+
+        map_maybe_uninit!(dst[0]).write(ValRaw::i64(ptr as i64));
+
+        Ok(())
+    }
+
+    fn load_result<'a>(
+        store: &StoreOpaque,
+        mem: &Memory,
+        ty: &Type,
+        src: &mut impl Iterator<Item = &'a ValRaw>,
+    ) -> Result<Val> {
+        let SizeAndAlignment { size, alignment } = ty.size_and_alignment();
+        // FIXME: needs to read an i64 for memory64
+        let ptr = usize::try_from(src.next().unwrap().get_u32())?;
+        if ptr % usize::try_from(alignment)? != 0 {
+            bail!("return pointer not aligned");
+        }
+
+        let bytes = mem
+            .as_slice()
+            .get(ptr..)
+            .and_then(|b| b.get(..size))
+            .ok_or_else(|| anyhow::anyhow!("pointer out of bounds of memory"))?;
+
+        ty.load(store, mem, bytes)
     }
 }

--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -321,7 +321,7 @@ impl Func {
                 if result_count > MAX_STACK_RESULTS {
                     Self::load_result(&Memory::new(store, &options), &result, &mut src.iter())
                 } else {
-                    result.lift(store, &options, &mut src.iter())
+                    Val::lift(&result, store, &options, &mut src.iter())
                 }
             },
         )
@@ -589,6 +589,6 @@ impl Func {
             .and_then(|b| b.get(..size))
             .ok_or_else(|| anyhow::anyhow!("pointer out of bounds of memory"))?;
 
-        ty.load(mem, bytes)
+        Val::load(ty, mem, bytes)
     }
 }

--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -315,12 +315,7 @@ impl Func {
             },
             |store, options, src: &[ValRaw; MAX_STACK_RESULTS]| {
                 if result_count > MAX_STACK_RESULTS {
-                    Self::load_result(
-                        store,
-                        &Memory::new(store, &options),
-                        &result,
-                        &mut src.iter(),
-                    )
+                    Self::load_result(&Memory::new(store, &options), &result, &mut src.iter())
                 } else {
                     result.lift(store, &options, &mut src.iter())
                 }
@@ -573,7 +568,6 @@ impl Func {
     }
 
     fn load_result<'a>(
-        store: &StoreOpaque,
         mem: &Memory,
         ty: &Type,
         src: &mut impl Iterator<Item = &'a ValRaw>,
@@ -591,6 +585,6 @@ impl Func {
             .and_then(|b| b.get(..size))
             .ok_or_else(|| anyhow::anyhow!("pointer out of bounds of memory"))?;
 
-        ty.load(store, mem, bytes)
+        ty.load(mem, bytes)
     }
 }

--- a/crates/wasmtime/src/component/func/options.rs
+++ b/crates/wasmtime/src/component/func/options.rs
@@ -213,7 +213,7 @@ impl<'a, T> MemoryMut<'a, T> {
 
 /// Like `MemoryMut` but for a read-only version that's used during lifting.
 pub struct Memory<'a> {
-    store: &'a StoreOpaque,
+    pub(crate) store: &'a StoreOpaque,
     options: &'a Options,
 }
 

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -158,14 +158,14 @@ where
         // count)
         if Params::flatten_count() <= MAX_STACK_PARAMS {
             if Return::flatten_count() <= MAX_STACK_RESULTS {
-                self.call_raw(
+                self.func.call_raw(
                     store,
                     &params,
                     Self::lower_stack_args,
                     Self::lift_stack_result,
                 )
             } else {
-                self.call_raw(
+                self.func.call_raw(
                     store,
                     &params,
                     Self::lower_stack_args,
@@ -174,14 +174,14 @@ where
             }
         } else {
             if Return::flatten_count() <= MAX_STACK_RESULTS {
-                self.call_raw(
+                self.func.call_raw(
                     store,
                     &params,
                     Self::lower_heap_args,
                     Self::lift_stack_result,
                 )
             } else {
-                self.call_raw(
+                self.func.call_raw(
                     store,
                     &params,
                     Self::lower_heap_args,
@@ -280,228 +280,10 @@ where
         Return::load(&memory, bytes)
     }
 
-    /// Invokes the underlying wasm function, lowering arguments and lifting the
-    /// result.
-    ///
-    /// The `lower` function and `lift` function provided here are what actually
-    /// do the lowering and lifting. The `LowerParams` and `LowerReturn` types
-    /// are what will be allocated on the stack for this function call. They
-    /// should be appropriately sized for the lowering/lifting operation
-    /// happening.
-    fn call_raw<T, LowerParams, LowerReturn>(
-        &self,
-        store: &mut StoreContextMut<'_, T>,
-        params: &Params,
-        lower: impl FnOnce(
-            &mut StoreContextMut<'_, T>,
-            &Options,
-            &Params,
-            &mut MaybeUninit<LowerParams>,
-        ) -> Result<()>,
-        lift: impl FnOnce(&StoreOpaque, &Options, &LowerReturn) -> Result<Return>,
-    ) -> Result<Return>
-    where
-        LowerParams: Copy,
-        LowerReturn: Copy,
-    {
-        let super::FuncData {
-            trampoline,
-            export,
-            options,
-            instance,
-            component_instance,
-            ..
-        } = store.0[self.func.0];
-
-        let space = &mut MaybeUninit::<ParamsAndResults<LowerParams, LowerReturn>>::uninit();
-
-        // Double-check the size/alignemnt of `space`, just in case.
-        //
-        // Note that this alone is not enough to guarantee the validity of the
-        // `unsafe` block below, but it's definitely required. In any case LLVM
-        // should be able to trivially see through these assertions and remove
-        // them in release mode.
-        let val_size = mem::size_of::<ValRaw>();
-        let val_align = mem::align_of::<ValRaw>();
-        assert!(mem::size_of_val(space) % val_size == 0);
-        assert!(mem::size_of_val(map_maybe_uninit!(space.params)) % val_size == 0);
-        assert!(mem::size_of_val(map_maybe_uninit!(space.ret)) % val_size == 0);
-        assert!(mem::align_of_val(space) == val_align);
-        assert!(mem::align_of_val(map_maybe_uninit!(space.params)) == val_align);
-        assert!(mem::align_of_val(map_maybe_uninit!(space.ret)) == val_align);
-
-        let instance = store.0[instance.0].as_ref().unwrap().instance();
-        let flags = instance.flags(component_instance);
-
-        unsafe {
-            // Test the "may enter" flag which is a "lock" on this instance.
-            // This is immediately set to `false` afterwards and note that
-            // there's no on-cleanup setting this flag back to true. That's an
-            // intentional design aspect where if anything goes wrong internally
-            // from this point on the instance is considered "poisoned" and can
-            // never be entered again. The only time this flag is set to `true`
-            // again is after post-return logic has completed successfully.
-            if !(*flags).may_enter() {
-                bail!("cannot reenter component instance");
-            }
-            (*flags).set_may_enter(false);
-
-            debug_assert!((*flags).may_leave());
-            (*flags).set_may_leave(false);
-            let result = lower(store, &options, params, map_maybe_uninit!(space.params));
-            (*flags).set_may_leave(true);
-            result?;
-
-            // This is unsafe as we are providing the guarantee that all the
-            // inputs are valid. The various pointers passed in for the function
-            // are all valid since they're coming from our store, and the
-            // `params_and_results` should have the correct layout for the core
-            // wasm function we're calling. Note that this latter point relies
-            // on the correctness of this module and `ComponentType`
-            // implementations, hence `ComponentType` being an `unsafe` trait.
-            crate::Func::call_unchecked_raw(
-                store,
-                export.anyfunc,
-                trampoline,
-                space.as_mut_ptr().cast(),
-            )?;
-
-            // Note that `.assume_init_ref()` here is unsafe but we're relying
-            // on the correctness of the structure of `LowerReturn` and the
-            // type-checking performed to acquire the `TypedFunc` to make this
-            // safe. It should be the case that `LowerReturn` is the exact
-            // representation of the return value when interpreted as
-            // `[ValRaw]`, and additionally they should have the correct types
-            // for the function we just called (which filled in the return
-            // values).
-            let ret = map_maybe_uninit!(space.ret).assume_init_ref();
-
-            // Lift the result into the host while managing post-return state
-            // here as well.
-            //
-            // After a successful lift the return value of the function, which
-            // is currently required to be 0 or 1 values according to the
-            // canonical ABI, is saved within the `Store`'s `FuncData`. This'll
-            // later get used in post-return.
-            (*flags).set_needs_post_return(true);
-            let val = lift(store.0, &options, ret)?;
-            let ret_slice = cast_storage(ret);
-            let data = &mut store.0[self.func.0];
-            assert!(data.post_return_arg.is_none());
-            match ret_slice.len() {
-                0 => data.post_return_arg = Some(ValRaw::i32(0)),
-                1 => data.post_return_arg = Some(ret_slice[0]),
-                _ => unreachable!(),
-            }
-            return Ok(val);
-        }
-
-        unsafe fn cast_storage<T>(storage: &T) -> &[ValRaw] {
-            assert!(std::mem::size_of_val(storage) % std::mem::size_of::<ValRaw>() == 0);
-            assert!(std::mem::align_of_val(storage) == std::mem::align_of::<ValRaw>());
-
-            std::slice::from_raw_parts(
-                (storage as *const T).cast(),
-                mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
-            )
-        }
+    /// See [`Func::post_return`]
+    pub fn post_return(&self, store: impl AsContextMut) -> Result<()> {
+        self.func.post_return(store)
     }
-
-    /// Invokes the `post-return` canonical ABI option, if specified, after a
-    /// [`TypedFunc::call`] has finished.
-    ///
-    /// For some more information on when to use this function see the
-    /// documentation for post-return in the [`TypedFunc::call`] method.
-    /// Otherwise though this function is a required method call after a
-    /// [`TypedFunc::call`] completes successfully. After the embedder has
-    /// finished processing the return value then this function must be invoked.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error in the case of a WebAssembly trap
-    /// happening during the execution of the `post-return` function, if
-    /// specified.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if it's not called under the correct
-    /// conditions. This can only be called after a previous invocation of
-    /// [`TypedFunc::call`] completes successfully, and this function can only
-    /// be called for the same [`TypedFunc`] that was `call`'d.
-    ///
-    /// If this function is called when [`TypedFunc::call`] was not previously
-    /// called, then it will panic. If a different [`TypedFunc`] for the same
-    /// component instance was invoked then this function will also panic
-    /// because the `post-return` needs to happen for the other function.
-    pub fn post_return(&self, mut store: impl AsContextMut) -> Result<()> {
-        let mut store = store.as_context_mut();
-        let data = &mut store.0[self.func.0];
-        let instance = data.instance;
-        let post_return = data.post_return;
-        let component_instance = data.component_instance;
-        let post_return_arg = data.post_return_arg.take();
-        let instance = store.0[instance.0].as_ref().unwrap().instance();
-        let flags = instance.flags(component_instance);
-
-        unsafe {
-            // First assert that the instance is in a "needs post return" state.
-            // This will ensure that the previous action on the instance was a
-            // function call above. This flag is only set after a component
-            // function returns so this also can't be called (as expected)
-            // during a host import for example.
-            //
-            // Note, though, that this assert is not sufficient because it just
-            // means some function on this instance needs its post-return
-            // called. We need a precise post-return for a particular function
-            // which is the second assert here (the `.expect`). That will assert
-            // that this function itself needs to have its post-return called.
-            //
-            // The theory at least is that these two asserts ensure component
-            // model semantics are upheld where the host properly calls
-            // `post_return` on the right function despite the call being a
-            // separate step in the API.
-            assert!(
-                (*flags).needs_post_return(),
-                "post_return can only be called after a function has previously been called",
-            );
-            let post_return_arg = post_return_arg.expect("calling post_return on wrong function");
-
-            // This is a sanity-check assert which shouldn't ever trip.
-            assert!(!(*flags).may_enter());
-
-            // Unset the "needs post return" flag now that post-return is being
-            // processed. This will cause future invocations of this method to
-            // panic, even if the function call below traps.
-            (*flags).set_needs_post_return(false);
-
-            // If the function actually had a `post-return` configured in its
-            // canonical options that's executed here.
-            //
-            // Note that if this traps (returns an error) this function
-            // intentionally leaves the instance in a "poisoned" state where it
-            // can no longer be entered because `may_enter` is `false`.
-            if let Some((func, trampoline)) = post_return {
-                crate::Func::call_unchecked_raw(
-                    &mut store,
-                    func.anyfunc,
-                    trampoline,
-                    &post_return_arg as *const ValRaw as *mut ValRaw,
-                )?;
-            }
-
-            // And finally if everything completed successfully then the "may
-            // enter" flag is set to `true` again here which enables further use
-            // of the component.
-            (*flags).set_may_enter(true);
-        }
-        Ok(())
-    }
-}
-
-#[repr(C)]
-union ParamsAndResults<Params: Copy, Return: Copy> {
-    params: Params,
-    ret: Return,
 }
 
 /// A trait representing a static list of parameters that can be passed to a
@@ -567,11 +349,9 @@ pub unsafe trait ComponentParams: ComponentType {
 // though, that correctness bugs in this trait implementation are highly likely
 // to lead to security bugs, which again leads to the `unsafe` in the trait.
 //
-// Also note that this trait specifically is not sealed because we'll
-// eventually have a proc macro that generates implementations of this trait
-// for external types in a `#[derive]`-like fashion.
-//
-// FIXME: need to write a #[derive(ComponentType)]
+// Also note that this trait specifically is not sealed because we have a proc
+// macro that generates implementations of this trait for external types in a
+// `#[derive]`-like fashion.
 pub unsafe trait ComponentType {
     /// Representation of the "lowered" form of this component value.
     ///
@@ -1005,7 +785,7 @@ unsafe impl Lower for str {
     }
 }
 
-fn lower_string<T>(mem: &mut MemoryMut<'_, T>, string: &str) -> Result<(usize, usize)> {
+pub(crate) fn lower_string<T>(mem: &mut MemoryMut<'_, T>, string: &str) -> Result<(usize, usize)> {
     match mem.string_encoding() {
         StringEncoding::Utf8 => {
             let ptr = mem.realloc(0, 0, 1, string.len())?;
@@ -1095,7 +875,9 @@ impl WasmStr {
         self._to_str(store.into().0)
     }
 
-    fn _to_str<'a>(&self, store: &'a StoreOpaque) -> Result<Cow<'a, str>> {
+    // TODO: this is only exposed as pub(crate) temporarily for use in `component::values` until we can implement
+    // `Lift` for `String`, `Box<str>`, etc.
+    pub(crate) fn _to_str<'a>(&self, store: &'a StoreOpaque) -> Result<Cow<'a, str>> {
         match self.options.string_encoding() {
             StringEncoding::Utf8 => self.decode_utf8(store),
             StringEncoding::Utf16 => self.decode_utf16(store),

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -9,7 +9,7 @@ mod instance;
 mod linker;
 mod matching;
 mod store;
-mod types;
+pub mod types;
 mod values;
 pub use self::component::Component;
 pub use self::func::{
@@ -38,5 +38,4 @@ pub mod __internal {
     pub use wasmtime_environ::component::{ComponentTypes, InterfaceType};
 }
 
-pub(crate) use self::func::lower_string;
 pub(crate) use self::store::ComponentStoreData;

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -9,6 +9,8 @@ mod instance;
 mod linker;
 mod matching;
 mod store;
+mod types;
+mod values;
 pub use self::component::Component;
 pub use self::func::{
     ComponentParams, ComponentType, Func, IntoComponentFunc, Lift, Lower, TypedFunc, WasmList,
@@ -16,6 +18,8 @@ pub use self::func::{
 };
 pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
+pub use self::types::Type;
+pub use self::values::Val;
 pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 
 // These items are expected to be used by an eventual
@@ -34,4 +38,5 @@ pub mod __internal {
     pub use wasmtime_environ::component::{ComponentTypes, InterfaceType};
 }
 
+pub(crate) use self::func::lower_string;
 pub(crate) use self::store::ComponentStoreData;

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -64,6 +64,18 @@ impl Handle<RecordIndex> {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct TupleIndex(TypeTupleIndex);
+
+impl Handle<TupleIndex> {
+    pub fn types(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
+        self.types[self.index.0]
+            .types
+            .iter()
+            .map(|ty| Type::from(ty, &self.types))
+    }
+}
+
 pub struct Case<'a> {
     pub name: &'a str,
     pub ty: Type,
@@ -78,30 +90,6 @@ impl Handle<VariantIndex> {
             name: &case.name,
             ty: Type::from(&case.ty, &self.types),
         })
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct FlagsIndex(TypeFlagsIndex);
-
-impl Handle<FlagsIndex> {
-    pub fn names(&self) -> impl ExactSizeIterator<Item = &str> {
-        self.types[self.index.0]
-            .names
-            .iter()
-            .map(|name| name.deref())
-    }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct TupleIndex(TypeTupleIndex);
-
-impl Handle<TupleIndex> {
-    pub fn types(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
-        self.types[self.index.0]
-            .types
-            .iter()
-            .map(|ty| Type::from(ty, &self.types))
     }
 }
 
@@ -139,6 +127,18 @@ impl Handle<ExpectedIndex> {
 
     pub fn err(&self) -> Type {
         Type::from(&self.types[self.index.0].err, &self.types)
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct FlagsIndex(TypeFlagsIndex);
+
+impl Handle<FlagsIndex> {
+    pub fn names(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.types[self.index.0]
+            .names
+            .iter()
+            .map(|name| name.deref())
     }
 }
 
@@ -183,12 +183,10 @@ pub enum Type {
     List(Handle<TypeIndex>),
     /// Record
     Record(Handle<RecordIndex>),
-    /// Variant
-    Variant(Handle<VariantIndex>),
-    /// Bit flags
-    Flags(Handle<FlagsIndex>),
     /// Tuple
     Tuple(Handle<TupleIndex>),
+    /// Variant
+    Variant(Handle<VariantIndex>),
     /// Enum
     Enum(Handle<EnumIndex>),
     /// Union
@@ -197,6 +195,8 @@ pub enum Type {
     Option(Handle<TypeIndex>),
     /// Expected
     Expected(Handle<ExpectedIndex>),
+    /// Bit flags
+    Flags(Handle<FlagsIndex>),
 }
 
 impl Type {
@@ -514,16 +514,12 @@ impl Type {
                 index: RecordIndex(*index),
                 types: types.clone(),
             }),
-            InterfaceType::Variant(index) => Type::Variant(Handle {
-                index: VariantIndex(*index),
-                types: types.clone(),
-            }),
-            InterfaceType::Flags(index) => Type::Flags(Handle {
-                index: FlagsIndex(*index),
-                types: types.clone(),
-            }),
             InterfaceType::Tuple(index) => Type::Tuple(Handle {
                 index: TupleIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Variant(index) => Type::Variant(Handle {
+                index: VariantIndex(*index),
                 types: types.clone(),
             }),
             InterfaceType::Enum(index) => Type::Enum(Handle {
@@ -540,6 +536,10 @@ impl Type {
             }),
             InterfaceType::Expected(index) => Type::Expected(Handle {
                 index: ExpectedIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Flags(index) => Type::Flags(Handle {
+                index: FlagsIndex(*index),
                 types: types.clone(),
             }),
         }
@@ -617,13 +617,13 @@ impl Type {
             Type::String => "string",
             Type::List(_) => "list",
             Type::Record(_) => "record",
-            Type::Variant(_) => "variant",
-            Type::Flags(_) => "flags",
             Type::Tuple(_) => "tuple",
+            Type::Variant(_) => "variant",
             Type::Enum(_) => "enum",
             Type::Union(_) => "union",
             Type::Option(_) => "option",
             Type::Expected(_) => "expected",
+            Type::Flags(_) => "flags",
         }
     }
 

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -1,0 +1,1032 @@
+use crate::component::func::{self, Lift, Memory, Options, WasmStr};
+use crate::component::values::{
+    self, Enum, Expected, Flags, List, Option, Record, Tuple, Union, Val, Variant,
+};
+use crate::store::StoreOpaque;
+use crate::ValRaw;
+use anyhow::{anyhow, bail, Context, Error, Result};
+use std::collections::HashMap;
+use std::fmt;
+use std::iter;
+use std::ops::Deref;
+use std::sync::Arc;
+use wasmtime_component_util::{DiscriminantSize, FlagsSize};
+use wasmtime_environ::component::{
+    ComponentTypes, InterfaceType, TypeEnumIndex, TypeExpectedIndex, TypeFlagsIndex,
+    TypeInterfaceIndex, TypeRecordIndex, TypeTupleIndex, TypeUnionIndex, TypeVariantIndex,
+};
+
+#[derive(Clone)]
+pub struct Handle<T> {
+    index: T,
+    types: Arc<ComponentTypes>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for Handle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Handle")
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+impl<T: PartialEq> PartialEq for Handle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index && Arc::ptr_eq(&self.types, &other.types)
+    }
+}
+
+impl<T: Eq> Eq for Handle<T> {}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct TypeIndex(TypeInterfaceIndex);
+
+impl Handle<TypeIndex> {
+    pub fn ty(&self) -> Type {
+        Type::from(&self.types[self.index.0], &self.types)
+    }
+}
+
+pub struct Field<'a> {
+    pub name: &'a str,
+    pub ty: Type,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct RecordIndex(TypeRecordIndex);
+
+impl Handle<RecordIndex> {
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = Field> {
+        self.types[self.index.0].fields.iter().map(|field| Field {
+            name: &field.name,
+            ty: Type::from(&field.ty, &self.types),
+        })
+    }
+}
+
+pub struct Case<'a> {
+    pub name: &'a str,
+    pub ty: Type,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct VariantIndex(TypeVariantIndex);
+
+impl Handle<VariantIndex> {
+    pub fn cases(&self) -> impl ExactSizeIterator<Item = Case> {
+        self.types[self.index.0].cases.iter().map(|case| Case {
+            name: &case.name,
+            ty: Type::from(&case.ty, &self.types),
+        })
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct FlagsIndex(TypeFlagsIndex);
+
+impl Handle<FlagsIndex> {
+    pub fn names(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.types[self.index.0]
+            .names
+            .iter()
+            .map(|name| name.deref())
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct TupleIndex(TypeTupleIndex);
+
+impl Handle<TupleIndex> {
+    pub fn types(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
+        self.types[self.index.0]
+            .types
+            .iter()
+            .map(|ty| Type::from(ty, &self.types))
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct EnumIndex(TypeEnumIndex);
+
+impl Handle<EnumIndex> {
+    pub fn names(&self) -> impl ExactSizeIterator<Item = &str> {
+        self.types[self.index.0]
+            .names
+            .iter()
+            .map(|name| name.deref())
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct UnionIndex(TypeUnionIndex);
+
+impl Handle<UnionIndex> {
+    pub fn types(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
+        self.types[self.index.0]
+            .types
+            .iter()
+            .map(|ty| Type::from(ty, &self.types))
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct ExpectedIndex(TypeExpectedIndex);
+
+impl Handle<ExpectedIndex> {
+    pub fn ok(&self) -> Type {
+        Type::from(&self.types[self.index.0].ok, &self.types)
+    }
+
+    pub fn err(&self) -> Type {
+        Type::from(&self.types[self.index.0].err, &self.types)
+    }
+}
+
+/// Represents the size and alignment requirements of the heap-serialized form of a type
+pub(crate) struct SizeAndAlignment {
+    pub(crate) size: usize,
+    pub(crate) alignment: u32,
+}
+
+/// Represents a component model interface type
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Type {
+    /// Unit
+    Unit,
+    /// Boolean
+    Bool,
+    /// Signed 8-bit integer
+    S8,
+    /// Unsigned 8-bit integer
+    U8,
+    /// Signed 16-bit integer
+    S16,
+    /// Unsigned 16-bit integer
+    U16,
+    /// Signed 32-bit integer
+    S32,
+    /// Unsigned 32-bit integer
+    U32,
+    /// Signed 64-bit integer
+    S64,
+    /// Unsigned 64-bit integer
+    U64,
+    /// 64-bit floating point value
+    Float32,
+    /// 64-bit floating point value
+    Float64,
+    /// 32-bit character
+    Char,
+    /// Character string
+    String,
+    /// List of values
+    List(Handle<TypeIndex>),
+    /// Record
+    Record(Handle<RecordIndex>),
+    /// Variant
+    Variant(Handle<VariantIndex>),
+    /// Bit flags
+    Flags(Handle<FlagsIndex>),
+    /// Tuple
+    Tuple(Handle<TupleIndex>),
+    /// Enum
+    Enum(Handle<EnumIndex>),
+    /// Union
+    Union(Handle<UnionIndex>),
+    /// Option
+    Option(Handle<TypeIndex>),
+    /// Expected
+    Expected(Handle<ExpectedIndex>),
+}
+
+impl Type {
+    /// Instantiate this type (which must be a `Type::List`) with the specified `values`.
+    pub fn new_list(&self, values: Box<[Val]>) -> Result<Val> {
+        if let Type::List(handle) = self {
+            let ty = handle.ty();
+            for (index, value) in values.iter().enumerate() {
+                ty.check(value)
+                    .with_context(|| format!("type mismatch for element {index} of list"))?;
+            }
+
+            Ok(Val::List(List {
+                ty: handle.clone(),
+                values,
+            }))
+        } else {
+            Err(anyhow!("cannot make list from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Record`) with the specified `values`.
+    pub fn new_record<
+        'a,
+        I: ExactSizeIterator<Item = (&'a str, Val)>,
+        II: IntoIterator<Item = (&'a str, Val), IntoIter = I>,
+    >(
+        &self,
+        values: II,
+    ) -> Result<Val> {
+        if let Type::Record(handle) = self {
+            let values = values.into_iter();
+
+            if values.len() != handle.fields().len() {
+                bail!(
+                    "expected {} value(s); got {}",
+                    handle.fields().len(),
+                    values.len()
+                );
+            }
+
+            Ok(Val::Record(Record {
+                ty: handle.clone(),
+                values: values
+                    .zip(handle.fields())
+                    .map(|((name, value), field)| {
+                        if name == field.name {
+                            field.ty.check(&value).with_context(|| {
+                                format!("type mismatch for field {name} of record")
+                            })?;
+
+                            Ok(value)
+                        } else {
+                            Err(anyhow!(
+                                "field name mismatch: expected {}; got {name}",
+                                field.name
+                            ))
+                        }
+                    })
+                    .collect::<Result<_>>()?,
+            }))
+        } else {
+            Err(anyhow!("cannot make record from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Tuple`) with the specified `values`.
+    pub fn new_tuple(&self, values: Box<[Val]>) -> Result<Val> {
+        if let Type::Tuple(handle) = self {
+            if values.len() != handle.types().len() {
+                bail!(
+                    "expected {} value(s); got {}",
+                    handle.types().len(),
+                    values.len()
+                );
+            }
+
+            for (index, (value, ty)) in values.iter().zip(handle.types()).enumerate() {
+                ty.check(value)
+                    .with_context(|| format!("type mismatch for field {index} of tuple"))?;
+            }
+
+            Ok(Val::Tuple(Tuple {
+                ty: handle.clone(),
+                values,
+            }))
+        } else {
+            Err(anyhow!("cannot make tuple from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Variant`) with the specified case `name` and `value`.
+    pub fn new_variant(&self, name: &str, value: Val) -> Result<Val> {
+        if let Type::Variant(handle) = self {
+            let (discriminant, ty) = handle
+                .cases()
+                .enumerate()
+                .find_map(|(index, case)| {
+                    if case.name == name {
+                        Some((index, case.ty))
+                    } else {
+                        None
+                    }
+                })
+                .ok_or_else(|| anyhow!("unknown variant case: {name}"))?;
+
+            ty.check(&value)
+                .with_context(|| format!("type mismatch for case {name} of variant"))?;
+
+            Ok(Val::Variant(Variant {
+                ty: handle.clone(),
+                discriminant: u32::try_from(discriminant)?,
+                value: Box::new(value),
+            }))
+        } else {
+            Err(anyhow!("cannot make variant from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Enum`) with the specified case `name`.
+    pub fn new_enum(&self, name: &str) -> Result<Val> {
+        if let Type::Enum(handle) = self {
+            let discriminant = u32::try_from(
+                handle
+                    .names()
+                    .position(|n| n == name)
+                    .ok_or_else(|| anyhow!("unknown enum case: {name}"))?,
+            )?;
+
+            Ok(Val::Enum(Enum {
+                ty: handle.clone(),
+                discriminant,
+            }))
+        } else {
+            Err(anyhow!("cannot make enum from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Union`) with the specified `discriminant` and `value`.
+    pub fn new_union(&self, discriminant: u32, value: Val) -> Result<Val> {
+        if let Type::Union(handle) = self {
+            if let Some(ty) = handle.types().nth(usize::try_from(discriminant)?) {
+                ty.check(&value)
+                    .with_context(|| format!("type mismatch for case {discriminant} of union"))?;
+
+                Ok(Val::Union(Union {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                }))
+            } else {
+                Err(anyhow!(
+                    "discriminant {discriminant} out of range: [0,{})",
+                    handle.types().len()
+                ))
+            }
+        } else {
+            Err(anyhow!("cannot make union from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Option`) with the specified `value`.
+    pub fn new_option(&self, value: std::option::Option<Val>) -> Result<Val> {
+        if let Type::Option(handle) = self {
+            let value = value
+                .map(|value| {
+                    handle
+                        .ty()
+                        .check(&value)
+                        .context("type mismatch for option")?;
+
+                    Ok::<_, Error>(value)
+                })
+                .transpose()?;
+
+            Ok(Val::Option(Option {
+                ty: handle.clone(),
+                discriminant: if value.is_none() { 0 } else { 1 },
+                value: Box::new(value.unwrap_or(Val::Unit)),
+            }))
+        } else {
+            Err(anyhow!("cannot make option from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Expected`) with the specified `value`.
+    pub fn new_expected(&self, value: Result<Val, Val>) -> Result<Val> {
+        if let Type::Expected(handle) = self {
+            Ok(Val::Expected(Expected {
+                ty: handle.clone(),
+                discriminant: if value.is_ok() { 0 } else { 1 },
+                value: Box::new(match value {
+                    Ok(value) => {
+                        handle
+                            .ok()
+                            .check(&value)
+                            .context("type mismatch for ok case of expected")?;
+                        value
+                    }
+                    Err(value) => {
+                        handle
+                            .err()
+                            .check(&value)
+                            .context("type mismatch for err case of expected")?;
+                        value
+                    }
+                }),
+            }))
+        } else {
+            Err(anyhow!("cannot make expected from {} type", self.desc()))
+        }
+    }
+
+    /// Instantiate this type (which must be a `Type::Flags`) with the specified flag `names`.
+    pub fn new_flags(&self, names: &[&str]) -> Result<Val> {
+        if let Type::Flags(handle) = self {
+            let map = handle
+                .names()
+                .enumerate()
+                .map(|(index, name)| (name, index))
+                .collect::<HashMap<_, _>>();
+
+            let mut values = vec![0_u32; values::u32_count_for_flag_count(handle.names().len())];
+
+            for name in names {
+                let index = map
+                    .get(name)
+                    .ok_or_else(|| anyhow!("unknown flag: {name}"))?;
+                values[index / 32] |= 1 << (index % 32);
+            }
+
+            Ok(Val::Flags(Flags {
+                ty: handle.clone(),
+                count: u32::try_from(map.len())?,
+                value: values.into(),
+            }))
+        } else {
+            Err(anyhow!("cannot make flags from {} type", self.desc()))
+        }
+    }
+
+    /// Retrieve any types nested within this type.
+    ///
+    /// For example, this will return the field types in order of declaration for a record type.  It will return
+    /// the element type for a list type and nothing for non-composite types like bool, u8, and string.
+    pub fn nested(&self) -> Box<[Type]> {
+        match self {
+            Type::Unit
+            | Type::Bool
+            | Type::S8
+            | Type::U8
+            | Type::S16
+            | Type::U16
+            | Type::S32
+            | Type::U32
+            | Type::S64
+            | Type::U64
+            | Type::Float32
+            | Type::Float64
+            | Type::Char
+            | Type::String
+            | Type::Enum(_)
+            | Type::Flags(_) => Box::new([]),
+
+            Type::List(handle) => Box::new([handle.ty()]),
+
+            Type::Record(handle) => handle.fields().map(|field| field.ty).collect(),
+
+            Type::Tuple(handle) => handle.types().collect(),
+
+            Type::Variant(handle) => handle.cases().map(|case| case.ty).collect(),
+
+            Type::Union(handle) => handle.types().collect(),
+
+            Type::Option(handle) => Box::new([handle.ty()]),
+
+            Type::Expected(handle) => Box::new([handle.ok(), handle.err()]),
+        }
+    }
+
+    pub(crate) fn check(&self, value: &Val) -> Result<()> {
+        if self == &value.ty() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "type mismatch: expected {}, got {}",
+                self.desc(),
+                value.ty().desc()
+            ))
+        }
+    }
+
+    /// Convert the specified `InterfaceType` to a `Type`.
+    pub(crate) fn from(ty: &InterfaceType, types: &Arc<ComponentTypes>) -> Self {
+        match ty {
+            InterfaceType::Unit => Type::Unit,
+            InterfaceType::Bool => Type::Bool,
+            InterfaceType::S8 => Type::S8,
+            InterfaceType::U8 => Type::U8,
+            InterfaceType::S16 => Type::S16,
+            InterfaceType::U16 => Type::U16,
+            InterfaceType::S32 => Type::S32,
+            InterfaceType::U32 => Type::U32,
+            InterfaceType::S64 => Type::S64,
+            InterfaceType::U64 => Type::U64,
+            InterfaceType::Float32 => Type::Float32,
+            InterfaceType::Float64 => Type::Float64,
+            InterfaceType::Char => Type::Char,
+            InterfaceType::String => Type::String,
+            InterfaceType::List(index) => Type::List(Handle {
+                index: TypeIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Record(index) => Type::Record(Handle {
+                index: RecordIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Variant(index) => Type::Variant(Handle {
+                index: VariantIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Flags(index) => Type::Flags(Handle {
+                index: FlagsIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Tuple(index) => Type::Tuple(Handle {
+                index: TupleIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Enum(index) => Type::Enum(Handle {
+                index: EnumIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Union(index) => Type::Union(Handle {
+                index: UnionIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Option(index) => Type::Option(Handle {
+                index: TypeIndex(*index),
+                types: types.clone(),
+            }),
+            InterfaceType::Expected(index) => Type::Expected(Handle {
+                index: ExpectedIndex(*index),
+                types: types.clone(),
+            }),
+        }
+    }
+
+    /// Return the number of stack slots needed to store values of this type in lowered form.
+    pub(crate) fn flatten_count(&self) -> usize {
+        match self {
+            Type::Unit => 0,
+
+            Type::Bool
+            | Type::S8
+            | Type::U8
+            | Type::S16
+            | Type::U16
+            | Type::S32
+            | Type::U32
+            | Type::S64
+            | Type::U64
+            | Type::Float32
+            | Type::Float64
+            | Type::Char
+            | Type::Enum(_) => 1,
+
+            Type::String | Type::List(_) => 2,
+
+            Type::Record(handle) => handle.fields().map(|field| field.ty.flatten_count()).sum(),
+
+            Type::Tuple(handle) => handle.types().map(|ty| ty.flatten_count()).sum(),
+
+            Type::Variant(handle) => {
+                1 + handle
+                    .cases()
+                    .map(|case| case.ty.flatten_count())
+                    .max()
+                    .unwrap_or(0)
+            }
+
+            Type::Union(handle) => {
+                1 + handle
+                    .types()
+                    .map(|ty| ty.flatten_count())
+                    .max()
+                    .unwrap_or(0)
+            }
+
+            Type::Option(handle) => 1 + handle.ty().flatten_count(),
+
+            Type::Expected(handle) => {
+                1 + handle
+                    .ok()
+                    .flatten_count()
+                    .max(handle.err().flatten_count())
+            }
+
+            Type::Flags(handle) => values::u32_count_for_flag_count(handle.names().len()),
+        }
+    }
+
+    fn desc(&self) -> &'static str {
+        match self {
+            Type::Unit => "unit",
+            Type::Bool => "bool",
+            Type::S8 => "s8",
+            Type::U8 => "u8",
+            Type::S16 => "s16",
+            Type::U16 => "u16",
+            Type::S32 => "s32",
+            Type::U32 => "u32",
+            Type::S64 => "s64",
+            Type::U64 => "u64",
+            Type::Float32 => "float32",
+            Type::Float64 => "float64",
+            Type::Char => "char",
+            Type::String => "string",
+            Type::List(_) => "list",
+            Type::Record(_) => "record",
+            Type::Variant(_) => "variant",
+            Type::Flags(_) => "flags",
+            Type::Tuple(_) => "tuple",
+            Type::Enum(_) => "enum",
+            Type::Union(_) => "union",
+            Type::Option(_) => "option",
+            Type::Expected(_) => "expected",
+        }
+    }
+
+    /// Deserialize a value of this type from core Wasm stack values.
+    pub(crate) fn lift<'a>(
+        &self,
+        store: &StoreOpaque,
+        options: &Options,
+        src: &mut impl Iterator<Item = &'a ValRaw>,
+    ) -> Result<Val> {
+        Ok(match self {
+            Type::Unit => Val::Unit,
+            Type::Bool => Val::Bool(bool::lift(store, options, next(src))?),
+            Type::S8 => Val::S8(i8::lift(store, options, next(src))?),
+            Type::U8 => Val::U8(u8::lift(store, options, next(src))?),
+            Type::S16 => Val::S16(i16::lift(store, options, next(src))?),
+            Type::U16 => Val::U16(u16::lift(store, options, next(src))?),
+            Type::S32 => Val::S32(i32::lift(store, options, next(src))?),
+            Type::U32 => Val::U32(u32::lift(store, options, next(src))?),
+            Type::S64 => Val::S64(i64::lift(store, options, next(src))?),
+            Type::U64 => Val::U64(u64::lift(store, options, next(src))?),
+            Type::Float32 => Val::Float32(u32::lift(store, options, next(src))?),
+            Type::Float64 => Val::Float64(u64::lift(store, options, next(src))?),
+            Type::Char => Val::Char(char::lift(store, options, next(src))?),
+            Type::String | Type::List(_) => {
+                // These won't fit in func::MAX_STACK_RESULTS as of this writing, so presumably we should never
+                // reach here
+                unreachable!()
+            }
+            Type::Record(handle) => Val::Record(Record {
+                ty: handle.clone(),
+                values: handle
+                    .fields()
+                    .map(|field| field.ty.lift(store, options, src))
+                    .collect::<Result<_>>()?,
+            }),
+            Type::Tuple(handle) => Val::Tuple(Tuple {
+                ty: handle.clone(),
+                values: handle
+                    .types()
+                    .map(|ty| ty.lift(store, options, src))
+                    .collect::<Result<_>>()?,
+            }),
+            Type::Variant(handle) => {
+                let (discriminant, value) =
+                    lift_variant(handle.cases().map(|case| case.ty), store, options, src)?;
+
+                Val::Variant(Variant {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Enum(handle) => {
+                let (discriminant, _) =
+                    lift_variant(handle.names().map(|_| Type::Unit), store, options, src)?;
+
+                Val::Enum(Enum {
+                    ty: handle.clone(),
+                    discriminant,
+                })
+            }
+            Type::Union(handle) => {
+                let (discriminant, value) = lift_variant(handle.types(), store, options, src)?;
+
+                Val::Union(Union {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Option(handle) => {
+                let (discriminant, value) =
+                    lift_variant([Type::Unit, handle.ty()].into_iter(), store, options, src)?;
+
+                Val::Option(Option {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Expected(handle) => {
+                let (discriminant, value) =
+                    lift_variant([handle.ok(), handle.err()].into_iter(), store, options, src)?;
+
+                Val::Expected(Expected {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Flags(handle) => {
+                let count = u32::try_from(handle.names().len()).unwrap();
+                assert!(count <= 32);
+                let value = iter::once(u32::lift(store, options, next(src))?).collect();
+
+                Val::Flags(Flags {
+                    ty: handle.clone(),
+                    count,
+                    value,
+                })
+            }
+        })
+    }
+
+    /// Deserialize a value of this type from the heap.
+    pub(crate) fn load(&self, store: &StoreOpaque, mem: &Memory, bytes: &[u8]) -> Result<Val> {
+        Ok(match self {
+            Type::Unit => Val::Unit,
+            Type::Bool => Val::Bool(bool::load(mem, bytes)?),
+            Type::S8 => Val::S8(i8::load(mem, bytes)?),
+            Type::U8 => Val::U8(u8::load(mem, bytes)?),
+            Type::S16 => Val::S16(i16::load(mem, bytes)?),
+            Type::U16 => Val::U16(u16::load(mem, bytes)?),
+            Type::S32 => Val::S32(i32::load(mem, bytes)?),
+            Type::U32 => Val::U32(u32::load(mem, bytes)?),
+            Type::S64 => Val::S64(i64::load(mem, bytes)?),
+            Type::U64 => Val::U64(u64::load(mem, bytes)?),
+            Type::Float32 => Val::Float32(u32::load(mem, bytes)?),
+            Type::Float64 => Val::Float64(u64::load(mem, bytes)?),
+            Type::Char => Val::Char(char::load(mem, bytes)?),
+            Type::String => Val::String(Box::from(
+                WasmStr::load(mem, bytes)?._to_str(store)?.deref(),
+            )),
+            Type::List(handle) => {
+                // FIXME: needs memory64 treatment
+                let ptr = u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize;
+                let len = u32::from_le_bytes(bytes[4..].try_into().unwrap()) as usize;
+                let element_type = handle.ty();
+                let SizeAndAlignment {
+                    size: element_size,
+                    alignment: element_alignment,
+                } = element_type.size_and_alignment();
+
+                match len
+                    .checked_mul(element_size)
+                    .and_then(|len| ptr.checked_add(len))
+                {
+                    Some(n) if n <= mem.as_slice().len() => {}
+                    _ => bail!("list pointer/length out of bounds of memory"),
+                }
+                if ptr % usize::try_from(element_alignment)? != 0 {
+                    bail!("list pointer is not aligned")
+                }
+
+                Val::List(List {
+                    ty: handle.clone(),
+                    values: (0..len)
+                        .map(|index| {
+                            element_type.load(
+                                store,
+                                mem,
+                                &mem.as_slice()[ptr + (index * element_size)..][..element_size],
+                            )
+                        })
+                        .collect::<Result<_>>()?,
+                })
+            }
+            Type::Record(handle) => Val::Record(Record {
+                ty: handle.clone(),
+                values: load_record(handle.fields().map(|field| field.ty), store, mem, bytes)?,
+            }),
+            Type::Tuple(handle) => Val::Tuple(Tuple {
+                ty: handle.clone(),
+                values: load_record(handle.types(), store, mem, bytes)?,
+            }),
+            Type::Variant(handle) => {
+                let (discriminant, value) =
+                    self.load_variant(handle.cases().map(|case| case.ty), store, mem, bytes)?;
+
+                Val::Variant(Variant {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Enum(handle) => {
+                let (discriminant, _) =
+                    self.load_variant(handle.names().map(|_| Type::Unit), store, mem, bytes)?;
+
+                Val::Enum(Enum {
+                    ty: handle.clone(),
+                    discriminant,
+                })
+            }
+            Type::Union(handle) => {
+                let (discriminant, value) = self.load_variant(handle.types(), store, mem, bytes)?;
+
+                Val::Union(Union {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Option(handle) => {
+                let (discriminant, value) =
+                    self.load_variant([Type::Unit, handle.ty()].into_iter(), store, mem, bytes)?;
+
+                Val::Option(Option {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Expected(handle) => {
+                let (discriminant, value) =
+                    self.load_variant([handle.ok(), handle.err()].into_iter(), store, mem, bytes)?;
+
+                Val::Expected(Expected {
+                    ty: handle.clone(),
+                    discriminant,
+                    value: Box::new(value),
+                })
+            }
+            Type::Flags(handle) => Val::Flags(Flags {
+                ty: handle.clone(),
+                count: u32::try_from(handle.names().len())?,
+                value: match FlagsSize::from_count(handle.names().len()) {
+                    FlagsSize::Size1 => iter::once(u8::load(mem, bytes)? as u32).collect(),
+                    FlagsSize::Size2 => iter::once(u16::load(mem, bytes)? as u32).collect(),
+                    FlagsSize::Size4Plus(n) => (0..n)
+                        .map(|index| u32::load(mem, &bytes[index * 4..][..4]))
+                        .collect::<Result<_>>()?,
+                },
+            }),
+        })
+    }
+
+    fn load_variant(
+        &self,
+        mut types: impl ExactSizeIterator<Item = Type>,
+        store: &StoreOpaque,
+        mem: &Memory,
+        bytes: &[u8],
+    ) -> Result<(u32, Val)> {
+        let discriminant_size = DiscriminantSize::from_count(types.len()).unwrap();
+        let discriminant = match discriminant_size {
+            DiscriminantSize::Size1 => u8::load(mem, &bytes[..1])? as u32,
+            DiscriminantSize::Size2 => u16::load(mem, &bytes[..2])? as u32,
+            DiscriminantSize::Size4 => u32::load(mem, &bytes[..4])?,
+        };
+        let ty = types.nth(discriminant as usize).ok_or_else(|| {
+            anyhow!(
+                "discriminant {} out of range [0..{})",
+                discriminant,
+                types.len()
+            )
+        })?;
+        let value = ty.load(
+            store,
+            mem,
+            &bytes[func::align_to(
+                usize::from(discriminant_size),
+                self.size_and_alignment().alignment,
+            )..][..ty.size_and_alignment().size],
+        )?;
+        Ok((discriminant, value))
+    }
+
+    /// Calculate the size and alignment requirements for the specified type.
+    pub(crate) fn size_and_alignment(&self) -> SizeAndAlignment {
+        match self {
+            Type::Unit => SizeAndAlignment {
+                size: 0,
+                alignment: 1,
+            },
+
+            Type::Bool | Type::S8 | Type::U8 => SizeAndAlignment {
+                size: 1,
+                alignment: 1,
+            },
+
+            Type::S16 | Type::U16 => SizeAndAlignment {
+                size: 2,
+                alignment: 2,
+            },
+
+            Type::S32 | Type::U32 | Type::Char | Type::Float32 => SizeAndAlignment {
+                size: 4,
+                alignment: 4,
+            },
+
+            Type::S64 | Type::U64 | Type::Float64 => SizeAndAlignment {
+                size: 8,
+                alignment: 8,
+            },
+
+            Type::String | Type::List(_) => SizeAndAlignment {
+                size: 8,
+                alignment: 4,
+            },
+
+            Type::Record(handle) => {
+                record_size_and_alignment(handle.fields().map(|field| field.ty))
+            }
+
+            Type::Tuple(handle) => record_size_and_alignment(handle.types()),
+
+            Type::Variant(handle) => variant_size_and_alignment(handle.cases().map(|case| case.ty)),
+
+            Type::Enum(handle) => variant_size_and_alignment(handle.names().map(|_| Type::Unit)),
+
+            Type::Union(handle) => variant_size_and_alignment(handle.types()),
+
+            Type::Option(handle) => {
+                variant_size_and_alignment([Type::Unit, handle.ty()].into_iter())
+            }
+
+            Type::Expected(handle) => {
+                variant_size_and_alignment([handle.ok(), handle.err()].into_iter())
+            }
+
+            Type::Flags(handle) => match FlagsSize::from_count(handle.names().len()) {
+                FlagsSize::Size1 => SizeAndAlignment {
+                    size: 1,
+                    alignment: 1,
+                },
+                FlagsSize::Size2 => SizeAndAlignment {
+                    size: 2,
+                    alignment: 2,
+                },
+                FlagsSize::Size4Plus(n) => SizeAndAlignment {
+                    size: n * 4,
+                    alignment: 4,
+                },
+            },
+        }
+    }
+
+    /// Calculate the aligned offset of a field of this type, updating `offset` to point to just after that field.
+    pub(crate) fn next_field(&self, offset: &mut usize) -> usize {
+        let SizeAndAlignment { size, alignment } = self.size_and_alignment();
+        *offset = func::align_to(*offset, alignment);
+        let result = *offset;
+        *offset += size;
+        result
+    }
+}
+
+fn load_record(
+    types: impl Iterator<Item = Type>,
+    store: &StoreOpaque,
+    mem: &Memory,
+    bytes: &[u8],
+) -> Result<Box<[Val]>> {
+    let mut offset = 0;
+    types
+        .map(|ty| {
+            ty.load(
+                store,
+                mem,
+                &bytes[ty.next_field(&mut offset)..][..ty.size_and_alignment().size],
+            )
+        })
+        .collect()
+}
+
+fn lift_variant<'a>(
+    mut types: impl ExactSizeIterator<Item = Type>,
+    store: &StoreOpaque,
+    options: &Options,
+    src: &mut impl Iterator<Item = &'a ValRaw>,
+) -> Result<(u32, Val)> {
+    let len = types.len();
+    let discriminant = next(src).get_u32();
+    let ty = types
+        .nth(discriminant as usize)
+        .ok_or_else(|| anyhow!("discriminant {} out of range [0..{})", discriminant, len))?;
+    let value = ty.lift(store, options, src)?;
+    Ok((discriminant, value))
+}
+
+fn record_size_and_alignment(types: impl Iterator<Item = Type>) -> SizeAndAlignment {
+    let mut offset = 0;
+    let mut align = 1;
+    for ty in types {
+        let SizeAndAlignment { size, alignment } = ty.size_and_alignment();
+        offset = func::align_to(offset, alignment) + size;
+        align = align.max(alignment);
+    }
+
+    SizeAndAlignment {
+        size: func::align_to(offset, align),
+        alignment: align,
+    }
+}
+
+fn variant_size_and_alignment(types: impl ExactSizeIterator<Item = Type>) -> SizeAndAlignment {
+    let discriminant_size = DiscriminantSize::from_count(types.len()).unwrap();
+    let mut alignment = 1;
+    let mut size = 0;
+    for ty in types {
+        let size_and_alignment = ty.size_and_alignment();
+        alignment = alignment.max(size_and_alignment.alignment);
+        size = size.max(size_and_alignment.size);
+    }
+
+    SizeAndAlignment {
+        size: func::align_to(usize::from(discriminant_size), alignment) + size,
+        alignment,
+    }
+}
+
+fn next<'a>(src: &mut impl Iterator<Item = &'a ValRaw>) -> &'a ValRaw {
+    src.next().unwrap()
+}

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -128,7 +128,7 @@ impl Record {
 }
 
 /// A `tuple` interface type
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub struct Tuple(Handle<TypeTupleIndex>);
 
 impl Tuple {
@@ -161,6 +161,26 @@ impl Tuple {
             .map(|ty| Type::from(ty, &self.0.types))
     }
 }
+
+impl PartialEq for Tuple {
+    fn eq(&self, other: &Self) -> bool {
+        if self.0 == other.0 {
+            return true;
+        }
+
+        let self_types = self.types();
+        let other_types = other.types();
+        if self_types.len() == other_types.len() {
+            self_types
+                .zip(other_types)
+                .all(|(self_type, other_type)| self_type == other_type)
+        } else {
+            false
+        }
+    }
+}
+
+impl Eq for Tuple {}
 
 /// A case declaration belonging to a `variant`
 pub struct Case<'a> {
@@ -270,7 +290,7 @@ impl Union {
 }
 
 /// An `option` interface type
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub struct Option(Handle<TypeInterfaceIndex>);
 
 impl Option {
@@ -299,8 +319,16 @@ impl Option {
     }
 }
 
+impl PartialEq for Option {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 || self.ty() == other.ty()
+    }
+}
+
+impl Eq for Option {}
+
 /// An `expected` interface type
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, Debug)]
 pub struct Expected(Handle<TypeExpectedIndex>);
 
 impl Expected {
@@ -336,6 +364,14 @@ impl Expected {
         Type::from(&self.0.types[self.0.index].err, &self.0.types)
     }
 }
+
+impl PartialEq for Expected {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 || (self.ok() == other.ok() && self.err() == other.err())
+    }
+}
+
+impl Eq for Expected {}
 
 /// A `flags` interface type
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -22,23 +22,16 @@ pub struct Record {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Tuple {
+    pub(crate) ty: Handle<TupleIndex>,
+    pub(crate) values: Box<[Val]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Variant {
     pub(crate) ty: Handle<VariantIndex>,
     pub(crate) discriminant: u32,
     pub(crate) value: Box<Val>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Flags {
-    pub(crate) ty: Handle<FlagsIndex>,
-    pub(crate) count: u32,
-    pub(crate) value: Box<[u32]>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Tuple {
-    pub(crate) ty: Handle<TupleIndex>,
-    pub(crate) values: Box<[Val]>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -66,6 +59,13 @@ pub struct Expected {
     pub(crate) ty: Handle<ExpectedIndex>,
     pub(crate) discriminant: u32,
     pub(crate) value: Box<Val>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Flags {
+    pub(crate) ty: Handle<FlagsIndex>,
+    pub(crate) count: u32,
+    pub(crate) value: Box<[u32]>,
 }
 
 /// Represents possible runtime values which a component function can either consume or produce
@@ -103,12 +103,10 @@ pub enum Val {
     List(List),
     /// Record
     Record(Record),
-    /// Variant
-    Variant(Variant),
-    /// Bit flags
-    Flags(Flags),
     /// Tuple
     Tuple(Tuple),
+    /// Variant
+    Variant(Variant),
     /// Enum
     Enum(Enum),
     /// Union
@@ -117,6 +115,8 @@ pub enum Val {
     Option(Option),
     /// Expected
     Expected(Expected),
+    /// Bit flags
+    Flags(Flags),
 }
 
 impl Val {
@@ -139,13 +139,13 @@ impl Val {
             Val::String(_) => Type::String,
             Val::List(List { ty, .. }) => Type::List(ty.clone()),
             Val::Record(Record { ty, .. }) => Type::Record(ty.clone()),
-            Val::Variant(Variant { ty, .. }) => Type::Variant(ty.clone()),
-            Val::Flags(Flags { ty, .. }) => Type::Flags(ty.clone()),
             Val::Tuple(Tuple { ty, .. }) => Type::Tuple(ty.clone()),
+            Val::Variant(Variant { ty, .. }) => Type::Variant(ty.clone()),
             Val::Enum(Enum { ty, .. }) => Type::Enum(ty.clone()),
             Val::Union(Union { ty, .. }) => Type::Union(ty.clone()),
             Val::Option(Option { ty, .. }) => Type::Option(ty.clone()),
             Val::Expected(Expected { ty, .. }) => Type::Expected(ty.clone()),
+            Val::Flags(Flags { ty, .. }) => Type::Flags(ty.clone()),
         }
     }
 

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -1,0 +1,389 @@
+use crate::component::func::{self, Lower, MemoryMut, Options, MAX_STACK_PARAMS};
+use crate::component::types::{
+    EnumIndex, ExpectedIndex, FlagsIndex, Handle, RecordIndex, SizeAndAlignment, TupleIndex, Type,
+    TypeIndex, UnionIndex, VariantIndex,
+};
+use crate::{map_maybe_uninit, AsContextMut, StoreContextMut, ValRaw};
+use anyhow::Result;
+use std::mem::MaybeUninit;
+use std::ops::Deref;
+use wasmtime_component_util::{DiscriminantSize, FlagsSize};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct List {
+    pub(crate) ty: Handle<TypeIndex>,
+    pub(crate) values: Box<[Val]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Record {
+    pub(crate) ty: Handle<RecordIndex>,
+    pub(crate) values: Box<[Val]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Variant {
+    pub(crate) ty: Handle<VariantIndex>,
+    pub(crate) discriminant: u32,
+    pub(crate) value: Box<Val>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Flags {
+    pub(crate) ty: Handle<FlagsIndex>,
+    pub(crate) count: u32,
+    pub(crate) value: Box<[u32]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Tuple {
+    pub(crate) ty: Handle<TupleIndex>,
+    pub(crate) values: Box<[Val]>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Enum {
+    pub(crate) ty: Handle<EnumIndex>,
+    pub(crate) discriminant: u32,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Union {
+    pub(crate) ty: Handle<UnionIndex>,
+    pub(crate) discriminant: u32,
+    pub(crate) value: Box<Val>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Option {
+    pub(crate) ty: Handle<TypeIndex>,
+    pub(crate) discriminant: u32,
+    pub(crate) value: Box<Val>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Expected {
+    pub(crate) ty: Handle<ExpectedIndex>,
+    pub(crate) discriminant: u32,
+    pub(crate) value: Box<Val>,
+}
+
+/// Represents possible runtime values which a component function can either consume or produce
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Val {
+    /// Unit
+    Unit,
+    /// Boolean
+    Bool(bool),
+    /// Signed 8-bit integer
+    S8(i8),
+    /// Unsigned 8-bit integer
+    U8(u8),
+    /// Signed 16-bit integer
+    S16(i16),
+    /// Unsigned 16-bit integer
+    U16(u16),
+    /// Signed 32-bit integer
+    S32(i32),
+    /// Unsigned 32-bit integer
+    U32(u32),
+    /// Signed 64-bit integer
+    S64(i64),
+    /// Unsigned 64-bit integer
+    U64(u64),
+    /// 32-bit floating point value
+    Float32(u32),
+    /// 64-bit floating point value
+    Float64(u64),
+    /// 32-bit character
+    Char(char),
+    /// Character string
+    String(Box<str>),
+    /// List of values
+    List(List),
+    /// Record
+    Record(Record),
+    /// Variant
+    Variant(Variant),
+    /// Bit flags
+    Flags(Flags),
+    /// Tuple
+    Tuple(Tuple),
+    /// Enum
+    Enum(Enum),
+    /// Union
+    Union(Union),
+    /// Option
+    Option(Option),
+    /// Expected
+    Expected(Expected),
+}
+
+impl Val {
+    /// Retrieve the [`Type`] of this value.
+    pub fn ty(&self) -> Type {
+        match self {
+            Val::Unit => Type::Unit,
+            Val::Bool(_) => Type::Bool,
+            Val::S8(_) => Type::S8,
+            Val::U8(_) => Type::U8,
+            Val::S16(_) => Type::S16,
+            Val::U16(_) => Type::U16,
+            Val::S32(_) => Type::S32,
+            Val::U32(_) => Type::U32,
+            Val::S64(_) => Type::S64,
+            Val::U64(_) => Type::U64,
+            Val::Float32(_) => Type::Float32,
+            Val::Float64(_) => Type::Float64,
+            Val::Char(_) => Type::Char,
+            Val::String(_) => Type::String,
+            Val::List(List { ty, .. }) => Type::List(ty.clone()),
+            Val::Record(Record { ty, .. }) => Type::Record(ty.clone()),
+            Val::Variant(Variant { ty, .. }) => Type::Variant(ty.clone()),
+            Val::Flags(Flags { ty, .. }) => Type::Flags(ty.clone()),
+            Val::Tuple(Tuple { ty, .. }) => Type::Tuple(ty.clone()),
+            Val::Enum(Enum { ty, .. }) => Type::Enum(ty.clone()),
+            Val::Union(Union { ty, .. }) => Type::Union(ty.clone()),
+            Val::Option(Option { ty, .. }) => Type::Option(ty.clone()),
+            Val::Expected(Expected { ty, .. }) => Type::Expected(ty.clone()),
+        }
+    }
+
+    /// Serialize this value as core Wasm stack values.
+    pub(crate) fn lower<T>(
+        &self,
+        store: &mut StoreContextMut<T>,
+        options: &Options,
+        dst: &mut MaybeUninit<[ValRaw; MAX_STACK_PARAMS]>,
+        offset: usize,
+    ) -> Result<()> {
+        match self {
+            Val::Unit => (),
+            Val::Bool(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(if *value { 1 } else { 0 }));
+            }
+            Val::S8(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i32(*value as i32));
+            }
+            Val::U8(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(*value as u32));
+            }
+            Val::S16(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i32(*value as i32));
+            }
+            Val::U16(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(*value as u32));
+            }
+            Val::S32(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i32(*value));
+            }
+            Val::U32(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(*value));
+            }
+            Val::S64(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i64(*value));
+            }
+            Val::U64(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u64(*value));
+            }
+            Val::Float32(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::f32(*value));
+            }
+            Val::Float64(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::f64(*value));
+            }
+            Val::Char(value) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(u32::from(*value)));
+            }
+            Val::String(value) => {
+                let (ptr, len) = super::lower_string(
+                    &mut MemoryMut::new(store.as_context_mut(), options),
+                    value,
+                )?;
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i64(ptr as i64));
+                map_maybe_uninit!(dst[offset + 1]).write(ValRaw::i64(len as i64));
+            }
+            Val::List(List { values, .. }) => {
+                let (ptr, len) =
+                    lower_list(&mut MemoryMut::new(store.as_context_mut(), options), values)?;
+                map_maybe_uninit!(dst[offset]).write(ValRaw::i64(ptr as i64));
+                map_maybe_uninit!(dst[offset + 1]).write(ValRaw::i64(len as i64));
+            }
+            Val::Record(Record { values, .. }) | Val::Tuple(Tuple { values, .. }) => {
+                for (index, value) in values.iter().enumerate() {
+                    value.lower(store, options, dst, offset + index)?;
+                }
+            }
+            Val::Variant(Variant {
+                discriminant,
+                value,
+                ..
+            })
+            | Val::Union(Union {
+                discriminant,
+                value,
+                ..
+            })
+            | Val::Option(Option {
+                discriminant,
+                value,
+                ..
+            })
+            | Val::Expected(Expected {
+                discriminant,
+                value,
+                ..
+            }) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(*discriminant));
+                value.lower(store, options, dst, offset + 1)?;
+            }
+            Val::Enum(Enum { discriminant, .. }) => {
+                map_maybe_uninit!(dst[offset]).write(ValRaw::u32(*discriminant));
+            }
+            Val::Flags(Flags { value, .. }) => {
+                for (index, value) in value.iter().enumerate() {
+                    map_maybe_uninit!(dst[offset + index]).write(ValRaw::u32(*value));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Serialize this value to the heap at the specified memory location.
+    pub(crate) fn store<T>(&self, mem: &mut MemoryMut<'_, T>, offset: usize) -> Result<()> {
+        match self {
+            Val::Unit => (),
+            Val::Bool(value) => value.store(mem, offset)?,
+            Val::S8(value) => value.store(mem, offset)?,
+            Val::U8(value) => value.store(mem, offset)?,
+            Val::S16(value) => value.store(mem, offset)?,
+            Val::U16(value) => value.store(mem, offset)?,
+            Val::S32(value) => value.store(mem, offset)?,
+            Val::U32(value) => value.store(mem, offset)?,
+            Val::S64(value) => value.store(mem, offset)?,
+            Val::U64(value) => value.store(mem, offset)?,
+            Val::Float32(value) => value.store(mem, offset)?,
+            Val::Float64(value) => value.store(mem, offset)?,
+            Val::Char(value) => value.store(mem, offset)?,
+            Val::String(value) => {
+                let (ptr, len) = super::lower_string(mem, value)?;
+                // FIXME: needs memory64 handling
+                *mem.get(offset + 0) = (ptr as i32).to_le_bytes();
+                *mem.get(offset + 4) = (len as i32).to_le_bytes();
+            }
+            Val::List(List { values, .. }) => {
+                let (ptr, len) = lower_list(mem, values)?;
+                // FIXME: needs memory64 handling
+                *mem.get(offset + 0) = (ptr as i32).to_le_bytes();
+                *mem.get(offset + 4) = (len as i32).to_le_bytes();
+            }
+            Val::Record(Record { values, .. }) | Val::Tuple(Tuple { values, .. }) => {
+                let mut offset = offset;
+                for value in values.deref() {
+                    value.store(mem, value.ty().next_field(&mut offset))?;
+                }
+            }
+            Val::Variant(Variant {
+                discriminant,
+                value,
+                ty,
+            }) => self.store_variant(*discriminant, value, ty.cases().len(), mem, offset)?,
+
+            Val::Enum(Enum { discriminant, ty }) => {
+                self.store_variant(*discriminant, &Val::Unit, ty.names().len(), mem, offset)?
+            }
+
+            Val::Union(Union {
+                discriminant,
+                value,
+                ty,
+            }) => self.store_variant(*discriminant, value, ty.types().len(), mem, offset)?,
+
+            Val::Option(Option {
+                discriminant,
+                value,
+                ..
+            })
+            | Val::Expected(Expected {
+                discriminant,
+                value,
+                ..
+            }) => self.store_variant(*discriminant, value, 2, mem, offset)?,
+
+            Val::Flags(Flags { count, value, .. }) => {
+                match FlagsSize::from_count(*count as usize) {
+                    FlagsSize::Size1 => u8::try_from(value[0]).unwrap().store(mem, offset)?,
+                    FlagsSize::Size2 => u16::try_from(value[0]).unwrap().store(mem, offset)?,
+                    FlagsSize::Size4Plus(_) => {
+                        let mut offset = offset;
+                        for value in value.deref() {
+                            value.store(mem, offset)?;
+                            offset += 4;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn store_variant<T>(
+        &self,
+        discriminant: u32,
+        value: &Val,
+        case_count: usize,
+        mem: &mut MemoryMut<'_, T>,
+        offset: usize,
+    ) -> Result<()> {
+        let discriminant_size = DiscriminantSize::from_count(case_count).unwrap();
+        match discriminant_size {
+            DiscriminantSize::Size1 => u8::try_from(discriminant).unwrap().store(mem, offset)?,
+            DiscriminantSize::Size2 => u16::try_from(discriminant).unwrap().store(mem, offset)?,
+            DiscriminantSize::Size4 => (discriminant).store(mem, offset)?,
+        }
+
+        value.store(
+            mem,
+            offset
+                + func::align_to(
+                    discriminant_size.into(),
+                    self.ty().size_and_alignment().alignment,
+                ),
+        )
+    }
+}
+
+/// Lower a list with the specified element type and values.
+fn lower_list<T>(mem: &mut MemoryMut<'_, T>, items: &[Val]) -> Result<(usize, usize)> {
+    let element_type = match items {
+        [item, ..] => item.ty(),
+        [] => Type::Unit,
+    };
+    let SizeAndAlignment {
+        size: element_size,
+        alignment: element_alignment,
+    } = element_type.size_and_alignment();
+    let size = items
+        .len()
+        .checked_mul(element_size)
+        .ok_or_else(|| anyhow::anyhow!("size overflow copying a list"))?;
+    let ptr = mem.realloc(0, 0, element_alignment, size)?;
+    let mut element_ptr = ptr;
+    for item in items {
+        item.store(mem, element_ptr)?;
+        element_ptr += element_size;
+    }
+    Ok((ptr, items.len()))
+}
+
+/// Calculate the size of a u32 array needed to represent the specified number of bit flags.
+///
+/// Note that this will always return at least 1, even if the `count` parameter is zero.
+pub(crate) fn u32_count_for_flag_count(count: usize) -> usize {
+    match FlagsSize::from_count(count) {
+        FlagsSize::Size1 | FlagsSize::Size2 => 1,
+        FlagsSize::Size4Plus(n) => n,
+    }
+}

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -41,6 +41,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wiggle-macro",
     // wasmtime
     "wasmtime-asm-macros",
+    "wasmtime-component-util",
     "wasmtime-component-macro",
     "wasmtime-jit-debug",
     "wasmtime-fiber",

--- a/tests/all/component_model/dynamic.rs
+++ b/tests/all/component_model/dynamic.rs
@@ -1,0 +1,392 @@
+use super::{make_echo_component, make_echo_component_with_params, Type};
+use anyhow::Result;
+use wasmtime::component::{Component, Func, Linker, Val};
+use wasmtime::{AsContextMut, Store};
+
+trait FuncExt {
+    fn call_and_post_return(&self, store: impl AsContextMut, args: &[Val]) -> Result<Val>;
+}
+
+impl FuncExt for Func {
+    fn call_and_post_return(&self, mut store: impl AsContextMut, args: &[Val]) -> Result<Val> {
+        let result = self.call(&mut store, args)?;
+        self.post_return(&mut store)?;
+        Ok(result)
+    }
+}
+
+#[test]
+fn primitives() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    for (input, ty, param) in [
+        (Val::Bool(true), "bool", Type::U8),
+        (Val::S8(-42), "s8", Type::S8),
+        (Val::U8(42), "u8", Type::U8),
+        (Val::S16(-4242), "s16", Type::S16),
+        (Val::U16(4242), "u16", Type::U16),
+        (Val::S32(-314159265), "s32", Type::I32),
+        (Val::U32(314159265), "u32", Type::I32),
+        (Val::S64(-31415926535897), "s64", Type::I64),
+        (Val::U64(31415926535897), "u64", Type::I64),
+        (Val::Float32(3.14159265_f32.to_bits()), "float32", Type::F32),
+        (Val::Float64(3.14159265_f64.to_bits()), "float64", Type::F64),
+        (Val::Char('🦀'), "char", Type::I32),
+    ] {
+        let component = Component::new(&engine, make_echo_component_with_params(ty, &[param]))?;
+        let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+        let func = instance.get_func(&mut store, "echo").unwrap();
+        let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+        assert_eq!(input, output);
+    }
+
+    // Sad path: type mismatch
+
+    let component = Component::new(
+        &engine,
+        make_echo_component_with_params("float64", &[Type::F64]),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let err = func
+        .call_and_post_return(&mut store, &[Val::U64(42)])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("type mismatch"), "{err}");
+
+    // Sad path: arity mismatch (too many)
+
+    let err = func
+        .call_and_post_return(
+            &mut store,
+            &[
+                Val::Float64(3.14159265_f64.to_bits()),
+                Val::Float64(3.14159265_f64.to_bits()),
+            ],
+        )
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("expected 1 argument(s), got 2"),
+        "{err}"
+    );
+
+    // Sad path: arity mismatch (too few)
+
+    let err = func.call_and_post_return(&mut store, &[]).unwrap_err();
+
+    assert!(
+        err.to_string().contains("expected 1 argument(s), got 0"),
+        "{err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn strings() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(&engine, make_echo_component("string", 8))?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let input = Val::String(Box::from("hello, component!"));
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    Ok(())
+}
+
+#[test]
+fn lists() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(&engine, make_echo_component("(list u32)", 8))?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let ty = &func.params(&store)[0];
+    let input = ty.new_list(Box::new([
+        Val::U32(32343),
+        Val::U32(79023439),
+        Val::U32(2084037802),
+    ]))?;
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    // Sad path: type mismatch
+
+    let err = ty
+        .new_list(Box::new([
+            Val::U32(32343),
+            Val::U32(79023439),
+            Val::Float32(3.14159265_f32.to_bits()),
+        ]))
+        .unwrap_err();
+
+    assert!(err.to_string().contains("type mismatch"), "{err}");
+
+    Ok(())
+}
+
+#[test]
+fn records() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(
+        &engine,
+        make_echo_component_with_params(
+            r#"(record (field "A" u32) (field "B" float64) (field "C" (record (field "D" bool) (field "E" u32))))"#,
+            &[Type::I32, Type::F64, Type::U8, Type::I32],
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let ty = &func.params(&store)[0];
+    let inner_type = &ty.nested()[2];
+    let input = ty.new_record([
+        ("A", Val::U32(32343)),
+        ("B", Val::Float64(3.14159265_f64.to_bits())),
+        (
+            "C",
+            inner_type.new_record([("D", Val::Bool(false)), ("E", Val::U32(2084037802))])?,
+        ),
+    ])?;
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    // Sad path: type mismatch
+
+    let err = ty
+        .new_record([
+            ("A", Val::S32(32343)),
+            ("B", Val::Float64(3.14159265_f64.to_bits())),
+            (
+                "C",
+                inner_type.new_record([("D", Val::Bool(false)), ("E", Val::U32(2084037802))])?,
+            ),
+        ])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("type mismatch"), "{err}");
+
+    // Sad path: too many fields
+
+    let err = ty
+        .new_record([
+            ("A", Val::U32(32343)),
+            ("B", Val::Float64(3.14159265_f64.to_bits())),
+            (
+                "C",
+                inner_type.new_record([("D", Val::Bool(false)), ("E", Val::U32(2084037802))])?,
+            ),
+            ("F", Val::Unit),
+        ])
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("expected 3 value(s); got 4"),
+        "{err}"
+    );
+
+    // Sad path: too few fields
+
+    let err = ty
+        .new_record([
+            ("A", Val::U32(32343)),
+            ("B", Val::Float64(3.14159265_f64.to_bits())),
+        ])
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("expected 3 value(s); got 2"),
+        "{err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn variants() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(
+        &engine,
+        make_echo_component_with_params(
+            r#"(variant (case "A" u32) (case "B" float64) (case "C" (record (field "D" bool) (field "E" u32))))"#,
+            &[Type::U8, Type::I64, Type::I32],
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let ty = &func.params(&store)[0];
+    let input = ty.new_variant("B", Val::Float64(3.14159265_f64.to_bits()))?;
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    // Sad path: type mismatch
+
+    let err = ty.new_variant("B", Val::U64(314159265)).unwrap_err();
+
+    assert!(err.to_string().contains("type mismatch"), "{err}");
+
+    // Sad path: unknown case
+
+    let err = ty.new_variant("D", Val::U64(314159265)).unwrap_err();
+
+    assert!(err.to_string().contains("unknown variant case"), "{err}");
+
+    Ok(())
+}
+
+#[test]
+fn flags() -> Result<()> {
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(
+        &engine,
+        make_echo_component_with_params(r#"(flags "A" "B" "C" "D" "E")"#, &[Type::U8]),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let ty = &func.params(&store)[0];
+    let input = ty.new_flags(&["B", "D"])?;
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    // Sad path: unknown flags
+
+    let err = ty.new_flags(&["B", "D", "F"]).unwrap_err();
+
+    assert!(err.to_string().contains("unknown flag"), "{err}");
+
+    Ok(())
+}
+
+#[test]
+fn everything() -> Result<()> {
+    // This serves to test both nested types and storing parameters on the heap (i.e. exceeding `MAX_STACK_PARAMS`)
+
+    let engine = super::engine();
+    let mut store = Store::new(&engine, ());
+
+    let component = Component::new(
+        &engine,
+        make_echo_component_with_params(
+            r#"
+            (record
+                (field "A" u32)
+                (field "B" (enum "1" "2"))
+                (field "C" (record (field "D" bool) (field "E" u32)))
+                (field "F" (list (flags "G" "H" "I")))
+                (field "J" (variant
+                               (case "K" u32)
+                               (case "L" float64)
+                               (case "M" (record (field "N" bool) (field "O" u32)))))
+                (field "P" s8)
+                (field "Q" s16)
+                (field "R" s32)
+                (field "S" s64)
+                (field "T" float32)
+                (field "U" float64)
+                (field "V" string)
+                (field "W" char)
+                (field "X" unit)
+                (field "Y" (tuple u32 u32))
+                (field "Z" (union u32 float64))
+                (field "AA" (option u32))
+                (field "BB" (expected string string))
+            )"#,
+            &[
+                Type::I32,
+                Type::U8,
+                Type::U8,
+                Type::I32,
+                Type::I32,
+                Type::I32,
+                Type::U8,
+                Type::I64,
+                Type::I32,
+                Type::S8,
+                Type::S16,
+                Type::I32,
+                Type::I64,
+                Type::F32,
+                Type::F64,
+                Type::I32,
+                Type::I32,
+                Type::I32,
+                Type::I32,
+                Type::I32,
+                Type::I64,
+                Type::U8,
+                Type::I32,
+                Type::U8,
+                Type::I32,
+                Type::I32,
+            ],
+        ),
+    )?;
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "echo").unwrap();
+    let ty = &func.params(&store)[0];
+    let types = ty.nested();
+    let (b_type, c_type, f_type, j_type, y_type, z_type, aa_type, bb_type) = (
+        &types[1], &types[2], &types[3], &types[4], &types[14], &types[15], &types[16], &types[17],
+    );
+    let f_element_type = &f_type.nested()[0];
+    let input = ty.new_record([
+        ("A", Val::U32(32343)),
+        ("B", b_type.new_enum("2")?),
+        (
+            "C",
+            c_type.new_record([("D", Val::Bool(false)), ("E", Val::U32(2084037802))])?,
+        ),
+        (
+            "F",
+            f_type.new_list(Box::new([f_element_type.new_flags(&["G", "I"])?]))?,
+        ),
+        (
+            "J",
+            j_type.new_variant("L", Val::Float64(3.14159265_f64.to_bits()))?,
+        ),
+        ("P", Val::S8(42)),
+        ("Q", Val::S16(4242)),
+        ("R", Val::S32(42424242)),
+        ("S", Val::S64(424242424242424242)),
+        ("T", Val::Float32(3.14159265_f32.to_bits())),
+        ("U", Val::Float64(3.14159265_f64.to_bits())),
+        ("V", Val::String(Box::from("wow, nice types"))),
+        ("W", Val::Char('🦀')),
+        ("X", Val::Unit),
+        (
+            "Y",
+            y_type.new_tuple(Box::new([Val::U32(42), Val::U32(24)]))?,
+        ),
+        (
+            "Z",
+            z_type.new_union(1, Val::Float64(3.14159265_f64.to_bits()))?,
+        ),
+        ("AA", aa_type.new_option(Some(Val::U32(314159265)))?),
+        (
+            "BB",
+            bb_type.new_expected(Ok(Val::String(Box::from("no problem"))))?,
+        ),
+    ])?;
+    let output = func.call_and_post_return(&mut store, &[input.clone()])?;
+
+    assert_eq!(input, output);
+
+    Ok(())
+}


### PR DESCRIPTION
This addresses #4310, introducing a new `component::values::Val` type for
representing component values dynamically.  It also adds a `call` method to
`component::func::Func`, which takes a slice of `Val`s as parameters and returns
a `Result<Val>` representing the result.

As an implementation detail, I've also added a `component::values::Type` type,
which is an owned, despecialized version of
`wasmtime_environ::component::InterfaceType`.  That serves two purposes:

- It allows us to despecialize as the first step, which reduces the number of cases to consider when typechecking and lowering.
- It avoids needing to borrow the store both mutably and immutably when lowering, as we would if we used `InterfaceType`s.

Finally, I happened to notice that the `ComponentType::SIZE32` calculation in
`expand_record_for_component_type` needed a correction, so I did that.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
