### PR TITLE
Cranelift: Remove the `LowerCtx` trait

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -81,23 +81,20 @@ impl ResultRSEImm12 {
 // Lowering: convert instruction inputs to forms that we can use.
 
 /// Lower an instruction input to a 64-bit constant, if possible.
-pub(crate) fn input_to_const<C: LowerCtx<I = Inst>>(ctx: &mut C, input: InsnInput) -> Option<u64> {
+pub(crate) fn input_to_const(ctx: &mut Lower<Inst>, input: InsnInput) -> Option<u64> {
     let input = ctx.get_input_as_source_or_const(input.insn, input.input);
     input.constant
 }
 
 /// Lower an instruction input to a constant register-shift amount, if possible.
-pub(crate) fn input_to_shiftimm<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn input_to_shiftimm(
+    ctx: &mut Lower<Inst>,
     input: InsnInput,
 ) -> Option<ShiftOpShiftImm> {
     input_to_const(ctx, input).and_then(ShiftOpShiftImm::maybe_from_shift)
 }
 
-pub(crate) fn const_param_to_u128<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    inst: IRInst,
-) -> Option<u128> {
+pub(crate) fn const_param_to_u128(ctx: &mut Lower<Inst>, inst: IRInst) -> Option<u128> {
     match ctx.get_immediate(inst) {
         Some(DataValue::V128(bytes)) => Some(u128::from_le_bytes(bytes)),
         _ => None,
@@ -139,7 +136,7 @@ impl NarrowValueMode {
 
 /// Emits instruction(s) to generate the given constant value into newly-allocated
 /// temporary registers, returning these registers.
-fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u128) -> ValueRegs<Reg> {
+fn generate_constant(ctx: &mut Lower<Inst>, ty: Type, c: u128) -> ValueRegs<Reg> {
     let from_bits = ty_bits(ty);
     let masked = if from_bits < 128 {
         c & ((1u128 << from_bits) - 1)
@@ -160,8 +157,8 @@ fn generate_constant<C: LowerCtx<I = Inst>>(ctx: &mut C, ty: Type, c: u128) -> V
 
 /// Extends a register according to `narrow_mode`.
 /// If extended, the value is always extended to 64 bits, for simplicity.
-fn extend_reg<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn extend_reg(
+    ctx: &mut Lower<Inst>,
     ty: Type,
     in_reg: Reg,
     is_const: bool,
@@ -232,10 +229,7 @@ fn extend_reg<C: LowerCtx<I = Inst>>(
 }
 
 /// Lowers an instruction input to multiple regs
-fn lower_value_to_regs<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    value: Value,
-) -> (ValueRegs<Reg>, Type, bool) {
+fn lower_value_to_regs(ctx: &mut Lower<Inst>, value: Value) -> (ValueRegs<Reg>, Type, bool) {
     trace!("lower_value_to_regs: value {:?}", value);
     let ty = ctx.value_ty(value);
     let inputs = ctx.get_value_as_source_or_const(value);
@@ -256,8 +250,8 @@ fn lower_value_to_regs<C: LowerCtx<I = Inst>>(
 /// The given register will be extended appropriately, according to
 /// `narrow_mode` and the input's type. If extended, the value is
 /// always extended to 64 bits, for simplicity.
-pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn put_input_in_reg(
+    ctx: &mut Lower<Inst>,
     input: InsnInput,
     narrow_mode: NarrowValueMode,
 ) -> Reg {
@@ -266,11 +260,7 @@ pub(crate) fn put_input_in_reg<C: LowerCtx<I = Inst>>(
 }
 
 /// Like above, only for values
-fn put_value_in_reg<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    value: Value,
-    narrow_mode: NarrowValueMode,
-) -> Reg {
+fn put_value_in_reg(ctx: &mut Lower<Inst>, value: Value, narrow_mode: NarrowValueMode) -> Reg {
     let (in_regs, ty, is_const) = lower_value_to_regs(ctx, value);
     let reg = in_regs
         .only_reg()
@@ -280,10 +270,7 @@ fn put_value_in_reg<C: LowerCtx<I = Inst>>(
 }
 
 /// Lower an instruction input to multiple regs
-pub(crate) fn put_input_in_regs<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    input: InsnInput,
-) -> ValueRegs<Reg> {
+pub(crate) fn put_input_in_regs(ctx: &mut Lower<Inst>, input: InsnInput) -> ValueRegs<Reg> {
     let value = ctx.input_as_value(input.insn, input.input);
     let (in_regs, _, _) = lower_value_to_regs(ctx, value);
     in_regs
@@ -300,8 +287,8 @@ pub(crate) fn put_input_in_regs<C: LowerCtx<I = Inst>>(
 /// divide or a right-shift or a compare-to-zero), `narrow_mode` should be
 /// set to `ZeroExtend` or `SignExtend` as appropriate, and the resulting
 /// register will be provided the extended value.
-fn put_input_in_rs<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn put_input_in_rs(
+    ctx: &mut Lower<Inst>,
     input: InsnInput,
     narrow_mode: NarrowValueMode,
 ) -> ResultRS {
@@ -334,8 +321,8 @@ fn put_input_in_rs<C: LowerCtx<I = Inst>>(
 /// vreg into which the source instruction will generate its value.
 ///
 /// See note on `put_input_in_rs` for a description of `narrow_mode`.
-fn put_input_in_rse<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn put_input_in_rse(
+    ctx: &mut Lower<Inst>,
     input: InsnInput,
     narrow_mode: NarrowValueMode,
 ) -> ResultRSE {
@@ -348,8 +335,8 @@ fn put_input_in_rse<C: LowerCtx<I = Inst>>(
     ResultRSE::from_rs(put_input_in_rs(ctx, input, narrow_mode))
 }
 
-fn get_as_extended_value<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn get_as_extended_value(
+    ctx: &mut Lower<Inst>,
     val: Value,
     narrow_mode: NarrowValueMode,
 ) -> Option<(Value, ExtendOp)> {
@@ -427,8 +414,8 @@ fn get_as_extended_value<C: LowerCtx<I = Inst>>(
     None
 }
 
-pub(crate) fn put_input_in_rse_imm12<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn put_input_in_rse_imm12(
+    ctx: &mut Lower<Inst>,
     input: InsnInput,
     narrow_mode: NarrowValueMode,
 ) -> ResultRSEImm12 {
@@ -526,8 +513,8 @@ type AddressAddend64List = SmallVec<[Reg; 4]>;
 /// additional masking of high-order bits, which is too complex. So, in essence, we
 /// descend any number of adds from the roots, collecting all 64-bit address addends;
 /// then possibly support extensions at these leaves.
-fn collect_address_addends<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn collect_address_addends(
+    ctx: &mut Lower<Inst>,
     roots: &[InsnInput],
 ) -> (AddressAddend64List, AddressAddend32List, i64) {
     let mut result32: AddressAddend32List = SmallVec::new();
@@ -597,8 +584,8 @@ fn collect_address_addends<C: LowerCtx<I = Inst>>(
 }
 
 /// Lower the address of a pair load or store.
-pub(crate) fn lower_pair_address<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_pair_address(
+    ctx: &mut Lower<Inst>,
     roots: &[InsnInput],
     offset: i32,
 ) -> PairAMode {
@@ -654,8 +641,8 @@ pub(crate) fn lower_pair_address<C: LowerCtx<I = Inst>>(
 }
 
 /// Lower the address of a load or store.
-pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_address(
+    ctx: &mut Lower<Inst>,
     elem_ty: Type,
     roots: &[InsnInput],
     offset: i32,
@@ -764,8 +751,8 @@ pub(crate) fn lower_address<C: LowerCtx<I = Inst>>(
     memarg
 }
 
-fn lower_add_addends<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+fn lower_add_addends(
+    ctx: &mut Lower<Inst>,
     rd: Writable<Reg>,
     addends64: AddressAddend64List,
     addends32: AddressAddend32List,
@@ -803,7 +790,7 @@ fn lower_add_addends<C: LowerCtx<I = Inst>>(
 
 /// Adds into `rd` a signed imm pattern matching the best instruction for it.
 // TODO: This function is duplicated in ctx.gen_add_imm
-fn lower_add_immediate<C: LowerCtx<I = Inst>>(ctx: &mut C, dst: Writable<Reg>, src: Reg, imm: i64) {
+fn lower_add_immediate(ctx: &mut Lower<Inst>, dst: Writable<Reg>, src: Reg, imm: i64) {
     // If we can fit offset or -offset in an imm12, use an add-imm
     // Otherwise, lower the constant first then add.
     if let Some(imm12) = Imm12::maybe_from_u64(imm as u64) {
@@ -834,21 +821,13 @@ fn lower_add_immediate<C: LowerCtx<I = Inst>>(ctx: &mut C, dst: Writable<Reg>, s
     }
 }
 
-pub(crate) fn lower_constant_u64<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    rd: Writable<Reg>,
-    value: u64,
-) {
+pub(crate) fn lower_constant_u64(ctx: &mut Lower<Inst>, rd: Writable<Reg>, value: u64) {
     for inst in Inst::load_constant(rd, value) {
         ctx.emit(inst);
     }
 }
 
-pub(crate) fn lower_constant_f32<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    rd: Writable<Reg>,
-    value: f32,
-) {
+pub(crate) fn lower_constant_f32(ctx: &mut Lower<Inst>, rd: Writable<Reg>, value: f32) {
     let alloc_tmp = |ty| ctx.alloc_tmp(ty).only_reg().unwrap();
 
     for inst in Inst::load_fp_constant32(rd, value.to_bits(), alloc_tmp) {
@@ -856,11 +835,7 @@ pub(crate) fn lower_constant_f32<C: LowerCtx<I = Inst>>(
     }
 }
 
-pub(crate) fn lower_constant_f64<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    rd: Writable<Reg>,
-    value: f64,
-) {
+pub(crate) fn lower_constant_f64(ctx: &mut Lower<Inst>, rd: Writable<Reg>, value: f64) {
     let alloc_tmp = |ty| ctx.alloc_tmp(ty).only_reg().unwrap();
 
     for inst in Inst::load_fp_constant64(rd, value.to_bits(), alloc_tmp) {
@@ -868,11 +843,7 @@ pub(crate) fn lower_constant_f64<C: LowerCtx<I = Inst>>(
     }
 }
 
-pub(crate) fn lower_constant_f128<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
-    rd: Writable<Reg>,
-    value: u128,
-) {
+pub(crate) fn lower_constant_f128(ctx: &mut Lower<Inst>, rd: Writable<Reg>, value: u128) {
     if value == 0 {
         // Fast-track a common case.  The general case, viz, calling `Inst::load_fp_constant128`,
         // is potentially expensive.
@@ -890,8 +861,8 @@ pub(crate) fn lower_constant_f128<C: LowerCtx<I = Inst>>(
     }
 }
 
-pub(crate) fn lower_splat_const<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_splat_const(
+    ctx: &mut Lower<Inst>,
     rd: Writable<Reg>,
     value: u64,
     size: VectorSize,
@@ -974,8 +945,8 @@ pub(crate) fn lower_fp_condcode(cc: FloatCC) -> Cond {
     }
 }
 
-pub(crate) fn lower_vector_compare<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_vector_compare(
+    ctx: &mut Lower<Inst>,
     rd: Writable<Reg>,
     mut rn: Reg,
     mut rm: Reg,
@@ -1114,8 +1085,8 @@ pub(crate) fn choose_32_64<T: Copy>(ty: Type, op32: T, op64: T) -> T {
 }
 
 /// Checks for an instance of `op` feeding the given input.
-pub(crate) fn maybe_input_insn<C: LowerCtx<I = Inst>>(
-    c: &mut C,
+pub(crate) fn maybe_input_insn(
+    c: &mut Lower<Inst>,
     input: InsnInput,
     op: Opcode,
 ) -> Option<IRInst> {
@@ -1137,8 +1108,8 @@ pub(crate) fn maybe_input_insn<C: LowerCtx<I = Inst>>(
 }
 
 /// Checks for an instance of any one of `ops` feeding the given input.
-pub(crate) fn maybe_input_insn_multi<C: LowerCtx<I = Inst>>(
-    c: &mut C,
+pub(crate) fn maybe_input_insn_multi(
+    c: &mut Lower<Inst>,
     input: InsnInput,
     ops: &[Opcode],
 ) -> Option<(Opcode, IRInst)> {
@@ -1155,8 +1126,8 @@ pub(crate) fn maybe_input_insn_multi<C: LowerCtx<I = Inst>>(
 ///
 /// FIXME cfallin 2020-03-30: this is really ugly. Factor out tree-matching stuff and make it
 /// a bit more generic.
-pub(crate) fn maybe_input_insn_via_conv<C: LowerCtx<I = Inst>>(
-    c: &mut C,
+pub(crate) fn maybe_input_insn_via_conv(
+    c: &mut Lower<Inst>,
     input: InsnInput,
     op: Opcode,
     conv: Opcode,
@@ -1222,8 +1193,8 @@ impl IcmpResult {
 ///
 /// We can lower into the status flags, or materialize the result into a register
 /// This is controlled by the `output` parameter.
-pub(crate) fn lower_icmp<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_icmp(
+    ctx: &mut Lower<Inst>,
     insn: IRInst,
     condcode: IntCC,
     output: IcmpOutput,
@@ -1478,7 +1449,7 @@ pub(crate) fn lower_icmp<C: LowerCtx<I = Inst>>(
     })
 }
 
-pub(crate) fn lower_fcmp_or_ffcmp_to_flags<C: LowerCtx<I = Inst>>(ctx: &mut C, insn: IRInst) {
+pub(crate) fn lower_fcmp_or_ffcmp_to_flags(ctx: &mut Lower<Inst>, insn: IRInst) {
     let ty = ctx.input_ty(insn, 0);
     let inputs = [InsnInput { insn, input: 0 }, InsnInput { insn, input: 1 }];
     let rn = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);
@@ -1493,8 +1464,8 @@ pub(crate) fn lower_fcmp_or_ffcmp_to_flags<C: LowerCtx<I = Inst>>(ctx: &mut C, i
 /// Materialize a boolean value into a register from the flags
 /// (e.g set by a comparison).
 /// A 0 / -1 (all-ones) result as expected for bool operations.
-pub(crate) fn materialize_bool_result<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn materialize_bool_result(
+    ctx: &mut Lower<Inst>,
     insn: IRInst,
     rd: Writable<Reg>,
     cond: Cond,
@@ -1524,10 +1495,9 @@ fn load_op_to_ty(op: Opcode) -> Option<Type> {
 /// Helper to lower a load instruction; this is used in several places, because
 /// a load can sometimes be merged into another operation.
 pub(crate) fn lower_load<
-    C: LowerCtx<I = Inst>,
-    F: FnMut(&mut C, ValueRegs<Writable<Reg>>, Type, AMode) -> CodegenResult<()>,
+    F: FnMut(&mut Lower<Inst>, ValueRegs<Writable<Reg>>, Type, AMode) -> CodegenResult<()>,
 >(
-    ctx: &mut C,
+    ctx: &mut Lower<Inst>,
     ir_inst: IRInst,
     inputs: &[InsnInput],
     output: InsnOutput,
@@ -1550,13 +1520,13 @@ pub(crate) fn lower_load<
 impl LowerBackend for AArch64Backend {
     type MInst = Inst;
 
-    fn lower<C: LowerCtx<I = Inst>>(&self, ctx: &mut C, ir_inst: IRInst) -> CodegenResult<()> {
+    fn lower(&self, ctx: &mut Lower<Inst>, ir_inst: IRInst) -> CodegenResult<()> {
         lower_inst::lower_insn_to_regs(ctx, ir_inst, &self.triple, &self.flags, &self.isa_flags)
     }
 
-    fn lower_branch_group<C: LowerCtx<I = Inst>>(
+    fn lower_branch_group(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Inst>,
         branches: &[IRInst],
         targets: &[MachLabel],
     ) -> CodegenResult<()> {

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -24,7 +24,7 @@ use crate::{
     isa::aarch64::inst::args::{ShiftOp, ShiftOpShiftImm},
     isa::aarch64::lower::{writable_vreg, writable_xreg, xreg},
     isa::unwind::UnwindInst,
-    machinst::{ty_bits, InsnOutput, LowerCtx, VCodeConstant, VCodeConstantData},
+    machinst::{ty_bits, InsnOutput, Lower, VCodeConstant, VCodeConstantData},
 };
 use regalloc2::PReg;
 use std::boxed::Box;
@@ -39,17 +39,14 @@ type BoxJTSequenceInfo = Box<JTSequenceInfo>;
 type BoxExternalName = Box<ExternalName>;
 
 /// The main entry point for lowering with ISLE.
-pub(crate) fn lower<C>(
-    lower_ctx: &mut C,
+pub(crate) fn lower(
+    lower_ctx: &mut Lower<MInst>,
     triple: &Triple,
     flags: &Flags,
     isa_flags: &IsaFlags,
     outputs: &[InsnOutput],
     inst: Inst,
-) -> Result<(), ()>
-where
-    C: LowerCtx<I = MInst>,
-{
+) -> Result<(), ()> {
     lower_common(
         lower_ctx,
         triple,
@@ -71,10 +68,7 @@ pub struct SinkableAtomicLoad {
     atomic_addr: Value,
 }
 
-impl<C> generated_code::Context for IsleContext<'_, C, Flags, IsaFlags, 6>
-where
-    C: LowerCtx<I = MInst>,
-{
+impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
 
     fn use_lse(&mut self, _: Inst) -> Option<()> {

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -19,8 +19,8 @@ use core::convert::TryFrom;
 use target_lexicon::Triple;
 
 /// Actually codegen an instruction's results into registers.
-pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_insn_to_regs(
+    ctx: &mut Lower<Inst>,
     insn: IRInst,
     triple: &Triple,
     flags: &Flags,
@@ -39,7 +39,7 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
         return Ok(());
     }
 
-    let implemented_in_isle = |ctx: &mut C| -> ! {
+    let implemented_in_isle = |ctx: &mut Lower<Inst>| -> ! {
         unreachable!(
             "implemented in ISLE: inst = `{}`, type = `{:?}`",
             ctx.dfg().display_inst(insn),
@@ -1621,8 +1621,8 @@ pub(crate) fn lower_insn_to_regs<C: LowerCtx<I = Inst>>(
     Ok(())
 }
 
-pub(crate) fn lower_branch<C: LowerCtx<I = Inst>>(
-    ctx: &mut C,
+pub(crate) fn lower_branch(
+    ctx: &mut Lower<Inst>,
     branches: &[IRInst],
     targets: &[MachLabel],
 ) -> CodegenResult<()> {

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -4,7 +4,7 @@ use crate::ir::Inst as IRInst;
 use crate::ir::Opcode;
 use crate::isa::s390x::inst::Inst;
 use crate::isa::s390x::S390xBackend;
-use crate::machinst::{InsnOutput, LowerBackend, LowerCtx, MachLabel};
+use crate::machinst::{InsnOutput, Lower, LowerBackend, MachLabel};
 use crate::CodegenResult;
 use smallvec::SmallVec;
 
@@ -16,7 +16,7 @@ pub mod isle;
 impl LowerBackend for S390xBackend {
     type MInst = Inst;
 
-    fn lower<C: LowerCtx<I = Inst>>(&self, ctx: &mut C, ir_inst: IRInst) -> CodegenResult<()> {
+    fn lower(&self, ctx: &mut Lower<Inst>, ir_inst: IRInst) -> CodegenResult<()> {
         let op = ctx.data(ir_inst).opcode();
         let outputs: SmallVec<[InsnOutput; 2]> = (0..ctx.num_outputs(ir_inst))
             .map(|i| InsnOutput {
@@ -278,9 +278,9 @@ impl LowerBackend for S390xBackend {
         }
     }
 
-    fn lower_branch_group<C: LowerCtx<I = Inst>>(
+    fn lower_branch_group(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Inst>,
         branches: &[IRInst],
         targets: &[MachLabel],
     ) -> CodegenResult<()> {

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -21,7 +21,7 @@ use crate::{
     isa::unwind::UnwindInst,
     isa::CallConv,
     machinst::abi_impl::ABIMachineSpec,
-    machinst::{InsnOutput, LowerCtx, VCodeConstant, VCodeConstantData},
+    machinst::{InsnOutput, Lower, VCodeConstant, VCodeConstantData},
 };
 use regalloc2::PReg;
 use smallvec::{smallvec, SmallVec};
@@ -46,17 +46,14 @@ type VecMInst = Vec<MInst>;
 type VecMInstBuilder = Cell<Vec<MInst>>;
 
 /// The main entry point for lowering with ISLE.
-pub(crate) fn lower<C>(
-    lower_ctx: &mut C,
+pub(crate) fn lower(
+    lower_ctx: &mut Lower<MInst>,
     triple: &Triple,
     flags: &Flags,
     isa_flags: &IsaFlags,
     outputs: &[InsnOutput],
     inst: Inst,
-) -> Result<(), ()>
-where
-    C: LowerCtx<I = MInst>,
-{
+) -> Result<(), ()> {
     lower_common(
         lower_ctx,
         triple,
@@ -69,17 +66,14 @@ where
 }
 
 /// The main entry point for branch lowering with ISLE.
-pub(crate) fn lower_branch<C>(
-    lower_ctx: &mut C,
+pub(crate) fn lower_branch(
+    lower_ctx: &mut Lower<MInst>,
     triple: &Triple,
     flags: &Flags,
     isa_flags: &IsaFlags,
     branch: Inst,
     targets: &[MachLabel],
-) -> Result<(), ()>
-where
-    C: LowerCtx<I = MInst>,
-{
+) -> Result<(), ()> {
     lower_common(
         lower_ctx,
         triple,
@@ -91,10 +85,7 @@ where
     )
 }
 
-impl<C> generated_code::Context for IsleContext<'_, C, Flags, IsaFlags, 6>
-where
-    C: LowerCtx<I = MInst>,
-{
+impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
 
     fn abi_sig(&mut self, sig_ref: SigRef) -> ABISig {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -30,7 +30,7 @@ use crate::{
         },
     },
     machinst::{
-        isle::*, valueregs, ABICaller, InsnInput, InsnOutput, LowerCtx, MachAtomicRmwOp, MachInst,
+        isle::*, valueregs, ABICaller, InsnInput, InsnOutput, Lower, MachAtomicRmwOp, MachInst,
         VCodeConstant, VCodeConstantData,
     },
 };
@@ -51,17 +51,14 @@ pub struct SinkableLoad {
 }
 
 /// The main entry point for lowering with ISLE.
-pub(crate) fn lower<C>(
-    lower_ctx: &mut C,
+pub(crate) fn lower(
+    lower_ctx: &mut Lower<MInst>,
     triple: &Triple,
     flags: &Flags,
     isa_flags: &IsaFlags,
     outputs: &[InsnOutput],
     inst: Inst,
-) -> Result<(), ()>
-where
-    C: LowerCtx<I = MInst>,
-{
+) -> Result<(), ()> {
     lower_common(
         lower_ctx,
         triple,
@@ -73,17 +70,14 @@ where
     )
 }
 
-pub(crate) fn lower_branch<C>(
-    lower_ctx: &mut C,
+pub(crate) fn lower_branch(
+    lower_ctx: &mut Lower<MInst>,
     triple: &Triple,
     flags: &Flags,
     isa_flags: &IsaFlags,
     branch: Inst,
     targets: &[MachLabel],
-) -> Result<(), ()>
-where
-    C: LowerCtx<I = MInst>,
-{
+) -> Result<(), ()> {
     lower_common(
         lower_ctx,
         triple,
@@ -95,10 +89,7 @@ where
     )
 }
 
-impl<C> Context for IsleContext<'_, C, Flags, IsaFlags, 6>
-where
-    C: LowerCtx<I = MInst>,
-{
+impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
 
     #[inline]
@@ -784,10 +775,7 @@ where
     }
 }
 
-impl<C> IsleContext<'_, C, Flags, IsaFlags, 6>
-where
-    C: LowerCtx<I = MInst>,
-{
+impl IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     fn abi_arg_slot_regs(&mut self, arg: &ABIArg) -> Option<WritableValueRegs> {
         match arg {
             &ABIArg::Slots { ref slots, .. } => match slots.len() {

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -194,45 +194,40 @@ pub trait ABICaller {
     /// Emit a copy of an argument value from a source register, prior to the call.
     /// For large arguments with associated stack buffer, this may load the address
     /// of the buffer into the argument register, if required by the ABI.
-    fn emit_copy_regs_to_arg<C: LowerCtx<I = Self::I>>(
-        &self,
-        ctx: &mut C,
-        idx: usize,
-        from_reg: ValueRegs<Reg>,
-    );
+    fn emit_copy_regs_to_arg(&self, ctx: &mut Lower<Self::I>, idx: usize, from_reg: ValueRegs<Reg>);
 
     /// Emit a copy of a large argument into its associated stack buffer, if any.
     /// We must be careful to perform all these copies (as necessary) before setting
     /// up the argument registers, since we may have to invoke memcpy(), which could
     /// clobber any registers already set up.  The back-end should call this routine
     /// for all arguments before calling emit_copy_regs_to_arg for all arguments.
-    fn emit_copy_regs_to_buffer<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_regs_to_buffer(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Self::I>,
         idx: usize,
         from_reg: ValueRegs<Reg>,
     );
 
     /// Emit a copy a return value into a destination register, after the call returns.
-    fn emit_copy_retval_to_regs<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_retval_to_regs(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Self::I>,
         idx: usize,
         into_reg: ValueRegs<Writable<Reg>>,
     );
 
     /// Emit code to pre-adjust the stack, prior to argument copies and call.
-    fn emit_stack_pre_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
+    fn emit_stack_pre_adjust(&self, ctx: &mut Lower<Self::I>);
 
     /// Emit code to post-adjust the satck, after call return and return-value copies.
-    fn emit_stack_post_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
+    fn emit_stack_post_adjust(&self, ctx: &mut Lower<Self::I>);
 
     /// Accumulate outgoing arguments.  This ensures that the caller (as
     /// identified via the CTX argument) allocates enough space in the
     /// prologue to hold all arguments and return values for this call.
     /// There is no code emitted at the call site, everything is done
     /// in the caller's function prologue.
-    fn accumulate_outgoing_args_size<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C);
+    fn accumulate_outgoing_args_size(&self, ctx: &mut Lower<Self::I>);
 
     /// Emit the call itself.
     ///
@@ -247,5 +242,5 @@ pub trait ABICaller {
     ///
     /// This function should only be called once, as it is allowed to re-use
     /// parts of the ABICaller object in emitting instructions.
-    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C);
+    fn emit_call(&mut self, ctx: &mut Lower<Self::I>);
 }

--- a/cranelift/codegen/src/machinst/abi_impl.rs
+++ b/cranelift/codegen/src/machinst/abi_impl.rs
@@ -1681,11 +1681,7 @@ impl<M: ABIMachineSpec> ABICallerImpl<M> {
     }
 }
 
-fn adjust_stack_and_nominal_sp<M: ABIMachineSpec, C: LowerCtx<I = M::I>>(
-    ctx: &mut C,
-    off: i32,
-    is_sub: bool,
-) {
+fn adjust_stack_and_nominal_sp<M: ABIMachineSpec>(ctx: &mut Lower<M::I>, off: i32, is_sub: bool) {
     if off == 0 {
         return;
     }
@@ -1707,24 +1703,24 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         }
     }
 
-    fn accumulate_outgoing_args_size<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
+    fn accumulate_outgoing_args_size(&self, ctx: &mut Lower<Self::I>) {
         let off = self.sig.sized_stack_arg_space + self.sig.sized_stack_ret_space;
         ctx.abi().accumulate_outgoing_args_size(off as u32);
     }
 
-    fn emit_stack_pre_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
+    fn emit_stack_pre_adjust(&self, ctx: &mut Lower<Self::I>) {
         let off = self.sig.sized_stack_arg_space + self.sig.sized_stack_ret_space;
-        adjust_stack_and_nominal_sp::<M, C>(ctx, off as i32, /* is_sub = */ true)
+        adjust_stack_and_nominal_sp::<M>(ctx, off as i32, /* is_sub = */ true)
     }
 
-    fn emit_stack_post_adjust<C: LowerCtx<I = Self::I>>(&self, ctx: &mut C) {
+    fn emit_stack_post_adjust(&self, ctx: &mut Lower<Self::I>) {
         let off = self.sig.sized_stack_arg_space + self.sig.sized_stack_ret_space;
-        adjust_stack_and_nominal_sp::<M, C>(ctx, off as i32, /* is_sub = */ false)
+        adjust_stack_and_nominal_sp::<M>(ctx, off as i32, /* is_sub = */ false)
     }
 
-    fn emit_copy_regs_to_buffer<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_regs_to_buffer(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Self::I>,
         idx: usize,
         from_regs: ValueRegs<Reg>,
     ) {
@@ -1754,9 +1750,9 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         }
     }
 
-    fn emit_copy_regs_to_arg<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_regs_to_arg(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Self::I>,
         idx: usize,
         from_regs: ValueRegs<Reg>,
     ) {
@@ -1837,9 +1833,9 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         }
     }
 
-    fn emit_copy_retval_to_regs<C: LowerCtx<I = Self::I>>(
+    fn emit_copy_retval_to_regs(
         &self,
-        ctx: &mut C,
+        ctx: &mut Lower<Self::I>,
         idx: usize,
         into_regs: ValueRegs<Writable<Reg>>,
     ) {
@@ -1873,7 +1869,7 @@ impl<M: ABIMachineSpec> ABICaller for ABICallerImpl<M> {
         }
     }
 
-    fn emit_call<C: LowerCtx<I = Self::I>>(&mut self, ctx: &mut C) {
+    fn emit_call(&mut self, ctx: &mut Lower<Self::I>) {
         let (uses, defs) = (
             mem::replace(&mut self.uses, Default::default()),
             mem::replace(&mut self.defs, Default::default()),

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -1,6 +1,6 @@
 //! Miscellaneous helpers for machine backends.
 
-use super::{InsnOutput, LowerCtx, VCodeInst, ValueRegs};
+use super::{InsnOutput, Lower, VCodeInst, ValueRegs};
 use super::{Reg, Writable};
 use crate::ir::Type;
 use std::ops::{Add, BitAnd, Not, Sub};
@@ -21,8 +21,8 @@ pub(crate) fn ty_has_float_or_vec_representation(ty: Type) -> bool {
 }
 
 /// Allocate a register for an instruction output and return it.
-pub(crate) fn get_output_reg<I: VCodeInst, C: LowerCtx<I = I>>(
-    ctx: &mut C,
+pub(crate) fn get_output_reg<I: VCodeInst>(
+    ctx: &mut Lower<I>,
     spec: InsnOutput,
 ) -> ValueRegs<Writable<Reg>> {
     ctx.get_output(spec.insn, spec.output)

--- a/cranelift/codegen/src/machinst/inst_common.rs
+++ b/cranelift/codegen/src/machinst/inst_common.rs
@@ -1,6 +1,6 @@
 //! A place to park MachInst::Inst fragments which are common across multiple architectures.
 
-use super::{LowerCtx, VCodeInst};
+use super::{Lower, VCodeInst};
 use crate::ir::{self, Inst as IRInst};
 use smallvec::SmallVec;
 
@@ -24,17 +24,14 @@ pub(crate) struct InsnOutput {
     pub(crate) output: usize,
 }
 
-pub(crate) fn insn_inputs<I: VCodeInst, C: LowerCtx<I = I>>(
-    ctx: &C,
-    insn: IRInst,
-) -> SmallVec<[InsnInput; 4]> {
+pub(crate) fn insn_inputs<I: VCodeInst>(ctx: &Lower<I>, insn: IRInst) -> SmallVec<[InsnInput; 4]> {
     (0..ctx.num_inputs(insn))
         .map(|i| InsnInput { insn, input: i })
         .collect()
 }
 
-pub(crate) fn insn_outputs<I: VCodeInst, C: LowerCtx<I = I>>(
-    ctx: &C,
+pub(crate) fn insn_outputs<I: VCodeInst>(
+    ctx: &Lower<I>,
     insn: IRInst,
 ) -> SmallVec<[InsnOutput; 4]> {
     (0..ctx.num_outputs(insn))


### PR DESCRIPTION
The trait had only one implementation: the `Lower` struct. It is easier to just
use that directly, and not introduce unnecessary layers of generics and
abstractions.

Once upon a time, there was hope that we would have other implementations of the
`LowerCtx` trait, that did things like lower CLIF to SMTLIB for
verification. However, this is not practical these days given the way that the
trait has evolved over time, and our verification efforts are focused on ISLE
now anyways, and we're actually making some progress on that front (much more
than anyone ever did on a second `LowerCtx` trait implementation!)

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
