### PR TITLE
Align functions according to their ISA's requirements

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -94,7 +94,7 @@ impl TargetIsa for AArch64Backend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
-            function_alignment: emit_result.constant_alignment,
+            alignment: emit_result.alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -94,6 +94,7 @@ impl TargetIsa for AArch64Backend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
+            function_alignment: emit_result.constant_alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -178,6 +178,10 @@ impl TargetIsa for AArch64Backend {
     fn map_regalloc_reg_to_dwarf(&self, reg: Reg) -> Result<u16, systemv::RegisterMappingError> {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
     }
+
+    fn function_alignment(&self) -> u32 {
+        4
+    }
 }
 
 impl fmt::Display for AArch64Backend {

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -181,7 +181,9 @@ impl TargetIsa for AArch64Backend {
     }
 
     fn function_alignment(&self) -> u32 {
-        4
+        // We use 32-byte alignment for performance reasons, but for correctness we would only need
+        // 4-byte alignment.
+        32
     }
 }
 

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -277,6 +277,9 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// will be "labeled" or might have calls between them, typically the number
     /// of defined functions in the object file.
     fn text_section_builder(&self, num_labeled_funcs: u32) -> Box<dyn TextSectionBuilder>;
+
+    /// The function alignment required by this ISA.
+    fn function_alignment(&self) -> u32;
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -160,6 +160,10 @@ impl TargetIsa for S390xBackend {
     fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
+
+    fn function_alignment(&self) -> u32 {
+        4
+    }
 }
 
 impl fmt::Display for S390xBackend {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -92,7 +92,7 @@ impl TargetIsa for S390xBackend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
-            function_alignment: emit_result.constant_alignment,
+            alignment: emit_result.alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -92,6 +92,7 @@ impl TargetIsa for S390xBackend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
+            function_alignment: emit_result.constant_alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -87,7 +87,7 @@ impl TargetIsa for X64Backend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
-            function_alignment: emit_result.constant_alignment,
+            alignment: emit_result.alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -87,6 +87,7 @@ impl TargetIsa for X64Backend {
             dynamic_stackslot_offsets,
             bb_starts: emit_result.bb_offsets,
             bb_edges: emit_result.bb_edges,
+            function_alignment: emit_result.constant_alignment,
         })
     }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -158,6 +158,8 @@ impl TargetIsa for X64Backend {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 
+    /// Align functions on x86 to 16 bytes, ensuring that rip-relative loads to SSE registers are
+    /// always from aligned memory.
     fn function_alignment(&self) -> u32 {
         16
     }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -157,6 +157,10 @@ impl TargetIsa for X64Backend {
     fn text_section_builder(&self, num_funcs: u32) -> Box<dyn TextSectionBuilder> {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
+
+    fn function_alignment(&self) -> u32 {
+        16
+    }
 }
 
 impl fmt::Display for X64Backend {

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -468,7 +468,11 @@ impl<I: VCodeInst> MachBuffer<I> {
     /// Align up to the given alignment.
     pub fn align_to(&mut self, align_to: CodeOffset) {
         trace!("MachBuffer: align to {}", align_to);
-        assert!(align_to.is_power_of_two());
+        assert!(
+            align_to.is_power_of_two(),
+            "{} is not a power of two",
+            align_to
+        );
         while self.cur_offset() & (align_to - 1) != 0 {
             self.put1(0);
         }

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1620,7 +1620,7 @@ impl<I: VCodeInst> MachTextSectionBuilder<I> {
 }
 
 impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
-    fn append(&mut self, named: bool, func: &[u8], align: Option<u32>) -> u64 {
+    fn append(&mut self, named: bool, func: &[u8], align: u32) -> u64 {
         // Conditionally emit an island if it's necessary to resolve jumps
         // between functions which are too far away.
         let size = func.len() as u32;
@@ -1628,7 +1628,7 @@ impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
             self.buf.emit_island_maybe_forced(self.force_veneers, size);
         }
 
-        self.buf.align_to(align.unwrap_or(I::LabelUse::ALIGN));
+        self.buf.align_to(align);
         let pos = self.buf.cur_offset();
         if named {
             self.buf

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -302,7 +302,7 @@ pub struct CompiledCodeBase<T: CompilePhase> {
     pub bb_edges: Vec<(CodeOffset, CodeOffset)>,
     /// Minimum alignment for the function, derived from the use of any
     /// pc-relative loads.
-    pub function_alignment: u32,
+    pub alignment: u32,
 }
 
 impl CompiledCodeStencil {
@@ -317,7 +317,7 @@ impl CompiledCodeStencil {
             dynamic_stackslot_offsets: self.dynamic_stackslot_offsets,
             bb_starts: self.bb_starts,
             bb_edges: self.bb_edges,
-            function_alignment: self.function_alignment,
+            alignment: self.alignment,
         }
     }
 }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -355,7 +355,7 @@ pub trait TextSectionBuilder {
     ///
     /// This function returns the offset at which the data was placed in the
     /// text section.
-    fn append(&mut self, labeled: bool, data: &[u8], align: Option<u32>) -> u64;
+    fn append(&mut self, labeled: bool, data: &[u8], align: u32) -> u64;
 
     /// Attempts to resolve a relocation for this function.
     ///

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -300,6 +300,9 @@ pub struct CompiledCodeBase<T: CompilePhase> {
     /// This info is generated only if the `machine_code_cfg_info`
     /// flag is set.
     pub bb_edges: Vec<(CodeOffset, CodeOffset)>,
+    /// Minimum alignment for the function, derived from the use of any
+    /// pc-relative loads.
+    pub function_alignment: u32,
 }
 
 impl CompiledCodeStencil {
@@ -314,6 +317,7 @@ impl CompiledCodeStencil {
             dynamic_stackslot_offsets: self.dynamic_stackslot_offsets,
             bb_starts: self.bb_starts,
             bb_edges: self.bb_edges,
+            function_alignment: self.function_alignment,
         }
     }
 }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -219,6 +219,9 @@ pub struct EmitResult<I: VCodeInst> {
 
     /// Stack frame size.
     pub frame_size: u32,
+
+    /// The alignment requirement for pc-relative loads.
+    pub constant_alignment: u32,
 }
 
 /// A builder for a VCode function body.
@@ -1036,7 +1039,10 @@ impl<I: VCodeInst> VCode<I> {
         }
 
         // Emit the constants used by the function.
+        let mut constant_alignment = 1;
         for (constant, data) in self.constants.iter() {
+            constant_alignment = data.alignment().max(constant_alignment);
+
             let label = buffer.get_label_for_constant(constant);
             buffer.defer_constant(label, data.alignment(), data.as_slice(), u32::max_value());
         }
@@ -1079,6 +1085,7 @@ impl<I: VCodeInst> VCode<I> {
             dynamic_stackslot_offsets: self.abi.dynamic_stackslot_offsets().clone(),
             value_labels_ranges,
             frame_size,
+            constant_alignment,
         }
     }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -221,7 +221,7 @@ pub struct EmitResult<I: VCodeInst> {
     pub frame_size: u32,
 
     /// The alignment requirement for pc-relative loads.
-    pub constant_alignment: u32,
+    pub alignment: u32,
 }
 
 /// A builder for a VCode function body.
@@ -1039,9 +1039,9 @@ impl<I: VCodeInst> VCode<I> {
         }
 
         // Emit the constants used by the function.
-        let mut constant_alignment = 1;
+        let mut alignment = 1;
         for (constant, data) in self.constants.iter() {
-            constant_alignment = data.alignment().max(constant_alignment);
+            alignment = data.alignment().max(alignment);
 
             let label = buffer.get_label_for_constant(constant);
             buffer.defer_constant(label, data.alignment(), data.as_slice(), u32::max_value());
@@ -1085,7 +1085,7 @@ impl<I: VCodeInst> VCode<I> {
             dynamic_stackslot_offsets: self.abi.dynamic_stackslot_offsets().clone(),
             value_labels_ranges,
             frame_size,
-            constant_alignment,
+            alignment,
         }
     }
 

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -745,9 +745,12 @@ impl Module for JITModule {
         &mut self,
         id: FuncId,
         func: &ir::Function,
+        _alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
     ) -> ModuleResult<ModuleCompiledFunction> {
+        // NOTE: the alignment parameter is unused as the jit always aligns functions on 16-byte
+        // boundaries.
         info!("defining function {} with bytes", id);
         let total_size: u32 = match bytes.len().try_into() {
             Ok(total_size) => total_size,

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -640,6 +640,7 @@ pub trait Module {
         &mut self,
         func_id: FuncId,
         func: &ir::Function,
+        alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
     ) -> ModuleResult<ModuleCompiledFunction>;
@@ -736,10 +737,11 @@ impl<M: Module> Module for &mut M {
         &mut self,
         func_id: FuncId,
         func: &ir::Function,
+        alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
     ) -> ModuleResult<ModuleCompiledFunction> {
-        (**self).define_function_bytes(func_id, func, bytes, relocs)
+        (**self).define_function_bytes(func_id, func, alignment, bytes, relocs)
     }
 
     fn define_data(&mut self, data: DataId, data_ctx: &DataContext) -> ModuleResult<()> {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -314,11 +314,13 @@ impl Module for ObjectModule {
         info!("defining function {}: {}", func_id, ctx.func.display());
         let mut code: Vec<u8> = Vec::new();
 
-        ctx.compile_and_emit(self.isa(), &mut code)?;
+        let res = ctx.compile_and_emit(self.isa(), &mut code)?;
+        let alignment = res.alignment as u64;
 
         self.define_function_bytes(
             func_id,
             &ctx.func,
+            alignment,
             &code,
             ctx.compiled_code().unwrap().buffer.relocs(),
         )
@@ -328,6 +330,7 @@ impl Module for ObjectModule {
         &mut self,
         func_id: FuncId,
         func: &ir::Function,
+        alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
     ) -> ModuleResult<ModuleCompiledFunction> {
@@ -348,7 +351,10 @@ impl Module for ObjectModule {
         }
         *defined = true;
 
-        let align = std::cmp::max(self.function_alignment, self.isa.symbol_alignment());
+        let align = self
+            .function_alignment
+            .max(self.isa.symbol_alignment())
+            .max(alignment);
         let (section, offset) = if self.per_function_section {
             let symbol_name = self.object.symbol(symbol).name.clone();
             let (section, offset) =

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -271,7 +271,8 @@ impl wasmtime_environ::Compiler for Compiler {
             &mut func_env,
         )?;
 
-        let (_, code_buf) = compile_maybe_cached(&mut context, isa, cache_ctx.as_mut())?;
+        let (code, code_buf) = compile_maybe_cached(&mut context, isa, cache_ctx.as_mut())?;
+        let alignment = code.function_alignment;
 
         let compiled_code = context.compiled_code().unwrap();
         let func_relocs = compiled_code
@@ -333,6 +334,7 @@ impl wasmtime_environ::Compiler for Compiler {
                 stack_maps,
                 start: 0,
                 length,
+                alignment,
             },
             address_map: address_transform,
         }))

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -272,7 +272,7 @@ impl wasmtime_environ::Compiler for Compiler {
         )?;
 
         let (code, code_buf) = compile_maybe_cached(&mut context, isa, cache_ctx.as_mut())?;
-        let alignment = code.function_alignment;
+        let alignment = code.alignment;
 
         let compiled_code = context.compiled_code().unwrap();
         let func_relocs = compiled_code

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -95,9 +95,11 @@ impl<'a> ModuleTextBuilder<'a> {
         func: &'a CompiledFunction,
     ) -> (SymbolId, Range<u64>) {
         let body_len = func.body.len() as u64;
-        let off = self
-            .text
-            .append(labeled, &func.body, self.isa.function_alignment());
+        let off = self.text.append(
+            labeled,
+            &func.body,
+            self.isa.function_alignment().max(func.info.alignment),
+        );
 
         let symbol_id = self.obj.add_symbol(Symbol {
             name,

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -95,7 +95,9 @@ impl<'a> ModuleTextBuilder<'a> {
         func: &'a CompiledFunction,
     ) -> (SymbolId, Range<u64>) {
         let body_len = func.body.len() as u64;
-        let off = self.text.append(labeled, &func.body, None);
+        let off = self
+            .text
+            .append(labeled, &func.body, Some(self.isa.function_alignment()));
 
         let symbol_id = self.obj.add_symbol(Symbol {
             name,

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -97,7 +97,7 @@ impl<'a> ModuleTextBuilder<'a> {
         let body_len = func.body.len() as u64;
         let off = self
             .text
-            .append(labeled, &func.body, Some(self.isa.function_alignment()));
+            .append(labeled, &func.body, self.isa.function_alignment());
 
         let symbol_id = self.obj.add_symbol(Symbol {
             name,
@@ -200,7 +200,7 @@ impl<'a> ModuleTextBuilder<'a> {
         if padding == 0 {
             return;
         }
-        self.text.append(false, &vec![0; padding], Some(1));
+        self.text.append(false, &vec![0; padding], 1);
     }
 
     /// Indicates that the text section has been written completely and this

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -28,6 +28,9 @@ pub struct FunctionInfo {
     pub start: u64,
     /// The size of the compiled function, in bytes.
     pub length: u32,
+
+    /// The alignment requirements of this function, in bytes.
+    pub alignment: u32,
 }
 
 /// Information about a compiled trampoline which the host can call to enter


### PR DESCRIPTION
Add a `function_alignment` function to the `TargetIsa` trait, and use it to align functions when generating objects. This fixes a bug on x86_64 where rip-relative loads to sse registers could cause a segfault, as functions weren't always guaranteed to be aligned to 16-byte addresses.

Fixes #4812 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
