### PR TITLE
cranelift: Don't log CLIF and assembly for whole functions at debug level

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -133,7 +133,7 @@ impl Context {
         self.verify_if(isa)?;
 
         let opt_level = isa.flags().opt_level();
-        log::debug!(
+        log::trace!(
             "Compiling (opt level {:?}):\n{}",
             opt_level,
             self.func.display()

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -76,7 +76,7 @@ impl TargetIsa for X64Backend {
         let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
-            log::debug!("disassembly:\n{}", disasm);
+            log::trace!("disassembly:\n{}", disasm);
         }
 
         Ok(MachCompileResult {


### PR DESCRIPTION
Too verbose. Only log them at trace level.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
