### PR TITLE
[fuzz] Fix order of arguments passed in to `wasm-spec-interpreter`

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
@@ -55,7 +55,7 @@ let extract_exported_func export = match export with
 (** Interpret the first exported function and return the result. Use provided
 parameters if they exist, otherwise use default (zeroed) values. *)
 let interpret_exn module_bytes opt_params =
-  let opt_params_ = Option.map (List.map convert_to_wasm) opt_params in
+  let opt_params_ = Option.map (List.rev_map convert_to_wasm) opt_params in
   let module_ = parse module_bytes in
   let m_isa = Ast_convert.convert_module (module_.it) in
   let fuel = Z.of_string "4611686018427387904" in

--- a/crates/fuzzing/wasm-spec-interpreter/src/with_library.rs
+++ b/crates/fuzzing/wasm-spec-interpreter/src/with_library.rs
@@ -119,4 +119,15 @@ mod tests {
             ])]
         );
     }
+
+    // See issue https://github.com/bytecodealliance/wasmtime/issues/4671.
+    #[test]
+    fn order_of_params() {
+        let module = wat::parse_file("tests/shr_s.wat").unwrap();
+
+        let parameters = Some(vec![Value::I32(1795123818), Value::I32(-2147483648)]);
+        let results = interpret(&module, parameters.clone()).unwrap();
+
+        assert_eq!(results, vec![Value::I32(1795123818)]);
+    }
 }

--- a/crates/fuzzing/wasm-spec-interpreter/tests/shr_s.wat
+++ b/crates/fuzzing/wasm-spec-interpreter/tests/shr_s.wat
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func (param i32 i32) (result i32)))
+  (func (;0;) (type 0) (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.shr_s
+  )
+  (export "test" (func 0))
+)


### PR DESCRIPTION
In #4671, the meta-differential fuzz target was finding errors when
running certain Wasm modules (specifically `shr_s` in that case).
@conrad-watt diagnosed the issue as a missing reversal in the operands
passed to the spec interpreter. This change fixes #4671 and adds an
additional unit test to keep it fixed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
