### PR TITLE
Fix sret for AArch64

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -452,3 +452,54 @@ block0:
 ;   str w7, [x11]
 ;   ret
 
+function %f17(i64 sret) {
+block0(v0: i64):
+    v1 = iconst.i64 42
+    store v1, v0
+    return
+}
+
+; block0:
+;   mov x5, x8
+;   movz x4, #42
+;   str x4, [x8]
+;   ret
+
+function %f18(i64) -> i64 {
+    fn0 = %g(i64 sret) -> i64
+
+block0(v0: i64):
+    v1 = call fn0(v0)
+    return v1
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   mov x8, x0
+;   ldr x5, 8 ; b 12 ; data TestCase { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
+;   blr x5
+;   mov x0, x8
+;   ldp fp, lr, [sp], #16
+;   ret
+
+function %f18(i64 sret) {
+    fn0 = %g(i64 sret)
+
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   str x24, [sp, #-16]!
+; block0:
+;   mov x24, x8
+;   ldr x5, 8 ; b 12 ; data TestCase { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } + 0
+;   blr x5
+;   mov x8, x24
+;   ldr x24, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -18,3 +18,45 @@ block0(v0: i64):
 ;   popq    %rbp
 ;   ret
 
+
+function %f1(i64, i64) -> i64 {
+    fn0 = %f2(i64 sret) -> i64
+
+block0(v0: i64, v1: i64):
+    v2 = call fn0(v1)
+    return v2
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rsi, %rdi
+;   load_ext_name %f2+0, %r9
+;   call    *%r9
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f3(i64 sret) {
+    fn0 = %f4(i64 sret)
+
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %r15, 0(%rsp)
+; block0:
+;   movq    %rdi, %r15
+;   load_ext_name %f4+0, %r8
+;   call    *%r8
+;   movq    %r15, %rax
+;   movq    0(%rsp), %r15
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+


### PR DESCRIPTION
AArch64 requires the struct return address argument to be stored in the x8 register. This register is never used for regular arguments.

According to https://github.com/Gankra/abi-checker cg_clif with this PR matches the abi of LLVM for big structs.

Marking as draft as the test fails with:

```
Register allocation error for vcode
VCode {
  Entry block: 0
Block 0:
    (original IR block: block0)
    (instruction range: 0 .. 6)
  Inst 0: mov %v128, x8
  Inst 1: mov %v129, %v128
  Inst 2: mov %v129, %v128
  Inst 3: mov x8, %v129
  Inst 4: mov x0, %v130
  Inst 5: ret
}

Error: EntryLivein
CLIF for error:
function %f17(i64 sret) -> i64 fast {
block0(v0: i64):
    return v0
}
```