### PR TITLE
cranelift: Fix `icmp.i128 eq` for aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -210,6 +210,14 @@
         (rd WritableReg)
         (cond Cond))
 
+       ;; A conditional comparison with a second register.
+       (CCmp
+        (size OperandSize)
+        (rn Reg)
+        (rm Reg)
+        (nzcv NZCV)
+        (cond Cond))
+
        ;; A conditional comparison with an immediate.
        (CCmpImm
         (size OperandSize)

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -2183,6 +2183,28 @@ fn test_aarch64_binemit() {
         "csetm x16, vs",
     ));
     insns.push((
+        Inst::CCmp {
+            size: OperandSize::Size64,
+            rn: xreg(22),
+            rm: xreg(1),
+            nzcv: NZCV::new(false, false, true, true),
+            cond: Cond::Eq,
+        },
+        "C30241FA",
+        "ccmp x22, x1, #nzCV, eq",
+    ));
+    insns.push((
+        Inst::CCmp {
+            size: OperandSize::Size32,
+            rn: xreg(3),
+            rm: xreg(28),
+            nzcv: NZCV::new(true, true, true, true),
+            cond: Cond::Gt,
+        },
+        "6FC05C7A",
+        "ccmp w3, w28, #NZCV, gt",
+    ));
+    insns.push((
         Inst::CCmpImm {
             size: OperandSize::Size64,
             rn: xreg(22),

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -674,6 +674,10 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
         &Inst::CSet { rd, .. } | &Inst::CSetm { rd, .. } => {
             collector.reg_def(rd);
         }
+        &Inst::CCmp { rn, rm, .. } => {
+            collector.reg_use(rn);
+            collector.reg_use(rm);
+        }
         &Inst::CCmpImm { rn, .. } => {
             collector.reg_use(rn);
         }
@@ -1530,6 +1534,19 @@ impl Inst {
                 let rd = pretty_print_ireg(rd.to_reg(), OperandSize::Size64, allocs);
                 let cond = cond.pretty_print(0, allocs);
                 format!("csetm {}, {}", rd, cond)
+            }
+            &Inst::CCmp {
+                size,
+                rn,
+                rm,
+                nzcv,
+                cond,
+            } => {
+                let rn = pretty_print_ireg(rn, size, allocs);
+                let rm = pretty_print_ireg(rm, size, allocs);
+                let nzcv = nzcv.pretty_print(0, allocs);
+                let cond = cond.pretty_print(0, allocs);
+                format!("ccmp {}, {}, {}, {}", rn, rm, nzcv, cond)
             }
             &Inst::CCmpImm {
                 size,

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -20,10 +20,8 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   eor x10, x0, x2
-;   eor x12, x1, x3
-;   orr x10, x10, x12
-;   subs x10, x10, xzr
+;   subs xzr, x0, x2
+;   ccmp x1, x3, #nzcv, eq
 ;   cset x0, eq
 ;   ret
 
@@ -34,10 +32,8 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   eor x10, x0, x2
-;   eor x12, x1, x3
-;   orr x10, x10, x12
-;   subs x10, x10, xzr
+;   subs xzr, x0, x2
+;   ccmp x1, x3, #nzcv, eq
 ;   cset x0, ne
 ;   ret
 
@@ -280,10 +276,8 @@ block1:
 }
 
 ; block0:
-;   eor x8, x0, x2
-;   eor x10, x1, x3
-;   orr x8, x8, x10
-;   subs x8, x8, xzr
+;   subs xzr, x0, x2
+;   ccmp x1, x3, #nzcv, eq
 ;   b.eq label1 ; b label2
 ; block1:
 ;   b label3
@@ -302,10 +296,8 @@ block1:
 }
 
 ; block0:
-;   eor x8, x0, x2
-;   eor x10, x1, x3
-;   orr x8, x8, x10
-;   subs x8, x8, xzr
+;   subs xzr, x0, x2
+;   ccmp x1, x3, #nzcv, eq
 ;   b.ne label1 ; b label2
 ; block1:
 ;   b label3

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -22,7 +22,8 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   eor x10, x0, x2
 ;   eor x12, x1, x3
-;   adds xzr, x10, x12
+;   orr x10, x10, x12
+;   subs x10, x10, xzr
 ;   cset x0, eq
 ;   ret
 
@@ -35,7 +36,8 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   eor x10, x0, x2
 ;   eor x12, x1, x3
-;   adds xzr, x10, x12
+;   orr x10, x10, x12
+;   subs x10, x10, xzr
 ;   cset x0, ne
 ;   ret
 
@@ -280,7 +282,8 @@ block1:
 ; block0:
 ;   eor x8, x0, x2
 ;   eor x10, x1, x3
-;   adds xzr, x8, x10
+;   orr x8, x8, x10
+;   subs x8, x8, xzr
 ;   b.eq label1 ; b label2
 ; block1:
 ;   b label3
@@ -301,7 +304,8 @@ block1:
 ; block0:
 ;   eor x8, x0, x2
 ;   eor x10, x1, x3
-;   adds xzr, x8, x10
+;   orr x8, x8, x10
+;   subs x8, x8, xzr
 ;   b.ne label1 ; b label2
 ; block1:
 ;   b label3

--- a/cranelift/filetests/filetests/runtests/i128-icmp.clif
+++ b/cranelift/filetests/filetests/runtests/i128-icmp.clif
@@ -20,6 +20,9 @@ block0(v0: i128, v1: i128):
 ; run: %icmp_eq_i128(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF, 0x00000000_00000001_00000000_00000001) == false
 ; run: %icmp_eq_i128(0x00000000_00000001_FFFFFFFF_FFFFFFFF, 0x00000000_00000001_00000000_00000001) == false
 
+; This is a regression test for aarch64, see: https://github.com/bytecodealliance/wasmtime/issues/4705
+; run: %icmp_eq_i128(36893488147419103231, 0) == false
+
 
 function %icmp_ne_i128(i128, i128) -> b1 {
 block0(v0: i128, v1: i128):


### PR DESCRIPTION
👋 Hey,

This fixes #4705. I mostly just copied what LLVM is doing (see: https://godbolt.org/z/GbvErThK1)

cc: @akirilov-arm 
cc: https://github.com/bjorn3/rustc_codegen_cranelift/issues/1256