### PR TITLE
Implement strings in adapter modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3333,6 +3342,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "cfg-if",
+ "encoding_rs",
  "indexmap",
  "libc",
  "log",
@@ -3653,6 +3663,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
+ "encoding_rs",
  "indexmap",
  "libc",
  "log",

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -10,8 +10,9 @@ use object::write::Object;
 use std::any::Any;
 use std::ops::Range;
 use wasmtime_environ::component::{
-    AlwaysTrapInfo, CanonicalOptions, Component, ComponentCompiler, ComponentTypes, FunctionInfo,
-    LowerImport, LoweredIndex, RuntimeAlwaysTrapIndex, VMComponentOffsets,
+    AlwaysTrapInfo, CanonicalOptions, Component, ComponentCompiler, ComponentTypes, FixedEncoding,
+    FunctionInfo, LowerImport, LoweredIndex, RuntimeAlwaysTrapIndex, RuntimeMemoryIndex,
+    RuntimeTranscoderIndex, Transcode, Transcoder, VMComponentOffsets,
 };
 use wasmtime_environ::{PrimaryMap, PtrSize, SignatureIndex, Trampoline, TrapCode, WasmFuncType};
 
@@ -47,42 +48,7 @@ impl ComponentCompiler for Compiler {
         let vmctx = builder.func.dfg.block_params(block0)[0];
 
         // Save the exit FP and return address for stack walking purposes.
-        //
-        // First we need to get the `VMRuntimeLimits`.
-        let limits = builder.ins().load(
-            pointer_type,
-            MemFlags::trusted(),
-            vmctx,
-            i32::try_from(offsets.limits()).unwrap(),
-        );
-        // Then save the exit Wasm FP to the limits. We dereference the current
-        // FP to get the previous FP because the current FP is the trampoline's
-        // FP, and we want the Wasm function's FP, which is the caller of this
-        // trampoline.
-        let trampoline_fp = builder.ins().get_frame_pointer(pointer_type);
-        let wasm_fp = builder.ins().load(
-            pointer_type,
-            MemFlags::trusted(),
-            trampoline_fp,
-            // The FP always points to the next older FP for all supported
-            // targets. See assertion in
-            // `crates/runtime/src/traphandlers/backtrace.rs`.
-            0,
-        );
-        builder.ins().store(
-            MemFlags::trusted(),
-            wasm_fp,
-            limits,
-            offsets.ptr.vmruntime_limits_last_wasm_exit_fp(),
-        );
-        // Finally save the Wasm return address to the limits.
-        let wasm_pc = builder.ins().get_return_address(pointer_type);
-        builder.ins().store(
-            MemFlags::trusted(),
-            wasm_pc,
-            limits,
-            offsets.ptr.vmruntime_limits_last_wasm_exit_pc(),
-        );
+        self.save_last_wasm_fp_and_pc(&mut builder, &offsets, vmctx);
 
         // Below this will incrementally build both the signature of the host
         // function we're calling as well as the list of arguments since the
@@ -219,15 +185,53 @@ impl ComponentCompiler for Compiler {
         Ok(Box::new(func))
     }
 
+    fn compile_transcoder(
+        &self,
+        component: &Component,
+        transcoder: &Transcoder,
+        types: &ComponentTypes,
+    ) -> Result<Box<dyn Any + Send>> {
+        let ty = &types[transcoder.signature];
+        let isa = &*self.isa;
+        let offsets = VMComponentOffsets::new(isa.pointer_bytes(), component);
+
+        let CompilerContext {
+            mut func_translator,
+            codegen_context: mut context,
+        } = self.take_context();
+
+        context.func = ir::Function::with_name_signature(
+            ir::ExternalName::user(0, 0),
+            crate::indirect_signature(isa, ty),
+        );
+
+        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
+        let block0 = builder.create_block();
+        builder.append_block_params_for_function_params(block0);
+        builder.switch_to_block(block0);
+        builder.seal_block(block0);
+
+        self.translate_transcode(&mut builder, &offsets, transcoder, block0);
+
+        let func: CompiledFunction = self.finish_trampoline(&mut context, isa)?;
+        self.save_context(CompilerContext {
+            func_translator,
+            codegen_context: context,
+        });
+        Ok(Box::new(func))
+    }
+
     fn emit_obj(
         &self,
         lowerings: PrimaryMap<LoweredIndex, Box<dyn Any + Send>>,
         always_trap: PrimaryMap<RuntimeAlwaysTrapIndex, Box<dyn Any + Send>>,
+        transcoders: PrimaryMap<RuntimeTranscoderIndex, Box<dyn Any + Send>>,
         trampolines: Vec<(SignatureIndex, Box<dyn Any + Send>)>,
         obj: &mut Object<'static>,
     ) -> Result<(
         PrimaryMap<LoweredIndex, FunctionInfo>,
         PrimaryMap<RuntimeAlwaysTrapIndex, AlwaysTrapInfo>,
+        PrimaryMap<RuntimeTranscoderIndex, FunctionInfo>,
         Vec<Trampoline>,
     )> {
         let module = Default::default();
@@ -264,6 +268,16 @@ impl ComponentCompiler for Compiler {
             })
             .collect();
 
+        let ret_transcoders = transcoders
+            .iter()
+            .map(|(i, func)| {
+                let func = func.downcast_ref::<CompiledFunction>().unwrap();
+                let name = format!("_wasmtime_transcoder{}", i.as_u32());
+                let range = text.named_func(&name, func);
+                range2info(range)
+            })
+            .collect();
+
         let ret_trampolines = trampolines
             .iter()
             .map(|(i, func)| {
@@ -275,6 +289,313 @@ impl ComponentCompiler for Compiler {
 
         text.finish()?;
 
-        Ok((ret_lowerings, ret_always_trap, ret_trampolines))
+        Ok((
+            ret_lowerings,
+            ret_always_trap,
+            ret_transcoders,
+            ret_trampolines,
+        ))
+    }
+}
+
+impl Compiler {
+    fn save_last_wasm_fp_and_pc(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        offsets: &VMComponentOffsets<u8>,
+        vmctx: ir::Value,
+    ) {
+        let pointer_type = self.isa.pointer_type();
+        // First we need to get the `VMRuntimeLimits`.
+        let limits = builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            vmctx,
+            i32::try_from(offsets.limits()).unwrap(),
+        );
+        // Then save the exit Wasm FP to the limits. We dereference the current
+        // FP to get the previous FP because the current FP is the trampoline's
+        // FP, and we want the Wasm function's FP, which is the caller of this
+        // trampoline.
+        let trampoline_fp = builder.ins().get_frame_pointer(pointer_type);
+        let wasm_fp = builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            trampoline_fp,
+            // The FP always points to the next older FP for all supported
+            // targets. See assertion in
+            // `crates/runtime/src/traphandlers/backtrace.rs`.
+            0,
+        );
+        builder.ins().store(
+            MemFlags::trusted(),
+            wasm_fp,
+            limits,
+            offsets.ptr.vmruntime_limits_last_wasm_exit_fp(),
+        );
+        // Finally save the Wasm return address to the limits.
+        let wasm_pc = builder.ins().get_return_address(pointer_type);
+        builder.ins().store(
+            MemFlags::trusted(),
+            wasm_pc,
+            limits,
+            offsets.ptr.vmruntime_limits_last_wasm_exit_pc(),
+        );
+    }
+
+    fn translate_transcode(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        offsets: &VMComponentOffsets<u8>,
+        transcoder: &Transcoder,
+        block: ir::Block,
+    ) {
+        let pointer_type = self.isa.pointer_type();
+        let vmctx = builder.func.dfg.block_params(block)[0];
+
+        // Save the exit FP and return address for stack walking purposes. This
+        // is used when an invalid encoding is encountered and a trap is raised.
+        self.save_last_wasm_fp_and_pc(builder, &offsets, vmctx);
+
+        // Determine the static signature of the host libcall for this transcode
+        // operation and additionally calculate the static offset within the
+        // transode libcalls array.
+        let func = &mut builder.func;
+        let (sig, offset) = match transcoder.op {
+            Transcode::Copy(FixedEncoding::Utf8) => host::utf8_to_utf8(self, func),
+            Transcode::Copy(FixedEncoding::Utf16) => host::utf16_to_utf16(self, func),
+            Transcode::Copy(FixedEncoding::Latin1) => host::latin1_to_latin1(self, func),
+            Transcode::Latin1ToUtf16 => host::latin1_to_utf16(self, func),
+            Transcode::Latin1ToUtf8 => host::latin1_to_utf8(self, func),
+            Transcode::Utf16ToCompactProbablyUtf16 => {
+                host::utf16_to_compact_probably_utf16(self, func)
+            }
+            Transcode::Utf16ToCompactUtf16 => host::utf16_to_compact_utf16(self, func),
+            Transcode::Utf16ToLatin1 => host::utf16_to_latin1(self, func),
+            Transcode::Utf16ToUtf8 => host::utf16_to_utf8(self, func),
+            Transcode::Utf8ToCompactUtf16 => host::utf8_to_compact_utf16(self, func),
+            Transcode::Utf8ToLatin1 => host::utf8_to_latin1(self, func),
+            Transcode::Utf8ToUtf16 => host::utf8_to_utf16(self, func),
+        };
+
+        // Load the host function pointer for this transcode which comes from a
+        // function pointer within the VMComponentContext's libcall array.
+        let transcode_libcalls_array = builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            vmctx,
+            i32::try_from(offsets.transcode_libcalls()).unwrap(),
+        );
+        let transcode_libcall = builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            transcode_libcalls_array,
+            i32::try_from(offset * u32::from(offsets.ptr.size())).unwrap(),
+        );
+
+        // Load the base pointers for the from/to linear memories.
+        let from_base = self.load_runtime_memory_base(builder, vmctx, offsets, transcoder.from);
+        let to_base = self.load_runtime_memory_base(builder, vmctx, offsets, transcoder.to);
+
+        // Helper function to cast a core wasm input to a host pointer type
+        // which will go into the host libcall.
+        let cast_to_pointer = |builder: &mut FunctionBuilder<'_>, val: ir::Value, is64: bool| {
+            let host64 = pointer_type == ir::types::I64;
+            if is64 == host64 {
+                val
+            } else if !is64 {
+                assert!(host64);
+                builder.ins().uextend(pointer_type, val)
+            } else {
+                assert!(!host64);
+                builder.ins().ireduce(pointer_type, val)
+            }
+        };
+
+        // Helper function to cast an input parameter to the host pointer type.
+        let len_param = |builder: &mut FunctionBuilder<'_>, param: usize, is64: bool| {
+            let val = builder.func.dfg.block_params(block)[2 + param];
+            cast_to_pointer(builder, val, is64)
+        };
+
+        // Helper function to interpret an input parameter as a pointer into
+        // linear memory. This will cast the input parameter to the host integer
+        // type and then add that value to the base.
+        //
+        // Note that bounds-checking happens in adapter modules, and this
+        // trampoline is simply calling the host libcall.
+        let ptr_param =
+            |builder: &mut FunctionBuilder<'_>, param: usize, is64: bool, base: ir::Value| {
+                let val = len_param(builder, param, is64);
+                builder.ins().iadd(base, val)
+            };
+
+        let Transcoder { to64, from64, .. } = *transcoder;
+        let mut args = Vec::new();
+
+        // Most transcoders share roughly the same signature despite doing very
+        // different things internally, so most libcalls are lumped together
+        // here.
+        match transcoder.op {
+            Transcode::Copy(_)
+            | Transcode::Latin1ToUtf16
+            | Transcode::Utf16ToCompactProbablyUtf16
+            | Transcode::Utf8ToLatin1
+            | Transcode::Utf16ToLatin1
+            | Transcode::Utf8ToUtf16 => {
+                args.push(ptr_param(builder, 0, from64, from_base));
+                args.push(len_param(builder, 1, from64));
+                args.push(ptr_param(builder, 2, to64, to_base));
+            }
+
+            Transcode::Utf16ToUtf8 | Transcode::Latin1ToUtf8 => {
+                args.push(ptr_param(builder, 0, from64, from_base));
+                args.push(len_param(builder, 1, from64));
+                args.push(ptr_param(builder, 2, to64, to_base));
+                args.push(len_param(builder, 3, to64));
+            }
+
+            Transcode::Utf8ToCompactUtf16 | Transcode::Utf16ToCompactUtf16 => {
+                args.push(ptr_param(builder, 0, from64, from_base));
+                args.push(len_param(builder, 1, from64));
+                args.push(ptr_param(builder, 2, to64, to_base));
+                args.push(len_param(builder, 3, to64));
+                args.push(len_param(builder, 4, to64));
+            }
+        };
+        let call = builder.ins().call_indirect(sig, transcode_libcall, &args);
+        let results = builder.func.dfg.inst_results(call).to_vec();
+        let mut raw_results = Vec::new();
+
+        // Helper to cast a host pointer integer type to the destination type.
+        let cast_from_pointer = |builder: &mut FunctionBuilder<'_>, val: ir::Value, is64: bool| {
+            let host64 = pointer_type == ir::types::I64;
+            if is64 == host64 {
+                val
+            } else if !is64 {
+                assert!(host64);
+                builder.ins().ireduce(ir::types::I32, val)
+            } else {
+                assert!(!host64);
+                builder.ins().uextend(ir::types::I64, val)
+            }
+        };
+
+        // Like the arguments the results are fairly similar across libcalls, so
+        // they're lumped into various buckets here.
+        match transcoder.op {
+            Transcode::Copy(_) | Transcode::Latin1ToUtf16 => {}
+
+            Transcode::Utf8ToUtf16
+            | Transcode::Utf16ToCompactProbablyUtf16
+            | Transcode::Utf8ToCompactUtf16
+            | Transcode::Utf16ToCompactUtf16 => {
+                raw_results.push(cast_from_pointer(builder, results[0], to64));
+            }
+
+            Transcode::Latin1ToUtf8
+            | Transcode::Utf16ToUtf8
+            | Transcode::Utf8ToLatin1
+            | Transcode::Utf16ToLatin1 => {
+                raw_results.push(cast_from_pointer(builder, results[0], from64));
+                raw_results.push(cast_from_pointer(builder, results[1], to64));
+            }
+        };
+
+        builder.ins().return_(&raw_results);
+        builder.finalize();
+    }
+
+    fn load_runtime_memory_base(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        vmctx: ir::Value,
+        offsets: &VMComponentOffsets<u8>,
+        mem: RuntimeMemoryIndex,
+    ) -> ir::Value {
+        let pointer_type = self.isa.pointer_type();
+        let from_vmmemory_definition = builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            vmctx,
+            i32::try_from(offsets.runtime_memory(mem)).unwrap(),
+        );
+        builder.ins().load(
+            pointer_type,
+            MemFlags::trusted(),
+            from_vmmemory_definition,
+            i32::from(offsets.ptr.vmmemory_definition_base()),
+        )
+    }
+}
+
+/// Module with macro-generated contents that will return the signature and
+/// offset for each of the host transcoder functions.
+///
+/// Note that a macro is used here to keep this in sync with the actual
+/// transcoder functions themselves which are also defined via a macro.
+#[allow(unused_mut)]
+mod host {
+    use crate::compiler::Compiler;
+    use cranelift_codegen::ir::{self, AbiParam};
+
+    macro_rules! host_transcode {
+        (
+            $(
+                $( #[$attr:meta] )*
+                $name:ident( $( $pname:ident: $param:ident ),* ) $( -> $result:ident )?;
+            )*
+        ) => {
+            $(
+                pub(super) fn $name(compiler: &Compiler, func: &mut ir::Function) -> (ir::SigRef, u32) {
+                    let pointer_type = compiler.isa.pointer_type();
+                    let params = vec![
+                        $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
+                    ];
+                    let mut returns = Vec::new();
+                    $(host_transcode!(@push_return pointer_type params returns $result);)?
+                    let sig = func.import_signature(ir::Signature {
+                        params,
+                        returns,
+                        call_conv: crate::wasmtime_call_conv(&*compiler.isa),
+                    });
+
+                    (sig, offsets::$name)
+                }
+            )*
+        };
+
+        (@ty $ptr:ident size) => ($ptr);
+        (@ty $ptr:ident ptr_u8) => ($ptr);
+        (@ty $ptr:ident ptr_u16) => ($ptr);
+
+        (@push_return $ptr:ident $params:ident $returns:ident size) => ($returns.push(AbiParam::new($ptr)););
+        (@push_return $ptr:ident $params:ident $returns:ident size_pair) => ({
+            $returns.push(AbiParam::new($ptr));
+            $returns.push(AbiParam::new($ptr));
+        });
+    }
+
+    wasmtime_environ::foreach_transcoder!(host_transcode);
+
+    mod offsets {
+        macro_rules! offsets {
+            (
+                $(
+                    $( #[$attr:meta] )*
+                    $name:ident($($t:tt)*) $( -> $result:ident )?;
+                )*
+            ) => {
+                offsets!(@declare (0) $($name)*);
+            };
+
+            (@declare ($n:expr)) => ();
+            (@declare ($n:expr) $name:ident $($rest:tt)*) => (
+                pub static $name: u32 = $n;
+                offsets!(@declare ($n + 1) $($rest)*);
+            );
+        }
+
+        wasmtime_environ::foreach_transcoder!(offsets);
     }
 }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1387,9 +1387,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         global_type: pointer_type,
                         readonly: true,
                     });
