### PR TITLE
Stop returning `NOTCAPABLE` errors from WASI calls.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
@@ -30,7 +30,7 @@ unsafe fn try_read_file(dir_fd: wasi::Fd) {
         wasi::fd_read(fd, &[iovec])
             .expect_err("reading bytes from file should fail")
             .raw_error(),
-        wasi::ERRNO_NOTCAPABLE
+        wasi::ERRNO_BADF
     );
 }
 

--- a/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
@@ -68,7 +68,7 @@ unsafe fn test_truncation_rights(dir_fd: wasi::Fd) {
             wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_TRUNC, 0, 0, 0)
                 .expect_err("truncating a file without path_filestat_set_size right")
                 .raw_error(),
-            wasi::ERRNO_NOTCAPABLE
+            wasi::ERRNO_PERM
         );
     }
 

--- a/crates/wasi-common/src/dir.rs
+++ b/crates/wasi-common/src/dir.rs
@@ -77,13 +77,12 @@ impl DirEntry {
             Ok(())
         } else {
             let missing = caps & !self.caps;
-            if missing.intersects(DirCaps::READDIR) {
-                Err(Error::not_dir()
-                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
+            let err = if missing.intersects(DirCaps::READDIR) {
+                Error::not_dir()
             } else {
-                Err(Error::perm()
-                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
-            }
+                Error::perm()
+            };
+            Err(err.context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
         }
     }
     pub fn capable_of_file(&self, caps: FileCaps) -> Result<(), Error> {

--- a/crates/wasi-common/src/dir.rs
+++ b/crates/wasi-common/src/dir.rs
@@ -76,15 +76,24 @@ impl DirEntry {
         if self.caps.contains(caps) {
             Ok(())
         } else {
-            Err(Error::not_capable().context(format!("desired {:?}, has {:?}", caps, self.caps,)))
+            let missing = caps & !self.caps;
+            if missing.intersects(DirCaps::READDIR) {
+                Err(Error::not_dir()
+                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
+            } else {
+                Err(Error::perm()
+                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
+            }
         }
     }
     pub fn capable_of_file(&self, caps: FileCaps) -> Result<(), Error> {
         if self.file_caps.contains(caps) {
             Ok(())
         } else {
-            Err(Error::not_capable()
-                .context(format!("desired {:?}, has {:?}", caps, self.file_caps)))
+            Err(Error::perm().context(format!(
+                "desired rights {:?}, has {:?}",
+                caps, self.file_caps
+            )))
         }
     }
     pub fn drop_caps_to(&mut self, caps: DirCaps, file_caps: FileCaps) -> Result<(), Error> {

--- a/crates/wasi-common/src/error.rs
+++ b/crates/wasi-common/src/error.rs
@@ -72,6 +72,9 @@ pub enum ErrorKind {
     /// Errno::Spipe: Invalid seek
     #[error("Spipe: Invalid seek")]
     Spipe,
+    /// Errno::Perm: Permission denied
+    #[error("Permission denied")]
+    Perm,
     /// Errno::NotCapable: Not capable
     #[error("Not capable")]
     NotCapable,
@@ -92,7 +95,7 @@ pub trait ErrorExt {
     fn overflow() -> Self;
     fn range() -> Self;
     fn seek_pipe() -> Self;
-    fn not_capable() -> Self;
+    fn perm() -> Self;
 }
 
 impl ErrorExt for Error {
@@ -138,7 +141,7 @@ impl ErrorExt for Error {
     fn seek_pipe() -> Self {
         ErrorKind::Spipe.into()
     }
-    fn not_capable() -> Self {
-        ErrorKind::NotCapable.into()
+    fn perm() -> Self {
+        ErrorKind::Perm.into()
     }
 }

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -239,16 +239,15 @@ impl FileEntry {
             Ok(())
         } else {
             let missing = caps & !self.caps;
-            if missing.intersects(FileCaps::READ | FileCaps::WRITE) {
+            let err = if missing.intersects(FileCaps::READ | FileCaps::WRITE) {
                 // `EBADF` is a little surprising here because it's also used
                 // for unknown-file-descriptor errors, but it's what POSIX uses
                 // in this situation.
-                Err(Error::badf()
-                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
+                Error::badf()
             } else {
-                Err(Error::perm()
-                    .context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
-            }
+                Error::perm()
+            };
+            Err(err.context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
         }
     }
 

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -84,6 +84,7 @@ impl From<ErrorKind> for types::Errno {
             ErrorKind::Range => Errno::Range,
             ErrorKind::Spipe => Errno::Spipe,
             ErrorKind::NotCapable => Errno::Notcapable,
+            ErrorKind::Perm => Errno::Perm,
         }
     }
 }


### PR DESCRIPTION
`ENOTCAPABLE` was an error code that is used as part of the rights
system, from CloudABI. There is a set of flags associated with each file
descriptor listing which operations can be performed with the file
descriptor, and if an attempt is made to perform an operation with a
file descriptor that isn't permitted by its rights flags, it fails with
`ENOTCAPABLE`.

WASI is removing the rights system. For example, WebAssembly/wasi-libc#294
removed support for translating `ENOTCAPABLE` into POSIX error codes, on
the assumption that engines should stop using it.

So as another step to migrating away from the rights system, remove uses
of the `ENOTCAPABLE` error.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
