### PR TITLE
cranelift: Print error message when basic blocks are invalid

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -496,9 +496,12 @@ impl<'a> FunctionBuilder<'a> {
         {
             // Iterate manually to provide more helpful error messages.
             for block in self.func_ctx.blocks.keys() {
-                if let Err((inst, _msg)) = self.func.is_block_basic(block) {
+                if let Err((inst, msg)) = self.func.is_block_basic(block) {
                     let inst_str = self.func.dfg.display_inst(inst);
-                    panic!("{} failed basic block invariants on {}", block, inst_str);
+                    panic!(
+                        "{} failed basic block invariants on {}: {}",
+                        block, inst_str, msg
+                    );
                 }
             }
         }


### PR DESCRIPTION
👋 Hey,
 
This PR changes the frontend to print not only the instruction that causes the block to be invalid, but what the actual issue is.

When working on the fuzzer this is helpful to pinpoint issues.

cc: @jameysharp 