### PR TITLE
Fix unused return value that is `#[must_use]`

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -348,7 +348,7 @@ pub extern "C" fn wasm_bench_create(
 pub extern "C" fn wasm_bench_free(state: *mut c_void) {
     assert!(!state.is_null());
     unsafe {
-        Box::from_raw(state as *mut BenchState);
+        drop(Box::from_raw(state as *mut BenchState));
     }
 }
 


### PR DESCRIPTION
Fixes this compiler warning:

```
warning: unused return value of `Box::<T>::from_raw` that must be used
   --> crates/bench-api/src/lib.rs:351:9
    |
351 |         Box::from_raw(state as *mut BenchState);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
