### PR TITLE
Remove unreachable x64 lowerings for iadd_imm

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -189,37 +189,6 @@
 
 ;; (No `iadd_ifcout` for `i128`.)
 
-;;;; Rules for `iadd_imm` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; `i64` and smaller.
-
-;; When the immediate fits in a `RegMemImm.Imm`, use that.
-(rule (lower (has_type (fits_in_64 ty) (iadd_imm y (simm32_from_imm64 x))))
-      (x64_add ty y x))
-
-;; Otherwise, put the immediate into a register.
-(rule (lower (has_type (fits_in_64 ty) (iadd_imm y (u64_from_imm64 x))))
-      (x64_add ty y (imm ty x)))
-
-;; `i128`
-
-;; When the immediate fits in a `RegMemImm.Imm`, use that.
-(rule (lower (has_type $I128 (iadd_imm y (simm32_from_imm64 x))))
-      (let ((y_regs ValueRegs y)
-            (y_lo Gpr (value_regs_get_gpr y_regs 0))
-            (y_hi Gpr (value_regs_get_gpr y_regs 1)))
-        (with_flags (x64_add_with_flags_paired $I64 y_lo x)
-                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
-
-;; Otherwise, put the immediate into a register.
-(rule (lower (has_type $I128 (iadd_imm y (u64_from_imm64 x))))
-      (let ((y_regs ValueRegs y)
-            (y_lo Gpr (value_regs_get_gpr y_regs 0))
-            (y_hi Gpr (value_regs_get_gpr y_regs 1))
-            (x_lo Gpr (imm $I64 x)))
-        (with_flags (x64_add_with_flags_paired $I64 y_lo x_lo)
-                    (x64_adc_paired $I64 y_hi (RegMemImm.Imm 0)))))
-
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `i64` and smaller.


### PR DESCRIPTION
All of the `*_imm` instructions are rewritten during legalization to an explicit `iconst` plus the general form of the operator, so backends never see them. Therefore these ISLE rules in the x64 backend can never match anything.

This came up in #4721 but is independent of that issue.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
