### PR TITLE
x64: Lower fcvt_from_uint in ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2629,6 +2629,11 @@
             (_ Unit (emit (MInst.XmmUnaryRmREvex op src dst))))
         dst))
 
+;; Helper for creating `vcvtudq2ps` instructions.
+(decl x64_vcvtudq2ps (XmmMem) Xmm)
+(rule (x64_vcvtudq2ps src)
+      (xmm_unary_rm_r_evex (Avx512Opcode.Vcvtudq2ps) src))
+
 ;; Helper for creating `vpabsq` instructions.
 (decl x64_vpabsq (XmmMem) Xmm)
 (rule (x64_vpabsq src)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2272,6 +2272,11 @@
 (rule (x64_punpcklwd src1 src2)
       (xmm_rm_r $I16X8 (SseOpcode.Punpcklwd) src1 src2))
 
+;; Helper for creating `unpcklps` instructions.
+(decl x64_unpcklps (Xmm XmmMem) Xmm)
+(rule (x64_unpcklps src1 src2)
+      (xmm_rm_r $I16X8 (SseOpcode.Unpcklps) src1 src2))
+
 ;; Helper for creating `andnps` instructions.
 (decl x64_andnps (Xmm XmmMem) Xmm)
 (rule (x64_andnps src1 src2)
@@ -3024,6 +3029,12 @@
             (_ Unit (emit (gen_move $I64 src_copy src)))
             (_ Unit (emit (MInst.CvtUint64ToFloatSeq size src_copy dst tmp_gpr1 tmp_gpr2))))
         dst))
+
+(decl fcvt_uint_mask_const () VCodeConstant)
+(extern constructor fcvt_uint_mask_const fcvt_uint_mask_const)
+
+(decl fcvt_uint_mask_high_const () VCodeConstant)
+(extern constructor fcvt_uint_mask_high_const fcvt_uint_mask_high_const)
 
 ;; Helpers for creating `pcmpeq*` instructions.
 (decl x64_pcmpeq (Type Xmm XmmMem) Xmm)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3014,6 +3014,17 @@
             (_ Unit (emit (MInst.GprToXmm (SseOpcode.Cvtsi2sd) x dst size))))
         dst))
 
+(decl cvt_u64_to_float_seq (Type Gpr) Xmm)
+(rule (cvt_u64_to_float_seq ty src)
+      (let ((size OperandSize (raw_operand_size_of_type ty))
+            (src_copy WritableGpr (temp_writable_gpr))
+            (dst WritableXmm (temp_writable_xmm))
+            (tmp_gpr1 WritableGpr (temp_writable_gpr))
+            (tmp_gpr2 WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (gen_move $I64 src_copy src)))
+            (_ Unit (emit (MInst.CvtUint64ToFloatSeq size src_copy dst tmp_gpr1 tmp_gpr2))))
+        dst))
+
 ;; Helpers for creating `pcmpeq*` instructions.
 (decl x64_pcmpeq (Type Xmm XmmMem) Xmm)
 (rule (x64_pcmpeq $I8X16 x y) (x64_pcmpeqb x y))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1658,6 +1658,10 @@
 (rule (x64_movdqu from)
       (xmm_unary_rm_r (SseOpcode.Movdqu) from))
 
+(decl x64_movapd (XmmMem) Xmm)
+(rule (x64_movapd src)
+      (xmm_unary_rm_r (SseOpcode.Movapd) src))
+
 (decl x64_pmovsxbw (XmmMem) Xmm)
 (rule (x64_pmovsxbw from)
       (xmm_unary_rm_r (SseOpcode.Pmovsxbw) from))

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -26,6 +26,17 @@ impl Inst {
             dst: WritableGpr::from_writable_reg(src).unwrap(),
         }
     }
+
+    fn xmm_unary_rm_r_evex(op: Avx512Opcode, src: RegMem, dst: Writable<Reg>) -> Inst {
+        src.assert_regclass_is(RegClass::Float);
+        debug_assert!(dst.to_reg().class() == RegClass::Float);
+        Inst::XmmUnaryRmREvex {
+            op,
+            src: XmmMem::new(src).unwrap(),
+            dst: WritableXmm::from_writable_reg(dst).unwrap(),
+        }
+    }
+
 }
 
 #[test]

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -36,7 +36,6 @@ impl Inst {
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
-
 }
 
 #[test]

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -307,16 +307,6 @@ impl Inst {
         }
     }
 
