### PR TITLE
Out-of-band fuel metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,6 +3609,7 @@ dependencies = [
  "memfd",
  "memoffset",
  "more-asserts",
+ "psm",
  "rand 0.8.5",
  "rustix",
  "thiserror",

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -152,6 +152,7 @@ pub trait Compiler: Send + Sync {
     /// function pointer argument which has the `ty` type provided.
     fn compile_host_to_wasm_trampoline(
         &self,
+        tunables: &Tunables,
         ty: &WasmFuncType,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
 
@@ -196,6 +197,7 @@ pub trait Compiler: Send + Sync {
         ty: &WasmFuncType,
         host_fn: usize,
         obj: &mut Object<'static>,
+        tunables: &Tunables,
     ) -> Result<(Trampoline, Trampoline)>;
 
     /// Creates a new `Object` file which is used to build the results of a

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -28,6 +28,11 @@ pub struct Tunables {
     /// will be consumed every time a wasm instruction is executed.
     pub consume_fuel: bool,
 
+    /// If set to true, the behavior of `consume_fuel` is modified to not include
+    /// inline checks for the fuel. Instead, the fuel is checked out-of-band by
+    /// a signal handler or a separate thread.
+    pub outband_fuel: bool,
+
     /// Whether or not we use epoch-based interruption.
     pub epoch_interruption: bool,
 
@@ -82,6 +87,7 @@ impl Default for Tunables {
             generate_native_debuginfo: false,
             parse_wasm_debuginfo: true,
             consume_fuel: false,
+            outband_fuel: false,
             epoch_interruption: false,
             static_memory_bound_is_maximum: false,
             guard_before_linear_memory: true,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ backtrace = { version = "0.3.61" }
 rand = "0.8.3"
 anyhow = "1.0.38"
 memfd = { version = "0.6.1", optional = true }
+psm = "0.1.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -38,6 +38,7 @@ mod instance;
 mod memory;
 mod mmap;
 mod mmap_vec;
+mod outband_fuel;
 mod table;
 mod traphandlers;
 mod vmcontext;
@@ -72,6 +73,7 @@ pub use crate::vmcontext::{
     VMRuntimeLimits, VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMTrampoline,
     ValRaw,
 };
+pub use outband_fuel::{init_outband_fuel, OutbandFuelCheckHandle, OutbandFuelSupport};
 
 mod module_id;
 pub use module_id::{CompiledModuleId, CompiledModuleIdAllocator};

--- a/crates/runtime/src/outband_fuel.rs
+++ b/crates/runtime/src/outband_fuel.rs
@@ -1,0 +1,79 @@
+//! Support for async fuel metering.
+
+#![allow(missing_docs)]
+
+use std::sync::Once;
+use std::sync::{Arc, Mutex};
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        mod macos;
+        use macos as sys;
+    } else if #[cfg(target_os = "linux")] {
+        mod linux;
+        use linux as sys;
+    } else {
+        // TODO: I need to make it compile on other platforms.
+    }
+}
+
+struct SharedInner(Option<sys::CheckHandle>);
+
+/// This struct is owned by a store.
+pub struct OutbandFuelSupport {
+    inner: Arc<Mutex<SharedInner>>,
+}
+
+impl OutbandFuelSupport {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SharedInner(None))),
+        }
+    }
+
+    pub fn new_checker(&self) -> OutbandFuelCheckHandle {
+        let inner = self.inner.clone();
+        OutbandFuelCheckHandle { inner }
+    }
+
+    pub fn enter_wasm(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.0 = Some(sys::CheckHandle::from_current_thread());
+    }
+
+    pub fn leave_wasm(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.0 = None;
+    }
+}
+
+/// A handle that allows checking for the out-of-fuel condition from another thread.
+pub struct OutbandFuelCheckHandle {
+    inner: Arc<Mutex<SharedInner>>,
+}
+
+impl OutbandFuelCheckHandle {
+    // TODO: Consider what happens in case different threads try to check at the same time.
+    pub fn check(&self) {
+        if let Ok(ref inner) = self.inner.try_lock() {
+            inner.0.as_ref().map(|handle| handle.check());
+        }
+    }
+}
+
+/// Globally-set callback to determine whether a program counter points at wasm
+/// generated code. Note, that trampolines are specifically excluded.
+///
+/// This is initialized during `init_traps` below. The definition lives within
+/// `wasmtime` currently.
+pub(crate) static mut IS_WASM_PC: fn(usize) -> bool = |_| false;
+
+/// This function is required to be called before a call to wasm code that supports out-of-band
+/// fuel metering.
+pub fn init_outband_fuel(is_wasm_pc: fn(usize) -> bool) {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| unsafe {
+        IS_WASM_PC = is_wasm_pc;
+        sys::platform_init();
+    });
+}

