### PR TITLE
Disable funcref generation for fuzz tests with inputs

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -190,6 +190,11 @@ where
     }
 
     pub fn generate_test(mut self) -> Result<TestCase> {
+        // If we're generating test inputs as well as a function, then we're planning to execute
+        // this function. That means that any function references in it need to exist. We don't yet
+        // have infrastructure for generating multiple functions, so just don't generate funcrefs.
+        self.config.funcrefs_per_function = 0..=0;
+
         let func = self.generate_func()?;
         let inputs = self.generate_test_inputs(&func.signature)?;
         Ok(TestCase { func, inputs })


### PR DESCRIPTION
Don't merge until we're ready to invalidate all of our currently-open `cranelift-fuzzgen` fuzz-bugs.

Per @afonso360's suggestion on #4758, this makes `cranelift-fuzzgen` stop generating references to functions which don't exist. It also disables generating libcalls, which weren't that big of a problem, but it's fine to just not test them until we have those bits in better shape.

This fixes #4757, fixes #4758, and fixes new fuzzbugs that are probably coming after we merged #4667.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
