### PR TITLE
Make wasi-common-std-sync's dependency on system-interface private.

### DIFF
--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -31,6 +31,7 @@ rustix = { version = "0.35.6", features = ["fs"] }
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.12.0"
 io-extras = "0.15.0"
+rustix = { version = "0.35.6", features = ["net"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -1,5 +1,6 @@
 use cap_fs_ext::MetadataExt;
 use fs_set_times::{SetTimes, SystemTimeSpec};
+use io_lifetimes::AsFilelike;
 use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
@@ -48,8 +49,8 @@ impl WasiFile for File {
         Ok(filetype_from(&meta.file_type()))
     }
     async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
-        let fdflags = self.0.get_fd_flags()?;
-        Ok(from_sysif_fdflags(fdflags))
+        let fdflags = get_fd_flags(&self.0)?;
+        Ok(fdflags)
     }
     async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
         if fdflags.intersects(
@@ -187,7 +188,10 @@ impl AsFd for File {
         self.0.as_fd()
     }
 }
-pub fn convert_systimespec(t: Option<wasi_common::SystemTimeSpec>) -> Option<SystemTimeSpec> {
+
+pub(crate) fn convert_systimespec(
+    t: Option<wasi_common::SystemTimeSpec>,
+) -> Option<SystemTimeSpec> {
     match t {
         Some(wasi_common::SystemTimeSpec::Absolute(t)) => {
             Some(SystemTimeSpec::Absolute(t.into_std()))
@@ -197,7 +201,7 @@ pub fn convert_systimespec(t: Option<wasi_common::SystemTimeSpec>) -> Option<Sys
     }
 }
 
-pub fn to_sysif_fdflags(f: wasi_common::file::FdFlags) -> system_interface::fs::FdFlags {
+pub(crate) fn to_sysif_fdflags(f: wasi_common::file::FdFlags) -> system_interface::fs::FdFlags {
     let mut out = system_interface::fs::FdFlags::empty();
     if f.contains(wasi_common::file::FdFlags::APPEND) {
         out |= system_interface::fs::FdFlags::APPEND;
@@ -216,7 +220,12 @@ pub fn to_sysif_fdflags(f: wasi_common::file::FdFlags) -> system_interface::fs::
     }
     out
 }
-pub fn from_sysif_fdflags(f: system_interface::fs::FdFlags) -> wasi_common::file::FdFlags {
+
+/// Return the file-descriptor flags for a given file-like object.
+///
+/// This returns the flags needed to implement [`WasiFile::get_fdflags`].
+pub fn get_fd_flags<Filelike: AsFilelike>(f: Filelike) -> io::Result<wasi_common::file::FdFlags> {
+    let f = f.as_filelike().get_fd_flags()?;
     let mut out = wasi_common::file::FdFlags::empty();
     if f.contains(system_interface::fs::FdFlags::APPEND) {
         out |= wasi_common::file::FdFlags::APPEND;
@@ -233,9 +242,10 @@ pub fn from_sysif_fdflags(f: system_interface::fs::FdFlags) -> wasi_common::file
     if f.contains(system_interface::fs::FdFlags::SYNC) {
         out |= wasi_common::file::FdFlags::SYNC;
     }
-    out
+    Ok(out)
 }
-pub fn convert_advice(advice: Advice) -> system_interface::fs::Advice {
+
+fn convert_advice(advice: Advice) -> system_interface::fs::Advice {
     match advice {
         Advice::Normal => system_interface::fs::Advice::Normal,
         Advice::Sequential => system_interface::fs::Advice::Sequential,

--- a/crates/wasi-common/cap-std-sync/src/net.rs
+++ b/crates/wasi-common/cap-std-sync/src/net.rs
@@ -230,7 +230,7 @@ macro_rules! wasi_stream_write_impl {
                 Ok(val)
             }
             async fn readable(&self) -> Result<(), Error> {
-                let (readable, _writeable) = self.0.is_read_write()?;
+                let (readable, _writeable) = is_read_write(&self.0)?;
                 if readable {
                     Ok(())
                 } else {
@@ -238,7 +238,7 @@ macro_rules! wasi_stream_write_impl {
                 }
             }
             async fn writable(&self) -> Result<(), Error> {
-                let (_readable, writeable) = self.0.is_read_write()?;
+                let (_readable, writeable) = is_read_write(&self.0)?;
                 if writeable {
                     Ok(())
                 } else {
@@ -315,4 +315,11 @@ pub fn get_fd_flags<Filelike: AsFilelike>(f: Filelike) -> io::Result<wasi_common
         out |= wasi_common::file::FdFlags::NONBLOCK;
     }
     Ok(out)
+}
+
+/// Return the file-descriptor flags for a given file-like object.
+///
+/// This returns the flags needed to implement [`WasiFile::get_fdflags`].
+pub fn is_read_write<Filelike: AsFilelike>(f: Filelike) -> io::Result<(bool, bool)> {
+    f.as_filelike().is_read_write()
 }

--- a/crates/wasi-common/cap-std-sync/src/net.rs
+++ b/crates/wasi-common/cap-std-sync/src/net.rs
@@ -1,7 +1,5 @@
 #[cfg(windows)]
 use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
-#[cfg(unix)]
-use io_lifetimes::AsFilelike;
 use io_lifetimes::AsSocketlike;
 #[cfg(unix)]
 use io_lifetimes::{AsFd, BorrowedFd};
@@ -306,9 +304,11 @@ pub fn filetype_from(ft: &cap_std::fs::FileType) -> FileType {
 /// Return the file-descriptor flags for a given file-like object.
 ///
 /// This returns the flags needed to implement [`WasiFile::get_fdflags`].
-pub fn get_fd_flags<Filelike: AsFilelike>(f: Filelike) -> io::Result<wasi_common::file::FdFlags> {
+pub fn get_fd_flags<Socketlike: AsSocketlike>(
+    f: Socketlike,
+) -> io::Result<wasi_common::file::FdFlags> {
     let mut out = wasi_common::file::FdFlags::empty();
-    if f.as_filelike()
+    if f.as_socketlike()
         .get_fd_flags()?
         .contains(system_interface::fs::FdFlags::NONBLOCK)
     {
@@ -320,6 +320,6 @@ pub fn get_fd_flags<Filelike: AsFilelike>(f: Filelike) -> io::Result<wasi_common
 /// Return the file-descriptor flags for a given file-like object.
 ///
 /// This returns the flags needed to implement [`WasiFile::get_fdflags`].
-pub fn is_read_write<Filelike: AsFilelike>(f: Filelike) -> io::Result<(bool, bool)> {
-    f.as_filelike().is_read_write()
+pub fn is_read_write<Socketlike: AsSocketlike>(f: Socketlike) -> io::Result<(bool, bool)> {
+    f.as_socketlike().is_read_write()
 }


### PR DESCRIPTION
Change some `pub` functions which exposed system-interface types to be
non-`pub`.

And, change `from_sysif_fdflags` functions to `get_fd_flags` functions
that take `impl AsFilelike` arguments instead of system-interface types.

With these changes, system-interface is no longer exposed in the
public API.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
