### PR TITLE
cranelift: Build a runtest case from fuzzer TestCase's

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -40,17 +40,35 @@ target x86_64
 
         writeln!(f, "{}", self.func)?;
 
+        writeln!(f, "; Note: the results in the below test cases are simply a placeholder and probably will be wrong\n")?;
+
         for input in self.inputs.iter() {
+            // TODO: We don't know the expected outputs, maybe we can run the interpreter
+            // here to figure them out? Should work, however we need to be careful to catch
+            // panics in case its the interpreter that is failing.
+            // For now create a placeholder output consisting of the zero value for the type
+            let returns = &self.func.signature.returns;
+            let placeholder_output = returns
+                .iter()
+                .map(|param| DataValue::read_from_slice(&[0; 16][..], param.value_type))
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            // If we have no output, we don't need the == condition
+            let test_condition = match returns.len() {
+                0 => String::new(),
+                1 => format!(" == {}", placeholder_output),
+                _ => format!(" == [{}]", placeholder_output),
+            };
+
             let args = input
                 .iter()
                 .map(|val| format!("{}", val))
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            // TODO: We don't know the expected outputs, maybe we can run the interpreter
-            // here to figure them out? Should work, however we need to be careful to catch
-            // panics in case its the interpreter that is failing.
-            writeln!(f, "; run: {}({}) == TODO", self.func.name, args)?;
+            writeln!(f, "; run: {}({}){}", self.func.name, args, test_condition)?;
         }
 
         Ok(())

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -8,18 +8,53 @@ use cranelift::codegen::ir::Function;
 use cranelift::codegen::Context;
 use cranelift::prelude::*;
 use cranelift_native::builder_with_options;
+use std::fmt;
 
 mod config;
 mod function_generator;
 
 pub type TestCaseInput = Vec<DataValue>;
 
-#[derive(Debug)]
 pub struct TestCase {
     pub func: Function,
     /// Generate multiple test inputs for each test case.
     /// This allows us to get more coverage per compilation, which may be somewhat expensive.
     pub inputs: Vec<TestCaseInput>,
+}
+
+impl fmt::Debug for TestCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#";; Fuzzgen test case
+
+test interpret
+test run
+set enable_llvm_abi_extensions
+target aarch64
+target s390x
+target x86_64
+
+"#
+        )?;
+
+        writeln!(f, "{}", self.func)?;
+
+        for input in self.inputs.iter() {
+            let args = input
+                .iter()
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            // TODO: We don't know the expected outputs, maybe we can run the interpreter
+            // here to figure them out? Should work, however we need to be careful to catch
+            // panics in case its the interpreter that is failing.
+            writeln!(f, "; run: {}({}) == TODO", self.func.name, args)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> Arbitrary<'a> for TestCase {


### PR DESCRIPTION
👋 Hey,

This is a quality of life improvement for the fuzzer. With the custom `Debug` impl we build a runtest test case that automatically executes in the interpreter and in the compiler backend.

The test case needs some changes in order to be actually executable, since we don't know what the expected output of the function is. But an improvement in the future could be to run the interpreter in the `Debug` impl and print those results as the expected.

The big thing here is that it also formats floats correctly, which with the previous impl we a pain to get into a runtest since they were printed in integer format.

Here's an example output:
```
;; Fuzzgen test case          
                              
test interpret                
test run                      
set enable_llvm_abi_extensions
target aarch64
target s390x
target x86_64

function u0:0(f64, i8, i32) system_v {
... function body
}

; run: u0:0(-0x0.0ff7d7dff00ffp-1022, 32, 255) == TODO
; run: u0:0(0.0, 0, 0) == TODO
```

cc: @jameysharp 