### PR TITLE
Reduce wasm invocations in the `stacks` fuzzer

### DIFF
--- a/crates/fuzzing/src/generators/stacks.rs
+++ b/crates/fuzzing/src/generators/stacks.rs
@@ -35,7 +35,7 @@ enum Op {
 impl<'a> Arbitrary<'a> for Stacks {
     fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let funcs = Self::arbitrary_funcs(u)?;
-        let n = u.len();
+        let n = u.len().min(200);
         let inputs = u.bytes(n)?.to_vec();
         Ok(Stacks { funcs, inputs })
     }


### PR DESCRIPTION
On oss-fuzz a test case has been found that executes 30k iterations of a
wasm trap which with a 60s timeout leaves 2ms for each invocation which
under fuzzing instrumentation is a bit of a stretch with a ~20x
slowdown. This commit places a limit on the number of inputs to the
fuzzer at 200 to keep it reasonably sized.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
