### PR TITLE
Update max tuple size in component api fuzzing

### DIFF
--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -123,8 +123,9 @@ pub enum Type {
     Record(VecInRange<Type, 0, 200>),
 
     // Tuples can only have up to 16 type parameters in wasmtime right now for
-    // the static API.
-    Tuple(VecInRange<Type, 0, 16>),
+    // the static API, but the standard library only supports `Debug` up to 11
+    // elements, so compromise at an even 10.
+    Tuple(VecInRange<Type, 0, 10>),
 
     // Like records, allow a good number of variants, but variants require at
     // least one case.


### PR DESCRIPTION
Fixes a build failure on #4673 where tuples of length 16 don't implement
`Debug` from the standard library.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
