### PR TITLE
x64: Ensure that constants are always 16 bytes for XmmMem

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1309,15 +1309,13 @@
 ;;
 ;; Asserts that the value goes into a XMM.
 (decl put_in_xmm_mem (Value) XmmMem)
-(rule (put_in_xmm_mem val)
-      (reg_mem_to_xmm_mem (put_in_reg_mem val)))
+(extern constructor put_in_xmm_mem put_in_xmm_mem)
 
 ;; Put a value into a `XmmMemImm`.
 ;;
 ;; Asserts that the value goes into a XMM.
 (decl put_in_xmm_mem_imm (Value) XmmMemImm)
-(rule (put_in_xmm_mem_imm val)
-      (xmm_mem_imm_new (put_in_reg_mem_imm val)))
+(extern constructor put_in_xmm_mem_imm put_in_xmm_mem_imm)
 
 ;; Construct an `InstOutput` out of a single GPR register.
 (decl output_gpr (Gpr) InstOutput)

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -146,7 +146,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
             //
             // NOTE: this is where behavior differs from `put_in_reg_mem`, as we always force
             // constants to be 16 bytes when a constant will be used in place of an xmm register.
-            let vcode_constant = self.emit_u128_le_const(c, 0);
+            let vcode_constant = self.emit_u128_le_const(c as u128);
             return XmmMemImm::new(RegMemImm::mem(SyntheticAmode::ConstantOffset(
                 vcode_constant,
             )))
@@ -173,7 +173,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
             //
             // NOTE: this is where behavior differs from `put_in_reg_mem`, as we always force
             // constants to be 16 bytes when a constant will be used in place of an xmm register.
-            let vcode_constant = self.emit_u128_le_const(c, 0);
+            let vcode_constant = self.emit_u128_le_const(c as u128);
             return XmmMem::new(RegMem::mem(SyntheticAmode::ConstantOffset(vcode_constant)))
                 .unwrap();
         }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -806,7 +806,7 @@ macro_rules! isle_prelude_methods {
 
         #[inline]
         fn emit_u128_le_const(&mut self, value: u128) -> VCodeConstant {
-            let data = VCodeConstantData::Generated(value.to_le_bytes().iter().cloned().collect());
+            let data = VCodeConstantData::Generated(value.to_le_bytes().iter().copied().collect());
             self.lower_ctx.use_constant(data)
         }
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -805,14 +805,8 @@ macro_rules! isle_prelude_methods {
         }
 
         #[inline]
-        fn emit_u128_le_const(&mut self, lower: u64, upper: u64) -> VCodeConstant {
-            let bytes = lower
-                .to_le_bytes()
-                .iter()
-                .chain(upper.to_le_bytes().iter())
-                .cloned()
-                .collect();
-            let data = VCodeConstantData::Generated(bytes);
+        fn emit_u128_le_const(&mut self, value: u128) -> VCodeConstant {
+            let data = VCodeConstantData::Generated(value.to_le_bytes().iter().cloned().collect());
             self.lower_ctx.use_constant(data)
         }
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -805,6 +805,18 @@ macro_rules! isle_prelude_methods {
         }
 
         #[inline]
+        fn emit_u128_le_const(&mut self, lower: u64, upper: u64) -> VCodeConstant {
+            let bytes = lower
+                .to_le_bytes()
+                .iter()
+                .chain(upper.to_le_bytes().iter())
+                .cloned()
+                .collect();
+            let data = VCodeConstantData::Generated(bytes);
+            self.lower_ctx.use_constant(data)
+        }
+
+        #[inline]
         fn const_to_vconst(&mut self, constant: Constant) -> VCodeConstant {
             self.lower_ctx.use_constant(VCodeConstantData::Pool(
                 constant,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -806,7 +806,7 @@ macro_rules! isle_prelude_methods {
 
         #[inline]
         fn emit_u128_le_const(&mut self, value: u128) -> VCodeConstant {
-            let data = VCodeConstantData::Generated(value.to_le_bytes().iter().copied().collect());
+            let data = VCodeConstantData::Generated(value.to_le_bytes().as_slice().into());
             self.lower_ctx.use_constant(data)
         }
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -573,7 +573,7 @@
 ;; Add a u128 little-endian constant to the in-memory constant pool and
 ;; return a VCodeConstant index that refers to it. This is
 ;; side-effecting but idempotent (constants are deduplicated).
-(decl emit_u128_le_const (u64 u64) VCodeConstant)
+(decl emit_u128_le_const (u128) VCodeConstant)
 (extern constructor emit_u128_le_const emit_u128_le_const)
 
 ;; Fetch the VCodeConstant associated with a Constant.

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -570,6 +570,12 @@
 (decl emit_u64_le_const (u64) VCodeConstant)
 (extern constructor emit_u64_le_const emit_u64_le_const)
 
+;; Add a u128 little-endian constant to the in-memory constant pool and
+;; return a VCodeConstant index that refers to it. This is
+;; side-effecting but idempotent (constants are deduplicated).
+(decl emit_u128_le_const (u64 u64) VCodeConstant)
+(extern constructor emit_u128_le_const emit_u128_le_const)
+
 ;; Fetch the VCodeConstant associated with a Constant.
 (decl const_to_vconst (Constant) VCodeConstant)
 (extern constructor const_to_vconst const_to_vconst)

--- a/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
+++ b/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
@@ -1,0 +1,17 @@
+test run
+set enable_llvm_abi_extensions
+target x86_64
+
+; Regression test for unaligned loads to xmm registers when relying on automatic
+; conversion to XmmMem arguments in ISLE.
+; https://github.com/bytecodealliance/wasmtime/issues/4761
+function %a() -> f64 {
+  ss0 = explicit_slot 59
+
+block0:
+  v0 = f64const 0x1.d7d7d7d7d006fp984
+  v1 = fcopysign v0, v0
+  return v1
+}
+
+; run: %a() == 0x1.d7d7d7d7d006fp984


### PR DESCRIPTION
Ensure that constants generated for the memory case of XmmMem values are always 16 bytes, ensuring that we don't accidantally perform an unaligned load.

Fixes #4761
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
