### PR TITLE
Port `AvgRound` & `SqmulRoundSat` to ISLE (AArch64)

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -592,6 +592,8 @@ fn define_simd_arithmetic(
             "avg_round",
             r#"
         Unsigned average with rounding: `a := (x + y + 1) // 2`
+
+        The addition does not lose any information (such as from overflow).
         "#,
             &formats.binary,
         )

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1542,6 +1542,13 @@
             (_ Unit (emit (MInst.VecLanes op dst src size))))
         dst))
 
+;; Helper for emitting `MInst.VecShiftImm` instructions.
+(decl vec_shift_imm (VecShiftImmOp u8 Reg VectorSize) Reg)
+(rule (vec_shift_imm op imm src size)
+      (let ((dst WritableReg (temp_writable_reg $I8X16))
+            (_ Unit (emit (MInst.VecShiftImm op dst src size imm))))
+        dst))
+
 ;; Helper for emitting `MInst.VecDup` instructions.
 (decl vec_dup (Reg VectorSize) Reg)
 (rule (vec_dup src size)

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -3952,6 +3952,18 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(8),
             rn: vreg(1),
             rm: vreg(3),
+            size: VectorSize::Size8x8,
+        },
+        "2814232E",
+        "urhadd v8.8b, v1.8b, v3.8b",
+    ));
+
+    insns.push((
+        Inst::VecRRR {
+            alu_op: VecALUOp::Urhadd,
+            rd: writable_vreg(8),
+            rn: vreg(1),
+            rm: vreg(3),
             size: VectorSize::Size8x16,
         },
         "2814236E",
@@ -3964,10 +3976,34 @@ fn test_aarch64_binemit() {
             rd: writable_vreg(2),
             rn: vreg(13),
             rm: vreg(6),
+            size: VectorSize::Size16x4,
+        },
+        "A215662E",
+        "urhadd v2.4h, v13.4h, v6.4h",
+    ));
+
+    insns.push((
+        Inst::VecRRR {
+            alu_op: VecALUOp::Urhadd,
+            rd: writable_vreg(2),
+            rn: vreg(13),
+            rm: vreg(6),
             size: VectorSize::Size16x8,
         },
         "A215666E",
         "urhadd v2.8h, v13.8h, v6.8h",
+    ));
+
+    insns.push((
+        Inst::VecRRR {
+            alu_op: VecALUOp::Urhadd,
+            rd: writable_vreg(8),
+            rn: vreg(12),
+            rm: vreg(14),
+            size: VectorSize::Size32x2,
+        },
+        "8815AE2E",
+        "urhadd v8.2s, v12.2s, v14.2s",
     ));
 
     insns.push((
@@ -5128,6 +5164,126 @@ fn test_aarch64_binemit() {
             op: VecShiftImmOp::Ushr,
             rd: writable_vreg(25),
             rn: vreg(6),
+            imm: 8,
+            size: VectorSize::Size8x8,
+        },
+        "D904082F",
+        "ushr v25.8b, v6.8b, #8",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size8x8,
+        },
+        "A5060F2F",
+        "ushr v5.8b, v21.8b, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
+            imm: 8,
+            size: VectorSize::Size8x16,
+        },
+        "D904086F",
+        "ushr v25.16b, v6.16b, #8",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size8x16,
+        },
+        "A5060F6F",
+        "ushr v5.16b, v21.16b, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
+            imm: 16,
+            size: VectorSize::Size16x4,
+        },
+        "D904102F",
+        "ushr v25.4h, v6.4h, #16",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size16x4,
+        },
+        "A5061F2F",
+        "ushr v5.4h, v21.4h, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
+            imm: 16,
+            size: VectorSize::Size16x8,
+        },
+        "D904106F",
+        "ushr v25.8h, v6.8h, #16",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size16x8,
+        },
+        "A5061F6F",
+        "ushr v5.8h, v21.8h, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
+            imm: 32,
+            size: VectorSize::Size32x2,
+        },
+        "D904202F",
+        "ushr v25.2s, v6.2s, #32",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size32x2,
+        },
+        "A5063F2F",
+        "ushr v5.2s, v21.2s, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
             imm: 32,
             size: VectorSize::Size32x4,
         },
@@ -5145,6 +5301,30 @@ fn test_aarch64_binemit() {
         },
         "A5063F6F",
         "ushr v5.4s, v21.4s, #1",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(25),
