### PR TITLE
Remove unnecessary parens around expression

### DIFF
--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -103,7 +103,7 @@ impl TableElement {
     /// The same warnings as for `into_table_values()` apply.
     pub(crate) unsafe fn into_ref_asserting_initialized(self) -> usize {
         match self {
-            Self::FuncRef(e) => (e as usize),
+            Self::FuncRef(e) => e as usize,
             Self::ExternRef(e) => e.map_or(0, |e| e.into_raw() as usize),
             Self::UninitFunc => panic!("Uninitialized table element value outside of table slot"),
         }


### PR DESCRIPTION
Fixes a compiler warning.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
