### PR TITLE
Deduplicate some size/align calculations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,6 +3559,7 @@ dependencies = [
  "wasmparser",
  "wasmprinter",
  "wasmtime-environ",
+ "wat",
 ]
 
 [[package]]

--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -298,7 +298,7 @@ fn expand_record_for_component_type(
     let mut lower_generic_params = TokenStream::new();
     let mut lower_generic_args = TokenStream::new();
     let mut lower_field_declarations = TokenStream::new();
-    let mut sizes = TokenStream::new();
+    let mut abi_list = TokenStream::new();
     let mut unique_types = HashSet::new();
 
     for (index, syn::Field { ident, ty, .. }) in fields.iter().enumerate() {
@@ -309,23 +309,12 @@ fn expand_record_for_component_type(
 
         lower_field_declarations.extend(quote!(#ident: #generic,));
 
-        sizes.extend(quote!(
-            size = #internal::align_to(size, <#ty as wasmtime::component::ComponentType>::ALIGN32);
-            size += <#ty as wasmtime::component::ComponentType>::SIZE32;
+        abi_list.extend(quote!(
+            <#ty as wasmtime::component::ComponentType>::ABI,
         ));
 
         unique_types.insert(ty);
     }
-
-    let alignments = unique_types
-        .into_iter()
-        .map(|ty| {
-            let align = quote!(<#ty as wasmtime::component::ComponentType>::ALIGN32);
-            quote!(if #align > align {
-                align = #align;
-            })
-        })
-        .collect::<TokenStream>();
 
     let generics = add_trait_bounds(generics, parse_quote!(wasmtime::component::ComponentType));
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -358,17 +347,8 @@ fn expand_record_for_component_type(
         unsafe impl #impl_generics wasmtime::component::ComponentType for #name #ty_generics #where_clause {
             type Lower = #lower <#lower_generic_args>;
 
-            const SIZE32: usize = {
-                let mut size = 0;
-                #sizes
-                #internal::align_to(size, Self::ALIGN32)
-            };
-
-            const ALIGN32: u32 = {
-                let mut align = 1;
-                #alignments
-                align
-            };
+            const ABI: #internal::CanonicalAbiInfo =
+                #internal::CanonicalAbiInfo::record_static(&[#abi_list]);
 
             #[inline]
             fn typecheck(
@@ -429,7 +409,7 @@ impl Expander for LiftExpander {
             loads.extend(quote!(#ident: <#ty as wasmtime::component::Lift>::load(
                 memory,
                 &bytes
-                    [#internal::next_field::<#ty>(&mut offset)..]
+                    [<#ty as wasmtime::component::ComponentType>::ABI.next_field32_size(&mut offset)..]
                     [..<#ty as wasmtime::component::ComponentType>::SIZE32]
             )?,));
         }
@@ -514,8 +494,6 @@ impl Expander for LiftExpander {
             DiscriminantSize::Size4 => quote!(u32::from_le_bytes(bytes[0..4].try_into()?)),
         };
 
-        let payload_offset = usize::from(discriminant_size);
-
         let expanded = quote! {
             unsafe impl #impl_generics wasmtime::component::Lift for #name #ty_generics #where_clause {
                 #[inline]
@@ -535,7 +513,8 @@ impl Expander for LiftExpander {
                     let align = <Self as wasmtime::component::ComponentType>::ALIGN32;
                     debug_assert!((bytes.as_ptr() as usize) % (align as usize) == 0);
                     let discrim = #from_bytes;
-                    let payload = &bytes[#internal::align_to(#payload_offset, align)..];
+                    let payload_offset = <Self as #internal::ComponentVariant>::PAYLOAD_OFFSET32;
+                    let payload = &bytes[payload_offset..];
                     Ok(match discrim {
                         #loads
                         discrim => #internal::anyhow::bail!("unexpected discriminant: {}", discrim),
@@ -575,7 +554,9 @@ impl Expander for LowerExpander {
             )?;));
 
             stores.extend(quote!(wasmtime::component::Lower::store(
-                &self.#ident, memory, #internal::next_field::<#ty>(&mut offset)
+                &self.#ident,
+                memory,
+                <#ty as wasmtime::component::ComponentType>::ABI.next_field32_size(&mut offset),
             )?;));
         }
 
@@ -640,10 +621,7 @@ impl Expander for LowerExpander {
                 lower = quote!(value.lower(store, options, #internal::map_maybe_uninit!(dst.payload.#ident)));
                 store = quote!(value.store(
                     memory,
-                    offset + #internal::align_to(
-                        #discriminant_size,
-                        <Self as wasmtime::component::ComponentType>::ALIGN32
-                    )
+                    offset + <Self as #internal::ComponentVariant>::PAYLOAD_OFFSET32,
                 ));
             } else {
                 pattern = quote!(Self::#ident);
@@ -749,7 +727,7 @@ impl Expander for ComponentTypeExpander {
         &self,
         name: &syn::Ident,
         generics: &syn::Generics,
-        discriminant_size: DiscriminantSize,
+        _discriminant_size: DiscriminantSize,
         cases: &[VariantCase],
         style: VariantStyle,
     ) -> Result<TokenStream> {
@@ -760,7 +738,7 @@ impl Expander for ComponentTypeExpander {
         let mut lower_payload_generic_args = TokenStream::new();
         let mut lower_payload_case_declarations = TokenStream::new();
         let mut lower_generic_args = TokenStream::new();
-        let mut sizes = TokenStream::new();
+        let mut abi_list = TokenStream::new();
         let mut unique_types = HashSet::new();
 
         for (index, VariantCase { attrs, ident, ty }) in cases.iter().enumerate() {
@@ -776,12 +754,7 @@ impl Expander for ComponentTypeExpander {
             let name = rename.unwrap_or_else(|| Literal::string(&ident.to_string()));
 
             if let Some(ty) = ty {
-                sizes.extend({
-                    let size = quote!(<#ty as wasmtime::component::ComponentType>::SIZE32);
-                    quote!(if #size > size {
-                        size = #size;
-                    })
-                });
+                abi_list.extend(quote!(<#ty as wasmtime::component::ComponentType>::ABI,));
 
                 case_names_and_checks.extend(match style {
                     VariantStyle::Variant => {
@@ -808,6 +781,7 @@ impl Expander for ComponentTypeExpander {
 
                 unique_types.insert(ty);
             } else {
+                abi_list.extend(quote!(<() as wasmtime::component::ComponentType>::ABI,));
                 case_names_and_checks.extend(match style {
                     VariantStyle::Variant => {
                         quote!((#name, <() as wasmtime::component::ComponentType>::typecheck),)
@@ -824,16 +798,6 @@ impl Expander for ComponentTypeExpander {
             lower_payload_case_declarations.extend(quote!(_dummy: ()));
         }
 
-        let alignments = unique_types
-            .into_iter()
-            .map(|ty| {
-                let align = quote!(<#ty as wasmtime::component::ComponentType>::ALIGN32);
-                quote!(if #align > align {
-                    align = #align;
-                })
-            })
-            .collect::<TokenStream>();
-
         let typecheck = match style {
             VariantStyle::Variant => quote!(typecheck_variant),
             VariantStyle::Union => quote!(typecheck_union),
@@ -844,7 +808,6 @@ impl Expander for ComponentTypeExpander {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let lower = format_ident!("Lower{}", name);
         let lower_payload = format_ident!("LowerPayload{}", name);
-        let discriminant_size = u32::from(discriminant_size);
 
         // You may wonder why we make the types of all the fields of the #lower struct and #lower_payload union
         // generic.  This is to work around a [normalization bug in
@@ -882,20 +845,12 @@ impl Expander for ComponentTypeExpander {
                     #internal::#typecheck(ty, types, &[#case_names_and_checks])
                 }
 
-                const SIZE32: usize = {
-                    let mut size = 0;
-                    #sizes
-                    #internal::align_to(
-                        #internal::align_to(#discriminant_size as usize, Self::ALIGN32) + size,
-                        Self::ALIGN32
-                    )
-                };
+                const ABI: #internal::CanonicalAbiInfo =
+                    #internal::CanonicalAbiInfo::variant_static(&[#abi_list]);
+            }
 
-                const ALIGN32: u32 = {
-                    let mut align = #discriminant_size;
-                    #alignments
-                    align
-                };
+            unsafe impl #impl_generics #internal::ComponentVariant for #name #ty_generics #where_clause {
+                const CASES: &'static [#internal::CanonicalAbiInfo] = &[#abi_list];
             }
         };
 

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -1,5 +1,5 @@
 /// Represents the possible sizes in bytes of the discriminant of a variant type in the component model
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DiscriminantSize {
     /// 8-bit discriminant
     Size1,
@@ -11,7 +11,7 @@ pub enum DiscriminantSize {
 
 impl DiscriminantSize {
     /// Calculate the size of discriminant needed to represent a variant with the specified number of cases.
-    pub fn from_count(count: usize) -> Option<Self> {
+    pub const fn from_count(count: usize) -> Option<Self> {
         if count <= 0xFF {
             Some(Self::Size1)
         } else if count <= 0xFFFF {
@@ -22,16 +22,21 @@ impl DiscriminantSize {
             None
         }
     }
+
+    /// Returns the size, in bytes, of this discriminant
+    pub const fn byte_size(&self) -> u32 {
+        match self {
+            DiscriminantSize::Size1 => 1,
+            DiscriminantSize::Size2 => 2,
+            DiscriminantSize::Size4 => 4,
+        }
+    }
 }
 
 impl From<DiscriminantSize> for u32 {
     /// Size of the discriminant as a `u32`
     fn from(size: DiscriminantSize) -> u32 {
-        match size {
-            DiscriminantSize::Size1 => 1,
-            DiscriminantSize::Size2 => 2,
-            DiscriminantSize::Size4 => 4,
-        }
+        size.byte_size()
     }
 }
 
@@ -60,7 +65,7 @@ pub enum FlagsSize {
 
 impl FlagsSize {
     /// Calculate the size needed to represent a value with the specified number of flags.
-    pub fn from_count(count: usize) -> FlagsSize {
+    pub const fn from_count(count: usize) -> FlagsSize {
         if count == 0 {
             FlagsSize::Size0
         } else if count <= 8 {
@@ -74,7 +79,7 @@ impl FlagsSize {
 }
 
 /// Divide `n` by `d`, rounding up in the case of a non-zero remainder.
-fn ceiling_divide(n: usize, d: usize) -> usize {
+const fn ceiling_divide(n: usize, d: usize) -> usize {
     (n + d - 1) / d
 }
 

--- a/crates/environ/fuzz/Cargo.toml
+++ b/crates/environ/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.9.0"
 libfuzzer-sys = "0.4"
 wasmparser = "0.88.0"
 wasmprinter = "0.2.37"
+wat = "1.0"
 wasmtime-environ = { path = ".." }
 component-fuzz-util = { path = "../../misc/component-fuzz-util", optional = true }
 

--- a/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
+++ b/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
@@ -10,9 +10,9 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use component_fuzz_util::Type as ValType;
+use component_fuzz_util::TestCase;
 use libfuzzer_sys::fuzz_target;
-use wasmparser::{Validator, WasmFeatures};
+use wasmparser::{Parser, Payload, Validator, WasmFeatures};
 use wasmtime_environ::component::*;
 use wasmtime_environ::fact::Module;
 
@@ -24,25 +24,10 @@ struct GenAdapterModule {
 
 #[derive(Arbitrary, Debug)]
 struct GenAdapter {
-    ty: FuncType,
     post_return: bool,
     lift_memory64: bool,
     lower_memory64: bool,
-    lift_encoding: GenStringEncoding,
-    lower_encoding: GenStringEncoding,
-}
-
-#[derive(Arbitrary, Debug)]
-struct FuncType {
-    params: Vec<ValType>,
-    result: ValType,
-}
-
-#[derive(Copy, Clone, Arbitrary, Debug)]
-enum GenStringEncoding {
-    Utf8,
-    Utf16,
-    CompactUtf16,
+    test: TestCase,
 }
 
 fuzz_target!(|module: GenAdapterModule| {
@@ -90,47 +75,74 @@ fn target(module: GenAdapterModule) {
 
     let mut adapters = Vec::new();
     for adapter in module.adapters.iter() {
-        let mut params = Vec::new();
-        for param in adapter.ty.params.iter() {
-            params.push((None, intern(&mut types, param)));
+        let wat_decls = adapter.test.declarations();
+        let wat = format!(
+            "(component
+                {types}
+                (type (func {params} {result}))
+            )",
+            types = wat_decls.types,
+            params = wat_decls.params,
+            result = wat_decls.result,
+        );
+        let wasm = wat::parse_str(&wat).unwrap();
+
+        let mut validator = Validator::new_with_features(WasmFeatures {
+            component_model: true,
+            ..Default::default()
+        });
+
+        types.push_type_scope();
+        for payload in Parser::new(0).parse_all(&wasm) {
+            let payload = payload.unwrap();
+            validator.payload(&payload).unwrap();
+            let section = match payload {
+                Payload::ComponentTypeSection(s) => s,
+                _ => continue,
+            };
+            for ty in section {
+                let ty = types.intern_component_type(&ty.unwrap()).unwrap();
+                types.push_component_typedef(ty);
+                let ty = match ty {
+                    TypeDef::ComponentFunc(ty) => ty,
+                    _ => continue,
+                };
+                adapters.push(Adapter {
+                    lift_ty: ty,
+                    lower_ty: ty,
+                    lower_options: AdapterOptions {
+                        instance: RuntimeComponentInstanceIndex::from_u32(0),
+                        string_encoding: convert_encoding(adapter.test.encoding1),
+                        memory64: adapter.lower_memory64,
+                        // Pessimistically assume that memory/realloc are going to be
+                        // required for this trampoline and provide it. Avoids doing
+                        // calculations to figure out whether they're necessary and
+                        // simplifies the fuzzer here without reducing coverage within FACT
+                        // itself.
+                        memory: Some(dummy_memory(adapter.lower_memory64)),
+                        realloc: Some(dummy_def()),
+                        // Lowering never allows `post-return`
+                        post_return: None,
+                    },
+                    lift_options: AdapterOptions {
+                        instance: RuntimeComponentInstanceIndex::from_u32(1),
+                        string_encoding: convert_encoding(adapter.test.encoding2),
+                        memory64: adapter.lift_memory64,
+                        memory: Some(dummy_memory(adapter.lift_memory64)),
+                        realloc: Some(dummy_def()),
+                        post_return: if adapter.post_return {
+                            Some(dummy_def())
+                        } else {
+                            None
+                        },
+                    },
+                    func: dummy_def(),
+                });
+            }
         }
-        let result = intern(&mut types, &adapter.ty.result);
-        let signature = types.add_func_type(TypeFunc {
-            params: params.into(),
-            result,
-        });
-        adapters.push(Adapter {
-            lift_ty: signature,
-            lower_ty: signature,
-            lower_options: AdapterOptions {
-                instance: RuntimeComponentInstanceIndex::from_u32(0),
-                string_encoding: adapter.lower_encoding.into(),
-                memory64: adapter.lower_memory64,
-                // Pessimistically assume that memory/realloc are going to be
-                // required for this trampoline and provide it. Avoids doing
-                // calculations to figure out whether they're necessary and
-                // simplifies the fuzzer here without reducing coverage within FACT
-                // itself.
-                memory: Some(dummy_memory(adapter.lower_memory64)),
-                realloc: Some(dummy_def()),
-                // Lowering never allows `post-return`
-                post_return: None,
-            },
-            lift_options: AdapterOptions {
-                instance: RuntimeComponentInstanceIndex::from_u32(1),
-                string_encoding: adapter.lift_encoding.into(),
-                memory64: adapter.lift_memory64,
-                memory: Some(dummy_memory(adapter.lift_memory64)),
-                realloc: Some(dummy_def()),
-                post_return: if adapter.post_return {
-                    Some(dummy_def())
-                } else {
-                    None
-                },
-            },
-            func: dummy_def(),
-        });
+        types.pop_type_scope();
     }
+
     let types = types.finish();
     let mut fact_module = Module::new(&types, module.debug);
     for (i, adapter) in adapters.iter().enumerate() {
@@ -161,94 +173,10 @@ fn target(module: GenAdapterModule) {
     panic!()
 }
 
-fn intern(types: &mut ComponentTypesBuilder, ty: &ValType) -> InterfaceType {
-    match ty {
-        ValType::Unit => InterfaceType::Unit,
-        ValType::Bool => InterfaceType::Bool,
-        ValType::U8 => InterfaceType::U8,
-        ValType::S8 => InterfaceType::S8,
-        ValType::U16 => InterfaceType::U16,
-        ValType::S16 => InterfaceType::S16,
-        ValType::U32 => InterfaceType::U32,
-        ValType::S32 => InterfaceType::S32,
-        ValType::U64 => InterfaceType::U64,
-        ValType::S64 => InterfaceType::S64,
-        ValType::Float32 => InterfaceType::Float32,
-        ValType::Float64 => InterfaceType::Float64,
-        ValType::Char => InterfaceType::Char,
-        ValType::String => InterfaceType::String,
-        ValType::List(ty) => {
-            let ty = intern(types, ty);
-            InterfaceType::List(types.add_interface_type(ty))
-        }
-        ValType::Record(tys) => {
-            let ty = TypeRecord {
-                fields: tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, ty)| RecordField {
-                        name: format!("f{i}"),
-                        ty: intern(types, ty),
-                    })
-                    .collect(),
-            };
-            InterfaceType::Record(types.add_record_type(ty))
-        }
-        ValType::Flags(size) => {
-            let ty = TypeFlags {
-                names: (0..size.as_usize()).map(|i| format!("f{i}")).collect(),
-            };
-            InterfaceType::Flags(types.add_flags_type(ty))
-        }
-        ValType::Tuple(tys) => {
-            let ty = TypeTuple {
-                types: tys.iter().map(|ty| intern(types, ty)).collect(),
-            };
-            InterfaceType::Tuple(types.add_tuple_type(ty))
-        }
-        ValType::Variant(cases) => {
-            let ty = TypeVariant {
-                cases: cases
-                    .iter()
-                    .enumerate()
-                    .map(|(i, ty)| VariantCase {
-                        name: format!("c{i}"),
-                        ty: intern(types, ty),
-                    })
-                    .collect(),
-            };
-            InterfaceType::Variant(types.add_variant_type(ty))
-        }
-        ValType::Union(tys) => {
-            let ty = TypeUnion {
-                types: tys.iter().map(|ty| intern(types, ty)).collect(),
-            };
-            InterfaceType::Union(types.add_union_type(ty))
-        }
-        ValType::Enum(size) => {
-            let ty = TypeEnum {
-                names: (0..size.as_usize()).map(|i| format!("c{i}")).collect(),
-            };
-            InterfaceType::Enum(types.add_enum_type(ty))
-        }
-        ValType::Option(ty) => {
-            let ty = intern(types, ty);
-            InterfaceType::Option(types.add_interface_type(ty))
-        }
-        ValType::Expected { ok, err } => {
-            let ok = intern(types, ok);
-            let err = intern(types, err);
-            InterfaceType::Expected(types.add_expected_type(TypeExpected { ok, err }))
-        }
-    }
-}
-
-impl From<GenStringEncoding> for StringEncoding {
-    fn from(gen: GenStringEncoding) -> StringEncoding {
-        match gen {
-            GenStringEncoding::Utf8 => StringEncoding::Utf8,
-            GenStringEncoding::Utf16 => StringEncoding::Utf16,
-            GenStringEncoding::CompactUtf16 => StringEncoding::CompactUtf16,
-        }
+fn convert_encoding(encoding: component_fuzz_util::StringEncoding) -> StringEncoding {
+    match encoding {
+        component_fuzz_util::StringEncoding::Utf8 => StringEncoding::Utf8,
+        component_fuzz_util::StringEncoding::Utf16 => StringEncoding::Utf16,
+        component_fuzz_util::StringEncoding::Latin1OrUtf16 => StringEncoding::CompactUtf16,
     }
 }

--- a/crates/misc/component-test-util/src/lib.rs
+++ b/crates/misc/component-test-util/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use arbitrary::Arbitrary;
 use std::mem::MaybeUninit;
 use wasmtime::component::__internal::{
-    ComponentTypes, InterfaceType, Memory, MemoryMut, Options, StoreOpaque,
+    CanonicalAbiInfo, ComponentTypes, InterfaceType, Memory, MemoryMut, Options, StoreOpaque,
 };
 use wasmtime::component::{ComponentParams, ComponentType, Func, Lift, Lower, TypedFunc, Val};
 use wasmtime::{AsContextMut, Config, Engine, StoreContextMut};
@@ -68,8 +68,7 @@ macro_rules! forward_impls {
         unsafe impl ComponentType for $a {
             type Lower = <$b as ComponentType>::Lower;
 
-            const SIZE32: usize = <$b as ComponentType>::SIZE32;
-            const ALIGN32: u32 = <$b as ComponentType>::ALIGN32;
+            const ABI: CanonicalAbiInfo = <$b as ComponentType>::ABI;
 
             #[inline]
             fn typecheck(ty: &InterfaceType, types: &ComponentTypes) -> Result<()> {

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -28,14 +28,14 @@ pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 #[doc(hidden)]
 pub mod __internal {
     pub use super::func::{
-        align_to, format_flags, next_field, typecheck_enum, typecheck_flags, typecheck_record,
-        typecheck_union, typecheck_variant, MaybeUninitExt, Memory, MemoryMut, Options,
+        format_flags, typecheck_enum, typecheck_flags, typecheck_record, typecheck_union,
+        typecheck_variant, ComponentVariant, MaybeUninitExt, Memory, MemoryMut, Options,
     };
     pub use crate::map_maybe_uninit;
     pub use crate::store::StoreOpaque;
     pub use anyhow;
     pub use wasmtime_environ;
-    pub use wasmtime_environ::component::{ComponentTypes, InterfaceType};
+    pub use wasmtime_environ::component::{CanonicalAbiInfo, ComponentTypes, InterfaceType};
 }
 
 pub(crate) use self::store::ComponentStoreData;

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -1,5 +1,5 @@
-use crate::component::func::{self, Lift, Lower, Memory, MemoryMut, Options};
-use crate::component::types::{self, SizeAndAlignment, Type};
+use crate::component::func::{Lift, Lower, Memory, MemoryMut, Options};
+use crate::component::types::{self, Type};
 use crate::store::StoreOpaque;
 use crate::{AsContextMut, StoreContextMut, ValRaw};
 use anyhow::{anyhow, bail, Context, Error, Result};
@@ -9,6 +9,7 @@ use std::iter;
 use std::mem::MaybeUninit;
 use std::ops::Deref;
 use wasmtime_component_util::{DiscriminantSize, FlagsSize};
+use wasmtime_environ::component::VariantInfo;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct List {
@@ -700,8 +701,12 @@ impl Val {
                 values: load_record(handle.types(), mem, bytes)?,
             }),
             Type::Variant(handle) => {
-                let (discriminant, value) =
-                    load_variant(ty, handle.cases().map(|case| case.ty), mem, bytes)?;
+                let (discriminant, value) = load_variant(
+                    handle.variant_info(),
+                    handle.cases().map(|case| case.ty),
+                    mem,
+                    bytes,
+                )?;
 
                 Val::Variant(Variant {
                     ty: handle.clone(),
@@ -710,8 +715,12 @@ impl Val {
                 })
             }
             Type::Enum(handle) => {
-                let (discriminant, _) =
-                    load_variant(ty, handle.names().map(|_| Type::Unit), mem, bytes)?;
+                let (discriminant, _) = load_variant(
+                    handle.variant_info(),
+                    handle.names().map(|_| Type::Unit),
+                    mem,
+                    bytes,
+                )?;
 
                 Val::Enum(Enum {
                     ty: handle.clone(),
@@ -719,7 +728,8 @@ impl Val {
                 })
             }
             Type::Union(handle) => {
-                let (discriminant, value) = load_variant(ty, handle.types(), mem, bytes)?;
+                let (discriminant, value) =
+                    load_variant(handle.variant_info(), handle.types(), mem, bytes)?;
 
                 Val::Union(Union {
                     ty: handle.clone(),
@@ -728,8 +738,12 @@ impl Val {
                 })
             }
             Type::Option(handle) => {
-                let (discriminant, value) =
-                    load_variant(ty, [Type::Unit, handle.ty()].into_iter(), mem, bytes)?;
+                let (discriminant, value) = load_variant(
+                    handle.variant_info(),
+                    [Type::Unit, handle.ty()].into_iter(),
+                    mem,
+                    bytes,
+                )?;
 
                 Val::Option(Option {
                     ty: handle.clone(),
@@ -738,8 +752,12 @@ impl Val {
                 })
             }
             Type::Expected(handle) => {
-                let (discriminant, value) =
-                    load_variant(ty, [handle.ok(), handle.err()].into_iter(), mem, bytes)?;
+                let (discriminant, value) = load_variant(
+                    handle.variant_info(),
+                    [handle.ok(), handle.err()].into_iter(),
+                    mem,
+                    bytes,
+                )?;
 
                 Val::Expected(Expected {
                     ty: handle.clone(),
@@ -845,7 +863,7 @@ impl Val {
 
     /// Serialize this value to the heap at the specified memory location.
     pub(crate) fn store<T>(&self, mem: &mut MemoryMut<'_, T>, offset: usize) -> Result<()> {
-        debug_assert!(offset % usize::try_from(self.ty().size_and_alignment().alignment)? == 0);
+        debug_assert!(offset % usize::try_from(self.ty().canonical_abi().align32)? == 0);
 
         match self {
             Val::Unit => (),
@@ -871,35 +889,39 @@ impl Val {
             Val::Record(Record { values, .. }) | Val::Tuple(Tuple { values, .. }) => {
                 let mut offset = offset;
                 for value in values.deref() {
-                    value.store(mem, value.ty().next_field(&mut offset))?;
+                    value.store(
+                        mem,
+                        value.ty().canonical_abi().next_field32_size(&mut offset),
+                    )?;
                 }
             }
             Val::Variant(Variant {
                 discriminant,
                 value,
                 ty,
-            }) => self.store_variant(*discriminant, value, ty.cases().len(), mem, offset)?,
+            }) => self.store_variant(*discriminant, value, ty.variant_info(), mem, offset)?,
 
             Val::Enum(Enum { discriminant, ty }) => {
-                self.store_variant(*discriminant, &Val::Unit, ty.names().len(), mem, offset)?
+                self.store_variant(*discriminant, &Val::Unit, ty.variant_info(), mem, offset)?
             }
 
             Val::Union(Union {
                 discriminant,
                 value,
                 ty,
-            }) => self.store_variant(*discriminant, value, ty.types().len(), mem, offset)?,
+            }) => self.store_variant(*discriminant, value, ty.variant_info(), mem, offset)?,
 
             Val::Option(Option {
                 discriminant,
                 value,
-                ..
-            })
-            | Val::Expected(Expected {
+                ty,
+            }) => self.store_variant(*discriminant, value, ty.variant_info(), mem, offset)?,
+
+            Val::Expected(Expected {
                 discriminant,
                 value,
-                ..
-            }) => self.store_variant(*discriminant, value, 2, mem, offset)?,
+                ty,
+            }) => self.store_variant(*discriminant, value, ty.variant_info(), mem, offset)?,
 
             Val::Flags(Flags { count, value, .. }) => {
                 match FlagsSize::from_count(*count as usize) {
@@ -924,34 +946,26 @@ impl Val {
         &self,
         discriminant: u32,
         value: &Val,
-        case_count: usize,
+        info: &VariantInfo,
         mem: &mut MemoryMut<'_, T>,
         offset: usize,
     ) -> Result<()> {
-        let discriminant_size = DiscriminantSize::from_count(case_count).unwrap();
-        match discriminant_size {
+        match info.size {
             DiscriminantSize::Size1 => u8::try_from(discriminant).unwrap().store(mem, offset)?,
             DiscriminantSize::Size2 => u16::try_from(discriminant).unwrap().store(mem, offset)?,
-            DiscriminantSize::Size4 => (discriminant).store(mem, offset)?,
+            DiscriminantSize::Size4 => discriminant.store(mem, offset)?,
         }
 
-        value.store(
-            mem,
-            offset
-                + func::align_to(
-                    discriminant_size.into(),
-                    self.ty().size_and_alignment().alignment,
-                ),
-        )
+        let offset = offset + usize::try_from(info.payload_offset32).unwrap();
+        value.store(mem, offset)
     }
 }
 
 fn load_list(handle: &types::List, mem: &Memory, ptr: usize, len: usize) -> Result<Val> {
     let element_type = handle.ty();
-    let SizeAndAlignment {
-        size: element_size,
-        alignment: element_alignment,
-    } = element_type.size_and_alignment();
+    let abi = element_type.canonical_abi();
+    let element_size = usize::try_from(abi.size32).unwrap();
+    let element_alignment = abi.align32;
 
     match len
         .checked_mul(element_size)
@@ -986,25 +1000,24 @@ fn load_record(
     let mut offset = 0;
     types
         .map(|ty| {
-            Val::load(
-                &ty,
-                mem,
-                &bytes[ty.next_field(&mut offset)..][..ty.size_and_alignment().size],
-            )
+            let abi = ty.canonical_abi();
+            let offset = abi.next_field32(&mut offset);
+            let offset = usize::try_from(offset).unwrap();
+            let size = usize::try_from(abi.size32).unwrap();
+            Val::load(&ty, mem, &bytes[offset..][..size])
         })
         .collect()
 }
 
 fn load_variant(
-    ty: &Type,
+    info: &VariantInfo,
     mut types: impl ExactSizeIterator<Item = Type>,
     mem: &Memory,
     bytes: &[u8],
 ) -> Result<(u32, Val)> {
-    let discriminant_size = DiscriminantSize::from_count(types.len()).unwrap();
-    let discriminant = match discriminant_size {
-        DiscriminantSize::Size1 => u8::load(mem, &bytes[..1])? as u32,
-        DiscriminantSize::Size2 => u16::load(mem, &bytes[..2])? as u32,
+    let discriminant = match info.size {
+        DiscriminantSize::Size1 => u32::from(u8::load(mem, &bytes[..1])?),
+        DiscriminantSize::Size2 => u32::from(u16::load(mem, &bytes[..2])?),
         DiscriminantSize::Size4 => u32::load(mem, &bytes[..4])?,
     };
     let case_ty = types.nth(discriminant as usize).ok_or_else(|| {
@@ -1014,14 +1027,9 @@ fn load_variant(
             types.len()
         )
     })?;
-    let value = Val::load(
-        &case_ty,
-        mem,
-        &bytes[func::align_to(
-            usize::from(discriminant_size),
-            ty.size_and_alignment().alignment,
-        )..][..case_ty.size_and_alignment().size],
-    )?;
+    let payload_offset = usize::try_from(info.payload_offset32).unwrap();
+    let case_size = usize::try_from(case_ty.canonical_abi().size32).unwrap();
+    let value = Val::load(&case_ty, mem, &bytes[payload_offset..][..case_size])?;
     Ok((discriminant, value))
 }
 
@@ -1050,19 +1058,18 @@ fn lower_list<T>(
     mem: &mut MemoryMut<'_, T>,
     items: &[Val],
 ) -> Result<(usize, usize)> {
-    let SizeAndAlignment {
-        size: element_size,
-        alignment: element_alignment,
-    } = element_type.size_and_alignment();
+    let abi = element_type.canonical_abi();
+    let elt_size = usize::try_from(abi.size32)?;
+    let elt_align = abi.align32;
     let size = items
         .len()
-        .checked_mul(element_size)
+        .checked_mul(elt_size)
         .ok_or_else(|| anyhow::anyhow!("size overflow copying a list"))?;
-    let ptr = mem.realloc(0, 0, element_alignment, size)?;
+    let ptr = mem.realloc(0, 0, elt_align, size)?;
     let mut element_ptr = ptr;
     for item in items {
         item.store(mem, element_ptr)?;
-        element_ptr += element_size;
+        element_ptr += elt_size;
     }
     Ok((ptr, items.len()))
 }


### PR DESCRIPTION
This commit is an effort to reduce the amount of complexity around
managing the size/alignment calculations of types in the canonical ABI.
Previously the logic for the size/alignment of a type was spread out
across a number of locations. While each individual calculation is not
really the most complicated thing in the world having the duplication in
so many places was constantly worrying me.

I've opted in this commit to centralize all of this within the runtime
at least, and now there's only one "duplicate" of this information in
the fuzzing infrastructure which is to some degree less important to
deduplicate. This commit introduces a new `CanonicalAbiInfo` type to
house all abi size/align information for both memory32 and memory64.
This new type is then used pervasively throughout fused adapter
compilation, dynamic `Val` management, and typed functions. This type
was also able to reduce the complexity of the macro-generated code
meaning that even `wasmtime-component-macro` is performing less math
than it was before.

One other major feature of this commit is that this ABI information is
now saved within a `ComponentTypes` structure. This avoids recursive
querying of size/align information frequently and instead effectively
caching it. This was a worry I had for the fused adapter compiler which
frequently sought out size/align information and would recursively
descend each type tree each time. The `fact-valid-module` fuzzer is now
nearly 10x faster in terms of iterations/s which I suspect is due to
this caching.

Closes #4592

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
