### PR TITLE
Improve the `fmt` output of the instantiate fuzz target

### DIFF
--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -1,38 +1,48 @@
 #![no_main]
 
-use libfuzzer_sys::arbitrary::{Result, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
-use wasmtime_fuzzing::oracles::Timeout;
-use wasmtime_fuzzing::{generators, oracles};
+use wasmtime_fuzzing::generators::Config;
+use wasmtime_fuzzing::oracles::{instantiate, Timeout};
+use wasmtime_fuzzing::wasm_smith::Module;
 
-fuzz_target!(|data: &[u8]| {
-    // errors in `run` have to do with not enough input in `data`, which we
-    // ignore here since it doesn't affect how we'd like to fuzz.
-    drop(run(data));
-});
-
-fn run(data: &[u8]) -> Result<()> {
-    let mut u = Unstructured::new(data);
-    let mut config: generators::Config = u.arbitrary()?;
-
-    // Pick either fuel, duration-based, or module-based timeout. Note that the
-    // module-based timeout is implemented with wasm-smith's
-    // `ensure_termination` option.
-    let timeout = if u.arbitrary()? {
-        config.generate_timeout(&mut u)?
-    } else {
-        Timeout::None
-    };
-
-    let module = config.generate(
-        &mut u,
-        if let Timeout::None = timeout {
-            Some(1000)
-        } else {
-            None
-        },
-    )?;
-
-    oracles::instantiate(&module.to_bytes(), true, &config, timeout);
-    Ok(())
+#[derive(Debug)]
+struct InstantiateInput {
+    config: Config,
+    timeout: Timeout,
+    module: Module,
 }
+
+impl<'a> Arbitrary<'a> for InstantiateInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut config: Config = u.arbitrary()?;
+
+        // Pick either fuel, duration-based, or module-based timeout. Note that the
+        // module-based timeout is implemented with wasm-smith's
+        // `ensure_termination` option.
+        let timeout = if u.arbitrary()? {
+            config.generate_timeout(u)?
+        } else {
+            Timeout::None
+        };
+
+        let module = config.generate(
+            u,
+            if let Timeout::None = timeout {
+                Some(1000)
+            } else {
+                None
+            },
+        )?;
+
+        Ok(InstantiateInput {
+            config,
+            timeout,
+            module,
+        })
+    }
+}
+
+fuzz_target!(|data: InstantiateInput| {
+    instantiate(&data.module.to_bytes(), true, &data.config, data.timeout);
+});

--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::arbitrary::{Result, Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use wasmtime_fuzzing::generators::Config;
 use wasmtime_fuzzing::oracles::{instantiate, Timeout};
@@ -14,7 +14,7 @@ struct InstantiateInput {
 }
 
 impl<'a> Arbitrary<'a> for InstantiateInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
         let mut config: Config = u.arbitrary()?;
 
         // Pick either fuel, duration-based, or module-based timeout. Note that the

--- a/fuzz/fuzz_targets/instantiate.rs
+++ b/fuzz/fuzz_targets/instantiate.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use libfuzzer_sys::arbitrary::{Result, Arbitrary, Unstructured};
+use libfuzzer_sys::arbitrary::{Arbitrary, Result, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use wasmtime_fuzzing::generators::Config;
 use wasmtime_fuzzing::oracles::{instantiate, Timeout};


### PR DESCRIPTION
Add an `Arbitrary` instance for the input to the `instantiate` fuzz target, so that `cargo fuzz fmt instantiate <file>` produces more meaningful output.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
