### PR TITLE
Remove some dead code from the abi code

### DIFF
--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -142,9 +142,6 @@ pub struct AbiParam {
     pub purpose: ArgumentPurpose,
     /// Method for extending argument to a full register.
     pub extension: ArgumentExtension,
-
-    /// Was the argument converted to pointer during legalization?
-    pub legalized_to_pointer: bool,
 }
 
 impl AbiParam {
@@ -154,7 +151,6 @@ impl AbiParam {
             value_type: vt,
             extension: ArgumentExtension::None,
             purpose: ArgumentPurpose::Normal,
-            legalized_to_pointer: false,
         }
     }
 
@@ -164,7 +160,6 @@ impl AbiParam {
             value_type: vt,
             extension: ArgumentExtension::None,
             purpose,
-            legalized_to_pointer: false,
         }
     }
 
@@ -190,9 +185,6 @@ impl AbiParam {
 impl fmt::Display for AbiParam {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.value_type)?;
-        if self.legalized_to_pointer {
-            write!(f, " ptr")?;
-        }
         match self.extension {
             ArgumentExtension::None => {}
             ArgumentExtension::Uext => write!(f, " uext")?,
@@ -252,29 +244,6 @@ pub enum ArgumentPurpose {
     /// a `StructReturn` pointer argument to also return that pointer in a register.
     StructReturn,
 
-    /// The link register.
-    ///
-    /// Most RISC architectures implement calls by saving the return address in a designated
-    /// register rather than pushing it on the stack. This is represented with a `Link` argument.
-    ///
-    /// Similarly, some return instructions expect the return address in a register represented as
-    /// a `Link` return value.
-    Link,
-
-    /// The frame pointer.
-    ///
-    /// This indicates the frame pointer register which has a special meaning in some ABIs.
-    ///
-    /// The frame pointer appears as an argument and as a return value since it is a callee-saved
-    /// register.
-    FramePointer,
-
-    /// A callee-saved register.
-    ///
-    /// Some calling conventions have registers that must be saved by the callee. These registers
-    /// are represented as `CalleeSaved` arguments and return values.
-    CalleeSaved,
-
     /// A VM context pointer.
     ///
     /// This is a pointer to a context struct containing details about the current sandbox. It is
@@ -300,9 +269,6 @@ impl fmt::Display for ArgumentPurpose {
             Self::Normal => "normal",
             Self::StructArgument(size) => return write!(f, "sarg({})", size),
             Self::StructReturn => "sret",
-            Self::Link => "link",
-            Self::FramePointer => "fp",
-            Self::CalleeSaved => "csr",
             Self::VMContext => "vmctx",
             Self::SignatureId => "sigid",
             Self::StackLimit => "stack_limit",
@@ -316,9 +282,6 @@ impl FromStr for ArgumentPurpose {
         match s {
             "normal" => Ok(Self::Normal),
             "sret" => Ok(Self::StructReturn),
-            "link" => Ok(Self::Link),
-            "fp" => Ok(Self::FramePointer),
-            "csr" => Ok(Self::CalleeSaved),
             "vmctx" => Ok(Self::VMContext),
             "sigid" => Ok(Self::SignatureId),
             "stack_limit" => Ok(Self::StackLimit),
@@ -396,8 +359,6 @@ mod tests {
         assert_eq!(t.sext().to_string(), "i32 sext");
         t.purpose = ArgumentPurpose::StructReturn;
         assert_eq!(t.to_string(), "i32 uext sret");
-        t.legalized_to_pointer = true;
-        assert_eq!(t.to_string(), "i32 ptr uext sret");
     }
 
     #[test]
@@ -405,9 +366,6 @@ mod tests {
         let all_purpose = [
             (ArgumentPurpose::Normal, "normal"),
             (ArgumentPurpose::StructReturn, "sret"),
-            (ArgumentPurpose::Link, "link"),
-            (ArgumentPurpose::FramePointer, "fp"),
-            (ArgumentPurpose::CalleeSaved, "csr"),
             (ArgumentPurpose::VMContext, "vmctx"),
             (ArgumentPurpose::SignatureId, "sigid"),
             (ArgumentPurpose::StackLimit, "stack_limit"),

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -134,20 +134,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         };
 
         for param in params {
-            // Validate "purpose".
-            match &param.purpose {
-                &ir::ArgumentPurpose::VMContext
-                | &ir::ArgumentPurpose::Normal
-                | &ir::ArgumentPurpose::StackLimit
-                | &ir::ArgumentPurpose::SignatureId
-                | &ir::ArgumentPurpose::StructReturn
-                | &ir::ArgumentPurpose::StructArgument(_) => {}
-                _ => panic!(
-                    "Unsupported argument purpose {:?} in signature: {:?}",
-                    param.purpose, params
-                ),
-            }
-
             assert!(
                 legal_type_for_machine(param.value_type),
                 "Invalid type for AArch64: {:?}",

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -249,20 +249,6 @@ impl ABIMachineSpec for S390xMachineDeps {
         for i in 0..params.len() {
             let mut param = params[i];
 
-            // Validate "purpose".
-            match &param.purpose {
-                &ir::ArgumentPurpose::VMContext
-                | &ir::ArgumentPurpose::Normal
-                | &ir::ArgumentPurpose::StackLimit
-                | &ir::ArgumentPurpose::SignatureId
-                | &ir::ArgumentPurpose::StructReturn
-                | &ir::ArgumentPurpose::StructArgument(_) => {}
-                _ => panic!(
-                    "Unsupported argument purpose {:?} in signature: {:?}",
-                    param.purpose, params
-                ),
-            }
-
             let intreg = in_int_reg(param.value_type);
             let fltreg = in_flt_reg(param.value_type);
             let vecreg = in_vec_reg(param.value_type);

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -70,20 +70,6 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
 
         for param in params {
-            // Validate "purpose".
-            match &param.purpose {
-                &ir::ArgumentPurpose::VMContext
-                | &ir::ArgumentPurpose::Normal
-                | &ir::ArgumentPurpose::StackLimit
-                | &ir::ArgumentPurpose::SignatureId
-                | &ir::ArgumentPurpose::StructReturn
-                | &ir::ArgumentPurpose::StructArgument(_) => {}
-                _ => panic!(
-                    "Unsupported argument purpose {:?} in signature: {:?}",
-                    param.purpose, params
-                ),
-            }
-
             if let ir::ArgumentPurpose::StructArgument(size) = param.purpose {
                 let offset = next_stack as i64;
                 let size = size as u64;

--- a/cranelift/docs/ir.md
+++ b/cranelift/docs/ir.md
@@ -404,7 +404,7 @@ paramlist    : param { "," param }
 retlist      : paramlist
 param        : type [paramext] [paramspecial]
 paramext     : "uext" | "sext"
-paramspecial : "sret" | "link" | "fp" | "csr" | "vmctx" | "sigid" | "stack_limit"
+paramspecial : "sarg" ( num ) | "sret" | "vmctx" | "sigid" | "stack_limit"
 callconv     : "fast" | "cold" | "system_v" | "windows_fastcall"
              | "wasmtime_system_v" | "wasmtime_fastcall"
              | "apple_aarch64" | "wasmtime_apple_aarch64"

--- a/cranelift/filetests/filetests/parser/call.clif
+++ b/cranelift/filetests/filetests/parser/call.clif
@@ -16,7 +16,7 @@ block1:
     v2 = f32const 0.0
     return v1, v2
 }
-; sameln: function %r1() -> i32, f32 
+; sameln: function %r1() -> i32, f32
 ; nextln: block1:
 ; nextln:     v1 = iconst.i32 3
 ; nextln:     v2 = f32const 0.0
@@ -84,11 +84,11 @@ block0:
 ; check: return
 
 ; Special purpose function arguments
-function %special1(i32 sret, i32 fp, i32 csr, i32 link) -> i32 link, i32 fp, i32 csr, i32 sret {
-block0(v1: i32, v2: i32, v3: i32, v4: i32):
-    return v4, v2, v3, v1
+function %special1(i32 sret, i32 stack_limit) -> i32 vmctx {
+block0(v1: i32, v2: i32):
+    return v1
 }
-; check: function %special1(i32 sret, i32 fp, i32 csr, i32 link) -> i32 link, i32 fp, i32 csr, i32 sret fast {
-; check: block0(v1: i32, v2: i32, v3: i32, v4: i32):
-; check:     return v4, v2, v3, v1
+; check: function %special1(i32 sret, i32 stack_limit) -> i32 vmctx fast {
+; check: block0(v1: i32, v2: i32):
+; check:     return v1
 ; check: }

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1406,10 +1406,10 @@ impl<'a> Parser<'a> {
 
     // Parse a single argument type with flags.
     fn parse_abi_param(&mut self) -> ParseResult<AbiParam> {
-        // abi-param ::= * type { flag } [ argumentloc ]
+        // abi-param ::= * type { flag }
         let mut arg = AbiParam::new(self.match_type("expected parameter type")?);
 
-        // abi-param ::= type * { flag } [ argumentloc ]
+        // abi-param ::= type * { flag }
         while let Some(Token::Identifier(s)) = self.token() {
             match s {
                 "uext" => arg.extension = ArgumentExtension::Uext,


### PR DESCRIPTION
These were originally used by the old backend framework as part of legalizing function signatures for the respective ABI.

Found while working on https://github.com/bytecodealliance/wasmtime/pull/4634.
