### PR TITLE
[fuzz] Document Wasm-JS conversions

### DIFF
--- a/crates/fuzzing/src/oracles/v8.rs
+++ b/crates/fuzzing/src/oracles/v8.rs
@@ -83,6 +83,8 @@ pub fn differential_v8_execution(wasm: &[u8], config: &crate::generators::Config
             ValType::ExternRef => Val::ExternRef(None),
             _ => unimplemented!(),
         });
+        // See https://webassembly.github.io/spec/js-api/index.html#tojsvalue
+        // for how the Wasm-to-JS conversions are done.
         v8_params.push(match param {
             ValType::I32 | ValType::F32 | ValType::F64 => v8::Number::new(&mut scope, 0.0).into(),
             ValType::I64 => v8::BigInt::new_from_i64(&mut scope, 0).into(),
@@ -215,6 +217,9 @@ fn eval<'s>(
 /// Asserts that the wasmtime value `a` matches the v8 value `b`.
 ///
 /// For NaN values simply just asserts that they're both NaN.
+///
+/// See https://webassembly.github.io/spec/js-api/index.html#towebassemblyvalue
+/// for how the JS-to-Wasm conversions are done.
 fn assert_val_match(a: &Val, b: &v8::Local<'_, v8::Value>, scope: &mut v8::HandleScope<'_>) {
     match *a {
         Val::I32(wasmtime) => {


### PR DESCRIPTION
During differential execution against V8, Wasm values need to be
converted back and forth from JS values. This change documents the
location in the specification where this is defined.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
