### PR TITLE
x64: Shrink Inst from 72 to 48 bytes

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -852,6 +852,7 @@
 (type BranchTarget (primitive BranchTarget))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
 (type CodeOffset (primitive CodeOffset))
+(type VecMachLabel extern (enum))
 
 (type ExtendOp extern
   (enum

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -880,6 +880,7 @@
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
+(type VecMachLabel extern (enum))
 
 ;; An ALU operation.
 (type ALUOp

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -364,8 +364,7 @@
                     (tmp1 WritableReg)
                     (tmp2 WritableReg)
                     (default_target MachLabel)
-                    (targets BoxVecMachLabel)
-                    (targets_for_term BoxVecMachLabel))
+                    (targets BoxVecMachLabel))
 
        ;; Indirect jump: jmpq (reg mem).
        (JmpUnknown (target RegMem))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -364,8 +364,8 @@
                     (tmp1 WritableReg)
                     (tmp2 WritableReg)
                     (default_target MachLabel)
-                    (targets VecMachLabel)
-                    (targets_for_term VecMachLabel))
+                    (targets BoxVecMachLabel)
+                    (targets_for_term BoxVecMachLabel))
 
        ;; Indirect jump: jmpq (reg mem).
        (JmpUnknown (target RegMem))
@@ -496,6 +496,8 @@
             SFence))
 
 (type BoxCallInfo extern (enum))
+
+(type BoxVecMachLabel extern (enum))
 
 ;; Get the `OperandSize` for a given `Type`, rounding smaller types up to 32 bits.
 (decl operand_size_of_type_32_64 (Type) OperandSize)

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -48,7 +48,7 @@ pub struct CallInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(72, std::mem::size_of::<Inst>());
+    assert_eq!(48, std::mem::size_of::<Inst>());
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -13,7 +13,6 @@ use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::{x64::settings as x64_settings, x64::X64Backend, CallConv};
-use crate::machinst::isle::BoxVecMachLabel;
 use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
@@ -3254,11 +3253,9 @@ impl LowerBackend for X64Backend {
                     };
                     ctx.emit(Inst::cmp_rmi_r(cmp_size, RegMemImm::imm(jt_size), idx));
 
-                    let targets_for_term: BoxVecMachLabel =
-                        Box::new(targets.iter().cloned().collect());
                     let default_target = targets[0];
 
-                    let jt_targets: BoxVecMachLabel =
+                    let jt_targets: Box<SmallVec<[MachLabel; 4]>> =
                         Box::new(targets.iter().skip(1).cloned().collect());
 
                     ctx.emit(Inst::JmpTableSeq {
@@ -3267,7 +3264,6 @@ impl LowerBackend for X64Backend {
                         tmp2,
                         default_target,
                         targets: jt_targets,
-                        targets_for_term,
                     });
                 }
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -13,11 +13,12 @@ use crate::isa::x64::abi::*;
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::isa::{x64::settings as x64_settings, x64::X64Backend, CallConv};
+use crate::machinst::isle::BoxVecMachLabel;
 use crate::machinst::lower::*;
 use crate::machinst::*;
 use crate::result::CodegenResult;
 use crate::settings::{Flags, TlsModel};
-use alloc::vec::Vec;
+use alloc::boxed::Box;
 use log::trace;
 use smallvec::SmallVec;
 use std::convert::TryFrom;
@@ -3253,10 +3254,12 @@ impl LowerBackend for X64Backend {
                     };
                     ctx.emit(Inst::cmp_rmi_r(cmp_size, RegMemImm::imm(jt_size), idx));
 
-                    let targets_for_term: Vec<MachLabel> = targets.to_vec();
+                    let targets_for_term: BoxVecMachLabel =
+                        Box::new(targets.iter().cloned().collect());
                     let default_target = targets[0];
 
-                    let jt_targets: Vec<MachLabel> = targets.iter().skip(1).cloned().collect();
+                    let jt_targets: BoxVecMachLabel =
+                        Box::new(targets.iter().skip(1).cloned().collect());
 
                     ctx.emit(Inst::JmpTableSeq {
                         idx,

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -29,10 +29,12 @@ use crate::{
         isle::*, InsnInput, InsnOutput, LowerCtx, MachAtomicRmwOp, VCodeConstant, VCodeConstantData,
     },
 };
+use smallvec::SmallVec;
 use std::boxed::Box;
 use std::convert::TryFrom;
 
 type BoxCallInfo = Box<CallInfo>;
+type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 
 pub struct SinkableLoad {
     inst: Inst,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -24,6 +24,7 @@ pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
 pub type VecMachLabel = Vec<MachLabel>;
+pub type BoxVecMachLabel = Box<SmallVec<[MachLabel; 16]>>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -23,7 +23,6 @@ pub type ValueRegs = crate::machinst::ValueRegs<Reg>;
 pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
-pub type VecMachLabel = Vec<MachLabel>;
 pub type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -23,7 +23,6 @@ pub type ValueRegs = crate::machinst::ValueRegs<Reg>;
 pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
-pub type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -24,7 +24,7 @@ pub type WritableValueRegs = crate::machinst::ValueRegs<WritableReg>;
 pub type InstOutput = SmallVec<[ValueRegs; 2]>;
 pub type InstOutputBuilder = Cell<InstOutput>;
 pub type VecMachLabel = Vec<MachLabel>;
-pub type BoxVecMachLabel = Box<SmallVec<[MachLabel; 16]>>;
+pub type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 pub type BoxExternalName = Box<ExternalName>;
 pub type Range = (usize, usize);
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -187,7 +187,6 @@
 ;;;; Common Mach Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (type MachLabel (primitive MachLabel))
-(type VecMachLabel extern (enum))
 (type ValueLabel (primitive ValueLabel))
 (type UnwindInst (primitive UnwindInst))
 (type ExternalName (primitive ExternalName))


### PR DESCRIPTION
This PR pulls out the effective parts of #4496, boxing the tables in `JmpTableSeq`. The performance is roughly the same, but sequential runs show a very small improvement in memory usage. The parameter to the `SmallVec` used in `BoxVecMachLabel` could do with some tuning: 4 performed better than 16, but I haven't experimented further.

## Sightglass spidermonkey benchmark

```
compilation :: nanoseconds :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 21407759.30 ± 19781778.63 (confidence = 99%)

  branch.so is 1.00x to 1.01x faster than main.so!
  main.so is 0.99x to 1.00x faster than branch.so!

  [2845686334 2898004956.07 2938721676] branch.so
  [2867347959 2919412715.37 2976040194] main.so

compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 77065090.93 ± 71216617.01 (confidence = 99%)

  branch.so is 1.00x to 1.01x faster than main.so!
  main.so is 0.99x to 1.00x faster than branch.so!

  [10244830916 10433179969.40 10579750838] branch.so
  [10322803658 10510245060.33 10714117852] main.so
```

## Memory usage on the spidermonkey benchmark

Running the spidermonkey 10 times:

```
for i in $(seq 1 10); do
  /usr/bin/time -f "%M" -- taskset 0x1 ~/wasmtime/target/release/wasmtime compile benchmark.wasm
done
```
| branch  | main   | trevor/box-jump-table-vectors |
| ------- | ------ | ------ |
|         | 105288 | 105288 |
|         | 105600 | 105496 |
|         | 105340 | 105396 |
|         | 105508 | 105148 |
|         | 105268 | 105340 |
|         | 105596 | 105396 |
|         | 105464 | 105428 |
|         | 105368 | 105464 |
|         | 105340 | 105248 |
|         | 105296 | 105240 |
| average(k) | 105406 | 105344 |


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
