### PR TITLE
Re-enable component model `*.wast` tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ wat = "1.0.47"
 once_cell = "1.9.0"
 rayon = "1.5.0"
 component-macro-test = { path = "crates/misc/component-macro-test" }
+wasmtime-wast = { path = "crates/wast", version = "=0.40.0", features = ['component-model'] }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { version = "0.36.0", features = ["Win32_System_Memory"] }

--- a/build.rs
+++ b/build.rs
@@ -28,9 +28,7 @@ fn main() -> anyhow::Result<()> {
             test_directory_module(out, "tests/misc_testsuite/simd", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/threads", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/memory64", strategy)?;
-            if cfg!(feature = "component-model") {
-                test_directory_module(out, "tests/misc_testsuite/component-model", strategy)?;
-            }
+            test_directory_module(out, "tests/misc_testsuite/component-model", strategy)?;
             Ok(())
         })?;
 

--- a/tests/all/component_model.rs
+++ b/tests/all/component_model.rs
@@ -88,6 +88,8 @@ const REALLOC_AND_FREE: &str = r#"
 "#;
 
 fn engine() -> Engine {
+    drop(env_logger::try_init());
+
     let mut config = Config::new();
     config.wasm_component_model(true);
 


### PR DESCRIPTION
These accidentally stopped running as part of #4556 on CI since I forgot
one more location to touch a feature gate.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