+            rn: vreg(6),
+            imm: 64,
+            size: VectorSize::Size64x2,
+        },
+        "D904406F",
+        "ushr v25.2d, v6.2d, #64",
+    ));
+
+    insns.push((
+        Inst::VecShiftImm {
+            op: VecShiftImmOp::Ushr,
+            rd: writable_vreg(5),
+            rn: vreg(21),
+            imm: 1,
+            size: VectorSize::Size64x2,
+        },
+        "A5067F6F",
+        "ushr v5.2d, v21.2d, #1",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -233,6 +233,27 @@
 (rule (lower (has_type (fits_in_32 ty) (iabs x)))
       (abs (OperandSize.Size32) (put_in_reg_sext32 x)))
 
+;;;; Rules for `avg_round` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $I64X2 (avg_round x y)))
+      (let ((one Reg (splat_const 1 (VectorSize.Size64x2)))
+            (c Reg (orr_vec x y (VectorSize.Size64x2)))
+            (c Reg (and_vec c one (VectorSize.Size64x2)))
+            (x Reg (vec_shift_imm (VecShiftImmOp.Ushr) 1 x
+                    (VectorSize.Size64x2)))
+            (y Reg (vec_shift_imm (VecShiftImmOp.Ushr) 1 y
+                    (VectorSize.Size64x2)))
+            (sum Reg (add_vec x y (VectorSize.Size64x2))))
+       (add_vec c sum (VectorSize.Size64x2))))
+
+(rule (lower (has_type (lane_fits_in_32 ty) (avg_round x y)))
+      (vec_rrr (VecALUOp.Urhadd) x y (vector_size ty)))
+
+;;;; Rules for `sqmul_round_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type ty @ (multi_lane _ _) (sqmul_round_sat x y)))
+      (vec_rrr (VecALUOp.Sqrdmulh) x y (vector_size ty)))
+
 ;;;; Rules for `fadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty @ (multi_lane _ _) (fadd rn rm)))

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1502,27 +1502,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::Iabs => implemented_in_isle(ctx),
-        Opcode::AvgRound => {
-            let ty = ty.unwrap();
-
-            if ty.lane_bits() == 64 {
-                return Err(CodegenError::Unsupported(format!(
-                    "AvgRound: Unsupported type: {:?}",
-                    ty
-                )));
-            }
-
-            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-            ctx.emit(Inst::VecRRR {
-                alu_op: VecALUOp::Urhadd,
-                rd,
-                rn,
-                rm,
-                size: VectorSize::from_ty(ty),
-            });
-        }
+        Opcode::AvgRound => implemented_in_isle(ctx),
 
         Opcode::Snarrow | Opcode::Unarrow | Opcode::Uunarrow => implemented_in_isle(ctx),
 
@@ -1583,28 +1563,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             }
         },
 
