### PR TITLE
x64: Port func_addr and symbol_value to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1530,11 +1530,6 @@
 (decl i64_from_offset (i64) Offset32)
 (extern extractor infallible i64_from_offset i64_from_offset)
 
-;; Accessors for `ExternalName`.
-
-(decl box_external_name (ExternalName) BoxExternalName)
-(extern constructor box_external_name box_external_name)
-
 ;; Accessors for `MemFlags`.
 
 (decl littleendian () MemFlags)

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -579,11 +579,6 @@ where
     }
 
     #[inline]
-    fn box_external_name(&mut self, name: ExternalName) -> BoxExternalName {
-        Box::new(name)
-    }
-
-    #[inline]
     fn memflags_trusted(&mut self) -> MemFlags {
         MemFlags::trusted()
     }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1488,6 +1488,15 @@
 
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Helper for constructing a LoadExtName instruction.
+(decl load_ext_name (ExternalName i64) Reg)
+(rule (load_ext_name extname offset)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.LoadExtName dst
+                                             (box_external_name extname)
+                                             offset))))
+        dst))
+
 ;; Load a value into a register.
 (decl x64_load (Type SyntheticAmode ExtKind) Reg)
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1492,9 +1492,7 @@
 (decl load_ext_name (ExternalName i64) Reg)
 (rule (load_ext_name extname offset)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LoadExtName dst
-                                             (box_external_name extname)
-                                             offset))))
+            (_ Unit (emit (MInst.LoadExtName dst extname offset))))
         dst))
 
 ;; Load a value into a register.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2828,6 +2828,16 @@
 (rule (lower (fence))
       (side_effect (x64_mfence)))
 
+;; Rules for `func_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (func_addr (func_ref_data _ extname _)))
+      (load_ext_name extname 0))
+
+;; Rules for `symbol_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (symbol_value (symbol_value_data extname _ offset)))
+      (load_ext_name extname offset))
+
 ;; Rules for `atomic_load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; This is a normal load. The x86-TSO memory model provides sufficient

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -17,7 +17,6 @@ use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
 use crate::settings::{Flags, TlsModel};
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use log::trace;
 use smallvec::SmallVec;
@@ -900,7 +899,31 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::Fdemote
         | Opcode::Fvdemote
         | Opcode::Icmp
-        | Opcode::Fcmp => {
+        | Opcode::Fcmp
+        | Opcode::Load
+        | Opcode::Uload8
+        | Opcode::Sload8
+        | Opcode::Uload16
+        | Opcode::Sload16
+        | Opcode::Uload32
+        | Opcode::Sload32
+        | Opcode::Sload8x8
+        | Opcode::Uload8x8
+        | Opcode::Sload16x4
+        | Opcode::Uload16x4
+        | Opcode::Sload32x2
+        | Opcode::Uload32x2
+        | Opcode::Store
+        | Opcode::Istore8
+        | Opcode::Istore16
+        | Opcode::Istore32
+        | Opcode::AtomicRmw
+        | Opcode::AtomicCas
+        | Opcode::AtomicLoad
+        | Opcode::AtomicStore
+        | Opcode::Fence
+        | Opcode::FuncAddr
+        | Opcode::SymbolValue => {
             implemented_in_isle(ctx);
         }
 
@@ -2076,68 +2099,6 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 };
                 emit_vm_call(ctx, flags, triple, libcall, insn, inputs, outputs)?;
             }
-        }
-
-        Opcode::Load
-        | Opcode::Uload8
-        | Opcode::Sload8
-        | Opcode::Uload16
-        | Opcode::Sload16
-        | Opcode::Uload32
-        | Opcode::Sload32
-        | Opcode::Sload8x8
-        | Opcode::Uload8x8
-        | Opcode::Sload16x4
-        | Opcode::Uload16x4
-        | Opcode::Sload32x2
-        | Opcode::Uload32x2 => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::Store | Opcode::Istore8 | Opcode::Istore16 | Opcode::Istore32 => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::AtomicRmw => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::AtomicCas => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::AtomicLoad => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::AtomicStore => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::Fence => {
-            implemented_in_isle(ctx);
-        }
-
-        Opcode::FuncAddr => {
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let (extname, _) = ctx.call_target(insn).unwrap();
-            let extname = extname.clone();
-            ctx.emit(Inst::LoadExtName {
-                dst,
-                name: Box::new(extname),
-                offset: 0,
-            });
-        }
-
-        Opcode::SymbolValue => {
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let (extname, _, offset) = ctx.symbol_value(insn).unwrap();
-            let extname = extname.clone();
-            ctx.emit(Inst::LoadExtName {
-                dst,
-                name: Box::new(extname),
-                offset,
-            });
         }
 
         Opcode::DynamicStackAddr => unimplemented!("DynamicStackAddr"),

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -531,6 +531,11 @@ macro_rules! isle_prelude_methods {
         }
 
         #[inline]
+        fn box_external_name(&mut self, extname: ExternalName) -> BoxExternalName {
+            Box::new(extname)
+        }
+
+        #[inline]
         fn symbol_value_data(
             &mut self,
             global_value: GlobalValue,

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -805,3 +805,4 @@
 (convert Reg InstOutput output_reg)
 (convert Value InstOutput output_value)
 (convert Offset32 u32 offset32_to_u32)
+(convert ExternalName BoxExternalName box_external_name)

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -656,6 +656,9 @@
 (decl symbol_value_data (ExternalName RelocDistance i64) GlobalValue)
 (extern extractor symbol_value_data symbol_value_data)
 
+(decl box_external_name (ExternalName) BoxExternalName)
+(extern constructor box_external_name box_external_name)
+
 ;; Accessor for `RelocDistance`.
 
 (decl reloc_distance_near () RelocDistance)

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -1,0 +1,35 @@
+test compile precise-output
+target x86_64
+
+function %func_addr() -> i64 {
+    fn0 = %func0(i64) -> i64
+
+block0:
+    v0 = func_addr.i64 fn0
+    return v0
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %func0+0, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %symbol_value() -> i64 {
+    gv0 = symbol %global0
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %global0+0, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+


### PR DESCRIPTION
Move the `func_addr` lowering for x64 into ISLE, and add a compile test for it. Additionally, change the `name` argument for `LoadExtAddr` from a `Box<ExternalName>` to `ExternalName`, as it greatly simplifies the interface with ISLE, and there didn't appear to be a downside.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
