### PR TITLE
s390x: Implement tls_value

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -59,6 +59,11 @@ pub enum Reloc {
     /// Set the add immediate field to the low 12 bits of the final address. Does not check for overflow.
     /// This is equivalent to `R_AARCH64_TLSGD_ADD_LO12_NC` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
     Aarch64TlsGdAddLo12Nc,
+
+    /// s390x TLS GD64 - 64-bit offset of tls_index for GD symbol in GOT
+    S390xTlsGd64,
+    /// s390x TLS GDCall - marker to enable optimization of TLS calls
+    S390xTlsGdCall,
 }
 
 impl fmt::Display for Reloc {
@@ -79,6 +84,8 @@ impl fmt::Display for Reloc {
             Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
             Self::Aarch64TlsGdAdrPage21 => write!(f, "Aarch64TlsGdAdrPage21"),
             Self::Aarch64TlsGdAddLo12Nc => write!(f, "Aarch64TlsGdAddLo12Nc"),
+            Self::S390xTlsGd64 => write!(f, "TlsGd64"),
+            Self::S390xTlsGdCall => write!(f, "TlsGdCall"),
         }
     }
 }

--- a/cranelift/codegen/src/ir/known_symbol.rs
+++ b/cranelift/codegen/src/ir/known_symbol.rs
@@ -1,0 +1,42 @@
+use core::fmt;
+use core::str::FromStr;
+#[cfg(feature = "enable-serde")]
+use serde::{Deserialize, Serialize};
+
+/// A well-known symbol.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub enum KnownSymbol {
+    /// ELF well-known linker symbol _GLOBAL_OFFSET_TABLE_
+    ElfGlobalOffsetTable,
+}
+
+impl fmt::Display for KnownSymbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+impl FromStr for KnownSymbol {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ElfGlobalOffsetTable" => Ok(Self::ElfGlobalOffsetTable),
+            _ => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parsing() {
+        assert_eq!(
+            "ElfGlobalOffsetTable".parse(),
+            Ok(KnownSymbol::ElfGlobalOffsetTable)
+        );
+    }
+}

--- a/cranelift/codegen/src/ir/libcall.rs
+++ b/cranelift/codegen/src/ir/libcall.rs
@@ -66,6 +66,8 @@ pub enum LibCall {
 
     /// Elf __tls_get_addr
     ElfTlsGetAddr,
+    /// Elf __tls_get_offset
+    ElfTlsGetOffset,
     // When adding a new variant make sure to add it to `all_libcalls` too.
 }
 
@@ -104,6 +106,7 @@ impl FromStr for LibCall {
             "Memcmp" => Ok(Self::Memcmp),
 
             "ElfTlsGetAddr" => Ok(Self::ElfTlsGetAddr),
+            "ElfTlsGetOffset" => Ok(Self::ElfTlsGetOffset),
             _ => Err(()),
         }
     }
@@ -173,6 +176,7 @@ impl LibCall {
             Memmove,
             Memcmp,
             ElfTlsGetAddr,
+            ElfTlsGetOffset,
         ]
     }
 
@@ -214,7 +218,8 @@ impl LibCall {
             | LibCall::Memset
             | LibCall::Memmove
             | LibCall::Memcmp
-            | LibCall::ElfTlsGetAddr => unimplemented!(),
+            | LibCall::ElfTlsGetAddr
+            | LibCall::ElfTlsGetOffset => unimplemented!(),
         }
 
         sig

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -15,6 +15,7 @@ mod heap;
 pub mod immediates;
 pub mod instructions;
 pub mod jumptable;
+pub(crate) mod known_symbol;
 pub mod layout;
 pub(crate) mod libcall;
 mod memflags;
@@ -50,6 +51,7 @@ pub use crate::ir::instructions::{
     InstructionData, Opcode, ValueList, ValueListPool, VariableArgs,
 };
 pub use crate::ir::jumptable::JumpTableData;