-        Opcode::SqmulRoundSat => {
-            let ty = ty.unwrap();
-
-            if !ty.is_vector() || (ty.lane_type() != I16 && ty.lane_type() != I32) {
-                return Err(CodegenError::Unsupported(format!(
-                    "SqmulRoundSat: Unsupported type: {:?}",
-                    ty
-                )));
-            }
-
-            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
-            let rm = put_input_in_reg(ctx, inputs[1], NarrowValueMode::None);
-
-            ctx.emit(Inst::VecRRR {
-                alu_op: VecALUOp::Sqrdmulh,
-                rd,
-                rn,
-                rm,
-                size: VectorSize::from_ty(ty),
-            });
-        }
+        Opcode::SqmulRoundSat => implemented_in_isle(ctx),
 
         Opcode::FcvtLowFromSint => {
             let ty = ty.unwrap();

--- a/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
@@ -1,0 +1,81 @@
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+function %average_rounding_i8x8(i8x8, i8x8) -> i8x8 {
+block0(v0: i8x8, v1: i8x8):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.8b, v0.8b, v1.8b
+;   ret
+
+function %average_rounding_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.16b, v0.16b, v1.16b
+;   ret
+
+function %average_rounding_i16x4(i16x4, i16x4) -> i16x4 {
+block0(v0: i16x4, v1: i16x4):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.4h, v0.4h, v1.4h
+;   ret
+
+function %average_rounding_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.8h, v0.8h, v1.8h
+;   ret
+
+function %average_rounding_i32x2(i32x2, i32x2) -> i32x2 {
+block0(v0: i32x2, v1: i32x2):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.2s, v0.2s, v1.2s
+;   ret
+
+function %average_rounding_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   urhadd v0.4s, v0.4s, v1.4s
+;   ret
+
+function %average_rounding_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = avg_round v0, v1
+    return v2
+}
+
+; block0:
+;   movz x6, #1
+;   dup v6.2d, x6
+;   orr v17.16b, v0.16b, v1.16b
+;   and v19.16b, v17.16b, v6.16b
+;   ushr v21.2d, v0.2d, #1
+;   ushr v23.2d, v1.2d, #1
+;   add v25.2d, v21.2d, v23.2d
+;   add v0.2d, v19.2d, v25.2d
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
@@ -1,3 +1,5 @@
+; the interpreter does not currently support some of these instructions
+; such as `avg_round` on SIMD values.
 test run
 target aarch64
 target s390x
@@ -171,6 +173,13 @@ block0(v0: f32x4):
     return v1
 }
 ; run: %fabs_f32x4([0x0.0 -0x1.0 0x2.0 -0x3.0]) == [0x0.0 0x1.0 0x2.0 0x3.0]
+
+function %average_rounding_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i8x16([0 0 0 1 42 19 -1 0xff 5 0 0 0 1 42 19 -1], [0 1 2 4 42 18 -1 0 10 0 1 2 4 42 18 -1]) == [0 1 1 3 42 19 -1 0x80 8 0 1 1 3 42 19 -1]
 
 function %average_rounding_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-avg-round.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round.clif
@@ -1,0 +1,51 @@
+; the interpreter does not currently support SIMD `avg_round`.
+test run
+target aarch64
+; x86_64 and s390x do not currently support 64-bit vectors, or
+; `avg_round` on `i64x2` values.
+; x86_64 also does not currently support `avg_round.i32x4`.
+
+function %average_rounding_i8x8(i8x8, i8x8) -> i8x8 {
+block0(v0: i8x8, v1: i8x8):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i8x8([0 0 0 1 42 19 -1 0xff], [0 1 2 4 42 18 -1 0]) == [0 1 1 3 42 19 -1 0x80]
+
+function %average_rounding_i16x4(i16x4, i16x4) -> i16x4 {
+block0(v0: i16x4, v1: i16x4):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i16x4([0 0 0 1], [0 1 2 4]) == [0 1 1 3]
+; run: %average_rounding_i16x4([42 19 -1 0xffff], [42 18 -1 0]) == [42 19 -1 0x8000]
+
+function %average_rounding_i32x2(i32x2, i32x2) -> i32x2 {
+block0(v0: i32x2, v1: i32x2):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i32x2([0 0], [0 1]) == [0 1]
+; run: %average_rounding_i32x2([0 1], [2 4]) == [1 3]
+; run: %average_rounding_i32x2([42 19], [42 18]) == [42 19]
+; run: %average_rounding_i32x2([-1 0xffffffff], [-1 0]) == [-1 0x80000000]
+; run: %average_rounding_i32x2([0xffffffff 0xfffffffd], [10 0xffffffff]) == [0x80000005 0xfffffffe]
+
+function %average_rounding_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i32x4([0 0 0 0xffffffff], [0 1 2 0]) == [0 1 1 0x80000000]
+; run: %average_rounding_i32x4([1 42 19 -1], [4 42 18 -1]) == [3 42 19 -1]
+
+function %average_rounding_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = avg_round v0, v1
+    return v2
+}
+; run: %average_rounding_i64x2([0 0], [0 1]) == [0 1]
+; run: %average_rounding_i64x2([0 1], [2 4]) == [1 3]
+; run: %average_rounding_i64x2([42 19], [42 18]) == [42 19]
+; run: %average_rounding_i64x2([-1 0xffffffffffffffff], [-1 0]) == [-1 0x8000000000000000]
+; run: %average_rounding_i64x2([0xffffffffffffffff 0xfffffffffffffffd], [10 0xffffffffffffffff]) == [0x8000000000000005 0xfffffffffffffffe]


### PR DESCRIPTION
Ported the existing implementations of the following opcodes on AArch64
to ISLE:
- `AvgRound`
  - Also introduced support for `i64x2` vectors, as per the docs.
- `SqmulRoundSat`

Copyright (c) 2022 Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
