### PR TITLE
Components: ignore type exports (for now).

### DIFF
--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -604,7 +604,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                 for export in s {
                     let export = export?;
 
-                    // TODO: remove this check once type exports are supported
+                    // TODO: https://github.com/bytecodealliance/wasmtime/issues/4494
                     // Currently, wit-component-based tooling creates components that
                     // export types to represent the interface of a component so that
                     // bindings can (potentially) be generated directly from the component

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -603,6 +603,16 @@ impl<'a, 'data> Translator<'a, 'data> {
                 self.validator.component_export_section(&s)?;
                 for export in s {
                     let export = export?;
+
+                    // TODO: remove this check once type exports are supported
+                    // Currently, wit-component-based tooling creates components that
+                    // export types to represent the interface of a component so that
+                    // bindings can (potentially) be generated directly from the component
+                    // itself without a wit file. For now, we ignore these exports in Wasmtime.
+                    if wasmparser::ComponentExternalKind::Type == export.kind {
+                        continue;
+                    }
+
                     let item = self.kind_to_item(export.kind, export.index);
                     let prev = self.result.exports.insert(export.name, item);
                     assert!(prev.is_none());

--- a/tests/all/component_model/instance.rs
+++ b/tests/all/component_model/instance.rs
@@ -55,20 +55,3 @@ fn instance_exports() -> Result<()> {
 
     Ok(())
 }
-
-#[test]
-fn instantiate_with_type_exports() -> Result<()> {
-    // For now, this just tests that we can instantiate a component with type exports
-    let engine = super::engine();
-    let component = r#"
-        (component
-            (type string)
-            (export "" (type 0))
-        )
-    "#;
-    let component = Component::new(&engine, component)?;
-    let mut store = Store::new(&engine, ());
-    let linker = Linker::new(&engine);
-    linker.instantiate(&mut store, &component)?;
-    Ok(())
-}

--- a/tests/all/component_model/instance.rs
+++ b/tests/all/component_model/instance.rs
@@ -55,3 +55,20 @@ fn instance_exports() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn instantiate_with_type_exports() -> Result<()> {
+    // For now, this just tests that we can instantiate a component with type exports
+    let engine = super::engine();
+    let component = r#"
+        (component
+            (type string)
+            (export "" (type 0))
+        )
+    "#;
+    let component = Component::new(&engine, component)?;
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    linker.instantiate(&mut store, &component)?;
+    Ok(())
+}

--- a/tests/misc_testsuite/component-model/instance.wast
+++ b/tests/misc_testsuite/component-model/instance.wast
@@ -67,6 +67,12 @@
   ))
 )
 
+;; Test to see if a component with a type export can be instantiated.
+(component
+    (type string)
+    (export "" (type 0))
+)
+
 ;; double-check the start function runs by ensuring that a trap shows up and it
 ;; sees the wrong value for the global import
 (assert_trap


### PR DESCRIPTION
This PR updates component translation to ignore type exports for now.

Components generated with `wit-component` contain type exports to give names to
types used within the component's functions based on the component's wit
definition.

The intention is to allow bindings to be generated with meaningful names
directly from a component. In the future, type exports (and imports) may be
used for more than this purpose to support things like resource types.

This PR effectively ignores type exports when translating the component as
they are not useful to executing a component at this time.

Closes #4415.