### PR TITLE
cranelift: fix build warning

### DIFF
--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -423,7 +423,8 @@ where
         }
         Opcode::GetPinnedReg => assign(state.get_pinned_reg()),
         Opcode::SetPinnedReg => {
-            state.set_pinned_reg(arg(0)?);
+            let arg0 = arg(0)?;
+            state.set_pinned_reg(arg0);
             ControlFlow::Continue
         }
         Opcode::TableAddr => {


### PR DESCRIPTION
In #4375 we introduced a code pattern that appears as a warning when
building the `cranelift-interpreter` crate:

```
warning: cannot borrow `*state` as mutable because it is also borrowed as immutable
   --> cranelift/interpreter/src/step.rs:412:13
    |
47  |     let arg = |index: usize| -> Result<V, StepError> {
    |               -------------------------------------- immutable borrow occurs here
48  |         let value_ref = inst_context.args()[index];
49  |         state
    |         ----- first borrow occurs due to use of `*state` in closure
...
412 |             state.set_pinned_reg(arg(0)?);
    |             ^^^^^^^^^^^^^^^^^^^^^---^^^^^
    |             |                    |
    |             |                    immutable borrow later used here
    |             mutable borrow occurs here
    |
    = note: `#[warn(mutable_borrow_reservation_conflict)]` on by default
    = warning: this borrowing pattern was not meant to be accepted, and may become a hard error in the future
    = note: for more information, see issue #59159 <https://github.com/rust-lang/rust/issues/59159>
```

This change fixes the warning.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