--- a/crates/runtime/src/outband_fuel/linux.rs
+++ b/crates/runtime/src/outband_fuel/linux.rs
@@ -1,0 +1,147 @@
+//! Linux specific implementation of `outband_fuel`.
+//!
+//! The implementation here is built around signal handlers. We register a custom signal handler
+//! for SIGUSR1. When a check handle is created it captures the current thread and process id.
+//!
+//! For performing the out-of-band check, a SIGUSR1 signal is sent using the `tgkill` system call.
+
+use crate::outband_fuel::IS_WASM_PC;
+use crate::traphandlers::{raise_lib_trap, tls};
+use std::io;
+use std::mem::{self, MaybeUninit};
+use std::ptr;
+use wasmtime_environ::TrapCode;
+
+#[inline]
+unsafe fn tgkill(tgid: libc::pid_t, tid: libc::pid_t, sig: libc::c_int) -> libc::c_int {
+    libc::syscall(libc::SYS_tgkill, tgid, tid, sig) as libc::c_int
+}
+
+pub struct CheckHandle {
+    /// The PID of the current process.
+    my_pid: libc::pid_t,
+    /// The TID of the target process.
+    target_tid: libc::pid_t,
+}
+
+impl CheckHandle {
+    pub fn from_current_thread() -> Self {
+        unsafe {
+            Self {
+                my_pid: libc::getpid(),
+                target_tid: libc::gettid(),
+            }
+        }
+    }
+
+    pub fn check(&self) {
+        unsafe {
+            // Send SIGUSR1 signal to the thread of interest.  Ignore the return value of the
+            // syscall deliberately.
+            let _ = tgkill(self.my_pid, self.target_tid, libc::SIGUSR1);
+        }
+    }
+}
+
+static mut PREV_SIGUSR1: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
+
+pub fn platform_init() {
+    unsafe {
+        let mut handler: libc::sigaction = mem::zeroed();
+        handler.sa_flags = libc::SA_SIGINFO;
+        handler.sa_sigaction = trap_handler as usize;
+        libc::sigemptyset(&mut handler.sa_mask);
+        if libc::sigaction(libc::SIGUSR1, &handler, PREV_SIGUSR1.as_mut_ptr()) != 0 {
+            panic!(
+                "unable to install signal handler for async fuel: {}",
+                io::Error::last_os_error(),
+            );
+        }
+    }
+}
+
+unsafe extern "C" fn trap_handler(
+    signum: libc::c_int,
+    siginfo: *mut libc::siginfo_t,
+    context: *mut libc::c_void,
+) {
+    let handled = tls::with(|info| {
+        // we don't check if the tls info is set, because it's may not be immediatelly after
+        // the pthread_t is initialized.
+        let info = match info {
+            Some(info) => info,
+            None => return true,
+        };
+
+        let thread_state = get_thread_state(context);
+        if IS_WASM_PC(thread_state.pc) {
+            // at this point the fuel register is defined.
+
+            // flush it into the VMRuntimeLimits.
+            *(*info.runtime_limits()).fuel_consumed.get() = thread_state.fuel;
+
+            // check if the fuel ran out and if so interrupt.
+            if thread_state.fuel > 0 {
+                raise_lib_trap(TrapCode::Interrupt);
+            }
+        }
+
+        true
+    });
+
+    if handled {
+        return;
+    }
+
+    // This signal is not for any compiled wasm code we expect, so we
+    // need to forward the signal to the next handler. If there is no
+    // next handler (SIG_IGN or SIG_DFL), then it's time to crash. To do
+    // this, we set the signal back to its original disposition and
+    // return. This will cause the faulting op to be re-executed which
+    // will crash in the normal way. If there is a next handler, call
+    // it. It will either crash synchronously, fix up the instruction
+    // so that execution can continue and return, or trigger a crash by
+    // returning the signal to it's original disposition and returning.
+    let previous = &*PREV_SIGUSR1.as_ptr();
+    if previous.sa_flags & libc::SA_SIGINFO != 0 {
+        mem::transmute::<usize, extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void)>(
+            previous.sa_sigaction,
+        )(signum, siginfo, context)
+    } else if previous.sa_sigaction == libc::SIG_DFL || previous.sa_sigaction == libc::SIG_IGN {
+        libc::sigaction(signum, previous, ptr::null_mut());
+    } else {
+        mem::transmute::<usize, extern "C" fn(libc::c_int)>(previous.sa_sigaction)(signum)
+    }
+}
+
+struct ThreadState {
+    pc: usize,
+    /// The contents of the fuel register.
+    ///
+    /// Only defined if `pc` points to a code compiled from wasm.
+    fuel: i64,
+}
+
+unsafe fn get_thread_state(cx: *mut libc::c_void) -> ThreadState {
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
+            let cx = &*(cx as *const libc::ucontext_t);
+            let rip = cx.uc_mcontext.gregs[libc::REG_RIP as usize] as *const u8;
+            let r15 = cx.uc_mcontext.gregs[libc::REG_R15 as usize];
+            ThreadState {
+                pc: rip as usize,
+                fuel: r15,
+            }
+        } else if #[cfg(all(target_os = "macos", target_arch = "aarch64"))] {
+            let cx = &*(cx as *const libc::ucontext_t);
+            let pc = (*cx.uc_mcontext).__ss.__pc as *const u8;
+            let x21 = (*cx.uc_mcontext).__ss.__x[21] as i64;
+            ThreadState {
+                pc: pc as usize,
+                fuel: x21,
+            }
+        } else {
+            panic!("unsupported platform")
+        }
+    }
+}