-    pub(crate) fn xmm_unary_rm_r_evex(op: Avx512Opcode, src: RegMem, dst: Writable<Reg>) -> Inst {
-        src.assert_regclass_is(RegClass::Float);
-        debug_assert!(dst.to_reg().class() == RegClass::Float);
-        Inst::XmmUnaryRmREvex {
-            op,
-            src: XmmMem::new(src).unwrap(),
-            dst: WritableXmm::from_writable_reg(dst).unwrap(),
-        }
-    }
-
     pub(crate) fn xmm_rm_r(op: SseOpcode, src: RegMem, dst: Writable<Reg>) -> Self {
         src.assert_regclass_is(RegClass::Float);
         debug_assert!(dst.to_reg().class() == RegClass::Float);

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -417,27 +417,6 @@ impl Inst {
         Inst::XmmCmpRmR { op, src, dst }
     }
 
-    pub(crate) fn cvt_u64_to_float_seq(
-        dst_size: OperandSize,
-        src: Writable<Reg>,
-        tmp_gpr1: Writable<Reg>,
-        tmp_gpr2: Writable<Reg>,
-        dst: Writable<Reg>,
-    ) -> Inst {
-        debug_assert!(dst_size.is_one_of(&[OperandSize::Size32, OperandSize::Size64]));
-        debug_assert!(src.to_reg().class() == RegClass::Int);
-        debug_assert!(tmp_gpr1.to_reg().class() == RegClass::Int);
-        debug_assert!(tmp_gpr2.to_reg().class() == RegClass::Int);
-        debug_assert!(dst.to_reg().class() == RegClass::Float);
-        Inst::CvtUint64ToFloatSeq {
-            src: WritableGpr::from_writable_reg(src).unwrap(),
-            dst: WritableXmm::from_writable_reg(dst).unwrap(),
-            tmp_gpr1: WritableGpr::from_writable_reg(tmp_gpr1).unwrap(),
-            tmp_gpr2: WritableGpr::from_writable_reg(tmp_gpr2).unwrap(),
-            dst_size,
-        }
-    }
-
     pub(crate) fn cvt_float_to_sint_seq(
         src_size: OperandSize,
         dst_size: OperandSize,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3034,3 +3034,12 @@
             (res Xmm (x64_unpcklps val uint_mask))
             (uint_mask_high Xmm (x64_xmm_load_const $I32X4 (fcvt_uint_mask_high_const))))
         (x64_subpd res uint_mask_high)))
+
+;; When AVX512VL and AVX512F are available,
+;; `fcvt_from_uint` can be lowered to a single instruction.
+(rule (lower (has_type (and (avx512vl_enabled) (avx512f_enabled) $F32X4)
+                       (fcvt_from_uint src)))
+      (x64_vcvtudq2ps src))
+
+;; (rule (lower (has_type $F32X4 (fcvt_from_uint src)))
+;;       (x64_vcvtudq2ps src))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3024,3 +3024,13 @@
 
 (rule (lower (has_type ty (fcvt_from_uint val @ (value_type $I64))))
       (cvt_u64_to_float_seq ty val))