-                    let base_offset = i32::from(self.offsets.vmmemory_definition_base());
+                    let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
                     let current_length_offset =
-                        i32::from(self.offsets.vmmemory_definition_current_length());
+                        i32::from(self.offsets.ptr.vmmemory_definition_current_length());
                     (memory, base_offset, current_length_offset)
                 } else {
                     let owned_index = self.module.owned_memory_index(def_index);
@@ -1410,9 +1410,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     global_type: pointer_type,
                     readonly: true,
                 });
-                let base_offset = i32::from(self.offsets.vmmemory_definition_base());
+                let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
                 let current_length_offset =
-                    i32::from(self.offsets.vmmemory_definition_current_length());
+                    i32::from(self.offsets.ptr.vmmemory_definition_current_length());
                 (memory, base_offset, current_length_offset)
             }
         };
@@ -1726,7 +1726,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         pos.ins()
                             .load(pointer_type, ir::MemFlags::trusted(), base, offset);
                     let vmmemory_definition_offset =
-                        i64::from(self.offsets.vmmemory_definition_current_length());
+                        i64::from(self.offsets.ptr.vmmemory_definition_current_length());
                     let vmmemory_definition_ptr =
                         pos.ins().iadd_imm(vmmemory_ptr, vmmemory_definition_offset);
                     // This atomic access of the
@@ -1758,7 +1758,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         .load(pointer_type, ir::MemFlags::trusted(), base, offset);
                 if is_shared {
                     let vmmemory_definition_offset =
-                        i64::from(self.offsets.vmmemory_definition_current_length());
+                        i64::from(self.offsets.ptr.vmmemory_definition_current_length());
                     let vmmemory_definition_ptr =
                         pos.ins().iadd_imm(vmmemory_ptr, vmmemory_definition_offset);
                     pos.ins().atomic_load(
@@ -1771,7 +1771,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         pointer_type,
                         ir::MemFlags::trusted(),
                         vmmemory_ptr,
-                        i32::from(self.offsets.vmmemory_definition_current_length()),
+                        i32::from(self.offsets.ptr.vmmemory_definition_current_length()),
                     )
                 }
             }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -48,3 +48,25 @@ pub use self::info::*;
 pub use self::translate::*;
 pub use self::types::*;
 pub use self::vmcomponent_offsets::*;
