### PR TITLE
[0.39.0] Backport CI fixes 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,17 @@
 --------------------------------------------------------------------------------
 
+## 0.39.1
+
+Released 2022-07-20.
+
+### Fixed
+
+* An s390x-specific codegen bug in addition to a mistake introduced in the fix
+  of CVE-2022-31146 were fixed.
+  [#4490](https://github.com/bytecodealliance/wasmtime/pull/4490)
+
+--------------------------------------------------------------------------------
+
 ## 0.39.0
 
 Released 2022-07-20.

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -262,7 +262,8 @@ where
     fn u64_from_value(&mut self, val: Value) -> Option<u64> {
         let inst = self.lower_ctx.dfg().value_def(val).inst()?;
         let constant = self.lower_ctx.get_constant(inst)?;
-        Some(constant)
+        let ty = self.lower_ctx.output_ty(inst, 0);
+        Some(zero_extend_to_u64(constant, self.ty_bits(ty).unwrap()))
     }
 
     #[inline]
@@ -594,6 +595,17 @@ where
     #[inline]
     fn emit(&mut self, inst: &MInst) -> Unit {
         self.lower_ctx.emit(inst.clone());
+    }
+}
+
+/// Zero-extend the low `from_bits` bits of `value` to a full u64.
+#[inline]
+fn zero_extend_to_u64(value: u64, from_bits: u8) -> u64 {
+    assert!(from_bits <= 64);
+    if from_bits >= 64 {
+        value
+    } else {
+        value & ((1u64 << from_bits) - 1)
     }
 }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -598,9 +598,14 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         // will be returned directly to `regalloc2` eventually and all
         // operands/results of instructions will use the alias-resolved vregs
         // from `regalloc2`'s perspective.
+        //
+        // Also note that `reftyped_vregs` can't have duplicates, so after the
+        // aliases are applied duplicates are removed.
         for reg in self.vcode.reftyped_vregs.iter_mut() {
             *reg = Self::resolve_vreg_alias_impl(&self.vcode.vreg_aliases, *reg);
         }
+        self.vcode.reftyped_vregs.sort();
+        self.vcode.reftyped_vregs.dedup();
 
         self.compute_preds_from_succs();
         self.vcode.debug_value_labels.sort_unstable();


### PR DESCRIPTION
This includes an s390x-specific fix for constants but an additional all-platforms fix for the `reftyped_vregs` array.