### PR TITLE
Don't be clever about representing non-CoW images

### DIFF
--- a/crates/runtime/src/cow_disabled.rs
+++ b/crates/runtime/src/cow_disabled.rs
@@ -35,7 +35,9 @@ impl ModuleMemoryImages {
 /// places (e.g. a `Memory`), we define a zero-sized type when memory is
 /// not included in the build.
 #[derive(Debug)]
-pub enum MemoryImageSlot {}
+pub struct MemoryImageSlot {
+    _priv: (),
+}
 
 #[allow(dead_code)]
 impl MemoryImageSlot {
@@ -48,26 +50,26 @@ impl MemoryImageSlot {
         _: usize,
         _: Option<&Arc<MemoryImage>>,
     ) -> Result<Self, InstantiationError> {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn no_clear_on_drop(&mut self) {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn clear_and_remain_ready(&mut self) -> Result<()> {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn has_image(&self) -> bool {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn is_dirty(&self) -> bool {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn set_heap_limit(&mut self, _: usize) -> Result<()> {
-        match *self {}
+        unreachable!();
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,7 +19,6 @@
         clippy::use_self
     )
 )]
-#![cfg_attr(not(memory_init_cow), allow(unused_variables, unreachable_code))]
 
 use anyhow::Error;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};


### PR DESCRIPTION
This commit fixes a build warning on Rust 1.63 when the `memory-init-cow`
feature is disabled in the `wasmtime-runtime` crate. Some "tricks" were
used prior to have the `MemoryImage` type be an empty `enum {}` but that
wreaks havoc with warnings so this commit instead just makes it a unit
struct and makes all methods panic (as they shouldn't be hit anyway).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
