### PR TITLE
Don't limit ExternalName::TestName length

### DIFF
--- a/cranelift/codegen/src/ir/extname.rs
+++ b/cranelift/codegen/src/ir/extname.rs
@@ -5,7 +5,7 @@
 //! Cranelift, which compiles functions independently.
 
 use crate::ir::{KnownSymbol, LibCall};
-use core::cmp;
+use alloc::boxed::Box;
 use core::fmt::{self, Write};
 use core::str::FromStr;
 
@@ -15,8 +15,6 @@ use serde::{Deserialize, Serialize};
 
 use super::entities::UserExternalNameRef;
 use super::function::FunctionParameters;
-
-pub(crate) const TESTCASE_NAME_LENGTH: usize = 16;
 
 /// An explicit name for a user-defined function, be it defined in code or in CLIF text.
 ///
@@ -79,36 +77,26 @@ impl fmt::Display for UserExternalName {
 }
 
 /// A name for a test case.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct TestcaseName {
-    /// How many of the bytes in `ascii` are valid?
-    length: u8,
-    /// Ascii bytes of the name.
-    ascii: [u8; TESTCASE_NAME_LENGTH],
-}
+pub struct TestcaseName(Box<[u8]>);
 
 impl fmt::Display for TestcaseName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('%')?;
-        for byte in self.ascii.iter().take(self.length as usize) {
-            f.write_char(*byte as char)?;
-        }
-        Ok(())
+        f.write_str(std::str::from_utf8(&self.0).unwrap())
+    }
+}
+
+impl fmt::Debug for TestcaseName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 
 impl TestcaseName {
     pub(crate) fn new<T: AsRef<[u8]>>(v: T) -> Self {
-        let vec = v.as_ref();
-        let len = cmp::min(vec.len(), TESTCASE_NAME_LENGTH);
-        let mut bytes = [0u8; TESTCASE_NAME_LENGTH];
-        bytes[0..len].copy_from_slice(&vec[0..len]);
-
-        Self {
-            length: len as u8,
-            ascii: bytes,
-        }
+        Self(v.as_ref().into())
     }
 }
 
