### PR TITLE
[s390x, abi_impl] Support struct args using explicit pointers

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -162,6 +162,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 assert!(size % 8 == 0, "StructArgument size is not properly aligned");
                 next_stack += size;
                 ret.push(ABIArg::StructArg {
+                    pointer: None,
                     offset,
                     size,
                     purpose: param.purpose,

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -624,10 +624,15 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
 
             abi.emit_stack_pre_adjust(ctx);
             assert!(inputs.len() == abi.num_args());
-            for i in abi.get_copy_to_arg_order() {
-                let input = inputs[i];
-                let arg_regs = put_input_in_regs(ctx, input);
-                abi.emit_copy_regs_to_arg(ctx, i, arg_regs);
+            let mut arg_regs = vec![];
+            for input in inputs {
+                arg_regs.push(put_input_in_regs(ctx, *input))
+            }
+            for (i, arg_regs) in arg_regs.iter().enumerate() {
+                abi.emit_copy_regs_to_buffer(ctx, i, *arg_regs);
+            }
+            for (i, arg_regs) in arg_regs.iter().enumerate() {
+                abi.emit_copy_regs_to_arg(ctx, i, *arg_regs);
             }
             abi.emit_call(ctx);
             for (i, output) in outputs.iter().enumerate() {

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -351,6 +351,12 @@
       (rd Reg)
       (mem MemArg))
 
+    ;; A memory copy of 1-256 bytes.
+    (Mvc
+      (dst MemArgPair)
+      (src MemArgPair)
+      (len_minus_one u8))
+
     ;; A load-multiple instruction.
     (LoadMultiple64
       (rt WritableReg)
@@ -1473,6 +1479,9 @@
 (decl uimm32shifted_from_inverted_value (UImm32Shifted) Value)
 (extern extractor uimm32shifted_from_inverted_value uimm32shifted_from_inverted_value)
 
+(decl len_minus_one (u8) u64)
+(extern extractor len_minus_one len_minus_one)
+
 
 ;; Helpers for masking shift amounts ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1547,6 +1556,9 @@
 
 (type MemArg extern (enum))
 
+(decl memarg_flags (MemArg) MemFlags)
+(extern constructor memarg_flags memarg_flags)
+
 (decl memarg_reg_plus_reg (Reg Reg u8 MemFlags) MemArg)
 (extern constructor memarg_reg_plus_reg memarg_reg_plus_reg)
 
@@ -1620,6 +1632,26 @@
           inst)
       (if (memarg_symbol_offset_sum sym_offset load_offset))
       inst)
+
+
+;; Accessors for `MemArgPair`.
+
+(type MemArgPair extern (enum))
+
+;; Convert a MemArg to a MemArgPair, reloading the address if necessary.
+(decl memarg_pair (MemArg) MemArgPair)
+(rule (memarg_pair (memarg_pair_from_memarg mem)) mem)
+(rule (memarg_pair mem) (memarg_pair_from_reg
+                          (load_addr mem) (memarg_flags mem)))
+
+;; Convert a MemArg to a MemArgPair if no reloading is necessary.
+(decl memarg_pair_from_memarg (MemArgPair) MemArg)
+(extern extractor memarg_pair_from_memarg memarg_pair_from_memarg)
+
+;; Create a MemArgPair from a single base register.
+(decl memarg_pair_from_reg (Reg MemFlags) MemArgPair)
+(extern constructor memarg_pair_from_reg memarg_pair_from_reg)
+
 
 ;; Helpers for stack-slot addresses ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2037,6 +2069,11 @@
 (decl storerev64 (Reg MemArg) SideEffectNoResult)
 (rule (storerev64 src addr)
       (SideEffectNoResult.Inst (MInst.StoreRev64 src addr)))
+
+;; Helper for emitting `MInst.Mvc` instructions.
+(decl mvc (MemArgPair MemArgPair u8) SideEffectNoResult)
+(rule (mvc dst src len_minus_one)
+      (SideEffectNoResult.Inst (MInst.Mvc dst src len_minus_one)))
 
 ;; Helper for emitting `MInst.FpuRR` instructions.
 (decl fpu_rr (Type FPUOp1 Reg) Reg)
@@ -2521,10 +2558,35 @@
 (rule (emit_arg_load $F64 mem) (vec_load_lane_undef $F64X2 mem 0))
 (rule (emit_arg_load (ty_vec128 ty) mem) (vec_load ty mem))
 
+;; Helpers to emit a memory copy (MVC or memcpy libcall).
+(decl emit_memcpy (MemArg MemArg u64) Unit)
+(rule (emit_memcpy dst src (len_minus_one len))
+      (emit_side_effect (mvc (memarg_pair dst) (memarg_pair src) len)))
+(rule (emit_memcpy dst src len)
+      (let ((libcall LibCallInfo (lib_call_info_memcpy))
+            (_ Unit (lib_accumulate_outgoing_args_size libcall))
+            (_ Unit (emit_mov $I64 (writable_gpr 2) (load_addr dst)))
+            (_ Unit (emit_mov $I64 (writable_gpr 3) (load_addr src)))
+            (_ Unit (emit_imm $I64 (writable_gpr 4) len)))
+        (emit_side_effect (lib_call libcall))))
+
+;; Prepare a stack copy of a single (oversized) argument.
+(decl copy_to_buffer (i64 ABIArg Value) InstOutput)
+(rule (copy_to_buffer base (abi_arg_only_slot slot) _) (output_none))
+(rule (copy_to_buffer base (abi_arg_struct_pointer _ offset size) val)
+      (let ((dst MemArg (memarg_stack_off base offset))
+            (src MemArg (memarg_reg_plus_off val 0 0 (memflags_trusted)))
+            (_ Unit (emit_memcpy dst src size)))
+        (output_none)))
+
 ;; Copy a single argument/return value to its slots.
+;; For oversized arguments, set the slot to the buffer address.
 (decl copy_to_arg (i64 ABIArg Value) Unit)
 (rule (copy_to_arg base (abi_arg_only_slot slot) val)
       (copy_val_to_arg_slot base slot val))
+(rule (copy_to_arg base (abi_arg_struct_pointer slot offset _) _)
+      (let ((ptr Reg (load_addr (memarg_stack_off base offset))))
+        (copy_reg_to_arg_slot base slot ptr)))
 
 ;; Copy a single argument/return value from its slots.
 (decl copy_from_arg (i64 ABIArg) ValueRegs)
@@ -3260,6 +3322,24 @@
 
 (decl abi_accumulate_outgoing_args_size (ABISig) Unit)
 (extern constructor abi_accumulate_outgoing_args_size abi_accumulate_outgoing_args_size)
+
+
+;; Helpers for generating calls to library routines ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(type LibCallInfo extern (enum))
+
+(decl lib_call_info_memcpy () LibCallInfo)
+(extern constructor lib_call_info_memcpy lib_call_info_memcpy)
+
+(decl lib_call_info (LibCallInfo) BoxCallInfo)
+(extern constructor lib_call_info lib_call_info)
+
+(decl lib_call (LibCallInfo) SideEffectNoResult)
+(rule (lib_call libcall)
+      (call_impl (writable_link_reg) (lib_call_info libcall)))
+
+(decl lib_accumulate_outgoing_args_size (LibCallInfo) Unit)
+(extern constructor lib_accumulate_outgoing_args_size lib_accumulate_outgoing_args_size)
 
 
 ;; Helpers for generating vector pack and unpack instructions ;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -145,6 +145,66 @@ impl MemArg {
     }
 }
 
+/// A memory argument for an instruction with two memory operands.
+/// We cannot use two instances of MemArg, because we do not have
+/// two free temp registers that would be needed to reload two
+/// addresses in the general case.  Also, two copies of MemArg would
+/// increase the size of Inst beyond its current limit.  Use this
+/// simplified form instead that never needs any reloads, and suffices
+/// for all current users.
+#[derive(Clone, Debug)]
+pub struct MemArgPair {
+    pub base: Reg,
+    pub disp: UImm12,
+    pub flags: MemFlags,
+}
+
+impl MemArgPair {
+    /// Convert a MemArg to a MemArgPair if possible.
+    pub fn maybe_from_memarg(mem: &MemArg) -> Option<MemArgPair> {
+        match mem {
+            &MemArg::BXD12 {
+                base,
+                index,
+                disp,
+                flags,
+            } => {
+                if index != zero_reg() {
+                    None
+                } else {
+                    Some(MemArgPair { base, disp, flags })
+                }
+            }
+            &MemArg::RegOffset { reg, off, flags } => {
+                if off < 0 {
+                    None
+                } else {
+                    let disp = UImm12::maybe_from_u64(off as u64)?;
+                    Some(MemArgPair {
+                        base: reg,
+                        disp,
+                        flags,
+                    })
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn can_trap(&self) -> bool {
+        !self.flags.notrap()
+    }
+
+    /// Edit registers with allocations.
+    pub fn with_allocs(&self, allocs: &mut AllocationConsumer<'_>) -> Self {
+        MemArgPair {
+            base: allocs.next(self.base),
+            disp: self.disp,
+            flags: self.flags,
+        }
+    }
+}
+
 //=============================================================================
 // Instruction sub-components (conditions, branches and branch targets):
 // definitions

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -5863,6 +5863,24 @@ fn test_s390x_binemit() {
     ));
 
     insns.push((
+        Inst::Mvc {
+            dst: MemArgPair {
+                base: gpr(2),
+                disp: UImm12::maybe_from_u64(0x345).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+            src: MemArgPair {
+                base: gpr(8),
+                disp: UImm12::maybe_from_u64(0x9ab).unwrap(),
+                flags: MemFlags::trusted(),
+            },
+            len_minus_one: 255,
+        },
+        "D2FF234589AB",
+        "mvc 837(255,%r2), 2475(%r8)",
+    ));
+
+    insns.push((
         Inst::LoadMultiple64 {
             rt: writable_gpr(8),
             rt2: writable_gpr(12),

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3591,16 +3591,30 @@
             (_ InstOutput (side_effect (abi_call_ind abi target (Opcode.CallIndirect)))))
         (lower_call_rets abi (range 0 (abi_num_rets abi)) (output_builder_new))))
 
-;; Lower function arguments by loading them into registers / stack slots.
+;; Lower function arguments.
 (decl lower_call_args (ABISig Range ValueSlice) InstOutput)
-(rule (lower_call_args abi (range_empty) _) (lower_call_ret_arg abi))
-(rule (lower_call_args abi (range_unwrap head tail) args)
-      (let ((idx usize (abi_copy_to_arg_order abi head))
-            (_ Unit (copy_to_arg 0 (abi_get_arg abi idx)
-                                 (value_slice_get args idx))))
-        (lower_call_args abi tail args)))
+(rule (lower_call_args abi range args)
+      (let ((_ InstOutput (lower_call_args_buffer abi range args))
+            (_ InstOutput (lower_call_args_slots abi range args)))
+        (lower_call_ret_arg abi)))
 
-;; Lower the implicit return-area pointer argument, if present.
+;; Lower function arguments (part 1): prepare buffer copies.
+(decl lower_call_args_buffer (ABISig Range ValueSlice) InstOutput)
+(rule (lower_call_args_buffer abi (range_empty) _) (output_none))
+(rule (lower_call_args_buffer abi (range_unwrap head tail) args)
+      (let ((_ InstOutput (copy_to_buffer 0 (abi_get_arg abi head)
+                                          (value_slice_get args head))))
+        (lower_call_args_buffer abi tail args)))
+
+;; Lower function arguments (part 2): set up registers / stack slots.
+(decl lower_call_args_slots (ABISig Range ValueSlice) InstOutput)
+(rule (lower_call_args_slots abi (range_empty) _) (output_none))
+(rule (lower_call_args_slots abi (range_unwrap head tail) args)
+      (let ((_ Unit (copy_to_arg 0 (abi_get_arg abi head)
+                                 (value_slice_get args head))))
+        (lower_call_args_slots abi tail args)))
+
+;; Lower function arguments (part 3): implicit return-area pointer.
 (decl lower_call_ret_arg (ABISig) InstOutput)
 (rule (lower_call_ret_arg (abi_no_ret_arg)) (output_none))
 (rule (lower_call_ret_arg abi @ (abi_ret_arg (abi_arg_only_slot slot)))

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -90,6 +90,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 assert!(size % 8 == 0, "StructArgument size is not properly aligned");
                 next_stack += size;
                 ret.push(ABIArg::StructArg {
+                    pointer: None,
                     offset,
                     size,
                     purpose: param.purpose,

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -712,12 +712,18 @@ where
             inputs.len(&self.lower_ctx.dfg().value_lists) - off,
             abi.num_args()
         );
-        for i in caller.get_copy_to_arg_order() {
+        let mut arg_regs = vec![];
+        for i in 0..abi.num_args() {
             let input = inputs
                 .get(off + i, &self.lower_ctx.dfg().value_lists)
                 .unwrap();
-            let arg_regs = self.lower_ctx.put_value_in_regs(input);
-            caller.emit_copy_regs_to_arg(self.lower_ctx, i, arg_regs);
+            arg_regs.push(self.lower_ctx.put_value_in_regs(input));
+        }
+        for (i, arg_regs) in arg_regs.iter().enumerate() {
+            caller.emit_copy_regs_to_buffer(self.lower_ctx, i, *arg_regs);
+        }
+        for (i, arg_regs) in arg_regs.iter().enumerate() {
+            caller.emit_copy_regs_to_arg(self.lower_ctx, i, *arg_regs);
         }
         caller.emit_call(self.lower_ctx);
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -780,10 +780,6 @@ macro_rules! isle_prelude_methods {
             regs.regs()[idx]
         }
 
-        fn abi_copy_to_arg_order(&mut self, abi: &ABISig, idx: usize) -> usize {
-            abi.copy_to_arg_order(idx)
-        }
-
         fn abi_num_args(&mut self, abi: &ABISig) -> usize {
             abi.num_args()
         }
@@ -825,6 +821,24 @@ macro_rules! isle_prelude_methods {
                 &ABIArg::Slots { ref slots, .. } => {
                     if slots.len() == 1 {
                         Some(slots[0])
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        }
+
+        fn abi_arg_struct_pointer(&mut self, arg: &ABIArg) -> Option<(ABIArgSlot, i64, u64)> {
+            match arg {
+                &ABIArg::StructArg {
+                    pointer,
+                    offset,
+                    size,
+                    ..
+                } => {
+                    if let Some(pointer) = pointer {
+                        Some((pointer, offset, size))
                     } else {
                         None
                     }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -828,10 +828,6 @@
     (Sext)
 ))
 
-;; Specific order for copying into arguments at callsites.
-(decl abi_copy_to_arg_order (ABISig usize) usize)
-(extern constructor abi_copy_to_arg_order abi_copy_to_arg_order)
-
 ;; Get the number of arguments expected.
 (decl abi_num_args (ABISig) usize)
 (extern constructor abi_num_args abi_num_args)
@@ -877,6 +873,11 @@
 ;; return value only requires a single slot to be passed.
 (decl abi_arg_only_slot (ABIArgSlot) ABIArg)
 (extern extractor abi_arg_only_slot abi_arg_only_slot)
+
+;; Extractor to detect the special case where a struct argument
+;; is explicitly passed by reference using a hidden pointer.
+(decl abi_arg_struct_pointer (ABIArgSlot i64 u64) ABIArg)
+(extern extractor abi_arg_struct_pointer abi_arg_struct_pointer)
 
 ;; Convert a real register number into a virtual register.
 (decl real_reg_to_reg (RealReg) Reg)

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -281,8 +281,8 @@ block0(v0: i64):
 ; block0:
 ;   mov x7, x0
 ;   movz x0, #42
-;   mov x1, x7
 ;   movz x2, #42
+;   mov x1, x7
 ;   ldr x10, 8 ; b 12 ; data TestCase { length: 3, ascii: [102, 49, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
 ;   blr x10
 ;   ldp fp, lr, [sp], #16

--- a/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
@@ -1,0 +1,124 @@
+test compile precise-output
+target s390x
+
+function u0:0(i64 sarg(64)) -> i8 system_v {
+block0(v0: i64):
+    v1 = load.i8 v0
+    return v1
+}
+
+; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+
+function u0:1(i64 sarg(64), i64) -> i8 system_v {
+block0(v0: i64, v1: i64):
+    v2 = load.i8 v1
+    v3 = load.i8 v0
+    v4 = iadd.i8 v2, v3
+    return v4
+}
+
+; block0:
+;   llc %r5, 0(%r3)
+;   llc %r2, 0(%r2)
+;   ark %r2, %r5, %r2
+;   br %r14
+
+function u0:2(i64) -> i8 system_v {
+fn1 = colocated u0:0(i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64):
+    v1 = call fn1(v0)
+    return v1
+}
+
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -224
+;   virtual_sp_offset_adjust 224
+; block0:
+;   mvc 160(63,%r15), 0(%r2)
+;   la %r2, 160(%r15)
+;   brasl %r14, u0:0
+;   lmg %r14, %r15, 336(%r15)
+;   br %r14
+
+function u0:3(i64, i64) -> i8 system_v {
+fn1 = colocated u0:0(i64, i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64, v1: i64):
+    v2 = call fn1(v0, v1)
+    return v2
+}
+
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -224
+;   virtual_sp_offset_adjust 224
+; block0:
+;   mvc 160(63,%r15), 0(%r3)
+;   la %r3, 160(%r15)
+;   brasl %r14, u0:0
+;   lmg %r14, %r15, 336(%r15)
+;   br %r14
+
+function u0:4(i64 sarg(256), i64 sarg(64)) -> i8 system_v {
+block0(v0: i64, v1: i64):
+    v2 = load.i8 v0
+    v3 = load.i8 v1
+    v4 = iadd.i8 v2, v3
+    return v4
+}
+
+; block0:
+;   llc %r5, 0(%r2)
+;   llc %r2, 0(%r3)
+;   ark %r2, %r5, %r2
+;   br %r14
+
+function u0:5(i64, i64, i64) -> i8 system_v {
+fn1 = colocated u0:0(i64, i64 sarg(256), i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = call fn1(v0, v1, v2)
+    return v3
+}
+
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -480
+;   virtual_sp_offset_adjust 480
+; block0:
+;   mvc 160(255,%r15), 0(%r3)
+;   mvc 416(63,%r15), 0(%r4)
+;   la %r3, 160(%r15)
+;   la %r4, 416(%r15)
+;   brasl %r14, u0:0
+;   lmg %r14, %r15, 592(%r15)
+;   br %r14
+
+function u0:6(i64, i64, i64) -> i8 system_v {
+fn1 = colocated u0:0(i64, i64 sarg(1024), i64 sarg(64)) -> i8 system_v
+
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = call fn1(v0, v1, v2)
+    return v3
+}
+
+;   stmg %r7, %r15, 56(%r15)
+;   aghi %r15, -1248
+;   virtual_sp_offset_adjust 1248
+; block0:
+;   lgr %r7, %r2
+;   lgr %r9, %r4
+;   la %r2, 160(%r15)
+;   la %r3, 0(%r3)
+;   lghi %r4, 1024
+;   brasl %r14, %Memcpy
+;   lgr %r4, %r9
+;   mvc 1184(63,%r15), 0(%r4)
+;   lgr %r2, %r7
+;   la %r3, 160(%r15)
+;   la %r4, 1184(%r15)
+;   brasl %r14, u0:0
+;   lmg %r7, %r15, 1304(%r15)
+;   br %r14
+


### PR DESCRIPTION
This adds support for StructArgument on s390x.  The ABI for this
platform requires that the address of the buffer holding the copy
of the struct argument is passed from caller to callee as hidden
pointer, using a register or overflow stack slot.

To implement this, I've added an optional "pointer" filed to
ABIArg::StructArg, and code to handle the pointer both in common
abi_impl code and the s390x back-end.

One notable change necessary to make this work involved the
"copy_to_arg_order" mechanism.  Currently, for struct args
we only need to copy the data (and that need to happen before
setting up any other args), while for non-struct args we only
need to set up the appropriate registers or stack slots.
This order is ensured by sorting the arguments appropriately
into a "copy_to_arg_order" list.

However, for struct args with explicit pointers we need to *both*
copy the data (again, before everything else), *and* set up a
register or stack slot.  Since we now need to touch the argument
twice, we cannot solve the ordering problem by a simple sort.
Instead, the abi_impl common code now provided *two* callbacks,
emit_copy_regs_to_buffer and emit_copy_regs_to_arg, and expects
the back end to first call copy..to_buffer for all args, and
then call copy.._to_arg for all args.  This required updates
to all back ends.

In the s390x back end, in addition to the new ABI code, I'm now
adding code to actually copy the struct data, using the MVC
instruction (for small buffers) or a memcpy libcall (for larger
buffers).  This also requires a bit of new infrastructure:
- MVC is the first memory-to-memory instruction we use, which
  needed a bit of memory argument tweaking
- We also need to set up the infrastructure to emit libcalls.

(FYI @cfallin - This implements the first half of issue #4565.)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
