### PR TITLE
Remove the `ansi_term` transitive dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,15 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,28 +2977,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
- "ansi_term",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3475,7 +3452,6 @@ dependencies = [
  "tempfile",
  "test-programs",
  "tokio",
- "tracing-subscriber",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ tempfile = "3.1.0"
 test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { path = "crates/runtime" }
 tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.1"
 wast = "46.0.0"
 criterion = "0.3.4"
 num_cpus = "1.13.0"

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -18,7 +18,7 @@ wiggle = { path = "..", features = ["tracing_log"] }
 [dev-dependencies]
 thiserror = "1.0"
 tracing = "0.1.26"
-tracing-subscriber = "0.3.1"
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt'] }
 env_logger = "0.9"
 
 [badges]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -42,10 +42,6 @@ criteria = "safe-to-deploy"
 version = "0.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.ansi_term]]
-version = "0.12.1"
-criteria = "safe-to-run"
-
 [[exemptions.anyhow]]
 version = "1.0.57"
 criteria = "safe-to-deploy"
@@ -1045,10 +1041,6 @@ criteria = "safe-to-deploy"
 [[exemptions.tracing-core]]
 version = "0.1.28"
 criteria = "safe-to-deploy"
-
-[[exemptions.tracing-log]]
-version = "0.1.3"
-criteria = "safe-to-run"
 
 [[exemptions.tracing-subscriber]]
 version = "0.3.11"


### PR DESCRIPTION
Only used during tests but this resolves #4742 by slimming the
dependency tree.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