@@ -236,6 +224,12 @@ mod tests {
     use core::u32;
     use cranelift_entity::EntityRef as _;
 
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn externalname_size() {
+        assert_eq!(core::mem::size_of::<ExternalName>(), 24);
+    }
+
     #[test]
     fn display_testcase() {
         assert_eq!(ExternalName::testcase("").display(None).to_string(), "%");
@@ -250,12 +244,11 @@ mod tests {
                 .to_string(),
             "%longname12345678"
         );
-        // Constructor will silently drop bytes beyond the 16th
         assert_eq!(
             ExternalName::testcase("longname123456789")
                 .display(None)
                 .to_string(),
-            "%longname12345678"
+            "%longname123456789"
         );
     }
 

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -30,7 +30,7 @@ block0(v0: i32):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -54,7 +54,7 @@ block0(v0: i32):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -91,7 +91,7 @@ block0(v0: i8):
 ;   movz x6, #42
 ;   movz x7, #42
 ;   strb w15, [sp]
-;   ldr x15, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x15, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x15
 ;   add sp, sp, #16
 ;   virtual_sp_offset_adjust -16
@@ -140,25 +140,25 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x11, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x11, 8 ; b 12 ; data TestCase(%g1) + 0
 ;   blr x11
 ;   str q0, [sp, #16]
-;   ldr x13, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x13, 8 ; b 12 ; data TestCase(%g1) + 0
 ;   blr x13
 ;   str q0, [sp, #32]
-;   ldr x15, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x15, 8 ; b 12 ; data TestCase(%g2) + 0
 ;   blr x15
 ;   ldr q0, [sp]
-;   ldr x1, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x1, 8 ; b 12 ; data TestCase(%g3) + 0
 ;   blr x1
 ;   ldr q0, [sp, #16]
-;   ldr x3, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x3, 8 ; b 12 ; data TestCase(%g4) + 0
 ;   blr x3
 ;   ldr q0, [sp, #32]
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g4) + 0
 ;   blr x5
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
@@ -184,25 +184,25 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x11, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x11, 8 ; b 12 ; data TestCase(%g0) + 0
 ;   blr x11
 ;   str q0, [sp, #16]
-;   ldr x13, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x13, 8 ; b 12 ; data TestCase(%g0) + 0
 ;   blr x13
 ;   str q0, [sp, #32]
-;   ldr x15, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x15, 8 ; b 12 ; data TestCase(%g1) + 0
 ;   blr x15
 ;   ldr q0, [sp]
-;   ldr x1, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x1, 8 ; b 12 ; data TestCase(%g2) + 0
 ;   blr x1
 ;   ldr q0, [sp, #16]
-;   ldr x3, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x3, 8 ; b 12 ; data TestCase(%g2) + 0
 ;   blr x3
 ;   ldr q0, [sp, #32]
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g2) + 0
 ;   blr x5
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
@@ -232,25 +232,25 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 48, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x11, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x11, 8 ; b 12 ; data TestCase(%g1) + 0
 ;   blr x11
 ;   str q0, [sp, #16]
-;   ldr x13, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x13, 8 ; b 12 ; data TestCase(%g2) + 0
 ;   blr x13
 ;   str q0, [sp, #32]
-;   ldr x15, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x15, 8 ; b 12 ; data TestCase(%g3) + 0
 ;   blr x15
 ;   ldr q0, [sp]
-;   ldr x1, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x1, 8 ; b 12 ; data TestCase(%g4) + 0
 ;   blr x1
 ;   ldr q0, [sp, #16]
-;   ldr x3, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x3, 8 ; b 12 ; data TestCase(%g5) + 0
 ;   blr x3
 ;   ldr q0, [sp, #32]
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 2, ascii: [103, 54, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g6) + 0
 ;   blr x5
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
@@ -283,7 +283,7 @@ block0(v0: i64):
 ;   movz x0, #42
 ;   movz x2, #42
 ;   mov x1, x7
-;   ldr x10, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 49, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x10, 8 ; b 12 ; data TestCase(%f11) + 0
 ;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -315,7 +315,7 @@ block0(v0: i64):
 ;   movz x3, #42
 ;   movz x0, #42
 ;   mov x2, x7
-;   ldr x10, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 49, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x10, 8 ; b 12 ; data TestCase(%f12) + 0
 ;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -347,7 +347,7 @@ block0(v0: i64):
 ;   movz x2, #42
 ;   movz x0, #42
 ;   mov x1, x7
-;   ldr x10, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 49, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x10, 8 ; b 12 ; data TestCase(%f13) + 0
 ;   blr x10
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -388,7 +388,7 @@ block0(v0: i128, v1: i64):
 ;   mov x6, x14
 ;   str x13, [sp]
 ;   str x15, [sp, #8]
-;   ldr x7, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 49, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x7, 8 ; b 12 ; data TestCase(%f14) + 0
 ;   blr x7
 ;   add sp, sp, #16
 ;   virtual_sp_offset_adjust -16
@@ -431,7 +431,7 @@ block0(v0: i128, v1: i64):
 ;   mov x6, x14
 ;   str x13, [sp]
 ;   str x15, [sp, #8]
-;   ldr x7, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 49, 53, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x7, 8 ; b 12 ; data TestCase(%f15) + 0
 ;   blr x7
 ;   add sp, sp, #16
 ;   virtual_sp_offset_adjust -16
@@ -477,7 +477,7 @@ block0(v0: i64):
 ;   mov fp, sp
 ; block0:
 ;   mov x8, x0
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   mov x0, x8
 ;   ldp fp, lr, [sp], #16
@@ -496,7 +496,7 @@ block0(v0: i64):
 ;   str x24, [sp, #-16]!
 ; block0:
 ;   mov x24, x8
-;   ldr x5, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [103, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x5, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x5
 ;   mov x8, x24
 ;   ldr x24, [sp], #16

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -69,7 +69,7 @@ block3(v7: r64, v8: r64):
 ; block0:
 ;   str x1, [sp, #16]
 ;   str x0, [sp, #8]
-;   ldr x3, 8 ; b 12 ; data TestCase(TestcaseName { length: 1, ascii: [102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x3, 8 ; b 12 ; data TestCase(%f) + 0
 ;   blr x3
 ;   mov x9, sp
 ;   ldr x11, [sp, #8]

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -42,7 +42,7 @@ block0(v0: i64):
 ;   subs xzr, sp, x0, UXTX
 ;   b.hs 8 ; udf
 ; block0:
-;   ldr x2, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 111, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x2, 8 ; b 12 ; data TestCase(%foo) + 0
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -65,7 +65,7 @@ block0(v0: i64):
 ;   subs xzr, sp, x16, UXTX
 ;   b.hs 8 ; udf
 ; block0:
-;   ldr x2, 8 ; b 12 ; data TestCase(TestcaseName { length: 3, ascii: [102, 111, 111, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x2, 8 ; b 12 ; data TestCase(%foo) + 0
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
@@ -11,6 +11,6 @@ block0:
 }
 
 ; block0:
-;   ldr x0, 8 ; b 12 ; data TestCase(TestcaseName { length: 9, ascii: [109, 121, 95, 103, 108, 111, 98, 97, 108, 0, 0, 0, 0, 0, 0, 0] }) + 0
+;   ldr x0, 8 ; b 12 ; data TestCase(%my_global) + 0
 ;   ret
 

--- a/cranelift/filetests/filetests/runtests/bint.clif
+++ b/cranelift/filetests/filetests/runtests/bint.clif
@@ -34,7 +34,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b1_i16_fals() == 0
+; run: %bint_b1_i16_false() == 0
 
 function %bint_b1_i32_true() -> i32 {
 block0:
@@ -50,7 +50,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b1_i32_fals() == 0
+; run: %bint_b1_i32_false() == 0
 
 function %bint_b1_i64_true() -> i64 {
 block0:
@@ -66,7 +66,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b1_i64_fals() == 0
+; run: %bint_b1_i64_false() == 0
 
 
 
@@ -101,7 +101,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b8_i16_fals() == 0
+; run: %bint_b8_i16_false() == 0
 
 function %bint_b8_i32_true() -> i32 {
 block0:
@@ -117,7 +117,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b8_i32_fals() == 0
+; run: %bint_b8_i32_false() == 0
 
 function %bint_b8_i64_true() -> i64 {
 block0:
@@ -133,7 +133,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b8_i64_fals() == 0
+; run: %bint_b8_i64_false() == 0
 
 
 
@@ -153,7 +153,7 @@ block0:
   v1 = bint.i8 v0
   return v1
 }
-; run: %bint_b16_i8_fals() == 0
+; run: %bint_b16_i8_false() == 0
 
 function %bint_b16_i16_true() -> i16 {
 block0:
@@ -161,7 +161,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b16_i16_tru() == 1
+; run: %bint_b16_i16_true() == 1
 
 function %bint_b16_i16_false() -> i16 {
 block0:
@@ -169,7 +169,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b16_i16_fal() == 0
+; run: %bint_b16_i16_false() == 0
 
 function %bint_b16_i32_true() -> i32 {
 block0:
@@ -177,7 +177,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b16_i32_tru() == 1
+; run: %bint_b16_i32_true() == 1
 
 function %bint_b16_i32_false() -> i32 {
 block0:
@@ -185,7 +185,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b16_i32_fal() == 0
+; run: %bint_b16_i32_false() == 0
 
 function %bint_b16_i64_true() -> i64 {
 block0:
@@ -193,7 +193,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b16_i64_tru() == 1
+; run: %bint_b16_i64_true() == 1
 
 function %bint_b16_i64_false() -> i64 {
 block0:
@@ -201,7 +201,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b16_i64_fal() == 0
+; run: %bint_b16_i64_false() == 0
 
 
 
@@ -220,7 +220,7 @@ block0:
   v1 = bint.i8 v0
   return v1
 }
-; run: %bint_b32_i8_fals() == 0
+; run: %bint_b32_i8_false() == 0
 
 function %bint_b32_i16_true() -> i16 {
 block0:
@@ -228,7 +228,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b32_i16_tru() == 1
+; run: %bint_b32_i16_true() == 1
 
 function %bint_b32_i16_false() -> i16 {
 block0:
@@ -236,7 +236,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b32_i16_fal() == 0
+; run: %bint_b32_i16_false() == 0
 
 function %bint_b32_i32_true() -> i32 {
 block0:
@@ -244,7 +244,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b32_i32_tru() == 1
+; run: %bint_b32_i32_true() == 1
 
 function %bint_b32_i32_false() -> i32 {
 block0:
@@ -252,7 +252,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b32_i32_fal() == 0
+; run: %bint_b32_i32_false() == 0
 
 function %bint_b32_i64_true() -> i64 {
 block0:
@@ -260,7 +260,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b32_i64_tru() == 1
+; run: %bint_b32_i64_true() == 1
 
 function %bint_b32_i64_false() -> i64 {
 block0:
@@ -268,7 +268,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b32_i64_fal() == 0
+; run: %bint_b32_i64_false() == 0
 
 
 
@@ -289,7 +289,7 @@ block0:
   v1 = bint.i8 v0
   return v1
 }
-; run: %bint_b64_i8_fals() == 0
+; run: %bint_b64_i8_false() == 0
 
 function %bint_b64_i16_true() -> i16 {
 block0:
@@ -297,7 +297,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b64_i16_tru() == 1
+; run: %bint_b64_i16_true() == 1
 
 function %bint_b64_i16_false() -> i16 {
 block0:
@@ -305,7 +305,7 @@ block0:
   v1 = bint.i16 v0
   return v1
 }
-; run: %bint_b64_i16_fal() == 0
+; run: %bint_b64_i16_false() == 0
 
 function %bint_b64_i32_true() -> i32 {
 block0:
@@ -313,7 +313,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b64_i32_tru() == 1
+; run: %bint_b64_i32_true() == 1
 
 function %bint_b64_i32_false() -> i32 {
 block0:
@@ -321,7 +321,7 @@ block0:
   v1 = bint.i32 v0
   return v1
 }
-; run: %bint_b64_i32_fal() == 0
+; run: %bint_b64_i32_false() == 0
 
 function %bint_b64_i64_true() -> i64 {
 block0:
@@ -329,7 +329,7 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b64_i64_tru() == 1
+; run: %bint_b64_i64_true() == 1
 
 function %bint_b64_i64_false() -> i64 {
 block0:
@@ -337,4 +337,4 @@ block0:
   v1 = bint.i64 v0
   return v1
 }
-; run: %bint_b64_i64_fal() == 0
+; run: %bint_b64_i64_false() == 0

--- a/cranelift/filetests/filetests/runtests/fibonacci.clif
+++ b/cranelift/filetests/filetests/runtests/fibonacci.clif
@@ -54,11 +54,11 @@ block2:
     v20 = iconst.i32 1
     return v20
 }
-; run: %fibonacci_recurs(0) == 1
-; run: %fibonacci_recurs(1) == 1
-; run: %fibonacci_recurs(2) == 1
-; run: %fibonacci_recurs(3) == 2
-; run: %fibonacci_recurs(4) == 3
-; run: %fibonacci_recurs(5) == 5
-; run: %fibonacci_recurs(6) == 8
-; run: %fibonacci_recurs(10) == 55
+; run: %fibonacci_recursive(0) == 1
+; run: %fibonacci_recursive(1) == 1
+; run: %fibonacci_recursive(2) == 1
+; run: %fibonacci_recursive(3) == 2
+; run: %fibonacci_recursive(4) == 3
+; run: %fibonacci_recursive(5) == 5
+; run: %fibonacci_recursive(6) == 8
+; run: %fibonacci_recursive(10) == 55

--- a/cranelift/filetests/filetests/runtests/i128-bint.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bint.clif
@@ -11,7 +11,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b1_i128_tru() == 1
+; run: %bint_b1_i128_true() == 1
 
 function %bint_b1_i128_false() -> i128 {
 block0:
@@ -19,7 +19,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b1_i128_fal() == 0
+; run: %bint_b1_i128_false() == 0
 
 function %bint_b8_i128_true() -> i128 {
 block0:
@@ -27,7 +27,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b8_i128_tru() == 1
+; run: %bint_b8_i128_true() == 1
 
 function %bint_b8_i128_false() -> i128 {
 block0:
@@ -35,7 +35,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b8_i128_fal() == 0
+; run: %bint_b8_i128_false() == 0
 
 function %bint_b16_i128_true() -> i128 {
 block0:
@@ -43,7 +43,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b16_i128_tr() == 1
+; run: %bint_b16_i128_true() == 1
 
 function %bint_b16_i128_false() -> i128 {
 block0:
@@ -51,7 +51,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b16_i128_fa() == 0
+; run: %bint_b16_i128_false() == 0
 
 function %bint_b32_i128_true() -> i128 {
 block0:
@@ -59,7 +59,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b32_i128_tr() == 1
+; run: %bint_b32_i128_true() == 1
 
 function %bint_b32_i128_false() -> i128 {
 block0:
@@ -67,7 +67,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b32_i128_fa() == 0
+; run: %bint_b32_i128_false() == 0
 
 function %bint_b64_i128_true() -> i128 {
 block0:
@@ -75,7 +75,7 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b64_i128_tr() == 1
+; run: %bint_b64_i128_true() == 1
 
 function %bint_b64_i128_false() -> i128 {
 block0:
@@ -83,4 +83,4 @@ block0:
   v1 = bint.i128 v0
   return v1
 }
-; run: %bint_b64_i128_fa() == 0
+; run: %bint_b64_i128_false() == 0

--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -14,5 +14,5 @@ block0(v0: i8):
     v2 = icmp sge v0, v1
     return v2
 }
-; run: %overflow_rhs_con(49) == true
-; run: %overflow_rhs_con(-65) == false
+; run: %overflow_rhs_const(49) == true
+; run: %overflow_rhs_const(-65) == false

--- a/cranelift/filetests/filetests/runtests/simd-icmp-nof.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-nof.clif
@@ -16,10 +16,10 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp nof v0, v1
     return v2
 }
-; run: %simd_icmp_nof_i1([0 0 1 0 0 0 0 0], [0 1 0 0xFFFF 0 0 0 0]) == [true true true true true true true true]
-; run: %simd_icmp_nof_i1([0x8000 0x7FFF 0x7FFF 0xFFFF 0 0 0 0], [0x8000 0x0001 0x7FFF 0x0001 0 0 0 0]) == [true true true true true true true true]
-; run: %simd_icmp_nof_i1([0x8000 0x7FFF 0x8000 0x7FFF 0 0 0 0], [0x0001 0x8000 0x7FFF 0xFFFF 0 0 0 0]) == [false false false false true true true true]
-; run: %simd_icmp_nof_i1([0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF], [0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF]) == [false false false false false false false false]
+; run: %simd_icmp_nof_i16([0 0 1 0 0 0 0 0], [0 1 0 0xFFFF 0 0 0 0]) == [true true true true true true true true]
+; run: %simd_icmp_nof_i16([0x8000 0x7FFF 0x7FFF 0xFFFF 0 0 0 0], [0x8000 0x0001 0x7FFF 0x0001 0 0 0 0]) == [true true true true true true true true]
+; run: %simd_icmp_nof_i16([0x8000 0x7FFF 0x8000 0x7FFF 0 0 0 0], [0x0001 0x8000 0x7FFF 0xFFFF 0 0 0 0]) == [false false false false true true true true]
+; run: %simd_icmp_nof_i16([0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF 0x7FFF], [0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF 0xFFFF]) == [false false false false false false false false]
 
 
 function %simd_icmp_nof_i32(i32x4, i32x4) -> b32x4 {
@@ -27,19 +27,19 @@ block0(v0: i32x4, v1: i32x4):
     v2 = icmp nof v0, v1
     return v2
 }
-; run: %simd_icmp_nof_i3([0 0 1 0], [0 1 0 0xFFFFFFFF]) == [true true true true]
-; run: %simd_icmp_nof_i3([0x80000000 0x7FFFFFFF 0x7FFFFFFF 0xFFFFFFFF], [0x80000000 0x00000001 0x7FFFFFFF 0x00000001]) == [true true true true]
-; run: %simd_icmp_nof_i3([0x80000000 0x7FFFFFFF 0x80000000 0x7FFFFFFF], [0x00000001 0x80000000 0x7FFFFFFF 0xFFFFFFFF]) == [false false false false]
-; run: %simd_icmp_nof_i3([0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF], [0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF]) == [false false false false]
+; run: %simd_icmp_nof_i32([0 0 1 0], [0 1 0 0xFFFFFFFF]) == [true true true true]
+; run: %simd_icmp_nof_i32([0x80000000 0x7FFFFFFF 0x7FFFFFFF 0xFFFFFFFF], [0x80000000 0x00000001 0x7FFFFFFF 0x00000001]) == [true true true true]
+; run: %simd_icmp_nof_i32([0x80000000 0x7FFFFFFF 0x80000000 0x7FFFFFFF], [0x00000001 0x80000000 0x7FFFFFFF 0xFFFFFFFF]) == [false false false false]
+; run: %simd_icmp_nof_i32([0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF 0x7FFFFFFF], [0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF]) == [false false false false]
 
 function %simd_icmp_nof_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp nof v0, v1
     return v2
 }
-; run: %simd_icmp_nof_i6([0 0], [0 1]) == [true true]
-; run: %simd_icmp_nof_i6([1 0], [0 0xFFFFFFFF_FFFFFFFF]) == [true true]
-; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x80000000_00000000 0x00000000_00000001]) == [true true]
-; run: %simd_icmp_nof_i6([0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0x00000000_00000001]) == [true true]
-; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x01 0x80000000_00000000]) == [false false]
-; run: %simd_icmp_nof_i6([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF]) == [false false]
+; run: %simd_icmp_nof_i64([0 0], [0 1]) == [true true]
+; run: %simd_icmp_nof_i64([1 0], [0 0xFFFFFFFF_FFFFFFFF]) == [true true]
+; run: %simd_icmp_nof_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x80000000_00000000 0x00000000_00000001]) == [true true]
+; run: %simd_icmp_nof_i64([0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0x00000000_00000001]) == [true true]
+; run: %simd_icmp_nof_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x01 0x80000000_00000000]) == [false false]
+; run: %simd_icmp_nof_i64([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], [0x7FFFFFFF_FFFFFFFF 0xFFFFFFFF_FFFFFFFF]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp sge v0, v1
     return v2
 }
-; run: %simd_icmp_sge_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [true true true false false true true true]
+; run: %simd_icmp_sge_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [true true true false false true true true]
 
 function %simd_icmp_sge_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp sge v0, v1
     return v2
 }
-; run: %simd_icmp_sge_i3([0 1 -1 0], [0 0 -1 1]) == [true true true false]
-; run: %simd_icmp_sge_i3([-5 1 0 0], [-1 1 0 0]) == [false true true true]
+; run: %simd_icmp_sge_i32([0 1 -1 0], [0 0 -1 1]) == [true true true false]
+; run: %simd_icmp_sge_i32([-5 1 0 0], [-1 1 0 0]) == [false true true true]
 
 function %simd_icmp_sge_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp sge v0, v1
     return v2
 }
-; run: %simd_icmp_sge_i6([0 1], [0 0]) == [true true]
-; run: %simd_icmp_sge_i6([-1 0], [-1 1]) == [true false]
-; run: %simd_icmp_sge_i6([-5 1], [-1 1]) == [false true]
-; run: %simd_icmp_sge_i6([0 0], [0 0]) == [true true]
+; run: %simd_icmp_sge_i64([0 1], [0 0]) == [true true]
+; run: %simd_icmp_sge_i64([-1 0], [-1 1]) == [true false]
+; run: %simd_icmp_sge_i64([-5 1], [-1 1]) == [false true]
+; run: %simd_icmp_sge_i64([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -12,7 +12,7 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp sgt v0, v1
     return v2
 }
-; run: %simd_icmp_sgt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false true false false]
+; run: %simd_icmp_sgt_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false true false false]
 
 
 function %simd_icmp_sgt_i32(i32x4, i32x4) -> b32x4 {
@@ -20,8 +20,8 @@ block0(v0: i32x4, v1: i32x4):
     v2 = icmp sgt v0, v1
     return v2
 }
-; run: %simd_icmp_sgt_i3([0 1 -1 0], [0 0 -1 1]) == [false true false false]
-; run: %simd_icmp_sgt_i3([-5 1 0 0], [-1 -1 0 0]) == [false true false false]
+; run: %simd_icmp_sgt_i32([0 1 -1 0], [0 0 -1 1]) == [false true false false]
+; run: %simd_icmp_sgt_i32([-5 1 0 0], [-1 -1 0 0]) == [false true false false]
 
 
 function %simd_icmp_sgt_i64(i64x2, i64x2) -> b64x2 {
@@ -29,7 +29,7 @@ block0(v0: i64x2, v1: i64x2):
     v2 = icmp sgt v0, v1
     return v2
 }
-; run: %simd_icmp_sgt_i6([0 1], [0 0 ]) == [false true]
-; run: %simd_icmp_sgt_i6([-1 0], [-1 1]) == [false false]
-; run: %simd_icmp_sgt_i6([-5 1], [-1 -1]) == [false true]
-; run: %simd_icmp_sgt_i6([0 0], [0 0]) == [false false]
+; run: %simd_icmp_sgt_i64([0 1], [0 0 ]) == [false true]
+; run: %simd_icmp_sgt_i64([-1 0], [-1 1]) == [false false]
+; run: %simd_icmp_sgt_i64([-5 1], [-1 -1]) == [false true]
+; run: %simd_icmp_sgt_i64([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -12,7 +12,7 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp sle v0, v1
     return v2
 }
-; run: %simd_icmp_sle_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true false true true]
+; run: %simd_icmp_sle_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true false true true]
 
 
 function %simd_icmp_sle_i32(i32x4, i32x4) -> b32x4 {
@@ -20,8 +20,8 @@ block0(v0: i32x4, v1: i32x4):
     v2 = icmp sle v0, v1
     return v2
 }
-; run: %simd_icmp_sle_i3([0 1 -1 0], [0 0 -1 1]) == [true false true true]
-; run: %simd_icmp_sle_i3([-5 1 0 0], [-1 -1 0 0]) == [true false true true]
+; run: %simd_icmp_sle_i32([0 1 -1 0], [0 0 -1 1]) == [true false true true]
+; run: %simd_icmp_sle_i32([-5 1 0 0], [-1 -1 0 0]) == [true false true true]
 
 
 function %simd_icmp_sle_i64(i64x2, i64x2) -> b64x2 {
@@ -29,7 +29,7 @@ block0(v0: i64x2, v1: i64x2):
     v2 = icmp sle v0, v1
     return v2
 }
-; run: %simd_icmp_sle_i6([0 1], [0 0 ]) == [true false]
-; run: %simd_icmp_sle_i6([-1 0], [-1 1]) == [true true]
-; run: %simd_icmp_sle_i6([-5 1], [-1 -1]) == [true false]
-; run: %simd_icmp_sle_i6([0 0], [0 0]) == [true true]
+; run: %simd_icmp_sle_i64([0 1], [0 0 ]) == [true false]
+; run: %simd_icmp_sle_i64([-1 0], [-1 1]) == [true true]
+; run: %simd_icmp_sle_i64([-5 1], [-1 -1]) == [true false]
+; run: %simd_icmp_sle_i64([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp slt v0, v1
     return v2
 }
-; run: %simd_icmp_slt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [false false false true true false false false]
+; run: %simd_icmp_slt_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 1 0 0]) == [false false false true true false false false]
 
 function %simd_icmp_slt_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp slt v0, v1
     return v2
 }
-; run: %simd_icmp_slt_i3([0 1 -1 0], [0 0 -1 1]) == [false false false true]
-; run: %simd_icmp_slt_i3([-5 1 0 0], [-1 1 0 0]) == [true false false false]
+; run: %simd_icmp_slt_i32([0 1 -1 0], [0 0 -1 1]) == [false false false true]
+; run: %simd_icmp_slt_i32([-5 1 0 0], [-1 1 0 0]) == [true false false false]
 
 function %simd_icmp_slt_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp slt v0, v1
     return v2
 }
-; run: %simd_icmp_slt_i6([0 1], [0 0]) == [false false]
-; run: %simd_icmp_slt_i6([-1 0], [-1 1]) == [false true]
-; run: %simd_icmp_slt_i6([-5 1], [-1 1]) == [true false]
-; run: %simd_icmp_slt_i6([0 0], [0 0]) == [false false]
+; run: %simd_icmp_slt_i64([0 1], [0 0]) == [false false]
+; run: %simd_icmp_slt_i64([-1 0], [-1 1]) == [false true]
+; run: %simd_icmp_slt_i64([-5 1], [-1 1]) == [true false]
+; run: %simd_icmp_slt_i64([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp uge v0, v1
     return v2
 }
-; run: %simd_icmp_uge_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true true true false false false true true]
+; run: %simd_icmp_uge_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true true true false false false true true]
 
 function %simd_icmp_uge_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp uge v0, v1
     return v2
 }
-; run: %simd_icmp_uge_i3([0 1 -1 0], [0 0 -1 1]) == [true true true false]
-; run: %simd_icmp_uge_i3([-5 1 0 0], [-1 -1 0 0]) == [false false true true]
+; run: %simd_icmp_uge_i32([0 1 -1 0], [0 0 -1 1]) == [true true true false]
+; run: %simd_icmp_uge_i32([-5 1 0 0], [-1 -1 0 0]) == [false false true true]
 
 function %simd_icmp_uge_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp uge v0, v1
     return v2
 }
-; run: %simd_icmp_uge_i6([0 1], [0 0]) == [true true]
-; run: %simd_icmp_uge_i6([-1 0], [-1 1]) == [true false]
-; run: %simd_icmp_uge_i6([-5 1], [-1 -1]) == [false false]
-; run: %simd_icmp_uge_i6([0 0], [0 0]) == [true true]
+; run: %simd_icmp_uge_i64([0 1], [0 0]) == [true true]
+; run: %simd_icmp_uge_i64([-1 0], [-1 1]) == [true false]
+; run: %simd_icmp_uge_i64([-5 1], [-1 -1]) == [false false]
+; run: %simd_icmp_uge_i64([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp ugt v0, v1
     return v2
 }
-; run: %simd_icmp_ugt_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false false false false]
+; run: %simd_icmp_ugt_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false true false false false false false false]
 
 function %simd_icmp_ugt_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp ugt v0, v1
     return v2
 }
-; run: %simd_icmp_ugt_i3([0 1 -1 0], [0 0 -1 1]) == [false true false false]
-; run: %simd_icmp_ugt_i3([-5 1 0 0], [-1 -1 0 0]) == [false false false false]
+; run: %simd_icmp_ugt_i32([0 1 -1 0], [0 0 -1 1]) == [false true false false]
+; run: %simd_icmp_ugt_i32([-5 1 0 0], [-1 -1 0 0]) == [false false false false]
 
 function %simd_icmp_ugt_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp ugt v0, v1
     return v2
 }
-; run: %simd_icmp_ugt_i6([0 1], [0 0]) == [false true]
-; run: %simd_icmp_ugt_i6([-1 0], [-1 1]) == [false false]
-; run: %simd_icmp_ugt_i6([-5 1], [-1 -1]) == [false false]
-; run: %simd_icmp_ugt_i6([0 0], [0 0]) == [false false]
+; run: %simd_icmp_ugt_i64([0 1], [0 0]) == [false true]
+; run: %simd_icmp_ugt_i64([-1 0], [-1 1]) == [false false]
+; run: %simd_icmp_ugt_i64([-5 1], [-1 -1]) == [false false]
+; run: %simd_icmp_ugt_i64([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp ule v0, v1
     return v2
 }
-; run: %simd_icmp_ule_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true true true true]
+; run: %simd_icmp_ule_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [true false true true true true true true]
 
 function %simd_icmp_ule_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp ule v0, v1
     return v2
 }
-; run: %simd_icmp_ule_i3([0 1 -1 0], [0 0 -1 1]) == [true false true true]
-; run: %simd_icmp_ule_i3([-5 1 0 0], [-1 -1 0 0]) == [true true true true]
+; run: %simd_icmp_ule_i32([0 1 -1 0], [0 0 -1 1]) == [true false true true]
+; run: %simd_icmp_ule_i32([-5 1 0 0], [-1 -1 0 0]) == [true true true true]
 
 function %simd_icmp_ule_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp ule v0, v1
     return v2
 }
-; run: %simd_icmp_ule_i6([0 1], [0 0]) == [true false]
-; run: %simd_icmp_ule_i6([-1 0], [-1 1]) == [true true]
-; run: %simd_icmp_ule_i6([-5 1], [-1 -1]) == [true true]
-; run: %simd_icmp_ule_i6([0 0], [0 0]) == [true true]
+; run: %simd_icmp_ule_i64([0 1], [0 0]) == [true false]
+; run: %simd_icmp_ule_i64([-1 0], [-1 1]) == [true true]
+; run: %simd_icmp_ule_i64([-5 1], [-1 -1]) == [true true]
+; run: %simd_icmp_ule_i64([0 0], [0 0]) == [true true]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -12,22 +12,22 @@ block0(v0: i16x8, v1: i16x8):
     v2 = icmp ult v0, v1
     return v2
 }
-; run: %simd_icmp_ult_i1([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false false false true true true false false]
+; run: %simd_icmp_ult_i16([0 1 -1 0 -5 1 0 0], [0 0 -1 1 -1 -1 0 0]) == [false false false true true true false false]
 
 function %simd_icmp_ult_i32(i32x4, i32x4) -> b32x4 {
 block0(v0: i32x4, v1: i32x4):
     v2 = icmp ult v0, v1
     return v2
 }
-; run: %simd_icmp_ult_i3([0 1 -1 0], [0 0 -1 1]) == [false false false true]
-; run: %simd_icmp_ult_i3([-5 1 0 0], [-1 -1 0 0]) == [true true false false]
+; run: %simd_icmp_ult_i32([0 1 -1 0], [0 0 -1 1]) == [false false false true]
+; run: %simd_icmp_ult_i32([-5 1 0 0], [-1 -1 0 0]) == [true true false false]
 
 function %simd_icmp_ult_i64(i64x2, i64x2) -> b64x2 {
 block0(v0: i64x2, v1: i64x2):
     v2 = icmp ult v0, v1
     return v2
 }
-; run: %simd_icmp_ult_i6([0 1], [0 0]) == [false false]
-; run: %simd_icmp_ult_i6([-1 0], [-1 1]) == [false true]
-; run: %simd_icmp_ult_i6([-5 1], [-1 -1]) == [true true]
-; run: %simd_icmp_ult_i6([0 0], [0 0]) == [false false]
+; run: %simd_icmp_ult_i64([0 1], [0 0]) == [false false]
+; run: %simd_icmp_ult_i64([-1 0], [-1 1]) == [false true]
+; run: %simd_icmp_ult_i64([-5 1], [-1 -1]) == [true true]
+; run: %simd_icmp_ult_i64([0 0], [0 0]) == [false false]

--- a/cranelift/filetests/filetests/runtests/stack-addr-32.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-32.clif
@@ -82,4 +82,4 @@ block0:
     v2 = icmp ne v0, v1
     return v2
 }
-; run: %multi_slot_diffe() == true
+; run: %multi_slot_different_addrs() == true

--- a/cranelift/filetests/filetests/runtests/stack.clif
+++ b/cranelift/filetests/filetests/runtests/stack.clif
@@ -72,8 +72,8 @@ block0(v0: i8, v1: i64):
     v3 = stack_load.i64 ss1
     return v2, v3
 }
-; run: %multi_slot_out_o(10, 1) == [10, 1]
-; run: %multi_slot_out_o(0, 2) == [0, 2]
+; run: %multi_slot_out_of_bounds_writes(10, 1) == [10, 1]
+; run: %multi_slot_out_of_bounds_writes(0, 2) == [0, 2]
 
 
 function %multi_slot_offset_writes(i8, i64) -> i8, i64 {
@@ -87,8 +87,8 @@ block0(v0: i8, v1: i64):
     v3 = stack_load.i64 ss1
     return v2, v3
 }
-; run: %multi_slot_offse(0, 1) == [0, 1]
-; run: %multi_slot_offse(1, 2) == [1, 2]
+; run: %multi_slot_offset_writes(0, 1) == [0, 1]
+; run: %multi_slot_offset_writes(1, 2) == [1, 2]
 
 function %huge_slots(i64) -> i64 {
     ss0 = explicit_slot 1048576 ; 1MB Slot

--- a/cranelift/filetests/filetests/simple_preopt/branch.clif
+++ b/cranelift/filetests/filetests/simple_preopt/branch.clif
@@ -41,7 +41,7 @@ block2:
     v4 = iconst.i32 2
     return v4
 }
-; sameln: function %icmp_to_brz_inve
+; sameln: function %icmp_to_brz_inverted_fold
 ; nextln: block0(v0: i32):
 ; nextln:     v1 = icmp_imm ne v0, 0
 ; nextln:     brnz v0, block2
@@ -67,7 +67,7 @@ block2:
     v3 = iconst.i32 2
     return v3
 }
-; sameln: function %br_icmp_inversio
+; sameln: function %br_icmp_inversion
 ; nextln: block0(v0: i32, v1: i32):
 ; nextln:     br_icmp ule v0, v1, block2
 ; nextln:     jump block1


### PR DESCRIPTION
Following up on discussion in #4667, here's a way to avoid making sweeping changes while still using reasonable names in filetests. @afonso360, how does this look to you? @cfallin, do the numbers here sound okay to you?

In order to keep the `ExternalName` enum small, the `TestcaseName` struct was limited to 17 bytes: a 1 byte length and a 16 byte buffer. Due to alignment, that made `ExternalName` 20 bytes.

That fixed-size buffer means that the names of functions in Cranelift filetests are truncated to fit, which limits our ability to give tests meaningful names. And I think meaningful names are important in tests.

This patch replaces the inline `TestcaseName` buffer with a heap-allocated slice. We don't care about performance for test names, so an indirection out to the heap is fine in that case. But we do care somewhat about the size of `ExternalName` when it's used during compiles.

On 64-bit systems, `Box<[u8]>` is 16 bytes, so `TestcaseName` gets one byte smaller. Unfortunately, its alignment is 8 bytes, so `ExternalName` grows from 20 to 24 bytes.

According to `valgrind --tool=dhat`, this change has very little effect on compiler performance. Building wasmtime with `--no-default-features --release`, and compiling the pulldown-cmark benchmark from Sightglass, I measured these differences between `main` and this patch:

- total number of allocations didn't change (`ExternalName::TestCase` is not used in normal compiles)
- 592 more bytes allocated over the process lifetime, out of 171.5MiB
- 320 more bytes allocated at peak heap size, out of 12MiB
- 0.24% more instructions executed
- 16,987 more bytes written
- 12,120 _fewer_ bytes read