### PR TITLE
Port `vconst` to ISLE (AArch64)

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2428,6 +2428,11 @@
       (if-let addr_reg (amode_is_reg addr))
       addr_reg)
 
+;; Lower a constant f64.
+(decl constant_f64 (u64) Reg)
+;; TODO: Port lower_constant_f64() to ISLE.
+(extern constructor constant_f64 constant_f64)
+
 ;; Lower a constant f128.
 (decl constant_f128 (u128) Reg)
 ;; TODO: Port lower_constant_f128() to ISLE.

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1628,6 +1628,15 @@
 (rule (lower (resumable_trap trap_code))
       (side_effect (udf trap_code)))
 
+;;;; Rules for `vconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (ty_vec128 _) (vconst (u128_from_constant x))))
+      (constant_f128 x))
+
+(rule (lower (has_type ty (vconst (u64_from_constant x))))
+      (if (ty_vec64 ty))
+      (constant_f64 x))
+
 ;;;; Rules for `splat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type ty (splat x @ (value_type in_ty))))

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -8,7 +8,6 @@
 //! - Floating-point immediates (FIMM instruction).
 
 use super::lower_inst;
-use crate::data_value::DataValue;
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::types::*;
 use crate::ir::Inst as IRInst;
@@ -92,13 +91,6 @@ pub(crate) fn input_to_shiftimm(
     input: InsnInput,
 ) -> Option<ShiftOpShiftImm> {
     input_to_const(ctx, input).and_then(ShiftOpShiftImm::maybe_from_shift)
-}
-
-pub(crate) fn const_param_to_u128(ctx: &mut Lower<Inst>, inst: IRInst) -> Option<u128> {
-    match ctx.get_immediate(inst) {
-        Some(DataValue::V128(bytes)) => Some(u128::from_le_bytes(bytes)),
-        _ => None,
-    }
 }
 
 /// How to handle narrow values loaded into registers; see note on `narrow_mode`

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -5,9 +5,9 @@ pub mod generated_code;
 
 // Types that the generated ISLE code uses via `use super::*`.
 use super::{
-    insn_inputs, lower_constant_f128, writable_zero_reg, zero_reg, AMode, ASIMDFPModImm,
-    ASIMDMovModImm, BranchTarget, CallIndInfo, CallInfo, Cond, CondBrKind, ExtendOp, FPUOpRI,
-    FloatCC, Imm12, ImmLogic, ImmShift, Inst as MInst, IntCC, JTSequenceInfo, MachLabel,
+    insn_inputs, lower_constant_f128, lower_constant_f64, writable_zero_reg, zero_reg, AMode,
+    ASIMDFPModImm, ASIMDMovModImm, BranchTarget, CallIndInfo, CallInfo, Cond, CondBrKind, ExtendOp,
+    FPUOpRI, FloatCC, Imm12, ImmLogic, ImmShift, Inst as MInst, IntCC, JTSequenceInfo, MachLabel,
     MoveWideConst, MoveWideOp, NarrowValueMode, Opcode, OperandSize, PairAMode, Reg, ScalarSize,
     ShiftOpAndAmt, UImm5, VecMisc2, VectorSize, NZCV,
 };