--- a/crates/runtime/src/outband_fuel/macos.rs
+++ b/crates/runtime/src/outband_fuel/macos.rs
@@ -1,0 +1,79 @@
+//! macOS implementation of `outband_fuel`.
+
+use mach::{
+    kern_return::kern_return_t,
+    mach_init::mach_thread_self,
+    mach_types::thread_port_t,
+    message::mach_msg_type_number_t,
+    thread_act::{thread_get_state, thread_resume, thread_suspend},
+    thread_status::{thread_state_flavor_t, thread_state_t},
+};
+use std::mem;
+
+pub static ARM_THREAD_STATE64: thread_state_flavor_t = 6;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub static THREAD_STATE_NONE: thread_state_flavor_t = 13;
+#[cfg(target_arch = "aarch64")]
+pub static THREAD_STATE_NONE: thread_state_flavor_t = 5;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialOrd, PartialEq, Eq, Ord)]
+pub struct arm_thread_state64_t {
+    pub __x: [u64; 29],
+    pub __fp: u64, // frame pointer x29
+    pub __lr: u64, // link register x30
+    pub __sp: u64, // stack pointer x31
+    pub __pc: u64,
+    pub __cpsr: u32,
+    pub __pad: u32,
+}
+
+impl arm_thread_state64_t {
+    pub fn count() -> mach_msg_type_number_t {
+        (mem::size_of::<Self>() / mem::size_of::<u32>()) as mach_msg_type_number_t
+    }
+}
+
+extern "C" {
+    pub fn thread_set_state(
+        target_act: thread_port_t,
+        flavor: thread_state_flavor_t,
+        new_state: thread_state_t,
+        new_stateCnt: mach_msg_type_number_t,
+    ) -> kern_return_t;
+}
+
+pub struct CheckHandle {
+    target: thread_port_t,
+}
+
+impl CheckHandle {
+    pub fn from_current_thread() -> Self {
+        Self {
+            // TODO: mach_thread_self requires deallocation to balance.
+            // also, chromium uses pthread_mach_thread_np(pthread_self()) which is two
+            // libc calls and no system calls.
+            // https://codereview.chromium.org/276043002/
+            target: unsafe { mach_thread_self() },
+        }
+    }
+
+    pub fn check(&self) {
+        // TODO:
+        // This function should:
+        //
+        // - check if the thread is the same as the current one. If it is then bail.
+        // - suspend the thread.
+        // - get the current state of the thread.
+        // - check the fuel register in the state.
+        // - if the fuel register is overflown, then modify the state to point to the trap shim,
+        //   and set the current state of the thread.
+        // - resume the thread.
+        unimplemented!()
+    }
+}
+
+// TODO: The trap shim. Among other things it should flush the fuel reg into the runtime limits.
+
+pub fn platform_init() {}

--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -357,7 +357,7 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
     // pointer value and if `MAP` changes happen after we read our entry that's
     // ok since they won't invalidate our entry.
     let pc = get_pc(&thread_state);
