### PR TITLE
x64: Lower fcopysign, ceil, floor, nearest, and trunc in ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3709,7 +3709,13 @@
         FmaF32
         FmaF64
         CeilF32
-        CeilF64))
+        CeilF64
+        FloorF32
+        FloorF64
+        NearestF32
+        NearestF64
+        TruncF32
+        TruncF64))
 
 (decl libcall_1 (LibCall Reg) Reg)
 (extern constructor libcall_1 libcall_1)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1120,6 +1120,15 @@
 (decl encode_fcmp_imm (FcmpImm) u8)
 (extern constructor encode_fcmp_imm encode_fcmp_imm)
 
+(type RoundImm extern
+      (enum RoundNearest
+            RoundDown
+            RoundUp
+            RoundZero))
+
+(decl encode_round_imm (RoundImm) u8)
+(extern constructor encode_round_imm encode_round_imm)
+
 ;;;; Newtypes for Different Register Classes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (type Gpr (primitive Gpr))
@@ -1393,6 +1402,9 @@
 
 (decl use_fma () Type)
 (extern extractor use_fma use_fma)
+
+(decl use_sse41 () Type)
+(extern extractor use_sse41 use_sse41)
 
 ;;;; Helpers for Merging and Sinking Immediates/Loads  ;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2575,6 +2587,42 @@
                     lane
                     size))
 
+;; Helper for creating `roundss` instructions.
+(decl x64_roundss (Xmm RoundImm) Xmm)
+(rule (x64_roundss src1 round)
+      (xmm_rm_r_imm (SseOpcode.Roundss)
+                    src1
+                    src1
+                    (encode_round_imm round)
+                    (OperandSize.Size32)))
+
+;; Helper for creating `roundsd` instructions.
+(decl x64_roundsd (Xmm RoundImm) Xmm)
+(rule (x64_roundsd src1 round)
+      (xmm_rm_r_imm (SseOpcode.Roundsd)
+                    src1
+                    src1
+                    (encode_round_imm round)
+                    (OperandSize.Size32)))
+
+;; Helper for creating `roundps` instructions.
+(decl x64_roundps (Xmm RoundImm) Xmm)
+(rule (x64_roundps src1 round)
+      (xmm_rm_r_imm (SseOpcode.Roundps)
+                    src1
+                    src1
+                    (encode_round_imm round)
+                    (OperandSize.Size32)))
+
+;; Helper for creating `roundpd` instructions.
+(decl x64_roundpd (Xmm RoundImm) Xmm)
+(rule (x64_roundpd src1 round)
+      (xmm_rm_r_imm (SseOpcode.Roundpd)
+                    src1
+                    src1
+                    (encode_round_imm round)
+                    (OperandSize.Size32)))
+
 ;; Helper for creating `pmaddwd` instructions.
 (decl x64_pmaddwd (Xmm XmmMem) Xmm)
 (rule (x64_pmaddwd src1 src2)
@@ -3659,7 +3707,12 @@
 (type LibCall extern
       (enum
         FmaF32
-        FmaF64))
+        FmaF64
+        CeilF32
+        CeilF64))
+
+(decl libcall_1 (LibCall Reg) Reg)
+(extern constructor libcall_1 libcall_1)
 
 (decl libcall_3 (LibCall Reg Reg Reg) Reg)
 (extern constructor libcall_3 libcall_3)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1770,7 +1770,8 @@ impl From<FloatCC> for FcmpImm {
 /// However the rounding immediate which this field helps make up, also includes
 /// bits 3 and 4 which define the rounding select and precision mask respectively.
 /// These two bits are not defined here and are implictly set to zero when encoded.
-pub(crate) enum RoundImm {
+#[derive(Clone, Copy)]
+pub enum RoundImm {
     RoundNearest = 0x00,
     RoundDown = 0x01,
     RoundUp = 0x02,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3319,3 +3319,18 @@
 
 (rule (lower (has_type $F64 (bitcast src @ (value_type $I64))))
       (bitcast_gpr_to_xmm $I64 src))
+
+;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type $F32 (fcopysign a @ (value_type $F32) b)))
+      (let ((sign_bit Xmm (imm $F32 0x80000000)))
+        (x64_orps
+          (x64_andnps sign_bit a)
+          (x64_andps sign_bit b))))
+
+(rule (lower (has_type $F64 (fcopysign a @ (value_type $F64) b)))
+      (let ((sign_bit Xmm (imm $F64 0x8000000000000000)))
+        (x64_orpd
+          (x64_andnpd sign_bit a)
+          (x64_andpd sign_bit b))))
+

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3373,3 +3373,23 @@
 
 (rule (lower (has_type (use_sse41) (floor a @ (value_type $F64X2))))
       (x64_roundpd a (RoundImm.RoundDown)))
