### PR TITLE
List preset's settings in generated comment

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/settings.rs
+++ b/cranelift/codegen/meta/src/cdsl/settings.rs
@@ -110,6 +110,15 @@ impl Preset {
         }
         layout
     }
+
+    pub fn setting_names<'a>(
+        &'a self,
+        group: &'a SettingGroup,
+    ) -> impl Iterator<Item = &'static str> + 'a {
+        self.values
+            .iter()
+            .map(|bool_index| group.settings[bool_index.0].name)
+    }
 }
 
 pub(crate) struct SettingGroup {

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -370,7 +370,11 @@ fn gen_descriptors(group: &SettingGroup, fmt: &mut Formatter) {
     );
     fmt.indent(|fmt| {
         for preset in &group.presets {
-            fmt.comment(preset.name);
+            fmt.comment(format!(
+                "{}: {}",
+                preset.name,
+                preset.setting_names(&group).collect::<Vec<_>>().join(", ")
+            ));
             for (mask, value) in preset.layout(&group) {
                 fmtln!(fmt, "(0b{:08b}, 0b{:08b}),", mask, value);
             }


### PR DESCRIPTION
Figuring out which boolean settings go into each preset is not easy by
inspecting the DSL source (e.g. meta/src/isa/x86.rs). This patch extends
the comments in the Rust that's generated by that DSL to list the names
of the settings together with the name of the preset.