+
+/// Helper macro to iterate over the transcoders that the host will provide
+/// adapter modules through libcalls.
+#[macro_export]
+macro_rules! foreach_transcoder {
+    ($mac:ident) => {
+        $mac! {
+            utf8_to_utf8(src: ptr_u8, len: size, dst: ptr_u8);
+            utf16_to_utf16(src: ptr_u16, len: size, dst: ptr_u16);
+            latin1_to_latin1(src: ptr_u8, len: size, dst: ptr_u8);
+            latin1_to_utf16(src: ptr_u8, len: size, dst: ptr_u16);
+            utf8_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> size;
+            utf16_to_utf8(src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size) -> size_pair;
+            latin1_to_utf8(src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size) -> size_pair;
+            utf16_to_compact_probably_utf16(src: ptr_u16, len: size, dst: ptr_u16) -> size;
+            utf8_to_latin1(src: ptr_u8, len: size, dst: ptr_u8) -> size_pair;
+            utf16_to_latin1(src: ptr_u16, len: size, dst: ptr_u8) -> size_pair;
+            utf8_to_compact_utf16(src: ptr_u8, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
+            utf16_to_compact_utf16(src: ptr_u16, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
+        }
+    };
+}

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -71,6 +71,9 @@ pub struct ComponentDfg {
     /// out of the inlining pass of translation.
     pub adapters: Intern<AdapterId, Adapter>,
 
+    /// Metadata about string transcoders needed by adapter modules.
+    pub transcoders: Intern<TranscoderId, Transcoder>,
+
     /// Metadata about all known core wasm instances created.
     ///
     /// This is mostly an ordered list and is not deduplicated based on contents
@@ -125,6 +128,7 @@ id! {
     pub struct PostReturnId(u32);
     pub struct AlwaysTrapId(u32);
     pub struct AdapterModuleId(u32);
+    pub struct TranscoderId(u32);
 }
 
 /// Same as `info::InstantiateModule`
@@ -158,6 +162,7 @@ pub enum CoreDef {
     Lowered(LowerImportId),
     AlwaysTrap(AlwaysTrapId),
     InstanceFlags(RuntimeComponentInstanceIndex),
+    Transcoder(TranscoderId),
 
     /// This is a special variant not present in `info::CoreDef` which
     /// represents that this definition refers to a fused adapter function. This
@@ -218,6 +223,18 @@ pub struct CanonicalOptions {
     pub memory: Option<MemoryId>,
     pub realloc: Option<ReallocId>,
     pub post_return: Option<PostReturnId>,
+}
+
+/// Same as `info::Transcoder`
+#[derive(Clone, Hash, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub struct Transcoder {
+    pub op: Transcode,
+    pub from: MemoryId,
+    pub from64: bool,
+    pub to: MemoryId,
+    pub to64: bool,
+    pub signature: SignatureIndex,
 }
 
 /// A helper structure to "intern" and deduplicate values of type `V` with an
@@ -292,6 +309,7 @@ impl ComponentDfg {
             runtime_instances: Default::default(),
             runtime_always_trap: Default::default(),
             runtime_lowerings: Default::default(),
+            runtime_transcoders: Default::default(),
         };
 
         // First the instances are all processed for instantiation. This will,
@@ -324,6 +342,7 @@ impl ComponentDfg {
             num_runtime_instances: linearize.runtime_instances.len() as u32,
             num_always_trap: linearize.runtime_always_trap.len() as u32,
             num_lowerings: linearize.runtime_lowerings.len() as u32,
+            num_transcoders: linearize.runtime_transcoders.len() as u32,
 
             imports: self.imports,
             import_types: self.import_types,
@@ -342,6 +361,7 @@ struct LinearizeDfg<'a> {
     runtime_instances: HashMap<RuntimeInstance, RuntimeInstanceIndex>,
     runtime_always_trap: HashMap<AlwaysTrapId, RuntimeAlwaysTrapIndex>,
     runtime_lowerings: HashMap<LowerImportId, LoweredIndex>,
+    runtime_transcoders: HashMap<TranscoderId, RuntimeTranscoderIndex>,
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]
@@ -459,6 +479,7 @@ impl LinearizeDfg<'_> {
             CoreDef::Lowered(id) => info::CoreDef::Lowered(self.runtime_lowering(*id)),
             CoreDef::InstanceFlags(i) => info::CoreDef::InstanceFlags(*i),
             CoreDef::Adapter(id) => info::CoreDef::Export(self.adapter(*id)),
+            CoreDef::Transcoder(id) => info::CoreDef::Transcoder(self.runtime_transcoder(*id)),
         }
     }
 
@@ -491,6 +512,35 @@ impl LinearizeDfg<'_> {
                     import,
                     canonical_abi,
                     options,
+                })
+            },
+        )
+    }
+
+    fn runtime_transcoder(&mut self, id: TranscoderId) -> RuntimeTranscoderIndex {
+        self.intern(
+            id,
+            |me| &mut me.runtime_transcoders,
+            |me, id| {
+                let info = &me.dfg.transcoders[id];
+                (
+                    info.op,
+                    me.runtime_memory(info.from),
+                    info.from64,
+                    me.runtime_memory(info.to),
+                    info.to64,
+                    info.signature,
+                )
+            },
+            |index, (op, from, from64, to, to64, signature)| {
+                GlobalInitializer::Transcoder(info::Transcoder {
+                    index,
+                    op,
+                    from,
+                    from64,
+                    to,
+                    to64,
+                    signature,
                 })
             },
         )

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -147,6 +147,10 @@ pub struct Component {
     /// The number of functions which "always trap" used to implement
     /// `canon.lower` of `canon.lift`'d functions within the same component.
     pub num_always_trap: u32,
+
+    /// The number of host transcoder functions needed for strings in adapter
+    /// modules.
+    pub num_transcoders: u32,
 }
 
 /// GlobalInitializer instructions to get processed when instantiating a component
@@ -207,6 +211,11 @@ pub enum GlobalInitializer {
 
     /// Same as `SaveModuleUpvar`, but for imports.
     SaveModuleImport(RuntimeImportIndex),
+
+    /// Similar to `ExtractMemory` and friends and indicates that a
+    /// `VMCallerCheckedAnyfunc` needs to be initialized for a transcoder
+    /// function and this will later be used to instantiate an adapter module.
+    Transcoder(Transcoder),
 }
 
 /// Metadata for extraction of a memory of what's being extracted and where it's
@@ -316,6 +325,9 @@ pub enum CoreDef {
     /// This is a reference to a wasm global which represents the
     /// runtime-managed flags for a wasm instance.
     InstanceFlags(RuntimeComponentInstanceIndex),
+    /// This refers to a cranelift-generated trampoline which calls to a
+    /// host-defined transcoding function.
+    Transcoder(RuntimeTranscoderIndex),
 }
 
 impl<T> From<CoreExport<T>> for CoreDef
@@ -433,3 +445,42 @@ pub enum StringEncoding {
     Utf16,
     CompactUtf16,
 }
+
+/// Information about a string transcoding function required by an adapter
+/// module.
+///
+/// A transcoder is used when strings are passed between adapter modules,
+/// optionally changing string encodings at the same time. The transcoder is
+/// implemented in a few different layers:
+///
+/// * Each generated adapter module has some glue around invoking the transcoder
+///   represented by this item. This involves bounds-checks and handling
+///   `realloc` for example.
+/// * Each transcoder gets a cranelift-generated trampoline which has the
+///   appropriate signature for the adapter module in question. Existence of
+///   this initializer indicates that this should be compiled by Cranelift.
+/// * The cranelift-generated trampoline will invoke a "transcoder libcall"
+///   which is implemented natively in Rust that has a signature independent of
+///   memory64 configuration options for example.
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct Transcoder {
+    /// The index of the transcoder being defined and initialized.
+    ///
+    /// This indicates which `VMCallerCheckedAnyfunc` slot is written to in a
+    /// `VMComponentContext`.
+    pub index: RuntimeTranscoderIndex,
+    /// The transcoding operation being performed.
+    pub op: Transcode,
+    /// The linear memory that the string is being read from.
+    pub from: RuntimeMemoryIndex,
+    /// Whether or not the source linear memory is 64-bit or not.
+    pub from64: bool,
+    /// The linear memory that the string is being written to.
+    pub to: RuntimeMemoryIndex,
+    /// Whether or not the destination linear memory is 64-bit or not.
+    pub to64: bool,
+    /// The wasm signature of the cranelift-generated trampoline.
+    pub signature: SignatureIndex,
+}
+
+pub use crate::fact::{FixedEncoding, Transcode};

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -116,7 +116,8 @@
 //! created.
 
 use crate::component::translate::*;
-use crate::fact::Module;
+use crate::fact;
+use crate::EntityType;
 use std::collections::HashSet;
 use wasmparser::WasmFeatures;
 
@@ -183,7 +184,7 @@ impl<'data> Translator<'_, 'data> {
         // the module using standard core wasm translation, and then fills out
         // the dfg metadata for each adapter.
         for (module_id, adapter_module) in state.adapter_modules.iter() {
-            let mut module = Module::new(
+            let mut module = fact::Module::new(
                 self.types.component_types(),
                 self.tunables.debug_adapter_modules,
             );
@@ -194,7 +195,7 @@ impl<'data> Translator<'_, 'data> {
                 names.push(name);
             }
             let wasm = module.encode();
-            let args = module.imports().to_vec();
+            let imports = module.imports().to_vec();
 
             // Extend the lifetime of the owned `wasm: Vec<u8>` on the stack to
             // a higher scope defined by our original caller. That allows to
@@ -240,9 +241,56 @@ impl<'data> Translator<'_, 'data> {
             // module is also recorded in the dfg. This metadata will be used
             // to generate `GlobalInitializer` entries during the linearization
             // final phase.
+            assert_eq!(imports.len(), translation.module.imports().len());
+            let args = imports
+                .iter()
+                .zip(translation.module.imports())
+                .map(|(arg, (_, _, ty))| fact_import_to_core_def(component, arg, ty))
+                .collect::<Vec<_>>();
             let static_index = self.static_modules.push(translation);
             let id = component.adapter_modules.push((static_index, args.into()));
             assert_eq!(id, module_id);
+        }
+    }
+}
+
+fn fact_import_to_core_def(
+    dfg: &mut dfg::ComponentDfg,
+    import: &fact::Import,
+    ty: EntityType,
+) -> dfg::CoreDef {
+    match import {
+        fact::Import::CoreDef(def) => def.clone(),
+        fact::Import::Transcode {
+            op,
+            from,
+            from64,
+            to,
+            to64,
+        } => {
+            fn unwrap_memory(def: &dfg::CoreDef) -> dfg::CoreExport<MemoryIndex> {
+                match def {
+                    dfg::CoreDef::Export(e) => e.clone().map_index(|i| match i {
+                        EntityIndex::Memory(i) => i,
+                        _ => unreachable!(),
+                    }),
+                    _ => unreachable!(),
+                }
+            }
+
+            let from = dfg.memories.push_uniq(unwrap_memory(from));
+            let to = dfg.memories.push_uniq(unwrap_memory(to));
+            dfg::CoreDef::Transcoder(dfg.transcoders.push_uniq(dfg::Transcoder {
+                op: *op,
+                from,
+                from64: *from64,
+                to,
+                to64: *to64,
+                signature: match ty {
+                    EntityType::Function(signature) => signature,
+                    _ => unreachable!(),
+                },
+            }))
         }
     }
 }
@@ -333,6 +381,9 @@ impl PartitionAdapterModules {
             dfg::CoreDef::Lowered(_)
             | dfg::CoreDef::AlwaysTrap(_)
             | dfg::CoreDef::InstanceFlags(_) => {}
+
+            // should not be in the dfg yet
+            dfg::CoreDef::Transcoder(_) => unreachable!(),
         }
     }
 

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -166,6 +166,13 @@ indices! {
     /// Index that represents an exported module from a component since that's
     /// currently the only use for saving the entire module state at runtime.
     pub struct RuntimeModuleIndex(u32);
+
+    /// Index into the list of transcoders identified during compilation.
+    ///
+    /// This is used to index the `VMCallerCheckedAnyfunc` slots reserved for
+    /// string encoders which reference linear memories defined within a
+    /// component.
+    pub struct RuntimeTranscoderIndex(u32);
 }
 
 // Reexport for convenience some core-wasm indices which are also used in the

--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -2,11 +2,13 @@
 //
 // struct VMComponentContext {
 //      magic: u32,
+//      transcode_libcalls: &'static VMBuiltinTranscodeArray,
 //      store: *mut dyn Store,
 //      limits: *const VMRuntimeLimits,
 //      flags: [VMGlobalDefinition; component.num_runtime_component_instances],
 //      lowering_anyfuncs: [VMCallerCheckedAnyfunc; component.num_lowerings],
 //      always_trap_anyfuncs: [VMCallerCheckedAnyfunc; component.num_always_trap],
+//      transcoder_anyfuncs: [VMCallerCheckedAnyfunc; component.num_transcoders],
 //      lowerings: [VMLowering; component.num_lowerings],
 //      memories: [*mut VMMemoryDefinition; component.num_memories],
 //      reallocs: [*mut VMCallerCheckedAnyfunc; component.num_reallocs],
@@ -15,7 +17,7 @@
 
 use crate::component::{
     Component, LoweredIndex, RuntimeAlwaysTrapIndex, RuntimeComponentInstanceIndex,
-    RuntimeMemoryIndex, RuntimePostReturnIndex, RuntimeReallocIndex,
+    RuntimeMemoryIndex, RuntimePostReturnIndex, RuntimeReallocIndex, RuntimeTranscoderIndex,
 };
 use crate::PtrSize;
 
