### PR TITLE
cranelift: Remove legalized_to_pointer from function generator

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -300,7 +300,6 @@ where
             value_type,
             purpose,
             extension,
-            legalized_to_pointer: false,
         })
     }
 


### PR DESCRIPTION
The build is broken since we merged both #4589 and #4653 at once.