### PR TITLE
Fix Invalid Instruction format in fuzzgen

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -902,6 +902,9 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
             fmtln!(fmt, "data.sign_extend_immediates(ctrl_typevar);");
         }
 
+        // Assert that this opcode belongs to this format
+        fmtln!(fmt, "assert_eq!(opcode.format(), InstructionFormat::from(&data), \"Wrong InstructionFormat for Opcode: {}\", opcode);");
+
         fmt.line("self.build(data, ctrl_typevar)");
     });
     fmtln!(fmt, "}");

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -903,7 +903,7 @@ fn gen_format_constructor(format: &InstructionFormat, fmt: &mut Formatter) {
         }
 
         // Assert that this opcode belongs to this format
-        fmtln!(fmt, "assert_eq!(opcode.format(), InstructionFormat::from(&data), \"Wrong InstructionFormat for Opcode: {}\", opcode);");
+        fmtln!(fmt, "debug_assert_eq!(opcode.format(), InstructionFormat::from(&data), \"Wrong InstructionFormat for Opcode: {}\", opcode);");
 
         fmt.line("self.build(data, ctrl_typevar)");
     });

--- a/cranelift/codegen/src/ir/builder.rs
+++ b/cranelift/codegen/src/ir/builder.rs
@@ -4,6 +4,7 @@
 //! function. Many of its methods are generated from the meta language instruction definitions.
 
 use crate::ir;
+use crate::ir::instructions::InstructionFormat;
 use crate::ir::types;
 use crate::ir::{DataFlowGraph, InstructionData};
 use crate::ir::{Inst, Opcode, Type, Value};
@@ -217,7 +218,7 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::condcodes::*;
     use crate::ir::types::*;
-    use crate::ir::{Function, InstBuilder, ValueDef};
+    use crate::ir::{Function, InstBuilder, Opcode, TrapCode, ValueDef};
 
     #[test]
     fn types() {
@@ -261,5 +262,18 @@ mod tests {
         let iconst = pos.prev_inst().unwrap();
         assert!(iadd != iconst);
         assert_eq!(pos.func.dfg.value_def(v0), ValueDef::Result(iconst, 0));
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_when_inserting_wrong_opcode() {
+        let mut func = Function::new();
+        let block0 = func.dfg.make_block();
+        let mut pos = FuncCursor::new(&mut func);
+        pos.insert_block(block0);
+
+        // We are trying to create a Opcode::Return with the InstData::Trap, which is obviously wrong
+        pos.ins()
+            .Trap(Opcode::Return, I32, TrapCode::BadConversionToInteger);
     }
 }


### PR DESCRIPTION
👋 Hey,

So in #4733 oss-fuzz discovered that we have pretty much been using the wrong instruction formats for all opcodes for a while... (Thanks @jameysharp for digging into this!).

This PR does 2 things:
* Force fuzzgen to use the correct InstructionFormat for each opcode 
* Add an assert to all InstructionFormat inserters to ensure that this does not happen again (even for other users of cranelift).

Fixes #4733
cc: @cfallin 