+
+;; Rules for `nearest` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (use_sse41) (nearest a @ (value_type $F32))))
+      (x64_roundss a (RoundImm.RoundNearest)))
+
+(rule (lower (nearest a @ (value_type $F32)))
+      (libcall_1 (LibCall.NearestF32) a))
+
+(rule (lower (has_type (use_sse41) (nearest a @ (value_type $F64))))
+      (x64_roundsd a (RoundImm.RoundNearest)))
+
+(rule (lower (nearest a @ (value_type $F64)))
+      (libcall_1 (LibCall.NearestF64) a))
+
+(rule (lower (has_type (use_sse41) (nearest a @ (value_type $F32X4))))
+      (x64_roundps a (RoundImm.RoundNearest)))
+
+(rule (lower (has_type (use_sse41) (nearest a @ (value_type $F64X2))))
+      (x64_roundpd a (RoundImm.RoundNearest)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3393,3 +3393,23 @@
 
 (rule (lower (has_type (use_sse41) (nearest a @ (value_type $F64X2))))
       (x64_roundpd a (RoundImm.RoundNearest)))
+
+;; Rules for `trunc` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (use_sse41) (trunc a @ (value_type $F32))))
+      (x64_roundss a (RoundImm.RoundZero)))
+
+(rule (lower (trunc a @ (value_type $F32)))
+      (libcall_1 (LibCall.TruncF32) a))
+
+(rule (lower (has_type (use_sse41) (trunc a @ (value_type $F64))))
+      (x64_roundsd a (RoundImm.RoundZero)))
+
+(rule (lower (trunc a @ (value_type $F64)))
+      (libcall_1 (LibCall.TruncF64) a))
+
+(rule (lower (has_type (use_sse41) (trunc a @ (value_type $F32X4))))
+      (x64_roundps a (RoundImm.RoundZero)))
+
+(rule (lower (has_type (use_sse41) (trunc a @ (value_type $F64X2))))
+      (x64_roundpd a (RoundImm.RoundZero)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3334,3 +3334,22 @@
           (x64_andnpd sign_bit a)
           (x64_andpd sign_bit b))))
 
+;; Rules for `ceil` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (use_sse41) (ceil a @ (value_type $F32))))
+      (x64_roundss a (RoundImm.RoundUp)))
+
+(rule (lower (ceil a @ (value_type $F32)))
+      (libcall_1 (LibCall.CeilF32) a))
+
+(rule (lower (has_type (use_sse41) (ceil a @ (value_type $F64))))
+      (x64_roundsd a (RoundImm.RoundUp)))
+
+(rule (lower (ceil a @ (value_type $F64)))
+      (libcall_1 (LibCall.CeilF64) a))
+
+(rule (lower (has_type (use_sse41) (ceil a @ (value_type $F32X4))))
+      (x64_roundps a (RoundImm.RoundUp)))
+
+(rule (lower (has_type (use_sse41) (ceil a @ (value_type $F64X2))))
+      (x64_roundpd a (RoundImm.RoundUp)))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3353,3 +3353,23 @@
 
 (rule (lower (has_type (use_sse41) (ceil a @ (value_type $F64X2))))
       (x64_roundpd a (RoundImm.RoundUp)))
