### PR TITLE
[0.40.0] Fix CI for Rust 1.63.0

### DIFF
--- a/crates/runtime/src/cow_disabled.rs
+++ b/crates/runtime/src/cow_disabled.rs
@@ -35,7 +35,9 @@ impl ModuleMemoryImages {
 /// places (e.g. a `Memory`), we define a zero-sized type when memory is
 /// not included in the build.
 #[derive(Debug)]
-pub enum MemoryImageSlot {}
+pub struct MemoryImageSlot {
+    _priv: (),
+}
 
 #[allow(dead_code)]
 impl MemoryImageSlot {
@@ -48,26 +50,26 @@ impl MemoryImageSlot {
         _: usize,
         _: Option<&Arc<MemoryImage>>,
     ) -> Result<Self, InstantiationError> {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn no_clear_on_drop(&mut self) {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn clear_and_remain_ready(&mut self) -> Result<()> {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn has_image(&self) -> bool {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn is_dirty(&self) -> bool {
-        match *self {}
+        unreachable!();
     }
 
     pub(crate) fn set_heap_limit(&mut self, _: usize) -> Result<()> {
-        match *self {}
+        unreachable!();
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -19,7 +19,6 @@
         clippy::use_self
     )
 )]
-#![cfg_attr(not(memory_init_cow), allow(unused_variables, unreachable_code))]
 
 use anyhow::Error;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};


### PR DESCRIPTION
This is a backport of https://github.com/bytecodealliance/wasmtime/commit/c1c48b4386edc17268c1acd66c3c22c67896ae4c to ensure that the 0.40.0 release CI will be able to progress in a week or so.