### PR TITLE
cranelift: Disable i128 divs on fuzzgen

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -196,17 +196,19 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::Imul, &[I64, I64], &[I64], insert_opcode),
     (Opcode::Imul, &[I128, I128], &[I128], insert_opcode),
     // Udiv
+    // udiv.i128 not implemented on x64: https://github.com/bytecodealliance/wasmtime/issues/4756
     (Opcode::Udiv, &[I8, I8], &[I8], insert_opcode),
     (Opcode::Udiv, &[I16, I16], &[I16], insert_opcode),
     (Opcode::Udiv, &[I32, I32], &[I32], insert_opcode),
     (Opcode::Udiv, &[I64, I64], &[I64], insert_opcode),
-    (Opcode::Udiv, &[I128, I128], &[I128], insert_opcode),
+    // (Opcode::Udiv, &[I128, I128], &[I128], insert_opcode),
     // Sdiv
+    // sdiv.i128 not implemented on x64: https://github.com/bytecodealliance/wasmtime/issues/4770
     (Opcode::Sdiv, &[I8, I8], &[I8], insert_opcode),
     (Opcode::Sdiv, &[I16, I16], &[I16], insert_opcode),
     (Opcode::Sdiv, &[I32, I32], &[I32], insert_opcode),
     (Opcode::Sdiv, &[I64, I64], &[I64], insert_opcode),
-    (Opcode::Sdiv, &[I128, I128], &[I128], insert_opcode),
+    // (Opcode::Sdiv, &[I128, I128], &[I128], insert_opcode),
     // Rotr
     (Opcode::Rotr, &[I8, I8], &[I8], insert_opcode),
     (Opcode::Rotr, &[I8, I16], &[I8], insert_opcode),


### PR DESCRIPTION
Do not merge!

This is going to change the fuzzer input format and invalidate the pending fuzzer issues.

Disables i128 div's from being generated since the x64 backend isn't ready for them yet.

Fixes: #4756
Fixes: #4770
cc: @cfallin @bnjbvr 