@@ -57,14 +59,18 @@ pub struct VMComponentOffsets<P> {
     /// Number of "always trap" functions which have their
     /// `VMCallerCheckedAnyfunc` stored inline in the `VMComponentContext`.
     pub num_always_trap: u32,
+    /// Number of transcoders needed for string conversion.
+    pub num_transcoders: u32,
 
     // precalculated offsets of various member fields
     magic: u32,
+    transcode_libcalls: u32,
     store: u32,
     limits: u32,
     flags: u32,
     lowering_anyfuncs: u32,
     always_trap_anyfuncs: u32,
+    transcoder_anyfuncs: u32,
     lowerings: u32,
     memories: u32,
     reallocs: u32,
@@ -93,12 +99,15 @@ impl<P: PtrSize> VMComponentOffsets<P> {
                 .try_into()
                 .unwrap(),
             num_always_trap: component.num_always_trap,
+            num_transcoders: component.num_transcoders,
             magic: 0,
+            transcode_libcalls: 0,
             store: 0,
             limits: 0,
             flags: 0,
             lowering_anyfuncs: 0,
             always_trap_anyfuncs: 0,
+            transcoder_anyfuncs: 0,
             lowerings: 0,
             memories: 0,
             reallocs: 0,
@@ -133,6 +142,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         fields! {
             size(magic) = 4u32,
             align(u32::from(ret.ptr.size())),
+            size(transcode_libcalls) = ret.ptr.size(),
             size(store) = cmul(2, ret.ptr.size()),
             size(limits) = ret.ptr.size(),
             align(16),
@@ -140,6 +150,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             align(u32::from(ret.ptr.size())),
             size(lowering_anyfuncs) = cmul(ret.num_lowerings, ret.ptr.size_of_vmcaller_checked_anyfunc()),
             size(always_trap_anyfuncs) = cmul(ret.num_always_trap, ret.ptr.size_of_vmcaller_checked_anyfunc()),
+            size(transcoder_anyfuncs) = cmul(ret.num_transcoders, ret.ptr.size_of_vmcaller_checked_anyfunc()),
             size(lowerings) = cmul(ret.num_lowerings, ret.ptr.size() * 2),
             size(memories) = cmul(ret.num_runtime_memories, ret.ptr.size()),
             size(reallocs) = cmul(ret.num_runtime_reallocs, ret.ptr.size()),
@@ -166,6 +177,12 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     #[inline]
     pub fn magic(&self) -> u32 {
         self.magic
+    }
+
+    /// The offset of the `transcode_libcalls` field.
+    #[inline]
+    pub fn transcode_libcalls(&self) -> u32 {
+        self.transcode_libcalls
     }
 
     /// The offset of the `flags` field.
@@ -212,6 +229,20 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     pub fn always_trap_anyfunc(&self, index: RuntimeAlwaysTrapIndex) -> u32 {
         assert!(index.as_u32() < self.num_always_trap);
         self.always_trap_anyfuncs()
+            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
+    }
+
+    /// The offset of the `transcoder_anyfuncs` field.
+    #[inline]
+    pub fn transcoder_anyfuncs(&self) -> u32 {
+        self.transcoder_anyfuncs
+    }
+
+    /// The offset of `VMCallerCheckedAnyfunc` for the `index` specified.
+    #[inline]
+    pub fn transcoder_anyfunc(&self, index: RuntimeTranscoderIndex) -> u32 {
+        assert!(index.as_u32() < self.num_transcoders);
+        self.transcoder_anyfuncs()
             + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
     }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -854,11 +854,11 @@ impl Compiler<'_, '_> {
             me.instruction(LocalGet(dst_byte_len)); // old_size
             me.ptr_uconst(dst_opts, 1); // align
             let factor = match src {
-                FE::Latin1 => 2u8,
+                FE::Latin1 => 2,
                 FE::Utf16 => 3,
                 _ => unreachable!(),
             };
-            // validate_string_length_u8(me, factor);
+            validate_string_length_u8(me, factor);
             me.convert_src_len_to_dst(src_len, src_opts.ptr(), dst_opts.ptr());
             me.ptr_uconst(dst_opts, factor.into());
             me.ptr_mul(dst_opts);

--- a/crates/environ/src/fact/transcode.rs
+++ b/crates/environ/src/fact/transcode.rs
@@ -1,0 +1,178 @@
+use crate::fact::core_types::CoreTypes;
+use crate::MemoryIndex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use wasm_encoder::{EntityType, ValType};
+
+pub struct Transcoders {
+    imported: HashMap<Transcoder, u32>,
+    prev_func_imports: u32,
+    imports: Vec<(String, EntityType, Transcoder)>,
+}
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq)]
+pub struct Transcoder {
+    pub from_memory: MemoryIndex,
+    pub from_memory64: bool,
+    pub to_memory: MemoryIndex,
+    pub to_memory64: bool,
+    pub op: Transcode,
+}
+
+/// Possible transcoding operations that must be provided by the host.
+///
+/// Note that each transcoding operation may have a unique signature depending
+/// on the precise operation.
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Transcode {
+    Copy(FixedEncoding),
+    Latin1ToUtf16,
+    Latin1ToUtf8,
+    Utf16ToCompactProbablyUtf16,
+    Utf16ToCompactUtf16,
+    Utf16ToLatin1,
+    Utf16ToUtf8,
+    Utf8ToCompactUtf16,
+    Utf8ToLatin1,
+    Utf8ToUtf16,
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub enum FixedEncoding {
+    Utf8,
+    Utf16,
+    Latin1,
+}
+
+impl Transcoders {
+    pub fn new(prev_func_imports: u32) -> Transcoders {
+        Transcoders {
+            imported: HashMap::new(),
+            prev_func_imports,
+            imports: Vec::new(),
+        }
+    }
+
+    pub fn import(&mut self, types: &mut CoreTypes, transcoder: Transcoder) -> u32 {
+        *self.imported.entry(transcoder).or_insert_with(|| {
+            let idx = self.prev_func_imports + (self.imports.len() as u32);
+            self.imports
+                .push((transcoder.name(), transcoder.ty(types), transcoder));
+            idx
+        })
+    }
+
+    pub fn imports(&self) -> impl Iterator<Item = (&str, &str, EntityType, &Transcoder)> {
+        self.imports
+            .iter()
+            .map(|(name, ty, transcoder)| ("transcode", &name[..], *ty, transcoder))
+    }
+}
+
+impl Transcoder {
+    fn name(&self) -> String {
+        format!(
+            "{} (mem{} => mem{})",
+            self.op.desc(),
+            self.from_memory.as_u32(),
+            self.to_memory.as_u32(),
+        )
+    }
+
+    fn ty(&self, types: &mut CoreTypes) -> EntityType {
+        let from_ptr = if self.from_memory64 {
+            ValType::I64
+        } else {
+            ValType::I32
+        };
+        let to_ptr = if self.to_memory64 {
+            ValType::I64
+        } else {
+            ValType::I32
+        };
+
+        let ty = match self.op {
+            // These direct transcodings take the source pointer, the source
+            // code units, and the destination pointer.
+            //
+            // The memories being copied between are part of each intrinsic and
+            // the destination code units are the same as the source.
+            // Note that the pointers are dynamically guaranteed to be aligned
+            // and in-bounds for the code units length as defined by the string
+            // encoding.
+            Transcode::Copy(_) | Transcode::Latin1ToUtf16 => {
+                types.function(&[from_ptr, from_ptr, to_ptr], &[])
+            }
+
+            // Transcoding from utf8 to utf16 takes the from ptr/len as well as
+            // a destination. The destination is valid for len*2 bytes. The
+            // return value is how many code units were written to the
+            // destination.
+            Transcode::Utf8ToUtf16 => types.function(&[from_ptr, from_ptr, to_ptr], &[to_ptr]),
+
+            // Transcoding to utf8 as a smaller format takes all the parameters
+            // and returns the amount of space consumed in the src/destination
+            Transcode::Utf16ToUtf8 | Transcode::Latin1ToUtf8 => {
+                types.function(&[from_ptr, from_ptr, to_ptr, to_ptr], &[from_ptr, to_ptr])
+            }
+
+            // The return type is a tagged length which indicates which was
+            // used
+            Transcode::Utf16ToCompactProbablyUtf16 => {
+                types.function(&[from_ptr, from_ptr, to_ptr], &[to_ptr])
+            }
+
+            // The initial step of transcoding from a fixed format to a compact
+            // format. Takes the ptr/len of the source the the destination
+            // pointer. The destination length is implicitly the same. Returns
+            // how many code units were consumed in the source, which is also
+            // how many bytes were written to the destination.
+            Transcode::Utf8ToLatin1 | Transcode::Utf16ToLatin1 => {
+                types.function(&[from_ptr, from_ptr, to_ptr], &[from_ptr, to_ptr])
+            }
+
+            // The final step of transcoding to a compact format when the fixed
+            // transcode has failed. This takes the ptr/len of the source that's
+            // remaining to transcode. Then this takes the destination ptr/len
+            // as well as the destination bytes written so far with latin1.
+            // Finally this returns the number of code units written to the
+            // destination.
+            Transcode::Utf8ToCompactUtf16 | Transcode::Utf16ToCompactUtf16 => {
+                types.function(&[from_ptr, from_ptr, to_ptr, to_ptr, to_ptr], &[to_ptr])
+            }
+        };
+        EntityType::Function(ty)
+    }
+}
+
+impl Transcode {
+    /// Returns a human-readable description for this transcoding operation.
+    pub fn desc(&self) -> &'static str {
+        match self {
+            Transcode::Copy(FixedEncoding::Utf8) => "utf8-to-utf8",
+            Transcode::Copy(FixedEncoding::Utf16) => "utf16-to-utf16",
+            Transcode::Copy(FixedEncoding::Latin1) => "latin1-to-latin1",
+            Transcode::Latin1ToUtf16 => "latin1-to-utf16",
+            Transcode::Latin1ToUtf8 => "latin1-to-utf8",
+            Transcode::Utf16ToCompactProbablyUtf16 => "utf16-to-compact-probably-utf16",
+            Transcode::Utf16ToCompactUtf16 => "utf16-to-compact-utf16",
+            Transcode::Utf16ToLatin1 => "utf16-to-latin1",
+            Transcode::Utf16ToUtf8 => "utf16-to-utf8",
+            Transcode::Utf8ToCompactUtf16 => "utf8-to-compact-utf16",
+            Transcode::Utf8ToLatin1 => "utf8-to-latin1",
+            Transcode::Utf8ToUtf16 => "utf8-to-utf16",
+        }
+    }
+}
+
+impl FixedEncoding {
+    pub(crate) fn width(&self) -> u8 {
+        match self {
+            FixedEncoding::Utf8 => 1,
+            FixedEncoding::Utf16 => 2,
+            FixedEncoding::Latin1 => 1,
+        }
+    }
+}

--- a/crates/environ/src/fact/traps.rs
+++ b/crates/environ/src/fact/traps.rs
@@ -30,6 +30,8 @@ pub enum Trap {
     InvalidDiscriminant,
     InvalidChar,
     ListByteLengthOverflow,
+    StringLengthTooBig,
+    StringLengthOverflow,
     AssertFailed(&'static str),
 }
 
@@ -105,6 +107,8 @@ impl fmt::Display for Trap {
             Trap::InvalidDiscriminant => "invalid variant discriminant".fmt(f),
             Trap::InvalidChar => "invalid char value specified".fmt(f),
             Trap::ListByteLengthOverflow => "byte size of list too large for i32".fmt(f),
+            Trap::StringLengthTooBig => "string byte size exceeds maximum".fmt(f),
+            Trap::StringLengthOverflow => "string byte size overflows i32".fmt(f),
             Trap::AssertFailed(s) => write!(f, "assertion failure: {}", s),
         }
     }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -974,7 +974,7 @@ impl Module {
 
     /// Returns an iterator of all the imports in this module, along with their
     /// module name, field name, and type that's being imported.
-    pub fn imports(&self) -> impl Iterator<Item = (&str, &str, EntityType)> {
+    pub fn imports(&self) -> impl ExactSizeIterator<Item = (&str, &str, EntityType)> {
         self.initializers.iter().map(move |i| match i {
             Initializer::Import { name, field, index } => {
                 (name.as_str(), field.as_str(), self.type_of(*index))

--- a/crates/misc/component-test-util/src/lib.rs
+++ b/crates/misc/component-test-util/src/lib.rs
@@ -35,7 +35,7 @@ impl FuncExt for Func {
     }
 }
 
-pub fn engine() -> Engine {
+pub fn config() -> Config {
     drop(env_logger::try_init());
 
     let mut config = Config::new();
@@ -48,7 +48,11 @@ pub fn engine() -> Engine {
         config.static_memory_maximum_size(0);
         config.dynamic_memory_guard_size(0);
     }
-    Engine::new(&config).unwrap()
+    config
+}
+
+pub fn engine() -> Engine {
+    Engine::new(&config()).unwrap()
 }
 
 /// Newtype wrapper for `f32` whose `PartialEq` impl considers NaNs equal to each other.

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.8.3"
 anyhow = "1.0.38"
 memfd = { version = "0.6.1", optional = true }
 paste = "1.0.3"
+encoding_rs = { version = "0.8.31", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"
@@ -62,4 +63,7 @@ pooling-allocator = []
 # need portable signal handling.
 posix-signals-on-macos = []
 
-component-model = ["wasmtime-environ/component-model"]
+component-model = [
+  "wasmtime-environ/component-model",
+  "dep:encoding_rs",
+]

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -18,12 +18,15 @@ use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use wasmtime_environ::component::{
     Component, LoweredIndex, RuntimeAlwaysTrapIndex, RuntimeComponentInstanceIndex,
-    RuntimeMemoryIndex, RuntimePostReturnIndex, RuntimeReallocIndex, StringEncoding,
-    VMComponentOffsets, FLAG_MAY_ENTER, FLAG_MAY_LEAVE, FLAG_NEEDS_POST_RETURN, VMCOMPONENT_MAGIC,
+    RuntimeMemoryIndex, RuntimePostReturnIndex, RuntimeReallocIndex, RuntimeTranscoderIndex,
+    StringEncoding, VMComponentOffsets, FLAG_MAY_ENTER, FLAG_MAY_LEAVE, FLAG_NEEDS_POST_RETURN,
+    VMCOMPONENT_MAGIC,
 };
 use wasmtime_environ::HostPtr;
 
 const INVALID_PTR: usize = 0xdead_dead_beef_beef_u64 as usize;
+
+mod transcode;
 
 /// Runtime representation of a component instance and all state necessary for
 /// the instance itself.
@@ -255,6 +258,14 @@ impl ComponentInstance {
         unsafe { self.anyfunc(self.offsets.always_trap_anyfunc(idx)) }
     }
 
+    /// Same as `lowering_anyfunc` except for the transcoding functions.
+    pub fn transcoder_anyfunc(
+        &self,
+        idx: RuntimeTranscoderIndex,
+    ) -> NonNull<VMCallerCheckedAnyfunc> {
+        unsafe { self.anyfunc(self.offsets.transcoder_anyfunc(idx)) }
+    }
+
     unsafe fn anyfunc(&self, offset: u32) -> NonNull<VMCallerCheckedAnyfunc> {
         let ret = self.vmctx_plus_offset::<VMCallerCheckedAnyfunc>(offset);
         debug_assert!((*ret).func_ptr.as_ptr() as usize != INVALID_PTR);
@@ -349,6 +360,16 @@ impl ComponentInstance {
         unsafe { self.set_anyfunc(self.offsets.always_trap_anyfunc(idx), func_ptr, type_index) }
     }
 
+    /// Same as `set_lowering` but for the transcoder functions.
+    pub fn set_transcoder(
+        &mut self,
+        idx: RuntimeTranscoderIndex,
+        func_ptr: NonNull<VMFunctionBody>,
+        type_index: VMSharedSignatureIndex,
+    ) {
+        unsafe { self.set_anyfunc(self.offsets.transcoder_anyfunc(idx), func_ptr, type_index) }
+    }
+
     unsafe fn set_anyfunc(
         &mut self,
         offset: u32,
@@ -366,6 +387,8 @@ impl ComponentInstance {
 
     unsafe fn initialize_vmctx(&mut self, store: *mut dyn Store) {
         *self.vmctx_plus_offset(self.offsets.magic()) = VMCOMPONENT_MAGIC;
+        *self.vmctx_plus_offset(self.offsets.transcode_libcalls()) =
+            &transcode::VMBuiltinTranscodeArray::INIT;
         *self.vmctx_plus_offset(self.offsets.store()) = store;
         *self.vmctx_plus_offset(self.offsets.limits()) = (*store).vmruntime_limits();
 
@@ -393,6 +416,11 @@ impl ComponentInstance {
             for i in 0..self.offsets.num_always_trap {
                 let i = RuntimeAlwaysTrapIndex::from_u32(i);
                 let offset = self.offsets.always_trap_anyfunc(i);
+                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+            }
+            for i in 0..self.offsets.num_transcoders {
+                let i = RuntimeTranscoderIndex::from_u32(i);
+                let offset = self.offsets.transcoder_anyfunc(i);
                 *self.vmctx_plus_offset(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_memories {
@@ -520,6 +548,19 @@ impl OwnedComponentInstance {
         unsafe {
             self.instance_mut()
                 .set_always_trap(idx, func_ptr, type_index)
+        }
+    }
+
+    /// See `ComponentInstance::set_transcoder`
+    pub fn set_transcoder(
+        &mut self,
+        idx: RuntimeTranscoderIndex,
+        func_ptr: NonNull<VMFunctionBody>,
+        type_index: VMSharedSignatureIndex,
+    ) {
+        unsafe {
+            self.instance_mut()
+                .set_transcoder(idx, func_ptr, type_index)
         }
     }
 }

--- a/crates/runtime/src/component/transcode.rs
+++ b/crates/runtime/src/component/transcode.rs
@@ -1,0 +1,446 @@
+//! Implementation of string transcoding required by the component model.
+
+use anyhow::{anyhow, Result};
+use std::cell::Cell;
+use std::slice;
+
+const UTF16_TAG: usize = 1 << 31;
+
+/// Macro to define the `VMBuiltinTranscodeArray` type which contains all of the
+/// function pointers to the actual transcoder functions. This structure is read
+/// by Cranelift-generated code, hence the `repr(C)`.
+///
+/// Note that this references the `trampolines` module rather than the functions
+/// below as the `trampolines` module has the raw ABI.
+///
+/// This is modeled after the similar macros and usages in `libcalls.rs` and
+/// `vmcontext.rs`
+macro_rules! define_transcoders {
+    (
+        $(
+            $( #[$attr:meta] )*
+            $name:ident( $( $pname:ident: $param:ident ),* ) $( -> $result:ident )?;
+        )*
+    ) => {
+        /// An array that stores addresses of builtin functions. We translate code
+        /// to use indirect calls. This way, we don't have to patch the code.
+        #[repr(C)]
+        pub struct VMBuiltinTranscodeArray {
+            $(
+                $name: unsafe extern "C" fn(
+                    $(define_transcoders!(@ty $param),)*
+                    $(define_transcoders!(@retptr $result),)?
+                ) $( -> define_transcoders!(@ty $result))?,
+            )*
+        }
+
+        impl VMBuiltinTranscodeArray {
+            pub const INIT: VMBuiltinTranscodeArray = VMBuiltinTranscodeArray {
+                $($name: trampolines::$name,)*
+            };
+        }
+    };
+
+    (@ty size) => (usize);
+    (@ty size_pair) => (usize);
+    (@ty ptr_u8) => (*mut u8);
+    (@ty ptr_u16) => (*mut u16);
+
+    (@retptr size_pair) => (*mut usize);
+    (@retptr size) => (());
+}
+
+wasmtime_environ::foreach_transcoder!(define_transcoders);
+
+/// Submodule with macro-generated constants which are the actual libcall
+/// transcoders that are invoked by Cranelift. These functions have a specific
+/// ABI defined by the macro itself and will defer to the actual bodies of each
+/// implementation following this submodule.
+#[allow(improper_ctypes_definitions)]
+mod trampolines {
+    macro_rules! transcoders {
+        (
+            $(
+                $( #[$attr:meta] )*
+                $name:ident( $( $pname:ident: $param:ident ),* ) $( -> $result:ident )?;
+            )*
+        ) => (
+            $(
+                pub unsafe extern "C" fn $name(
+                    $($pname : define_transcoders!(@ty $param),)*
+                    // If a result is given then a `size_pair` results gets its
+                    // second result value passed via a return pointer here, so
+                    // optionally indicate a return pointer.
+                    $(_retptr: define_transcoders!(@retptr $result))?
+                ) $( -> define_transcoders!(@ty $result))? {
+                    $(transcoders!(@validate_param $pname $param);)*
+
+                    // Always catch panics to avoid trying to unwind from Rust
+                    // into Cranelift-generated code which would lead to a Bad
+                    // Time.
+                    //
+                    // Additionally assume that every function below returns a
+                    // `Result` where errors turn into traps.
+                    let result = std::panic::catch_unwind(|| {
+                        super::$name($($pname),*)
+                    });
+                    match result {
+                        Ok(Ok(ret)) => transcoders!(@convert_ret ret _retptr $($result)?),
+                        Ok(Err(err)) => crate::traphandlers::raise_trap(err.into()),
+                        Err(panic) => crate::traphandlers::resume_panic(panic),
+                    }
+                }
+            )*
+        );
+
+        (@convert_ret $ret:ident $retptr:ident) => ($ret);
+        (@convert_ret $ret:ident $retptr:ident size) => ($ret);
+        (@convert_ret $ret:ident $retptr:ident size_pair) => ({
+            let (a, b) = $ret;
+            *$retptr = b;
+            a
+        });
+
+        (@validate_param $arg:ident ptr_u16) => ({
+            // This should already be guaranteed by the canonical ABI and our
+            // adapter modules, but double-check here to be extra-sure. If this
+            // is a perf concern it can become a `debug_assert!`.
+            assert!(($arg as usize) % 2 == 0, "unaligned 16-bit pointer");
+        });
+        (@validate_param $arg:ident $ty:ident) => ();
+    }
+
+    wasmtime_environ::foreach_transcoder!(transcoders);
+}
+
+/// This property should already be guaranteed by construction in the component
+/// model but assert it here to be extra sure. Nothing below is sound if regions
+/// can overlap.
+fn assert_no_overlap<T, U>(a: &[T], b: &[U]) {
+    let a_start = a.as_ptr() as usize;
+    let a_end = a_start + (a.len() * std::mem::size_of::<T>());
+    let b_start = b.as_ptr() as usize;
+    let b_end = b_start + (b.len() * std::mem::size_of::<U>());
+
+    if a_start < b_start {
+        assert!(a_end < b_start);
+    } else {
+        assert!(b_end < a_start);
+    }
+}
+
+/// Converts a utf8 string to a utf8 string.
+///
+/// The length provided is length of both the source and the destination
+/// buffers. No value is returned other than whether an invalid string was
+/// found.
+unsafe fn utf8_to_utf8(src: *mut u8, len: usize, dst: *mut u8) -> Result<()> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    log::trace!("utf8-to-utf8 {len}");
+    let src = std::str::from_utf8(src).map_err(|_| anyhow!("invalid utf8 encoding"))?;
+    dst.copy_from_slice(src.as_bytes());
+    Ok(())
+}
+
+/// Converts a utf16 string to a utf16 string.
+///
+/// The length provided is length of both the source and the destination
+/// buffers. No value is returned other than whether an invalid string was
+/// found.
+unsafe fn utf16_to_utf16(src: *mut u16, len: usize, dst: *mut u16) -> Result<()> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    log::trace!("utf16-to-utf16 {len}");
+    run_utf16_to_utf16(src, dst)?;
+    Ok(())
+}
+
+/// Transcodes utf16 to itself, returning whether all code points were inside of
+/// the latin1 space.
+fn run_utf16_to_utf16(src: &[u16], mut dst: &mut [u16]) -> Result<bool> {
+    let mut all_latin1 = true;
+    for ch in std::char::decode_utf16(src.iter().map(|i| u16::from_le(*i))) {
+        let ch = ch.map_err(|_| anyhow!("invalid utf16 encoding"))?;
+        all_latin1 = all_latin1 && u8::try_from(u32::from(ch)).is_ok();
+        let result = ch.encode_utf16(dst);
+        let size = result.len();
+        for item in result {
+            *item = item.to_le();
+        }
+        dst = &mut dst[size..];
+    }
+    Ok(all_latin1)
+}
+
+/// Converts a latin1 string to a latin1 string.
+///
+/// Given that all byte sequences are valid latin1 strings this is simply a
+/// memory copy.
+unsafe fn latin1_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<()> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    log::trace!("latin1-to-latin1 {len}");
+    dst.copy_from_slice(src);
+    Ok(())
+}
+
+/// Converts a latin1 string to a utf16 string.
+///
+/// This simply inflates the latin1 characters to the u16 code points. The
+/// length provided is the same length of the source and destination buffers.
+unsafe fn latin1_to_utf16(src: *mut u8, len: usize, dst: *mut u16) -> Result<()> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    for (src, dst) in src.iter().zip(dst) {
+        *dst = u16::from(*src).to_le();
+    }
+    log::trace!("latin1-to-utf16 {len}");
+    Ok(())
+}
+
+/// Converts utf8 to utf16.
+///
+/// The length provided is the same unit length of both buffers, and the
+/// returned value from this function is how many u16 units were written.
+unsafe fn utf8_to_utf16(src: *mut u8, len: usize, dst: *mut u16) -> Result<usize> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+
+    let result = run_utf8_to_utf16(src, dst)?;
+    log::trace!("utf8-to-utf16 {len} => {result}");
+    Ok(result)
+}
+
+fn run_utf8_to_utf16(src: &[u8], dst: &mut [u16]) -> Result<usize> {
+    let src = std::str::from_utf8(src).map_err(|_| anyhow!("invalid utf8 encoding"))?;
+    let mut amt = 0;
+    for (i, dst) in src.encode_utf16().zip(dst) {
+        *dst = i.to_le();
+        amt += 1;
+    }
+    Ok(amt)
+}
+
+/// Converts utf16 to utf8.
+///
+/// Each buffer is specified independently here and the returned value is a pair
+/// of the number of code units read and code units written. This might perform
+/// a partial transcode if the destination buffer is not large enough to hold
+/// the entire contents.
+unsafe fn utf16_to_utf8(
+    src: *mut u16,
+    src_len: usize,
+    dst: *mut u8,
+    dst_len: usize,
+) -> Result<(usize, usize)> {
+    let src = slice::from_raw_parts(src, src_len);
+    let mut dst = slice::from_raw_parts_mut(dst, dst_len);
+    assert_no_overlap(src, dst);
+
+    // This iterator will convert to native endianness and additionally count
+    // how many items have been read from the iterator so far. This
+    // count is used to return how many of the source code units were read.
+    let src_iter_read = Cell::new(0);
+    let src_iter = src.iter().map(|i| {
+        src_iter_read.set(src_iter_read.get() + 1);
+        u16::from_le(*i)
+    });
+
+    let mut src_read = 0;
+    let mut dst_written = 0;
+
+    for ch in std::char::decode_utf16(src_iter) {
+        let ch = ch.map_err(|_| anyhow!("invalid utf16 encoding"))?;
+
+        // If the destination doesn't have enough space for this character
+        // then the loop is ended and this function will be called later with a
+        // larger destination buffer.
+        if dst.len() < 4 && dst.len() < ch.len_utf8() {
+            break;
+        }
+
+        // Record that characters were read and then convert the `char` to
+        // utf-8, advancing the destination buffer.
+        src_read = src_iter_read.get();
+        let len = ch.encode_utf8(dst).len();
+        dst_written += len;
+        dst = &mut dst[len..];
+    }
+
+    log::trace!("utf16-to-utf8 {src_len}/{dst_len} => {src_read}/{dst_written}");
+    Ok((src_read, dst_written))
+}
+
+/// Converts latin1 to utf8.
+///
+/// Receives the independent size of both buffers and returns the number of code
+/// units read and code units written (both bytes in this case).
+///
+/// This may perform a partial encoding if the destination is not large enough.
+unsafe fn latin1_to_utf8(
+    src: *mut u8,
+    src_len: usize,
+    dst: *mut u8,
+    dst_len: usize,
+) -> Result<(usize, usize)> {
+    let src = slice::from_raw_parts(src, src_len);
+    let dst = slice::from_raw_parts_mut(dst, dst_len);
+    assert_no_overlap(src, dst);
+    let (read, written) = encoding_rs::mem::convert_latin1_to_utf8_partial(src, dst);
+    log::trace!("latin1-to-utf8 {src_len}/{dst_len} => ({read}, {written})");
+    Ok((read, written))
+}
+
+/// Converts utf16 to "latin1+utf16", probably using a utf16 encoding.
+///
+/// The length specified is the length of both the source and destination
+/// buffers. If the source string has any characters that don't fit in the
+/// latin1 code space (0xff and below) then a utf16-tagged length will be
+/// returned. Otherwise the string is "deflated" from a utf16 string to a latin1
+/// string and the latin1 length is returned.
+unsafe fn utf16_to_compact_probably_utf16(
+    src: *mut u16,
+    len: usize,
+    dst: *mut u16,
+) -> Result<usize> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    let all_latin1 = run_utf16_to_utf16(src, dst)?;
+    if all_latin1 {
+        let (left, dst, right) = dst.align_to_mut::<u8>();
+        assert!(left.is_empty());
+        assert!(right.is_empty());
+        for i in 0..len {
+            dst[i] = dst[2 * i];
+        }
+        log::trace!("utf16-to-compact-probably-utf16 {len} => latin1 {len}");
+        Ok(len)
+    } else {
+        log::trace!("utf16-to-compact-probably-utf16 {len} => utf16 {len}");
+        Ok(len | UTF16_TAG)
+    }
+}
+
+/// Converts a utf8 string to latin1.
+///
+/// The length specified is the same length of both the input and the output
+/// buffers.
+///
+/// Returns the number of code units read from the source and the number of code
+/// units written to the destination.
+///
+/// Note that this may not convert the entire source into the destination if the
+/// original utf8 string has usvs not representable in latin1.
+unsafe fn utf8_to_latin1(src: *mut u8, len: usize, dst: *mut u8) -> Result<(usize, usize)> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+    let read = encoding_rs::mem::utf8_latin1_up_to(src);
+    let written = encoding_rs::mem::convert_utf8_to_latin1_lossy(&src[..read], dst);
+    log::trace!("utf8-to-latin1 {len} => ({read}, {written})");
+    Ok((read, written))
+}
+
+/// Converts a utf16 string to latin1
+///
+/// This is the same as `utf8_to_latin1` in terms of parameters/results.
+unsafe fn utf16_to_latin1(src: *mut u16, len: usize, dst: *mut u8) -> Result<(usize, usize)> {
+    let src = slice::from_raw_parts(src, len);
+    let dst = slice::from_raw_parts_mut(dst, len);
+    assert_no_overlap(src, dst);
+
+    let mut size = 0;
+    for (src, dst) in src.iter().zip(dst) {
+        let src = u16::from_le(*src);
+        match u8::try_from(src) {
+            Ok(src) => *dst = src,
+            Err(_) => break,
+        }
+        size += 1;
+    }
+    log::trace!("utf16-to-latin1 {len} => {size}");
+    Ok((size, size))
+}
+
+/// Converts a utf8 string to a utf16 string which has been partially converted
+/// as latin1 prior.
+///
+/// The original string has already been partially transcoded with
+/// `utf8_to_latin1` and that was determined to not be able to transcode the
+/// entire string. The substring of the source that couldn't be encoded into
+/// latin1 is passed here via `src` and `src_len`.
+///
+/// The destination buffer is specified by `dst` and `dst_len`. The first
+/// `latin1_bytes_so_far` bytes (not code units) of the `dst` buffer have
+/// already been filled in with latin1 characters and need to be inflated
+/// in-place to their utf16 equivalents.
+///
+/// After the initial latin1 code units have been inflated the entirety of `src`
+/// is then transcoded into the remaining space within `dst`.
+unsafe fn utf8_to_compact_utf16(
+    src: *mut u8,
+    src_len: usize,
+    dst: *mut u16,
+    dst_len: usize,
+    latin1_bytes_so_far: usize,
+) -> Result<usize> {
+    let src = slice::from_raw_parts(src, src_len);
+    let dst = slice::from_raw_parts_mut(dst, dst_len);
+    assert_no_overlap(src, dst);
+
+    let dst = inflate_latin1_bytes(dst, latin1_bytes_so_far);
+    let result = run_utf8_to_utf16(src, dst)?;
+    log::trace!("utf8-to-compact-utf16 {src_len}/{dst_len}/{latin1_bytes_so_far} => {result}");
+    Ok(result + latin1_bytes_so_far)
+}
+
+/// Same as `utf8_to_compact_utf16` but for utf16 source strings.
+unsafe fn utf16_to_compact_utf16(
+    src: *mut u16,
+    src_len: usize,
+    dst: *mut u16,
+    dst_len: usize,
+    latin1_bytes_so_far: usize,
+) -> Result<usize> {
+    let src = slice::from_raw_parts(src, src_len);
+    let dst = slice::from_raw_parts_mut(dst, dst_len);
+    assert_no_overlap(src, dst);
+
+    let dst = inflate_latin1_bytes(dst, latin1_bytes_so_far);
+    run_utf16_to_utf16(src, dst)?;
+    let result = src.len();
+    log::trace!("utf16-to-compact-utf16 {src_len}/{dst_len}/{latin1_bytes_so_far} => {result}");
+    Ok(result + latin1_bytes_so_far)
+}
+
+/// Inflates the `latin1_bytes_so_far` number of bytes written to the beginning
+/// of `dst` into u16 codepoints.
+///
+/// Returns the remaining space in the destination that can be transcoded into,
+/// slicing off the prefix of the string that was inflated from the latin1
+/// bytes.
+fn inflate_latin1_bytes(dst: &mut [u16], latin1_bytes_so_far: usize) -> &mut [u16] {
+    // Note that `latin1_bytes_so_far` is a byte measure while `dst` is a region
+    // of u16 units. This `split_at_mut` uses the byte index as an index into
+    // the u16 unit because each of the latin1 bytes will become a whole code
+    // unit in the destination which is 2 bytes large.
+    let (to_inflate, rest) = dst.split_at_mut(latin1_bytes_so_far);
+
+    // Use a byte-oriented view to inflate the original latin1 bytes.
+    let (left, mid, right) = unsafe { to_inflate.align_to_mut::<u8>() };
+    assert!(left.is_empty());
+    assert!(right.is_empty());
+    for i in (0..latin1_bytes_so_far).rev() {
+        mid[2 * i] = mid[i];
+        mid[2 * i + 1] = 0;
+    }
+
+    return rest;
+}

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -255,7 +255,7 @@ mod test_vmmemory_definition {
     use super::VMMemoryDefinition;
     use memoffset::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{Module, VMOffsets};
+    use wasmtime_environ::{Module, PtrSize, VMOffsets};
 
     #[test]
     fn check_vmmemory_definition_offsets() {
@@ -263,15 +263,15 @@ mod test_vmmemory_definition {
         let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
             size_of::<VMMemoryDefinition>(),
-            usize::from(offsets.size_of_vmmemory_definition())
+            usize::from(offsets.ptr.size_of_vmmemory_definition())
         );
         assert_eq!(
             offset_of!(VMMemoryDefinition, base),
-            usize::from(offsets.vmmemory_definition_base())
+            usize::from(offsets.ptr.vmmemory_definition_base())
         );
         assert_eq!(
             offset_of!(VMMemoryDefinition, current_length),
-            usize::from(offsets.vmmemory_definition_current_length())
+            usize::from(offsets.ptr.vmmemory_definition_current_length())
         );
         /* TODO: Assert that the size of `current_length` matches.
         assert_eq!(

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -37,6 +37,7 @@ once_cell = "1.12.0"
 rayon = { version = "1.0", optional = true }
 object = { version = "0.29", default-features = false, features = ['read_core', 'elf'] }
 async-trait = { version = "0.1.51", optional = true }
+encoding_rs = { version = "0.8.31", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.36.0"
@@ -116,4 +117,5 @@ component-model = [
   "wasmtime-runtime/component-model",
   "dep:wasmtime-component-macro",
   "dep:wasmtime-component-util",
+  "dep:encoding_rs",
 ]

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1462,6 +1462,15 @@ impl Config {
 
         compiler.build()
     }
+
+    /// Internal setting for whether adapter modules for components will have
+    /// extra WebAssembly instructions inserted performing more debug checks
+    /// then are necessary.
+    #[cfg(feature = "component-model")]
+    pub fn debug_adapter_modules(&mut self, debug: bool) -> &mut Self {
+        self.tunables.debug_adapter_modules = debug;
+        self
+    }
 }
 
 fn round_up_to_pages(val: u64) -> u64 {

--- a/deny.toml
+++ b/deny.toml
@@ -14,10 +14,9 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "Apache-2.0",
     "BSD-2-Clause",
-    "CC0-1.0",
+    "BSD-3-Clause",
     "ISC",
     "MIT",
-    "MPL-2.0",
     "Zlib",
 ]
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -311,6 +311,10 @@ criteria = "safe-to-deploy"
 version = "0.3.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.encoding_rs]]
+version = "0.8.31"
+criteria = "safe-to-deploy"
+
 [[exemptions.env_logger]]
 version = "0.7.1"
 criteria = "safe-to-deploy"

--- a/tests/all/component_model.rs
+++ b/tests/all/component_model.rs
@@ -12,6 +12,7 @@ mod instance;
 mod macros;
 mod nested;
 mod post_return;
+mod strings;
 
 #[test]
 fn components_importing_modules() -> Result<()> {

--- a/tests/all/component_model/strings.rs
+++ b/tests/all/component_model/strings.rs
@@ -1,0 +1,574 @@
+use super::REALLOC_AND_FREE;
+use anyhow::Result;
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Engine, Store, StoreContextMut, Trap, TrapCode};
+
+const UTF16_TAG: u32 = 1 << 31;
+
+// Special cases that this tries to test:
+//
+// * utf8 -> utf8
+//    * various code point sizes
+//
+// * utf8 -> utf16 - the adapter here will make a pessimistic allocation that's
+//   twice the size of the utf8 encoding for the utf16 destination
+//    * utf16 byte size is twice the utf8 size
+//    * utf16 byte size is less than twice the utf8 size
+//
+// * utf8 -> latin1+utf16 - attempts to convert to latin1 then falls back to a
+//   pessimistic utf16 allocation that's downsized if necessary
+//    * utf8 fits exactly in latin1
+//    * utf8 fits latin1 but is bigger byte-wise
+//    * utf8 is not latin1 and fits utf16 allocation precisely (NOT POSSIBLE)
+//    * utf8 is not latin1 and utf16 is smaller than allocation
+//
+// * utf16 -> utf8 - this starts with an optimistic size and then reallocates to
+//   a pessimistic size, interesting cases are:
+//    * utf8 size is 0.5x the utf16 byte size (perfect fit in initial alloc)
+//    * utf8 size is 1.5x the utf16 byte size (perfect fit in larger alloc)
+//    * utf8 size is 0.5x-1.5x the utf16 size (larger alloc is downsized)
+//
+// * utf16 -> utf16
+//    * various code point sizes
+//
+// * utf16 -> latin1+utf16 - attempts to convert to latin1 then falls back to a
+//   pessimistic utf16 allocation that's downsized if necessary
+//    * utf16 fits exactly in latin1
+//    * utf16 fits latin1 but is bigger byte-wise (NOT POSSIBLE)
+//    * utf16 is not latin1 and fits utf16 allocation precisely
+//    * utf16 is not latin1 and utf16 is smaller than allocation (NOT POSSIBLE)
+//
+// * compact-utf16 -> utf8 dynamically determines between one of
+//    * latin1 -> utf8
+//      * latin1 size matches utf8 size
+//      * latin1 is smaller than utf8 size
+//    * utf16 -> utf8
+//      * covered above
+//
+// * compact-utf16 -> utf16 dynamically determines between one of
+//    * latin1 -> utf16 - latin1 size always matches utf16
+//      * test various code points
+//    * utf16 -> utf16
+//      * covered above
+//
+// * compact-utf16 -> compact-utf16 dynamically determines between one of
+//    * latin1 -> latin1
+//      * not much interesting here
+//    * utf16 -> compact-utf16-to-compact-probably-utf16
+//      * utf16 actually fits within latin1
+//      * otherwise not more interesting than utf16 -> utf16
+//
+const STRINGS: &[&str] = &[
+    "",
+    // 1 byte in utf8, 2 bytes in utf16
+    "x",
+    "hello this is a particularly long string yes it is it keeps going",
+    // 35 bytes in utf8, 23 units in utf16, 23 bytes in latin1
+    "à á â ã ä å æ ç è é ê ë",
+    // 47 bytes in utf8, 31 units in utf16
+    "Ξ Ο Π Ρ Σ Τ Υ Φ Χ Ψ Ω Ϊ Ϋ ά έ ή",
+    // 24 bytes in utf8, 8 units in utf16
+    "ＳＴＵＶＷＸＹＺ",
+    // 16 bytes in utf8, 8 units in utf16
+    "ËÌÍÎÏÐÑÒ",
+    // 4 bytes in utf8, 1 unit in utf16
+    "\u{10000}",
+    // latin1-compatible prefix followed by utf8/16-requiring suffix
+    //
+    // 24 bytes in utf8, 13 units in utf16, first 8 usvs are latin1-compatible
+    "à ascii ＶＷＸＹＺ",
+];
+
+static ENCODINGS: [&str; 3] = ["utf8", "utf16", "latin1+utf16"];
+
+#[test]
+fn roundtrip() -> Result<()> {
+    for debug in [true, false] {
+        let mut config = component_test_util::config();
+        config.debug_adapter_modules(debug);
+        let engine = Engine::new(&config)?;
+        for src in ENCODINGS {
+            for dst in ENCODINGS {
+                test_roundtrip(&engine, src, dst)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn test_roundtrip(engine: &Engine, src: &str, dst: &str) -> Result<()> {
+    println!("src={src} dst={dst}");
+
+    let mk_echo = |name: &str, encoding: &str| {
+        format!(
+            r#"
+(component {name}
+    (import "echo" (func $echo (param string) (result string)))
+    (core instance $libc (instantiate $libc))
+    (core func $echo (canon lower (func $echo)
+        (memory $libc "memory")
+        (realloc (func $libc "realloc"))
+        string-encoding={encoding}
+    ))
+    (core instance $echo (instantiate $echo
+        (with "libc" (instance $libc))
+        (with "" (instance (export "echo" (func $echo))))
+    ))
+    (func (export "echo") (param string) (result string)
+        (canon lift
+            (core func $echo "echo")
+            (memory $libc "memory")
+            (realloc (func $libc "realloc"))
+            string-encoding={encoding}
+        )
+    )
+)
+            "#
+        )
+    };
+
+    let src = mk_echo("$src", src);
+    let dst = mk_echo("$dst", dst);
+    let component = format!(
+        r#"
+(component
+    (import "host" (func $host (param string) (result string)))
+
+    (core module $libc
+        (memory (export "memory") 1)
+        {REALLOC_AND_FREE}
+    )
+    (core module $echo
+        (import "" "echo" (func $echo (param i32 i32 i32)))
+        (import "libc" "memory" (memory 0))
+        (import "libc" "realloc" (func $realloc (param i32 i32 i32 i32) (result i32)))
+
+        (func (export "echo") (param i32 i32) (result i32)
+            (local $retptr i32)
+            (local.set $retptr
+                (call $realloc
+                    (i32.const 0)
+                    (i32.const 0)
+                    (i32.const 4)
+                    (i32.const 8)))
+            (call $echo
+                (local.get 0)
+                (local.get 1)
+                (local.get $retptr))
+            local.get $retptr
+        )
+    )
+
+    {src}
+    {dst}
+
+    (instance $dst (instantiate $dst (with "echo" (func $host))))
+    (instance $src (instantiate $src (with "echo" (func $dst "echo"))))
+    (export "echo" (func $src "echo"))
+)
+"#
+    );
+    let component = Component::new(engine, &component)?;
+    let mut store = Store::new(engine, String::new());
+    let mut linker = Linker::new(engine);
+    linker
+        .root()
+        .func_wrap("host", |store: StoreContextMut<String>, arg: String| {
+            assert_eq!(*store.data(), arg);
+            Ok(arg)
+        })?;
+    let instance = linker.instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(String,), String, _>(&mut store, "echo")?;
+
+    for string in STRINGS {
+        println!("testing string {string:?}");
+        *store.data_mut() = string.to_string();
+        let ret = func.call(&mut store, (string.to_string(),))?;
+        assert_eq!(ret, *string);
+        func.post_return(&mut store)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn ptr_out_of_bounds() -> Result<()> {
+    let engine = component_test_util::engine();
+    for src in ENCODINGS {
+        for dst in ENCODINGS {
+            test_ptr_out_of_bounds(&engine, src, dst)?;
+        }
+    }
+    Ok(())
+}
+
+fn test_ptr_out_of_bounds(engine: &Engine, src: &str, dst: &str) -> Result<()> {
+    let component = format!(
+        r#"
+(component
+  (component $c
+    (core module $m
+      (func (export "") (param i32 i32))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+      (memory (export "memory") 1)
+    )
+    (core instance $m (instantiate $m))
+    (func (export "") (param string)
+      (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory")
+        string-encoding={dst})
+    )
+  )
+
+  (component $c2
+    (import "" (func $f (param string)))
+    (core module $libc
+      (memory (export "memory") 1)
+    )
+    (core instance $libc (instantiate $libc))
+    (core func $f (canon lower (func $f) string-encoding={src} (memory $libc "memory")))
+    (core module $m
+      (import "" "" (func $f (param i32 i32)))
+
+      (func $start (call $f (i32.const 0x8000_0000) (i32.const 1)))
+      (start $start)
+    )
+    (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+  )
+
+  (instance $c (instantiate $c))
+  (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+)
+"#
+    );
+
+    let component = Component::new(engine, &component)?;
+    let mut store = Store::new(engine, ());
+    let trap = Linker::new(engine)
+        .instantiate(&mut store, &component)
+        .err()
+        .unwrap()
+        .downcast::<Trap>()?;
+    assert_eq!(trap.trap_code(), Some(TrapCode::MemoryOutOfBounds));
+    Ok(())
+}
+
+// Test that even if the ptr+len calculation overflows then a trap still
+// happens.
+#[test]
+fn ptr_overflow() -> Result<()> {
+    let engine = component_test_util::engine();
+    for src in ENCODINGS {
+        for dst in ENCODINGS {
+            test_ptr_overflow(&engine, src, dst)?;
+        }
+    }
+    Ok(())
+}
+
+fn test_ptr_overflow(engine: &Engine, src: &str, dst: &str) -> Result<()> {
+    let component = format!(
+        r#"
+(component
+  (component $c
+    (core module $m
+      (func (export "") (param i32 i32))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+      (memory (export "memory") 1)
+    )
+    (core instance $m (instantiate $m))
+    (func (export "") (param string)
+      (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory")
+        string-encoding={dst})
+    )
+  )
+
+  (component $c2
+    (import "" (func $f (param string)))
+    (core module $libc
+      (memory (export "memory") 1)
+    )
+    (core instance $libc (instantiate $libc))
+    (core func $f (canon lower (func $f) string-encoding={src} (memory $libc "memory")))
+    (core module $m
+      (import "" "" (func $f (param i32 i32)))
+
+      (func (export "f") (param i32) (call $f (i32.const 1000) (local.get 0)))
+    )
+    (core instance $m (instantiate $m (with "" (instance (export "" (func $f))))))
+    (func (export "f") (param u32) (canon lift (core func $m "f")))
+  )
+
+  (instance $c (instantiate $c))
+  (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  (export "f" (func $c2 "f"))
+)
+"#
+    );
+
+    let component = Component::new(engine, &component)?;
+    let mut store = Store::new(engine, ());
+
+    let mut test_overflow = |size: u32, code: TrapCode| -> Result<()> {
+        println!("src={src} dst={dst} size={size:#x}");
+        let instance = Linker::new(engine).instantiate(&mut store, &component)?;
+        let func = instance.get_typed_func::<(u32,), (), _>(&mut store, "f")?;
+        let trap = func
+            .call(&mut store, (size,))
+            .unwrap_err()
+            .downcast::<Trap>()?;
+        assert_eq!(trap.trap_code(), Some(code));
+        Ok(())
+    };
+
+    let max = 1 << 31;
+    let unreachable = TrapCode::UnreachableCodeReached;
+    let oob = TrapCode::MemoryOutOfBounds;
+
+    match src {
+        "utf8" => {
+            // This exceeds MAX_STRING_BYTE_LENGTH
+            test_overflow(max, unreachable)?;
+
+            if dst == "utf16" {
+                // exceeds MAX_STRING_BYTE_LENGTH when multiplied
+                test_overflow(max / 2, unreachable)?;
+
+                // Technically this fails on the first string, not the second.
+                // Ideally this would test the overflow check on the second
+                // string though.
+                test_overflow(max / 2 - 100, oob)?;
+            } else {
+                // This will point into unmapped memory
+                test_overflow(max - 100, oob)?;
+            }
+        }
+
+        "utf16" => {
+            test_overflow(max / 2, unreachable)?;
+            test_overflow(max / 2 - 100, oob)?;
+        }
+
+        "latin1+utf16" => {
+            test_overflow((max / 2) | UTF16_TAG, unreachable)?;
+            // tag a utf16 string with the max length and it should overflow.
+            test_overflow((max / 2 - 100) | UTF16_TAG, oob)?;
+        }
+
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+// Test that that the pointer returned from `realloc` is bounds-checked.
+#[test]
+fn realloc_oob() -> Result<()> {
+    let engine = component_test_util::engine();
+    for src in ENCODINGS {
+        for dst in ENCODINGS {
+            test_realloc_oob(&engine, src, dst)?;
+        }
+    }
+    Ok(())
+}
+
+fn test_realloc_oob(engine: &Engine, src: &str, dst: &str) -> Result<()> {
+    let component = format!(
+        r#"
+(component
+  (component $c
+    (core module $m
+      (func (export "") (param i32 i32))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 100_000)
+      (memory (export "memory") 1)
+    )
+    (core instance $m (instantiate $m))
+    (func (export "") (param string)
+      (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory")
+        string-encoding={dst})
+    )
+  )
+
+  (component $c2
+    (import "" (func $f (param string)))
+    (core module $libc
+      (memory (export "memory") 1)
+    )
+    (core instance $libc (instantiate $libc))
+    (core func $f (canon lower (func $f) string-encoding={src} (memory $libc "memory")))
+    (core module $m
+      (import "" "" (func $f (param i32 i32)))
+
+      (func (export "f") (call $f (i32.const 1000) (i32.const 10)))
+    )
+    (core instance $m (instantiate $m (with "" (instance (export "" (func $f))))))
+    (func (export "f") (canon lift (core func $m "f")))
+  )
+
+  (instance $c (instantiate $c))
+  (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  (export "f" (func $c2 "f"))
+)
+"#
+    );
+
+    let component = Component::new(engine, &component)?;
+    let mut store = Store::new(engine, ());
+
+    let instance = Linker::new(engine).instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(), (), _>(&mut store, "f")?;
+    let trap = func.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap.trap_code(), Some(TrapCode::MemoryOutOfBounds));
+    Ok(())
+}
+
+// Test that that the pointer returned from `realloc` is bounds-checked.
+#[test]
+fn raw_string_encodings() -> Result<()> {
+    let engine = component_test_util::engine();
+    test_invalid_string_encoding(&engine, "utf8", "utf8", &[0xff], 1)?;
+    let array = b"valid string until \xffthen valid again";
+    test_invalid_string_encoding(&engine, "utf8", "utf8", array, array.len() as u32)?;
+    test_invalid_string_encoding(&engine, "utf8", "utf16", array, array.len() as u32)?;
+    let array = b"symbol \xce\xa3 until \xffthen valid";
+    test_invalid_string_encoding(&engine, "utf8", "utf8", array, array.len() as u32)?;
+    test_invalid_string_encoding(&engine, "utf8", "utf16", array, array.len() as u32)?;
+    test_invalid_string_encoding(&engine, "utf8", "latin1+utf16", array, array.len() as u32)?;
+    test_invalid_string_encoding(&engine, "utf16", "utf8", &[0x01, 0xd8], 1)?;
+    test_invalid_string_encoding(&engine, "utf16", "utf16", &[0x01, 0xd8], 1)?;
+    test_invalid_string_encoding(
+        &engine,
+        "utf16",
+        "latin1+utf16",
+        &[0xff, 0xff, 0x01, 0xd8],
+        2,
+    )?;
+    test_invalid_string_encoding(
+        &engine,
+        "latin1+utf16",
+        "utf8",
+        &[0x01, 0xd8],
+        1 | UTF16_TAG,
+    )?;
+    test_invalid_string_encoding(
+        &engine,
+        "latin1+utf16",
+        "utf16",
+        &[0x01, 0xd8],
+        1 | UTF16_TAG,
+    )?;
+    test_invalid_string_encoding(
+        &engine,
+        "latin1+utf16",
+        "utf16",
+        &[0xff, 0xff, 0x01, 0xd8],
+        2 | UTF16_TAG,
+    )?;
+    test_invalid_string_encoding(
+        &engine,
+        "latin1+utf16",
+        "latin1+utf16",
+        &[0xab, 0x00, 0xff, 0xff, 0x01, 0xd8],
+        3 | UTF16_TAG,
+    )?;
+
+    // This latin1+utf16 string should get compressed to latin1 across the
+    // boundary.
+    test_valid_string_encoding(
+        &engine,
+        "latin1+utf16",
+        "latin1+utf16",
+        &[0xab, 0x00, 0xff, 0x00],
+        2 | UTF16_TAG,
+    )?;
+    Ok(())
+}
+
+fn test_invalid_string_encoding(
+    engine: &Engine,
+    src: &str,
+    dst: &str,
+    bytes: &[u8],
+    len: u32,
+) -> Result<()> {
+    let trap = test_raw_when_encoded(engine, src, dst, bytes, len)?.unwrap();
+    let src = src.replace("latin1+", "");
+    assert!(
+        trap.to_string()
+            .contains(&format!("invalid {src} encoding")),
+        "bad error: {}",
+        trap,
+    );
+    Ok(())
+}
+
+fn test_valid_string_encoding(
+    engine: &Engine,
+    src: &str,
+    dst: &str,
+    bytes: &[u8],
+    len: u32,
+) -> Result<()> {
+    let err = test_raw_when_encoded(engine, src, dst, bytes, len)?;
+    assert!(err.is_none());
+    Ok(())
+}
+
+fn test_raw_when_encoded(
+    engine: &Engine,
+    src: &str,
+    dst: &str,
+    bytes: &[u8],
+    len: u32,
+) -> Result<Option<Trap>> {
+    let component = format!(
+        r#"
+(component
+  (component $c
+    (core module $m
+      (func (export "") (param i32 i32))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+      (memory (export "memory") 1)
+    )
+    (core instance $m (instantiate $m))
+    (func (export "") (param string)
+      (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory")
+        string-encoding={dst})
+    )
+  )
+
+  (component $c2
+    (import "" (func $f (param string)))
+    (core module $libc
+      (memory (export "memory") 1)
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+    )
+    (core instance $libc (instantiate $libc))
+    (core func $f (canon lower (func $f) string-encoding={src} (memory $libc "memory")))
+    (core module $m
+      (import "" "" (func $f (param i32 i32)))
+
+      (func (export "f") (param i32 i32 i32) (call $f (local.get 0) (local.get 2)))
+    )
+    (core instance $m (instantiate $m (with "" (instance (export "" (func $f))))))
+    (func (export "f") (param (list u8)) (param u32) (canon lift (core func $m "f")
+        (memory $libc "memory")
+        (realloc (func $libc "realloc"))))
+  )
+
+  (instance $c (instantiate $c))
+  (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  (export "f" (func $c2 "f"))
+)
+"#
+    );
+
+    let component = Component::new(engine, &component)?;
+    let mut store = Store::new(engine, ());
+
+    let instance = Linker::new(engine).instantiate(&mut store, &component)?;
+    let func = instance.get_typed_func::<(&[u8], u32), (), _>(&mut store, "f")?;
+    match func.call(&mut store, (bytes, len)) {
+        Ok(_) => Ok(None),
+        Err(e) => Ok(Some(e.downcast()?)),
+    }
+}

--- a/tests/misc_testsuite/component-model/strings.wast
+++ b/tests/misc_testsuite/component-model/strings.wast
@@ -105,4 +105,4 @@
     (instance $c (instantiate $c))
     (instance $c2 (instantiate $c2 (with "" (func $c ""))))
   )
-  "out of bounds")
+  "unreachable")

--- a/tests/misc_testsuite/component-model/strings.wast
+++ b/tests/misc_testsuite/component-model/strings.wast
@@ -1,0 +1,108 @@
+;; unaligned utf16 string
+(assert_trap
+  (component
+    (component $c
+      (core module $m
+        (func (export "") (param i32 i32))
+        (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        (memory (export "memory") 1)
+      )
+      (core instance $m (instantiate $m))
+      (func (export "") (param string)
+        (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory"))
+      )
+    )
+
+    (component $c2
+      (import "" (func $f (param string)))
+      (core module $libc
+        (memory (export "memory") 1)
+      )
+      (core instance $libc (instantiate $libc))
+      (core func $f (canon lower (func $f) string-encoding=utf16 (memory $libc "memory")))
+      (core module $m
+        (import "" "" (func $f (param i32 i32)))
+
+        (func $start (call $f (i32.const 1) (i32.const 0)))
+        (start $start)
+      )
+      (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+    )
+
+    (instance $c (instantiate $c))
+    (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  )
+  "unreachable")
+
+;; unaligned latin1+utf16 string, even with the latin1 encoding
+(assert_trap
+  (component
+    (component $c
+      (core module $m
+        (func (export "") (param i32 i32))
+        (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        (memory (export "memory") 1)
+      )
+      (core instance $m (instantiate $m))
+      (func (export "") (param string)
+        (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory"))
+      )
+    )
+
+    (component $c2
+      (import "" (func $f (param string)))
+      (core module $libc
+        (memory (export "memory") 1)
+      )
+      (core instance $libc (instantiate $libc))
+      (core func $f (canon lower (func $f) string-encoding=latin1+utf16 (memory $libc "memory")))
+      (core module $m
+        (import "" "" (func $f (param i32 i32)))
+
+        (func $start (call $f (i32.const 1) (i32.const 0)))
+        (start $start)
+      )
+      (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+    )
+
+    (instance $c (instantiate $c))
+    (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  )
+  "unreachable")
+
+;; out of bounds utf8->utf8 string
+(assert_trap
+  (component
+    (component $c
+      (core module $m
+        (func (export "") (param i32 i32))
+        (func (export "realloc") (param i32 i32 i32 i32) (result i32) i32.const 0)
+        (memory (export "memory") 1)
+      )
+      (core instance $m (instantiate $m))
+      (func (export "") (param string)
+        (canon lift (core func $m "") (realloc (func $m "realloc")) (memory $m "memory")
+          string-encoding=utf8)
+      )
+    )
+
+    (component $c2
+      (import "" (func $f (param string)))
+      (core module $libc
+        (memory (export "memory") 1)
+      )
+      (core instance $libc (instantiate $libc))
+      (core func $f (canon lower (func $f) string-encoding=utf8 (memory $libc "memory")))
+      (core module $m
+        (import "" "" (func $f (param i32 i32)))
+
+        (func $start (call $f (i32.const 0x8000_0000) (i32.const 1)))
+        (start $start)
+      )
+      (core instance (instantiate $m (with "" (instance (export "" (func $f))))))
+    )
+
+    (instance $c (instantiate $c))
+    (instance $c2 (instantiate $c2 (with "" (func $c ""))))
+  )
+  "out of bounds")


### PR DESCRIPTION
This commit is a hefty addition to Wasmtime's support for the component
model. This implements the final remaining type (in the current type
hierarchy) unimplemented in adapter module trampolines: strings. Strings
are the most complicated type to implement in adapter trampolines
because they are highly structured chunks of data in memory (according
to specific encodings). Additionally each lift/lower operation can
choose its own encoding for strings meaning that Wasmtime, the host, may
have to convert between any pairwise ordering of string encodings.

The `CanonicalABI.md` in the component-model repo in general specifies
all the fiddly bits of string encoding so there's not a ton of wiggle
room for Wasmtime to get creative. This PR largely "just" implements
that. The high-level architecture of this implementation is:

* Fused adapters are first identified to determine src/dst string
  encodings. This statically fixes what transcoding operation is being
  performed.

* The generated adapter will be responsible for managing calls to
  `realloc` and performing bounds checks. The adapter itself does not
  perform memory copies or validation of string contents, however.
  Instead each transcoding operation is modeled as an imported function
  into the adapter module.  This means that the adapter module
  dynamically, during compile time, determines what string transcoders
  are needed. Note that an imported transcoder is not only parameterized
  over the transcoding operation but additionally which memory is the
  source and which is the destination.

* The imported core wasm functions are modeled as a new
  `CoreDef::Transcoder` structure. These transcoders end up being small
  Cranelift-compiled trampolines. The Cranelift-compiled trampoline will
  load the actual base pointer of memory and add it to the relative
  pointers passed as function arguments. This trampoline then calls a
  transcoder "libcall" which enters Rust-defined functions for actual
  transcoding operations.

* Each possible transcoding operation is implemented in Rust with a
  unique name and a unique signature depending on the needs of the
  transcoder. I've tried to document inline what each transcoder does.

This means that the `Module::translate_string` in adapter modules is by
far the largest translation method. The main reason for this is due to
the management around calling the imported transcoder functions in the
face of validating string pointer/lengths and performing the dance of
`realloc`-vs-transcode at the right time. I've tried to ensure that each
individual case in transcoding is documented well enough to understand
what's going on as well.

Additionally in this PR is a full implementation in the host for the
`latin1+utf16` encoding which means that both lifting and lowering host
strings now works with this encoding.

Currently the implementation of each transcoder function is likely far
from optimal. Where possible I've leaned on the standard library itself
and for latin1-related things I'm leaning on the `encoding_rs` crate. I
initially tried to implement everything with `encoding_rs` but was
unable to uniformly do so easily. For now I settled on trying to get a
known-correct (even in the face of endianness) implementation for all of
these transcoders. If an when performance becomes an issue it should be
possible to implement more optimized versions of each of these
transcoding operations.

Testing this commit has been somewhat difficult and my general plan,
like with the `(list T)` type, is to rely heavily on fuzzing to cover
the various cases here. In this PR though I've added a simple test that
pushes some statically known strings through all the pairs of encodings
between source and destination. I've attempted to pick "interesting"
strings that one way or another stress the various paths in each
transcoding operation to ideally get full branch coverage there.
Additionally a suite of "negative" tests have also been added to ensure
that validity of encoding is actually checked.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Closes #4309