### PR TITLE
Update ISLE error message: unknown term in expr, not pattern.

### DIFF
--- a/cranelift/isle/isle/isle_examples/fail/extra_parens.isle
+++ b/cranelift/isle/isle/isle_examples/fail/extra_parens.isle
@@ -1,0 +1,6 @@
+(type u32 (primitive u32))
+
+(decl f (u32) u32)
+;; Should get an error about `x` not being a term, with a suggestion that it is
+;; a bound var instead.
+(rule (f x) (x))

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -1782,7 +1782,19 @@ impl TermEnv {
                 let tid = match self.term_map.get(&name) {
                     Some(t) => t,
                     None => {
-                        tyenv.report_error(pos, format!("Unknown term in pattern: '{}'", sym.0));
+                        // Maybe this was actually a variable binding and the user has placed
+                        // parens around it by mistake? (See #4775.)
+                        if bindings.vars.iter().any(|b| b.name == name) {
+                            tyenv.report_error(
+                                pos,
+                                format!(
+                                    "Unknown term in expression: '{}'. Variable binding under this name exists; try removing the parens?", sym.0));
+                        } else {
+                            tyenv.report_error(
+                                pos,
+                                format!("Unknown term in expression: '{}'", sym.0),
+                            );
+                        }
                         return None;
                     }
                 };


### PR DESCRIPTION
This was likely a copy-paste from the `ast::Pattern` case, but here it
is checking a term name in `ast::Expr` and so should say "... in
expression", not "... in pattern".

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
