### PR TITLE
Don't try to report file size or timestamps for stdio streams.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_filestat_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_filestat_get.rs
@@ -1,0 +1,25 @@
+unsafe fn test_fd_filestat_get() {
+
+    let stat = wasi::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
+    assert_eq!(stat.size, 0, "stdio size should be 0");
+    assert_eq!(stat.atim, 0, "stdio atim should be 0");
+    assert_eq!(stat.mtim, 0, "stdio mtim should be 0");
+    assert_eq!(stat.ctim, 0, "stdio ctim should be 0");
+
+    let stat = wasi::fd_filestat_get(libc::STDOUT_FILENO as u32).expect("failed filestat 1");
+    assert_eq!(stat.size, 0, "stdio size should be 0");
+    assert_eq!(stat.atim, 0, "stdio atim should be 0");
+    assert_eq!(stat.mtim, 0, "stdio mtim should be 0");
+    assert_eq!(stat.ctim, 0, "stdio ctim should be 0");
+
+    let stat = wasi::fd_filestat_get(libc::STDERR_FILENO as u32).expect("failed filestat 2");
+    assert_eq!(stat.size, 0, "stdio size should be 0");
+    assert_eq!(stat.atim, 0, "stdio atim should be 0");
+    assert_eq!(stat.mtim, 0, "stdio mtim should be 0");
+    assert_eq!(stat.ctim, 0, "stdio ctim should be 0");
+}
+
+fn main() {
+    // Run the tests.
+    unsafe { test_fd_filestat_get() }
+}

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -16,7 +16,7 @@ use io_lifetimes::{AsFd, BorrowedFd};
 #[cfg(windows)]
 use io_lifetimes::{AsHandle, BorrowedHandle};
 use wasi_common::{
-    file::{FdFlags, FileType, Filestat, WasiFile},
+    file::{FdFlags, FileType, WasiFile},
     Error, ErrorExt,
 };
 

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -126,19 +126,6 @@ macro_rules! wasi_file_write_impl {
             async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
                 Ok(FdFlags::APPEND)
             }
-            async fn get_filestat(&mut self) -> Result<Filestat, Error> {
-                let meta = self.0.as_filelike_view::<File>().metadata()?;
-                Ok(Filestat {
-                    device_id: 0,
-                    inode: 0,
-                    filetype: self.get_filetype().await?,
-                    nlink: 0,
-                    size: meta.len(),
-                    atim: meta.accessed().ok(),
-                    mtim: meta.modified().ok(),
-                    ctim: meta.created().ok(),
-                })
-            }
             async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 let n = (&*self.0.as_filelike_view::<File>()).write_vectored(bufs)?;
                 Ok(n.try_into().map_err(|c| Error::range().context(c))?)


### PR DESCRIPTION
Calling `File::metadata()` on a stdio stream handle fails on Windows, where
the stdio streams are not files.

This `File::metadata()` call was effectively only being used to add file size
and timestamps to the result of `filestat_get`. It's common for users to
redirect stdio streams to interesting places, and applications
generally shouldn't change their behavior depending on the size or
timestamps of the file, if the streams are redirected to a file, so just
leave these fields to 0, which is commonly understood to represent
"unknown".

Fixes #4497.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
