### PR TITLE
Remove binary_imm64 and int_compare_imm instructions

### DIFF
--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -7,7 +7,6 @@ pub(crate) struct Formats {
     pub(crate) atomic_rmw: Rc<InstructionFormat>,
     pub(crate) binary: Rc<InstructionFormat>,
     pub(crate) binary_imm8: Rc<InstructionFormat>,
-    pub(crate) binary_imm64: Rc<InstructionFormat>,
     pub(crate) branch: Rc<InstructionFormat>,
     pub(crate) branch_float: Rc<InstructionFormat>,
     pub(crate) branch_icmp: Rc<InstructionFormat>,
@@ -22,7 +21,6 @@ pub(crate) struct Formats {
     pub(crate) func_addr: Rc<InstructionFormat>,
     pub(crate) heap_addr: Rc<InstructionFormat>,
     pub(crate) int_compare: Rc<InstructionFormat>,
-    pub(crate) int_compare_imm: Rc<InstructionFormat>,
     pub(crate) int_cond: Rc<InstructionFormat>,
     pub(crate) int_cond_trap: Rc<InstructionFormat>,
     pub(crate) int_select: Rc<InstructionFormat>,
@@ -74,8 +72,6 @@ impl Formats {
 
             binary_imm8: Builder::new("BinaryImm8").value().imm(&imm.uimm8).build(),
 
-            binary_imm64: Builder::new("BinaryImm64").value().imm(&imm.imm64).build(),
-
             // The select instructions are controlled by the second VALUE operand.
             // The first VALUE operand is the controlling flag which has a derived type.
             // The fma instruction has the same constraint on all inputs.
@@ -108,12 +104,6 @@ impl Formats {
                 .imm(&imm.intcc)
                 .value()
                 .value()
-                .build(),
-
-            int_compare_imm: Builder::new("IntCompareImm")
-                .imm(&imm.intcc)
-                .value()
-                .imm(&imm.imm64)
                 .build(),
 
             int_cond: Builder::new("IntCond").imm(&imm.intcc).value().build(),

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1790,28 +1790,6 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
-    let a = &Operand::new("a", b1);
-    let x = &Operand::new("x", iB);
-    let Y = &Operand::new("Y", &imm.imm64);
-
-    ig.push(
-        Inst::new(
-            "icmp_imm",
-            r#"
-        Compare scalar integer to a constant.
-
-        This is the same as the `icmp` instruction, except one operand is
-        a sign extended 64 bit immediate constant.
-
-        This instruction can only compare scalars. Use `icmp` for
-        lane-wise vector comparisons.
-        "#,
-            &formats.int_compare_imm,
-        )
-        .operands_in(vec![Cond, x, Y])
-        .operands_out(vec![a]),
-    );
-
     let f = &Operand::new("f", iflags);
     let x = &Operand::new("x", iB);
     let y = &Operand::new("y", iB);
@@ -1828,21 +1806,6 @@ pub(crate) fn define(
             &formats.binary,
         )
         .operands_in(vec![x, y])
-        .operands_out(vec![f]),
-    );
-
-    ig.push(
-        Inst::new(
-            "ifcmp_imm",
-            r#"
-        Compare scalar integer to a constant and return flags.
-
-        Like `icmp_imm`, but returns integer CPU flags instead of testing
-        a specific condition code.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
         .operands_out(vec![f]),
     );
 
@@ -2049,131 +2012,6 @@ pub(crate) fn define(
             .can_trap(true),
         );
     }
-
-    let a = &Operand::new("a", iB);
-    let x = &Operand::new("x", iB);
-    let Y = &Operand::new("Y", &imm.imm64);
-
-    ig.push(
-        Inst::new(
-            "iadd_imm",
-            r#"
-        Add immediate integer.
-
-        Same as `iadd`, but one operand is a sign extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "imul_imm",
-            r#"
-        Integer multiplication by immediate constant.
-
-        Same as `imul`, but one operand is a sign extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "udiv_imm",
-            r#"
-        Unsigned integer division by an immediate constant.
-
-        Same as `udiv`, but one operand is a zero extended 64 bit immediate constant.
-
-        This operation traps if the divisor is zero.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "sdiv_imm",
-            r#"
-        Signed integer division by an immediate constant.
-
-        Same as `sdiv`, but one operand is a sign extended 64 bit immediate constant.
-
-        This operation traps if the divisor is zero, or if the result is not
-        representable in `B` bits two's complement. This only happens
-        when `x = -2^{B-1}, Y = -1`.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "urem_imm",
-            r#"
-        Unsigned integer remainder with immediate divisor.
-
-        Same as `urem`, but one operand is a zero extended 64 bit immediate constant.
-
-        This operation traps if the divisor is zero.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "srem_imm",
-            r#"
-        Signed integer remainder with immediate divisor.
-
-        Same as `srem`, but one operand is a sign extended 64 bit immediate constant.
-
-        This operation traps if the divisor is zero.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "irsub_imm",
-            r#"
-        Immediate reverse wrapping subtraction: `a := Y - x \pmod{2^B}`.
-        
-        The immediate operand is a sign extended 64 bit constant.
-
-        Also works as integer negation when `Y = 0`. Use `iadd_imm`
-        with a negative immediate operand for the reverse immediate
-        subtraction.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
 
     let a = &Operand::new("a", iB);
     let x = &Operand::new("x", iB);
@@ -2554,64 +2392,8 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
-    let x = &Operand::new("x", iB);
-    let Y = &Operand::new("Y", &imm.imm64);
-    let a = &Operand::new("a", iB);
-
-    ig.push(
-        Inst::new(
-            "band_imm",
-            r#"
-        Bitwise and with immediate.
-
-        Same as `band`, but one operand is a zero extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "bor_imm",
-            r#"
-        Bitwise or with immediate.
-
-        Same as `bor`, but one operand is a zero extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "bxor_imm",
-            r#"
-        Bitwise xor with immediate.
-
-        Same as `bxor`, but one operand is a zero extended 64 bit immediate constant.
-
-        Polymorphic over all scalar integer types, but does not support vector
-        types.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
     let x = &Operand::new("x", Int).with_doc("Scalar or vector value to shift");
     let y = &Operand::new("y", iB).with_doc("Number of bits to shift");
-    let Y = &Operand::new("Y", &imm.imm64);
     let a = &Operand::new("a", Int);
 
     ig.push(
@@ -2639,34 +2421,6 @@ pub(crate) fn define(
             &formats.binary,
         )
         .operands_in(vec![x, y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "rotl_imm",
-            r#"
-        Rotate left by immediate.
-
-        Same as `rotl`, but one operand is a zero extended 64 bit immediate constant.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "rotr_imm",
-            r#"
-        Rotate right by immediate.
-
-        Same as `rotr`, but one operand is a zero extended 64 bit immediate constant.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
         .operands_out(vec![a]),
     );
 
@@ -2728,48 +2482,6 @@ pub(crate) fn define(
             &formats.binary,
         )
         .operands_in(vec![x, y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "ishl_imm",
-            r#"
-        Integer shift left by immediate.
-
-        The shift amount is masked to the size of ``x``.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "ushr_imm",
-            r#"
-        Unsigned shift right by immediate.
-
-        The shift amount is masked to the size of the register.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
-        .operands_out(vec![a]),
-    );
-
-    ig.push(
-        Inst::new(
-            "sshr_imm",
-            r#"
-        Signed shift right by immediate.
-
-        The shift amount is masked to the size of the register.
-        "#,
-            &formats.binary_imm64,
-        )
-        .operands_in(vec![x, Y])
         .operands_out(vec![a]),
     );
 

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::ir::atomic_rmw_op::AtomicRmwOp;
 pub use crate::ir::builder::{
-    InsertBuilder, InstBuilder, InstBuilderBase, InstInserterBase, ReplaceBuilder,
+    InsertBuilder, InstBuilder, InstBuilderBase, InstImmBuilder, InstInserterBase, ReplaceBuilder,
 };
 pub use crate::ir::constant::{ConstantData, ConstantPool};
 pub use crate::ir::dfg::{DataFlowGraph, ValueDef};

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -1470,14 +1470,7 @@ pub(crate) fn lower_insn_to_regs(
             ctx.emit(alu_inst_imm12(ALUOp::AddS, ty, rd, rn, rm));
         }
 
-        Opcode::IaddImm
-        | Opcode::ImulImm
-        | Opcode::UdivImm
-        | Opcode::SdivImm
-        | Opcode::UremImm
-        | Opcode::SremImm
-        | Opcode::IrsubImm
-        | Opcode::IaddCin
+        Opcode::IaddCin
         | Opcode::IaddIfcin
         | Opcode::IaddCout
         | Opcode::IaddCarry
@@ -1487,17 +1480,7 @@ pub(crate) fn lower_insn_to_regs(
         | Opcode::IsubBout
         | Opcode::IsubIfbout
         | Opcode::IsubBorrow
-        | Opcode::IsubIfborrow
-        | Opcode::BandImm
-        | Opcode::BorImm
-        | Opcode::BxorImm
-        | Opcode::RotlImm
-        | Opcode::RotrImm
-        | Opcode::IshlImm
-        | Opcode::UshrImm
-        | Opcode::SshrImm
-        | Opcode::IcmpImm
-        | Opcode::IfcmpImm => {
+        | Opcode::IsubIfborrow => {
             panic!("ALU+imm and ALU+carry ops should not appear here!");
         }
 

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -245,14 +245,7 @@ impl LowerBackend for S390xBackend {
             | Opcode::BrTable => {
                 panic!("Branch opcode reached non-branch lowering logic!");
             }
-            Opcode::IaddImm
-            | Opcode::ImulImm
-            | Opcode::UdivImm
-            | Opcode::SdivImm
-            | Opcode::UremImm
-            | Opcode::SremImm
-            | Opcode::IrsubImm
-            | Opcode::IaddCin
+            Opcode::IaddCin
             | Opcode::IaddIfcin
             | Opcode::IaddCout
             | Opcode::IaddCarry
@@ -262,17 +255,7 @@ impl LowerBackend for S390xBackend {
             | Opcode::IsubBout
             | Opcode::IsubIfbout
             | Opcode::IsubBorrow
-            | Opcode::IsubIfborrow
-            | Opcode::BandImm
-            | Opcode::BorImm
-            | Opcode::BxorImm
-            | Opcode::RotlImm
-            | Opcode::RotrImm
-            | Opcode::IshlImm
-            | Opcode::UshrImm
-            | Opcode::SshrImm
-            | Opcode::IcmpImm
-            | Opcode::IfcmpImm => {
+            | Opcode::IsubIfborrow => {
                 panic!("ALU+imm and ALU+carry ops should not appear here!");
             }
         }

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -189,37 +189,6 @@
 
 ;; (No `iadd_ifcout` for `i128`.)
 
-;;;; Rules for `iadd_imm` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; `i64` and smaller.
-
-;; When the immediate fits in a `RegMemImm.Imm`, use that.
-(rule (lower (has_type (fits_in_64 ty) (iadd_imm y (simm32_from_imm64 x))))
-      (x64_add ty y x))
-
-;; Otherwise, put the immediate into a register.
-(rule (lower (has_type (fits_in_64 ty) (iadd_imm y (u64_from_imm64 x))))
-      (x64_add ty y (imm ty x)))
-
-;; `i128`
-
-;; When the immediate fits in a `RegMemImm.Imm`, use that.
-(rule (lower (has_type $I128 (iadd_imm y (simm32_from_imm64 x))))
-      (let ((y_regs ValueRegs y)
-            (y_lo Gpr (value_regs_get_gpr y_regs 0))
-            (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (with_flags (x64_add_with_flags_paired $I64 y_lo x)
-                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
-
-;; Otherwise, put the immediate into a register.
-(rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
-      (let ((y_regs ValueRegs y)
-            (y_lo Gpr (value_regs_get_gpr y_regs 0))
-            (y_hi Gpr (value_regs_get_gpr y_regs 1))
-            (x_lo Gpr (imm $I64 x)))
-        (with_flags (x64_add_with_flags_paired $I64 y_lo x_lo)
-                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
-
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -1747,14 +1747,7 @@ fn lower_insn_to_regs(
             panic!("Should never reach ifcmp/ffcmp as isel root!");
         }
 
-        Opcode::IaddImm
-        | Opcode::ImulImm
-        | Opcode::UdivImm
-        | Opcode::SdivImm
-        | Opcode::UremImm
-        | Opcode::SremImm
-        | Opcode::IrsubImm
-        | Opcode::IaddCin
+        Opcode::IaddCin
         | Opcode::IaddIfcin
         | Opcode::IaddCout
         | Opcode::IaddCarry
@@ -1764,17 +1757,7 @@ fn lower_insn_to_regs(
         | Opcode::IsubBout
         | Opcode::IsubIfbout
         | Opcode::IsubBorrow
-        | Opcode::IsubIfborrow
-        | Opcode::BandImm
-        | Opcode::BorImm
-        | Opcode::BxorImm
-        | Opcode::RotlImm
-        | Opcode::RotrImm
-        | Opcode::IshlImm
-        | Opcode::UshrImm
-        | Opcode::SshrImm
-        | Opcode::IcmpImm
-        | Opcode::IfcmpImm => {
+        | Opcode::IsubIfborrow => {
             panic!("ALU+imm and ALU+carry ops should not appear here!");
         }
 

--- a/cranelift/codegen/src/legalizer/globalvalue.rs
+++ b/cranelift/codegen/src/legalizer/globalvalue.rs
@@ -4,7 +4,7 @@
 //! instruction into code that depends on the kind of global value referenced.
 
 use crate::cursor::{Cursor, FuncCursor};
-use crate::ir::{self, InstBuilder};
+use crate::ir::{self, InstBuilder, InstImmBuilder};
 use crate::isa::TargetIsa;
 
 /// Expand a `global_value` instruction according to the definition of the global value.
@@ -80,7 +80,7 @@ fn iadd_imm_addr(
     };
 
     // Simply replace the `global_value` instruction with an `iadd_imm`, reusing the result value.
-    pos.func.dfg.replace(inst).iadd_imm(lhs, offset);
+    pos.replace(inst).iadd_imm(lhs, offset);
 }
 
 /// Expand a `global_value` instruction for a load global.

--- a/cranelift/codegen/src/legalizer/heap.rs
+++ b/cranelift/codegen/src/legalizer/heap.rs
@@ -7,7 +7,7 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::condcodes::IntCC;
 use crate::ir::immediates::Uimm32;
-use crate::ir::{self, InstBuilder, RelSourceLoc};
+use crate::ir::{self, InstBuilder, InstImmBuilder, RelSourceLoc};
 use crate::isa::TargetIsa;
 
 /// Expand a `heap_addr` instruction according to the definition of the heap.

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -15,9 +15,7 @@
 
 use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
-use crate::ir::immediates::Imm64;
-use crate::ir::types::{I128, I64};
-use crate::ir::{self, InstBuilder, InstructionData, MemFlags, Value};
+use crate::ir::{self, InstBuilder, InstructionData, MemFlags};
 use crate::isa::TargetIsa;
 
 mod globalvalue;
@@ -27,21 +25,6 @@ mod table;
 use self::globalvalue::expand_global_value;
 use self::heap::expand_heap_addr;
 use self::table::expand_table_addr;
-
-fn imm_const(pos: &mut FuncCursor, arg: Value, imm: Imm64, is_signed: bool) -> Value {
-    let ty = pos.func.dfg.value_type(arg);
-    match (ty, is_signed) {
-        (I128, true) => {
-            let imm = pos.ins().iconst(I64, imm);
-            pos.ins().sextend(I128, imm)
-        }
-        (I128, false) => {
-            let imm = pos.ins().iconst(I64, imm);
-            pos.ins().uextend(I128, imm)
-        }
-        _ => pos.ins().iconst(ty.lane_type(), imm),
-    }
-}
 
 /// Perform a simple legalization by expansion of the function, without
 /// platform-specific transforms.
@@ -172,88 +155,6 @@ pub fn simple_legalize(func: &mut ir::Function, cfg: &mut ControlFlowGraph, isa:
                     arg,
                     offset,
                 } => expand_table_addr(isa, inst, &mut pos.func, table, arg, offset),
-
-                InstructionData::BinaryImm64 { opcode, arg, imm } => {
-                    let is_signed = match opcode {
-                        ir::Opcode::IaddImm
-                        | ir::Opcode::IrsubImm
-                        | ir::Opcode::ImulImm
-                        | ir::Opcode::SdivImm
-                        | ir::Opcode::SremImm
-                        | ir::Opcode::IfcmpImm => true,
-                        _ => false,
-                    };
-
-                    let imm = imm_const(&mut pos, arg, imm, is_signed);
-                    let replace = pos.func.dfg.replace(inst);
-                    match opcode {
-                        // bitops
-                        ir::Opcode::BandImm => {
-                            replace.band(arg, imm);
-                        }
-                        ir::Opcode::BorImm => {
-                            replace.bor(arg, imm);
-                        }
-                        ir::Opcode::BxorImm => {
-                            replace.bxor(arg, imm);
-                        }
-                        // bitshifting
-                        ir::Opcode::IshlImm => {
-                            replace.ishl(arg, imm);
-                        }
-                        ir::Opcode::RotlImm => {
-                            replace.rotl(arg, imm);
-                        }
-                        ir::Opcode::RotrImm => {
-                            replace.rotr(arg, imm);
-                        }
-                        ir::Opcode::SshrImm => {
-                            replace.sshr(arg, imm);
-                        }
-                        ir::Opcode::UshrImm => {
-                            replace.ushr(arg, imm);
-                        }
-                        // math
-                        ir::Opcode::IaddImm => {
-                            replace.iadd(arg, imm);
-                        }
-                        ir::Opcode::IrsubImm => {
-                            // note: arg order reversed
-                            replace.isub(imm, arg);
-                        }
-                        ir::Opcode::ImulImm => {
-                            replace.imul(arg, imm);
-                        }
-                        ir::Opcode::SdivImm => {
-                            replace.sdiv(arg, imm);
-                        }
-                        ir::Opcode::SremImm => {
-                            replace.srem(arg, imm);
-                        }
-                        ir::Opcode::UdivImm => {
-                            replace.udiv(arg, imm);
-                        }
-                        ir::Opcode::UremImm => {
-                            replace.urem(arg, imm);
-                        }
-                        // comparisons
-                        ir::Opcode::IfcmpImm => {
-                            replace.ifcmp(arg, imm);
-                        }
-                        _ => prev_pos = pos.position(),
-                    };
-                }
-
-                // comparisons
-                InstructionData::IntCompareImm {
-                    opcode: ir::Opcode::IcmpImm,
-                    cond,
-                    arg,
-                    imm,
-                } => {
-                    let imm = imm_const(&mut pos, arg, imm, true);
-                    pos.func.dfg.replace(inst).icmp(cond, arg, imm);
-                }
 
                 _ => {
                     prev_pos = pos.position();

--- a/cranelift/codegen/src/legalizer/table.rs
+++ b/cranelift/codegen/src/legalizer/table.rs
@@ -6,7 +6,7 @@
 use crate::cursor::{Cursor, FuncCursor};
 use crate::ir::condcodes::IntCC;
 use crate::ir::immediates::Offset32;
-use crate::ir::{self, InstBuilder};
+use crate::ir::{self, InstBuilder, InstImmBuilder};
 use crate::isa::TargetIsa;
 
 /// Expand a `table_addr` instruction according to the definition of the table.

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -95,30 +95,17 @@ fn harvest_candidate_lhs(
     let should_trace = |val| match func.dfg.value_def(val) {
         ir::ValueDef::Result(inst, 0) => match func.dfg[inst].opcode() {
                 ir::Opcode::Iadd
-                | ir::Opcode::IaddImm
-                | ir::Opcode::IrsubImm
                 | ir::Opcode::Imul
-                | ir::Opcode::ImulImm
                 | ir::Opcode::Udiv
-                | ir::Opcode::UdivImm
                 | ir::Opcode::Sdiv
-                | ir::Opcode::SdivImm
                 | ir::Opcode::Urem
-                | ir::Opcode::UremImm
                 | ir::Opcode::Srem
-                | ir::Opcode::SremImm
                 | ir::Opcode::Band
-                | ir::Opcode::BandImm
                 | ir::Opcode::Bor
-                | ir::Opcode::BorImm
                 | ir::Opcode::Bxor
-                | ir::Opcode::BxorImm
                 | ir::Opcode::Ishl
-                | ir::Opcode::IshlImm
                 | ir::Opcode::Sshr
-                | ir::Opcode::SshrImm
                 | ir::Opcode::Ushr
-                | ir::Opcode::UshrImm
                 | ir::Opcode::Select
                 | ir::Opcode::Uextend
                 | ir::Opcode::Sextend
@@ -192,42 +179,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::Add { a, b }.into()
                     }
-                    (ir::Opcode::IaddImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Add { a, b }.into()
-                    }
-                    (ir::Opcode::IrsubImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let b = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let a = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Sub { a, b }.into()
-                    }
                     (ir::Opcode::Imul, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Mul { a, b }.into()
-                    }
-                    (ir::Opcode::ImulImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Mul { a, b }.into()
                     }
                     (ir::Opcode::Udiv, _) => {
@@ -235,31 +189,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::Udiv { a, b }.into()
                     }
-                    (ir::Opcode::UdivImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Udiv { a, b }.into()
-                    }
                     (ir::Opcode::Sdiv, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Sdiv { a, b }.into()
-                    }
-                    (ir::Opcode::SdivImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Sdiv { a, b }.into()
                     }
                     (ir::Opcode::Urem, _) => {
@@ -267,31 +199,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::Urem { a, b }.into()
                     }
-                    (ir::Opcode::UremImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Urem { a, b }.into()
-                    }
                     (ir::Opcode::Srem, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Srem { a, b }.into()
-                    }
-                    (ir::Opcode::SremImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Srem { a, b }.into()
                     }
                     (ir::Opcode::Band, _) => {
@@ -299,31 +209,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::And { a, b }.into()
                     }
-                    (ir::Opcode::BandImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::And { a, b }.into()
-                    }
                     (ir::Opcode::Bor, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Or { a, b }.into()
-                    }
-                    (ir::Opcode::BorImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Or { a, b }.into()
                     }
                     (ir::Opcode::Bxor, _) => {
@@ -331,31 +219,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::Xor { a, b }.into()
                     }
-                    (ir::Opcode::BxorImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Xor { a, b }.into()
-                    }
                     (ir::Opcode::Ishl, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Shl { a, b }.into()
-                    }
-                    (ir::Opcode::IshlImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Shl { a, b }.into()
                     }
                     (ir::Opcode::Sshr, _) => {
@@ -363,31 +229,9 @@ fn harvest_candidate_lhs(
                         let b = arg(allocs, 1);
                         ast::Instruction::Ashr { a, b }.into()
                     }
-                    (ir::Opcode::SshrImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
-                        ast::Instruction::Ashr { a, b }.into()
-                    }
                     (ir::Opcode::Ushr, _) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        ast::Instruction::Lshr { a, b }.into()
-                    }
-                    (ir::Opcode::UshrImm, ir::InstructionData::BinaryImm64 { imm, .. }) => {
-                        let a = arg(allocs, 0);
-                        let value: i64 = (*imm).into();
-                        let value: i128 = value.into();
-                        let b = ast::Constant {
-                            value,
-                            r#type: souper_type_of(&func.dfg, val),
-                        }
-                        .into();
                         ast::Instruction::Lshr { a, b }.into()
                     }
                     (ir::Opcode::Select, _) => {
@@ -430,8 +274,7 @@ fn harvest_candidate_lhs(
                         let a = arg(allocs, 0);
                         ast::Instruction::Trunc { a }.into()
                     }
-                    (ir::Opcode::Icmp, ir::InstructionData::IntCompare { cond, .. })
-                    | (ir::Opcode::IcmpImm, ir::InstructionData::IntCompare { cond, .. }) => {
+                    (ir::Opcode::Icmp, ir::InstructionData::IntCompare { cond, .. }) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
                         match cond {

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -769,12 +769,10 @@ impl<'a> Verifier<'a> {
             | UnaryBool { .. }
             | Binary { .. }
             | BinaryImm8 { .. }
-            | BinaryImm64 { .. }
             | Ternary { .. }
             | TernaryImm8 { .. }
             | Shuffle { .. }
             | IntCompare { .. }
-            | IntCompareImm { .. }
             | IntCond { .. }
             | FloatCompare { .. }
             | FloatCond { .. }

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -400,7 +400,6 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         } => write!(w, " {}", constant_handle),
         Binary { args, .. } => write!(w, " {}, {}", args[0], args[1]),
         BinaryImm8 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
-        BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
         Ternary { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
         MultiAry { ref args, .. } => {
             if args.is_empty() {
@@ -418,7 +417,6 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             write!(w, " {}, {}, {}", args[0], args[1], data)
         }
         IntCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
-        IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, imm),
         IntCond { cond, arg, .. } => write!(w, " {} {}", cond, arg),
         FloatCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
         FloatCond { cond, arg, .. } => write!(w, " {} {}", cond, arg),

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -9,9 +9,9 @@ use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{
     types, AbiParam, Block, DataFlowGraph, DynamicStackSlot, DynamicStackSlotData, ExtFuncData,
     ExternalName, FuncRef, Function, GlobalValue, GlobalValueData, Heap, HeapData, Inst,
-    InstBuilder, InstBuilderBase, InstructionData, JumpTable, JumpTableData, LibCall, MemFlags,
-    RelSourceLoc, SigRef, Signature, StackSlot, StackSlotData, Type, Value, ValueLabel,
-    ValueLabelAssignments, ValueLabelStart,
+    InstBuilder, InstBuilderBase, InstImmBuilder, InstructionData, JumpTable, JumpTableData,
+    LibCall, MemFlags, RelSourceLoc, SigRef, Signature, StackSlot, StackSlotData, Type, Value,
+    ValueLabel, ValueLabelAssignments, ValueLabelStart,
 };
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_codegen::packed_option::PackedOption;
@@ -160,6 +160,12 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
             self.builder.fill_current_block()
         }
         (inst, &mut self.builder.func.dfg)
+    }
+}
+
+impl<'f, 'c> InstImmBuilder<'c> for FuncInstBuilder<'c, 'f> {
+    fn insert_const(&mut self, ty: ir::Type, c: ir::immediates::Imm64) -> Value {
+        self.builder.ins().iconst(ty, c)
     }
 }
 

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -766,7 +766,9 @@ mod tests {
     use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::instructions::BranchInfo;
     use cranelift_codegen::ir::types::*;
-    use cranelift_codegen::ir::{Function, Inst, InstBuilder, JumpTableData, Opcode};
+    use cranelift_codegen::ir::{
+        Function, Inst, InstBuilder, InstImmBuilder, JumpTableData, Opcode,
+    };
     use cranelift_codegen::settings;
     use cranelift_codegen::verify_function;
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -472,19 +472,9 @@ where
             &arg(0)?,
             &arg(1)?,
         )?),
-        Opcode::IcmpImm => assign(icmp(
-            ctrl_ty,
-            inst.cond_code().unwrap(),
-            &arg(0)?,
-            &imm_as_ctrl_ty()?,
-        )?),
-        Opcode::Ifcmp | Opcode::IfcmpImm => {
+        Opcode::Ifcmp => {
             let arg0 = arg(0)?;
-            let arg1 = match inst.opcode() {
-                Opcode::Ifcmp => arg(1)?,
-                Opcode::IfcmpImm => imm_as_ctrl_ty()?,
-                _ => unreachable!(),
-            };
+            let arg1 = arg(1)?;
             state.clear_flags();
             for f in &[
                 IntCC::Equal,
@@ -639,13 +629,6 @@ where
         Opcode::Sdiv => binary_can_trap(Value::div, arg(0)?, arg(1)?)?,
         Opcode::Urem => binary_unsigned_can_trap(Value::rem, arg(0)?, arg(1)?)?,
         Opcode::Srem => binary_can_trap(Value::rem, arg(0)?, arg(1)?)?,
-        Opcode::IaddImm => binary(Value::add, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::ImulImm => binary(Value::mul, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::UdivImm => binary_unsigned_can_trap(Value::div, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::SdivImm => binary_can_trap(Value::div, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::UremImm => binary_unsigned_can_trap(Value::rem, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::SremImm => binary_can_trap(Value::rem, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::IrsubImm => binary(Value::sub, imm_as_ctrl_ty()?, arg(0)?)?,
         Opcode::IaddCin => choose(
             Value::into_bool(arg(2)?)?,
             Value::add(Value::add(arg(0)?, arg(1)?)?, Value::int(1, ctrl_ty)?)?,
@@ -697,19 +680,11 @@ where
         Opcode::BandNot => binary(Value::and, arg(0)?, Value::not(arg(1)?)?)?,
         Opcode::BorNot => binary(Value::or, arg(0)?, Value::not(arg(1)?)?)?,
         Opcode::BxorNot => binary(Value::xor, arg(0)?, Value::not(arg(1)?)?)?,
-        Opcode::BandImm => binary(Value::and, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::BorImm => binary(Value::or, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::BxorImm => binary(Value::xor, arg(0)?, imm_as_ctrl_ty()?)?,
         Opcode::Rotl => binary(Value::rotl, arg(0)?, arg(1)?)?,
         Opcode::Rotr => binary(Value::rotr, arg(0)?, arg(1)?)?,
-        Opcode::RotlImm => binary(Value::rotl, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::RotrImm => binary(Value::rotr, arg(0)?, imm_as_ctrl_ty()?)?,
         Opcode::Ishl => binary(Value::shl, arg(0)?, arg(1)?)?,
         Opcode::Ushr => binary_unsigned(Value::ushr, arg(0)?, arg(1)?)?,
         Opcode::Sshr => binary(Value::ishr, arg(0)?, arg(1)?)?,
-        Opcode::IshlImm => binary(Value::shl, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::UshrImm => binary_unsigned(Value::ushr, arg(0)?, imm_as_ctrl_ty()?)?,
-        Opcode::SshrImm => binary(Value::ishr, arg(0)?, imm_as_ctrl_ty()?)?,
         Opcode::Bitrev => assign(Value::reverse_bits(arg(0)?)?),
         Opcode::Clz => assign(arg(0)?.leading_zeros()?),
         Opcode::Cls => {

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2795,16 +2795,6 @@ impl<'a> Parser<'a> {
                 let imm = self.match_uimm8("expected unsigned 8-bit immediate")?;
                 InstructionData::BinaryImm8 { opcode, arg, imm }
             }
-            InstructionFormat::BinaryImm64 => {
-                let lhs = self.match_value("expected SSA value first operand")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let rhs = self.match_imm64("expected immediate integer second operand")?;
-                InstructionData::BinaryImm64 {
-                    opcode,
-                    arg: lhs,
-                    imm: rhs,
-                }
-            }
             InstructionFormat::Ternary => {
                 // Names here refer to the `select` instruction.
                 // This format is also use by `fma`.
@@ -2936,18 +2926,6 @@ impl<'a> Parser<'a> {
                     opcode,
                     cond,
                     args: [lhs, rhs],
-                }
-            }
-            InstructionFormat::IntCompareImm => {
-                let cond = self.match_enum("expected intcc condition code")?;
-                let lhs = self.match_value("expected SSA value first operand")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
-                let rhs = self.match_imm64("expected immediate second operand")?;
-                InstructionData::IntCompareImm {
-                    opcode,
-                    cond,
-                    arg: lhs,
-                    imm: rhs,
                 }
             }
             InstructionFormat::IntCond => {

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -85,7 +85,8 @@ use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
-    self, AtomicRmwOp, ConstantData, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
+    self, AtomicRmwOp, ConstantData, InstBuilder, InstImmBuilder, JumpTableData, MemFlags, Value,
+    ValueLabel,
 };
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_frontend::{FunctionBuilder, Variable};

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -16,7 +16,7 @@ use crate::{
 use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::immediates::{Offset32, Uimm64};
-use cranelift_codegen::ir::{self, InstBuilder};
+use cranelift_codegen::ir::{self, InstBuilder, InstImmBuilder};
 use cranelift_codegen::ir::{types::*, UserFuncName};
 use cranelift_codegen::isa::{CallConv, TargetFrontendConfig};
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -4,7 +4,7 @@ use crate::compiler::{Compiler, CompilerContext};
 use crate::obj::ModuleTextBuilder;
 use crate::CompiledFunction;
 use anyhow::Result;
-use cranelift_codegen::ir::{self, InstBuilder, MemFlags};
+use cranelift_codegen::ir::{self, InstBuilder, InstImmBuilder, MemFlags};
 use cranelift_frontend::FunctionBuilder;
 use object::write::Object;
 use std::any::Any;

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3,7 +3,9 @@ use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::*;
 use cranelift_codegen::ir::immediates::{Imm64, Offset32, Uimm64};
 use cranelift_codegen::ir::types::*;
-use cranelift_codegen::ir::{AbiParam, ArgumentPurpose, Function, InstBuilder, Signature};
+use cranelift_codegen::ir::{
+    AbiParam, ArgumentPurpose, Function, InstBuilder, InstImmBuilder, Signature,
+};
 use cranelift_codegen::isa::{self, TargetFrontendConfig, TargetIsa};
 use cranelift_entity::EntityRef;
 use cranelift_frontend::FunctionBuilder;


### PR DESCRIPTION
I have no idea yet whether this is a good change, and it definitely
should not be merged as-is. The main issues are that there are a bunch
of tests I haven't fixed up, and some optimizations I've removed. Also I
have no performance measurements yet to see what effect this has on
either compile time or generated code quality.

I just wanted to understand what the `*_imm` instructions were used for,
and trying to grep for them didn't work out well. So I removed them to
let the compiler tell me where they're used instead.

To avoid having to make as many changes, I introduced a `InstImmBuilder`
trait. It provides methods like `iadd_imm` which emit the pair of
instructions that legalization would have decomposed that instruction
into eventually anyway.

I have several questions that this may help with answering:

- Is there significant savings, in IR code size and/or compile time,
  from inlining one immediate operand into some instructions at the
  frontend? Or is the widespread frontend use of these instructions just
  for convenience?

- Can simple_preopt cleanly identify arithmetic identities involving
  constants without rewriting to use these combined forms?

- Is there a compile-time cost to simple_preopt rewriting into combined
  forms, only for legalization to rewrite them away again soon after?

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
