### PR TITLE
Enable back-edge CFI by default on macOS

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -780,6 +780,11 @@
        (Pacisp
         (key APIKey))
 
+       ;; Strip pointer authentication code from instruction address in LR;
+       ;; equivalent to a no-op if Pointer authentication (FEAT_PAuth) is not
+       ;; supported.
+       (Xpaclri)
+
        ;; Marker, no-op in generated code: SP "virtual offset" is adjusted. This
        ;; controls how AMode::NominalSPOffset args are lowered.
        (VirtualSPOffsetAdj
@@ -1356,6 +1361,9 @@
 ))
 
 ;; Extractors for target features ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(decl pure sign_return_address_disabled () Unit)
+(extern constructor sign_return_address_disabled sign_return_address_disabled)
+
 (decl use_lse () Inst)
 (extern extractor use_lse use_lse)
 
@@ -2577,4 +2585,11 @@
 
 (decl aarch64_link () Reg)
 (rule (aarch64_link)
+      (if (sign_return_address_disabled))
       (mov_preg (preg_link)))
+
+(rule (aarch64_link)
+      ;; This constructor is always used for non-leaf functions, so it is safe
+      ;; to clobber LR.
+      (let ((_ Unit (emit (MInst.Xpaclri))))
+           (mov_preg (preg_link))))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3121,6 +3121,7 @@ impl MachInstEmit for Inst {
 
                 sink.put4(0xd503233f | key << 6);
             }
+            &Inst::Xpaclri => sink.put4(0xd50320ff),
             &Inst::VirtualSPOffsetAdj { offset } => {
                 trace!(
                     "virtual sp offset adjusted by {} -> {}",

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -57,6 +57,7 @@ fn test_aarch64_binemit() {
         "retab",
     ));
     insns.push((Inst::Pacisp { key: APIKey::B }, "7F2303D5", "pacibsp"));
+    insns.push((Inst::Xpaclri, "FF2003D5", "xpaclri"));
     insns.push((Inst::Nop0, "", "nop-zero-len"));
     insns.push((Inst::Nop4, "1F2003D5", "nop"));
     insns.push((Inst::Csdb, "9F2203D5", "csdb"));

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -981,12 +981,7 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_def(rd);
             collector.reg_use(rn);
         }
-        &Inst::Ret { ref rets } => {
-            for &ret in rets {
-                collector.reg_use(ret);
-            }
-        }
-        &Inst::AuthenticatedRet { ref rets, .. } => {
+        &Inst::Ret { ref rets } | &Inst::AuthenticatedRet { ref rets, .. } => {
             for &ret in rets {
                 collector.reg_use(ret);
             }
@@ -1039,7 +1034,10 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_def(rd);
             memarg_operands(mem, collector);
         }
-        &Inst::Pacisp { .. } => {}
+        &Inst::Pacisp { .. } | &Inst::Xpaclri => {
+            // Neither LR nor SP is an allocatable register, so there is no need
+            // to do anything.
+        }
         &Inst::VirtualSPOffsetAdj { .. } => {}
 
         &Inst::ElfTlsGetAddr { .. } => {
@@ -2715,6 +2713,7 @@ impl Inst {
 
                 "paci".to_string() + key + "sp"
             }
+            &Inst::Xpaclri => "xpaclri".to_string(),
             &Inst::VirtualSPOffsetAdj { offset } => {
                 state.virtual_sp_offset += offset;
                 format!("virtual_sp_offset_adjust {}", offset)

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -71,6 +71,14 @@ pub struct SinkableAtomicLoad {
 impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
 
+    fn sign_return_address_disabled(&mut self) -> Option<()> {
+        if self.isa_flags.sign_return_address() {
+            None
+        } else {
+            Some(())
+        }
+    }
+
     fn use_lse(&mut self, _: Inst) -> Option<()> {
         if self.isa_flags.use_lse() {
             Some(())

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -138,6 +138,9 @@ pub fn builder_with_options(infer_native_flags: bool) -> Result<isa::Builder, &'
         }
 
         if cfg!(target_os = "macos") {
+            // Pointer authentication is always available on Apple Silicon.
+            isa_builder.enable("sign_return_address").unwrap();
+            // macOS enforces the use of the B key for return addresses.
             isa_builder.enable("sign_return_address_with_bkey").unwrap();
         }
     }

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -234,6 +234,8 @@ mod tests {
                 .any(|s| s.contains("look_for_me"))
                 // TODO: apparently windows unwind routines don't unwind through fibers, so this will always fail. Is there a way we can fix that?
                 || cfg!(windows)
+                // TODO: the system libunwind is broken (#2808)
+                || cfg!(all(target_os = "macos", target_arch = "aarch64"))
             );
         }
 

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -128,6 +128,16 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                     test: is_aarch64_feature_detected,
 
                     std: "lse" => clif: "has_lse",
+                    // even though the natural correspondence seems to be
+                    // between "paca" and "has_pauth", the latter has no effect
+                    // in isolation, so we actually use the setting that affects
+                    // code generation
+                    std: "paca" => clif: "sign_return_address",
+                    // "paca" and "pacg" check for the same underlying
+                    // architectural feature, so we use the latter to cover more
+                    // code generation settings, of which we have chosen the one
+                    // with the most significant effect
+                    std: "pacg" => clif: "sign_return_address_all" ratio: 1 in 2,
                 },
             };
             return Ok(CodegenSettings::Target {


### PR DESCRIPTION
This PR is a follow-up to #3606. One fiber test is still using the system unwinder implementation, so I have disabled it conservatively.