### PR TITLE
x64: Remove unnecessary register use when comparing against constants

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1080,6 +1080,9 @@
 (decl cc_invert (CC) CC)
 (extern constructor cc_invert cc_invert)
 
+(decl intcc_reverse (IntCC) IntCC)
+(extern constructor intcc_reverse intcc_reverse)
+
 (decl floatcc_inverse (FloatCC) FloatCC)
 (extern constructor floatcc_inverse floatcc_inverse)
 
@@ -3177,6 +3180,10 @@
 (rule (emit_cmp cc a @ (value_type ty) b)
       (let ((size OperandSize (raw_operand_size_of_type ty)))
         (icmp_cond_result (x64_cmp size b a) cc)))
+
+(rule 1 (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
+      (let ((size OperandSize (raw_operand_size_of_type ty)))
+        (icmp_cond_result (x64_cmp size a b) (intcc_reverse cc))))
 
 ;; For I128 values (held in two GPRs), the instruction sequences depend on what
 ;; kind of condition is tested.

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3181,6 +3181,9 @@
       (let ((size OperandSize (raw_operand_size_of_type ty)))
         (icmp_cond_result (x64_cmp size b a) cc)))
 
+;; As a special case, reverse the arguments to the comparison when the LHS is a
+;; constant. This ensures that we avoid moving the constant into a register when
+;; performing the comparison.
 (rule 1 (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
       (let ((size OperandSize (raw_operand_size_of_type ty)))
         (icmp_cond_result (x64_cmp size a b) (intcc_reverse cc))))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3184,7 +3184,7 @@
 ;; As a special case, reverse the arguments to the comparison when the LHS is a
 ;; constant. This ensures that we avoid moving the constant into a register when
 ;; performing the comparison.
-(rule 1 (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
+(rule (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
       (let ((size OperandSize (raw_operand_size_of_type ty)))
         (icmp_cond_result (x64_cmp size a b) (intcc_reverse cc))))
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -611,6 +611,11 @@ where
     }
 
     #[inline]
+    fn intcc_reverse(&mut self, cc: &IntCC) -> IntCC {
+        cc.reverse()
+    }
+
+    #[inline]
     fn floatcc_inverse(&mut self, cc: &FloatCC) -> FloatCC {
         cc.inverse()
     }

--- a/cranelift/filetests/filetests/isa/x64/b1.clif
+++ b/cranelift/filetests/filetests/isa/x64/b1.clif
@@ -73,6 +73,71 @@ block2:
 ;   popq    %rbp
 ;   ret
 
+function %f3(i64) -> i32 {
+block0(v0: i64):
+  v1 = iconst.i32 1
+  v2 = load.i32 v0
+  v3 = icmp eq v1, v2
+  brnz v3, block1
+  jump block2
+block1:
+  v4 = iconst.i32 1
+  return v4
+block2:
+  v5 = iconst.i32 1
+  return v5
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movl    0(%rdi), %r9d
+;   movl    $1, %r10d
+;   cmpl    %r9d, %r10d
+;   jz      label1; j label2
+; block1:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(i64) -> i32 {
+block0(v0: i64):
+  v1 = iconst.i32 1
+  v2 = load.i32 v0
+  v3 = icmp eq v2, v1
+  brnz v3, block1
+  jump block2
+block1:
+  v4 = iconst.i32 1
+  return v4
+block2:
+  v5 = iconst.i32 1
+  return v5
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movl    0(%rdi), %r8d
+;   cmpl    $1, %r8d
+;   jz      label1; j label2
+; block1:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
 function %test_x_slt_0_i64(i64) -> b1 {
 block0(v0: i64):
     v1 = iconst.i64 0

--- a/cranelift/filetests/filetests/isa/x64/b1.clif
+++ b/cranelift/filetests/filetests/isa/x64/b1.clif
@@ -91,9 +91,8 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    0(%rdi), %r9d
-;   movl    $1, %r10d
-;   cmpl    %r9d, %r10d
+;   movl    0(%rdi), %r8d
+;   cmpl    $1, %r8d
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax


### PR DESCRIPTION
When lowering instructions like `icmp eq (iconst 0), v2`, we currently store the constant `0` in a register before performing the comparison. The result is that for inputs like the following:

```
  v1 = iconst.i32 1
  v2 = load.i32 v0
  v3 = icmp eq v1, v2
  brnz v3, block1
```

we generate this assembly:

```
  movl    0(%rdi), %r9d                                                              
  movl    $1, %r10d                                                                  
  cmpl    %r9d, %r10d                                                                
  jz      label1; j label2 
```

This PR introduces a case into `emit_cmp` that handles constants on the left-hand side of a comparison by swapping the order and reversing the operation. With this new rule, we emit the following assembly for the clif snippet above:

```
  movl    0(%rdi), %r8d                                                          
  cmpl    $1, %r8d 
  jz      label1; j label2 
```
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
