### PR TITLE
Limit the type hierarchies in component fuzzing

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -300,7 +300,6 @@ where
             value_type,
             purpose,
             extension,
-            legalized_to_pointer: false,
         })
     }
 


### PR DESCRIPTION
For now `wasmparser` has a hard limit on the size of tuples and such at
1000 recursive types within the tuple itself. Respect this limit by
limiting the width of recursive types generated for the `component_api`
fuzzer. This commit unifies this new requirement with the preexisting
`TupleArray` and `NonEmptyArray` types into one `VecInRange<T, L, H>`
which allow expressing all of these various requirements in one type.