### PR TITLE
cranelift: Avoid lowering VEX instructions with memory encodings

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3007,22 +3007,30 @@
         dst))
 
 ;; Helper for creating `vfmadd213ss` instructions.
-(decl x64_vfmadd213ss (Xmm Xmm XmmMem) Xmm)
+; TODO: This should have the (Xmm Xmm XmmMem) signature
+; but we don't support VEX memory encodings yet
+(decl x64_vfmadd213ss (Xmm Xmm Xmm) Xmm)
 (rule (x64_vfmadd213ss x y z)
       (xmm_rmr_vex (AvxOpcode.Vfmadd213ss) x y z))
 
 ;; Helper for creating `vfmadd213sd` instructions.
-(decl x64_vfmadd213sd (Xmm Xmm XmmMem) Xmm)
+; TODO: This should have the (Xmm Xmm XmmMem) signature
+; but we don't support VEX memory encodings yet
+(decl x64_vfmadd213sd (Xmm Xmm Xmm) Xmm)
 (rule (x64_vfmadd213sd x y z)
       (xmm_rmr_vex (AvxOpcode.Vfmadd213sd) x y z))
 
 ;; Helper for creating `vfmadd213ps` instructions.
-(decl x64_vfmadd213ps (Xmm Xmm XmmMem) Xmm)
+; TODO: This should have the (Xmm Xmm XmmMem) signature
+; but we don't support VEX memory encodings yet
+(decl x64_vfmadd213ps (Xmm Xmm Xmm) Xmm)
 (rule (x64_vfmadd213ps x y z)
       (xmm_rmr_vex (AvxOpcode.Vfmadd213ps) x y z))
 
 ;; Helper for creating `vfmadd213pd` instructions.
-(decl x64_vfmadd213pd (Xmm Xmm XmmMem) Xmm)
+; TODO: This should have the (Xmm Xmm XmmMem) signature
+; but we don't support VEX memory encodings yet
+(decl x64_vfmadd213pd (Xmm Xmm Xmm) Xmm)
 (rule (x64_vfmadd213pd x y z)
       (xmm_rmr_vex (AvxOpcode.Vfmadd213pd) x y z))
 

--- a/cranelift/filetests/filetests/runtests/fma.clif
+++ b/cranelift/filetests/filetests/runtests/fma.clif
@@ -136,3 +136,16 @@ block0(v0: f64, v1: f64, v2: f64):
 ; run: %fma_is_nan_f64(-NaN, 0x0.0, 0x0.0) == 1
 ; run: %fma_is_nan_f64(0x0.0, -NaN, 0x0.0) == 1
 ; run: %fma_is_nan_f64(0x0.0, 0x0.0, -NaN) == 1
+
+; This is a regression test for the native fma instruction
+; Discovered by the fuzzer in: https://github.com/bytecodealliance/wasmtime/issues/4759
+function %fma_load_f32(f32, f32, f32) -> f32 {
+    ss0 = explicit_slot 4
+
+block0(v0: f32, v1: f32, v2: f32):
+    stack_store.f32 v2, ss0
+    v3 = stack_load.f32 ss0
+    v4 = fma v0, v1, v3
+    return v4
+}
+; run: %fma_load_f32(0x9.0, 0x9.0, 0x9.0) == 0x1.680000p6


### PR DESCRIPTION
This avoids these lowerings for now, but I filed https://github.com/bytecodealliance/wasmtime/issues/4767 as future improvement that we should do.

Fixes: #4759