### PR TITLE
Cranelift: extend docs on Inst to discuss `call` instructions

### DIFF
--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -88,12 +88,15 @@ impl Value {
 ///
 /// Most usage of `Inst` is internal. `Inst`ructions are returned by
 /// [`InstBuilder`](super::InstBuilder) instructions that do not return a
-/// [`Value`], such as control flow and trap instructions.
+/// [`Value`], such as control flow and trap instructions, as well as instructions that return a
+/// variable (potentially zero!) number of values, like call or call-indirect instructions.
 ///
 /// If you look around the API, you can find many inventive uses for `Inst`,
 /// such as [annotating specific instructions with a comment][inst_comment]
 /// or [performing reflection at compile time](super::DataFlowGraph::analyze_branch)
-/// on the type of instruction.
+/// on the type of instruction. A more typical use of `Inst` would be to obtain the results of a
+/// call via [`inst_results`](super::DataFlowGraph::inst_results) or its analogue in
+/// `cranelift_frontend::FuncBuilder`.
 ///
 /// [inst_comment]: https://github.com/bjorn3/rustc_codegen_cranelift/blob/0f8814fd6da3d436a90549d4bb19b94034f2b19c/src/pretty_clif.rs
 ///

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -89,14 +89,14 @@ impl Value {
 /// Most usage of `Inst` is internal. `Inst`ructions are returned by
 /// [`InstBuilder`](super::InstBuilder) instructions that do not return a
 /// [`Value`], such as control flow and trap instructions, as well as instructions that return a
-/// variable (potentially zero!) number of values, like call or call-indirect instructions.
+/// variable (potentially zero!) number of values, like call or call-indirect instructions. To get
+/// the `Value` of such instructions, use [`inst_results`](super::DataFlowGraph::inst_results) or
+/// its analogue in `cranelift_frontend::FuncBuilder`.
 ///
 /// If you look around the API, you can find many inventive uses for `Inst`,
 /// such as [annotating specific instructions with a comment][inst_comment]
 /// or [performing reflection at compile time](super::DataFlowGraph::analyze_branch)
-/// on the type of instruction. A more typical use of `Inst` would be to obtain the results of a
-/// call via [`inst_results`](super::DataFlowGraph::inst_results) or its analogue in
-/// `cranelift_frontend::FuncBuilder`.
+/// on the type of instruction.
 ///
 /// [inst_comment]: https://github.com/bjorn3/rustc_codegen_cranelift/blob/0f8814fd6da3d436a90549d4bb19b94034f2b19c/src/pretty_clif.rs
 ///


### PR DESCRIPTION
the docs on `Inst` note that the type is returned by non-resultful
instructions built from `InstBuilder`, but did _not_ note that it is
also returned by `call` and `call_indirect`. if you're trying to learn
and use Cranelift by following the docs, this means you'd follow a doc
link to `Inst` that implies that `call` does not return a value - this
is actively misleading, since you'd want to use the returned `Inst` to
find exactly those returned values!

so, this adds a few sentences talking about the case of call `Inst`s.