### PR TITLE
Enable rpm package autobuilds on Fedora Copr

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,44 @@
+# Make targets are run from the root directory
+WD := $(shell pwd)
+COPR_DIR := $(WD)/.copr
+
+# outdir is needed by the make_srpm build type on Fedora copr
+# https://docs.pagure.org/copr.copr/user_documentation.html#make-srpm
+outdir ?= $(COPR_DIR)
+RPM_OPTS ?= --define "_sourcedir $(COPR_DIR)" --define "_specdir $(COPR_DIR)" --define "_builddir $(COPR_DIR)" --define "_srcrpmdir $(outdir)" --define "_rpmdir $(outdir)" --define "_buildrootdir $(COPR_DIR)/.build"
+
+# Only the minimum dependencies to generate the srpm  using Copr's make_srpm
+# method.
+SRPM_DEPS ?= git git-archive-all
+
+ifneq ($(shell id -u), 0)
+SUDO_CMD := sudo
+endif
+
+# These dirs need to be added as safe.directory otherwise Copr's make_srpm complains
+GIT_SAFE_DIRS := tests/spec_testsuite crates/c-api/wasm-c-api crates/wasi-common/WASI crates/wasi-nn/spec crates/wasi-crypto/spec
+
+safe-dir-gitconfig:
+	$(foreach SAFE_DIR,$(GIT_SAFE_DIRS),$(shell git config --global --add safe.directory $(WD)/$(SAFE_DIR)))
+
+clean-safe-dir-gitconfig:
+	$(foreach SAFE_DIR,$(GIT_SAFE_DIRS),$(shell git config --global --unset-all safe.directory $(SAFE_DIR)))
+
+srpm-dep:
+	$(SUDO_CMD) dnf -y install $(SRPM_DEPS)
+
+prep: srpm-dep
+	$(MAKE) -f $(COPR_DIR)/Makefile safe-dir-gitconfig
+	git-archive-all --prefix=wasmtime-HEAD/ --force-submodules $(COPR_DIR)/wasmtime-HEAD.tar.gz
+	$(MAKE) -f $(COPR_DIR)/Makefile clean-safe-dir-gitconfig
+
+spec-generate: srpm-dep
+	sed 's/\#GIT_COMMIT_ID\#/$(shell git rev-parse --short HEAD)/' $(COPR_DIR)/wasmtime.spec.in > $(COPR_DIR)/wasmtime.spec
+
+srpm: prep spec-generate
+	rpmbuild -bs $(RPM_OPTS) $(COPR_DIR)/wasmtime.spec
+
+rpm: prep spec-generate
+	rpmbuild -bb $(RPM_OPTS) $(COPR_DIR)/wasmtime.spec
+
+all: srpm rpm

--- a/.copr/wasmtime.spec.in
+++ b/.copr/wasmtime.spec.in
@@ -1,0 +1,77 @@
+%global desc Standalone runtime for WebAssembly
+%global desc_c_api C API files for %{name}
+%global desc_c_api_devel C API Header files for %{name}
+
+%if 0%{?fedora} >= 36
+%global with_debug 1
+%else
+%global with_debug 0
+%endif
+
+%if 0%{?with_debug}
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%else
+%global debug_package %{nil}
+%endif
+
+Summary: %desc
+Name: wasmtime
+Epoch: 101
+Version: 0.0
+%define build_timestamp %{lua: print(os.date("%Y%m%d%H%M%S"))}
+Release: %{build_timestamp}.#GIT_COMMIT_ID#%{?dist}
+# `make tarball-prep` will generate this from HEAD commit in the repo root dir
+Source0: %{name}-HEAD.tar.gz
+License: ASL 2.0
+URL: https://github.com/bytecodealliance/%{name}
+BuildRequires: cargo
+BuildRequires: git-core
+
+%description
+%desc
+
+%package c-api
+Summary: %desc_c_api
+
+%description c-api
+%desc_c_api
+
+%package c-api-devel
+Summary: %desc_c_api_devel
+
+%description c-api-devel
+%desc_c_api_devel
+
+%prep
+%autosetup -Sgit -n %{name}-HEAD
+
+%build
+cargo build --release
+cargo build --release -p %{name}-c-api
+
+%install
+install -dp %{buildroot}%{_bindir}
+install -Dp -m0755 target/release/%{name} %{buildroot}%{_bindir}
+
+install -dp %{buildroot}%{_includedir}/%{name}
+install -Dp -m0644 crates/c-api/include/%{name}/*.h %{buildroot}%{_includedir}/%{name}
+install -Dp -m0644 crates/c-api/include/*.h %{buildroot}%{_includedir}
+install -Dp -m0644 crates/c-api/wasm-c-api/include/*.h %{buildroot}%{_includedir}
+
+install -dp %{buildroot}%{_libdir}
+install -Dp -m0755 target/release/lib%{name}.so %{buildroot}%{_libdir}
+
+%files
+%license LICENSE
+%{_bindir}/%{name}
+
+%files c-api
+%license crates/c-api/LICENSE
+%{_libdir}/lib%{name}.so
+
+%files c-api-devel
+%license crates/c-api/LICENSE
+%dir %{_includedir}/%{name}
+%{_includedir}/%{name}/*.h
+%{_includedir}/*.h


### PR DESCRIPTION
This commit adds `.copr/Makefile` and `.copr/wasmtime.spec.in` which
combined with a webhook will trigger rpm package builds on Fedora's Copr
environment after every upstream PR merge.

Successful copr build needs to ensure a successful:
```
make -f .copr/Makefile srpm outdir=FOO
```

The resulting rpm package epoch:name-version-release will have the format:
`101:wasmtime-0.0-$(BUILD_TIMESTAMP).$(GIT_SHORTCOMMIT).$(DIST)`

- Epoch is set to 101 to override any distro-supplied wasmtime packages,
  regardless of version.
- Version is set to 0.0 to reflect unreleased version.
- The $(DIST) tag will be the output of `rpm --eval %{?dist}`. So,
  Fedora 36 will have `.fc36`, rhel9 will have `.el9` and so on.

Fixes: #4570

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #4570 , or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [-] This PR contains test cases, if meaningful.
- [-] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).

@alexcrichton @cfallin PTAL and please include any rpm testers you know of to review this.

Successful copr build with this commit is at: https://copr.fedorainfracloud.org/coprs/lsm5/wasmtime/build/4725938/

To test the current build:
```
$ sudo dnf -y copr enable lsm5/wasmtime
$ sudo dnf install wasmtime
```
@giuseppe @font @flouthoc PTAL and test if you have the time.

I will add copr integration info in a followup comment.