### PR TITLE
Add a cranelift flag to enable/disable verbose logs for regalloc2

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -18,6 +18,18 @@ pub(crate) fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "regalloc_verbose_logs",
+        "Enable verbose debug logs for regalloc2.",
+        r#"
+            This adds extra logging for regalloc2 output, that is quite valuable to understand
+            decisions taken by the register allocator as well as debugging it. It is disabled by
+            default, as it can cause many log calls which can slow down compilation by a large
+            amount.
+        "#,
+        false,
+    );
+
     settings.add_enum(
         "opt_level",
         "Optimization level for generated code.",

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -33,7 +33,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     let regalloc_result = {
         let _tt = timing::regalloc();
         let mut options = RegallocOptions::default();
-        options.verbose_log = log::log_enabled!(log::Level::Trace);
+        options.verbose_log = b.flags().regalloc_verbose_logs();
         regalloc2::run(&vcode, machine_env, &options)
             .map_err(|err| {
                 log::error!(

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -527,6 +527,7 @@ libcall_call_conv = "isa_default"
 baldrdash_prologue_words = 0
 probestack_size_log2 = 12
 regalloc_checker = false
+regalloc_verbose_logs = false
 enable_alias_analysis = true
 enable_verifier = true
 is_pic = false

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -389,6 +389,7 @@ impl Engine {
             | "enable_simd"
             | "enable_verifier"
             | "regalloc_checker"
+            | "regalloc_verbose_logs"
             | "is_pic"
             | "machine_code_cfg_info"
             | "tls_model" // wasmtime doesn't use tls right now


### PR DESCRIPTION
Instead of relying on the `log_enabled` check to decide whether to enable regalloc2 verbose logs, I propose to use an explicit Cranelift flag to do that, as it's more explicit and allows downstream users to use the `log::trace!()` level without suffering from a big performance penalty.

The flag is disabled by default, because I assume this is only useful when debugging regalloc2 or understanding the decisions it took during register allocation.

As a matter of fact, in our embedding where we enable the `Trace` level to get all logs (and filter them selectively in some `tracing` subscribers), this is a 32% compile time speedup when compiling a large module in parallel on my machine.