### PR TITLE
wasmtime: let serialization mismatch tests pass with `RUST_BACKTRACE=1` set

### DIFF
--- a/crates/wasmtime/src/module/serialization.rs
+++ b/crates/wasmtime/src/module/serialization.rs
@@ -607,14 +607,13 @@ mod test {
 
         match serialized.into_module(&engine) {
             Ok(_) => unreachable!(),
-            Err(e) => assert_eq!(
-                format!("{:?}", e),
+            Err(e) => assert!(format!("{:?}", e).starts_with(
                 "\
 compilation settings of module incompatible with native host
 
 Caused by:
     setting \"avoid_div_traps\" is configured to Bool(false) which is not supported"
-            ),
+            )),
         }
 
         Ok(())
@@ -634,14 +633,13 @@ Caused by:
 
         match serialized.into_module(&engine) {
             Ok(_) => unreachable!(),
-            Err(e) => assert_eq!(
-                format!("{:?}", e),
+            Err(e) => assert!(format!("{:?}", e).starts_with(
                 "\
 compilation settings of module incompatible with native host
 
 Caused by:
     cannot test if target-specific flag \"not_a_flag\" is available at runtime",
-            ),
+            )),
         }
 
         Ok(())


### PR DESCRIPTION

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
