### PR TITLE
cranelift: Add LibCalls to the interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand 0.8.5",
+ "smallvec",
  "target-lexicon",
  "wasmtime",
  "wasmtime-fuzzing",

--- a/cranelift/codegen/src/ir/libcall.rs
+++ b/cranelift/codegen/src/ir/libcall.rs
@@ -1,7 +1,7 @@
 //! Naming well-known routines in the runtime library.
 
 use crate::{
-    ir::{types, AbiParam, ExternalName, FuncRef, Function, Opcode, Signature, Type},
+    ir::{types, AbiParam, ExternalName, FuncRef, Function, Signature},
     isa::CallConv,
 };
 use core::fmt;
@@ -23,20 +23,6 @@ pub enum LibCall {
     /// probe for stack overflow. These are emitted for functions which need
     /// when the `enable_probestack` setting is true.
     Probestack,
-    /// udiv.i64
-    UdivI64,
-    /// sdiv.i64
-    SdivI64,
-    /// urem.i64
-    UremI64,
-    /// srem.i64
-    SremI64,
-    /// ishl.i64
-    IshlI64,
-    /// ushr.i64
-    UshrI64,
-    /// sshr.i64
-    SshrI64,
     /// ceil.f32
     CeilF32,
     /// ceil.f64
@@ -85,13 +71,6 @@ impl FromStr for LibCall {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "Probestack" => Ok(Self::Probestack),
-            "UdivI64" => Ok(Self::UdivI64),
-            "SdivI64" => Ok(Self::SdivI64),
-            "UremI64" => Ok(Self::UremI64),
-            "SremI64" => Ok(Self::SremI64),
-            "IshlI64" => Ok(Self::IshlI64),
-            "UshrI64" => Ok(Self::UshrI64),
-            "SshrI64" => Ok(Self::SshrI64),
             "CeilF32" => Ok(Self::CeilF32),
             "CeilF64" => Ok(Self::CeilF64),
             "FloorF32" => Ok(Self::FloorF32),
@@ -115,54 +94,11 @@ impl FromStr for LibCall {
 }
 
 impl LibCall {
-    /// Get the well-known library call name to use as a replacement for an instruction with the
-    /// given opcode and controlling type variable.
-    ///
-    /// Returns `None` if no well-known library routine name exists for that instruction.
-    pub fn for_inst(opcode: Opcode, ctrl_type: Type) -> Option<Self> {
-        Some(match ctrl_type {
-            types::I64 => match opcode {
-                Opcode::Udiv => Self::UdivI64,
-                Opcode::Sdiv => Self::SdivI64,
-                Opcode::Urem => Self::UremI64,
-                Opcode::Srem => Self::SremI64,
-                Opcode::Ishl => Self::IshlI64,
-                Opcode::Ushr => Self::UshrI64,
-                Opcode::Sshr => Self::SshrI64,
-                _ => return None,
-            },
-            types::F32 => match opcode {
-                Opcode::Ceil => Self::CeilF32,
-                Opcode::Floor => Self::FloorF32,
-                Opcode::Trunc => Self::TruncF32,
-                Opcode::Nearest => Self::NearestF32,
-                Opcode::Fma => Self::FmaF32,
-                _ => return None,
-            },
-            types::F64 => match opcode {
-                Opcode::Ceil => Self::CeilF64,
-                Opcode::Floor => Self::FloorF64,
-                Opcode::Trunc => Self::TruncF64,
-                Opcode::Nearest => Self::NearestF64,
-                Opcode::Fma => Self::FmaF64,
-                _ => return None,
-            },
-            _ => return None,
-        })
-    }
-
     /// Get a list of all known `LibCall`'s.
     pub fn all_libcalls() -> &'static [LibCall] {
         use LibCall::*;
         &[
             Probestack,
-            UdivI64,
-            SdivI64,
-            UremI64,
-            SremI64,
-            IshlI64,
-            UshrI64,
-            SshrI64,
             CeilF32,
             CeilF64,
             FloorF32,
@@ -188,17 +124,6 @@ impl LibCall {
         let mut sig = Signature::new(call_conv);
 
         match self {
-            LibCall::UdivI64
-            | LibCall::SdivI64
-            | LibCall::UremI64
-            | LibCall::SremI64
-            | LibCall::IshlI64
-            | LibCall::UshrI64
-            | LibCall::SshrI64 => {
-                sig.params.push(AbiParam::new(I64));
-                sig.params.push(AbiParam::new(I64));
-                sig.returns.push(AbiParam::new(I64));
-            }
             LibCall::CeilF32 | LibCall::FloorF32 | LibCall::TruncF32 | LibCall::NearestF32 => {
                 sig.params.push(AbiParam::new(F32));
                 sig.returns.push(AbiParam::new(F32));

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -833,12 +833,11 @@ where
                 let signature = self.generate_signature()?;
                 (name, signature)
             } else {
-                // Use udivi64 as an example of a libcall function.
-                let mut signature = Signature::new(CallConv::Fast);
-                signature.params.push(AbiParam::new(I64));
-                signature.params.push(AbiParam::new(I64));
-                signature.returns.push(AbiParam::new(I64));
-                (ExternalName::LibCall(LibCall::UdivI64), signature)
+                // Use ishli64 as an example of a libcall function.
+                // TODO: Expand this to more libcall's
+                let libcall = LibCall::IshlI64;
+                let signature = libcall.signature(CallConv::Fast);
+                (ExternalName::LibCall(libcall), signature)
             };
 
             let sig_ref = builder.import_signature(sig.clone());

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -465,6 +465,16 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::Call, &[], &[], insert_call),
 ];
 
+/// These libcalls need a interpreter implementation in `cranelift-fuzzgen.rs`
+const ALLOWED_LIBCALLS: &'static [LibCall] = &[
+    LibCall::CeilF32,
+    LibCall::CeilF64,
+    LibCall::FloorF32,
+    LibCall::FloorF64,
+    LibCall::TruncF32,
+    LibCall::TruncF64,
+];
+
 pub struct FunctionGenerator<'r, 'data>
 where
     'data: 'r,
@@ -504,6 +514,12 @@ where
     fn generate_callconv(&mut self) -> Result<CallConv> {
         // TODO: Generate random CallConvs per target
         Ok(CallConv::SystemV)
+    }
+
+    fn system_callconv(&mut self) -> CallConv {
+        // TODO: This currently only runs on linux, so this is the only choice
+        // We should improve this once we generate flags and targets
+        CallConv::SystemV
     }
 
     fn generate_type(&mut self) -> Result<Type> {
@@ -833,10 +849,10 @@ where
                 let signature = self.generate_signature()?;
                 (name, signature)
             } else {
-                // Use sdivi64 as an example of a libcall function.
-                // TODO: Expand this to more libcall's
-                let libcall = LibCall::SdivI64;
-                let signature = libcall.signature(CallConv::Fast);
+                let libcall = *self.u.choose(ALLOWED_LIBCALLS)?;
+                // TODO: Use [CallConv::for_libcall] once we generate flags.
+                let callconv = self.system_callconv();
+                let signature = libcall.signature(callconv);
                 (ExternalName::LibCall(libcall), signature)
             };
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -833,7 +833,7 @@ where
                 let signature = self.generate_signature()?;
                 (name, signature)
             } else {
-                // Use udivi64 as an example of a libcall function.
+                // Use sdivi64 as an example of a libcall function.
                 // TODO: Expand this to more libcall's
                 let libcall = LibCall::SdivI64;
                 let signature = libcall.signature(CallConv::Fast);

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -833,9 +833,9 @@ where
                 let signature = self.generate_signature()?;
                 (name, signature)
             } else {
-                // Use ishli64 as an example of a libcall function.
+                // Use udivi64 as an example of a libcall function.
                 // TODO: Expand this to more libcall's
-                let libcall = LibCall::IshlI64;
+                let libcall = LibCall::UdivI64;
                 let signature = libcall.signature(CallConv::Fast);
                 (ExternalName::LibCall(libcall), signature)
             };

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -835,7 +835,7 @@ where
             } else {
                 // Use udivi64 as an example of a libcall function.
                 // TODO: Expand this to more libcall's
-                let libcall = LibCall::UdivI64;
+                let libcall = LibCall::SdivI64;
                 let signature = libcall.signature(CallConv::Fast);
                 (ExternalName::LibCall(libcall), signature)
             };

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -4,9 +4,7 @@ use crate::address::{Address, AddressSize};
 use crate::interpreter::LibCallHandler;
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-use cranelift_codegen::ir::{
-    FuncRef, Function, GlobalValue, Heap, LibCall, StackSlot, Type, Value,
-};
+use cranelift_codegen::ir::{FuncRef, Function, GlobalValue, Heap, StackSlot, Type, Value};
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -27,7 +25,7 @@ pub trait State<'a, V> {
     /// Retrieve a reference to the currently executing [Function].
     fn get_current_function(&self) -> &'a Function;
     /// Retrieve the handler callback for a [LibCall]
-    fn get_libcall(&self, libcall: LibCall) -> Option<LibCallHandler<V>>;
+    fn get_libcall_handler(&self) -> LibCallHandler<V>;
     /// Record that an interpreter has called into a new [Function].
     fn push_frame(&mut self, function: &'a Function);
     /// Record that an interpreter has returned from a called [Function].
@@ -134,7 +132,7 @@ where
         unimplemented!()
     }
 
-    fn get_libcall(&self, _libcall: LibCall) -> Option<LibCallHandler<V>> {
+    fn get_libcall_handler(&self) -> LibCallHandler<V> {
         unimplemented!()
     }
 

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -1,9 +1,12 @@
 //! Cranelift instructions modify the state of the machine; the [State] trait describes these
 //! ways this can happen.
 use crate::address::{Address, AddressSize};
+use crate::interpreter::LibCallHandler;
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-use cranelift_codegen::ir::{FuncRef, Function, GlobalValue, Heap, StackSlot, Type, Value};
+use cranelift_codegen::ir::{
+    FuncRef, Function, GlobalValue, Heap, LibCall, StackSlot, Type, Value,
+};
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -23,6 +26,8 @@ pub trait State<'a, V> {
     fn get_function(&self, func_ref: FuncRef) -> Option<&'a Function>;
     /// Retrieve a reference to the currently executing [Function].
     fn get_current_function(&self) -> &'a Function;
+    /// Retrieve the handler callback for a [LibCall]
+    fn get_libcall(&self, libcall: LibCall) -> Option<LibCallHandler<V>>;
     /// Record that an interpreter has called into a new [Function].
     fn push_frame(&mut self, function: &'a Function);
     /// Record that an interpreter has returned from a called [Function].
@@ -126,6 +131,10 @@ where
     }
 
     fn get_current_function(&self) -> &'a Function {
+        unimplemented!()
+    }
+
+    fn get_libcall(&self, _libcall: LibCall) -> Option<LibCallHandler<V>> {
         unimplemented!()
     }
 

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -24,7 +24,7 @@ pub trait State<'a, V> {
     fn get_function(&self, func_ref: FuncRef) -> Option<&'a Function>;
     /// Retrieve a reference to the currently executing [Function].
     fn get_current_function(&self) -> &'a Function;
-    /// Retrieve the handler callback for a [LibCall]
+    /// Retrieve the handler callback for a [LibCall](cranelift_codegen::ir::LibCall)
     fn get_libcall_handler(&self) -> LibCallHandler<V>;
     /// Record that an interpreter has called into a new [Function].
     fn push_frame(&mut self, function: &'a Function);

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -7,8 +7,8 @@ use crate::value::{Value, ValueConversionKind, ValueError, ValueResult};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::{
-    types, Block, ExternalName, FuncRef, Function, InstructionData, Opcode, TrapCode, Type,
-    Value as ValueRef,
+    types, AbiParam, Block, ExternalName, FuncRef, Function, InstructionData, Opcode, TrapCode,
+    Type, Value as ValueRef,
 };
 use log::trace;
 use smallvec::{smallvec, SmallVec};
@@ -16,6 +16,14 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::ops::RangeFrom;
 use thiserror::Error;
+
+/// Ensures that all types in args are the same as expected by the signature
+fn validate_signature_params(sig: &[AbiParam], args: &[impl Value]) -> bool {
+    args.iter()
+        .map(|r| r.ty())
+        .zip(sig.iter().map(|r| r.value_type))
+        .all(|(a, b)| a == b)
+}
 
 /// Interpret a single Cranelift instruction. Note that program traps and interpreter errors are
 /// distinct: a program trap results in `Ok(Flow::Trap(...))` whereas an interpretation error (e.g.
@@ -321,13 +329,8 @@ where
 
             // Check the types of the arguments. This is usually done by the verifier, but nothing
             // guarantees that the user has ran that.
-            let args_diff = args
-                .iter()
-                .map(|r| r.ty())
-                .zip(signature.params.iter().map(|r| r.value_type))
-                .any(|(a, b)| a != b);
-
-            if args_diff {
+            let args_match = validate_signature_params(&signature.params[..], &args[..]);
+            if !args_match {
                 return Ok(ControlFlow::Trap(CraneliftTrap::User(
                     TrapCode::BadSignature,
                 )));
@@ -353,16 +356,10 @@ where
                     };
 
                     // Check that what the handler returned is what we expect.
-                    let rets_diff = res
-                        .iter()
-                        .map(|r| r.ty())
-                        .zip(signature.returns.iter().map(|r| r.value_type))
-                        .any(|(a, b)| a != b);
-
-                    if rets_diff {
-                        ControlFlow::Trap(CraneliftTrap::User(TrapCode::BadSignature))
-                    } else {
+                    if validate_signature_params(&signature.returns[..], &res[..]) {
                         ControlFlow::Assign(res)
+                    } else {
+                        ControlFlow::Trap(CraneliftTrap::User(TrapCode::BadSignature))
                     }
                 }
                 ExternalName::KnownSymbol(_) => unimplemented!(),

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -349,6 +349,10 @@ where
 
                     // We don't transfer control to a libcall, we just execute it and return the results
                     let res = handler(args);
+                    let res = match res {
+                        Err(trap) => return Ok(ControlFlow::Trap(CraneliftTrap::User(trap))),
+                        Ok(rets) => rets,
+                    };
 
                     // Check that what the handler returned is what we expect.
                     let rets_diff = res

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -55,13 +55,6 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub fn default_libcall_names() -> Box<dyn Fn(ir::LibCall) -> String + Send + Sync> {
     Box::new(move |libcall| match libcall {
         ir::LibCall::Probestack => "__cranelift_probestack".to_owned(),
-        ir::LibCall::UdivI64 => "__udivdi3".to_owned(),
-        ir::LibCall::SdivI64 => "__divdi3".to_owned(),
-        ir::LibCall::UremI64 => "__umoddi3".to_owned(),
-        ir::LibCall::SremI64 => "__moddi3".to_owned(),
-        ir::LibCall::IshlI64 => "__ashldi3".to_owned(),
-        ir::LibCall::UshrI64 => "__lshrdi3".to_owned(),
-        ir::LibCall::SshrI64 => "__ashrdi3".to_owned(),
         ir::LibCall::CeilF32 => "ceilf".to_owned(),
         ir::LibCall::CeilF64 => "ceil".to_owned(),
         ir::LibCall::FloorF32 => "floorf".to_owned(),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,6 +19,7 @@ cranelift-interpreter = { path = "../cranelift/interpreter" }
 cranelift-fuzzgen = { path = "../cranelift/fuzzgen" }
 libfuzzer-sys = "0.4.0"
 target-lexicon = "0.12"
+smallvec = "1.6.1"
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
 component-test-util = { path = "../crates/misc/component-test-util" }

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -10,7 +10,9 @@ use cranelift_filetests::function_runner::{CompiledFunction, SingleFunctionCompi
 use cranelift_fuzzgen::*;
 use cranelift_interpreter::environment::FuncIndex;
 use cranelift_interpreter::environment::FunctionStore;
-use cranelift_interpreter::interpreter::{Interpreter, InterpreterError, InterpreterState};
+use cranelift_interpreter::interpreter::{
+    Interpreter, InterpreterError, InterpreterState, LibCallValues,
+};
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_interpreter::step::CraneliftTrap;
 use smallvec::{smallvec, SmallVec};
@@ -59,7 +61,7 @@ fn build_interpreter(testcase: &TestCase) -> Interpreter {
 
     let state = InterpreterState::default()
         .with_function_store(env)
-        .with_libcall_handler(&|libcall: LibCall, args: SmallVec<[DataValue; 1]>| {
+        .with_libcall_handler(|libcall: LibCall, args: LibCallValues<DataValue>| {
             use LibCall::*;
             Ok(smallvec![match (libcall, &args[..]) {
                 (CeilF32, [DataValue::F32(a)]) => DataValue::F32(a.ceil()),

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -60,7 +60,7 @@ fuzz_target!(|testcase: TestCase| {
 
         let state = InterpreterState::default()
             .with_function_store(env)
-            .with_libcall(LibCall::UdivI64, &|args| match &args[..] {
+            .with_libcall(LibCall::SdivI64, &|args| match &args[..] {
                 [DataValue::I64(a), DataValue::I64(b)] => a
                     .checked_div(*b)
                     .map(|res| Ok(smallvec![DataValue::I64(res)]))


### PR DESCRIPTION
👋 Hey,

This does not fix any of the issues reported by the fuzzer so far, but I think that is just a coincidence, since at some point it will generate a libcall and we cannot handle those either.

Edit: Actually this may have already been reported, but have returned the same error as  #4758 so it wasn't reported separately.

This allows the interpreter to register libcall handlers and invoke them when called.

I switched the fuzzer generated libcall from Udiv to Ishl, reason being that we don't want libcalls that can trap. Both functions have identical signatures so we shouldn't have any input format changes to the fuzzer.