### PR TITLE
Fix an issue in adapter module partitioning

### DIFF
--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -352,6 +352,7 @@ enum RuntimeInstance {
 
 impl LinearizeDfg<'_> {
     fn instantiate(&mut self, instance: InstanceId, args: &Instance) {
+        log::trace!("creating instance {instance:?}");
         let instantiation = match args {
             Instance::Static(index, args) => InstantiateModule::Static(
                 *index,
@@ -500,8 +501,10 @@ impl LinearizeDfg<'_> {
     where
         T: Clone,
     {
+        let instance = export.instance;
+        log::trace!("referencing export of {instance:?}");
         info::CoreExport {
-            instance: self.runtime_instances[&RuntimeInstance::Normal(export.instance)],
+            instance: self.runtime_instances[&RuntimeInstance::Normal(instance)],
             item: export.item.clone(),
         }
     }


### PR DESCRIPTION
When an adapter module depends on a particular core wasm instance this
means that it actually depends on not only that instance but all prior
core wasm instances as well. This is because core wasm instances must be
instantiated in the specified order within a component and that cannot
change depending on the dataflow between adapters. This commit fixes a
possible panic from linearizing the component dfg where an adapter
module tried to depend on an instance that hadn't been instantiated yet
because the ordering dependency between core wasm instances hadn't been
modeled.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
