### PR TITLE
x64: Migrate selectif and selectif_spectre_guard to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3158,6 +3158,14 @@
 
 ;; Emit a conditional move based on the result of an icmp.
 (decl select_icmp (IcmpCondResult Value Value) ValueRegs)
+
+;; Ensure that we put the `x` argument into a register for single-register
+;; gpr-typed arguments, as we rely on this for the legalization of heap_addr and
+;; loading easily computed constants (like 0) from memory is too expensive.
+(rule (select_icmp (IcmpCondResult.Condition producer cc) x @ (value_type (is_gpr_type (is_single_register_type ty))) y)
+      (with_flags producer (cmove ty cc (put_in_gpr x) y)))
+
+;; Otherwise, fall back on the behavior of `cmove_from_values`.
 (rule (select_icmp (IcmpCondResult.Condition producer cc) x @ (value_type ty) y)
       (with_flags producer (cmove_from_values ty cc x y)))
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3140,7 +3140,6 @@
           (ConsumesFlags.ConsumesFlagsSideEffect
             (MInst.JmpTableSeq idx tmp1 tmp2 default_target jt_targets)))))
 
-
 ;;;; Comparisons ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (type IcmpCondResult (enum (Condition (producer ProducesFlags) (cc CC))))
@@ -3156,6 +3155,11 @@
 (decl lower_icmp_bool (IcmpCondResult) ValueRegs)
 (rule (lower_icmp_bool (IcmpCondResult.Condition producer cc))
       (with_flags producer (x64_setcc cc)))
+
+;; Emit a conditional move based on the result of an icmp.
+(decl select_icmp (IcmpCondResult Value Value) ValueRegs)
+(rule (select_icmp (IcmpCondResult.Condition producer cc) x @ (value_type ty) y)
+      (with_flags producer (cmove_from_values ty cc x y)))
 
 (decl emit_cmp (IntCC Value Value) IcmpCondResult)
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -645,21 +645,6 @@ impl Inst {
         }
     }
 
-    pub(crate) fn xmm_cmove(ty: Type, cc: CC, src: RegMem, dst: Writable<Reg>) -> Inst {
-        debug_assert!(ty == types::F32 || ty == types::F64 || ty.is_vector());
-        src.assert_regclass_is(RegClass::Float);
-        debug_assert!(dst.to_reg().class() == RegClass::Float);
-        let src = XmmMem::new(src).unwrap();
-        let dst = WritableXmm::from_writable_reg(dst).unwrap();
-        Inst::XmmCmove {
-            ty,
-            cc,
-            consequent: src,
-            alternative: dst.to_reg(),
-            dst,
-        }
-    }
-
     pub(crate) fn push64(src: RegMemImm) -> Inst {
         src.assert_regclass_is(RegClass::Int);
         let src = GprMemImm::new(src).unwrap();

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2948,8 +2948,8 @@
 
 ;; Rules for `selectif` and `selectif_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type ty (selectif cc (ifcmp a b) x y)))
+(rule (lower (selectif cc (ifcmp a b) x y))
       (select_icmp (emit_cmp cc a b) x y))
 
-(rule (lower (has_type ty (selectif_spectre_guard cc (ifcmp a b) x y)))
+(rule (lower (selectif_spectre_guard cc (ifcmp a b) x y))
       (select_icmp (emit_cmp cc a b) x y))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2945,3 +2945,11 @@
 
 (rule (lower_branch (br_table idx @ (value_type ty) _ _) (jump_table_targets default_target jt_targets))
       (side_effect (jmp_table_seq ty idx default_target jt_targets)))
+
+;; Rules for `selectif` and `selectif_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type ty (selectif cc (ifcmp a b) x y)))
+      (select_icmp (emit_cmp cc a b) x y))
+
+(rule (lower (has_type ty (selectif_spectre_guard cc (ifcmp a b) x y)))
+      (select_icmp (emit_cmp cc a b) x y))

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -25,9 +25,8 @@ block0(v0: i32, v1: i64):
 ;   jbe     label1; j label2
 ; block1:
 ;   addq    %rax, 0(%rsi), %rax
-;   xorq    %rdx, %rdx, %rdx
 ;   cmpq    %rdi, %rcx
-;   cmovnbeq %rdx, %rax, %rax
+;   cmovnbeq const(VCodeConstant(0)), %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -25,8 +25,9 @@ block0(v0: i32, v1: i64):
 ;   jbe     label1; j label2
 ; block1:
 ;   addq    %rax, 0(%rsi), %rax
+;   xorq    %rdx, %rdx, %rdx
 ;   cmpq    %rdi, %rcx
-;   cmovnbeq const(VCodeConstant(0)), %rax, %rax
+;   cmovnbeq %rdx, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
Lower `selectif` and `selectif_spectre_guard` in ISLE, which allows a lot of code related to `emit_cmp` to be removed from the x64 lower.rs module.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