-    if !super::IS_WASM_PC(pc as usize) {
+    if !super::IS_WASM_TRAP_PC(pc as usize) {
         return false;
     }
 
@@ -384,6 +384,7 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
 /// of the wasm code.
 unsafe extern "C" fn unwind(wasm_pc: *const u8) -> ! {
     let jmp_buf = tls::with(|state| {
+        // TODO: flush the fuel reg into VMRuntimeLimits.
         let state = state.unwrap();
         state.capture_backtrace(wasm_pc);
         state.jmp_buf.get()

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -312,6 +312,7 @@ impl Component {
             types: &ComponentTypes,
             provided_trampolines: &HashSet<SignatureIndex>,
         ) -> Result<Vec<(SignatureIndex, Box<dyn Any + Send>)>> {
+            let tunables = &engine.config().tunables;
             // All lowered functions will require a trampoline to be available in
             // case they're used when entering wasm. For example a lowered function
             // could be immediately lifted in which case we'll need a trampoline to
@@ -340,7 +341,12 @@ impl Component {
             trampolines_to_compile.sort();
             engine.run_maybe_parallel(trampolines_to_compile.clone(), |i| {
                 let ty = &types[*i];
-                Ok((*i, engine.compiler().compile_host_to_wasm_trampoline(ty)?))
+                Ok((
+                    *i,
+                    engine
+                        .compiler()
+                        .compile_host_to_wasm_trampoline(tunables, ty)?,
+                ))
             })
         }
     }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -417,7 +417,9 @@ pub use crate::module::Module;
 pub use crate::r#ref::ExternRef;
 #[cfg(feature = "async")]
 pub use crate::store::CallHookHandler;
-pub use crate::store::{AsContext, AsContextMut, CallHook, Store, StoreContext, StoreContextMut};
+pub use crate::store::{
+    AsContext, AsContextMut, CallHook, OutbandFuelCheckHandle, Store, StoreContext, StoreContextMut,
+};
 pub use crate::trap::*;
 pub use crate::types::*;
 pub use crate::values::*;
@@ -454,6 +456,7 @@ fn _assert_send_sync() {
     _assert::<ExternRef>();
     _assert::<InstancePre<()>>();
     _assert::<InstancePre<*mut u8>>();
+    _assert::<OutbandFuelCheckHandle>();
 
     #[cfg(feature = "async")]
     fn _call_async(s: &mut Store<()>, f: Func) {

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -25,7 +25,7 @@ use wasmtime_runtime::{
 mod registry;
 mod serialization;
 
-pub use registry::{is_wasm_trap_pc, ModuleRegistry};
+pub use registry::{is_wasm_pc, is_wasm_trap_pc, ModuleRegistry};
 #[cfg(feature = "component-model")]
 pub use registry::{register_component, unregister_component};
 pub use serialization::SerializedModule;
@@ -404,7 +404,7 @@ impl Module {
             || -> Result<_> {
                 engine.run_maybe_parallel(translation.exported_signatures.clone(), |sig| {
                     let ty = &types[sig];
-                    Ok(compiler.compile_host_to_wasm_trampoline(ty)?)
+                    Ok(compiler.compile_host_to_wasm_trampoline(tunables, ty)?)
                 })
             },
         );

--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -414,6 +414,7 @@ impl<'a> SerializedModule<'a> {
             generate_native_debuginfo,
             parse_wasm_debuginfo,
             consume_fuel,
+            outband_fuel,
             epoch_interruption,
             static_memory_bound_is_maximum,
             guard_before_linear_memory,
@@ -454,6 +455,7 @@ impl<'a> SerializedModule<'a> {
             "WebAssembly backtrace support",
         )?;
         Self::check_bool(consume_fuel, other.consume_fuel, "fuel support")?;
+        Self::check_bool(outband_fuel, other.outband_fuel, "outband fuel")?;
         Self::check_bool(
             epoch_interruption,
             other.epoch_interruption,

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -115,10 +115,12 @@ where
     F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<(), Trap> + Send + Sync + 'static,
 {
     let mut obj = engine.compiler().object()?;
+    let tunables = &engine.config().tunables;
     let (t1, t2) = engine.compiler().emit_trampoline_obj(
         ft.as_wasm_func_type(),
         stub_fn::<F> as usize,
         &mut obj,
+        tunables,
     )?;
     let obj = wasmtime_jit::mmap_vec_from_obj(obj)?;
 

--- a/examples/fuel.rs
+++ b/examples/fuel.rs
@@ -8,26 +8,50 @@ use wasmtime::*;
 fn main() -> Result<()> {
     let mut config = Config::new();
     config.consume_fuel(true);
+    config.outband_fuel(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
-    store.add_fuel(10_000)?;
+    store.add_fuel(114_057_726)?;
     let module = Module::from_file(store.engine(), "examples/fuel.wat")?;
     let instance = Instance::new(&mut store, &module, &[])?;
 
+    init_outband_fuel_check(&store);
+
     // Invoke `fibonacci` export with higher and higher numbers until we exhaust our fuel.
-    let fibonacci = instance.get_typed_func::<i32, i32, _>(&mut store, "fibonacci")?;
+    // HACK: I did not bother fixing the trampolines stuff for the typed funcs.
+    let fibonacci = instance
+        .get_func(&mut store, "fibonacci")
+        .ok_or_else(|| anyhow::anyhow!("fuel.wat does not export 'fibonacci'"))?;
     for n in 1.. {
         let fuel_before = store.fuel_consumed().unwrap();
-        let output = match fibonacci.call(&mut store, n) {
-            Ok(v) => v,
+        let mut outputs = [Val::I32(0)];
+        let output = match fibonacci.call(&mut store, &[Val::I32(n as i32)], &mut outputs) {
+            Ok(()) => outputs[0].clone().unwrap_i32(),
             Err(_) => {
-                println!("Exhausted fuel computing fib({})", n);
+                let fuel_consumed = store.fuel_consumed().unwrap() - fuel_before;
+                println!(
+                    "Exhausted fuel computing fib({}), consumed: {} fuel",
+                    n, fuel_consumed
+                );
                 break;
             }
         };
         let fuel_consumed = store.fuel_consumed().unwrap() - fuel_before;
-        println!("fib({}) = {} [consumed {} fuel]", n, output, fuel_consumed);
+        // println!("fib({}) = {} [consumed {} fuel]", n, output, fuel_consumed);
         store.add_fuel(fuel_consumed)?;
     }
     Ok(())
+}
+
+fn init_outband_fuel_check<T>(store: &Store<T>) {
+    let checker = store.current_thread_outband_fuel_checker();
+    std::thread::spawn(move || loop {
+        #[allow(deprecated)]
+        std::thread::sleep_ms(1000);
+        checker.check();
+    });
+
+    // wait for some time to allow the spawned thread to start.
+    #[allow(deprecated)]
+    std::thread::sleep_ms(100);
 }

--- a/examples/fuel.wat
+++ b/examples/fuel.wat
@@ -2,7 +2,7 @@
   (func $fibonacci (param $n i32) (result i32)
     (if
       (i32.lt_s (local.get $n) (i32.const 2))
-      (unreachable)
+      (return (local.get $n))
     )
     (i32.add
       (call $fibonacci (i32.sub (local.get $n) (i32.const 1)))

--- a/examples/fuel.wat
+++ b/examples/fuel.wat
@@ -2,7 +2,7 @@
   (func $fibonacci (param $n i32) (result i32)
     (if
       (i32.lt_s (local.get $n) (i32.const 2))
-      (return (local.get $n))
+      (unreachable)
     )
     (i32.add
       (call $fibonacci (i32.sub (local.get $n) (i32.const 1)))

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -26,6 +26,7 @@ impl<'a> Parse<'a> for FuelWast<'a> {
 
 #[test]
 fn run() -> Result<()> {
+    env_logger::init();
     let test = std::fs::read_to_string("tests/all/fuel.wast")?;
     let buf = ParseBuffer::new(&test)?;
     let mut wast = parser::parse::<FuelWast<'_>>(&buf)?;
@@ -115,7 +116,9 @@ fn iloop() {
         let module = Module::new(&engine, wat).unwrap();
         let mut store = Store::new(&engine, ());
         store.add_fuel(10_000).unwrap();
-        let error = Instance::new(&mut store, &module, &[]).err().unwrap();
+        let error = Instance::new(&mut store, &module, &[])
+            .err()
+            .expect("expected error");
         assert!(
             error.to_string().contains("all fuel consumed"),
             "bad error: {}",


### PR DESCRIPTION
This is a prototype of the solution for https://github.com/bytecodealliance/wasmtime/issues/4109[^1]. This is very rough and is not intended to be landed as is. Rather, this PR here is to validate that this approach is sensible.

[^1]: I decided to change the name from slacked metering. First, I wanted to avoid mentioning async, so that's why it's not async fuel metering, since that async is orthogonal to the async currently used in wasmtime (as in `Func::call_async`). At the same time I don't know if slacked conveys the meaning (English is not my mother tongue). So I figured that that "out-of-band metering" is a better name. I contract it to `outband` in code, I assume it's fine since I saw people using it elsewhere. Please let me know if you have a better name!

## Introduction

The regular fuel metering holds the fuel in the `vmctx->rumtime_limits->fuel_consumed`. At the beginning of each function, the value is loaded into a local variable. Roughly every basic block the value is increased with the cost of that basic block. The value is checked for overflow at function entries and loop headers. If fuel overflowed, then a certain libcall handles it.  Before leaving a function (normally, through a call or before a trap), the fuel is dumped into the VMRuntimeLimits.

WIth the out-of-band fuel metering, the fuel is now promoted to a dedicated register tapping to the `pinned_reg` cranelift feature. The value is still increased every basic block, but the value does not leave the pinned register within wasm. Only at the wasm-host boundaries, i.e. trampolines & libcalls (not implemented as of this PR, coming later), is the fuel value loaded in or flushed from the pinned register into the `VMRuntimeLimits`. 

Also, no checks are performed in the wasm. The checks are meant to be performed either when crossing the wasm-host boundary or asynchronously. Specifically, on Linux, the check is performed by sending a signal each, e.g., 1ms. The signal handler checks if the signal came from the wasmtime (on a best effort basis) and if the program counter points at some the JIT code. If it does, then that means the pinned register holds the currently consumed fuel value. If the fuel value is overflown, we bail out unwinding the wasm stack.

This kind of mechanism showed a great improvement in performance on our tests while still being deterministic as long as the in-wasm state is irrelevant in the case of the OOG.

Now, the prototype here right now targets x86_64 Linux. There is a plan to support aarch64 and macOS. Windows should also be possible to implement. The prototype does not support async. It would be great to support it, but additional work is required.

## Implementation Notes and Rationale

### Mutex

Right now, before entering we save the tid of the calling thread. This is because theoretically the store can be called from different threads. I also wanted to prepare for the async: potentially the future can be polled on any thread, with each fiber switch we can find ourselves on a new thread.

The problem is with Linux, it turns out that sending signals is a bit of a hassle. The signal's sender cannot know if the destination thread is dead or alive. Moreover, the tid can theoretically be reused and thus a signal could be sent to the wrong thread.

At first, I thought it might be a problem performance-wise, but now I don't think so. The reason is: that the mutex does not get too contended. The mutex is taken on wasm entry & exit and also during the out-of-band fuel check. The latter also uses `try_lock`. The interesting case is when the wasm tries to exit to host but the mutex is held: in that case, the exit will be delayed until the out-of-band check request is finished.

### `rt_tgsigqueueinfo`

I resorted to using a raw syscall `rt_tgsigqueueinfo` on Linux to send the signal. 

I thought about using `pthread_sigqueue` (in constrast to just `pthread_kill`) because it allows to send a `sival`. This is helpful to tell if the signal is coming from wasmtime or not. However, turns out that at least glibc does a bunch of syscalls that we probably don't want to have inside of the out-of-band fuel check request. So I decided to go straight for `rt_tgsigqueueinfo`. It takes the `siginfo_t` but it seems like the kernel does not use that and passes it as is, so I used this opportunity pass dummy values.

Another potential problem that I am not sure needs to be tackled: the `pid` is cached during the creation of the out-of-band check handle. This is not entirely correct since theoretically, it can change, but I figured it does not warrant worrying.

## Future Work

If this gets a green light, then several things will need to be done in the future:

As I mentioned above it should work on other platforms, namely aarch64, macOS, and possibly Windows.

Then, make it work with async. That is actually a bit tricky. The main problem revolves around handling the yields. Specifically with Linux, if a signal handler interrupted the wasm code and figured it was OOG, it should yield the execution. Not sure how good is the idea to switch fibers from inside a signal handler. With macOS/Windows it's not any better: the check thread should manipulate the target thread so that it's possible to switch the fiber.

In case, that works, we can think of applying the same technique we use here for a high-performance substitution for the [epoch interrupts](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/Can.20async.20traps.20subsume.20epoch-interruptions.3F).
