### PR TITLE
clif-util: always use `pretty-env-logger`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,7 +706,6 @@ dependencies = [
  "cranelift-preopt",
  "cranelift-reader",
  "cranelift-wasm",
- "file-per-thread-logger",
  "filecheck",
  "indicatif",
  "log",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -36,7 +36,6 @@ wat = { version = "1.0.45", optional = true }
 target-lexicon = { version = "0.12", features = ["std"] }
 pretty_env_logger = "0.4.0"
 rayon = { version = "1", optional = true }
-file-per-thread-logger = "0.1.2"
 indicatif = "0.13.0"
 thiserror = "1.0.15"
 walkdir = "2.2"

--- a/cranelift/src/cat.rs
+++ b/cranelift/src/cat.rs
@@ -15,14 +15,9 @@ pub struct Options {
     /// Specify input file(s) to be used. Use '-' for stdin.
     #[clap(required = true)]
     files: Vec<PathBuf>,
-
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
 }
 
 pub fn run(options: &Options) -> Result<()> {
-    crate::handle_debug_flag(options.debug);
     for (i, f) in options.files.iter().enumerate() {
         if i != 0 {
             println!();

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -13,7 +13,6 @@
 )]
 
 use clap::Parser;
-use cranelift_codegen::dbg::LOG_FILENAME_PREFIX;
 use std::path::PathBuf;
 
 mod bugpoint;
@@ -30,14 +29,6 @@ mod souper_harvest;
 
 #[cfg(feature = "wasm")]
 mod wasm;
-
-fn handle_debug_flag(debug: bool) {
-    if debug {
-        pretty_env_logger::init();
-    } else {
-        file_per_thread_logger::initialize(LOG_FILENAME_PREFIX);
-    }
-}
 
 /// Cranelift code generator utility.
 #[derive(Parser)]
@@ -73,10 +64,6 @@ struct TestOptions {
     #[clap(short = 'T')]
     time_passes: bool,
 
-    /// Enable debug output on stderr/stdout
-    #[clap(short = 'd')]
-    debug: bool,
-
     /// Specify an input file to be used. Use '-' for stdin.
     #[clap(required = true)]
     files: Vec<PathBuf>,
@@ -92,10 +79,6 @@ struct PassOptions {
     /// Print pass timing report for test
     #[clap(short = 'T')]
     time_passes: bool,
-
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
 
     /// Specify an input file to be used. Use '-' for stdin.
     file: PathBuf,
@@ -113,6 +96,8 @@ struct PassOptions {
 struct CompiledWithoutSupportOptions {}
 
 fn main() -> anyhow::Result<()> {
+    pretty_env_logger::init();
+
     match Commands::parse() {
         Commands::Cat(c) => cat::run(&c)?,
         Commands::Run(r) => run::run(&r)?,
@@ -135,7 +120,6 @@ fn main() -> anyhow::Result<()> {
         ),
 
         Commands::Test(t) => {
-            handle_debug_flag(t.debug);
             cranelift_filetests::run(
                 t.verbose,
                 t.time_passes,
@@ -146,7 +130,6 @@ fn main() -> anyhow::Result<()> {
             )?;
         }
         Commands::Pass(p) => {
-            handle_debug_flag(p.debug);
             cranelift_filetests::run_passes(
                 p.verbose,
                 p.time_passes,

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -37,14 +37,9 @@ pub struct Options {
 
     /// Specify an input file to be used. Use '-' for stdin.
     files: Vec<PathBuf>,
-
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
 }
 
 pub fn run(options: &Options) -> Result<()> {
-    crate::handle_debug_flag(options.debug);
     let parsed = parse_sets_and_triple(&options.settings, &options.target)?;
     for path in &options.files {
         let name = String::from(path.as_os_str().to_string_lossy());

--- a/cranelift/src/interpret.rs
+++ b/cranelift/src/interpret.rs
@@ -17,10 +17,6 @@ pub struct Options {
     #[clap(required = true)]
     files: Vec<PathBuf>,
 
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
-
     /// Be more verbose
     #[clap(short, long)]
     verbose: bool,
@@ -28,8 +24,6 @@ pub struct Options {
 
 /// Run files through the Cranelift interpreter, interpreting any functions with annotations.
 pub fn run(options: &Options) -> anyhow::Result<()> {
-    crate::handle_debug_flag(options.debug);
-
     let mut total = 0;
     let mut errors = 0;
     for file in iterate_files(&options.files) {
@@ -179,7 +173,6 @@ mod test {
     fn filetests() {
         run(&Options {
             files: vec![PathBuf::from("../filetests/filetests/interpreter")],
-            debug: true,
             verbose: true,
         })
         .unwrap()

--- a/cranelift/src/print_cfg.rs
+++ b/cranelift/src/print_cfg.rs
@@ -16,14 +16,9 @@ pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
     #[clap(required = true)]
     files: Vec<PathBuf>,
-
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
 }
 
 pub fn run(options: &Options) -> Result<()> {
-    crate::handle_debug_flag(options.debug);
     for (i, f) in options.files.iter().enumerate() {
         if i != 0 {
             println!();

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -17,17 +17,12 @@ pub struct Options {
     #[clap(required = true)]
     files: Vec<PathBuf>,
 
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
-
     /// Be more verbose
     #[clap(short, long)]
     verbose: bool,
 }
 
 pub fn run(options: &Options) -> Result<()> {
-    crate::handle_debug_flag(options.debug);
     let stdin_exist = options
         .files
         .iter()

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -90,10 +90,6 @@ pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
     files: Vec<PathBuf>,
 
-    /// Enable debug output on stderr/stdout
-    #[clap(short)]
-    debug: bool,
-
     /// Print bytecode size
     #[clap(short = 'X')]
     print_size: bool,
@@ -137,8 +133,6 @@ impl std::str::FromStr for ColorOpt {
 }
 
 pub fn run(options: &Options) -> Result<()> {
-    crate::handle_debug_flag(options.debug);
-
     let parsed = parse_sets_and_triple(&options.settings, &options.target)?;
     for path in &options.files {
         let name = String::from(path.as_os_str().to_string_lossy());


### PR DESCRIPTION
Rather than sometimes using `file-per-thread-logger`.

Also remove the debug CLI flags, so that we can always just define
`RUST_LOG=...` to get logging and don't need to also do other things.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