+pub use crate::ir::known_symbol::KnownSymbol;
 pub use crate::ir::layout::Layout;
 pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::{Endianness, MemFlags};

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -424,6 +424,17 @@
       (rd WritableReg)
       (imm UImm32Shifted))
 
+    ;; Load 32-bit access register into GPR.
+    (LoadAR
+      (rd WritableReg)
+      (ar u8))
+
+    ;; Insert 32-bit access register into low half of a GPR.
+    ;; (Identical operation to LoadAR, but considers rd to be use/def.)
+    (InsertAR
+      (rd WritableReg)
+      (ar u8))
+
     ;; A sign- or zero-extend operation.
     (Extend
       (rd WritableReg)
@@ -857,11 +868,10 @@
       (ridx Reg)
       (targets VecMachLabel))
 
-    ;; Load an inline symbol reference with RelocDistance::Far.
-    (LoadExtNameFar
+    ;; Load an inline symbol reference with relocation.
+    (LoadSymbolReloc
       (rd WritableReg)
-      (name BoxExternalName)
-      (offset i64))
+      (symbol_reloc BoxSymbolReloc))
 
     ;; Load address referenced by `mem` into `rd`.
     (LoadAddr
@@ -902,6 +912,23 @@
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxJTSequenceInfo (primitive BoxJTSequenceInfo))
 (type VecMachLabel extern (enum))
+
+;; A symbol reference carrying relocation information.
+(type SymbolReloc
+  (enum
+    ;; Absolute symbol reference (with optional offset).
+    (Absolute
+      (name ExternalName)
+      (offset i64))
+    ;; Reference to a TLS symbol in general-dynamic mode.
+    (TlsGd
+      (name ExternalName))))
+
+;; Boxed version of SymbolReloc to save space.
+(type BoxSymbolReloc (primitive BoxSymbolReloc))
+(decl box_symbol_reloc (SymbolReloc) BoxSymbolReloc)
+(extern constructor box_symbol_reloc box_symbol_reloc)
+(convert SymbolReloc BoxSymbolReloc box_symbol_reloc)
 
 ;; An ALU operation.
 (type ALUOp
@@ -1613,6 +1640,9 @@
 (decl memarg_symbol (ExternalName i32 MemFlags) MemArg)
 (extern constructor memarg_symbol memarg_symbol)
 
+(decl memarg_got () MemArg)
+(extern constructor memarg_got memarg_got)
+
 ;; Create a MemArg refering to a stack address formed by
 ;; adding a base (relative to SP) and an offset.
 (decl memarg_stack_off (i64 i64) MemArg)
@@ -2120,6 +2150,20 @@
 (rule (mvc dst src len_minus_one)
       (SideEffectNoResult.Inst (MInst.Mvc dst src len_minus_one)))
 
+;; Helper for emitting `MInst.LoadAR` instructions.
+(decl load_ar (u8) Reg)
+(rule (load_ar ar)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.LoadAR dst ar))))
+        dst))
+
+;; Helper for emitting `MInst.InsertAR` instructions.
+(decl insert_ar (Reg u8) Reg)
+(rule (insert_ar src ar)
+      (let ((dst WritableReg (copy_writable_reg $I64 src))
+            (_ Unit (emit (MInst.InsertAR dst ar))))
+        dst))
+
 ;; Helper for emitting `MInst.FpuRR` instructions.
 (decl fpu_rr (Type FPUOp1 Reg) Reg)
 (rule (fpu_rr ty op src)
@@ -2393,12 +2437,11 @@
             (_ Unit (emit (MInst.VecReplicateLane size dst src lane_imm))))
         dst))
 
-;; Helper for emitting `MInst.LoadExtNameFar` instructions.
-(decl load_ext_name_far (ExternalName i64) Reg)
-(rule (load_ext_name_far name offset)
+;; Helper for emitting `MInst.LoadSymbolReloc` instructions.
+(decl load_symbol_reloc (SymbolReloc) Reg)
+(rule (load_symbol_reloc symbol_reloc)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (boxed_name BoxExternalName (box_external_name name))
-            (_ Unit (emit (MInst.LoadExtNameFar dst boxed_name offset))))
+            (_ Unit (emit (MInst.LoadSymbolReloc dst symbol_reloc))))
         dst))
 
 ;; Helper for emitting `MInst.LoadAddr` instructions.