+
+;; Algorithm uses unpcklps to help create a float that is equivalent
+;; 0x1.0p52 + double(src). 0x1.0p52 is unique because at this exponent
+;; every value of the mantissa represents a corresponding uint32 number.
+;; When we subtract 0x1.0p52 we are left with double(src).
+(rule (lower (has_type $F64X2 (fcvt_from_uint (uwiden_low val @ (value_type $I32X4)))))
+      (let ((uint_mask Xmm (x64_xmm_load_const $I32X4 (fcvt_uint_mask_const)))
+            (res Xmm (x64_unpcklps val uint_mask))
+            (uint_mask_high Xmm (x64_xmm_load_const $I32X4 (fcvt_uint_mask_high_const))))
+        (x64_subpd res uint_mask_high)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3037,9 +3037,52 @@
 
 ;; When AVX512VL and AVX512F are available,
 ;; `fcvt_from_uint` can be lowered to a single instruction.
-(rule (lower (has_type (and (avx512vl_enabled) (avx512f_enabled) $F32X4)
-                       (fcvt_from_uint src)))
+;;
+;; NOTE: the priority of 1 here is to break ties with the next case for $F32X4,
+;; as it doesn't require either of the avx512 extensions to be enabled.
+(rule 1 (lower (has_type (and (avx512vl_enabled) (avx512f_enabled) $F32X4)
+                         (fcvt_from_uint src)))
       (x64_vcvtudq2ps src))
 
-;; (rule (lower (has_type $F32X4 (fcvt_from_uint src)))
-;;       (x64_vcvtudq2ps src))
+;; Converting packed unsigned integers to packed floats
+;; requires a few steps. There is no single instruction
+;; lowering for converting unsigned floats but there is for
+;; converting packed signed integers to float (cvtdq2ps). In
+;; the steps below we isolate the upper half (16 bits) and
+;; lower half (16 bits) of each lane and then we convert
+;; each half separately using cvtdq2ps meant for signed
+;; integers. In order for this to work for the upper half
+;; bits we must shift right by 1 (divide by 2) these bits in
+;; order to ensure the most significant bit is 0 not signed,
+;; and then after the conversion we double the value.
+;; Finally we add the converted values where addition will
+;; correctly round.
+;;
+;; Sequence:
+;; -> A = 0xffffffff
+;; -> Ah = 0xffff0000
+;; -> Al = 0x0000ffff
+;; -> Convert(Al) // Convert int to float
+;; -> Ah = Ah >> 1 // Shift right 1 to assure Ah conversion isn't treated as signed
+;; -> Convert(Ah) // Convert .. with no loss of significant digits from previous shift
+;; -> Ah = Ah + Ah // Double Ah to account for shift right before the conversion.
+;; -> dst = Ah + Al // Add the two floats together
+(rule (lower (has_type $F32X4 (fcvt_from_uint a)))
+      (let (;;  get the low 16 bits
+            (a_lo Xmm (x64_pslld a (RegMemImm.Imm 16)))
+            (a_lo Xmm (x64_psrld a_lo (RegMemImm.Imm 16)))
+
+            ;; get the high 16 bits
+            (a_hi Xmm (x64_psubd a a_lo))
+
+            ;; convert the low 16 bits
+            (a_lo Xmm (x64_cvtdq2ps a_lo))
+
+            ;; shift the high bits by 1, convert, and double to get the correct
+            ;; value
+            (a_hi Xmm (x64_psrld a_hi (RegMemImm.Imm 1)))
+            (a_hi Xmm (x64_cvtdq2ps a_hi))
+            (a_hi Xmm (x64_addps a_hi a_hi)))
+
+        ;; add together the two converted values
+        (x64_addps a_hi a_lo)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3021,3 +3021,6 @@
 
 (rule (lower (has_type $F64 (fcvt_from_uint val @ (value_type (fits_in_32 (ty_int ty))))))
       (x64_cvtsi2sd $I64 (extend_to_gpr val $I64 (ExtendKind.Zero))))
+
+(rule (lower (has_type ty (fcvt_from_uint val @ (value_type $I64))))
+      (cvt_u64_to_float_seq ty val))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3013,3 +3013,11 @@
 
 (rule (lower (fcvt_low_from_sint a @ (value_type ty)))
       (x64_cvtdq2pd ty a))
+
+;; Rules for `fcvt_from_uint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $F32 (fcvt_from_uint val @ (value_type (fits_in_32 (ty_int ty))))))
+      (x64_cvtsi2ss $I64 (extend_to_gpr val $I64 (ExtendKind.Zero))))
+
+(rule (lower (has_type $F64 (fcvt_from_uint val @ (value_type (fits_in_32 (ty_int ty))))))
+      (x64_cvtsi2sd $I64 (extend_to_gpr val $I64 (ExtendKind.Zero))))

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -589,70 +589,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             if !ty.is_vector() {
                 implemented_in_isle(ctx);
             } else if output_ty == types::F64X2 {
-                if let Some(uwiden) = matches_input(ctx, inputs[0], Opcode::UwidenLow) {
-                    let uwiden_input = InsnInput {
-                        insn: uwiden,
-                        input: 0,
-                    };
-                    let src = put_input_in_reg(ctx, uwiden_input);
-                    let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-                    let input_ty = ctx.input_ty(uwiden, 0);
-
-                    // Matches_input further obfuscates which Wasm instruction this is ultimately
-                    // lowering. Check here that the types are as expected for F64x2ConvertLowI32x4U.
-                    debug_assert!(input_ty == types::I32X4);
-
-                    // Algorithm uses unpcklps to help create a float that is equivalent
-                    // 0x1.0p52 + double(src). 0x1.0p52 is unique because at this exponent
-                    // every value of the mantissa represents a corresponding uint32 number.
-                    // When we subtract 0x1.0p52 we are left with double(src).
-                    let uint_mask = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
-                    ctx.emit(Inst::gen_move(dst, src, types::I32X4));
-
-                    static UINT_MASK: [u8; 16] = [
-                        0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0x00, 0x00,
-                    ];
-
-                    let uint_mask_const =
-                        ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK));
-
-                    ctx.emit(Inst::xmm_load_const(
-                        uint_mask_const,
-                        uint_mask,
-                        types::I32X4,
-                    ));
-
-                    // Creates 0x1.0p52 + double(src)
-                    ctx.emit(Inst::xmm_rm_r(
-                        SseOpcode::Unpcklps,
-                        RegMem::from(uint_mask),
-                        dst,
-                    ));
-
-                    static UINT_MASK_HIGH: [u8; 16] = [
-                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00,
-                        0x00, 0x00, 0x30, 0x43,
-                    ];
-
-                    let uint_mask_high_const =
-                        ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK_HIGH));
-                    let uint_mask_high = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
-                    ctx.emit(Inst::xmm_load_const(
-                        uint_mask_high_const,
-                        uint_mask_high,
-                        types::I32X4,
-                    ));
-
-                    // 0x1.0p52 + double(src) - 0x1.0p52
-                    ctx.emit(Inst::xmm_rm_r(
-                        SseOpcode::Subpd,
-                        RegMem::from(uint_mask_high),
-                        dst,
-                    ));
-                } else {
-                    panic!("Unsupported FcvtFromUint conversion types: {}", ty);
-                }
+                implemented_in_isle(ctx);
             } else {
                 assert_eq!(ctx.input_ty(insn, 0), types::I32X4);
                 let src = put_input_in_reg(ctx, inputs[0]);

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -578,95 +578,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         | Opcode::Selectif
         | Opcode::SelectifSpectreGuard
         | Opcode::FcvtFromSint
-        | Opcode::FcvtLowFromSint => {
+        | Opcode::FcvtLowFromSint
+        | Opcode::FcvtFromUint => {
             implemented_in_isle(ctx);
         }
 
-        Opcode::FcvtFromUint => {
-            let ty = ty.unwrap();
-            let output_ty = ctx.output_ty(insn, 0);
-
-            if !ty.is_vector() {
-                implemented_in_isle(ctx);
-            } else if output_ty == types::F64X2 {
-                implemented_in_isle(ctx);
-            } else {
-                assert_eq!(ctx.input_ty(insn, 0), types::I32X4);
-                let src = put_input_in_reg(ctx, inputs[0]);
-                let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-
-                if isa_flags.use_avx512vl_simd() && isa_flags.use_avx512f_simd() {
-                    implemented_in_isle(ctx);
-                } else {
-                    // Converting packed unsigned integers to packed floats
-                    // requires a few steps. There is no single instruction
-                    // lowering for converting unsigned floats but there is for
-                    // converting packed signed integers to float (cvtdq2ps). In
-                    // the steps below we isolate the upper half (16 bits) and
-                    // lower half (16 bits) of each lane and then we convert
-                    // each half separately using cvtdq2ps meant for signed
-                    // integers. In order for this to work for the upper half
-                    // bits we must shift right by 1 (divide by 2) these bits in
-                    // order to ensure the most significant bit is 0 not signed,
-                    // and then after the conversion we double the value.
-                    // Finally we add the converted values where addition will
-                    // correctly round.
-                    //
-                    // Sequence:
-                    // -> A = 0xffffffff
-                    // -> Ah = 0xffff0000
-                    // -> Al = 0x0000ffff
-                    // -> Convert(Al) // Convert int to float
-                    // -> Ah = Ah >> 1 // Shift right 1 to assure Ah conversion isn't treated as signed
-                    // -> Convert(Ah) // Convert .. with no loss of significant digits from previous shift
-                    // -> Ah = Ah + Ah // Double Ah to account for shift right before the conversion.
-                    // -> dst = Ah + Al // Add the two floats together
-
-                    // Create a temporary register
-                    let tmp = ctx.alloc_tmp(types::I32X4).only_reg().unwrap();
-                    ctx.emit(Inst::xmm_unary_rm_r(
-                        SseOpcode::Movapd,
-                        RegMem::reg(src),
-                        tmp,
-                    ));
-                    ctx.emit(Inst::gen_move(dst, src, ty));
-
-                    // Get the low 16 bits
-                    ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Pslld, RegMemImm::imm(16), tmp));
-                    ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Psrld, RegMemImm::imm(16), tmp));
-
-                    // Get the high 16 bits
-                    ctx.emit(Inst::xmm_rm_r(SseOpcode::Psubd, RegMem::from(tmp), dst));
-
-                    // Convert the low 16 bits
-                    ctx.emit(Inst::xmm_unary_rm_r(
-                        SseOpcode::Cvtdq2ps,
-                        RegMem::from(tmp),
-                        tmp,
-                    ));
-
-                    // Shift the high bits by 1, convert, and double to get the correct value.
-                    ctx.emit(Inst::xmm_rmi_reg(SseOpcode::Psrld, RegMemImm::imm(1), dst));
-                    ctx.emit(Inst::xmm_unary_rm_r(
-                        SseOpcode::Cvtdq2ps,
-                        RegMem::from(dst),
-                        dst,
-                    ));
-                    ctx.emit(Inst::xmm_rm_r(
-                        SseOpcode::Addps,
-                        RegMem::reg(dst.to_reg()),
-                        dst,
-                    ));
-
-                    // Add together the two converted values.
-                    ctx.emit(Inst::xmm_rm_r(
-                        SseOpcode::Addps,
-                        RegMem::reg(tmp.to_reg()),
-                        dst,
-                    ));
-                }
-            }
-        }
 
         Opcode::FcvtToUint | Opcode::FcvtToUintSat | Opcode::FcvtToSint | Opcode::FcvtToSintSat => {
             let src = put_input_in_reg(ctx, inputs[0]);

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -596,13 +596,7 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
                 let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
 
                 if isa_flags.use_avx512vl_simd() && isa_flags.use_avx512f_simd() {
-                    // When AVX512VL and AVX512F are available,
-                    // `fcvt_from_uint` can be lowered to a single instruction.
-                    ctx.emit(Inst::xmm_unary_rm_r_evex(
-                        Avx512Opcode::Vcvtudq2ps,
-                        RegMem::reg(src),
-                        dst,
-                    ));
+                    implemented_in_isle(ctx);
                 } else {
                     // Converting packed unsigned integers to packed floats
                     // requires a few steps. There is no single instruction

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -583,7 +583,6 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
             implemented_in_isle(ctx);
         }
 
-
         Opcode::FcvtToUint | Opcode::FcvtToUintSat | Opcode::FcvtToSint | Opcode::FcvtToSintSat => {
             let src = put_input_in_reg(ctx, inputs[0]);
             let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -583,39 +583,11 @@ fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         }
 
         Opcode::FcvtFromUint => {
-            let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
             let ty = ty.unwrap();
-            let input_ty = ctx.input_ty(insn, 0);
             let output_ty = ctx.output_ty(insn, 0);
 
             if !ty.is_vector() {
-                match input_ty {
-                    types::I8 | types::I16 | types::I32 => {
-                        implemented_in_isle(ctx);
-                    }
-
-                    types::I64 => {
-                        let src = put_input_in_reg(ctx, inputs[0]);
-
-                        let src_copy = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                        ctx.emit(Inst::gen_move(src_copy, src, types::I64));
-
-                        let tmp_gpr1 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                        let tmp_gpr2 = ctx.alloc_tmp(types::I64).only_reg().unwrap();
-                        ctx.emit(Inst::cvt_u64_to_float_seq(
-                            if ty == types::F64 {
-                                OperandSize::Size64
-                            } else {
-                                OperandSize::Size32
-                            },
-                            src_copy,
-                            tmp_gpr1,
-                            tmp_gpr2,
-                            dst,
-                        ));
-                    }
-                    _ => panic!("unexpected input type for FcvtFromUint: {:?}", input_ty),
-                };
+                implemented_in_isle(ctx);
             } else if output_ty == types::F64X2 {
                 if let Some(uwiden) = matches_input(ctx, inputs[0], Opcode::UwidenLow) {
                     let uwiden_input = InsnInput {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -773,12 +773,14 @@ where
 
     #[inline]
     fn fcvt_uint_mask_const(&mut self) -> VCodeConstant {
-        self.lower_ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK))
+        self.lower_ctx
+            .use_constant(VCodeConstantData::WellKnown(&UINT_MASK))
     }
 
     #[inline]
     fn fcvt_uint_mask_high_const(&mut self) -> VCodeConstant {
-        self.lower_ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK_HIGH))
+        self.lower_ctx
+            .use_constant(VCodeConstantData::WellKnown(&UINT_MASK_HIGH))
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -770,6 +770,16 @@ where
     fn jump_table_size(&mut self, targets: &BoxVecMachLabel) -> u32 {
         targets.len() as u32
     }
+
+    #[inline]
+    fn fcvt_uint_mask_const(&mut self) -> VCodeConstant {
+        self.lower_ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK))
+    }
+
+    #[inline]
+    fn fcvt_uint_mask_high_const(&mut self) -> VCodeConstant {
+        self.lower_ctx.use_constant(VCodeConstantData::WellKnown(&UINT_MASK_HIGH))
+    }
 }
 
 impl<C> IsleContext<'_, C, Flags, IsaFlags, 6>
@@ -891,3 +901,11 @@ fn to_simm32(constant: i64) -> Option<GprMemImm> {
         None
     }
 }
+
+const UINT_MASK: [u8; 16] = [
+    0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+const UINT_MASK_HIGH: [u8; 16] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43,
+];

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -1,0 +1,18 @@
+test compile precise-output
+set enable_simd
+target x86_64 has_avx512vl has_avx512f
+
+function %f1(i32x4) -> f32x4 {
+block0(v0: i32x4):
+  v1 = fcvt_from_uint.f32x4 v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vcvtudq2ps %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -170,10 +170,10 @@ block0(v0: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm5
-;   unpcklps %xmm0, %xmm5, %xmm0
-;   load_const VCodeConstant(1), %xmm8
-;   subpd   %xmm0, %xmm8, %xmm0
+;   load_const VCodeConstant(0), %xmm3
+;   unpcklps %xmm0, %xmm3, %xmm0
+;   load_const VCodeConstant(1), %xmm7
+;   subpd   %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -152,10 +152,10 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   cvtsi2ss %rax, %xmm6
 ;   movl    %edx, %eax
 ;   cvtsi2ss %rax, %xmm7
-;   u64_to_f32_seq %rcx, %xmm15, %r8, %rdx
+;   u64_to_f32_seq %rcx, %xmm4, %r8, %rdx
 ;   addss   %xmm0, %xmm6, %xmm0
 ;   addss   %xmm0, %xmm7, %xmm0
-;   addss   %xmm0, %xmm15, %xmm0
+;   addss   %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -146,16 +146,17 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbq  %dil, %r8
-;   cvtsi2ss %r8, %xmm0
-;   movzwq  %si, %r8
-;   cvtsi2ss %r8, %xmm12
-;   movl    %edx, %r8d
-;   cvtsi2ss %r8, %xmm15
-;   u64_to_f32_seq %rcx, %xmm2, %r9, %r10
-;   addss   %xmm0, %xmm12, %xmm0
+;   movzbq  %dil, %rax
+;   cvtsi2ss %rax, %xmm0
+;   movzwq  %si, %rax
+;   cvtsi2ss %rax, %xmm6
+;   movl    %edx, %eax
+;   cvtsi2ss %rax, %xmm7
+;   u64_to_f32_seq %rcx, %xmm15, %r8, %rdx
+;   addss   %xmm0, %xmm6, %xmm0
+;   addss   %xmm0, %xmm7, %xmm0
 ;   addss   %xmm0, %xmm15, %xmm0
-;   addss   %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -187,15 +187,15 @@ block0(v0: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm5
-;   pslld   %xmm5, $16, %xmm5
-;   psrld   %xmm5, $16, %xmm5
-;   psubd   %xmm0, %xmm5, %xmm0
-;   cvtdq2ps %xmm5, %xmm5
+;   movdqa  %xmm0, %xmm4
+;   pslld   %xmm4, $16, %xmm4
+;   psrld   %xmm4, $16, %xmm4
+;   psubd   %xmm0, %xmm4, %xmm0
+;   cvtdq2ps %xmm4, %xmm9
 ;   psrld   %xmm0, $1, %xmm0
 ;   cvtdq2ps %xmm0, %xmm0
 ;   addps   %xmm0, %xmm0, %xmm0
-;   addps   %xmm0, %xmm5, %xmm0
+;   addps   %xmm0, %xmm9, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -178,3 +178,25 @@ block0(v0: i32x4):
 ;   popq    %rbp
 ;   ret
 
+function %f12(i32x4) -> f32x4 {
+block0(v0: i32x4):
+  v1 = fcvt_from_uint.f32x4 v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movdqa  %xmm0, %xmm5
+;   pslld   %xmm5, $16, %xmm5
+;   psrld   %xmm5, $16, %xmm5
+;   psubd   %xmm0, %xmm5, %xmm0
+;   cvtdq2ps %xmm5, %xmm5
+;   psrld   %xmm0, $1, %xmm0
+;   cvtdq2ps %xmm0, %xmm0
+;   addps   %xmm0, %xmm0, %xmm0
+;   addps   %xmm0, %xmm5, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -160,3 +160,21 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   popq    %rbp
 ;   ret
 
+function %f11(i32x4) -> f64x2 {
+block0(v0: i32x4):
+  v1 = uwiden_low v0
+  v2 = fcvt_from_uint.f64x2 v1
+  return v2
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_const VCodeConstant(0), %xmm5
+;   unpcklps %xmm0, %xmm5, %xmm0
+;   load_const VCodeConstant(1), %xmm8
+;   subpd   %xmm0, %xmm8, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -131,3 +131,31 @@ block0(v0: i32x4):
 ;   popq    %rbp
 ;   ret
 
+function %f10(i8, i16, i32, i64) -> f32 {
+block0(v0: i8, v1: i16, v2: i32, v3: i64):
+  v4 = fcvt_from_uint.f32 v0
+  v5 = fcvt_from_uint.f32 v1
+  v6 = fcvt_from_uint.f32 v2
+  v7 = fcvt_from_uint.f32 v3
+  v8 = fadd.f32 v4, v5
+  v9 = fadd.f32 v8, v6
+  v10 = fadd.f32 v9, v7
+  return v10
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movzbq  %dil, %r8
+;   cvtsi2ss %r8, %xmm0
+;   movzwq  %si, %r8
+;   cvtsi2ss %r8, %xmm12
+;   movl    %edx, %r8d
+;   cvtsi2ss %r8, %xmm15
+;   u64_to_f32_seq %rcx, %xmm2, %r9, %r10
+;   addss   %xmm0, %xmm12, %xmm0
+;   addss   %xmm0, %xmm15, %xmm0
+;   addss   %xmm0, %xmm2, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret


### PR DESCRIPTION
Lower `fcvt_from_uint` in ISLE, instead of rust.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
