### PR TITLE
[WIP] x64: Shrink Inst size from 72 to 40 bytes

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -265,14 +265,6 @@ impl MemFlags {
         self.set_vmctx();
         self
     }
-
-    pub(crate) fn as_u8(self) -> u8 {
-        self.bits
-    }
-
-    pub(crate) fn from_u8(bits: u8) -> Self {
-        Self { bits }
-    }
 }
 
 impl fmt::Display for MemFlags {

--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -265,6 +265,14 @@ impl MemFlags {
         self.set_vmctx();
         self
     }
+
+    pub(crate) fn as_u8(self) -> u8 {
+        self.bits
+    }
+
+    pub(crate) fn from_u8(bits: u8) -> Self {
+        Self { bits }
+    }
 }
 
 impl fmt::Display for MemFlags {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -487,7 +487,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             Writable::from_reg(regs::rax()),
         ));
         insts.push(Inst::CallKnown {
-            dest: ExternalName::LibCall(LibCall::Probestack),
+            dest: Box::new(ExternalName::LibCall(LibCall::Probestack)),
             info: Box::new(CallInfo {
                 uses: smallvec![regs::rax()],
                 defs: smallvec![],

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -23,7 +23,7 @@
        ;; Integer arithmetic read-modify-write on memory.
        (AluRM (size OperandSize) ;; 4 or 8
               (op AluRmiROpcode)
-              (src1_dst SyntheticAmode)
+              (src1_dst PackedAmode)
               (src2 Gpr))
 
        ;; Instructions on general-purpose registers that only read src and
@@ -115,11 +115,11 @@
                  (dst WritableGpr))
 
        ;; A plain 64-bit integer load, since MovZX_RM_R can't represent that.
-       (Mov64MR (src SyntheticAmode)
+       (Mov64MR (src PackedAmode)
                 (dst WritableGpr))
 
        ;; Loads the memory address of addr into dst.
-       (LoadEffectiveAddress (addr SyntheticAmode)
+       (LoadEffectiveAddress (addr PackedAmode)
                              (dst WritableGpr))
 
        ;; Sign-extended loads and moves: movs (bl bq wl wq lq) addr reg.
@@ -130,7 +130,7 @@
        ;; Integer stores: mov (b w l q) reg addr.
        (MovRM (size OperandSize) ;; 1, 2, 4, or 8
               (src Gpr)
-              (dst SyntheticAmode))
+              (dst PackedAmode))
 
        ;; Arithmetic shifts: (shl shr sar) (b w l q) imm reg.
        (ShiftR (size OperandSize) ;; 1, 2, 4, or 8
@@ -219,7 +219,7 @@
        ;; movq
        (XmmMovRM (op SseOpcode)
                  (src Reg)
-                 (dst SyntheticAmode))
+                 (dst PackedAmode))
 
        ;; XMM (vector) unary op (to move a constant value into an xmm register):
        ;; movups
@@ -314,7 +314,7 @@
        ;; Control flow instructions.
 
        ;; Direct call: call simm32.
-       (CallKnown (dest ExternalName)
+       (CallKnown (dest BoxExternalName)
                   (info BoxCallInfo))
 
        ;; Indirect call: callq (reg mem)
@@ -405,7 +405,7 @@
        (LockCmpxchg (ty Type) ;; I8, I16, I32, or I64
                     (replacement Reg)
                     (expected Reg)
-                    (mem SyntheticAmode)
+                    (mem PackedAmode)
                     (dst_old WritableReg))
 
        ;; A synthetic instruction, based on a loop around a native `lock
@@ -435,7 +435,7 @@
        ;;   instruction.
        (AtomicRmwSeq (ty Type) ;; I8, I16, I32, or I64
                      (op MachAtomicRmwOp)
-                     (mem SyntheticAmode)
+                     (mem PackedAmode)
                      (operand Reg)
                      (temp WritableReg)
                      (dst_old WritableReg))
@@ -471,11 +471,11 @@
 
        ;; A call to the `ElfTlsGetAddr` libcall. Returns address of TLS symbol
        ;; in `rax`.
-       (ElfTlsGetAddr (symbol ExternalName))
+       (ElfTlsGetAddr (symbol BoxExternalName))
 
        ;; A Mach-O TLS symbol access. Returns address of the TLS symbol in
        ;; `rax`.
-       (MachOTlsGetAddr (symbol ExternalName))
+       (MachOTlsGetAddr (symbol BoxExternalName))
 
        ;; An unwind pseudoinstruction describing the state of the machine at
        ;; this program point.
@@ -722,7 +722,7 @@
 (type RegMemImm extern
       (enum
        (Reg (reg Reg))
-       (Mem (addr SyntheticAmode))
+       (Mem (addr PackedAmode))
        (Imm (simm32 u32))))
 
 ;; Put the given clif value into a `RegMemImm` operand.
@@ -737,7 +737,7 @@
 (type RegMem extern
       (enum
        (Reg (reg Reg))
-       (Mem (addr SyntheticAmode))))
+       (Mem (addr PackedAmode))))
 
 ;; Put the given clif value into a `RegMem` operand.
 ;;
@@ -749,6 +749,14 @@
 (extern constructor put_in_reg_mem put_in_reg_mem)
 
 ;; Addressing modes.
+
+(type PackedAmode extern (enum))
+
+(decl pack_synthetic_amode (SyntheticAmode) PackedAmode)
+(extern constructor pack_synthetic_amode pack_synthetic_amode)
+
+(decl unpack_packed_amode (PackedAmode) SyntheticAmode)
+(extern constructor unpack_packed_amode unpack_packed_amode)
 
 (type SyntheticAmode extern (enum))
 
@@ -1489,11 +1497,11 @@
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Load a value into a register.
-(decl x64_load (Type SyntheticAmode ExtKind) Reg)
+(decl x64_load (Type PackedAmode ExtKind) Reg)
 
 (rule (x64_load (fits_in_32 ty) addr (ExtKind.SignExtend))
       (x64_movsx (ext_mode (ty_bytes ty) 8)
-             addr))
+             (unpack_packed_amode addr)))
 
 (rule (x64_load $I64 addr _ext_kind)
       (let ((dst WritableGpr (temp_writable_gpr))
@@ -1502,28 +1510,28 @@
 
 (rule (x64_load $F32 addr _ext_kind)
       (xmm_unary_rm_r (SseOpcode.Movss)
-                      addr))
+                      (unpack_packed_amode addr)))
 
 (rule (x64_load $F64 addr _ext_kind)
       (xmm_unary_rm_r (SseOpcode.Movsd)
-                      addr))
+                      (unpack_packed_amode addr)))
 
 (rule (x64_load $F32X4 addr _ext_kind)
       (xmm_unary_rm_r (SseOpcode.Movups)
-                      addr))
+                      (unpack_packed_amode addr)))
 
 (rule (x64_load $F64X2 addr _ext_kind)
       (xmm_unary_rm_r (SseOpcode.Movupd)
-                      addr))
+                      (unpack_packed_amode addr)))
 
 (rule (x64_load (multi_lane _bits _lanes) addr _ext_kind)
       (xmm_unary_rm_r (SseOpcode.Movdqu)
-                      addr))
+                      (unpack_packed_amode addr)))
 
 (decl x64_mov (Amode) Reg)
 (rule (x64_mov addr)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.Mov64MR addr dst))))
+            (_ Unit (emit (MInst.Mov64MR (pack_synthetic_amode addr) dst))))
         dst))
 
 (decl x64_movzx (ExtMode GprMem) Gpr)
@@ -1585,11 +1593,11 @@
 (decl x64_movrm (Type SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_movrm ty addr data)
       (let ((size OperandSize (raw_operand_size_of_type ty)))
-        (SideEffectNoResult.Inst (MInst.MovRM size data addr))))
+        (SideEffectNoResult.Inst (MInst.MovRM size data (pack_synthetic_amode addr)))))
 
 (decl x64_xmm_movrm (SseOpcode SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_xmm_movrm op addr data)
-      (SideEffectNoResult.Inst (MInst.XmmMovRM op data addr)))
+      (SideEffectNoResult.Inst (MInst.XmmMovRM op data (pack_synthetic_amode addr))))
 
 ;; Load a constant into an XMM register.
 (decl x64_xmm_load_const (Type VCodeConstant) Xmm)
@@ -2663,7 +2671,8 @@
 (decl x64_lea (SyntheticAmode) Gpr)
 (rule (x64_lea addr)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LoadEffectiveAddress addr dst))))
+            (amode PackedAmode (pack_synthetic_amode addr))
+            (_ Unit (emit (MInst.LoadEffectiveAddress amode dst))))
         dst))
 
 ;; Helper for creating `ud2` instructions.
@@ -2898,7 +2907,8 @@
 (decl alu_rm (Type AluRmiROpcode Amode Gpr) SideEffectNoResult)
 (rule (alu_rm ty opcode src1_dst src2)
       (let ((size OperandSize (operand_size_of_type_32_64 ty)))
-        (SideEffectNoResult.Inst (MInst.AluRM size opcode src1_dst src2))))
+        (SideEffectNoResult.Inst
+          (MInst.AluRM size opcode (pack_synthetic_amode src1_dst) src2))))
 
 (decl x64_add_mem (Type Amode Gpr) SideEffectNoResult)
 (rule (x64_add_mem ty addr val)
@@ -2929,14 +2939,16 @@
 (decl x64_cmpxchg (Type Gpr Gpr SyntheticAmode) Gpr)
 (rule (x64_cmpxchg ty expected replacement addr)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LockCmpxchg ty replacement expected addr dst))))
+            (amode PackedAmode (pack_synthetic_amode addr))
+            (_ Unit (emit (MInst.LockCmpxchg ty replacement expected amode dst))))
         dst))
 
 (decl x64_atomic_rmw_seq (Type MachAtomicRmwOp SyntheticAmode Gpr) Gpr)
 (rule (x64_atomic_rmw_seq ty op mem input)
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.AtomicRmwSeq ty op mem input tmp dst))))
+            (amode PackedAmode (pack_synthetic_amode mem))
+            (_ Unit (emit (MInst.AtomicRmwSeq ty op amode input tmp dst))))
         dst))
 
 ;; CLIF IR has one enumeration for atomic operations (`AtomicRmwOp`) while the
@@ -2995,6 +3007,7 @@
 (convert SyntheticAmode GprMem synthetic_amode_to_gpr_mem)
 (convert Amode XmmMem amode_to_xmm_mem)
 (convert SyntheticAmode XmmMem synthetic_amode_to_xmm_mem)
+(convert SyntheticAmode PackedAmode pack_synthetic_amode)
 
 (convert IntCC CC intcc_to_cc)
 (convert AtomicRmwOp MachAtomicRmwOp atomic_rmw_op_to_mach_atomic_rmw_op)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -364,8 +364,8 @@
                     (tmp1 WritableReg)
                     (tmp2 WritableReg)
                     (default_target MachLabel)
-                    (targets VecMachLabel)
-                    (targets_for_term VecMachLabel))
+                    (targets BoxVecMachLabel)
+                    (targets_for_term BoxVecMachLabel))
 
        ;; Indirect jump: jmpq (reg mem).
        (JmpUnknown (target RegMem))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -482,7 +482,9 @@
        (Unwind (inst UnwindInst))
 
        ;; A pseudoinstruction that just keeps a value alive.
-       (DummyUse (reg Reg))))
+       (DummyUse (reg Reg) (pad Padding))))
+
+(type Padding extern (enum))
 
 (type OperandSize extern
       (enum Size8

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -437,6 +437,7 @@ pub enum PackedAmodeTag {
 }
 
 impl PackedAmodeTag {
+    #[inline(always)]
     fn value(self) -> u8 {
         match self {
             Self::ImmReg => 0,
@@ -449,6 +450,7 @@ impl PackedAmodeTag {
 }
 
 impl From<&PackedAmode> for PackedAmodeTag {
+    #[inline(always)]
     fn from(val: &PackedAmode) -> Self {
         match val.0 as u8 {
             0 => PackedAmodeTag::ImmReg,
@@ -481,30 +483,36 @@ impl From<&PackedAmode> for PackedAmodeTag {
 pub struct PackedAmode(u64, u64);
 
 impl PackedAmode {
+    #[inline(always)]
     fn mem_flags(&self) -> MemFlags {
         MemFlags::from_u8((self.0 >> 16) as u8)
     }
 
+    #[inline(always)]
     fn shift(&self) -> u8 {
         (self.0 >> 8) as u8
     }
 
+    #[inline(always)]
     fn base_vreg(&self) -> VReg {
         let val = (self.1 & 0xfffffff) as usize;
         assert!(val < VReg::MAX);
         VReg::new(val, RegClass::Int)
     }
 
+    #[inline(always)]
     fn index_vreg(&self) -> VReg {
         let val = ((self.1 >> 32) & 0xfffffff) as usize;
         assert!(val < VReg::MAX);
         VReg::new(val, RegClass::Int)
     }
 
+    #[inline(always)]
     fn simm32(&self) -> u32 {
         (self.0 >> 32) as u32
     }
 
+    #[inline(always)]
     fn imm_reg(simm32: u32, base: Reg, flags: MemFlags) -> Self {
         let tag = PackedAmodeTag::ImmReg.value() as u64;
         let flags = (flags.as_u8() as u64) << 16;
@@ -513,6 +521,7 @@ impl PackedAmode {
         Self(tag | flags | simm32, base)
     }
 
+    #[inline(always)]
     fn as_imm_reg(&self) -> Amode {
         Amode::ImmReg {
             simm32: self.simm32(),
@@ -521,6 +530,7 @@ impl PackedAmode {
         }
     }
 
+    #[inline(always)]
     fn imm_reg_reg_shift(simm32: u32, base: Gpr, index: Gpr, shift: u8, flags: MemFlags) -> Self {
         let tag = PackedAmodeTag::ImmRegRegShift.value() as u64;
         let shift = (shift as u64) << 8;
@@ -531,6 +541,7 @@ impl PackedAmode {
         Self(tag | shift | flags | simm32, base | index)
     }
 
+    #[inline(always)]
     fn as_imm_reg_reg_shift(&self) -> Amode {
         Amode::ImmRegRegShift {
             simm32: self.simm32(),
@@ -541,42 +552,49 @@ impl PackedAmode {
         }
     }
 
+    #[inline(always)]
     fn rip_relative(target: MachLabel) -> Self {
         let tag = PackedAmodeTag::RipRelative.value() as u64;
         let target = (target.as_u32() as u64) << 32;
         Self(tag | target, 0)
     }
 
+    #[inline(always)]
     fn as_rip_relative(&self) -> Amode {
         Amode::RipRelative {
             target: MachLabel::from_u32((self.0 >> 32) as u32),
         }
     }
 
+    #[inline(always)]
     fn nominal_sp_offset(simm32: u32) -> Self {
         let tag = PackedAmodeTag::NominalSPOffset.value() as u64;
         let simm32 = (simm32 as u64) << 32;
         Self(tag | simm32, 0)
     }
 
+    #[inline(always)]
     fn as_nominal_sp_offset(&self) -> SyntheticAmode {
         SyntheticAmode::NominalSPOffset {
             simm32: (self.0 >> 32) as u32,
         }
     }
 
+    #[inline(always)]
     fn constant_offset(offset: VCodeConstant) -> Self {
         let tag = PackedAmodeTag::ConstantOffset.value() as u64;
         let offset = (offset.as_u32() as u64) << 32;
         Self(tag | offset, 0)
     }
 
+    #[inline(always)]
     fn as_constant_offset(&self) -> SyntheticAmode {
         SyntheticAmode::ConstantOffset(VCodeConstant::from_u32((self.0 >> 32) as u32))
     }
 }
 
 impl From<Amode> for PackedAmode {
+    #[inline(always)]
     fn from(amode: Amode) -> Self {
         match amode {
             Amode::ImmReg {
@@ -599,6 +617,7 @@ impl From<Amode> for PackedAmode {
 }
 
 impl From<SyntheticAmode> for PackedAmode {
+    #[inline(always)]
     fn from(amode: SyntheticAmode) -> Self {
         match amode {
             SyntheticAmode::Real(amode) => amode.into(),
@@ -611,6 +630,7 @@ impl From<SyntheticAmode> for PackedAmode {
 impl TryFrom<PackedAmode> for Amode {
     type Error = ();
 
+    #[inline(always)]
     fn try_from(val: PackedAmode) -> Result<Self, ()> {
         match PackedAmodeTag::from(&val) {
             PackedAmodeTag::ImmReg => Ok(val.as_imm_reg()),
@@ -623,6 +643,7 @@ impl TryFrom<PackedAmode> for Amode {
 }
 
 impl From<PackedAmode> for SyntheticAmode {
+    #[inline(always)]
     fn from(val: PackedAmode) -> Self {
         match PackedAmodeTag::from(&val) {
             PackedAmodeTag::ImmReg => SyntheticAmode::Real(val.as_imm_reg()),

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -424,7 +424,9 @@ pub(crate) fn emit(
                     )
                 }
                 RegMem::Mem { addr: src } => {
-                    let amode = SyntheticAmode::from(src.clone()).finalize(state, sink).with_allocs(allocs);
+                    let amode = SyntheticAmode::from(src.clone())
+                        .finalize(state, sink)
+                        .with_allocs(allocs);
                     emit_std_enc_mem(
                         sink,
                         info,
@@ -737,7 +739,9 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &SyntheticAmode::from(src.clone()).finalize(state, sink).with_allocs(allocs);
+                    let src = &SyntheticAmode::from(src.clone())
+                        .finalize(state, sink)
+                        .with_allocs(allocs);
 
                     emit_std_reg_mem(
                         sink,
@@ -839,7 +843,9 @@ pub(crate) fn emit(
                 }
 
                 RegMem::Mem { addr: src } => {
-                    let src = &SyntheticAmode::from(src.clone()).finalize(state, sink).with_allocs(allocs);
+                    let src = &SyntheticAmode::from(src.clone())
+                        .finalize(state, sink)
+                        .with_allocs(allocs);
 
                     emit_std_reg_mem(
                         sink,
@@ -990,7 +996,9 @@ pub(crate) fn emit(
                         emit_std_reg_reg(sink, prefix, opcode_bytes, 2, dst, reg, rex);
                     }
                     RegMemImm::Mem { addr } => {
-                        let addr = &SyntheticAmode::from(addr.clone()).finalize(state, sink).with_allocs(allocs);
+                        let addr = &SyntheticAmode::from(addr.clone())
+                            .finalize(state, sink)
+                            .with_allocs(allocs);
                         emit_std_reg_mem(sink, info, prefix, opcode_bytes, 2, dst, addr, rex, 0);
                     }
                     RegMemImm::Imm { .. } => unreachable!(),
@@ -1038,7 +1046,9 @@ pub(crate) fn emit(
                 }
 
                 RegMemImm::Mem { addr } => {
-                    let addr = &SyntheticAmode::from(addr.clone()).finalize(state, sink).with_allocs(allocs);
+                    let addr = &SyntheticAmode::from(addr.clone())
+                        .finalize(state, sink)
+                        .with_allocs(allocs);
                     // Whereas here we revert to the "normal" G-E ordering for CMP.
                     let opcode = match (*size, is_cmp) {
                         (OperandSize::Size8, true) => 0x3A,
@@ -1119,7 +1129,9 @@ pub(crate) fn emit(
                     emit_std_reg_reg(sink, prefix, opcode, 2, dst, reg, rex_flags);
                 }
                 RegMem::Mem { addr } => {
-                    let addr = &SyntheticAmode::from(addr.clone()).finalize(state, sink).with_allocs(allocs);
+                    let addr = &SyntheticAmode::from(addr.clone())
+                        .finalize(state, sink)
+                        .with_allocs(allocs);
                     emit_std_reg_mem(sink, info, prefix, opcode, 2, dst, addr, rex_flags, 0);
                 }
             }

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4600,25 +4600,28 @@ fn test_x64_emit() {
 
     // ========================================================
     // Pertaining to atomics.
-    let am1: SyntheticAmode =
-        Amode::imm_reg_reg_shift(321, Gpr::new(r10).unwrap(), Gpr::new(rdx).unwrap(), 2).into();
+    let am1: PackedAmode = PackedAmode::from(Amode::imm_reg_reg_shift(
+        321,
+        Gpr::new(r10).unwrap(),
+        Gpr::new(rdx).unwrap(),
+        2,
+    ));
     // `am2` doesn't contribute any 1 bits to the rex prefix, so we must use it when testing
     // for retention of the apparently-redundant rex prefix in the 8-bit case.
-    let am2: SyntheticAmode = Amode::imm_reg_reg_shift(
+    let am2: PackedAmode = PackedAmode::from(Amode::imm_reg_reg_shift(
         -12345i32 as u32,
         Gpr::new(rcx).unwrap(),
         Gpr::new(rsi).unwrap(),
         3,
-    )
-    .into();
+    ));
     // Use `r9` with a 0 offset.
-    let am3: SyntheticAmode = Amode::imm_reg(0, r9).into();
+    let am3: PackedAmode = PackedAmode::from(Amode::imm_reg(0, r9));
 
     // A general 8-bit case.
     insns.push((
         Inst::LockCmpxchg {
             ty: types::I8,
-            mem: am1,
+            mem: am1.into(),
             replacement: rbx,
             expected: rax,
             dst_old: w_rax,
@@ -4836,10 +4839,10 @@ fn test_x64_emit() {
 
     insns.push((
         Inst::ElfTlsGetAddr {
-            symbol: ExternalName::User {
+            symbol: Box::new(ExternalName::User {
                 namespace: 0,
                 index: 0,
-            },
+            }),
         },
         "66488D3D00000000666648E800000000",
         "%rax = elf_tls_get_addr User { namespace: 0, index: 0 }",
@@ -4847,10 +4850,10 @@ fn test_x64_emit() {
 
     insns.push((
         Inst::MachOTlsGetAddr {
-            symbol: ExternalName::User {
+            symbol: Box::new(ExternalName::User {
                 namespace: 0,
                 index: 0,
-            },
+            }),
         },
         "488B3D00000000FF17",
         "%rax = macho_tls_get_addr User { namespace: 0, index: 0 }",

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -48,7 +48,7 @@ pub struct CallInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(48, std::mem::size_of::<Inst>());
+    assert_eq!(40, std::mem::size_of::<Inst>());
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1692,7 +1692,7 @@ impl PrettyPrint for Inst {
                 format!("unwind {:?}", inst)
             }
 
-            Inst::DummyUse { reg } => {
+            Inst::DummyUse { reg, .. } => {
                 let reg = pretty_print_reg(*reg, 8, allocs);
                 format!("dummy_use {}", reg)
             }
@@ -2112,7 +2112,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
 
         Inst::Unwind { .. } => {}
 
-        Inst::DummyUse { reg } => {
+        Inst::DummyUse { reg, .. } => {
             collector.reg_use(*reg);
         }
     }
@@ -2362,7 +2362,7 @@ impl MachInst for Inst {
     }
 
     fn gen_dummy_use(reg: Reg) -> Self {
-        Inst::DummyUse { reg }
+        Inst::DummyUse { reg, pad: [0; 64] }
     }
 
     fn worst_case_size() -> CodeOffset {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -256,8 +256,8 @@ fn input_to_reg_mem_imm<C: LowerCtx<I = Inst>>(ctx: &mut C, spec: InsnInput) -> 
     match non_reg_input_to_sext_imm(input, input_ty) {
         Some(x) => RegMemImm::imm(x),
         None => match input_to_reg_mem(ctx, spec) {
-            RegMem::Reg { reg } => RegMemImm::reg(reg),
-            RegMem::Mem { addr } => RegMemImm::mem(addr),
+            RegMem::Reg { reg } => RegMemImm::Reg { reg },
+            RegMem::Mem { addr } => RegMemImm::Mem { addr },
         },
     }
 }
@@ -2746,14 +2746,18 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let (name, _, _) = ctx.symbol_value(insn).unwrap();
                 let symbol = name.clone();
-                ctx.emit(Inst::ElfTlsGetAddr { symbol });
+                ctx.emit(Inst::ElfTlsGetAddr {
+                    symbol: Box::new(symbol),
+                });
                 ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
             }
             TlsModel::Macho => {
                 let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
                 let (name, _, _) = ctx.symbol_value(insn).unwrap();
                 let symbol = name.clone();
-                ctx.emit(Inst::MachOTlsGetAddr { symbol });
+                ctx.emit(Inst::MachOTlsGetAddr {
+                    symbol: Box::new(symbol),
+                });
                 ctx.emit(Inst::gen_move(dst, regs::rax(), types::I64));
             }
             _ => {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -3308,8 +3308,8 @@ impl LowerBackend for X64Backend {
                         tmp1,
                         tmp2,
                         default_target,
-                        targets: jt_targets,
-                        targets_for_term,
+                        targets: Box::new(jt_targets),
+                        targets_for_term: Box::new(targets_for_term),
                     });
                 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -256,9 +256,7 @@ where
     fn sink_load(&mut self, load: &SinkableLoad) -> RegMemImm {
         self.lower_ctx.sink_inst(load.inst);
         let addr = lower_to_amode(self.lower_ctx, load.addr_input, load.offset);
-        RegMemImm::Mem {
-            addr: SyntheticAmode::Real(addr),
-        }
+        RegMemImm::mem(SyntheticAmode::Real(addr))
     }
 
     #[inline]
@@ -572,6 +570,16 @@ where
     #[inline]
     fn atomic_rmw_op_to_mach_atomic_rmw_op(&mut self, op: &AtomicRmwOp) -> MachAtomicRmwOp {
         MachAtomicRmwOp::from(*op)
+    }
+
+    #[inline]
+    fn pack_synthetic_amode(&mut self, amode: &SyntheticAmode) -> PackedAmode {
+        PackedAmode::from(amode.clone())
+    }
+
+    #[inline]
+    fn unpack_packed_amode(&mut self, packed: &PackedAmode) -> SyntheticAmode {
+        SyntheticAmode::from(packed.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -34,6 +34,8 @@ use std::convert::TryFrom;
 
 type BoxCallInfo = Box<CallInfo>;
 
+type Padding = [u8; 64];
+
 pub struct SinkableLoad {
     inst: Inst,
     addr_input: InsnInput,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -24,7 +24,7 @@ pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
 pub type VecMachLabel = Vec<MachLabel>;
-pub type BoxVecMachLabel = Box<Vec<MachLabel>>;
+pub type BoxVecMachLabel = Box<VecMachLabel>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -24,6 +24,7 @@ pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
 pub type VecMachLabel = Vec<MachLabel>;
+pub type BoxVecMachLabel = Box<Vec<MachLabel>>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);
 

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -84,6 +84,10 @@ impl Reg {
     pub fn is_virtual(self) -> bool {
         self.to_virtual_reg().is_some()
     }
+
+    pub(crate) fn vreg(self) -> usize {
+        self.0.vreg()
+    }
 }
 
 impl std::fmt::Debug for Reg {

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -188,6 +188,7 @@
 
 (type MachLabel (primitive MachLabel))
 (type VecMachLabel extern (enum))
+(type BoxVecMachLabel (primitive BoxVecMachLabel))
 (type ValueLabel (primitive ValueLabel))
 (type UnwindInst (primitive UnwindInst))
 (type ExternalName (primitive ExternalName))


### PR DESCRIPTION
Experimenting with shrinking down the size of `Instr` for the x64 backend. The current state of this PR is that it shrinks the size of `Instr` to 40 bytes by packing the `SyntheticAmode` into 12 bytes instead of 20. There appears to be very little change relative to the main branch in terms of compilation performance when running the spidermonkey benchmark:

```
compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm 

  Δ = 57577216.56 ± 40606058.89 (confidence = 99%)

  branch.so is 0.99x to 1.00x faster than main.so!
  main.so is 1.00x to 1.01x faster than branch.so!

  [10309078912 10526961950.50 10728893296] branch.so
  [10257691628 10469384733.94 10666653846] main.so

compilation :: nanoseconds :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 15991943.37 ± 11279098.93 (confidence = 99%)

  branch.so is 0.99x to 1.00x faster than main.so!
  main.so is 1.00x to 1.01x faster than branch.so!

  [2863534784 2924059356.84 2980149200] branch.so
  [2849263391 2908067413.47 2962864337] main.so
```
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
