### PR TITLE
cranelift: Correctly parse ISA value flags in `clif-util`

### DIFF
--- a/cranelift/src/utils.rs
+++ b/cranelift/src/utils.rs
@@ -64,6 +64,9 @@ pub fn parse_sets_and_triple(
         Err(ParseOptionError::UnknownFlag { name, .. }) => {
             unknown_settings.push(name);
         }
+        Err(ParseOptionError::UnknownValue { name, value, .. }) => {
+            unknown_settings.push(format!("{}={}", name, value));
+        }
         Err(ParseOptionError::Generic(err)) => return Err(err.into()),
         Ok(()) => {}
     }


### PR DESCRIPTION
When parsing ISA specific values we were accidentally discarding the value of the flag, and treating it always as a boolean flag. 

This would cause a `clif-util` invocation such as
`cargo run -- compile -D --set has_sse41=false --target x86_64 test.clif`

to be interpreted as `--set has_sse41` and enable that feature instead
of disabling it.