### PR TITLE
[0.39.0]: Fix a possible panic with null-containing element segments

### DIFF
--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -280,7 +280,9 @@ impl Table {
         };
 
         for (item, slot) in items.zip(elements) {
-            *slot = item as usize;
+            unsafe {
+                *slot = TableElement::FuncRef(item).into_table_value();
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This is a backport of https://github.com/bytecodealliance/wasmtime/pull/4455 to the 0.39.0 release branch.