### PR TITLE
Implement `char` type in adapter fusion

### DIFF
--- a/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
+++ b/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
@@ -51,6 +51,7 @@ enum ValType {
     S64,
     Float32,
     Float64,
+    Char,
     Record(Vec<ValType>),
     Tuple(Vec<ValType>),
     Variant(NonZeroLenVec<ValType>),
@@ -206,6 +207,7 @@ fn intern(types: &mut ComponentTypesBuilder, ty: &ValType) -> InterfaceType {
         ValType::S64 => InterfaceType::S64,
         ValType::Float32 => InterfaceType::Float32,
         ValType::Float64 => InterfaceType::Float64,
+        ValType::Char => InterfaceType::Char,
         ValType::Record(tys) => {
             let ty = TypeRecord {
                 fields: tys

--- a/crates/environ/src/fact/traps.rs
+++ b/crates/environ/src/fact/traps.rs
@@ -28,6 +28,7 @@ pub enum Trap {
     CannotEnter,
     UnalignedPointer,
     InvalidDiscriminant,
+    InvalidChar,
     AssertFailed(&'static str),
 }
 
@@ -101,6 +102,7 @@ impl fmt::Display for Trap {
             Trap::CannotEnter => "cannot enter instance".fmt(f),
             Trap::UnalignedPointer => "pointer not aligned correctly".fmt(f),
             Trap::InvalidDiscriminant => "invalid variant discriminant".fmt(f),
+            Trap::InvalidChar => "invalid char value specified".fmt(f),
             Trap::AssertFailed(s) => write!(f, "assertion failure: {}", s),
         }
     }


### PR DESCRIPTION
This commit implements the translation of `char` which validates that
it's in the valid range of unicode scalar values. The precise validation
here is lifted from LLVM in the hopes that it's probably better than
whatever I would concoct by hand.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