+
+;; Rules for `floor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (use_sse41) (floor a @ (value_type $F32))))
+      (x64_roundss a (RoundImm.RoundDown)))
+
+(rule (lower (floor a @ (value_type $F32)))
+      (libcall_1 (LibCall.FloorF32) a))
+
+(rule (lower (has_type (use_sse41) (floor a @ (value_type $F64))))
+      (x64_roundsd a (RoundImm.RoundDown)))
+
+(rule (lower (floor a @ (value_type $F64)))
+      (libcall_1 (LibCall.FloorF64) a))
+
+(rule (lower (has_type (use_sse41) (floor a @ (value_type $F32X4))))
+      (x64_roundps a (RoundImm.RoundDown)))
+
+(rule (lower (has_type (use_sse41) (floor a @ (value_type $F64X2))))
+      (x64_roundpd a (RoundImm.RoundDown)))

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -570,26 +570,26 @@ fn lower_insn_to_regs(
         | Opcode::Bitcast
         | Opcode::Fabs
         | Opcode::Fneg
-        | Opcode::Fcopysign => {
+        | Opcode::Fcopysign
+        | Opcode::Ceil => {
             implemented_in_isle(ctx);
         }
 
-        Opcode::Ceil | Opcode::Floor | Opcode::Nearest | Opcode::Trunc => {
+        Opcode::Floor | Opcode::Nearest | Opcode::Trunc => {
             let ty = ty.unwrap();
             if isa_flags.use_sse41() {
                 let mode = match op {
-                    Opcode::Ceil => RoundImm::RoundUp,
                     Opcode::Floor => RoundImm::RoundDown,
                     Opcode::Nearest => RoundImm::RoundNearest,
                     Opcode::Trunc => RoundImm::RoundZero,
-                    _ => panic!("unexpected opcode {:?} in Ceil/Floor/Nearest/Trunc", op),
+                    _ => panic!("unexpected opcode {:?} in Floor/Nearest/Trunc", op),
                 };
                 let op = match ty {
                     types::F32 => SseOpcode::Roundss,
                     types::F64 => SseOpcode::Roundsd,
                     types::F32X4 => SseOpcode::Roundps,
                     types::F64X2 => SseOpcode::Roundpd,
-                    _ => panic!("unexpected type {:?} in Ceil/Floor/Nearest/Trunc", ty),
+                    _ => panic!("unexpected type {:?} in Floor/Nearest/Trunc", ty),
                 };
                 let src = input_to_reg_mem(ctx, inputs[0]);
                 let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
@@ -605,8 +605,6 @@ fn lower_insn_to_regs(
                 // Note, for vector types on platforms that don't support sse41
                 // the execution will panic here.
                 let libcall = match (op, ty) {
-                    (Opcode::Ceil, types::F32) => LibCall::CeilF32,
-                    (Opcode::Ceil, types::F64) => LibCall::CeilF64,
                     (Opcode::Floor, types::F32) => LibCall::FloorF32,
                     (Opcode::Floor, types::F64) => LibCall::FloorF64,
                     (Opcode::Nearest, types::F32) => LibCall::NearestF32,
@@ -614,7 +612,7 @@ fn lower_insn_to_regs(
                     (Opcode::Trunc, types::F32) => LibCall::TruncF32,
                     (Opcode::Trunc, types::F64) => LibCall::TruncF64,
                     _ => panic!(
-                        "unexpected type/opcode {:?}/{:?} in Ceil/Floor/Nearest/Trunc",
+                        "unexpected type/opcode {:?}/{:?} in Floor/Nearest/Trunc",
                         ty, op
                     ),
                 };

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -571,25 +571,25 @@ fn lower_insn_to_regs(
         | Opcode::Fabs
         | Opcode::Fneg
         | Opcode::Fcopysign
-        | Opcode::Ceil => {
+        | Opcode::Ceil
+        | Opcode::Floor => {
             implemented_in_isle(ctx);
         }
 
-        Opcode::Floor | Opcode::Nearest | Opcode::Trunc => {
+        Opcode::Nearest | Opcode::Trunc => {
             let ty = ty.unwrap();
             if isa_flags.use_sse41() {
                 let mode = match op {
-                    Opcode::Floor => RoundImm::RoundDown,
                     Opcode::Nearest => RoundImm::RoundNearest,
                     Opcode::Trunc => RoundImm::RoundZero,
-                    _ => panic!("unexpected opcode {:?} in Floor/Nearest/Trunc", op),
+                    _ => panic!("unexpected opcode {:?} in Nearest/Trunc", op),
                 };
                 let op = match ty {
                     types::F32 => SseOpcode::Roundss,
                     types::F64 => SseOpcode::Roundsd,
                     types::F32X4 => SseOpcode::Roundps,
                     types::F64X2 => SseOpcode::Roundpd,
-                    _ => panic!("unexpected type {:?} in Floor/Nearest/Trunc", ty),
+                    _ => panic!("unexpected type {:?} in Nearest/Trunc", ty),
                 };
                 let src = input_to_reg_mem(ctx, inputs[0]);
                 let dst = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
@@ -605,14 +605,12 @@ fn lower_insn_to_regs(
                 // Note, for vector types on platforms that don't support sse41
                 // the execution will panic here.
                 let libcall = match (op, ty) {
-                    (Opcode::Floor, types::F32) => LibCall::FloorF32,
-                    (Opcode::Floor, types::F64) => LibCall::FloorF64,
                     (Opcode::Nearest, types::F32) => LibCall::NearestF32,
                     (Opcode::Nearest, types::F64) => LibCall::NearestF64,
                     (Opcode::Trunc, types::F32) => LibCall::TruncF32,
                     (Opcode::Trunc, types::F64) => LibCall::TruncF64,
                     _ => panic!(
-                        "unexpected type/opcode {:?}/{:?} in Floor/Nearest/Trunc",
+                        "unexpected type/opcode {:?}/{:?} in Nearest/Trunc",
                         ty, op
                     ),
                 };

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -1,0 +1,33 @@
+test compile precise-output
+target x86_64 has_sse41=false
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %CeilF32+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %CeilF64+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -1,0 +1,59 @@
+test compile precise-output
+target x86_64 has_sse41=true
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundss $2, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundsd $2, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundps $2, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f64x2) -> f64x2 {
+block0(v0: f64x2):
+  v1 = ceil v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundpd $2, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -1,0 +1,43 @@
+test compile precise-output
+target x86_64
+
+function %f1(f32, f32) -> f32 {
+block0(v0: f32, v1: f32):
+  v2 = fcopysign v0, v1
+  return v2
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movl    $-2147483648, %r11d
+;   movd    %r11d, %xmm7
+;   movdqa  %xmm0, %xmm14
+;   movdqa  %xmm7, %xmm0
+;   andnps  %xmm0, %xmm14, %xmm0
+;   andps   %xmm1, %xmm7, %xmm1
+;   orps    %xmm0, %xmm1, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f1(f64, f64) -> f64 {
+block0(v0: f64, v1: f64):
+  v2 = fcopysign v0, v1
+  return v2
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movabsq $-9223372036854775808, %r11
+;   movq    %r11, %xmm7
+;   movdqa  %xmm0, %xmm14
+;   movdqa  %xmm7, %xmm0
+;   andnpd  %xmm0, %xmm14, %xmm0
+;   andpd   %xmm1, %xmm7, %xmm1
+;   orpd    %xmm0, %xmm1, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -10,13 +10,13 @@ block0(v0: f32, v1: f32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $-2147483648, %r11d
-;   movd    %r11d, %xmm7
+;   movl    $-2147483648, %r8d
+;   movd    %r8d, %xmm9
 ;   movdqa  %xmm0, %xmm14
-;   movdqa  %xmm7, %xmm0
+;   movdqa  %xmm9, %xmm0
 ;   andnps  %xmm0, %xmm14, %xmm0
-;   andps   %xmm1, %xmm7, %xmm1
-;   orps    %xmm0, %xmm1, %xmm0
+;   andps   %xmm9, %xmm1, %xmm9
+;   orps    %xmm0, %xmm9, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -30,13 +30,13 @@ block0(v0: f64, v1: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movabsq $-9223372036854775808, %r11
-;   movq    %r11, %xmm7
+;   movabsq $-9223372036854775808, %r8
+;   movq    %r8, %xmm9
 ;   movdqa  %xmm0, %xmm14
-;   movdqa  %xmm7, %xmm0
+;   movdqa  %xmm9, %xmm0
 ;   andnpd  %xmm0, %xmm14, %xmm0
-;   andpd   %xmm1, %xmm7, %xmm1
-;   orpd    %xmm0, %xmm1, %xmm0
+;   andpd   %xmm9, %xmm1, %xmm9
+;   orpd    %xmm0, %xmm9, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -1,0 +1,33 @@
+test compile precise-output
+target x86_64 has_sse41=false
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %FloorF32+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %FloorF64+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/floor.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor.clif
@@ -1,0 +1,59 @@
+test compile precise-output
+target x86_64 has_sse41=true
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundss $1, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundsd $1, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundps $1, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f64x2) -> f64x2 {
+block0(v0: f64x2):
+  v1 = floor v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundpd $1, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -1,0 +1,33 @@
+test compile precise-output
+target x86_64 has_sse41=false
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %NearestF32+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %NearestF64+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -1,0 +1,59 @@
+test compile precise-output
+target x86_64 has_sse41=true
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundss $0, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundsd $0, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundps $0, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f64x2) -> f64x2 {
+block0(v0: f64x2):
+  v1 = nearest v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundpd $0, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -1,0 +1,33 @@
+test compile precise-output
+target x86_64 has_sse41=false
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %TruncF32+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   load_ext_name %TruncF64+0, %r8
+;   call    *%r8
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/trunc.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc.clif
@@ -1,0 +1,59 @@
+test compile precise-output
+target x86_64 has_sse41=true
+
+function %f1(f32) -> f32 {
+block0(v0: f32):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundss $3, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f2(f64) -> f64 {
+block0(v0: f64):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundsd $3, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f32x4) -> f32x4 {
+block0(v0: f32x4):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundps $3, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %f4(f64x2) -> f64x2 {
+block0(v0: f64x2):
+  v1 = trunc v0
+  return v1
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   roundpd $3, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+


### PR DESCRIPTION
Add tests for `fcopysign`, `ceil`, `floor`, `nearest`, and `trunc`, and lower all of those instructions in ISLE.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
