### PR TITLE
Try using `windows-latest` CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,8 +217,8 @@ jobs:
           - os: ubuntu-latest
           # defaults to x86_64-apple-darwin
           - os: macos-latest
-          - os: windows-2019
-          - os: windows-2019
+          - os: windows-latest
+          - os: windows-latest
             target: x86_64-pc-windows-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -302,11 +302,11 @@ jobs:
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
       env:
         RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os == 'windows-2019'
+      if: matrix.target == '' && matrix.os == 'windows-latest'
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
       env:
         RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os != 'windows-2019'
+      if: matrix.target == '' && matrix.os != 'windows-latest'
 
     # Build and test all features
     - run: ./ci/run-tests.sh --locked


### PR DESCRIPTION
See if our `windows-2019` woes are solved now that backtraces are using
frame pointers instead of native APIs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
