### PR TITLE
cranelift: Add a new, optional flag for preserving frame pointers

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -238,6 +238,19 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_bool(
+        "preserve_frame_pointers",
+        "Preserve frame pointers",
+        r#"
+            Preserving frame pointers -- even inside leaf functions -- makes it
+            easy to capture the stack of a running program, without requiring any
+            side tables or metadata (like `.eh_frame` sections). Many sampling
+            profilers and similar tools walk frame pointers to capture stacks.
+            Enabling this option will play nice with those tools.
+        "#,
+        false,
+    );
+
+    settings.add_bool(
         "machine_code_cfg_info",
         "Generate CFG metadata for machine code.",
         r#"
@@ -324,7 +337,7 @@ pub(crate) fn define() -> SettingGroup {
             for the out-of-bounds case, a misspeculation of that conditional
             branch (falsely predicted in-bounds) will select an in-bounds
             index to load on the speculative path.
-            
+
             This option is enabled by default because it is highly
             recommended for secure sandboxing. The embedder should consider
             the security implications carefully before disabling this option.

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1410,12 +1410,13 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
 
         if !self.call_conv.extends_baldrdash() {
             self.fixed_frame_storage_size += total_stacksize;
-            self.setup_frame = M::is_frame_setup_needed(
-                self.is_leaf,
-                self.stack_args_size(),
-                clobbered_callee_saves.len(),
-                self.fixed_frame_storage_size,
-            );
+            self.setup_frame = self.flags.preserve_frame_pointers()
+                || M::is_frame_setup_needed(
+                    self.is_leaf,
+                    self.stack_args_size(),
+                    clobbered_callee_saves.len(),
+                    self.fixed_frame_storage_size,
+                );
 
             insts.extend(
                 M::gen_debug_frame_info(self.call_conv, &self.flags, &self.isa_flags).into_iter(),

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -541,6 +541,7 @@ enable_atomics = true
 enable_safepoints = false
 enable_llvm_abi_extensions = false
 unwind_info = true
+preserve_frame_pointers = false
 machine_code_cfg_info = false
 emit_all_ones_funcaddrs = false
 enable_probestack = true

--- a/cranelift/filetests/filetests/isa/aarch64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf.clif
@@ -1,0 +1,15 @@
+;; Test compilation of leaf functions without preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target aarch64
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+; block0:
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
@@ -1,0 +1,18 @@
+;; Test compilation of leaf functions while preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=true
+target aarch64
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   ldp fp, lr, [sp], #16
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf.clif
@@ -1,0 +1,20 @@
+;; Test compilation of leaf functions without preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target x86_64
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
@@ -1,0 +1,20 @@
+;; Test compilation of leaf functions while preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=true
+target x86_64
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -393,6 +393,7 @@ impl Engine {
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now
             | "opt_level" // opt level doesn't change semantics
+            | "preserve_frame_pointers" // we don't currently rely on frame pointers
             | "enable_alias_analysis" // alias analysis-based opts don't change semantics
             | "probestack_func_adjusts_sp" // probestack above asserted disabled
             | "probestack_size_log2" // probestack above asserted disabled


### PR DESCRIPTION
This flag is optional, but when it is set then Cranelift backends must preserve frame pointers (or ISA equivalent).

Preserving frame pointers -- even inside leaf functions -- makes it easy to capture the stack of a running program, without requiring any side tables or metadata (like `.eh_frame` sections). Many sampling profilers and similar tools walk frame pointers to capture stacks. Enabling this option will play nice with those tools.

Our `x64` backend already unconditionally preserves frame pointers, so it is trivially conforming with this new flag.

Our `aarch64` backend preserves frame pointers or not based on whether the `machinst` framework tells it to or not by calling `gen_prologue_frame_setup`, and the `machinst` framework looks at this new flag when deciding whether to call the backend's implementation of `gen_prologue_frame_setup`, so it is conforming with this new flag.

However, our `s390x` backend has an empty implementation of `gen_prologue_frame_setup`, and so it is _not_ preserving frame pointers when this new flag is set. We will need a follow up PR that brings our `s390x` backend into conformance with this new flag.

cc @uweigand, your help with this last bit would be very appreciated, as I'm not familiar with `s390x`.

cc https://github.com/bytecodealliance/wasmtime/pull/4431

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
