### PR TITLE
[fuzz] Configure the `differential` target

### DIFF
--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -140,7 +140,7 @@ pub fn build_allowed_env_list<'a>(
         // Check that the names are either all additions or all subtractions.
         let subtract_from_defaults = configured.iter().all(|c| c.starts_with("-"));
         let add_from_defaults = configured.iter().all(|c| !c.starts_with("-"));
-        let keep = if subtract_from_defaults { 1.. } else { 0.. };
+        let start = if subtract_from_defaults { 1 } else { 0 };
         if !subtract_from_defaults && !add_from_defaults {
             panic!(
                 "all configured values must either subtract or add from defaults; found mixed values: {:?}",
@@ -150,7 +150,7 @@ pub fn build_allowed_env_list<'a>(
 
         // Check that the configured names are valid ones.
         for c in configured {
-            if !defaults.contains(&&c[keep.clone()]) {
+            if !defaults.contains(&&c[start..]) {
                 panic!(
                     "invalid environment configuration `{}`; must be one of: {:?}",
                     c, defaults
@@ -161,7 +161,7 @@ pub fn build_allowed_env_list<'a>(
         // Select only the allowed names.
         let mut allowed = Vec::with_capacity(defaults.len());
         for &d in defaults {
-            let mentioned = configured.iter().any(|c| &c[keep.clone()] == d);
+            let mentioned = configured.iter().any(|c| &c[start..] == d);
             if (add_from_defaults && mentioned) || (subtract_from_defaults && !mentioned) {
                 allowed.push(d);
             }

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -23,8 +23,8 @@ static SETUP: Once = Once::new();
 // - ALLOWED_ENGINES=wasmi,spec cargo +nightly fuzz run ...
 // - ALLOWED_ENGINES=-v8 cargo +nightly fuzz run ...
 // - ALLOWED_MODULES=single-inst cargo +nightly fuzz run ...
-static mut ALLOWED_ENGINES: Vec<String> = vec![];
-static mut ALLOWED_MODULES: Vec<String> = vec![];
+static mut ALLOWED_ENGINES: Vec<&str> = vec![];
+static mut ALLOWED_MODULES: Vec<&str> = vec![];
 
 // Statistics about what's actually getting executed during fuzzing
 static STATS: RuntimeStats = RuntimeStats::new();
@@ -76,10 +76,10 @@ fn run(data: &[u8]) -> Result<()> {
         let module = SingleInstModule::new(u, &mut config.module_config)?;
         Ok(module.to_bytes())
     };
-    if unsafe { ALLOWED_MODULES }.is_empty() {
+    if unsafe { ALLOWED_MODULES.is_empty() } {
         panic!("unable to generate a module to fuzz against; check `ALLOWED_MODULES`")
     }
-    let wasm = match u.choose(unsafe { &ALLOWED_MODULES.as_slice() }).unwrap() {
+    let wasm = match *u.choose(unsafe { ALLOWED_MODULES.as_slice() })? {
         "wasm-smith" => build_wasm_smith_module(&mut u, &mut config)?,
         "single-inst" => build_single_inst_module(&mut u, &mut config)?,
         _ => unreachable!(),

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -76,17 +76,13 @@ fn run(data: &[u8]) -> Result<()> {
         let module = SingleInstModule::new(u, &mut config.module_config)?;
         Ok(module.to_bytes())
     };
-    let wasm = match unsafe { &ALLOWED_MODULES.as_slice() } {
-        &[] => panic!("unable to generate a module to fuzz against; check `ALLOWED_MODULES`"),
-        &[n] if n == "wasm-smith" => build_wasm_smith_module(&mut u, &mut config)?,
-        &[n] if n == "single-inst" => build_single_inst_module(&mut u, &mut config)?,
-        _ => {
-            if u.arbitrary()? {
-                build_wasm_smith_module(&mut u, &mut config)?
-            } else {
-                build_single_inst_module(&mut u, &mut config)?
-            }
-        }
+    if unsafe { ALLOWED_MODULES }.is_empty() {
+        panic!("unable to generate a module to fuzz against; check `ALLOWED_MODULES`")
+    }
+    let wasm = match u.choose(unsafe { &ALLOWED_MODULES.as_slice() }).unwrap() {
+        "wasm-smith" => build_wasm_smith_module(&mut u, &mut config)?,
+        "single-inst" => build_single_inst_module(&mut u, &mut config)?,
+        _ => unreachable!(),
     };
     log_wasm(&wasm);
 

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -37,15 +37,17 @@ fuzz_target!(|data: &[u8]| {
 
         // Retrieve the configuration for this fuzz target from `ALLOWED_*`
         // environment variables.
+        let allowed_engines = build_allowed_env_list(
+            parse_env_list("ALLOWED_ENGINES"),
+            &["wasmtime", "wasmi", "spec", "v8"],
+        );
+        let allowed_modules = build_allowed_env_list(
+            parse_env_list("ALLOWED_MODULES"),
+            &["wasm-smith", "single-inst"],
+        );
         unsafe {
-            ALLOWED_ENGINES = build_allowed_env_list(
-                parse_env_list("ALLOWED_ENGINES"),
-                &["wasmtime", "wasmi", "spec", "v8"],
-            );
-            ALLOWED_MODULES = build_allowed_env_list(
-                parse_env_list("ALLOWED_MODULES"),
-                &["wasm-smith", "single-inst"],
-            );
+            ALLOWED_ENGINES = allowed_engines;
+            ALLOWED_MODULES = allowed_modules;
         }
     });
 


### PR DESCRIPTION
This change is a follow-on from #4515 to add the ability to configure
the `differential` fuzz target by limiting which engines and modules are
used for fuzzing. This is incredibly useful when troubleshooting, e.g.,
when an engine is more prone to failure, we can target that engine
exclusively. The effect of this configuration is visible in the
statistics now printed out from #4739.

Engines are configured using the `ALLOWED_ENGINES` environment variable.
We can either subtract from the set of allowed engines (e.g.,
`ALLOWED_ENGINES=-v8`) or build up a set of allowed engines (e.g.,
`ALLOWED_ENGINES=wasmi,spec`), but not both at the same time.
`ALLOWED_ENGINES` only configures the left-hand side engine; the
right-hand side is always Wasmtime. When omitted, `ALLOWED_ENGINES`
defaults to [`wasmtime`, `wasmi`, `spec`, `v8`].

The generated WebAssembly modules are configured using
`ALLOWED_MODULES`. This environment variables works the same as above
but the available options are: [`wasm-smith`, `single-inst`].

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
