### PR TITLE
Fix a bad bounds check in component trampolines

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -1574,7 +1574,7 @@ impl Compiler<'_, '_> {
         // If the byte size of memory is greater than the final address of the
         // string then the string is invalid. Note that if it's precisely equal
         // then that's ok.
-        self.instruction(I64GtU);
+        self.instruction(I64GeU);
         self.instruction(BrIf(1));
 
         self.instruction(End);

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -127,7 +127,7 @@ impl fmt::Debug for Record {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Tuple {
     ty: types::Tuple,
     values: Box<[Val]>,
@@ -163,6 +163,16 @@ impl Tuple {
     /// Returns the list of values that this tuple contains.
     pub fn values(&self) -> &[Val] {
         &self.values
+    }
+}
+
+impl fmt::Debug for Tuple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut tuple = f.debug_tuple("");
+        for val in self.values() {
+            tuple.field(val);
+        }
+        tuple.finish()
     }
 }
 
@@ -227,7 +237,7 @@ impl fmt::Debug for Variant {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Enum {
     ty: types::Enum,
     discriminant: u32,
@@ -259,7 +269,13 @@ impl Enum {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+impl fmt::Debug for Enum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.discriminant(), f)
+    }
+}
+
+#[derive(PartialEq, Eq, Clone)]
 pub struct Union {
     ty: types::Union,
     discriminant: u32,
@@ -300,6 +316,14 @@ impl Union {
     /// Returns the payload value for this union.
     pub fn payload(&self) -> &Val {
         &self.value
+    }
+}
+
+impl fmt::Debug for Union {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple(&format!("U{}", self.discriminant()))
+            .field(self.payload())
+            .finish()
     }
 }
 


### PR DESCRIPTION
A `GtU` condition needed to actually be `GeU`, as the comment right
above it stated but apparently I forgot to translate the comment to
actual code. This fixes a fuzz bug that arose from oss-fuzz over the
weekend.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
