### PR TITLE
wiggle's atoms_async test requires wasmtime_async

### DIFF
--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -30,6 +30,11 @@ proptest = "1.0.0"
 tokio = { version = "1", features = ["rt-multi-thread","time", "macros"] }
 
 [[test]]
+name = "atoms_async"
+path = "tests/atoms_async.rs"
+required-features = ["wasmtime_async"]
+
+[[test]]
 name = "wasmtime_async"
 path = "tests/wasmtime_async.rs"
 required-features = ["wasmtime_async", "wasmtime/wat"]


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
