### PR TITLE
ci: pin toolchain to 1.62.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,8 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: 1.62.1
 
     # Check some feature combinations of the `wasmtime` crate
     - run: cargo check -p wasmtime --no-default-features
@@ -237,6 +239,8 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: 1.62.1
 
     # Install targets in order to build various tests throughout the repo
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown ${{ matrix.target }}
@@ -408,6 +412,8 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: 1.62.1
     - uses: ./.github/actions/binary-compatible-builds
       with:
         name: ${{ matrix.build }}


### PR DESCRIPTION
This change temporarily pins the Rust toolchain used to 1.62.1. The
switch to 1.63.0 on August 11th seems to cause issues when checking the
mutability of certain variables:
https://github.com/bytecodealliance/wasmtime/runs/7791537726?check_suite_focus=true#step:4:106.

This commit can be reverted when that issue is fixed upstream.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