@@ -482,6 +482,14 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
 
     fn amode_is_reg(&mut self, address: &AMode) -> Option<Reg> {
         address.is_reg()
+    }
+
+    fn constant_f64(&mut self, value: u64) -> Reg {
+        let rd = self.temp_writable_reg(I8X16);
+
+        lower_constant_f64(self.lower_ctx, rd, f64::from_bits(value));
+
+        rd.to_reg()
     }
 
     fn constant_f128(&mut self, value: u128) -> Reg {

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -662,11 +662,7 @@ pub(crate) fn lower_insn_to_regs(
             panic!("Branch opcode reached non-branch lowering logic!");
         }
 
-        Opcode::Vconst => {
-            let value = const_param_to_u128(ctx, insn).expect("Invalid immediate bytes");
-            let rd = get_output_reg(ctx, outputs[0]).only_reg().unwrap();
-            lower_constant_f128(ctx, rd, value);
-        }
+        Opcode::Vconst => implemented_in_isle(ctx),
 
         Opcode::RawBitcast => {
             let rm = put_input_in_reg(ctx, inputs[0], NarrowValueMode::None);

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -684,6 +684,12 @@ macro_rules! isle_prelude_methods {
         }
 
         #[inline]
+        fn u64_from_constant(&mut self, constant: Constant) -> Option<u64> {
+            let bytes = self.lower_ctx.get_constant_data(constant).as_slice();
+            Some(u64::from_le_bytes(bytes.try_into().ok()?))
+        }
+
+        #[inline]
         fn u128_from_constant(&mut self, constant: Constant) -> Option<u128> {
             let bytes = self.lower_ctx.get_constant_data(constant).as_slice();
             Some(u128::from_le_bytes(bytes.try_into().ok()?))

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1388,12 +1388,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         match inst_data {
             InstructionData::Shuffle { imm, .. } => {
                 let mask = self.f.dfg.immediates.get(imm.clone()).unwrap().as_slice();
-                let value = if mask.len() == 16 {
-                    DataValue::V128(mask.try_into().expect("a 16-byte vector mask"))
-                } else if mask.len() == 8 {
-                    DataValue::V64(mask.try_into().expect("an 8-byte vector mask"))
-                } else {
-                    panic!("unexpected Shuffle mask length {}", mask.len())
+                let value = match mask.len() {
+                    16 => DataValue::V128(mask.try_into().expect("a 16-byte vector mask")),
+                    8 => DataValue::V64(mask.try_into().expect("an 8-byte vector mask")),
+                    length => panic!("unexpected Shuffle mask length {}", length),
                 };
                 Some(value)
             }
@@ -1401,13 +1399,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 constant_handle, ..
             } => {
                 let buffer = self.f.dfg.constants.get(constant_handle.clone()).as_slice();
-
-                let value = if buffer.len() == 16 {
-                    DataValue::V128(buffer.try_into().expect("a 16-byte data buffer"))
-                } else if buffer.len() == 8 {
-                    DataValue::V64(buffer.try_into().expect("an 8-byte data buffer"))
-                } else {
-                    panic!("unexpected UnaryConst buffer length {}", buffer.len())
+                let value = match buffer.len() {
+                    16 => DataValue::V128(buffer.try_into().expect("a 16-byte data buffer")),
+                    8 => DataValue::V64(buffer.try_into().expect("an 8-byte data buffer")),
+                    length => panic!("unexpected UnaryConst buffer length {}", length),
                 };
                 Some(value)
             }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -799,6 +799,11 @@
 (decl u128_from_constant (u128) Constant)
 (extern extractor u128_from_constant u128_from_constant)
 
+;; Accessor for `Constant` as u64.
+
+(decl u64_from_constant (u64) Constant)
+(extern extractor u64_from_constant u64_from_constant)
+
 
 ;;;; Helpers for tail recursion loops ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
@@ -1,0 +1,39 @@
+test interpret
+test run
+target aarch64
+; x86_64 and s390x do not support 64-bit vectors.
+
+function %vconst_zeroes() -> i8x8 {
+block0:
+    v0 = vconst.i8x8 0x00
+    return v0
+}
+; run: %vconst_zeroes() == [0 0 0 0 0 0 0 0]
+
+function %vconst_ones() -> i8x8 {
+block0:
+    v0 = vconst.i8x8 0xffffffffffffffff
+    return v0
+}
+; run: %vconst_ones() == [255 255 255 255 255 255 255 255]
+
+function %vconst_i8x8() -> i8x8 {
+block0:
+    v0 = vconst.i8x8 [0 31 63 95 127 159 191 255]
+    return v0
+}
+; run: %vconst_i8x8() == [0 31 63 95 127 159 191 255]
+
+function %vconst_i16x4() -> i16x4 {
+block0:
+    v0 = vconst.i16x4 [0 255 32767 65535]
+    return v0
+}
+; run: %vconst_i16x4() == [0 255 32767 65535]
+
+function %vconst_i32x2() -> i32x2 {
+block0:
+    v0 = vconst.i32x2 [0 4294967295]
+    return v0
+}
+; run: %vconst_i32x2() == [0 4294967295]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -75,12 +75,10 @@ where
                     .constants
                     .get(constant_handle.clone())
                     .as_slice();
-                if ctrl_ty.bytes() == 16 {
-                    DataValue::V128(buffer.try_into().expect("a 16-byte data buffer"))
-                } else if ctrl_ty.bytes() == 8 {
-                    DataValue::V64(buffer.try_into().expect("an 8-byte data buffer"))
-                } else {
-                    panic!("unexpected UnaryConst buffer length {}", buffer.len())
+                match ctrl_ty.bytes() {
+                    16 => DataValue::V128(buffer.try_into().expect("a 16-byte data buffer")),
+                    8 => DataValue::V64(buffer.try_into().expect("an 8-byte data buffer")),
+                    length => panic!("unexpected UnaryConst buffer length {}", length),
                 }
             }
             InstructionData::Shuffle { imm, .. } => {
@@ -91,12 +89,10 @@ where
                     .get(imm)
                     .unwrap()
                     .as_slice();
-                if ctrl_ty.bytes() == 16 {
-                    DataValue::V128(mask.try_into().expect("a 16-byte vector mask"))
-                } else if ctrl_ty.bytes() == 8 {
-                    DataValue::V64(mask.try_into().expect("an 8-byte vector mask"))
-                } else {
-                    panic!("unexpected Shuffle mask length {}", mask.len())
+                match ctrl_ty.bytes() {
+                    16 => DataValue::V128(mask.try_into().expect("a 16-byte vector mask")),
+                    8 => DataValue::V64(mask.try_into().expect("an 8-byte vector mask")),
+                    length => panic!("unexpected Shuffle mask length {}", length),
                 }
             }
             _ => inst.imm_value().unwrap(),

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -75,7 +75,13 @@ where
                     .constants
                     .get(constant_handle.clone())
                     .as_slice();
-                DataValue::V128(buffer.try_into().expect("a 16-byte data buffer"))
+                if ctrl_ty.bytes() == 16 {
+                    DataValue::V128(buffer.try_into().expect("a 16-byte data buffer"))
+                } else if ctrl_ty.bytes() == 8 {
+                    DataValue::V64(buffer.try_into().expect("an 8-byte data buffer"))
+                } else {
+                    panic!("unexpected UnaryConst buffer length {}", buffer.len())
+                }
             }
             InstructionData::Shuffle { imm, .. } => {
                 let mask = state
@@ -85,7 +91,13 @@ where
                     .get(imm)
                     .unwrap()
                     .as_slice();
-                DataValue::V128(mask.try_into().expect("a 16-byte vector mask"))
+                if ctrl_ty.bytes() == 16 {
+                    DataValue::V128(mask.try_into().expect("a 16-byte vector mask"))
+                } else if ctrl_ty.bytes() == 8 {
+                    DataValue::V64(mask.try_into().expect("an 8-byte vector mask"))
+                } else {
+                    panic!("unexpected Shuffle mask length {}", mask.len())
+                }
             }
             _ => inst.imm_value().unwrap(),
         })


### PR DESCRIPTION
Ported the existing implementation of `vconst` to ISLE for AArch64, and
added support for 64-bit vector constants.

Also introduced 64-bit `vconst` support to the interpreter.

Copyright (c) 2022 Arm Limited

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
