### PR TITLE
Don't use libtest harness for filetests

### DIFF
--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -13,6 +13,11 @@ edition = "2021"
 name = "clif-util"
 path = "src/clif-util.rs"
 
+[[test]]
+name = "filetests"
+path = "tests/filetests.rs"
+harness = false
+
 [dependencies]
 cfg-if = "1.0"
 cranelift-codegen = { path = "codegen", version = "0.88.0" }

--- a/cranelift/tests/filetests.rs
+++ b/cranelift/tests/filetests.rs
@@ -1,6 +1,5 @@
-#[test]
-fn filetests() {
+fn main() -> anyhow::Result<()> {
     // Run all the filetests in the following directories.
-    cranelift_filetests::run(false, false, &["filetests".into(), "docs".into()])
-        .expect("test harness");
+    cranelift_filetests::run(false, false, &["filetests".into(), "docs".into()])?;
+    Ok(())
 }


### PR DESCRIPTION
We are using our own test harness for filetests and embedding it in libtest isn't useful. It only hides test output until the end and results in unnecessary noise.

# Old failure output

```
    Finished test [unoptimized + debuginfo] target(s) in 0.11s
     Running tests/filetests.rs (/home/gh-bjorn3/wasmtime/target/debug/deps/filetests-1d6c16a18cf427e6)

running 1 test
test filetests ... FAILED

failures:

---- filetests stdout ----
thread 'worker #4' panicked at 'StructReturn return value not present!', cranelift/codegen/src/machinst/lower.rs:736:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'worker #10' panicked at 'StructReturn return value not present!', cranelift/codegen/src/machinst/lower.rs:736:26
FAIL filetests/filetests/isa/aarch64/call.clif: panicked in worker #10: StructReturn return value not present!
FAIL filetests/filetests/isa/x64/struct-ret.clif: panicked in worker #4: StructReturn return value not present!
444 tests
thread 'filetests' panicked at 'test harness: 2 failures', cranelift/tests/filetests.rs:5:10


failures:
    filetests

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.84s

error: test failed, to rerun pass '--test filetests'
```

# New failure output

```
    Finished test [unoptimized + debuginfo] target(s) in 6.15s
     Running tests/filetests.rs (/home/gh-bjorn3/wasmtime/target/debug/deps/filetests-1d6c16a18cf427e6)
thread 'worker #31' panicked at 'StructReturn return value not present!', cranelift/codegen/src/machinst/lower.rs:736:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'worker #1' panicked at 'StructReturn return value not present!', cranelift/codegen/src/machinst/lower.rs:736:26
FAIL filetests/filetests/isa/aarch64/call.clif: panicked in worker #1: StructReturn return value not present!
FAIL filetests/filetests/isa/x64/struct-ret.clif: panicked in worker #31: StructReturn return value not present!
444 tests
Error: 2 failures
error: test failed, to rerun pass '--test filetests'
```