### PR TITLE
x64: Compare source arguments in produces_const

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -766,13 +766,13 @@ impl Inst {
     /// same as the first register (already handled).
     fn produces_const(&self) -> bool {
         match self {
-            Self::AluRmiR { op, src2, dst, .. } => {
-                src2.clone().to_reg_mem_imm().to_reg() == Some(dst.to_reg().to_reg())
+            Self::AluRmiR { op, src1, src2, .. } => {
+                src2.clone().to_reg_mem_imm().to_reg() == Some(src1.to_reg())
                     && (*op == AluRmiROpcode::Xor || *op == AluRmiROpcode::Sub)
             }
 
-            Self::XmmRmR { op, src2, dst, .. } => {
-                src2.clone().to_reg_mem().to_reg() == Some(dst.to_reg().to_reg())
+            Self::XmmRmR { op, src1, src2, .. } => {
+                src2.clone().to_reg_mem().to_reg() == Some(src1.to_reg())
                     && (*op == SseOpcode::Xorps
                         || *op == SseOpcode::Xorpd
                         || *op == SseOpcode::Pxor
@@ -783,9 +783,13 @@ impl Inst {
             }
 
             Self::XmmRmRImm {
-                op, src2, dst, imm, ..
+                op,
+                src1,
+                src2,
+                imm,
+                ..
             } => {
-                src2.to_reg() == Some(dst.to_reg())
+                src2.to_reg() == Some(src1.clone())
                     && (*op == SseOpcode::Cmppd || *op == SseOpcode::Cmpps)
                     && *imm == FcmpImm::Equal.encode()
             }


### PR DESCRIPTION
This PR changes the behavior of `produces_const` in the x64 backend to check that the two source registers are the same, rather than check that the second source and destination are the same. The reason for this change is a mismatch in behavior between the ISLE constructors for those pseudo instructions and the existing rust functions for constructing them: the rust functions always ensure that the first source and destination registers are the same, while the isle functions introduce a fresh destination register and take the two sources as arguments.

This change preserves the existing behavior for instructions constructed through the rust functions, but allows the lower.isle to use instructions like `(x64_xor x x)` where `x` is a fresh register without causing a panic in RA2.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
