### PR TITLE
Update behavior of zero-length lists/strings

### DIFF
--- a/crates/wasmtime/src/component/func/options.rs
+++ b/crates/wasmtime/src/component/func/options.rs
@@ -1,5 +1,6 @@
 use crate::store::{StoreId, StoreOpaque};
 use crate::StoreContextMut;
+use crate::Trap;
 use anyhow::{bail, Result};
 use std::ptr::NonNull;
 use wasmtime_environ::component::StringEncoding;
@@ -96,19 +97,15 @@ impl Options {
         };
 
         if result % old_align != 0 {
-            bail!("realloc return: result not aligned");
+            bail!(Trap::new("realloc return: result not aligned"));
         }
         let result = usize::try_from(result)?;
 
         let memory = self.memory_mut(store.0);
 
-        let result_slice = if new_size == 0 {
-            &mut []
-        } else {
-            match memory.get_mut(result..).and_then(|s| s.get_mut(..new_size)) {
-                Some(end) => end,
-                None => bail!("realloc return: beyond end of memory"),
-            }
+        let result_slice = match memory.get_mut(result..).and_then(|s| s.get_mut(..new_size)) {
+            Some(end) => end,
+            None => bail!(Trap::new("realloc return: beyond end of memory")),
         };
 
         Ok((result_slice, result))

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -875,9 +875,7 @@ fn lower_string<T>(mem: &mut MemoryMut<'_, T>, string: &str) -> Result<(usize, u
                 );
             }
             let ptr = mem.realloc(0, 0, 1, string.len())?;
-            if string.len() > 0 {
-                mem.as_slice_mut()[ptr..][..string.len()].copy_from_slice(string.as_bytes());
-            }
+            mem.as_slice_mut()[ptr..][..string.len()].copy_from_slice(string.as_bytes());
             Ok((ptr, string.len()))
         }
 
@@ -894,17 +892,15 @@ fn lower_string<T>(mem: &mut MemoryMut<'_, T>, string: &str) -> Result<(usize, u
             }
             let mut ptr = mem.realloc(0, 0, 2, size)?;
             let mut copied = 0;
-            if size > 0 {
-                let bytes = &mut mem.as_slice_mut()[ptr..][..size];
-                for (u, bytes) in string.encode_utf16().zip(bytes.chunks_mut(2)) {
-                    let u_bytes = u.to_le_bytes();
-                    bytes[0] = u_bytes[0];
-                    bytes[1] = u_bytes[1];
-                    copied += 1;
-                }
-                if (copied * 2) < size {
-                    ptr = mem.realloc(ptr, size, 2, copied * 2)?;
-                }
+            let bytes = &mut mem.as_slice_mut()[ptr..][..size];
+            for (u, bytes) in string.encode_utf16().zip(bytes.chunks_mut(2)) {
+                let u_bytes = u.to_le_bytes();
+                bytes[0] = u_bytes[0];
+                bytes[1] = u_bytes[1];
+                copied += 1;
+            }
+            if (copied * 2) < size {
+                ptr = mem.realloc(ptr, size, 2, copied * 2)?;
             }
             Ok((ptr, copied))
         }

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -1127,19 +1127,21 @@ fn some_traps() -> Result<()> {
             err,
         );
     }
-    instance(&mut store)?
+    let err = instance(&mut store)?
         .get_typed_func::<(&[u8],), (), _>(&mut store, "take-list-base-oob")?
         .call(&mut store, (&[],))
-        .unwrap();
+        .unwrap_err();
+    assert_oob(&err);
     let err = instance(&mut store)?
         .get_typed_func::<(&[u8],), (), _>(&mut store, "take-list-base-oob")?
         .call(&mut store, (&[1],))
         .unwrap_err();
     assert_oob(&err);
-    instance(&mut store)?
+    let err = instance(&mut store)?
         .get_typed_func::<(&str,), (), _>(&mut store, "take-string-base-oob")?
         .call(&mut store, ("",))
-        .unwrap();
+        .unwrap_err();
+    assert_oob(&err);
     let err = instance(&mut store)?
         .get_typed_func::<(&str,), (), _>(&mut store, "take-string-base-oob")?
         .call(&mut store, ("x",))
@@ -1191,13 +1193,13 @@ fn some_traps() -> Result<()> {
     // For this function the first allocation, the space to store all the
     // arguments, is in-bounds but then all further allocations, such as for
     // each individual string, are all out of bounds.
-    instance(&mut store)?
+    let err = instance(&mut store)?
         .get_typed_func::<(&str, &str, &str, &str, &str, &str, &str, &str, &str, &str), (), _>(
             &mut store,
             "take-many-second-oob",
         )?
         .call(&mut store, ("", "", "", "", "", "", "", "", "", ""))
-        .unwrap();
+        .unwrap_err();
     assert_oob(&err);
     let err = instance(&mut store)?
         .get_typed_func::<(&str, &str, &str, &str, &str, &str, &str, &str, &str, &str), (), _>(

--- a/tests/misc_testsuite/component-model/adapter.wast
+++ b/tests/misc_testsuite/component-model/adapter.wast
@@ -130,4 +130,4 @@
   )
   (export "empty-list" (func $f))
 )
-(assert_return (invoke "empty-list" (list.const)) (unit.const))
+(assert_trap (invoke "empty-list" (list.const)) "realloc return: beyond end of memory")


### PR DESCRIPTION
The spec was expected to change to not bounds-check 0-byte lists/strings
but has since been updated to match `memory.copy` which does indeed
check the pointer for 0-byte copies.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
