### PR TITLE
Track type information during component translation

### DIFF
--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -390,6 +390,7 @@ impl<'a> Inliner<'a> {
             // NB: at this time only lowered imported functions are supported.
             Lower(func, options) => {
                 let canonical_abi = frame.translation.funcs[frame.funcs.next_key()];
+                let lower_ty = frame.translation.component_funcs[*func];
 
                 let options_lower = self.canonical_options(frame, options);
                 let func = match &frame.component_funcs[*func] {
@@ -476,13 +477,14 @@ impl<'a> Inliner<'a> {
                     // the return values, copy them from `options_lift` to
                     // `options_lower`, and then return.
                     ComponentFuncDef::Lifted {
-                        ty,
+                        ty: lift_ty,
                         func,
                         options: options_lift,
                     } => {
                         // These are the various compilation options for lifting
                         // and lowering.
-                        drop(ty); // component-model function type
+                        drop(lift_ty); // type used when lifting the core function
+                        drop(lower_ty); // type used when lowering the core function
                         drop(func); // original core wasm function that was lifted
                         drop(options_lift); // options during `canon lift`
                         drop(options_lower); // options during `canon lower`


### PR DESCRIPTION
This commit augments the current translation phase of components with
extra machinery to track the type information of component items such as
instances, components, and functions. The end goal of this commit is to
enable the `Lower` instruction to know the type of the component
function being lowered. Currently during the inlining pass where
component fusion is detected the type of the lifted function is known,
but to implement fusion entirely the type of the lowered function must
be known. Note that these two types are expected to be different to
allow for the subtyping rules specified by the component model.

For now nothing is actually done with this information other than noting
its presence in the face of a lifted-then-lowered function. My hope
though was to split this out for a separate review to avoid making a
future component-adapter-compiler-containing-PR too large.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
