### PR TITLE
Split `global_asm!` helper macros out from `wasmtime-fibers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,6 +3340,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-asm-macros"
+version = "0.40.0"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "wasmtime-bench-api"
 version = "0.19.0"
 dependencies = [
@@ -3509,6 +3516,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "rustix",
+ "wasmtime-asm-macros",
  "windows-sys",
 ]
 

--- a/crates/asm-macros/Cargo.toml
+++ b/crates/asm-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["The Wasmtime Project Developers"]
+description = "Macros for defining asm functions in Wasmtime"
+edition = "2021"
+license = "Apache-2.0 WITH LLVM-exception"
+name = "wasmtime-asm-macros"
+repository = "https://github.com/bytecodealliance/wasmtime"
+version = "0.40.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cfg-if = "1"

--- a/crates/asm-macros/src/lib.rs
+++ b/crates/asm-macros/src/lib.rs
@@ -1,0 +1,66 @@
+//! This crate defines a macro named `asm_func!` which is suitable for
+//! generating a single `global_asm!`-defined function.
+//!
+//! This macro takes care of platform-specific directives to get the symbol
+//! attributes correct (e.g. ELF symbols get a size and are flagged as a
+//! function) and additionally handles visibility across platforms. All symbols
+//! should be visible to Rust but not visible externally outside of a `*.so`.
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        #[macro_export]
+        macro_rules! asm_func {
+            ($name:tt, $($body:tt)*) => {
+                std::arch::global_asm!(concat!(
+                    ".p2align 4\n",
+                    ".private_extern _", $name, "\n",
+                    ".global _", $name, "\n",
+                    "_", $name, ":\n",
+                    $($body)*
+                ));
+            };
+        }
+
+        #[macro_export]
+        macro_rules! asm_sym {
+            ($name:tt) => (concat!("_", $name))
+        }
+    } else {
+        // Note that for now this "else" clause just assumes that everything
+        // other than macOS is ELF and has the various directives here for
+        // that.
+        cfg_if::cfg_if! {
+            if #[cfg(target_arch = "arm")] {
+                #[macro_export]
+                macro_rules! elf_func_type_header {
+                    ($name:tt) => (concat!(".type ", $name, ",%function\n"))
+                }
+            } else {
+                #[macro_export]
+                macro_rules! elf_func_type_header {
+                    ($name:tt) => (concat!(".type ", $name, ",@function\n"))
+                }
+            }
+        }
+
+        #[macro_export]
+        macro_rules! asm_func {
+            ($name:tt, $($body:tt)*) => {
+                std::arch::global_asm!(concat!(
+                    ".p2align 4\n",
+                    ".hidden ", $name, "\n",
+                    ".global ", $name, "\n",
+                    $crate::elf_func_type_header!($name),
+                    $name, ":\n",
+                    $($body)*
+                    ".size ", $name, ",.-", $name,
+                ));
+            };
+        }
+
+        #[macro_export]
+        macro_rules! asm_sym {
+            ($name:tt) => ($name)
+        }
+    }
+}

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.35.6", features = ["mm", "param"] }
+wasmtime-asm-macros = { version = "=0.40.0", path = "../asm-macros" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.1"

--- a/crates/fiber/src/unix/aarch64.rs
+++ b/crates/fiber/src/unix/aarch64.rs
@@ -18,6 +18,8 @@
 //   `DW_CFA_AARCH64_negate_ra_state` DWARF operation (aliased with the
 //   `.cfi_window_save` assembler directive) informs an unwinder about this
 
+use wasmtime_asm_macros::asm_func;
+
 cfg_if::cfg_if! {
     if #[cfg(target_os = "macos")] {
         macro_rules! cfi_window_save { () => (""); }

--- a/crates/fiber/src/unix/arm.rs
+++ b/crates/fiber/src/unix/arm.rs
@@ -8,6 +8,8 @@
 // Also at this time this file is heavily based off the x86_64 file, so you'll
 // probably want to read that one as well.
 
+use wasmtime_asm_macros::{asm_func, asm_sym};
+
 // fn(top_of_stack(%r0): *mut u8)
 asm_func!(
     "wasmtime_fiber_switch",

--- a/crates/fiber/src/unix/x86.rs
+++ b/crates/fiber/src/unix/x86.rs
@@ -10,6 +10,8 @@
 // different so the reserved space at the top of the stack is 8 bytes, not 16
 // bytes. Still two pointers though.
 
+use wasmtime_asm_macros::{asm_func, asm_sym};
+
 // fn(top_of_stack: *mut u8)
 asm_func!(
     "wasmtime_fiber_switch",

--- a/crates/fiber/src/unix/x86_64.rs
+++ b/crates/fiber/src/unix/x86_64.rs
@@ -5,6 +5,8 @@
 // all the other bits. Documentation tries to reference various bits here and
 // there but try to make sure to read over everything before tweaking things!
 
+use wasmtime_asm_macros::{asm_func, asm_sym};
+
 // fn(top_of_stack(rdi): *mut u8)
 asm_func!(
     "wasmtime_fiber_switch",

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -40,6 +40,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wiggle-generate",
     "wiggle-macro",
     // wasmtime
+    "wasmtime-asm-macros",
     "wasmtime-component-macro",
     "wasmtime-jit-debug",
     "wasmtime-fiber",


### PR DESCRIPTION
This moves them into a new `wasmtime-asm-macros` crate that can be used not just
from the `wasmtime-fibers` crate but also from other crates (e.g. we will need
them in https://github.com/bytecodealliance/wasmtime/pull/4431).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
