### PR TITLE
x64: Lower nop in ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3757,3 +3757,9 @@
 
         ;; SHUFPS xmm_y, xmm_xmp, 0x88
         (x64_shufps dst zeros 0x88)))
+
+;; Rules for `nop` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (nop))
+      (invalid_reg))
+

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -459,7 +459,8 @@ fn lower_insn_to_regs(
         | Opcode::Isplit
         | Opcode::TlsValue
         | Opcode::SqmulRoundSat
-        | Opcode::Uunarrow => {
+        | Opcode::Uunarrow
+        | Opcode::Nop => {
             let ty = if outputs.len() > 0 {
                 Some(ctx.output_ty(insn, 0))
             } else {
@@ -572,13 +573,7 @@ fn lower_insn_to_regs(
         | Opcode::BrTable => {
             panic!("Branch opcode reached non-branch lowering logic!");
         }
-
-        Opcode::Nop => {
-            // Nothing.
-        }
     }
-
-    Ok(())
 }
 
 //=============================================================================


### PR DESCRIPTION
Lower `nop` in ISLE in the x64 backend, and remove the final `Ok(())` from the `lower` function to assert that all cases that aren't handled in ISLE will panic.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
