### PR TITLE
WIP Cranelift: Avoid many small allocations in `remove_constant_phis` pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +535,7 @@ dependencies = [
 name = "cranelift-codegen"
 version = "0.88.0"
 dependencies = [
+ "arrayvec",
  "bincode",
  "cranelift-bforest",
  "cranelift-codegen-meta",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 edition = "2021"
 
 [dependencies]
+arrayvec = "0.7"
 cranelift-codegen-shared = { path = "./shared", version = "0.88.0" }
 cranelift-entity = { path = "../entity", version = "0.88.0" }
 cranelift-bforest = { path = "../bforest", version = "0.88.0" }


### PR DESCRIPTION
By having a single, large allocation instead.

The motivation is that the `SmallVec` for each block's outgoing edges' actual argument values was often running out of their inline capacity and triggering heap allocations.

Unfortunately, this seems to ultimately be a ~3% slow down on our `spidermonkey.wasm` benchmark, probably due to the new bounds checks caused from indexing into the single large allocation.

```
compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 121036165.40 ± 64555091.05 (confidence = 99%)

  main.so is 1.01x to 1.05x faster than backing-values.so!

  [3983134514 4236785350.52 4613932381] backing-values.so
  [3790337770 4115749185.12 4653228728] main.so

compilation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [165139806 179373271.11 208813013] backing-values.so
  [165229705 175595715.17 202773232] main.so

compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm

  No difference in performance.

  [188779955 224630804.71 270825205] backing-values.so
  [189541100 222431248.35 281750519] main.so
```

Just opening this PR for posterity and if anyone else gets any ideas here.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
