### PR TITLE
Fix a soundness issue with lowering variants

### DIFF
--- a/crates/fuzzing/src/generators/component_types.rs
+++ b/crates/fuzzing/src/generators/component_types.rs
@@ -141,6 +141,7 @@ macro_rules! define_static_api_test {
 
             let mut config = Config::new();
             config.wasm_component_model(true);
+            config.debug_adapter_modules(input.arbitrary()?);
             let engine = Engine::new(&config).unwrap();
             let wat = declarations.make_component();
             let wat = wat.as_bytes();

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1087,7 +1087,9 @@ pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbi
 
     let case = input.arbitrary::<TestCase>()?;
 
-    let engine = component_test_util::engine();
+    let mut config = component_test_util::config();
+    config.debug_adapter_modules(input.arbitrary()?);
+    let engine = Engine::new(&config).unwrap();
     let mut store = Store::new(&engine, (Box::new([]) as Box<[Val]>, None));
     let wat = case.declarations().make_component();
     let wat = wat.as_bytes();

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -983,7 +983,13 @@ impl ValRaw {
     /// Creates a WebAssembly `i32` value
     #[inline]
     pub fn i32(i: i32) -> ValRaw {
-        ValRaw { i32: i.to_le() }
+        // Note that this is intentionally not setting the `i32` field, instead
+        // setting the `i64` field with a zero-extended version of `i`. For more
+        // information on this see the comments on `Lower for Result` in the
+        // `wasmtime` crate. Otherwise though all `ValRaw` constructors are
+        // otherwise constrained to guarantee that the initial 64-bits are
+        // always initialized.
+        ValRaw::u64((i as u32).into())
     }
 
     /// Creates a WebAssembly `i64` value
@@ -995,7 +1001,9 @@ impl ValRaw {
     /// Creates a WebAssembly `i32` value
     #[inline]
     pub fn u32(i: u32) -> ValRaw {
-        ValRaw::i32(i as i32)
+        // See comments in `ValRaw::i32` for why this is setting the upper
+        // 32-bits as well.
+        ValRaw::u64(i.into())
     }
 
     /// Creates a WebAssembly `i64` value
@@ -1007,7 +1015,9 @@ impl ValRaw {
     /// Creates a WebAssembly `f32` value
     #[inline]
     pub fn f32(i: u32) -> ValRaw {
-        ValRaw { f32: i.to_le() }
+        // See comments in `ValRaw::i32` for why this is setting the upper
+        // 32-bits as well.
+        ValRaw::u64(i.into())
     }
 
     /// Creates a WebAssembly `f64` value

--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -37,15 +37,20 @@ use wasmtime_runtime::{Export, ExportFunction, VMTrampoline};
 #[doc(hidden)]
 #[macro_export]
 macro_rules! map_maybe_uninit {
-    ($maybe_uninit:ident $($field:tt)*) => (#[allow(unused_unsafe)] unsafe {
-        use $crate::component::__internal::MaybeUninitExt;
+    ($maybe_uninit:ident $($field:tt)*) => ({
+        #[allow(unused_unsafe)]
+        {
+            unsafe {
+                use $crate::component::__internal::MaybeUninitExt;
 
-        let m: &mut std::mem::MaybeUninit<_> = $maybe_uninit;
-        // Note the usage of `addr_of_mut!` here which is an attempt to "stay
-        // safe" here where we never accidentally create `&mut T` where `T` is
-        // actually uninitialized, hopefully appeasing the Rust unsafe
-        // guidelines gods.
-        m.map(|p| std::ptr::addr_of_mut!((*p)$($field)*))
+                let m: &mut std::mem::MaybeUninit<_> = $maybe_uninit;
+                // Note the usage of `addr_of_mut!` here which is an attempt to "stay
+                // safe" here where we never accidentally create `&mut T` where `T` is
+                // actually uninitialized, hopefully appeasing the Rust unsafe
+                // guidelines gods.
+                m.map(|p| std::ptr::addr_of_mut!((*p)$($field)*))
+            }
+        }
     })
 }
 

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -8,6 +8,7 @@ mod func;
 mod instance;
 mod linker;
 mod matching;
+mod storage;
 mod store;
 pub mod types;
 mod values;
@@ -28,8 +29,9 @@ pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 #[doc(hidden)]
 pub mod __internal {
     pub use super::func::{
-        format_flags, typecheck_enum, typecheck_flags, typecheck_record, typecheck_union,
-        typecheck_variant, ComponentVariant, MaybeUninitExt, Memory, MemoryMut, Options,
+        format_flags, lower_payload, typecheck_enum, typecheck_flags, typecheck_record,
+        typecheck_union, typecheck_variant, ComponentVariant, MaybeUninitExt, Memory, MemoryMut,
+        Options,
     };
     pub use crate::map_maybe_uninit;
     pub use crate::store::StoreOpaque;

--- a/crates/wasmtime/src/component/storage.rs
+++ b/crates/wasmtime/src/component/storage.rs
@@ -1,0 +1,43 @@
+use crate::ValRaw;
+use std::mem::{self, MaybeUninit};
+use std::slice;
+
+fn assert_raw_slice_compat<T>() {
+    assert!(mem::size_of::<T>() % mem::size_of::<ValRaw>() == 0);
+    assert!(mem::align_of::<T>() == mem::align_of::<ValRaw>());
+}
+
+/// Converts a `<T as ComponentType>::Lower` representation to a slice of
+/// `ValRaw`.
+pub unsafe fn storage_as_slice<T>(storage: &T) -> &[ValRaw] {
+    assert_raw_slice_compat::<T>();
+
+    slice::from_raw_parts(
+        (storage as *const T).cast(),
+        mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
+    )
+}
+
+/// Same as `storage_as_slice`, but mutable.
+pub unsafe fn storage_as_slice_mut<T>(storage: &mut T) -> &mut [ValRaw] {
+    assert_raw_slice_compat::<T>();
+
+    slice::from_raw_parts_mut(
+        (storage as *mut T).cast(),
+        mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
+    )
+}
+
+/// Same as `storage_as_slice`, but in reverse and mutable.
+pub unsafe fn slice_to_storage_mut<T>(slice: &mut [ValRaw]) -> &mut MaybeUninit<T> {
+    assert_raw_slice_compat::<T>();
+
+    // This is an actual runtime assertion which if performance calls for we may
+    // need to relax to a debug assertion. This notably tries to ensure that we
+    // stay within the bounds of the number of actual values given rather than
+    // reading past the end of an array. This shouldn't actually trip unless
+    // there's a bug in Wasmtime though.
+    assert!(mem::size_of_val(slice) >= mem::size_of::<T>());
+
+    &mut *slice.as_mut_ptr().cast()
+}

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -875,10 +875,14 @@ impl Val {
             }) => {
                 next_mut(dst).write(ValRaw::u32(*discriminant));
                 value.lower(store, options, dst)?;
+
+                // For the remaining lowered representation of this variant that
+                // the payload didn't write we write out zeros here to ensure
+                // the entire variant is written.
                 let value_flat = value.ty().canonical_abi().flat_count(usize::MAX).unwrap();
                 let variant_flat = self.ty().canonical_abi().flat_count(usize::MAX).unwrap();
                 for _ in (1 + value_flat)..variant_flat {
-                    next_mut(dst).write(ValRaw::u32(0));
+                    next_mut(dst).write(ValRaw::u64(0));
                 }
             }
             Val::Enum(Enum { discriminant, .. }) => {


### PR DESCRIPTION
This commit fixes a soundness issue lowering variants in the component
model where host memory could be leaked to the guest module by accident.
In reviewing code recently for `Val::lower` I noticed that the variant
lowering was extending the payload with `ValRaw::u32(0)` to
appropriately fit the size of the variant. In reading this it appeared
incorrect to me due to the fact that it should be `ValRaw::u64(0)` since
up to 64-bits can be read. Additionally this implementation was also
incorrect because the lowered representation of the payload itself was
not possibly zero-extended to 64-bits to accommodate other variants.

It turned out these issues were benign because with the dynamic
surface area to the component model the arguments were all initialized
to 0 anyway. The static version of the API, however, does not initialize
arguments to 0 and I wanted to initially align these two implementations
so I updated the variant implementation of lowering for dynamic values
and removed the zero-ing of arguments.

To test this change I updated the `debug` mode of adapter module
generation to assert that the upper bits of values in wasm are always
zero when the value is casted down (during `stack_get` which only
happens with variants). I then threaded through the `debug` boolean
configuration parameter into the dynamic and static fuzzers.

To my surprise this new assertion tripped even after the fix was
applied. It turns out, though, that there was other leakage of bits
through other means that I was previously unaware of. At the primitive
level lowerings of types like `u32` will have a `Lower` representation
of `ValRaw` and the lowering is simply `dst.write(ValRaw::i32(self))`,
or the equivalent thereof. The problem, that the fuzzers detected, with
this pattern is that the `ValRaw` type is 16-bytes, and
`ValRaw::i32(X)` only initializes the first 4. This meant that all the
lowerings for all primitives were writing up to 12 bytes of garbage from
the host for the wasm module to read.

It turned out that this write of a `ValRaw` was sometimes 16 bytes and
sometimes the appropriate size depending on the number of optimizations
in play. With enough inlining for example `dst.write(ValRaw::i32(self))`
would only write 4 bytes, as expected. In debug mode though without
inlining 16 bytes would be written, including the garbage from the upper
bits.

To solve this issue I ended up taking a somewhat different approach. I
primarily updated the `ValRaw` constructors to simply always extend the
values internally to 64-bits, meaning that the low 8 bytes of a `ValRaw`
is always initialized. This prevents any undefined data from leaking
from the host into a wasm module, and means that values are also
zero-extended even if they're only used in 32-bit contexts outside of a
variant. This felt like the best fix for now, though, in terms of
not really having a performance impact while additionally not requiring
a rewrite of all lowerings.

This solution ended up also neatly removing the "zero out the entire
payload" logic that was previously require. Now after a payload is
lowered only the tail end of the payload, up to the size of the variant,
is zeroed out. This means that each lowered argument is written to at
most once which should hopefully be a small performance boost for
calling into functions as well.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
