### PR TITLE
Make the subtract lazy in the icache fuzz target

### DIFF
--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -96,7 +96,7 @@ fuzz_target!(|func: SingleFunction| {
                     let imm = imm.bits();
                     cursor.func.dfg[inst] = ir::InstructionData::UnaryImm {
                         opcode: ir::Opcode::Iconst,
-                        imm: Imm64::new(imm.checked_add(1).unwrap_or(imm - 1)),
+                        imm: Imm64::new(imm.checked_add(1).unwrap_or_else(|| imm - 1)),
                     };
                 } else {
                     cursor.func.dfg[inst] = ir::InstructionData::UnaryImm {


### PR DESCRIPTION
This unchecked, always-performed subtract *could* be the cause of #4731,
if the immediate was 0 in the first place.