### PR TITLE
s390x: Support preserve_frame_pointers flag

### DIFF
--- a/cranelift/filetests/filetests/isa/s390x/leaf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf.clif
@@ -1,0 +1,15 @@
+;; Test compilation of leaf functions without preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target s390x
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+; block0:
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
@@ -1,0 +1,21 @@
+;; Test compilation of leaf functions while preserving frame pointers.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=true
+target s390x
+
+function %leaf(i64) -> i64 {
+block0(v0: i64):
+    return v0
+}
+
+;   stmg %r14, %r15, 112(%r15)
+;   lgr %r1, %r15
+;   aghi %r15, -160
+;   virtual_sp_offset_adjust 160
+;   stg %r1, 0(%r15)
+; block0:
+;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+


### PR DESCRIPTION
On s390x, we do not have a frame pointer that can be used to chain
stack frames for easy unwinding.  Instead, our ABI defines a stack
"backchain" mechanism that can be used to the same effect.

This PR uses that backchain mechanism to implement the new
preserve_frame_pointers flags introduced here:
https://github.com/bytecodealliance/wasmtime/pull/4469

FYI @fitzgen @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