@@ -3404,6 +3447,9 @@
 
 (decl lib_call_info_memcpy () LibCallInfo)
 (extern constructor lib_call_info_memcpy lib_call_info_memcpy)
+
+(decl lib_call_info_tls_get_offset (SymbolReloc) LibCallInfo)
+(extern constructor lib_call_info_tls_get_offset lib_call_info_tls_get_offset)
 
 (decl lib_call_info (LibCallInfo) BoxCallInfo)
 (extern constructor lib_call_info lib_call_info)

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -6828,6 +6828,7 @@ fn test_s390x_binemit() {
                 opcode: Opcode::Call,
                 caller_callconv: CallConv::SystemV,
                 callee_callconv: CallConv::SystemV,
+                tls_symbol: None,
             }),
         },
         "C0E500000000",

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -2388,7 +2388,7 @@
 
 ;; Load the address of a function, general case.
 (rule (lower (func_addr (func_ref_data _ name _)))
-      (load_ext_name_far name 0))
+      (load_symbol_reloc (SymbolReloc.Absolute name 0)))
 
 
 ;;;; Rules for `symbol_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2401,7 +2401,34 @@
 
 ;; Load the address of a symbol, general case.
 (rule (lower (symbol_value (symbol_value_data name _ offset)))
-      (load_ext_name_far name offset))
+      (load_symbol_reloc (SymbolReloc.Absolute name offset)))
+
+
+;;;; Rules for `tls_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Load the address of a TLS symbol (ELF general-dynamic model).
+(rule (lower (tls_value (symbol_value_data name _ 0)))
+      (if (tls_model_is_elf_gd))
+      (let ((symbol SymbolReloc (SymbolReloc.TlsGd name))
+            (got Reg (load_addr (memarg_got)))
+            (got_offset Reg (load_symbol_reloc symbol))
+            (tls_offset Reg (lib_call_tls_get_offset got got_offset symbol)))
+        (add_reg $I64 tls_offset (thread_pointer))))
+
+;; Helper to perform a call to the __tls_get_offset library routine.
+(decl lib_call_tls_get_offset (Reg Reg SymbolReloc) Reg)
+(rule (lib_call_tls_get_offset got got_offset symbol)
+      (let ((libcall LibCallInfo (lib_call_info_tls_get_offset symbol))
+            (_ Unit (lib_accumulate_outgoing_args_size libcall))
+            (_ Unit (emit_mov $I64 (writable_gpr 12) got))
+            (_ Unit (emit_mov $I64 (writable_gpr 2) got_offset))
+            (_ Unit (emit_side_effect (lib_call libcall))))
+        (copy_reg $I64 (writable_gpr 2))))
+
+;; Helper to extract the current thread pointer from %a0/%a1.
+(decl thread_pointer () Reg)
+(rule (thread_pointer)
+      (insert_ar (lshl_imm $I64 (load_ar 0) 32) 1))
 
 
 ;;;; Rules for `load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3811,7 +3838,7 @@
       (let ((abi ABISig (abi_sig sig_ref))
             (_ Unit (abi_accumulate_outgoing_args_size abi))
             (_ InstOutput (lower_call_args abi (range 0 (abi_num_args abi)) args))
-            (target Reg (load_ext_name_far name 0))
+            (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
             (_ InstOutput (side_effect (abi_call_ind abi target (Opcode.Call)))))
         (lower_call_rets abi (range 0 (abi_num_rets abi)) (output_builder_new))))
 

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -189,6 +189,7 @@ impl LowerBackend for S390xBackend {
             | Opcode::StackAddr
             | Opcode::FuncAddr
             | Opcode::SymbolValue
+            | Opcode::TlsValue
             | Opcode::GetFramePointer
             | Opcode::GetStackPointer
             | Opcode::GetReturnAddress => {
@@ -200,7 +201,6 @@ impl LowerBackend for S390xBackend {
             }
 
             Opcode::ConstAddr
-            | Opcode::TlsValue
             | Opcode::GetPinnedReg
             | Opcode::SetPinnedReg
             | Opcode::Vsplit

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -15,6 +15,7 @@ pub use crate::isa::unwind::UnwindInst;
 pub use crate::machinst::{
     ABIArg, ABIArgSlot, ABISig, InputSourceInst, RealReg, Reg, RelocDistance, Writable,
 };
+pub use crate::settings::TlsModel;
 
 pub type Unit = ();
 pub type ValueSlice = (ValueList, usize);
@@ -610,6 +611,15 @@ macro_rules! isle_prelude_methods {
 
         fn avoid_div_traps(&mut self, _: Type) -> Option<()> {
             if self.flags.avoid_div_traps() {
+                Some(())
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        fn tls_model_is_elf_gd(&mut self) -> Option<()> {
+            if self.flags.tls_model() == TlsModel::ElfGd {
                 Some(())
             } else {
                 None

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -755,6 +755,9 @@
 (decl avoid_div_traps () Type)
 (extern extractor avoid_div_traps avoid_div_traps)
 
+(decl pure tls_model_is_elf_gd () Unit)
+(extern constructor tls_model_is_elf_gd tls_model_is_elf_gd)
+
 ;;;; Helpers for accessing instruction data ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Accessor for `FuncRef`.

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -1,0 +1,26 @@
+test compile precise-output
+set tls_model=elf_gd
+target s390x
+
+function u0:0(i32) -> i64 {
+gv0 = symbol colocated tls u1:0
+
+block0(v0: i32):
+    v1 = global_value.i64 gv0
+    return v1
+}
+
+;   stmg %r12, %r15, 96(%r15)
+;   aghi %r15, -160
+;   virtual_sp_offset_adjust 160
+; block0:
+;   larl %r12, %ElfGlobalOffsetTable + 0
+;   bras %r1, 12 ; data u1:0@tlsgd ; lg %r2, 0(%r1)
+;   brasl %r14, %ElfTlsGetOffset:tls_gdcall:u1:0
+;   ear %r3, %a0
+;   sllg %r4, %r3, 32
+;   ear %r4, %a1
+;   agr %r2, %r4
+;   lmg %r12, %r15, 256(%r15)
+;   br %r14
+

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -78,5 +78,6 @@ pub fn default_libcall_names() -> Box<dyn Fn(ir::LibCall) -> String + Send + Syn
         ir::LibCall::Memcmp => "memcmp".to_owned(),
 
         ir::LibCall::ElfTlsGetAddr => "__tls_get_addr".to_owned(),
+        ir::LibCall::ElfTlsGetOffset => "__tls_get_offset".to_owned(),
     })
 }


### PR DESCRIPTION
Implement the tls_value for s390 in the ELF general-dynamic mode.

Notable differences to the x86_64 implementation are:
- We use a `__tls_get_offset` libcall instead of `__tls_get_addr`.
- The current thread pointer (stored in a pair of access registers)
  needs to be added to the result of `__tls_get_offset`.
- `__tls_get_offset` has a variant ABI that requires the address of
  the GOT (global offset table) is passed in %r12.

This means we need a new libcall entries for `__tls_get_offset`.
In addition, we also need a way to access `_GLOBAL_OFFSET_TABLE_`.
The latter is a "magic" symbol with a well-known name defined
by the ABI and recognized by the linker.  This patch introduces
a new `ExternalName::KnownSymbol` variant to support such names
(originally due to @afonso360).

We also need to emit a relocation on a symbol placed in a
constant pool, as well as an extra relocation on the call
to `__tls_get_offset` required for TLS linker optimization.

Needed by the cg_clif frontend.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
