### PR TITLE
Cranelift: Remove unused `ABICaller::signature` method

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -191,9 +191,6 @@ pub trait ABICaller {
     /// Get the number of arguments expected.
     fn num_args(&self) -> usize;
 
-    /// Access the (possibly legalized) signature.
-    fn signature(&self) -> &Signature;
-
     /// Emit a copy of an argument value from a source register, prior to the call.
     /// For large arguments with associated stack buffer, this may load the address
     /// of the buffer into the argument register, if required by the ABI.

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1601,8 +1601,6 @@ impl<M: ABIMachineSpec> ABICallee for ABICalleeImpl<M> {
 
 /// ABI object for a callsite.
 pub struct ABICallerImpl<M: ABIMachineSpec> {
-    /// CLIF-level signature, possibly normalized.
-    ir_sig: ir::Signature,
     /// The called function's signature.
     sig: ABISig,
     /// All uses for the callsite, i.e., function args.
@@ -1645,7 +1643,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
         let sig = ABISig::from_func_sig::<M>(&ir_sig, flags)?;
         let (uses, defs, clobbers) = sig.call_uses_defs_clobbers::<M>();
         Ok(ABICallerImpl {
-            ir_sig,
             sig,
             uses,
             defs,
@@ -1671,7 +1668,6 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
         let sig = ABISig::from_func_sig::<M>(&ir_sig, flags)?;
         let (uses, defs, clobbers) = sig.call_uses_defs_clobbers::<M>();
         Ok(ABICallerImpl {
-            ir_sig,
             sig,
             uses,
             defs,
@@ -1702,10 +1698,6 @@ fn adjust_stack_and_nominal_sp<M: ABIMachineSpec, C: LowerCtx<I = M::I>>(
 
 impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
     type I = M::I;
-
-    fn signature(&self) -> &ir::Signature {
-        &self.ir_sig
-    }
 
     fn num_args(&self) -> usize {
         if self.sig.stack_ret_arg.is_some() {


### PR DESCRIPTION
And the `ABICallerImpl::ir_sig` field that was used to implement that
method. This removes 56 bytes from the size of `ABICallerImpl` and gives us
speed ups to compilation of about 7% on all benchmarks.

```
compilation :: nanoseconds :: benchmarks/pulldown-cmark/benchmark.wasm

  Δ = 8205119.48 ± 4069474.25 (confidence = 99%)

  main.so is 0.91x to 0.97x faster than feature.so!
  feature.so is 1.03x to 1.10x faster than main.so!

  [117729152 132258110.36 167484097] main.so
  [107486500 124052990.88 138008797] feature.so

compilation :: nanoseconds :: benchmarks/bz2/benchmark.wasm

  Δ = 4645258.32 ± 1981104.59 (confidence = 99%)

  main.so is 0.92x to 0.97x faster than feature.so!
  feature.so is 1.03x to 1.08x faster than main.so!

  [76562171 85504479.28 93116863] main.so
  [75180650 80859220.96 90591978] feature.so

compilation :: nanoseconds :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 150575617.54 ± 65021102.57 (confidence = 99%)

  main.so is 0.92x to 0.97x faster than feature.so!
  feature.so is 1.03x to 1.08x faster than main.so!

  [2573089039 2843117485.10 3175982602] main.so
  [2559784932 2692541867.56 3143529008] feature.so
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
