### PR TITLE
cranelift: Fix `icmp_imm` for small types in interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/icmp-eq-imm.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq-imm.clif
@@ -1,0 +1,77 @@
+test interpret
+test run
+target aarch64
+target x86_64
+target s390x
+
+function %icmp_imm_eq_i8(i8) -> b1 {
+block0(v0: i8):
+    v1 = icmp_imm eq v0, 0x44
+    return v1
+}
+; run: %icmp_imm_eq_i8(0) == false
+; run: %icmp_imm_eq_i8(-1) == false
+; run: %icmp_imm_eq_i8(0x44) == true
+
+function %icmp_neg_eq_i8(i8) -> b1 {
+block0(v0: i8):
+    v1 = icmp_imm eq v0, 0xf4
+    return v1
+}
+; run: %icmp_neg_eq_i8(0) == false
+; run: %icmp_neg_eq_i8(-1) == false
+; run: %icmp_neg_eq_i8(0xf4) == true
+
+function %icmp_imm_eq_i16(i16) -> b1 {
+block0(v0: i16):
+    v1 = icmp_imm eq v0, 0x4444
+    return v1
+}
+; run: %icmp_imm_eq_i16(0) == false
+; run: %icmp_imm_eq_i16(-1) == false
+; run: %icmp_imm_eq_i16(0x4444) == true
+
+function %icmp_neg_eq_i16(i16) -> b1 {
+block0(v0: i16):
+    v1 = icmp_imm eq v0, 0xff44
+    return v1
+}
+; run: %icmp_neg_eq_i16(0) == false
+; run: %icmp_neg_eq_i16(-1) == false
+; run: %icmp_neg_eq_i16(0xff44) == true
+
+function %icmp_imm_eq_i32(i32) -> b1 {
+block0(v0: i32):
+    v1 = icmp_imm eq v0, 0x4444_4444
+    return v1
+}
+; run: %icmp_imm_eq_i32(0) == false
+; run: %icmp_imm_eq_i32(-1) == false
+; run: %icmp_imm_eq_i32(0x4444_4444) == true
+
+function %icmp_neg_eq_i32(i32) -> b1 {
+block0(v0: i32):
+    v1 = icmp_imm eq v0, 0xffff_4444
+    return v1
+}
+; run: %icmp_neg_eq_i32(0) == false
+; run: %icmp_neg_eq_i32(-1) == false
+; run: %icmp_neg_eq_i32(0xffff_4444) == true
+
+function %icmp_imm_eq_i64(i64) -> b1 {
+block0(v0: i64):
+    v1 = icmp_imm eq v0, 0x4444_4444_4444_4444
+    return v1
+}
+; run: %icmp_imm_eq_i64(0) == false
+; run: %icmp_imm_eq_i64(-1) == false
+; run: %icmp_imm_eq_i64(0x4444_4444_4444_4444) == true
+
+function %icmp_neg_eq_i64(i64) -> b1 {
+block0(v0: i64):
+    v1 = icmp_imm eq v0, 0xffff_ffff_4444_4444
+    return v1
+}
+; run: %icmp_neg_eq_i64(0) == false
+; run: %icmp_neg_eq_i64(-1) == false
+; run: %icmp_neg_eq_i64(0xffff_ffff_4444_4444) == true

--- a/cranelift/filetests/filetests/runtests/icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_eq_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ne.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_ne_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sge.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 
 function %icmp_sge_i8(i8, i8) -> b1 {

--- a/cranelift/filetests/filetests/runtests/icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sgt.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 
 function %icmp_sgt_i8(i8, i8) -> b1 {

--- a/cranelift/filetests/filetests/runtests/icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sle.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 
 function %icmp_sle_i8(i8, i8) -> b1 {

--- a/cranelift/filetests/filetests/runtests/icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-slt.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_slt_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-uge.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_uge_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ule.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_ule_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ult.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
+target s390x
 
 function %icmp_ult_i8(i8, i8) -> b1 {
 block0(v0: i8, v1: i8):

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -294,9 +294,7 @@ impl Value for DataValue {
         Ok(match kind {
             ValueConversionKind::Exact(ty) => match (self, ty) {
                 // TODO a lot to do here: from bmask to ireduce to raw_bitcast...
-                (DataValue::I64(n), types::I32) => DataValue::I32(i32::try_from(n)?),
-                (DataValue::I64(n), types::I64) => DataValue::I64(n),
-                (DataValue::I64(n), types::I128) => DataValue::I128(n as i128),
+                (DataValue::I64(n), ty) if ty.is_int() => DataValue::from_integer(n as i128, ty)?,
                 (DataValue::F32(n), types::I32) => DataValue::I32(n.bits() as i32),
                 (DataValue::F64(n), types::I64) => DataValue::I64(n.bits() as i64),
                 (DataValue::B(b), t) if t.is_bool() => DataValue::B(b),


### PR DESCRIPTION
👋 Hey,

This was discovered by fuzzgen after fixing the switch API.

This PR also enables a bunch of `icmp` tests for s390x that were probably forgotten. 

CC: #4502
CC: @jameysharp