### PR TITLE
Implement other variant-like types in adapter fusion

### DIFF
--- a/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
+++ b/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
@@ -16,6 +16,9 @@ use wasmparser::{Validator, WasmFeatures};
 use wasmtime_environ::component::*;
 use wasmtime_environ::fact::Module;
 
+// Allow inflating to 16 bits but don't go further.
+const MAX_ENUM_SIZE: usize = 257;
+
 #[derive(Arbitrary, Debug)]
 struct GenAdapterModule {
     debug: bool,
@@ -54,6 +57,10 @@ enum ValType {
     Record(Vec<ValType>),
     Tuple(Vec<ValType>),
     Variant(NonZeroLenVec<ValType>),
+    Union(NonZeroLenVec<ValType>),
+    Enum(usize),
+    Option(Box<ValType>),
+    Expected(Box<ValType>, Box<ValType>),
 }
 
 #[derive(Copy, Clone, Arbitrary, Debug)]
@@ -237,6 +244,29 @@ fn intern(types: &mut ComponentTypesBuilder, ty: &ValType) -> InterfaceType {
                     .collect(),
             };
             InterfaceType::Variant(types.add_variant_type(ty))
+        }
+        ValType::Union(tys) => {
+            let ty = TypeUnion {
+                types: tys.0.iter().map(|ty| intern(types, ty)).collect(),
+            };
+            InterfaceType::Union(types.add_union_type(ty))
+        }
+        ValType::Enum(size) => {
+            let size = size % MAX_ENUM_SIZE;
+            let size = if size == 0 { 1 } else { size };
+            let ty = TypeEnum {
+                names: (0..size).map(|i| format!("c{i}")).collect(),
+            };
+            InterfaceType::Enum(types.add_enum_type(ty))
+        }
+        ValType::Option(ty) => {
+            let ty = intern(types, ty);
+            InterfaceType::Option(types.add_interface_type(ty))
+        }
+        ValType::Expected(ok, err) => {
+            let ok = intern(types, ok);
+            let err = intern(types, err);
+            InterfaceType::Expected(types.add_expected_type(TypeExpected { ok, err }))
         }
     }
 }

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -588,7 +588,7 @@ impl ComponentTypesBuilder {
             }
             wasmparser::ComponentDefinedType::List(e) => {
                 let ty = self.valtype(e);
-                InterfaceType::List(self.intern_interface_type(ty))
+                InterfaceType::List(self.add_interface_type(ty))
             }
             wasmparser::ComponentDefinedType::Tuple(e) => InterfaceType::Tuple(self.tuple_type(e)),
             wasmparser::ComponentDefinedType::Flags(e) => InterfaceType::Flags(self.flags_type(e)),
@@ -596,7 +596,7 @@ impl ComponentTypesBuilder {
             wasmparser::ComponentDefinedType::Union(e) => InterfaceType::Union(self.union_type(e)),
             wasmparser::ComponentDefinedType::Option(e) => {
                 let ty = self.valtype(e);
-                InterfaceType::Option(self.intern_interface_type(ty))
+                InterfaceType::Option(self.add_interface_type(ty))
             }
             wasmparser::ComponentDefinedType::Expected { ok, error } => {
                 InterfaceType::Expected(self.expected_type(ok, error))
@@ -616,14 +616,6 @@ impl ComponentTypesBuilder {
                 }
             }
         }
-    }
-
-    fn intern_interface_type(&mut self, ty: InterfaceType) -> TypeInterfaceIndex {
-        intern(
-            &mut self.interface_types,
-            &mut self.component_types.interface_types,
-            ty,
-        )
     }
 
     fn record_type(&mut self, record: &[(&str, wasmparser::ComponentValType)]) -> TypeRecordIndex {
@@ -675,14 +667,14 @@ impl ComponentTypesBuilder {
         let e = TypeEnum {
             names: variants.iter().map(|s| s.to_string()).collect(),
         };
-        intern(&mut self.enums, &mut self.component_types.enums, e)
+        self.add_enum_type(e)
     }
 
     fn union_type(&mut self, types: &[wasmparser::ComponentValType]) -> TypeUnionIndex {
         let union = TypeUnion {
             types: types.iter().map(|ty| self.valtype(ty)).collect(),
         };
-        intern(&mut self.unions, &mut self.component_types.unions, union)
+        self.add_union_type(union)
     }
 
     fn expected_type(
@@ -694,11 +686,7 @@ impl ComponentTypesBuilder {
             ok: self.valtype(ok),
             err: self.valtype(err),
         };
-        intern(
-            &mut self.expecteds,
-            &mut self.component_types.expecteds,
-            expected,
-        )
+        self.add_expected_type(expected)
     }
 
     /// Interns a new function type within this type information.
@@ -719,6 +707,30 @@ impl ComponentTypesBuilder {
     /// Interns a new variant type within this type information.
     pub fn add_variant_type(&mut self, ty: TypeVariant) -> TypeVariantIndex {
         intern(&mut self.variants, &mut self.component_types.variants, ty)
+    }
+
+    /// Interns a new union type within this type information.
+    pub fn add_union_type(&mut self, ty: TypeUnion) -> TypeUnionIndex {
+        intern(&mut self.unions, &mut self.component_types.unions, ty)
+    }
+
+    /// Interns a new enum type within this type information.
+    pub fn add_enum_type(&mut self, ty: TypeEnum) -> TypeEnumIndex {
+        intern(&mut self.enums, &mut self.component_types.enums, ty)
+    }
+
+    /// Interns a new expected type within this type information.
+    pub fn add_expected_type(&mut self, ty: TypeExpected) -> TypeExpectedIndex {
+        intern(&mut self.expecteds, &mut self.component_types.expecteds, ty)
+    }
+
+    /// Interns a new expected type within this type information.
+    pub fn add_interface_type(&mut self, ty: InterfaceType) -> TypeInterfaceIndex {
+        intern(
+            &mut self.interface_types,
+            &mut self.component_types.interface_types,
+            ty,
+        )
     }
 }
 


### PR DESCRIPTION
This commit fills out the adapter fusion compiler for the `union`,
`enum`, `option,` and `result` types. The preexisting support for
`variant` types was refactored slightly to be extensible to all of these
other types and they all now call into the same common translation code.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
