### PR TITLE
Update 0.40.0 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,12 +25,6 @@ internally have been made along the lines of:
   with features like `i128` support, supporting more ABIs, etc.
 * Much more of the component model has been implemented and is now fuzzed.
 
-This release also has a number of improvements to Cranelift compile times. With
-the [sightglass benchmark suite][sightglass] benchmarks show a 30-40%
-improvement in compile times.
-
-[sightglass]: https://github.com/bytecodealliance/sightglass
-
 Finally this release is currently scheduled to be the last `0.*` release of
 Wasmtime. The upcoming release of Wasmtime on September 20 is planned to be
 Wasmtime's 1.0 release. More information about what 1.0 means for Wasmtime is

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -21,8 +21,9 @@ internally have been made along the lines of:
 * Many more instructions are now implemented with ISLE instead of handwritten
   lowerings.
 * Many improvements to the cranelift-based fuzzing.
-* Many platform improvements for s390x for running `rustc_codegen_cranelift`
-  with features like `i128` support, supporting more ABIs, etc.
+* Many platform improvements for s390x including full SIMD support, running
+  `rustc_codegen_cranelift` with features like `i128`, supporting more
+  ABIs, etc.
 * Much more of the component model has been implemented and is now fuzzed.
 
 Finally this release is currently scheduled to be the last `0.*` release of

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,9 +14,60 @@ Unreleased.
 
 Unreleased.
 
+This was a relatively quiet release in terms of user-facing features where most
+of the work was around the internals of Wasmtime and Cranelift. Improvements
+internally have been made along the lines of:
+
+* Many more instructions are now implemented with ISLE instead of handwritten
+  lowerings.
+* Many improvements to the cranelift-based fuzzing.
+* Many platform improvements for s390x for running `rustc_codegen_cranelift`
+  with features like `i128` support, supporting more ABIs, etc.
+* Much more of the component model has been implemented and is now fuzzed.
+
+This release also has a number of improvements to Cranelift compile times. With
+the [sightglass benchmark suite][sightglass] benchmarks show a 30-40%
+improvement in compile times.
+
+[sightglass]: https://github.com/bytecodealliance/sightglass
+
+Finally this release is currently scheduled to be the last `0.*` release of
+Wasmtime. The upcoming release of Wasmtime on September 20 is planned to be
+Wasmtime's 1.0 release. More information about what 1.0 means for Wasmtime is
+available in the [1.0 RFC]
+
+[1.0 RFC]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-one-dot-oh.md
+
 ### Added
 
-### Changed
+* Stack walking has been reimplemented with frame pointers rather than with
+  native unwind information. This means that backtraces are feasible to capture
+  in performance-critical environments and in general stack walking is much
+  faster than before.
+  [#4431](https://github.com/bytecodealliance/wasmtime/pull/4431)
+
+* The WebAssembly `simd` proposal is now fully implemented for the s390x
+  backend.
+  [#4427](https://github.com/bytecodealliance/wasmtime/pull/4427)
+
+* Support for AArch64 has been added in the experimental native debuginfo
+  support that Wasmtime has.
+  [#4468](https://github.com/bytecodealliance/wasmtime/pull/4468)
+
+* Support building the C API of Wasmtime with CMake has been added.
+  [#4369](https://github.com/bytecodealliance/wasmtime/pull/4369)
+
+* Clarification was added to Wasmtime's documentation about "tiers of support"
+  for various features.
+  [#4479](https://github.com/bytecodealliance/wasmtime/pull/4479)
+
+### Fixed
+
+* Support for `filestat_get` has been improved for stdio streams in WASI.
+  [#4531](https://github.com/bytecodealliance/wasmtime/pull/4531)
+
+* Enabling the `vtune` feature no longer breaks builds on AArch64.
+  [#4533](https://github.com/bytecodealliance/wasmtime/pull/4533)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Not a ton happened in terms of user-facing improvements here so I
outlined some internal changes as well. The cumulative effect of
improving compile times is Sightglass showing 30-40% improvements for
major benchmarks. Additionally I wrote down a note indicating that this
is likely the last `0.*` release and the next release of Wasmtime on
September 20 is planned to be 1.0.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
