### PR TITLE
x64: Remove handling of `cmpps` and `cmppd` in `produces_const`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -782,18 +782,6 @@ impl Inst {
                         || *op == SseOpcode::Pcmpeqq)
             }
 
-            Self::XmmRmRImm {
-                op,
-                src1,
-                src2,
-                imm,
-                ..
-            } => {
-                src2.to_reg() == Some(src1.clone())
-                    && (*op == SseOpcode::Cmppd || *op == SseOpcode::Cmpps)
-                    && *imm == FcmpImm::Equal.encode()
-            }
-
             _ => false,
         }
     }


### PR DESCRIPTION
On `main`, the `cmpps` and `cmppd` instructions will be treated as producing constants if their arguments are the same and their immediate operand is `0`, which corresponds to ordered equality. The runtime behavior of this instruction is not constant however, as it will output a lane of `0`s if either of the corresponding components are `NaN`.

This PR removes the special handling of `cmpps` and `cmppd` from `produces_const`, as it's not correctly identifying constants. An alternative approach here would be to say that unordered equality will produce constants, looking instead for the immediate value `8`. We don't currently have any way of emitting unordered equality tests, so that would be an optimization that would be worth making if we add that capability in the future.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
