### PR TITLE
Don't let fuzz targets import `arbitrary` directly

### DIFF
--- a/crates/misc/component-fuzz-util/src/lib.rs
+++ b/crates/misc/component-fuzz-util/src/lib.rs
@@ -575,8 +575,8 @@ pub fn rust_type(ty: &Type, name_counter: &mut u32, declarations: &mut TokenStre
                     }
                 }
 
-                impl<'a> Arbitrary<'a> for #type_name {
-                    fn arbitrary(input: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+                impl<'a> arbitrary::Arbitrary<'a> for #type_name {
+                    fn arbitrary(input: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
                         let mut flags = #type_name::default();
                         for flag in [#names] {
                             if input.arbitrary()? {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,14 +10,13 @@ cargo-fuzz = true
 
 [dependencies]
 anyhow = { version = "1.0.19" }
-arbitrary = { version = "1.1.0", features = ["derive"] }
 cranelift-codegen = { path = "../cranelift/codegen", features = ["incremental-cache"] }
 cranelift-reader = { path = "../cranelift/reader" }
 cranelift-wasm = { path = "../cranelift/wasm" }
 cranelift-filetests = { path = "../cranelift/filetests" }
 cranelift-interpreter = { path = "../cranelift/interpreter" }
 cranelift-fuzzgen = { path = "../cranelift/fuzzgen" }
-libfuzzer-sys = "0.4.0"
+libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 target-lexicon = "0.12"
 smallvec = "1.6.1"
 wasmtime = { path = "../crates/wasmtime" }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -121,15 +121,15 @@ mod component {
 
         let module = quote! {
             #[allow(unused_imports)]
-            fn static_component_api_target(input: &mut arbitrary::Unstructured) -> arbitrary::Result<()> {
+            fn static_component_api_target(input: &mut libfuzzer_sys::arbitrary::Unstructured) -> libfuzzer_sys::arbitrary::Result<()> {
                 use anyhow::Result;
-                use arbitrary::{Unstructured, Arbitrary};
-                use component_test_util::{self, Float32, Float64};
                 use component_fuzz_util::Declarations;
+                use component_test_util::{self, Float32, Float64};
+                use libfuzzer_sys::arbitrary::{self, Arbitrary};
+                use std::borrow::Cow;
                 use std::sync::{Arc, Once};
                 use wasmtime::component::{ComponentType, Lift, Lower};
                 use wasmtime_fuzzing::generators::component_types;
-                use std::borrow::Cow;
 
                 const SEED: u64 = #seed;
 

--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
+use libfuzzer_sys::{arbitrary, fuzz_target};
 use wasmtime_fuzzing::oracles;
 
 include!(concat!(env!("OUT_DIR"), "/static_component_api.rs"));

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -15,7 +15,7 @@ use cranelift_interpreter::interpreter::{
 };
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_interpreter::step::CraneliftTrap;
-use smallvec::{smallvec, SmallVec};
+use smallvec::smallvec;
 
 const INTERPRETER_FUEL: u64 = 4096;
 


### PR DESCRIPTION
The version of the `arbitrary` crate used in fuzz targets needs to be
the same as the version used in `libfuzzer-sys`. That's why the latter
crate re-exports the former.

But we need to make sure to consistently use the re-exported version.
That's most easily done if that's the only version we have available.
However, `fuzz/Cargo.toml` declared a direct dependency on `arbitrary`,
making it available for import, and leading to that version being used
in a couple places.

There were two copies of `arbitrary` built before, even though they were
the same version: one with the `derive` feature turned on, through the
direct dependency, and one with it turned off when imported through
`libfuzzer-sys`. So I haven't specifically tested this but fuzzer builds
might be slightly faster now.

I have not removed the build-dep on `arbitrary`, because `build.rs` is
not invoked by libFuzzer and so it doesn't matter what version of
`arbitrary` it uses.

Our other crates, like `cranelift-fuzzgen` and `wasmtime-fuzzing`, can
still accidentally use a different version of `arbitrary` than the fuzz
targets which rely on them. This commit only fixes the direct cases
within `fuzz/**`.