### PR TITLE
[cranelift] Rejigger the `compile` API

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -122,8 +122,7 @@ impl Context {
         let code_info = compiled_code.code_info();
         let old_len = mem.len();
         mem.resize(old_len + code_info.total_size as usize, 0);
-        let new_info = unsafe { compiled_code.emit_to_memory(mem.as_mut_ptr().add(old_len)) };
-        debug_assert!(new_info == code_info);
+        mem[old_len..].copy_from_slice(compiled_code.code_buffer());
         Ok(compiled_code)
     }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -7,7 +7,7 @@ use crate::isa::aarch64::settings as aarch64_settings;
 use crate::isa::unwind::systemv;
 use crate::isa::{Builder as IsaBuilder, TargetIsa};
 use crate::machinst::{
-    compile, MachCompileResult, MachTextSectionBuilder, Reg, TextSectionBuilder, VCode,
+    compile, CompiledCode, MachTextSectionBuilder, Reg, TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
 use crate::settings as shared_settings;
@@ -65,11 +65,7 @@ impl AArch64Backend {
 }
 
 impl TargetIsa for AArch64Backend {
-    fn compile_function(
-        &self,
-        func: &Function,
-        want_disasm: bool,
-    ) -> CodegenResult<MachCompileResult> {
+    fn compile_function(&self, func: &Function, want_disasm: bool) -> CodegenResult<CompiledCode> {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
@@ -84,7 +80,7 @@ impl TargetIsa for AArch64Backend {
             log::debug!("disassembly:\n{}", disasm);
         }
 
-        Ok(MachCompileResult {
+        Ok(CompiledCode {
             buffer,
             frame_size,
             disasm: emit_result.disasm,
@@ -125,7 +121,7 @@ impl TargetIsa for AArch64Backend {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &MachCompileResult,
+        result: &CompiledCode,
         kind: crate::machinst::UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
         use crate::isa::unwind::UnwindInfo;

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -49,7 +49,7 @@ use crate::flowgraph;
 use crate::ir::{self, Function};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv::RegisterMappingError;
-use crate::machinst::{MachCompileResult, TextSectionBuilder, UnwindInfoKind};
+use crate::machinst::{CompiledCode, TextSectionBuilder, UnwindInfoKind};
 use crate::settings;
 use crate::settings::SetResult;
 use crate::CodegenResult;
@@ -230,11 +230,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     fn dynamic_vector_bytes(&self, dynamic_ty: ir::Type) -> u32;
 
     /// Compile the given function.
-    fn compile_function(
-        &self,
-        func: &Function,
-        want_disasm: bool,
-    ) -> CodegenResult<MachCompileResult>;
+    fn compile_function(&self, func: &Function, want_disasm: bool) -> CodegenResult<CompiledCode>;
 
     #[cfg(feature = "unwind")]
     /// Map a regalloc::Reg to its corresponding DWARF register.
@@ -254,7 +250,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &MachCompileResult,
+        result: &CompiledCode,
         kind: UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>>;
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -7,7 +7,7 @@ use crate::isa::s390x::settings as s390x_settings;
 use crate::isa::unwind::systemv::RegisterMappingError;
 use crate::isa::{Builder as IsaBuilder, TargetIsa};
 use crate::machinst::{
-    compile, MachCompileResult, MachTextSectionBuilder, Reg, TextSectionBuilder, VCode,
+    compile, CompiledCode, MachTextSectionBuilder, Reg, TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
 use crate::settings as shared_settings;
@@ -64,11 +64,7 @@ impl S390xBackend {
 }
 
 impl TargetIsa for S390xBackend {
-    fn compile_function(
-        &self,
-        func: &Function,
-        want_disasm: bool,
-    ) -> CodegenResult<MachCompileResult> {
+    fn compile_function(&self, func: &Function, want_disasm: bool) -> CodegenResult<CompiledCode> {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
@@ -83,7 +79,7 @@ impl TargetIsa for S390xBackend {
             log::debug!("disassembly:\n{}", disasm);
         }
 
-        Ok(MachCompileResult {
+        Ok(CompiledCode {
             buffer,
             frame_size,
             disasm: emit_result.disasm,
@@ -127,7 +123,7 @@ impl TargetIsa for S390xBackend {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &MachCompileResult,
+        result: &CompiledCode,
         kind: crate::machinst::UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
         use crate::isa::unwind::UnwindInfo;

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -9,9 +9,7 @@ use crate::isa::unwind::systemv;
 use crate::isa::x64::{inst::regs::create_reg_env_systemv, settings as x64_settings};
 use crate::isa::Builder as IsaBuilder;
 use crate::machinst::Reg;
-use crate::machinst::{
-    compile, MachCompileResult, MachTextSectionBuilder, TextSectionBuilder, VCode,
-};
+use crate::machinst::{compile, CompiledCode, MachTextSectionBuilder, TextSectionBuilder, VCode};
 use crate::result::{CodegenError, CodegenResult};
 use crate::settings::{self as shared_settings, Flags};
 use alloc::{boxed::Box, vec::Vec};
@@ -59,11 +57,7 @@ impl X64Backend {
 }
 
 impl TargetIsa for X64Backend {
-    fn compile_function(
-        &self,
-        func: &Function,
-        want_disasm: bool,
-    ) -> CodegenResult<MachCompileResult> {
+    fn compile_function(&self, func: &Function, want_disasm: bool) -> CodegenResult<CompiledCode> {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
@@ -78,7 +72,7 @@ impl TargetIsa for X64Backend {
             log::trace!("disassembly:\n{}", disasm);
         }
 
-        Ok(MachCompileResult {
+        Ok(CompiledCode {
             buffer,
             frame_size,
             disasm: emit_result.disasm,
@@ -119,7 +113,7 @@ impl TargetIsa for X64Backend {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &MachCompileResult,
+        result: &CompiledCode,
         kind: crate::machinst::UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
         use crate::isa::unwind::UnwindInfo;

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -114,7 +114,7 @@ mod value_label;
 #[cfg(feature = "souper-harvest")]
 mod souper_harvest;
 
-pub use crate::result::{CodegenError, CodegenResult};
+pub use crate::result::{CodegenError, CodegenResult, CompileError};
 
 /// Even when trace logging is disabled, the trace macro has a significant performance cost so we
 /// disable it by default.

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -273,7 +273,7 @@ pub trait MachInstEmitState<I: MachInst>: Default + Clone + Debug {
 
 /// The result of a `MachBackend::compile_function()` call. Contains machine
 /// code (as bytes) and a disassembly, if requested.
-pub struct MachCompileResult {
+pub struct CompiledCode {
     /// Machine code.
     pub buffer: MachBufferFinalized,
     /// Size of stack frame, in bytes.
@@ -300,7 +300,7 @@ pub struct MachCompileResult {
     pub bb_edges: Vec<(CodeOffset, CodeOffset)>,
 }
 
-impl MachCompileResult {
+impl CompiledCode {
     /// Get a `CodeInfo` describing section sizes from this compilation result.
     pub fn code_info(&self) -> CodeInfo {
         CodeInfo {

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -48,7 +48,6 @@ use crate::binemit::{Addend, CodeInfo, CodeOffset, Reloc, StackMap};
 use crate::ir::{DynamicStackSlot, SourceLoc, StackSlot, Type};
 use crate::result::CodegenResult;
 use crate::settings::Flags;
-use crate::timing;
 use crate::value_label::ValueLabelsRanges;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -308,26 +307,9 @@ impl CompiledCode {
         }
     }
 
-    /// Emit machine code directly into raw memory.
-    ///
-    /// Write all of the function's machine code to the memory at `mem`.
-    ///
-    /// The machine code is not relocated.
-    /// Instead, any relocations can be obtained from this struct's field `buffer`.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe since it does not perform bounds checking on the memory buffer,
-    /// and it can't guarantee that the `mem` pointer is valid.
-    ///
-    /// Returns information about the emitted code and data.
-    #[deny(unsafe_op_in_unsafe_fn)]
-    pub unsafe fn emit_to_memory(&self, mem: *mut u8) -> CodeInfo {
-        let _tt = timing::binemit();
-        let info = self.code_info();
-        let mem = unsafe { std::slice::from_raw_parts_mut(mem, info.total_size as usize) };
-        mem.copy_from_slice(self.buffer.data());
-        info
+    /// Returns a reference to the machine code generated for this function compilation.
+    pub fn code_buffer(&self) -> &[u8] {
+        self.buffer.data()
     }
 }
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -48,6 +48,7 @@ use crate::binemit::{Addend, CodeInfo, CodeOffset, Reloc, StackMap};
 use crate::ir::{DynamicStackSlot, SourceLoc, StackSlot, Type};
 use crate::result::CodegenResult;
 use crate::settings::Flags;
+use crate::timing;
 use crate::value_label::ValueLabelsRanges;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -305,6 +306,28 @@ impl MachCompileResult {
         CodeInfo {
             total_size: self.buffer.total_size(),
         }
+    }
+
+    /// Emit machine code directly into raw memory.
+    ///
+    /// Write all of the function's machine code to the memory at `mem`.
+    ///
+    /// The machine code is not relocated.
+    /// Instead, any relocations can be obtained from this struct's field `buffer`.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe since it does not perform bounds checking on the memory buffer,
+    /// and it can't guarantee that the `mem` pointer is valid.
+    ///
+    /// Returns information about the emitted code and data.
+    #[deny(unsafe_op_in_unsafe_fn)]
+    pub unsafe fn emit_to_memory(&self, mem: *mut u8) -> CodeInfo {
+        let _tt = timing::binemit();
+        let info = self.code_info();
+        let mem = unsafe { std::slice::from_raw_parts_mut(mem, info.total_size as usize) };
+        mem.copy_from_slice(self.buffer.data());
+        info
     }
 }
 

--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -2,7 +2,7 @@
 
 use regalloc2::checker::CheckerErrors;
 
-use crate::verifier::VerifierErrors;
+use crate::{ir::Function, verifier::VerifierErrors};
 use std::string::String;
 
 /// A compilation error.
@@ -81,3 +81,22 @@ impl From<VerifierErrors> for CodegenError {
         CodegenError::Verifier { 0: source }
     }
 }
+
+/// Compilation error, with the accompanying function to help printing it.
+pub struct CompileError<'a> {
+    /// Underlying `CodegenError` that triggered the error.
+    pub inner: CodegenError,
+    /// Function we tried to compile, for display purposes.
+    pub func: &'a Function,
+}
+
+// By default, have `CompileError` be displayed as the internal error, and let consumers care if
+// they want to use the func field for adding details.
+impl<'a> core::fmt::Debug for CompileError<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// A convenient alias for a `Result` that uses `CompileError` as the error type.
+pub type CompileResult<'a, T> = Result<T, CompileError<'a>>;

--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -68,7 +68,6 @@ define_passes! {
 
     regalloc: "Register allocation",
     regalloc_checker: "Register allocation symbolic verification",
-    binemit: "Binary machine code emission",
     layout_renumber: "Layout full renumbering",
 
     canonicalize_nans: "Canonicalization of NaNs",

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -241,14 +241,11 @@ fn compile(function: Function, isa: &dyn TargetIsa) -> Result<Mmap, CompilationE
     context.func = function;
 
     // Compile and encode the result to machine code.
-    let code_info = context.compile(isa)?;
-    let mut code_page = MmapMut::map_anon(code_info.total_size as usize)?;
+    let compile_result = context.compile(isa).map_err(|err| err.inner)?;
+    let mut code_page = MmapMut::map_anon(compile_result.code_info().total_size as usize)?;
 
     unsafe {
-        context
-            .mach_compile_result()
-            .expect("we should have a result after a successful compilation")
-            .emit_to_memory(code_page.as_mut_ptr());
+        compile_result.emit_to_memory(code_page.as_mut_ptr());
     };
 
     let code_page = code_page.make_exec()?;

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -244,9 +244,7 @@ fn compile(function: Function, isa: &dyn TargetIsa) -> Result<Mmap, CompilationE
     let compiled_code = context.compile(isa).map_err(|err| err.inner)?;
     let mut code_page = MmapMut::map_anon(compiled_code.code_info().total_size as usize)?;
 
-    unsafe {
-        compiled_code.emit_to_memory(code_page.as_mut_ptr());
-    };
+    code_page.copy_from_slice(compiled_code.code_buffer());
 
     let code_page = code_page.make_exec()?;
     trace!(

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -245,7 +245,11 @@ fn compile(function: Function, isa: &dyn TargetIsa) -> Result<Mmap, CompilationE
     let mut code_page = MmapMut::map_anon(code_info.total_size as usize)?;
 
     unsafe {
-        context.emit_to_memory(code_page.as_mut_ptr());
+        context
+            .mach_compile_result
+            .as_ref()
+            .expect("we should have a result after a successful compilation")
+            .emit_to_memory(code_page.as_mut_ptr());
     };
 
     let code_page = code_page.make_exec()?;

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -246,8 +246,7 @@ fn compile(function: Function, isa: &dyn TargetIsa) -> Result<Mmap, CompilationE
 
     unsafe {
         context
-            .mach_compile_result
-            .as_ref()
+            .mach_compile_result()
             .expect("we should have a result after a successful compilation")
             .emit_to_memory(code_page.as_mut_ptr());
     };

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -241,11 +241,11 @@ fn compile(function: Function, isa: &dyn TargetIsa) -> Result<Mmap, CompilationE
     context.func = function;
 
     // Compile and encode the result to machine code.
-    let compile_result = context.compile(isa).map_err(|err| err.inner)?;
-    let mut code_page = MmapMut::map_anon(compile_result.code_info().total_size as usize)?;
+    let compiled_code = context.compile(isa).map_err(|err| err.inner)?;
+    let mut code_page = MmapMut::map_anon(compiled_code.code_info().total_size as usize)?;
 
     unsafe {
-        compile_result.emit_to_memory(code_page.as_mut_ptr());
+        compiled_code.emit_to_memory(code_page.as_mut_ptr());
     };
 
     let code_page = code_page.make_exec()?;

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -4,7 +4,6 @@
 
 use crate::subtest::{run_filecheck, Context, SubTest};
 use anyhow::{bail, Result};
-use cranelift_codegen::binemit::CodeInfo;
 use cranelift_codegen::ir;
 use cranelift_reader::{TestCommand, TestOption};
 use log::info;
@@ -54,16 +53,12 @@ impl SubTest for TestCompile {
         // With `MachBackend`s, we need to explicitly request dissassembly results.
         comp_ctx.set_disasm(true);
 
-        let CodeInfo { total_size, .. } = comp_ctx
+        let compile_result = comp_ctx
             .compile(isa)
-            .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, e))?;
+            .map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?;
+        let total_size = compile_result.code_info().total_size;
 
-        let disasm = comp_ctx
-            .mach_compile_result()
-            .unwrap()
-            .disasm
-            .as_ref()
-            .unwrap();
+        let disasm = compile_result.disasm.as_ref().unwrap();
 
         info!("Generated {} bytes of code:\n{}", total_size, disasm);
 

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -59,8 +59,7 @@ impl SubTest for TestCompile {
             .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, e))?;
 
         let disasm = comp_ctx
-            .mach_compile_result
-            .as_ref()
+            .mach_compile_result()
             .unwrap()
             .disasm
             .as_ref()

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -53,12 +53,12 @@ impl SubTest for TestCompile {
         // With `MachBackend`s, we need to explicitly request dissassembly results.
         comp_ctx.set_disasm(true);
 
-        let compile_result = comp_ctx
+        let compiled_code = comp_ctx
             .compile(isa)
             .map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?;
-        let total_size = compile_result.code_info().total_size;
+        let total_size = compiled_code.code_info().total_size;
 
-        let disasm = compile_result.disasm.as_ref().unwrap();
+        let disasm = compiled_code.disasm.as_ref().unwrap();
 
         info!("Generated {} bytes of code:\n{}", total_size, disasm);
 

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -4,10 +4,7 @@ use crate::{compiled_blob::CompiledBlob, memory::Memory};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::settings::Configurable;
 use cranelift_codegen::{self, ir, settings, MachReloc};
-use cranelift_codegen::{
-    binemit::{CodeInfo, Reloc},
-    CodegenError,
-};
+use cranelift_codegen::{binemit::Reloc, CodegenError};
 use cranelift_entity::SecondaryMap;
 use cranelift_module::{
     DataContext, DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleCompiledFunction,
@@ -684,11 +681,8 @@ impl Module for JITModule {
             return Err(ModuleError::DuplicateDefinition(decl.name.to_owned()));
         }
 
-        let CodeInfo {
-            total_size: code_size,
-            ..
-        } = ctx.compile(self.isa())?;
-        let compile_result = ctx.mach_compile_result().unwrap();
+        let compile_result = ctx.compile(self.isa())?;
+        let code_size = compile_result.code_info().total_size;
 
         let size = code_size as usize;
         let ptr = self

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -691,7 +691,10 @@ impl Module for JITModule {
             .allocate(size, EXECUTABLE_DATA_ALIGNMENT)
             .expect("TODO: handle OOM etc.");
 
-        unsafe { compiled_code.emit_to_memory(ptr) };
+        {
+            let mem = unsafe { std::slice::from_raw_parts_mut(ptr, size) };
+            mem.copy_from_slice(compiled_code.code_buffer());
+        }
 
         let relocs = compiled_code.buffer.relocs().to_vec();
 

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -681,8 +681,8 @@ impl Module for JITModule {
             return Err(ModuleError::DuplicateDefinition(decl.name.to_owned()));
         }
 
-        let compile_result = ctx.compile(self.isa())?;
-        let code_size = compile_result.code_info().total_size;
+        let compiled_code = ctx.compile(self.isa())?;
+        let code_size = compiled_code.code_info().total_size;
 
         let size = code_size as usize;
         let ptr = self
@@ -691,9 +691,9 @@ impl Module for JITModule {
             .allocate(size, EXECUTABLE_DATA_ALIGNMENT)
             .expect("TODO: handle OOM etc.");
 
-        unsafe { compile_result.emit_to_memory(ptr) };
+        unsafe { compiled_code.emit_to_memory(ptr) };
 
-        let relocs = compile_result.buffer.relocs().to_vec();
+        let relocs = compiled_code.buffer.relocs().to_vec();
 
         self.record_function_for_perf(ptr, size, &decl.name);
         self.compiled_functions[id] = Some(CompiledBlob { ptr, size, relocs });

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -696,7 +696,13 @@ impl Module for JITModule {
             .allocate(size, EXECUTABLE_DATA_ALIGNMENT)
             .expect("TODO: handle OOM etc.");
 
-        unsafe { ctx.emit_to_memory(ptr) };
+        unsafe {
+            ctx.mach_compile_result
+                .as_ref()
+                .expect("we should have a result after a successful compilation")
+                .emit_to_memory(ptr)
+        };
+
         let relocs = ctx
             .mach_compile_result
             .as_ref()

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -9,7 +9,7 @@ use super::HashMap;
 use crate::data_context::DataContext;
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::{binemit, MachReloc};
-use cranelift_codegen::{ir, isa, CodegenError, Context};
+use cranelift_codegen::{ir, isa, CodegenError, CompileError, Context};
 use std::borrow::ToOwned;
 use std::string::String;
 
@@ -190,6 +190,12 @@ pub enum ModuleError {
 
     /// Wraps a generic error from a backend
     Backend(anyhow::Error),
+}
+
+impl<'a> From<CompileError<'a>> for ModuleError {
+    fn from(err: CompileError<'a>) -> Self {
+        Self::Compilation(err.inner)
+    }
 }
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -313,11 +313,7 @@ impl Module for ObjectModule {
 
         ctx.compile_and_emit(self.isa(), &mut code)?;
 
-        self.define_function_bytes(
-            func_id,
-            &code,
-            ctx.mach_compile_result().unwrap().buffer.relocs(),
-        )
+        self.define_function_bytes(func_id, &code, ctx.compiled_code().unwrap().buffer.relocs())
     }
 
     fn define_function_bytes(

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -316,7 +316,7 @@ impl Module for ObjectModule {
         self.define_function_bytes(
             func_id,
             &code,
-            ctx.mach_compile_result.as_ref().unwrap().buffer.relocs(),
+            ctx.mach_compile_result().unwrap().buffer.relocs(),
         )
     }
 

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -68,10 +68,9 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             let mut mem = vec![];
 
             // Compile and encode the result to machine code.
-            context
+            let result = context
                 .compile_and_emit(isa, &mut mem)
-                .map_err(|err| anyhow::anyhow!("{}", pretty_error(&context.func, err)))?;
-            let result = context.mach_compile_result().unwrap();
+                .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
             let code_info = result.code_info();
 
             if options.print {
@@ -79,6 +78,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             }
 
             if options.disasm {
+                let result = context.mach_compile_result().unwrap();
                 print_all(
                     isa,
                     &mem,

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -68,17 +68,17 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             let mut mem = vec![];
 
             // Compile and encode the result to machine code.
-            let result = context
+            let compiled_code = context
                 .compile_and_emit(isa, &mut mem)
                 .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
-            let code_info = result.code_info();
+            let code_info = compiled_code.code_info();
 
             if options.print {
                 println!("{}", context.func.display());
             }
 
             if options.disasm {
-                let result = context.mach_compile_result().unwrap();
+                let result = context.compiled_code().unwrap();
                 print_all(
                     isa,
                     &mem,

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -71,7 +71,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             context
                 .compile_and_emit(isa, &mut mem)
                 .map_err(|err| anyhow::anyhow!("{}", pretty_error(&context.func, err)))?;
-            let result = context.mach_compile_result.as_ref().unwrap();
+            let result = context.mach_compile_result().unwrap();
             let code_info = result.code_info();
 
             if options.print {

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -257,10 +257,10 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             }
             (vec![], vec![], vec![])
         } else {
-            let result = context
+            let compiled_code = context
                 .compile_and_emit(isa, &mut mem)
                 .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
-            let code_info = result.code_info();
+            let code_info = compiled_code.code_info();
 
             if options.print_size {
                 println!(
@@ -279,9 +279,9 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
                 saved_size = Some(code_info.total_size);
             }
             (
-                result.buffer.relocs().to_vec(),
-                result.buffer.traps().to_vec(),
-                result.buffer.stack_maps().to_vec(),
+                compiled_code.buffer.relocs().to_vec(),
+                compiled_code.buffer.traps().to_vec(),
+                compiled_code.buffer.stack_maps().to_vec(),
             )
         };
 
@@ -298,13 +298,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
                 println!("; Exported as \"{}\"", export_name);
             }
             let value_ranges = if options.value_ranges {
-                Some(
-                    context
-                        .mach_compile_result()
-                        .unwrap()
-                        .value_labels_ranges
-                        .clone(),
-                )
+                Some(context.compiled_code().unwrap().value_labels_ranges.clone())
             } else {
                 None
             };

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -260,7 +260,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             context
                 .compile_and_emit(isa, &mut mem)
                 .map_err(|err| anyhow::anyhow!("{}", pretty_error(&context.func, err)))?;
-            let result = context.mach_compile_result.as_ref().unwrap();
+            let result = context.mach_compile_result().unwrap();
             let code_info = result.code_info();
 
             if options.print_size {
@@ -301,8 +301,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             let value_ranges = if options.value_ranges {
                 Some(
                     context
-                        .mach_compile_result
-                        .as_ref()
+                        .mach_compile_result()
                         .unwrap()
                         .value_labels_ranges
                         .clone(),

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -257,10 +257,9 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
             }
             (vec![], vec![], vec![])
         } else {
-            context
+            let result = context
                 .compile_and_emit(isa, &mut mem)
-                .map_err(|err| anyhow::anyhow!("{}", pretty_error(&context.func, err)))?;
-            let result = context.mach_compile_result().unwrap();
+                .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
             let code_info = result.code_info();
 
             if options.print_size {


### PR DESCRIPTION
This small refactoring makes it clearer to me that emitting to memory
doesn't require anything else from the compilation `Context`. While it's
a trivial change, it's a small public API change that shouldn't cause
too much trouble, and doesn't seem RFC-worthy. Happy to hear different
opinions about this, though!
