### PR TITLE
Limit the size of functions in the `stacks` fuzzer

### DIFF
--- a/crates/fuzzing/src/generators/stacks.rs
+++ b/crates/fuzzing/src/generators/stacks.rs
@@ -11,6 +11,7 @@ use arbitrary::{Arbitrary, Result, Unstructured};
 use wasm_encoder::Instruction;
 
 const MAX_FUNCS: usize = 20;
+const MAX_OPS: usize = 1_000;
 
 /// Generate a Wasm module that keeps track of its current call stack, to
 /// compare to the host.
@@ -50,7 +51,10 @@ impl Stacks {
         let mut work_list = vec![0];
 
         while let Some(f) = work_list.pop() {
-            let mut ops = u.arbitrary::<Vec<Op>>()?;
+            let mut ops = u
+                .arbitrary_iter::<Op>()?
+                .take(MAX_OPS)
+                .collect::<Result<Vec<_>>>()?;
             for op in &mut ops {
                 match op {
                     Op::CallThroughHost(idx) | Op::Call(idx) => {


### PR DESCRIPTION
The fuzzers recently found a timeout in this fuzz test case related to
the compile time of the generated module. Inspecting the generated
module showed that it had 100k+ opcodes for one function, so this commit
updates the fuzzer to limit the number of operations per-function to a
smaller amount to avoid timeout limits.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
