### PR TITLE
cranelift: Test calling across different calling conventions

### DIFF
--- a/cranelift/filetests/filetests/runtests/call.clif
+++ b/cranelift/filetests/filetests/runtests/call.clif
@@ -66,3 +66,22 @@ block0(v0: b1):
 }
 ; run: %call_b1(true) == false
 ; run: %call_b1(false) == true
+
+
+
+; Tests calling across different calling conventions
+
+function %callee_fast_i64(i64) -> i64 fast {
+block0(v0: i64):
+    v1 = iadd_imm.i64 v0, 10
+    return v1
+}
+
+function %call_sysv_i64(i64) -> i64 system_v {
+    fn0 = %callee_fast_i64(i64) -> i64 fast
+
+block0(v0: i64):
+    v1 = call fn0(v0)
+    return v1
+}
+; run: %call_sysv_i64(10) == 20

--- a/cranelift/filetests/filetests/runtests/call.clif
+++ b/cranelift/filetests/filetests/runtests/call.clif
@@ -71,14 +71,14 @@ block0(v0: b1):
 
 ; Tests calling across different calling conventions
 
-function %callee_fast_i64(i64) -> i64 fast {
+function %callee_wasm_i64(i64) -> i64 wasmtime_system_v {
 block0(v0: i64):
     v1 = iadd_imm.i64 v0, 10
     return v1
 }
 
 function %call_sysv_i64(i64) -> i64 system_v {
-    fn0 = %callee_fast_i64(i64) -> i64 fast
+    fn0 = %callee_wasm_i64(i64) -> i64 wasmtime_system_v
 
 block0(v0: i64):
     v1 = call fn0(v0)

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -326,10 +326,6 @@ impl<'a> Trampoline<'a> {
 /// Compilation Error when compiling a function.
 #[derive(Error, Debug)]
 pub enum CompilationError {
-    /// This Target ISA is invalid for the current host.
-    #[error("Cross-compilation not currently supported; use the host's default calling convention \
-    or remove the specified calling convention in the function signature to use the host's default.")]
-    InvalidTargetIsa,
     /// Cranelift codegen error.
     #[error("Cranelift codegen error")]
     CodegenError(#[from] CodegenError),


### PR DESCRIPTION
👋 Hey,

This is a continuation of the TODO items in #4667 . It looks like #4667 accidentally already enables us to mix calling conventions so we don't need to do anything except remove an unused error.

This is an important feature for https://github.com/bytecodealliance/wasmtime/issues/4566 since we decided to mark big/little endian behaviour via calling convention, so this allows us to write runtests for that.