### PR TITLE
Don't allocate in DataFlowGraph::block_param_types

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -14,7 +14,6 @@ use crate::ir::{
 use crate::packed_option::ReservedValue;
 use crate::write::write_operands;
 use crate::HashMap;
-use alloc::vec::Vec;
 use core::fmt;
 use core::iter;
 use core::mem;
@@ -907,11 +906,8 @@ impl DataFlowGraph {
     }
 
     /// Get the types of the parameters on `block`.
-    pub fn block_param_types(&self, block: Block) -> Vec<Type> {
-        self.block_params(block)
-            .iter()
-            .map(|&v| self.value_type(v))
-            .collect()
+    pub fn block_param_types(&self, block: Block) -> impl Iterator<Item = Type> + '_ {
+        self.block_params(block).iter().map(|&v| self.value_type(v))
     }
 
     /// Append a parameter with type `ty` to `block`.


### PR DESCRIPTION
DHAT reports that when compiling the Spidermonkey Sightglass benchmark,
there are over 100k of these Vec allocations, averaging less than 4
bytes, and with an average lifetime of only about 500 instructions.

This function is only called from one place, which immediately converts
it into an iterator. So this commit just returns the iterator that was
previously being collected into a Vec. The iterator has to borrow from
the DataFlowGraph, so this would change borrow-check results, but in the
one caller that turns out to be okay.

(That sole caller is in cranelift/codegen/src/machinst/lower.rs, in
Lower::lower().)

According to Sightglass, this is a compile-time improvement of between
2% and 12% on the Spidermonkey benchmark:

instantiation :: nanoseconds :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 14628.76 ± 10318.59 (confidence = 99%)

  main-0e6ffd024.so is 0.87x to 0.98x faster than no-small-vecs.so!
  no-small-vecs.so is 1.02x to 1.14x faster than main-0e6ffd024.so!

  [142023 187464.24 301522] main-0e6ffd024.so
  [103742 172835.48 263917] no-small-vecs.so

compilation :: nanoseconds :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 362392705.93 ± 267070467.06 (confidence = 99%)

  main-0e6ffd024.so is 0.89x to 0.98x faster than no-small-vecs.so!
  no-small-vecs.so is 1.02x to 1.12x faster than main-0e6ffd024.so!

  [3655734131 5522594697.83 6471126699] main-0e6ffd024.so
  [3278129811 5160201991.90 5810600015] no-small-vecs.so

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
