### PR TITLE
Enable cargo-vet

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,25 @@ jobs:
         echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check bans licenses
 
+  # Ensure dependencies are vetted. See https://mozilla.github.io/cargo-vet/
+  cargo_vet:
+    name: Cargo vet
+    runs-on: ubuntu-latest
+    env:
+      CARGO_VET_VERSION: 0.2.0
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - uses: actions/cache@v2
+      with:
+        path: ${{ runner.tool_cache }}/cargo-vet
+        key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
+    - run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+    - run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+    - run: cargo vet --locked
+
   doc:
     name: Doc build
     runs-on: ubuntu-latest

--- a/supply-chain/README
+++ b/supply-chain/README
@@ -1,0 +1,7 @@
+This directory contains the state for cargo-vet, a tool to help projects ensure
+that third-party Rust dependencies have been audited by a trusted entity.
+
+More about the tool can be found here: https://mozilla.github.io/cargo-vet/
+
+The audits.toml file may be imported by other projects, and therefore should be
+handled with care. Ask for help if you're not sure.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,0 +1,5 @@
+
+# cargo-vet audits file
+
+[audits]
+

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,0 +1,1297 @@
+
+# cargo-vet config file
+
+[policy.wasi-crypto]
+audit-as-crates-io = false
+
+[policy.witx]
+audit-as-crates-io = false
+
+[[exemptions.addr2line]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.adler]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.aead]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.aes-gcm]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ahash]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.aho-corasick]]
+version = "0.7.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.ambient-authority]]
+version = "0.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ansi_term]]
+version = "0.12.1"
+criteria = "safe-to-run"
+
+[[exemptions.anyhow]]
+version = "1.0.57"
+criteria = "safe-to-deploy"
+
+[[exemptions.arbitrary]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.async-trait]]
+version = "0.1.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.atty]]
+version = "0.2.14"
+criteria = "safe-to-deploy"
+
+[[exemptions.autocfg]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.autocfg]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.backtrace]]
+version = "0.3.66"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.base64ct]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.bincode]]
+version = "1.3.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bit-set]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.bit-vec]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bitflags]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.block-buffer]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.bstr]]
+version = "0.2.17"
+criteria = "safe-to-run"
+
+[[exemptions.bumpalo]]
+version = "3.9.1"
+criteria = "safe-to-run"
+
+[[exemptions.byteorder]]
+version = "1.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.bytes]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-fs-ext]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-primitives]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-rand]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-std]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cap-tempfile]]
+version = "0.25.0"
+criteria = "safe-to-run"
+
+[[exemptions.cap-time-ext]]
+version = "0.25.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.capstone]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.capstone-sys]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cast]]
+version = "0.2.7"
+criteria = "safe-to-run"
+
+[[exemptions.cc]]
+version = "1.0.73"
+criteria = "safe-to-deploy"
+
+[[exemptions.cfg-if]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.chacha20poly1305]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cipher]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap]]
+version = "2.34.0"
+criteria = "safe-to-run"
+
+[[exemptions.clap]]
+version = "3.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_derive]]
+version = "3.2.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.clap_lex]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.console]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.const-oid]]
+version = "0.6.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpp_demangle]]
+version = "0.3.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.cpufeatures]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.crc32fast]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.criterion]]
+version = "0.3.5"
+criteria = "safe-to-run"
+
+[[exemptions.criterion-plot]]
+version = "0.4.4"
+criteria = "safe-to-run"
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-deque]]
+version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-epoch]]
+version = "0.9.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-utils]]
+version = "0.8.10"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-bigint]]
+version = "0.2.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.crypto-mac]]
+version = "0.11.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.csv]]
+version = "1.1.6"
+criteria = "safe-to-run"
+
+[[exemptions.csv-core]]
+version = "0.1.10"
+criteria = "safe-to-run"
+
+[[exemptions.ctr]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.cty]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.curve25519-dalek]]
+version = "3.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.der]]
+version = "0.4.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.derivative]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.derive_arbitrary]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.digest]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.directories-next]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-next]]
+version = "2.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dirs-sys-next]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.downcast-rs]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.dunce]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ecdsa]]
+version = "0.12.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519]]
+version = "1.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ed25519-dalek]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.egg]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.either]]
+version = "1.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.elliptic-curve]]
+version = "0.10.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.encode_unicode]]
+version = "0.3.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_logger]]
+version = "0.7.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.env_logger]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.errno]]
+version = "0.2.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.errno-dragonfly]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.fallible-iterator]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fastrand]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ff]]
+version = "0.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.file-per-thread-logger]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.filecheck]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.filetime]]
+version = "0.2.16"
+criteria = "safe-to-run"
+
+[[exemptions.flagset]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.fnv]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.fs-set-times]]
+version = "0.17.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.fslock]]
+version = "0.1.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.fxhash]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.generic-array]]
+version = "0.14.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.1.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.getrandom]]
+version = "0.2.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.ghash]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.gimli]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.glob]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.group]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.half]]
+version = "1.8.2"
+criteria = "safe-to-run"
+
+[[exemptions.hashbrown]]
+version = "0.12.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.heck]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.1.19"
+criteria = "safe-to-deploy"
+
+[[exemptions.hermit-abi]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hkdf]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.hmac]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.humantime]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.humantime]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.id-arena]]
+version = "2.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.indexmap]]
+version = "1.9.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.indicatif]]
+version = "0.13.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.instant]]
+version = "0.1.12"
+criteria = "safe-to-deploy"
+
+[[exemptions.io-extras]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.io-lifetimes]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ipnet]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.is-terminal]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.is_ci]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.itertools]]
+version = "0.10.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.itoa]]
+version = "0.4.8"
+criteria = "safe-to-run"
+
+[[exemptions.itoa]]
+version = "1.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ittapi]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ittapi-sys]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.jobserver]]
+version = "0.1.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.js-sys]]
+version = "0.3.57"
+criteria = "safe-to-run"
+
+[[exemptions.k256]]
+version = "0.9.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.lazy_static]]
+version = "1.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.leb128]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.libc]]
+version = "0.2.126"
+criteria = "safe-to-deploy"
+
+[[exemptions.libfuzzer-sys]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.libloading]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.libm]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.linux-raw-sys]]
+version = "0.0.46"
+criteria = "safe-to-deploy"
+
+[[exemptions.listenfd]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.lock_api]]
+version = "0.4.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.log]]
+version = "0.4.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.mach]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.maybe-owned]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.memchr]]
+version = "2.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.memfd]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.memmap2]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.memoffset]]
+version = "0.6.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.memory_units]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette]]
+version = "5.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miette-derive]]
+version = "5.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.miniz_oxide]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.mio]]
+version = "0.8.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.miow]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.more-asserts]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.ntapi]]
+version = "0.3.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-bigint-dig]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-integer]]
+version = "0.1.45"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-iter]]
+version = "0.1.43"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-rational]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.num-traits]]
+version = "0.2.15"
+criteria = "safe-to-deploy"
+
+[[exemptions.num_cpus]]
+version = "1.13.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.number_prefix]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.object]]
+version = "0.29.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ocaml-boxroot-sys]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ocaml-interop]]
+version = "0.8.8"
+criteria = "safe-to-deploy"
+
+[[exemptions.ocaml-sys]]
+version = "0.22.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.once_cell]]
+version = "1.12.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.oorandom]]
+version = "11.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.opaque-debug]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.openvino]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.openvino-finder]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.openvino-sys]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.os_pipe]]
+version = "0.9.2"
+criteria = "safe-to-run"
+
+[[exemptions.os_str_bytes]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.owo-colors]]
+version = "3.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.p256]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.parity-wasm]]
+version = "0.42.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.parking_lot_core]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.paste]]
+version = "1.0.7"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem-rfc7468]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pin-project-lite]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs1]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pkcs8]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.plotters]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-backend]]
+version = "0.3.2"
+criteria = "safe-to-run"
+
+[[exemptions.plotters-svg]]
+version = "0.3.1"
+criteria = "safe-to-run"
+
+[[exemptions.poly1305]]
+version = "0.7.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.polyval]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.ppv-lite86]]
+version = "0.2.16"
+criteria = "safe-to-deploy"
+
+[[exemptions.pqcrypto]]
+version = "0.14.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.pqcrypto-internals]]
+version = "0.2.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pqcrypto-kyber]]
+version = "0.7.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.pqcrypto-traits]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.pretty_env_logger]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-error]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro-error-attr]]
+version = "1.0.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.proc-macro2]]
+version = "1.0.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.proptest]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.psm]]
+version = "0.1.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.quick-error]]
+version = "1.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.quick-error]]
+version = "2.0.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.quote]]
+version = "1.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand]]
+version = "0.8.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_chacha]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_chacha]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.5.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_core]]
+version = "0.6.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_hc]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rand_xorshift]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rawbytes]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon]]
+version = "1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.rayon-core]]
+version = "1.9.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_syscall]]
+version = "0.2.13"
+criteria = "safe-to-deploy"
+
+[[exemptions.redox_users]]
+version = "0.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.regalloc2]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex]]
+version = "1.5.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.regex-automata]]
+version = "0.1.10"
+criteria = "safe-to-run"
+
+[[exemptions.regex-syntax]]
+version = "0.6.25"
+criteria = "safe-to-deploy"
+
+[[exemptions.region]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.remove_dir_all]]
+version = "0.5.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.rsa]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc-demangle]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustc_version]]
+version = "0.4.0"
+criteria = "safe-to-run"
+
+[[exemptions.rustix]]
+version = "0.35.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.rusty-fork]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ryu]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.same-file]]
+version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.scopeguard]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.semver]]
+version = "1.0.9"
+criteria = "safe-to-run"
+
+[[exemptions.serde]]
+version = "1.0.137"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_cbor]]
+version = "0.11.2"
+criteria = "safe-to-run"
+
+[[exemptions.serde_derive]]
+version = "1.0.137"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_json]]
+version = "1.0.80"
+criteria = "safe-to-deploy"
+
+[[exemptions.sha2]]
+version = "0.9.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.sharded-slab]]
+version = "0.1.4"
+criteria = "safe-to-run"
+
+[[exemptions.shellexpand]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.shuffling-allocator]]
+version = "1.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.signature]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.similar]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.slice-group-by]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.smallvec]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.smawk]]
+version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.socket2]]
+version = "0.4.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.souper-ir]]
+version = "2.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.spin]]
+version = "0.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.spki]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.stable_deref_trait]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.static_assertions]]
+version = "1.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.strsim]]
+version = "0.10.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.subtle]]
+version = "2.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.supports-color]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.supports-hyperlinks]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.supports-unicode]]
+version = "1.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.symbolic_expressions]]
+version = "5.0.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "1.0.92"
+criteria = "safe-to-deploy"
+
+[[exemptions.synstructure]]
+version = "0.12.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-interface]]
+version = "0.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.target-lexicon]]
+version = "0.12.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.tempfile]]
+version = "3.3.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.termcolor]]
+version = "1.1.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.terminal_size]]
+version = "0.1.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.textwrap]]
+version = "0.11.0"
+criteria = "safe-to-run"
+
+[[exemptions.textwrap]]
+version = "0.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror]]
+version = "1.0.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.thiserror-impl]]
+version = "1.0.31"
+criteria = "safe-to-deploy"
+
+[[exemptions.thread_local]]
+version = "1.1.4"
+criteria = "safe-to-run"
+
+[[exemptions.tinytemplate]]
+version = "1.2.1"
+criteria = "safe-to-run"
+
+[[exemptions.tokio]]
+version = "1.18.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-macros]]
+version = "1.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.toml]]
+version = "0.5.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing]]
+version = "0.1.34"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-attributes]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-core]]
+version = "0.1.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.tracing-log]]
+version = "0.1.3"
+criteria = "safe-to-run"
+
+[[exemptions.tracing-subscriber]]
+version = "0.3.11"
+criteria = "safe-to-run"
+
+[[exemptions.typenum]]
+version = "1.15.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-linebreak]]
+version = "0.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-width]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.unicode-xid]]
+version = "0.2.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.universal-hash]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.uuid]]
+version = "1.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.v8]]
+version = "0.44.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.valuable]]
+version = "0.1.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.version_check]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.wait-timeout]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.walkdir]]
+version = "2.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.9.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.10.2+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasi]]
+version = "0.11.0+wasi-snapshot-preview1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.80"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-backend]]
+version = "0.2.80"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.80"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.80"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-shared]]
+version = "0.2.80"
+criteria = "safe-to-run"
+
+[[exemptions.wasm-encoder]]
+version = "0.14.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-mutate]]
+version = "0.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasm-smith]]
+version = "0.11.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmi]]
+version = "0.11.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmi-validation]]
+version = "0.4.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmparser]]
+version = "0.87.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wasmprinter]]
+version = "0.2.37"
+criteria = "safe-to-deploy"
+
+[[exemptions.wast]]
+version = "35.0.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.wast]]
+version = "43.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.wat]]
+version = "1.0.45"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-sys]]
+version = "0.3.57"
+criteria = "safe-to-run"
+
+[[exemptions.which]]
+version = "4.2.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi]]
+version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-i686-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-util]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.winapi-x86_64-pc-windows-gnu]]
+version = "0.4.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_aarch64_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_gnu]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_i686_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_gnu]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows_x86_64_msvc]]
+version = "0.36.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.winx]]
+version = "0.33.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.xoodyak]]
+version = "0.7.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize]]
+version = "1.4.3"
+criteria = "safe-to-deploy"
+
+[[exemptions.zeroize_derive]]
+version = "1.3.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd]]
+version = "0.11.1+zstd.1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-safe]]
+version = "5.0.1+zstd.1.5.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zstd-sys]]
+version = "2.0.1+zstd.1.5.2"
+criteria = "safe-to-deploy"
+

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,0 +1,5 @@
+
+# cargo-vet imports lock
+
+[audits]
+


### PR DESCRIPTION
Cargo-vet is a new tool developed by Mozilla to ensure that third-party Rust dependencies have been audited by a trusted entity. You can read more about it [here](https://mozilla.github.io/cargo-vet/index.html).

We've successfully rolled out this tool for Firefox and largely ironed out the kinks. The next step is to pilot the cross-organization sharing capabilities, which we'd like to do with the Bytecode Alliance. We're still putting the finishing touches on those features in the tool, but as a first step we can get up and running in single-user mode and make sure everything works as expected.