### PR TITLE
doc: fix c set strategy doc

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -197,9 +197,6 @@ WASMTIME_CONFIG_PROP(void, wasm_memory64, bool)
  * \brief Configures how JIT code will be compiled.
  *
  * This setting is #WASMTIME_STRATEGY_AUTO by default.
- *
- * If the compilation strategy selected could not be enabled then an error is
- * returned.
  */
 WASMTIME_CONFIG_PROP(void, strategy, wasmtime_strategy_t)
 


### PR DESCRIPTION
In #4252 I changed the signature and doc of the rust code, but forgot to change the doc for c.
Set strategy no longer returns error.
This commit fixes that.