### PR TITLE
cranelift: Use requested ISA Flags in run tests

### DIFF
--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -113,6 +113,17 @@ impl Value {
             _ => None,
         }
     }
+
+    /// Builds a string from the current value
+    pub fn value_string(&self) -> String {
+        match self.kind() {
+            SettingKind::Enum => self.as_enum().map(|b| b.to_string()),
+            SettingKind::Num => self.as_num().map(|b| b.to_string()),
+            SettingKind::Bool => self.as_bool().map(|b| b.to_string()),
+            SettingKind::Preset => unreachable!(),
+        }
+        .unwrap()
+    }
 }
 
 impl fmt::Display for Value {

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
@@ -1,5 +1,6 @@
 test run
 target s390x
+target s390x has_mie2
 target aarch64
 target aarch64 has_lse
 target x86_64

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
@@ -1,5 +1,6 @@
 test run
 target s390x
+target s390x has_mie2
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly
@@ -457,4 +458,3 @@ block0(v0: i32, v1: i64, v2: i8):
 ; run: %atomic_rmw_xchg_big_i8(0x12345678, 2, 0xff) == 0x1234ff78
 ; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0x11) == 0x12345611
 ; run: %atomic_rmw_xchg_big_i8(0x12345678, 3, 0xff) == 0x123456ff
-

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -1,5 +1,6 @@
 test run
 target s390x
+target s390x has_mie2
 target aarch64
 target aarch64 has_lse
 target x86_64
@@ -456,4 +457,3 @@ block0(v0: i32, v1: i64, v2: i8):
 ; run: %atomic_rmw_xchg_little_i8(0x12345678, 1, 0xff) == 0x1234ff78
 ; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0x11) == 0x12345611
 ; run: %atomic_rmw_xchg_little_i8(0x12345678, 0, 0xff) == 0x123456ff
-

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -1,6 +1,7 @@
 test run
 target aarch64
 target s390x
+target s390x has_mie2
 ; target x86_64 TODO: Not yet implemented on x86_64
 
 function %bnot_band() -> b1 {

--- a/cranelift/filetests/filetests/runtests/br.clif
+++ b/cranelift/filetests/filetests/runtests/br.clif
@@ -1,7 +1,6 @@
 test interpret
 test run
 target aarch64
-target arm
 target s390x
 target x86_64
 

--- a/cranelift/filetests/filetests/runtests/clz.clif
+++ b/cranelift/filetests/filetests/runtests/clz.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target x86_64 has_lzcnt
 
 function %clz_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/const.clif
+++ b/cranelift/filetests/filetests/runtests/const.clif
@@ -1,6 +1,5 @@
 test run
 target aarch64
-target arm
 target s390x
 target x86_64
 

--- a/cranelift/filetests/filetests/runtests/ctz.clif
+++ b/cranelift/filetests/filetests/runtests/ctz.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target x86_64 has_bmi1
 
 function %ctz_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/div-checks.clif
+++ b/cranelift/filetests/filetests/runtests/div-checks.clif
@@ -1,6 +1,5 @@
 test run
 target aarch64
-target arm
 target s390x
 set avoid_div_traps=false
 target x86_64

--- a/cranelift/filetests/filetests/runtests/popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/popcnt.clif
@@ -2,7 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
-target x86_64 has_popcnt=1
+target x86_64 has_popcnt
 
 function %popcnt_i8(i8) -> i8 {
 block0(v0: i8):


### PR DESCRIPTION
👋 Hey,

This PR Enables using the ISA flags that run tests request. We skip tests that request flags that the host arch does not support.

I did a quick pass on the backends to find ops that we have optimizations based on flags and enabled the tests for those.

Fixes #1891