### PR TITLE
components: process extract memory initializers for adapters.

### DIFF
--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -493,9 +493,12 @@ impl PartitionAdapterModules {
             GlobalInitializer::LowerImport(_) => self.items.lowerings += 1,
             GlobalInitializer::AlwaysTrap(_) => self.items.always_trap += 1,
 
+            GlobalInitializer::ExtractMemory(memory) => {
+                self.process_core_export(&mut memory.export);
+            }
+
             // Nothing is defined or referenced by these initializers that we
             // need to worry about here.
-            GlobalInitializer::ExtractMemory(_) => {}
             GlobalInitializer::SaveStaticModule(_) => {}
             GlobalInitializer::SaveModuleImport(_) => {}
         }

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -862,7 +862,7 @@ impl<'a> Inliner<'a> {
         }
     }
 
-    /// Translatees an `AdapterOptions` into a `CanonicalOptions` where
+    /// Translates an `AdapterOptions` into a `CanonicalOptions` where
     /// memories/functions are inserted into the global initializer list for
     /// use at runtime. This is only used for lowered host functions and lifted
     /// functions exported to the host.

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -256,7 +256,7 @@ impl<'a> Instantiator<'a> {
 
                     // Note that the unsafety here should be ok because the
                     // validity of the component means that type-checks have
-                    // already been performed. This maens that the unsafety due
+                    // already been performed. This means that the unsafety due
                     // to imports having the wrong type should not happen here.
                     let i =
                         unsafe { crate::Instance::new_started(store, module, imports.as_ref())? };

--- a/tests/misc_testsuite/component-model/fused.wast
+++ b/tests/misc_testsuite/component-model/fused.wast
@@ -1393,3 +1393,182 @@
   )
   (instance (instantiate $c2 (with "" (instance $c1))))
 )
+
+(component
+  (core module $m
+    (func (export ""))
+  )
+  (core instance $m (instantiate $m))
+  (func $foo (canon lift (core func $m "")))
+
+  (component $c
+    (import "" (func $foo))
+
+    (core func $foo (canon lower (func $foo)))
+    (core module $m2
+      (import "" "" (func))
+      (start 0)
+    )
+    (core instance $m2 (instantiate $m2 (with "" (instance (export "" (func $foo))))))
+  )
+
+  (instance $c (instantiate $c (with "" (func $foo))))
+)
+
+(component
+  (component
+    (core module
+      (func $execute (param i32 i32)
+        unreachable
+      )
+      (func $canonical_abi_realloc (param i32 i32 i32 i32) (result i32)
+        unreachable
+      )
+      (memory 1)
+      (export "memory" (memory 0))
+      (export "execute" (func $execute))
+      (export "canonical_abi_realloc" (func $canonical_abi_realloc))
+    )
+    (core instance (instantiate 0))
+    (core alias export 0 "memory" (memory))
+    (core alias export 0 "canonical_abi_realloc" (func))
+    (core alias export 0 "execute" (func))
+    (func (param "x" (list u8)) (canon lift (core func 1) (memory 0) (realloc 0)))
+    (export "execute" (func 0))
+  )
+  (component
+    (type 
+      (instance
+        (export "execute" (func (param "x" (list u8))))
+      )
+    )
+    (import "backend" (instance (type 0)))
+    (core module
+      (func $execute (param i32 i32)
+        unreachable
+      )
+      (func $canonical_abi_realloc (param i32 i32 i32 i32) (result i32)
+        unreachable
+      )
+      (memory 1)
+      (export "memory" (memory 0))
+      (export "execute" (func $execute))
+      (export "canonical_abi_realloc" (func $canonical_abi_realloc))
+    )
+    (core module
+      (type (func (param i32 i32)))
+      (func (type 0) (param i32 i32)
+        local.get 0
+        local.get 1
+        call_indirect (type 0)
+      )
+      (table 1 1 funcref)
+      (export "0" (func 0))
+      (export "$imports" (table 0))
+    )
+    (core module
+      (type (func (param i32 i32)))
+      (import "" "0" (func (type 0)))
+      (import "" "$imports" (table 1 1 funcref))
+      (elem (i32.const 0) func 0)
+    )
+    (core instance (instantiate 1))
+    (core alias export 0 "0" (func))
+    (core instance 
+      (export "execute" (func 0))
+    )
+    (core instance (instantiate 0
+        (with "backend" (instance 1))
+      )
+    )
+    (core alias export 2 "memory" (memory))
+    (core alias export 2 "canonical_abi_realloc" (func))
+    (core alias export 0 "$imports" (table))
+    (alias export 0 "execute" (func))
+    (core func (canon lower (func 0) (memory 0) (realloc 1)))
+    (core instance 
+      (export "$imports" (table 0))
+      (export "0" (func 2))
+    )
+    (core instance (instantiate 2
+        (with "" (instance 3))
+      )
+    )
+    (core alias export 2 "execute" (func))
+    (func (param "x" (list u8)) (canon lift (core func 3) (memory 0) (realloc 1)))
+    (export "execute" (func 1))
+  )
+  (component
+    (type 
+      (instance
+        (export "execute" (func (param "x" (list u8))))
+      )
+    )
+    (import "backend" (instance (type 0)))
+    (core module
+      (func $execute (param i32 i32)
+        unreachable
+      )
+      (func $canonical_abi_realloc (param i32 i32 i32 i32) (result i32)
+        unreachable
+      )
+      (memory 1)
+      (export "memory" (memory 0))
+      (export "execute" (func $execute))
+      (export "canonical_abi_realloc" (func $canonical_abi_realloc))
+    )
+    (core module
+      (type (func (param i32 i32)))
+      (func (type 0) (param i32 i32)
+        local.get 0
+        local.get 1
+        call_indirect (type 0)
+      )
+      (table 1 1 funcref)
+      (export "0" (func 0))
+      (export "$imports" (table 0))
+    )
+    (core module
+      (type (func (param i32 i32)))
+      (import "" "0" (func (type 0)))
+      (import "" "$imports" (table 1 1 funcref))
+      (elem (i32.const 0) func 0)
+    )
+    (core instance (instantiate 1))
+    (core alias export 0 "0" (func))
+    (core instance 
+      (export "execute" (func 0))
+    )
+    (core instance (instantiate 0
+        (with "backend" (instance 1))
+      )
+    )
+    (core alias export 2 "memory" (memory))
+    (core alias export 2 "canonical_abi_realloc" (func))
+    (core alias export 0 "$imports" (table))
+    (alias export 0 "execute" (func))
+    (core func (canon lower (func 0) (memory 0) (realloc 1)))
+    (core instance 
+      (export "$imports" (table 0))
+      (export "0" (func 2))
+    )
+    (core instance (instantiate 2
+        (with "" (instance 3))
+      )
+    )
+    (core alias export 2 "execute" (func))
+    (func (param "x" (list u8)) (canon lift (core func 3) (memory 0) (realloc 1)))
+    (export "execute" (func 1))
+  )
+  (instance (instantiate 0))
+  (instance (instantiate 1
+      (with "backend" (instance 0))
+    )
+  )
+  (instance (instantiate 2
+      (with "backend" (instance 1))
+    )
+  )
+  (alias export 2 "execute" (func))
+  (export "execute" (func 0))
+)


### PR DESCRIPTION
This PR fixes an issue where the `ExtractMemory` initializer wasn't
processed for adapters, leading to incorrect runtime instance indexes in
the initializer resulting from the insertion of adapter instances.

Ultimately this would either resolve the memory from the wrong instance
or panic if the referenced instance didn't export a memory when
instantiating the component.

The fix is to fixup the memory export's instance when processing global
initializers.
