### PR TITLE
wasmtime: Add lots of logging for `externref`s and `table_ops` fuzz target

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1338,6 +1338,7 @@ impl<I: VCodeInst> MachBuffer<I> {
                 (start_offset, end_offset)
             }
         };
+        trace!("Adding stack map for offsets {start:#x}..{end:#x}");
         self.stack_maps.push(MachStackMap {
             offset: start,
             offset_end: end,

--- a/crates/runtime/src/traphandlers/backtrace.rs
+++ b/crates/runtime/src/traphandlers/backtrace.rs
@@ -198,7 +198,7 @@ impl Backtrace {
         // contiguous sequence of Wasm frames, and we have nothing to
         // walk through here.
         if first_wasm_sp == -1_isize as usize {
-            log::trace!("Empty sequence of Wasm frames");
+            log::trace!("=== Done tracing (empty sequence of Wasm frames) ===");
             return ControlFlow::Continue(());
         }
 
@@ -224,8 +224,8 @@ impl Backtrace {
             arch::assert_fp_is_aligned(fp);
 
             log::trace!("--- Tracing through one Wasm frame ---");
-            log::trace!("pc = 0x{:016x}", pc);
-            log::trace!("fp = 0x{:016x}", fp);
+            log::trace!("pc = {:p}", pc as *const ());
+            log::trace!("fp = {:p}", fp as *const ());
 
             f(Frame { pc, fp })?;
 
@@ -234,6 +234,7 @@ impl Backtrace {
             // and have now reached a host frame. We're done iterating
             // through this contiguous sequence of Wasm frames.
             if arch::reached_entry_sp(fp, first_wasm_sp) {
+                log::trace!("=== Done tracing contiguous sequence of Wasm frames ===");
                 return ControlFlow::Continue(());
             }
 


### PR DESCRIPTION
I essentially add these same logs back in every time I'm debugging something
related to this fuzz target or `externref`s in general. Probably like 5 times
I've added roughly these logs. We should just make them available whenever we
need them via `RUST_LOG=wasmtime_runtime=trace`.

This also changes a couple `if let`s to `unwrap`s that are now infallible after #4431.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
