### PR TITLE
Refactor and optimize the flat type calculations

### DIFF
--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -1015,7 +1015,7 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
             });
         }
         FlagsSize::Size4Plus(n) => {
-            count = n;
+            count = usize::from(n);
             as_array = TokenStream::new();
             bitor = TokenStream::new();
             bitor_assign = TokenStream::new();
@@ -1072,7 +1072,7 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
                 .map(|i| {
                     let field = format_ident!("__inner{}", i);
 
-                    let init = if index / 32 == i {
+                    let init = if index / 32 == usize::from(i) {
                         1_u32 << (index % 32)
                     } else {
                         0

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -60,7 +60,7 @@ pub enum FlagsSize {
     /// Flags can fit in a u16
     Size2,
     /// Flags can fit in a specified number of u32 fields
-    Size4Plus(usize),
+    Size4Plus(u8),
 }
 
 impl FlagsSize {
@@ -73,7 +73,11 @@ impl FlagsSize {
         } else if count <= 16 {
             FlagsSize::Size2
         } else {
-            FlagsSize::Size4Plus(ceiling_divide(count, 32))
+            let amt = ceiling_divide(count, 32);
+            if amt > (u8::MAX as usize) {
+                panic!("too many flags");
+            }
+            FlagsSize::Size4Plus(amt as u8)
         }
     }
 }

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -174,7 +174,6 @@ impl Factc {
         }
         types.pop_type_scope();
 
-        let types = types.finish();
         let mut fact_module = Module::new(&types, self.debug);
         for (i, adapter) in adapters.iter().enumerate() {
             fact_module.adapt(&format!("adapter{i}"), adapter);

--- a/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
+++ b/crates/environ/fuzz/fuzz_targets/fact-valid-module.rs
@@ -143,7 +143,6 @@ fn target(module: GenAdapterModule) {
         types.pop_type_scope();
     }
 
-    let types = types.finish();
     let mut fact_module = Module::new(&types, module.debug);
     for (i, adapter) in adapters.iter().enumerate() {
         fact_module.adapt(&format!("adapter{i}"), adapter);

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -184,10 +184,7 @@ impl<'data> Translator<'_, 'data> {
         // the module using standard core wasm translation, and then fills out
         // the dfg metadata for each adapter.
         for (module_id, adapter_module) in state.adapter_modules.iter() {
-            let mut module = fact::Module::new(
-                self.types.component_types(),
-                self.tunables.debug_adapter_modules,
-            );
+            let mut module = fact::Module::new(self.types, self.tunables.debug_adapter_modules);
             let mut names = Vec::with_capacity(adapter_module.adapters.len());
             for adapter in adapter_module.adapters.iter() {
                 let name = format!("adapter{}", adapter.as_u32());

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1,3 +1,4 @@
+use crate::component::{MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
 use crate::{
     EntityType, Global, GlobalInit, ModuleTypes, ModuleTypesBuilder, PrimaryMap, SignatureIndex,
 };
@@ -318,12 +319,32 @@ pub struct ComponentTypesBuilder {
 
     component_types: ComponentTypes,
     module_types: ModuleTypesBuilder,
+
+    // Cache of what the "flat" representation of all types are which is only
+    // used at compile-time and not used at runtime, hence the location here
+    // as opposed to `ComponentTypes`.
+    flat: FlatTypesCache,
 }
 
 #[derive(Default)]
 struct TypeScope {
     core: PrimaryMap<TypeIndex, TypeDef>,
     component: PrimaryMap<ComponentTypeIndex, TypeDef>,
+}
+
+macro_rules! intern_and_fill_flat_types {
+    ($me:ident, $name:ident, $val:ident) => {{
+        if let Some(idx) = $me.$name.get(&$val) {
+            return *idx;
+        }
+        let idx = $me.component_types.$name.push($val.clone());
+        let mut storage = FlatTypesStorage::new();
+        storage.$name($me, &$val);
+        let idx2 = $me.flat.$name.push(storage);
+        assert_eq!(idx, idx2);
+        $me.$name.insert($val, idx);
+        return idx;
+    }};
 }
 
 impl ComponentTypesBuilder {
@@ -769,42 +790,42 @@ impl ComponentTypesBuilder {
 
     /// Interns a new record type within this type information.
     pub fn add_record_type(&mut self, ty: TypeRecord) -> TypeRecordIndex {
-        intern(&mut self.records, &mut self.component_types.records, ty)
+        intern_and_fill_flat_types!(self, records, ty)
     }
 
     /// Interns a new flags type within this type information.
     pub fn add_flags_type(&mut self, ty: TypeFlags) -> TypeFlagsIndex {
-        intern(&mut self.flags, &mut self.component_types.flags, ty)
+        intern_and_fill_flat_types!(self, flags, ty)
     }
 
     /// Interns a new tuple type within this type information.
     pub fn add_tuple_type(&mut self, ty: TypeTuple) -> TypeTupleIndex {
-        intern(&mut self.tuples, &mut self.component_types.tuples, ty)
+        intern_and_fill_flat_types!(self, tuples, ty)
     }
 
     /// Interns a new variant type within this type information.
     pub fn add_variant_type(&mut self, ty: TypeVariant) -> TypeVariantIndex {
-        intern(&mut self.variants, &mut self.component_types.variants, ty)
+        intern_and_fill_flat_types!(self, variants, ty)
     }
 
     /// Interns a new union type within this type information.
     pub fn add_union_type(&mut self, ty: TypeUnion) -> TypeUnionIndex {
-        intern(&mut self.unions, &mut self.component_types.unions, ty)
+        intern_and_fill_flat_types!(self, unions, ty)
     }
 
     /// Interns a new enum type within this type information.
     pub fn add_enum_type(&mut self, ty: TypeEnum) -> TypeEnumIndex {
-        intern(&mut self.enums, &mut self.component_types.enums, ty)
+        intern_and_fill_flat_types!(self, enums, ty)
     }
 
     /// Interns a new option type within this type information.
     pub fn add_option_type(&mut self, ty: TypeOption) -> TypeOptionIndex {
-        intern(&mut self.options, &mut self.component_types.options, ty)
+        intern_and_fill_flat_types!(self, options, ty)
     }
 
     /// Interns a new expected type within this type information.
     pub fn add_expected_type(&mut self, ty: TypeExpected) -> TypeExpectedIndex {
-        intern(&mut self.expecteds, &mut self.component_types.expecteds, ty)
+        intern_and_fill_flat_types!(self, expecteds, ty)
     }
 
     /// Interns a new expected type within this type information.
@@ -814,6 +835,43 @@ impl ComponentTypesBuilder {
             &mut self.component_types.interface_types,
             ty,
         )
+    }
+
+    /// Returns the canonical ABI information about the specified type.
+    pub fn canonical_abi(&self, ty: &InterfaceType) -> &CanonicalAbiInfo {
+        self.component_types.canonical_abi(ty)
+    }
+
+    /// Returns the "flat types" for the given interface type used in the
+    /// canonical ABI.
+    ///
+    /// Returns `None` if the type is too large to be represented via flat types
+    /// in the canonical abi.
+    pub fn flat_types(&self, ty: &InterfaceType) -> Option<FlatTypes<'_>> {
+        match ty {
+            InterfaceType::Unit => Some(FlatTypes::EMPTY),
+            InterfaceType::U8
+            | InterfaceType::S8
+            | InterfaceType::Bool
+            | InterfaceType::U16
+            | InterfaceType::S16
+            | InterfaceType::U32
+            | InterfaceType::S32
+            | InterfaceType::Char => Some(FlatTypes::I32),
+            InterfaceType::U64 | InterfaceType::S64 => Some(FlatTypes::I64),
+            InterfaceType::Float32 => Some(FlatTypes::F32),
+            InterfaceType::Float64 => Some(FlatTypes::F64),
+            InterfaceType::String | InterfaceType::List(_) => Some(FlatTypes::POINTER_PAIR),
+
+            InterfaceType::Record(i) => self.flat.records[*i].as_flat_types(),
+            InterfaceType::Variant(i) => self.flat.variants[*i].as_flat_types(),
+            InterfaceType::Tuple(i) => self.flat.tuples[*i].as_flat_types(),
+            InterfaceType::Flags(i) => self.flat.flags[*i].as_flat_types(),
+            InterfaceType::Enum(i) => self.flat.enums[*i].as_flat_types(),
+            InterfaceType::Union(i) => self.flat.unions[*i].as_flat_types(),
+            InterfaceType::Option(i) => self.flat.options[*i].as_flat_types(),
+            InterfaceType::Expected(i) => self.flat.expecteds[*i].as_flat_types(),
+        }
     }
 }
 
@@ -1395,4 +1453,256 @@ pub struct TypeExpected {
     pub abi: CanonicalAbiInfo,
     /// Byte information about this variant type.
     pub info: VariantInfo,
+}
+
+const MAX_FLAT_TYPES: usize = if MAX_FLAT_PARAMS > MAX_FLAT_RESULTS {
+    MAX_FLAT_PARAMS
+} else {
+    MAX_FLAT_RESULTS
+};
+
+/// Flat representation of a type in just core wasm types.
+pub struct FlatTypes<'a> {
+    /// The flat representation of this type in 32-bit memories.
+    pub memory32: &'a [FlatType],
+    /// The flat representation of this type in 64-bit memories.
+    pub memory64: &'a [FlatType],
+}
+
+#[allow(missing_docs)]
+impl FlatTypes<'_> {
+    pub const EMPTY: FlatTypes<'static> = FlatTypes::new(&[]);
+    pub const I32: FlatTypes<'static> = FlatTypes::new(&[FlatType::I32]);
+    pub const I64: FlatTypes<'static> = FlatTypes::new(&[FlatType::I64]);
+    pub const F32: FlatTypes<'static> = FlatTypes::new(&[FlatType::F32]);
+    pub const F64: FlatTypes<'static> = FlatTypes::new(&[FlatType::F64]);
+    pub const POINTER_PAIR: FlatTypes<'static> = FlatTypes {
+        memory32: &[FlatType::I32, FlatType::I32],
+        memory64: &[FlatType::I64, FlatType::I64],
+    };
+
+    const fn new(flat: &[FlatType]) -> FlatTypes<'_> {
+        FlatTypes {
+            memory32: flat,
+            memory64: flat,
+        }
+    }
+
+    /// Returns the number of flat types used to represent this type.
+    ///
+    /// Note that this length is the same regardless to the size of memory.
+    pub fn len(&self) -> usize {
+        assert_eq!(self.memory32.len(), self.memory64.len());
+        self.memory32.len()
+    }
+}
+
+// Note that this is intentionally duplicated here to keep the size to 1 byte
+// irregardless to changes in the core wasm type system since this will only
+// ever use integers/floats for the forseeable future.
+#[derive(PartialEq, Eq, Copy, Clone)]
+#[allow(missing_docs)]
+pub enum FlatType {
+    I32,
+    I64,
+    F32,
+    F64,
+}
+
+#[derive(Default)]
+struct FlatTypesCache {
+    records: PrimaryMap<TypeRecordIndex, FlatTypesStorage>,
+    variants: PrimaryMap<TypeVariantIndex, FlatTypesStorage>,
+    tuples: PrimaryMap<TypeTupleIndex, FlatTypesStorage>,
+    enums: PrimaryMap<TypeEnumIndex, FlatTypesStorage>,
+    flags: PrimaryMap<TypeFlagsIndex, FlatTypesStorage>,
+    unions: PrimaryMap<TypeUnionIndex, FlatTypesStorage>,
+    options: PrimaryMap<TypeOptionIndex, FlatTypesStorage>,
+    expecteds: PrimaryMap<TypeExpectedIndex, FlatTypesStorage>,
+}
+
+struct FlatTypesStorage {
+    // This could be represented as `Vec<FlatType>` but on 64-bit architectures
+    // that's 24 bytes. Otherwise `FlatType` is 1 byte large and
+    // `MAX_FLAT_TYPES` is 16, so it should ideally be more space-efficient to
+    // use a flat array instead of a heap-based vector.
+    memory32: [FlatType; MAX_FLAT_TYPES],
+    memory64: [FlatType; MAX_FLAT_TYPES],
+
+    // Tracks the number of flat types pushed into this storage. If this is
+    // `MAX_FLAT_TYPES + 1` then this storage represents an un-reprsentable
+    // type in flat types.
+    len: u8,
+}
+
+impl FlatTypesStorage {
+    fn new() -> FlatTypesStorage {
+        FlatTypesStorage {
+            memory32: [FlatType::I32; MAX_FLAT_TYPES],
+            memory64: [FlatType::I32; MAX_FLAT_TYPES],
+            len: 0,
+        }
+    }
+
+    fn as_flat_types(&self) -> Option<FlatTypes<'_>> {
+        let len = usize::from(self.len);
+        if len > MAX_FLAT_TYPES {
+            assert_eq!(len, MAX_FLAT_TYPES + 1);
+            None
+        } else {
+            Some(FlatTypes {
+                memory32: &self.memory32[..len],
+                memory64: &self.memory64[..len],
+            })
+        }
+    }
+
+    /// Pushes a new flat type into this list using `t32` for 32-bit memories
+    /// and `t64` for 64-bit memories.
+    ///
+    /// Returns whether the type was actually pushed or whether this list of
+    /// flat types just exceeded the maximum meaning that it is now
+    /// unrepresentable with a flat list of types.
+    fn push(&mut self, t32: FlatType, t64: FlatType) -> bool {
+        let len = usize::from(self.len);
+        if len < MAX_FLAT_TYPES {
+            self.memory32[len] = t32;
+            self.memory64[len] = t64;
+            self.len += 1;
+            true
+        } else {
+            // If this was the first one to go over then flag the length as
+            // being incompatible with a flat representation.
+            if len == MAX_FLAT_TYPES {
+                self.len += 1;
+            }
+            false
+        }
+    }
+
+    /// Builds up all flat types internally using the specified representation
+    /// for all of the component fields of the record.
+    fn build_record<'a>(&mut self, types: impl Iterator<Item = Option<FlatTypes<'a>>>) {
+        for ty in types {
+            let types = match ty {
+                Some(types) => types,
+                None => {
+                    self.len = u8::try_from(MAX_FLAT_TYPES + 1).unwrap();
+                    return;
+                }
+            };
+            for (t32, t64) in types.memory32.iter().zip(types.memory64) {
+                if !self.push(*t32, *t64) {
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Builds up the flat types used to represent a `variant` which notably
+    /// handles "join"ing types together so each case is representable as a
+    /// single flat list of types.
+    fn build_variant<'a, I>(&mut self, cases: I)
+    where
+        I: IntoIterator<Item = Option<FlatTypes<'a>>>,
+    {
+        let cases = cases.into_iter();
+        self.push(FlatType::I32, FlatType::I32);
+
+        for ty in cases {
+            let types = match ty {
+                Some(types) => types,
+                // If this case isn't representable with a flat list of types
+                // then this variant also isn't representable.
+                None => {
+                    self.len = u8::try_from(MAX_FLAT_TYPES + 1).unwrap();
+                    return;
+                }
+            };
+            // If the case used all of the flat types then the discriminant
+            // added for this variant means that this variant is no longer
+            // representable.
+            if types.memory32.len() >= MAX_FLAT_TYPES {
+                self.len = u8::try_from(MAX_FLAT_TYPES + 1).unwrap();
+                return;
+            }
+            let dst = self.memory32.iter_mut().zip(&mut self.memory64).skip(1);
+            for (i, ((t32, t64), (dst32, dst64))) in types
+                .memory32
+                .iter()
+                .zip(types.memory64)
+                .zip(dst)
+                .enumerate()
+            {
+                if i + 1 < usize::from(self.len) {
+                    // If this index hs already been set by some previous case
+                    // then the types are joined together.
+                    dst32.join(*t32);
+                    dst64.join(*t64);
+                } else {
+                    // Otherwise if this is the first time that the
+                    // representation has gotten this large then the destination
+                    // is simply whatever the type is. The length is also
+                    // increased here to indicate this.
+                    self.len += 1;
+                    *dst32 = *t32;
+                    *dst64 = *t64;
+                }
+            }
+        }
+    }
+
+    fn records(&mut self, types: &ComponentTypesBuilder, ty: &TypeRecord) {
+        self.build_record(ty.fields.iter().map(|f| types.flat_types(&f.ty)));
+    }
+
+    fn tuples(&mut self, types: &ComponentTypesBuilder, ty: &TypeTuple) {
+        self.build_record(ty.types.iter().map(|t| types.flat_types(t)));
+    }
+
+    fn enums(&mut self, _types: &ComponentTypesBuilder, _ty: &TypeEnum) {
+        self.push(FlatType::I32, FlatType::I32);
+    }
+
+    fn flags(&mut self, _types: &ComponentTypesBuilder, ty: &TypeFlags) {
+        match FlagsSize::from_count(ty.names.len()) {
+            FlagsSize::Size0 => {}
+            FlagsSize::Size1 | FlagsSize::Size2 => {
+                self.push(FlatType::I32, FlatType::I32);
+            }
+            FlagsSize::Size4Plus(n) => {
+                for _ in 0..n {
+                    self.push(FlatType::I32, FlatType::I32);
+                }
+            }
+        }
+    }
+
+    fn variants(&mut self, types: &ComponentTypesBuilder, ty: &TypeVariant) {
+        self.build_variant(ty.cases.iter().map(|c| types.flat_types(&c.ty)))
+    }
+
+    fn unions(&mut self, types: &ComponentTypesBuilder, ty: &TypeUnion) {
+        self.build_variant(ty.types.iter().map(|t| types.flat_types(t)))
+    }
+
+    fn expecteds(&mut self, types: &ComponentTypesBuilder, ty: &TypeExpected) {
+        self.build_variant([types.flat_types(&ty.ok), types.flat_types(&ty.err)]);
+    }
+
+    fn options(&mut self, types: &ComponentTypesBuilder, ty: &TypeOption) {
+        self.build_variant([Some(FlatTypes::EMPTY), types.flat_types(&ty.ty)]);
+    }
+}
+
+impl FlatType {
+    fn join(&mut self, other: FlatType) {
+        if *self == other {
+            return;
+        }
+        *self = match (*self, other) {
+            (FlatType::I32, FlatType::F32) | (FlatType::F32, FlatType::I32) => FlatType::I32,
+            _ => FlatType::I64,
+        };
+    }
 }

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -20,8 +20,8 @@
 
 use crate::component::dfg::CoreDef;
 use crate::component::{
-    Adapter, AdapterOptions as AdapterOptionsDfg, ComponentTypes, InterfaceType, StringEncoding,
-    TypeFuncIndex,
+    Adapter, AdapterOptions as AdapterOptionsDfg, ComponentTypesBuilder, InterfaceType,
+    StringEncoding, TypeFuncIndex,
 };
 use crate::fact::transcode::Transcoder;
 use crate::{EntityRef, FuncIndex, GlobalIndex, MemoryIndex, PrimaryMap};
@@ -41,7 +41,7 @@ pub struct Module<'a> {
     /// Whether or not debug code is inserted into the adapters themselves.
     debug: bool,
     /// Type information from the creator of this `Module`
-    types: &'a ComponentTypes,
+    types: &'a ComponentTypesBuilder,
 
     /// Core wasm type section that's incrementally built
     core_types: core_types::CoreTypes,
@@ -125,7 +125,7 @@ enum Context {
 
 impl<'a> Module<'a> {
     /// Creates an empty module.
-    pub fn new(types: &'a ComponentTypes, debug: bool) -> Module<'a> {
+    pub fn new(types: &'a ComponentTypesBuilder, debug: bool) -> Module<'a> {
         Module {
             debug,
             types,

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -1,9 +1,10 @@
 //! Size, align, and flattening information about component model types.
 
-use crate::component::{ComponentTypes, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
+use crate::component::{
+    ComponentTypesBuilder, FlatType, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
+};
 use crate::fact::{AdapterOptions, Context, Options};
 use wasm_encoder::ValType;
-use wasmtime_component_util::FlagsSize;
 
 /// Metadata about a core wasm signature which is created for a component model
 /// signature.
@@ -23,7 +24,7 @@ pub struct Signature {
     pub results_indirect: bool,
 }
 
-impl ComponentTypes {
+impl ComponentTypesBuilder {
     /// Calculates the core wasm function signature for the component function
     /// type specified within `Context`.
     ///
@@ -34,31 +35,39 @@ impl ComponentTypes {
         let ty = &self[options.ty];
         let ptr_ty = options.options.ptr();
 
-        let mut params = self.flatten_types(&options.options, ty.params.iter().map(|(_, ty)| *ty));
         let mut params_indirect = false;
-        if params.len() > MAX_FLAT_PARAMS {
-            params = vec![ptr_ty];
-            params_indirect = true;
-        }
+        let mut params = match self.flatten_types(
+            &options.options,
+            MAX_FLAT_PARAMS,
+            ty.params.iter().map(|(_, ty)| *ty),
+        ) {
+            Some(list) => list,
+            None => {
+                params_indirect = true;
+                vec![ptr_ty]
+            }
+        };
 
-        let mut results = self.flatten_types(&options.options, [ty.result]);
         let mut results_indirect = false;
-        if results.len() > MAX_FLAT_RESULTS {
-            results_indirect = true;
-            match context {
-                // For a lifted function too-many-results gets translated to a
-                // returned pointer where results are read from. The callee
-                // allocates space here.
-                Context::Lift => results = vec![ptr_ty],
-                // For a lowered function too-many-results becomes a return
-                // pointer which is passed as the last argument. The caller
-                // allocates space here.
-                Context::Lower => {
-                    results.truncate(0);
-                    params.push(ptr_ty);
+        let results = match self.flatten_types(&options.options, MAX_FLAT_RESULTS, [ty.result]) {
+            Some(list) => list,
+            None => {
+                results_indirect = true;
+                match context {
+                    // For a lifted function too-many-results gets translated to a
+                    // returned pointer where results are read from. The callee
+                    // allocates space here.
+                    Context::Lift => vec![ptr_ty],
+                    // For a lowered function too-many-results becomes a return
+                    // pointer which is passed as the last argument. The caller
+                    // allocates space here.
+                    Context::Lower => {
+                        params.push(ptr_ty);
+                        Vec::new()
+                    }
                 }
             }
-        }
+        };
         Signature {
             params,
             results,
@@ -72,115 +81,31 @@ impl ComponentTypes {
     pub(super) fn flatten_types(
         &self,
         opts: &Options,
+        max: usize,
         tys: impl IntoIterator<Item = InterfaceType>,
-    ) -> Vec<ValType> {
-        let mut result = Vec::new();
+    ) -> Option<Vec<ValType>> {
+        let mut dst = Vec::new();
         for ty in tys {
-            self.push_flat(opts, &ty, &mut result);
-        }
-        result
-    }
-
-    fn push_flat(&self, opts: &Options, ty: &InterfaceType, dst: &mut Vec<ValType>) {
-        match ty {
-            InterfaceType::Unit => {}
-
-            InterfaceType::Bool
-            | InterfaceType::S8
-            | InterfaceType::U8
-            | InterfaceType::S16
-            | InterfaceType::U16
-            | InterfaceType::S32
-            | InterfaceType::U32
-            | InterfaceType::Char => dst.push(ValType::I32),
-
-            InterfaceType::S64 | InterfaceType::U64 => dst.push(ValType::I64),
-
-            InterfaceType::Float32 => dst.push(ValType::F32),
-            InterfaceType::Float64 => dst.push(ValType::F64),
-
-            InterfaceType::String | InterfaceType::List(_) => {
-                dst.push(opts.ptr());
-                dst.push(opts.ptr());
-            }
-            InterfaceType::Record(r) => {
-                for field in self[*r].fields.iter() {
-                    self.push_flat(opts, &field.ty, dst);
+            let flat = self.flat_types(&ty)?;
+            let types = if opts.memory64 {
+                flat.memory64
+            } else {
+                flat.memory32
+            };
+            for ty in types {
+                let ty = match ty {
+                    FlatType::I32 => ValType::I32,
+                    FlatType::I64 => ValType::I64,
+                    FlatType::F32 => ValType::F32,
+                    FlatType::F64 => ValType::F64,
+                };
+                if dst.len() == max {
+                    return None;
                 }
-            }
-            InterfaceType::Tuple(t) => {
-                for ty in self[*t].types.iter() {
-                    self.push_flat(opts, ty, dst);
-                }
-            }
-            InterfaceType::Flags(f) => {
-                let flags = &self[*f];
-                match FlagsSize::from_count(flags.names.len()) {
-                    FlagsSize::Size0 => {}
-                    FlagsSize::Size1 | FlagsSize::Size2 => dst.push(ValType::I32),
-                    FlagsSize::Size4Plus(n) => {
-                        dst.extend((0..n).map(|_| ValType::I32));
-                    }
-                }
-            }
-            InterfaceType::Enum(_) => dst.push(ValType::I32),
-            InterfaceType::Option(t) => {
-                dst.push(ValType::I32);
-                self.push_flat(opts, &self[*t].ty, dst);
-            }
-            InterfaceType::Variant(t) => {
-                dst.push(ValType::I32);
-                let pos = dst.len();
-                let mut tmp = Vec::new();
-                for case in self[*t].cases.iter() {
-                    self.push_flat_variant(opts, &case.ty, pos, &mut tmp, dst);
-                }
-            }
-            InterfaceType::Union(t) => {
-                dst.push(ValType::I32);
-                let pos = dst.len();
-                let mut tmp = Vec::new();
-                for ty in self[*t].types.iter() {
-                    self.push_flat_variant(opts, ty, pos, &mut tmp, dst);
-                }
-            }
-            InterfaceType::Expected(t) => {
-                dst.push(ValType::I32);
-                let e = &self[*t];
-                let pos = dst.len();
-                let mut tmp = Vec::new();
-                self.push_flat_variant(opts, &e.ok, pos, &mut tmp, dst);
-                self.push_flat_variant(opts, &e.err, pos, &mut tmp, dst);
+                dst.push(ty);
             }
         }
-    }
-
-    fn push_flat_variant(
-        &self,
-        opts: &Options,
-        ty: &InterfaceType,
-        pos: usize,
-        tmp: &mut Vec<ValType>,
-        dst: &mut Vec<ValType>,
-    ) {
-        tmp.truncate(0);
-        self.push_flat(opts, ty, tmp);
-        for (i, a) in tmp.iter().enumerate() {
-            match dst.get_mut(pos + i) {
-                Some(b) => join(*a, b),
-                None => dst.push(*a),
-            }
-        }
-
-        fn join(a: ValType, b: &mut ValType) {
-            if a == *b {
-                return;
-            }
-            match (a, *b) {
-                (ValType::I32, ValType::F32) | (ValType::F32, ValType::I32) => *b = ValType::I32,
-                _ => *b = ValType::I64,
-            }
-        }
+        Some(dst)
     }
 
     pub(super) fn align(&self, opts: &Options, ty: &InterfaceType) -> u32 {

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -16,7 +16,7 @@
 //! can be somewhat arbitrary, an intentional decision.
 
 use crate::component::{
-    CanonicalAbiInfo, ComponentTypes, InterfaceType, StringEncoding, TypeEnumIndex,
+    CanonicalAbiInfo, ComponentTypesBuilder, InterfaceType, StringEncoding, TypeEnumIndex,
     TypeExpectedIndex, TypeFlagsIndex, TypeInterfaceIndex, TypeOptionIndex, TypeRecordIndex,
     TypeTupleIndex, TypeUnionIndex, TypeVariantIndex, VariantInfo, FLAG_MAY_ENTER, FLAG_MAY_LEAVE,
     MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
@@ -36,7 +36,7 @@ const MAX_STRING_BYTE_LENGTH: u32 = 1 << 31;
 const UTF16_TAG: u32 = 1 << 31;
 
 struct Compiler<'a, 'b> {
-    types: &'a ComponentTypes,
+    types: &'a ComponentTypesBuilder,
     module: &'b mut Module<'a>,
     result: FunctionId,
 
@@ -279,14 +279,16 @@ impl Compiler<'_, '_> {
         // TODO: handle subtyping
         assert_eq!(src_tys.len(), dst_tys.len());
 
-        let src_flat = self
-            .types
-            .flatten_types(lower_opts, src_tys.iter().copied());
-        let dst_flat = self.types.flatten_types(lift_opts, dst_tys.iter().copied());
+        let src_flat =
+            self.types
+                .flatten_types(lower_opts, MAX_FLAT_PARAMS, src_tys.iter().copied());
+        let dst_flat =
+            self.types
+                .flatten_types(lift_opts, MAX_FLAT_PARAMS, dst_tys.iter().copied());
 
-        let src = if src_flat.len() <= MAX_FLAT_PARAMS {
+        let src = if let Some(flat) = &src_flat {
             Source::Stack(Stack {
-                locals: &param_locals[..src_flat.len()],
+                locals: &param_locals[..flat.len()],
                 opts: lower_opts,
             })
         } else {
@@ -303,8 +305,8 @@ impl Compiler<'_, '_> {
             Source::Memory(self.memory_operand(lower_opts, TempLocal::new(addr, ty), align))
         };
 
-        let dst = if dst_flat.len() <= MAX_FLAT_PARAMS {
-            Destination::Stack(&dst_flat, lift_opts)
+        let dst = if let Some(flat) = &dst_flat {
+            Destination::Stack(flat, lift_opts)
         } else {
             // If there are too many parameters then space is allocated in the
             // destination module for the parameters via its `realloc` function.
@@ -348,10 +350,14 @@ impl Compiler<'_, '_> {
         let lift_opts = &adapter.lift.options;
         let lower_opts = &adapter.lower.options;
 
-        let src_flat = self.types.flatten_types(lift_opts, [src_ty]);
-        let dst_flat = self.types.flatten_types(lower_opts, [dst_ty]);
+        let src_flat = self
+            .types
+            .flatten_types(lift_opts, MAX_FLAT_RESULTS, [src_ty]);
+        let dst_flat = self
+            .types
+            .flatten_types(lower_opts, MAX_FLAT_RESULTS, [dst_ty]);
 
-        let src = if src_flat.len() <= MAX_FLAT_RESULTS {
+        let src = if src_flat.is_some() {
             Source::Stack(Stack {
                 locals: result_locals,
                 opts: lift_opts,
@@ -368,8 +374,8 @@ impl Compiler<'_, '_> {
             Source::Memory(self.memory_operand(lift_opts, TempLocal::new(addr, ty), align))
         };
 
-        let dst = if dst_flat.len() <= MAX_FLAT_RESULTS {
-            Destination::Stack(&dst_flat, lower_opts)
+        let dst = if let Some(flat) = &dst_flat {
+            Destination::Stack(flat, lower_opts)
         } else {
             // This is slightly different than `translate_params` where the
             // return pointer was provided by the caller of this function
@@ -2775,7 +2781,7 @@ impl<'a> Source<'a> {
     /// offset for each memory-based type.
     fn record_field_srcs<'b>(
         &'b self,
-        types: &'b ComponentTypes,
+        types: &'b ComponentTypesBuilder,
         fields: impl IntoIterator<Item = InterfaceType> + 'b,
     ) -> impl Iterator<Item = Source<'a>> + 'b
     where
@@ -2788,7 +2794,7 @@ impl<'a> Source<'a> {
                 Source::Memory(mem)
             }
             Source::Stack(stack) => {
-                let cnt = types.flatten_types(stack.opts, [ty]).len() as u32;
+                let cnt = types.flat_types(&ty).unwrap().len() as u32;
                 offset += cnt;
                 Source::Stack(stack.slice((offset - cnt) as usize..offset as usize))
             }
@@ -2798,13 +2804,13 @@ impl<'a> Source<'a> {
     /// Returns the corresponding discriminant source and payload source f
     fn payload_src(
         &self,
-        types: &ComponentTypes,
+        types: &ComponentTypesBuilder,
         info: &VariantInfo,
         case: &InterfaceType,
     ) -> Source<'a> {
         match self {
             Source::Stack(s) => {
-                let flat_len = types.flatten_types(s.opts, [*case]).len();
+                let flat_len = types.flat_types(case).unwrap().len();
                 Source::Stack(s.slice(1..s.locals.len()).slice(0..flat_len))
             }
             Source::Memory(mem) => {
@@ -2830,7 +2836,7 @@ impl<'a> Destination<'a> {
     /// Same as `Source::record_field_srcs` but for destinations.
     fn record_field_dsts<'b>(
         &'b self,
-        types: &'b ComponentTypes,
+        types: &'b ComponentTypesBuilder,
         fields: impl IntoIterator<Item = InterfaceType> + 'b,
     ) -> impl Iterator<Item = Destination> + 'b
     where
@@ -2843,7 +2849,7 @@ impl<'a> Destination<'a> {
                 Destination::Memory(mem)
             }
             Destination::Stack(s, opts) => {
-                let cnt = types.flatten_types(opts, [ty]).len() as u32;
+                let cnt = types.flat_types(&ty).unwrap().len() as u32;
                 offset += cnt;
                 Destination::Stack(&s[(offset - cnt) as usize..offset as usize], opts)
             }
@@ -2853,13 +2859,13 @@ impl<'a> Destination<'a> {
     /// Returns the corresponding discriminant source and payload source f
     fn payload_dst(
         &self,
-        types: &ComponentTypes,
+        types: &ComponentTypesBuilder,
         info: &VariantInfo,
         case: &InterfaceType,
     ) -> Destination {
         match self {
             Destination::Stack(s, opts) => {
-                let flat_len = types.flatten_types(opts, [*case]).len();
+                let flat_len = types.flat_types(case).unwrap().len();
                 Destination::Stack(&s[1..][..flat_len], opts)
             }
             Destination::Memory(mem) => {
@@ -2883,7 +2889,7 @@ impl<'a> Destination<'a> {
 
 fn next_field_offset<'a>(
     offset: &mut u32,
-    types: &ComponentTypes,
+    types: &ComponentTypesBuilder,
     field: &InterfaceType,
     mem: &Memory<'a>,
 ) -> Memory<'a> {
@@ -2930,7 +2936,7 @@ struct VariantCase<'a> {
     dst_ty: &'a InterfaceType,
 }
 
-fn variant_info<I>(types: &ComponentTypes, cases: I) -> VariantInfo
+fn variant_info<I>(types: &ComponentTypesBuilder, cases: I) -> VariantInfo
 where
     I: IntoIterator<Item = InterfaceType>,
     I::IntoIter: ExactSizeIterator,

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -1943,6 +1943,7 @@ impl Compiler<'_, '_> {
             FlagsSize::Size4Plus(n) => {
                 let srcs = src.record_field_srcs(self.types, (0..n).map(|_| InterfaceType::U32));
                 let dsts = dst.record_field_dsts(self.types, (0..n).map(|_| InterfaceType::U32));
+                let n = usize::from(n);
                 for (i, (src, dst)) in srcs.zip(dsts).enumerate() {
                     let mask = if i == n - 1 && (cnt % 32 != 0) {
                         (1 << (cnt % 32)) - 1

--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -166,7 +166,7 @@ fn u32_count_from_flag_count(count: usize) -> usize {
     match FlagsSize::from_count(count) {
         FlagsSize::Size0 => 0,
         FlagsSize::Size1 | FlagsSize::Size2 => 1,
-        FlagsSize::Size4Plus(n) => n,
+        FlagsSize::Size4Plus(n) => n.into(),
     }
 }
 
@@ -270,7 +270,7 @@ impl Type {
                     alignment: 2,
                 },
                 FlagsSize::Size4Plus(n) => SizeAndAlignment {
-                    size: n * 4,
+                    size: usize::from(n) * 4,
                     alignment: 4,
                 },
             },


### PR DESCRIPTION
It appears that given any amount of recursion in Wasmtime based on the type structure of a component the fuzzers will find a stack overflow. To that end this commit fixes an issue that the fuzzers have found where calculating the flat type representation was overflowing the stack due to the recursive nature of the implementation.

The fix here additionally improves upon the previous implementation by caching flat type information per-type instead of recomputing it each time it's queried. This means there's no special need to handle recursion one way or another here and it also greatly improves performance, especially for the `fact-valid-module` fuzzer. 
