### PR TITLE
Cranelift: Deduplicate ABI signatures during lowering

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -26,7 +26,7 @@ use crate::{
         immediates::*, types::*, AtomicRmwOp, ExternalName, Inst, InstructionData, MemFlags,
         TrapCode, Value, ValueList,
     },
-    isa::aarch64::abi::{AArch64Caller, AArch64MachineDeps},
+    isa::aarch64::abi::AArch64Caller,
     isa::aarch64::inst::args::{ShiftOp, ShiftOpShiftImm},
     isa::aarch64::lower::{writable_vreg, writable_xreg, xreg},
     isa::unwind::UnwindInst,
@@ -80,7 +80,7 @@ impl IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
 
 impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
-    isle_prelude_caller_methods!(AArch64MachineDeps, AArch64Caller);
+    isle_prelude_caller_methods!(crate::isa::aarch64::abi::AArch64MachineDeps, AArch64Caller);
 
     fn sign_return_address_disabled(&mut self) -> Option<()> {
         if self.isa_flags.sign_return_address() {

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -7,8 +7,8 @@ use crate::isa::aarch64::settings as aarch64_settings;
 use crate::isa::unwind::systemv;
 use crate::isa::{Builder as IsaBuilder, TargetIsa};
 use crate::machinst::{
-    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, TextSectionBuilder,
-    VCode,
+    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
+    TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
 use crate::settings as shared_settings;
@@ -58,10 +58,11 @@ impl AArch64Backend {
         &self,
         func: &Function,
         flags: shared_settings::Flags,
-    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
+    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output, SigSet)> {
         let emit_info = EmitInfo::new(flags.clone());
-        let abi = abi::AArch64Callee::new(func, self, &self.isa_flags)?;
-        compile::compile::<AArch64Backend>(func, self, abi, &self.machine_env, emit_info)
+        let sigs = SigSet::new::<abi::AArch64MachineDeps>(func, &self.flags)?;
+        let abi = abi::AArch64Callee::new(func, self, &self.isa_flags, &sigs)?;
+        compile::compile::<AArch64Backend>(func, self, abi, &self.machine_env, emit_info, sigs)
     }
 }
 
@@ -72,9 +73,14 @@ impl TargetIsa for AArch64Backend {
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil> {
         let flags = self.flags();
-        let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
+        let (vcode, regalloc_result, sigs) = self.compile_vcode(func, flags.clone())?;
 
-        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags.machine_code_cfg_info());
+        let emit_result = vcode.emit(
+            &sigs,
+            &regalloc_result,
+            want_disasm,
+            flags.machine_code_cfg_info(),
+        );
         let frame_size = emit_result.frame_size;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer.finish();

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -58,7 +58,7 @@ impl AArch64Backend {
         &self,
         func: &Function,
         flags: shared_settings::Flags,
-    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output, SigSet)> {
+    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
         let emit_info = EmitInfo::new(flags.clone());
         let sigs = SigSet::new::<abi::AArch64MachineDeps>(func, &self.flags)?;
         let abi = abi::AArch64Callee::new(func, self, &self.isa_flags, &sigs)?;
@@ -73,10 +73,9 @@ impl TargetIsa for AArch64Backend {
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil> {
         let flags = self.flags();
-        let (vcode, regalloc_result, sigs) = self.compile_vcode(func, flags.clone())?;
+        let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
         let emit_result = vcode.emit(
-            &sigs,
             &regalloc_result,
             want_disasm,
             flags.machine_code_cfg_info(),

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -75,11 +75,7 @@ impl TargetIsa for AArch64Backend {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
-        let emit_result = vcode.emit(
-            &regalloc_result,
-            want_disasm,
-            flags.machine_code_cfg_info(),
-        );
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags.machine_code_cfg_info());
         let frame_size = emit_result.frame_size;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer.finish();

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -3610,30 +3610,30 @@
 
 ;; Helpers for generating `call` instructions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl abi_sig (SigRef) ABISig)
+(decl abi_sig (SigRef) Sig)
 (extern constructor abi_sig abi_sig)
 
-(decl abi_call_info (ABISig ExternalName Opcode) BoxCallInfo)
+(decl abi_call_info (Sig ExternalName Opcode) BoxCallInfo)
 (extern constructor abi_call_info abi_call_info)
 
-(decl abi_call_ind_info (ABISig Reg Opcode) BoxCallIndInfo)
+(decl abi_call_ind_info (Sig Reg Opcode) BoxCallIndInfo)
 (extern constructor abi_call_ind_info abi_call_ind_info)
 
 (decl writable_link_reg () WritableReg)
 (rule (writable_link_reg) (writable_gpr 14))
 
-(decl abi_call (ABISig ExternalName Opcode) SideEffectNoResult)
+(decl abi_call (Sig ExternalName Opcode) SideEffectNoResult)
 (rule (abi_call abi name opcode)
       (call_impl (writable_link_reg) (abi_call_info abi name opcode)))
 
-(decl abi_call_ind (ABISig Reg Opcode) SideEffectNoResult)
+(decl abi_call_ind (Sig Reg Opcode) SideEffectNoResult)
 (rule (abi_call_ind abi target opcode)
       (call_ind_impl (writable_link_reg) (abi_call_ind_info abi target opcode)))
 
-(decl abi_accumulate_outgoing_args_size (ABISig) Unit)
+(decl abi_accumulate_outgoing_args_size (Sig) Unit)
 (extern constructor abi_accumulate_outgoing_args_size abi_accumulate_outgoing_args_size)
 
-(decl abi_lane_order (ABISig) LaneOrder)
+(decl abi_lane_order (Sig) LaneOrder)
 (extern constructor abi_lane_order abi_lane_order)
 
 

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -4060,7 +4060,7 @@
 
 ;; Direct call to an in-range function.
 (rule (lower (call (func_ref_data sig_ref name (reloc_distance_near)) args))
-      (let ((abi ABISig (abi_sig sig_ref))
+      (let ((abi Sig (abi_sig sig_ref))
             (_ Unit (abi_accumulate_outgoing_args_size abi))
             (_ InstOutput (lower_call_args abi (range 0 (abi_num_args abi)) args))
             (_ InstOutput (side_effect (abi_call abi name (Opcode.Call)))))
@@ -4068,7 +4068,7 @@
 
 ;; Direct call to an out-of-range function (implicitly via pointer).
 (rule (lower (call (func_ref_data sig_ref name _) args))
-      (let ((abi ABISig (abi_sig sig_ref))
+      (let ((abi Sig (abi_sig sig_ref))
             (_ Unit (abi_accumulate_outgoing_args_size abi))
             (_ InstOutput (lower_call_args abi (range 0 (abi_num_args abi)) args))
             (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
@@ -4077,7 +4077,7 @@
 
 ;; Indirect call.
 (rule (lower (call_indirect sig_ref ptr args))
-      (let ((abi ABISig (abi_sig sig_ref))
+      (let ((abi Sig (abi_sig sig_ref))
             (target Reg (put_in_reg ptr))
             (_ Unit (abi_accumulate_outgoing_args_size abi))
             (_ InstOutput (lower_call_args abi (range 0 (abi_num_args abi)) args))
@@ -4085,14 +4085,14 @@
         (lower_call_rets abi (range 0 (abi_num_rets abi)) (output_builder_new))))
 
 ;; Lower function arguments.
-(decl lower_call_args (ABISig Range ValueSlice) InstOutput)
+(decl lower_call_args (Sig Range ValueSlice) InstOutput)
 (rule (lower_call_args abi range args)
       (let ((_ InstOutput (lower_call_args_buffer abi range args))
             (_ InstOutput (lower_call_args_slots abi range args)))
         (lower_call_ret_arg abi)))
 
 ;; Lower function arguments (part 1): prepare buffer copies.
-(decl lower_call_args_buffer (ABISig Range ValueSlice) InstOutput)
+(decl lower_call_args_buffer (Sig Range ValueSlice) InstOutput)
 (rule (lower_call_args_buffer abi (range_empty) _) (output_none))
 (rule (lower_call_args_buffer abi (range_unwrap head tail) args)
       (let ((_ InstOutput (copy_to_buffer 0 (abi_get_arg abi head)
@@ -4100,7 +4100,7 @@
         (lower_call_args_buffer abi tail args)))
 
 ;; Lower function arguments (part 2): set up registers / stack slots.
-(decl lower_call_args_slots (ABISig Range ValueSlice) InstOutput)
+(decl lower_call_args_slots (Sig Range ValueSlice) InstOutput)
 (rule (lower_call_args_slots abi (range_empty) _) (output_none))
 (rule (lower_call_args_slots abi (range_unwrap head tail) args)
       (let ((_ Unit (copy_to_arg (abi_lane_order abi)
@@ -4109,7 +4109,7 @@
         (lower_call_args_slots abi tail args)))
 
 ;; Lower function arguments (part 3): implicit return-area pointer.
-(decl lower_call_ret_arg (ABISig) InstOutput)
+(decl lower_call_ret_arg (Sig) InstOutput)
 (rule (lower_call_ret_arg (abi_no_ret_arg)) (output_none))
 (rule (lower_call_ret_arg abi @ (abi_ret_arg (abi_arg_only_slot slot)))
       (let ((ret_arg Reg (load_addr (memarg_stack_off (abi_sized_stack_arg_space abi) 0)))
@@ -4117,7 +4117,7 @@
         (output_none)))
 
 ;; Lower function return values by collecting them from registers / stack slots.
-(decl lower_call_rets (ABISig Range InstOutputBuilder) InstOutput)
+(decl lower_call_rets (Sig Range InstOutputBuilder) InstOutput)
 (rule (lower_call_rets abi (range_empty) builder) (output_builder_finish builder))
 (rule (lower_call_rets abi (range_unwrap head tail) builder)
       (let ((ret ValueRegs (copy_from_arg (abi_lane_order abi)

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -90,16 +90,16 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
     isle_prelude_methods!();
 
     fn abi_sig(&mut self, sig_ref: SigRef) -> Sig {
-        self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref)
+        self.lower_ctx.sigs().abi_sig_for_sig_ref(sig_ref)
     }
 
     fn abi_lane_order(&mut self, abi: &Sig) -> LaneOrder {
-        lane_order_for_call_conv(self.lower_ctx.sigs[*abi].call_conv())
+        lane_order_for_call_conv(self.lower_ctx.sigs()[*abi].call_conv())
     }
 
     fn abi_accumulate_outgoing_args_size(&mut self, abi: &Sig) -> Unit {
-        let off = self.lower_ctx.sigs[*abi].sized_stack_arg_space()
-            + self.lower_ctx.sigs[*abi].sized_stack_ret_space();
+        let off = self.lower_ctx.sigs()[*abi].sized_stack_arg_space()
+            + self.lower_ctx.sigs()[*abi].sized_stack_ret_space();
         self.lower_ctx
             .abi_mut()
             .accumulate_outgoing_args_size(off as u32);
@@ -107,30 +107,30 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
 
     fn abi_call_info(&mut self, abi: &Sig, name: ExternalName, opcode: &Opcode) -> BoxCallInfo {
         let (uses, defs, clobbers) =
-            self.lower_ctx.sigs[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
+            self.lower_ctx.sigs()[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
         Box::new(CallInfo {
             dest: name.clone(),
             uses,
             defs,
             clobbers,
             opcode: *opcode,
-            caller_callconv: self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
-            callee_callconv: self.lower_ctx.sigs[*abi].call_conv(),
+            caller_callconv: self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
+            callee_callconv: self.lower_ctx.sigs()[*abi].call_conv(),
             tls_symbol: None,
         })
     }
 
     fn abi_call_ind_info(&mut self, abi: &Sig, target: Reg, opcode: &Opcode) -> BoxCallIndInfo {
         let (uses, defs, clobbers) =
-            self.lower_ctx.sigs[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
+            self.lower_ctx.sigs()[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
         Box::new(CallIndInfo {
             rn: target,
             uses,
             defs,
             clobbers,
             opcode: *opcode,
-            caller_callconv: self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
-            callee_callconv: self.lower_ctx.sigs[*abi].call_conv(),
+            caller_callconv: self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
+            callee_callconv: self.lower_ctx.sigs()[*abi].call_conv(),
         })
     }
 
@@ -156,7 +156,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
     }
 
     fn lib_call_info(&mut self, info: &LibCallInfo) -> BoxCallInfo {
-        let caller_callconv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
+        let caller_callconv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
         let callee_callconv = CallConv::for_libcall(&self.flags, caller_callconv);
 
         // Uses and defs are defined by the particular libcall.
@@ -406,7 +406,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
     #[inline]
     fn lane_order(&mut self) -> Option<LaneOrder> {
         Some(lane_order_for_call_conv(
-            self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
+            self.lower_ctx.abi().call_conv(self.lower_ctx.sigs()),
         ))
     }
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -89,46 +89,48 @@ pub(crate) fn lower_branch(
 impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     isle_prelude_methods!();
 
-    fn abi_sig(&mut self, sig_ref: SigRef) -> ABISig {
-        let sig = &self.lower_ctx.dfg().signatures[sig_ref];
-        ABISig::from_func_sig::<S390xMachineDeps>(sig, self.flags).unwrap()
+    fn abi_sig(&mut self, sig_ref: SigRef) -> Sig {
+        self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref)
     }
 
-    fn abi_lane_order(&mut self, abi: &ABISig) -> LaneOrder {
-        lane_order_for_call_conv(abi.call_conv())
+    fn abi_lane_order(&mut self, abi: &Sig) -> LaneOrder {
+        lane_order_for_call_conv(self.lower_ctx.sigs[*abi].call_conv())
     }
 
-    fn abi_accumulate_outgoing_args_size(&mut self, abi: &ABISig) -> Unit {
-        let off = abi.sized_stack_arg_space() + abi.sized_stack_ret_space();
+    fn abi_accumulate_outgoing_args_size(&mut self, abi: &Sig) -> Unit {
+        let off = self.lower_ctx.sigs[*abi].sized_stack_arg_space()
+            + self.lower_ctx.sigs[*abi].sized_stack_ret_space();
         self.lower_ctx
-            .abi()
+            .abi_mut()
             .accumulate_outgoing_args_size(off as u32);
     }
 
-    fn abi_call_info(&mut self, abi: &ABISig, name: ExternalName, opcode: &Opcode) -> BoxCallInfo {
-        let (uses, defs, clobbers) = abi.call_uses_defs_clobbers::<S390xMachineDeps>();
+    fn abi_call_info(&mut self, abi: &Sig, name: ExternalName, opcode: &Opcode) -> BoxCallInfo {
+        let (uses, defs, clobbers) =
+            self.lower_ctx.sigs[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
         Box::new(CallInfo {
             dest: name.clone(),
             uses,
             defs,
             clobbers,
             opcode: *opcode,
-            caller_callconv: self.lower_ctx.abi().call_conv(),
-            callee_callconv: abi.call_conv(),
+            caller_callconv: self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
+            callee_callconv: self.lower_ctx.sigs[*abi].call_conv(),
             tls_symbol: None,
         })
     }
 
-    fn abi_call_ind_info(&mut self, abi: &ABISig, target: Reg, opcode: &Opcode) -> BoxCallIndInfo {
-        let (uses, defs, clobbers) = abi.call_uses_defs_clobbers::<S390xMachineDeps>();
+    fn abi_call_ind_info(&mut self, abi: &Sig, target: Reg, opcode: &Opcode) -> BoxCallIndInfo {
+        let (uses, defs, clobbers) =
+            self.lower_ctx.sigs[*abi].call_uses_defs_clobbers::<S390xMachineDeps>();
         Box::new(CallIndInfo {
             rn: target,
             uses,
             defs,
             clobbers,
             opcode: *opcode,
-            caller_callconv: self.lower_ctx.abi().call_conv(),
-            callee_callconv: abi.call_conv(),
+            caller_callconv: self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
+            callee_callconv: self.lower_ctx.sigs[*abi].call_conv(),
         })
     }
 
@@ -149,12 +151,12 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
     fn lib_accumulate_outgoing_args_size(&mut self, _: &LibCallInfo) -> Unit {
         // Libcalls only require the register save area.
         self.lower_ctx
-            .abi()
+            .abi_mut()
             .accumulate_outgoing_args_size(REG_SAVE_AREA_SIZE);
     }
 
     fn lib_call_info(&mut self, info: &LibCallInfo) -> BoxCallInfo {
-        let caller_callconv = self.lower_ctx.abi().call_conv();
+        let caller_callconv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
         let callee_callconv = CallConv::for_libcall(&self.flags, caller_callconv);
 
         // Uses and defs are defined by the particular libcall.
@@ -403,7 +405,9 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
 
     #[inline]
     fn lane_order(&mut self) -> Option<LaneOrder> {
-        Some(lane_order_for_call_conv(self.lower_ctx.abi().call_conv()))
+        Some(lane_order_for_call_conv(
+            self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs),
+        ))
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -56,7 +56,7 @@ impl S390xBackend {
     fn compile_vcode(
         &self,
         func: &Function,
-    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output, SigSet)> {
+    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
         let emit_info = EmitInfo::new(self.isa_flags.clone());
         let sigs = SigSet::new::<abi::S390xMachineDeps>(func, &self.flags)?;
         let abi = abi::S390xCallee::new(func, self, &self.isa_flags, &sigs)?;
@@ -71,10 +71,9 @@ impl TargetIsa for S390xBackend {
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil> {
         let flags = self.flags();
-        let (vcode, regalloc_result, sigs) = self.compile_vcode(func)?;
+        let (vcode, regalloc_result) = self.compile_vcode(func)?;
 
         let emit_result = vcode.emit(
-            &sigs,
             &regalloc_result,
             want_disasm,
             flags.machine_code_cfg_info(),

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -73,11 +73,7 @@ impl TargetIsa for S390xBackend {
         let flags = self.flags();
         let (vcode, regalloc_result) = self.compile_vcode(func)?;
 
-        let emit_result = vcode.emit(
-            &regalloc_result,
-            want_disasm,
-            flags.machine_code_cfg_info(),
-        );
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags.machine_code_cfg_info());
         let frame_size = emit_result.frame_size;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer.finish();

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -153,21 +153,31 @@ fn emit_vm_call(
     // TODO avoid recreating signatures for every single Libcall function.
     let call_conv = CallConv::for_libcall(flags, CallConv::triple_default(triple));
     let sig = libcall.signature(call_conv);
-    let caller_conv = ctx.abi().call_conv();
+    let caller_conv = ctx.abi().call_conv(&ctx.sigs);
 
-    let mut abi = X64Caller::from_func(&sig, &extname, dist, caller_conv, flags)?;
+    if !ctx.sigs.have_abi_sig_for_signature(&sig) {
+        ctx.sigs
+            .make_abi_sig_from_ir_signature::<X64ABIMachineSpec>(sig.clone(), flags)?;
+    }
+
+    let mut abi =
+        X64Caller::from_libcall(&ctx.sigs, &sig, &extname, dist, caller_conv, flags.clone())?;
 
     abi.emit_stack_pre_adjust(ctx);
 
-    assert_eq!(inputs.len(), abi.num_args());
+    assert_eq!(inputs.len(), abi.num_args(&ctx.sigs));
 
     for (i, input) in inputs.iter().enumerate() {
-        abi.emit_copy_regs_to_arg(ctx, i, ValueRegs::one(*input));
+        for inst in abi.gen_copy_regs_to_arg(ctx, i, ValueRegs::one(*input)) {
+            ctx.emit(inst);
+        }
     }
 
     abi.emit_call(ctx);
     for (i, output) in outputs.iter().enumerate() {
-        abi.emit_copy_retval_to_regs(ctx, i, ValueRegs::one(*output));
+        for inst in abi.gen_copy_retval_to_regs(ctx, i, ValueRegs::one(*output)) {
+            ctx.emit(inst);
+        }
     }
     abi.emit_stack_post_adjust(ctx);
 

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -153,19 +153,19 @@ fn emit_vm_call(
     // TODO avoid recreating signatures for every single Libcall function.
     let call_conv = CallConv::for_libcall(flags, CallConv::triple_default(triple));
     let sig = libcall.signature(call_conv);
-    let caller_conv = ctx.abi().call_conv(&ctx.sigs);
+    let caller_conv = ctx.abi().call_conv(ctx.sigs());
 
-    if !ctx.sigs.have_abi_sig_for_signature(&sig) {
-        ctx.sigs
+    if !ctx.sigs().have_abi_sig_for_signature(&sig) {
+        ctx.sigs_mut()
             .make_abi_sig_from_ir_signature::<X64ABIMachineSpec>(sig.clone(), flags)?;
     }
 
     let mut abi =
-        X64Caller::from_libcall(&ctx.sigs, &sig, &extname, dist, caller_conv, flags.clone())?;
+        X64Caller::from_libcall(ctx.sigs(), &sig, &extname, dist, caller_conv, flags.clone())?;
 
     abi.emit_stack_pre_adjust(ctx);
 
-    assert_eq!(inputs.len(), abi.num_args(&ctx.sigs));
+    assert_eq!(inputs.len(), abi.num_args(ctx.sigs()));
 
     for (i, input) in inputs.iter().enumerate() {
         for inst in abi.gen_copy_regs_to_arg(ctx, i, ValueRegs::one(*input)) {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -720,7 +720,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     fn libcall_1(&mut self, libcall: &LibCall, a: Reg) -> Reg {
-        let call_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
+        let call_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
         let ret_ty = libcall.signature(call_conv).returns[0].value_type;
         let output_reg = self.lower_ctx.alloc_tmp(ret_ty).only_reg().unwrap();
 
@@ -738,7 +738,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     fn libcall_3(&mut self, libcall: &LibCall, a: Reg, b: Reg, c: Reg) -> Reg {
-        let call_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
+        let call_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
         let ret_ty = libcall.signature(call_conv).returns[0].value_type;
         let output_reg = self.lower_ctx.alloc_tmp(ret_ty).only_reg().unwrap();
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -24,7 +24,7 @@ use crate::{
         settings::Flags,
         unwind::UnwindInst,
         x64::{
-            abi::{X64ABIMachineSpec, X64Caller},
+            abi::X64Caller,
             inst::{args::*, regs, CallInfo},
             settings::Flags as IsaFlags,
         },
@@ -720,7 +720,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     fn libcall_1(&mut self, libcall: &LibCall, a: Reg) -> Reg {
-        let call_conv = self.lower_ctx.abi().call_conv();
+        let call_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
         let ret_ty = libcall.signature(call_conv).returns[0].value_type;
         let output_reg = self.lower_ctx.alloc_tmp(ret_ty).only_reg().unwrap();
 
@@ -738,7 +738,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     fn libcall_3(&mut self, libcall: &LibCall, a: Reg, b: Reg, c: Reg) -> Reg {
-        let call_conv = self.lower_ctx.abi().call_conv();
+        let call_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
         let ret_ty = libcall.signature(call_conv).returns[0].value_type;
         let output_reg = self.lower_ctx.alloc_tmp(ret_ty).only_reg().unwrap();
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -49,7 +49,7 @@ impl X64Backend {
         &self,
         func: &Function,
         flags: Flags,
-    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output, SigSet)> {
+    ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
         // This performs lowering to VCode, register-allocates the code, computes
         // block layout and finalizes branches. The result is ready for binary emission.
         let emit_info = EmitInfo::new(flags.clone(), self.x64_flags.clone());
@@ -66,14 +66,9 @@ impl TargetIsa for X64Backend {
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil> {
         let flags = self.flags();
-        let (vcode, regalloc_result, sigs) = self.compile_vcode(func, flags.clone())?;
+        let (vcode, regalloc_result) = self.compile_vcode(func, flags.clone())?;
 
-        let emit_result = vcode.emit(
-            &sigs,
-            &regalloc_result,
-            want_disasm,
-            flags.machine_code_cfg_info(),
-        );
+        let emit_result = vcode.emit(&regalloc_result, want_disasm, flags.machine_code_cfg_info());
         let frame_size = emit_result.frame_size;
         let value_labels_ranges = emit_result.value_labels_ranges;
         let buffer = emit_result.buffer.finish();

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -17,13 +17,16 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     abi: Callee<<<B as LowerBackend>::MInst as MachInst>::ABIMachineSpec>,
     machine_env: &MachineEnv,
     emit_info: <B::MInst as MachInstEmit>::Info,
-) -> CodegenResult<(VCode<B::MInst>, regalloc2::Output)> {
+    sigs: SigSet,
+) -> CodegenResult<(VCode<B::MInst>, regalloc2::Output, SigSet)> {
     // Compute lowered block order.
     let block_order = BlockLoweringOrder::new(f);
+
     // Build the lowering context.
-    let lower = Lower::new(f, abi, emit_info, block_order)?;
+    let lower = crate::machinst::Lower::new(f, abi, emit_info, block_order, sigs)?;
+
     // Lower the IR.
-    let vcode = {
+    let (vcode, sigs) = {
         let _tt = timing::vcode_lower();
         lower.lower(b)?
     };
@@ -66,5 +69,5 @@ pub fn compile<B: LowerBackend + TargetIsa>(
             .expect("register allocation checker");
     }
 
-    Ok((vcode, regalloc_result))
+    Ok((vcode, regalloc_result, sigs))
 }

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -18,7 +18,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     machine_env: &MachineEnv,
     emit_info: <B::MInst as MachInstEmit>::Info,
     sigs: SigSet,
-) -> CodegenResult<(VCode<B::MInst>, regalloc2::Output, SigSet)> {
+) -> CodegenResult<(VCode<B::MInst>, regalloc2::Output)> {
     // Compute lowered block order.
     let block_order = BlockLoweringOrder::new(f);
 
@@ -26,7 +26,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     let lower = crate::machinst::Lower::new(f, abi, emit_info, block_order, sigs)?;
 
     // Lower the IR.
-    let (vcode, sigs) = {
+    let vcode = {
         let _tt = timing::vcode_lower();
         lower.lower(b)?
     };
@@ -69,5 +69,5 @@ pub fn compile<B: LowerBackend + TargetIsa>(
             .expect("register allocation checker");
     }
 
-    Ok((vcode, regalloc_result, sigs))
+    Ok((vcode, regalloc_result))
 }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -14,7 +14,7 @@ pub use crate::ir::{
 };
 pub use crate::isa::unwind::UnwindInst;
 pub use crate::machinst::{
-    ABIArg, ABIArgSlot, ABISig, InputSourceInst, Lower, RealReg, Reg, RelocDistance, VCodeInst,
+    ABIArg, ABIArgSlot, InputSourceInst, Lower, RealReg, Reg, RelocDistance, Sig, VCodeInst,
     Writable,
 };
 pub use crate::settings::TlsModel;
@@ -938,40 +938,40 @@ macro_rules! isle_prelude_methods {
             regs.regs()[idx]
         }
 
-        fn abi_num_args(&mut self, abi: &ABISig) -> usize {
-            abi.num_args()
+        fn abi_num_args(&mut self, abi: &Sig) -> usize {
+            self.lower_ctx.sigs[*abi].num_args()
         }
 
-        fn abi_get_arg(&mut self, abi: &ABISig, idx: usize) -> ABIArg {
-            abi.get_arg(idx)
+        fn abi_get_arg(&mut self, abi: &Sig, idx: usize) -> ABIArg {
+            self.lower_ctx.sigs[*abi].get_arg(idx)
         }
 
-        fn abi_num_rets(&mut self, abi: &ABISig) -> usize {
-            abi.num_rets()
+        fn abi_num_rets(&mut self, abi: &Sig) -> usize {
+            self.lower_ctx.sigs[*abi].num_rets()
         }
 
-        fn abi_get_ret(&mut self, abi: &ABISig, idx: usize) -> ABIArg {
-            abi.get_ret(idx)
+        fn abi_get_ret(&mut self, abi: &Sig, idx: usize) -> ABIArg {
+            self.lower_ctx.sigs[*abi].get_ret(idx)
         }
 
-        fn abi_ret_arg(&mut self, abi: &ABISig) -> Option<ABIArg> {
-            abi.get_ret_arg()
+        fn abi_ret_arg(&mut self, abi: &Sig) -> Option<ABIArg> {
+            self.lower_ctx.sigs[*abi].get_ret_arg()
         }
 
-        fn abi_no_ret_arg(&mut self, abi: &ABISig) -> Option<()> {
-            if let Some(_) = abi.get_ret_arg() {
+        fn abi_no_ret_arg(&mut self, abi: &Sig) -> Option<()> {
+            if let Some(_) = self.lower_ctx.sigs[*abi].get_ret_arg() {
                 None
             } else {
                 Some(())
             }
         }
 
-        fn abi_sized_stack_arg_space(&mut self, abi: &ABISig) -> i64 {
-            abi.sized_stack_arg_space()
+        fn abi_sized_stack_arg_space(&mut self, abi: &Sig) -> i64 {
+            self.lower_ctx.sigs[*abi].sized_stack_arg_space()
         }
 
-        fn abi_sized_stack_ret_space(&mut self, abi: &ABISig) -> i64 {
-            abi.sized_stack_ret_space()
+        fn abi_sized_stack_ret_space(&mut self, abi: &Sig) -> i64 {
+            self.lower_ctx.sigs[*abi].sized_stack_ret_space()
         }
 
         fn abi_arg_only_slot(&mut self, arg: &ABIArg) -> Option<ABIArgSlot> {
@@ -1094,12 +1094,19 @@ macro_rules! isle_prelude_caller_methods {
             dist: RelocDistance,
             args @ (inputs, off): ValueSlice,
         ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv();
+            let caller_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
             let sig = &self.lower_ctx.dfg().signatures[sig_ref];
             let num_rets = sig.returns.len();
-            let abi = ABISig::from_func_sig::<$abispec>(sig, self.flags).unwrap();
-            let caller =
-                <$abicaller>::from_func(sig, &extname, dist, caller_conv, self.flags).unwrap();
+            let abi = self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref);
+            let caller = <$abicaller>::from_func(
+                &self.lower_ctx.sigs,
+                sig_ref,
+                &extname,
+                dist,
+                caller_conv,
+                self.flags.clone(),
+            )
+            .unwrap();
 
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,
@@ -1115,14 +1122,20 @@ macro_rules! isle_prelude_caller_methods {
             val: Value,
             args @ (inputs, off): ValueSlice,
         ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv();
+            let caller_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
             let ptr = self.put_in_reg(val);
             let sig = &self.lower_ctx.dfg().signatures[sig_ref];
             let num_rets = sig.returns.len();
-            let abi = ABISig::from_func_sig::<$abispec>(sig, self.flags).unwrap();
-            let caller =
-                <$abicaller>::from_ptr(sig, ptr, Opcode::CallIndirect, caller_conv, self.flags)
-                    .unwrap();
+            let abi = self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref);
+            let caller = <$abicaller>::from_ptr(
+                &self.lower_ctx.sigs,
+                sig_ref,
+                ptr,
+                Opcode::CallIndirect,
+                caller_conv,
+                self.flags.clone(),
+            )
+            .unwrap();
 
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,
@@ -1142,19 +1155,21 @@ macro_rules! isle_prelude_method_helpers {
     ($abicaller:ty) => {
         fn gen_call_common(
             &mut self,
-            abi: ABISig,
+            abi: Sig,
             num_rets: usize,
             mut caller: $abicaller,
             (inputs, off): ValueSlice,
         ) -> InstOutput {
             caller.emit_stack_pre_adjust(self.lower_ctx);
 
+            let num_args = self.lower_ctx.sigs[abi].num_args();
+
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,
-                abi.num_args()
+                num_args
             );
             let mut arg_regs = vec![];
-            for i in 0..abi.num_args() {
+            for i in 0..num_args {
                 let input = inputs
                     .get(off + i, &self.lower_ctx.dfg().value_lists)
                     .unwrap();
@@ -1164,15 +1179,19 @@ macro_rules! isle_prelude_method_helpers {
                 caller.emit_copy_regs_to_buffer(self.lower_ctx, i, *arg_regs);
             }
             for (i, arg_regs) in arg_regs.iter().enumerate() {
-                caller.emit_copy_regs_to_arg(self.lower_ctx, i, *arg_regs);
+                for inst in caller.gen_copy_regs_to_arg(self.lower_ctx, i, *arg_regs) {
+                    self.lower_ctx.emit(inst);
+                }
             }
             caller.emit_call(self.lower_ctx);
 
             let mut outputs = InstOutput::new();
             for i in 0..num_rets {
-                let ret = abi.get_ret(i);
+                let ret = self.lower_ctx.sigs[abi].get_ret(i);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();
-                caller.emit_copy_retval_to_regs(self.lower_ctx, i, retval_regs.clone());
+                for inst in caller.gen_copy_retval_to_regs(self.lower_ctx, i, retval_regs.clone()) {
+                    self.lower_ctx.emit(inst);
+                }
                 outputs.push(valueregs::non_writable_value_regs(retval_regs));
             }
             caller.emit_stack_post_adjust(self.lower_ctx);

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -939,27 +939,27 @@ macro_rules! isle_prelude_methods {
         }
 
         fn abi_num_args(&mut self, abi: &Sig) -> usize {
-            self.lower_ctx.sigs[*abi].num_args()
+            self.lower_ctx.sigs()[*abi].num_args()
         }
 
         fn abi_get_arg(&mut self, abi: &Sig, idx: usize) -> ABIArg {
-            self.lower_ctx.sigs[*abi].get_arg(idx)
+            self.lower_ctx.sigs()[*abi].get_arg(idx)
         }
 
         fn abi_num_rets(&mut self, abi: &Sig) -> usize {
-            self.lower_ctx.sigs[*abi].num_rets()
+            self.lower_ctx.sigs()[*abi].num_rets()
         }
 
         fn abi_get_ret(&mut self, abi: &Sig, idx: usize) -> ABIArg {
-            self.lower_ctx.sigs[*abi].get_ret(idx)
+            self.lower_ctx.sigs()[*abi].get_ret(idx)
         }
 
         fn abi_ret_arg(&mut self, abi: &Sig) -> Option<ABIArg> {
-            self.lower_ctx.sigs[*abi].get_ret_arg()
+            self.lower_ctx.sigs()[*abi].get_ret_arg()
         }
 
         fn abi_no_ret_arg(&mut self, abi: &Sig) -> Option<()> {
-            if let Some(_) = self.lower_ctx.sigs[*abi].get_ret_arg() {
+            if let Some(_) = self.lower_ctx.sigs()[*abi].get_ret_arg() {
                 None
             } else {
                 Some(())
@@ -967,11 +967,11 @@ macro_rules! isle_prelude_methods {
         }
 
         fn abi_sized_stack_arg_space(&mut self, abi: &Sig) -> i64 {
-            self.lower_ctx.sigs[*abi].sized_stack_arg_space()
+            self.lower_ctx.sigs()[*abi].sized_stack_arg_space()
         }
 
         fn abi_sized_stack_ret_space(&mut self, abi: &Sig) -> i64 {
-            self.lower_ctx.sigs[*abi].sized_stack_ret_space()
+            self.lower_ctx.sigs()[*abi].sized_stack_ret_space()
         }
 
         fn abi_arg_only_slot(&mut self, arg: &ABIArg) -> Option<ABIArgSlot> {
@@ -1094,12 +1094,12 @@ macro_rules! isle_prelude_caller_methods {
             dist: RelocDistance,
             args @ (inputs, off): ValueSlice,
         ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
+            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
             let sig = &self.lower_ctx.dfg().signatures[sig_ref];
             let num_rets = sig.returns.len();
-            let abi = self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref);
+            let abi = self.lower_ctx.sigs().abi_sig_for_sig_ref(sig_ref);
             let caller = <$abicaller>::from_func(
-                &self.lower_ctx.sigs,
+                self.lower_ctx.sigs(),
                 sig_ref,
                 &extname,
                 dist,
@@ -1122,13 +1122,13 @@ macro_rules! isle_prelude_caller_methods {
             val: Value,
             args @ (inputs, off): ValueSlice,
         ) -> InstOutput {
-            let caller_conv = self.lower_ctx.abi().call_conv(&self.lower_ctx.sigs);
+            let caller_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
             let ptr = self.put_in_reg(val);
             let sig = &self.lower_ctx.dfg().signatures[sig_ref];
             let num_rets = sig.returns.len();
-            let abi = self.lower_ctx.sigs.abi_sig_for_sig_ref(sig_ref);
+            let abi = self.lower_ctx.sigs().abi_sig_for_sig_ref(sig_ref);
             let caller = <$abicaller>::from_ptr(
-                &self.lower_ctx.sigs,
+                self.lower_ctx.sigs(),
                 sig_ref,
                 ptr,
                 Opcode::CallIndirect,
@@ -1162,7 +1162,7 @@ macro_rules! isle_prelude_method_helpers {
         ) -> InstOutput {
             caller.emit_stack_pre_adjust(self.lower_ctx);
 
-            let num_args = self.lower_ctx.sigs[abi].num_args();
+            let num_args = self.lower_ctx.sigs()[abi].num_args();
 
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,
@@ -1187,7 +1187,7 @@ macro_rules! isle_prelude_method_helpers {
 
             let mut outputs = InstOutput::new();
             for i in 0..num_rets {
-                let ret = self.lower_ctx.sigs[abi].get_ret(i);
+                let ret = self.lower_ctx.sigs()[abi].get_ret(i);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();
                 for inst in caller.gen_copy_retval_to_regs(self.lower_ctx, i, retval_regs.clone()) {
                     self.lower_ctx.emit(inst);

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -300,7 +300,12 @@ impl<I: VCodeInst> VCodeBuilder<I> {
     }
 
     /// Access the ABI object.
-    pub fn abi(&mut self) -> &mut Callee<I::ABIMachineSpec> {
+    pub fn abi(&self) -> &Callee<I::ABIMachineSpec> {
+        &self.vcode.abi
+    }
+
+    /// Access the ABI object.
+    pub fn abi_mut(&mut self) -> &mut Callee<I::ABIMachineSpec> {
         &mut self.vcode.abi
     }
 
@@ -743,12 +748,13 @@ impl<I: VCodeInst> VCode<I> {
     /// is consumed by the emission process.
     pub fn emit(
         mut self,
+        sigs: &SigSet,
         regalloc: &regalloc2::Output,
         want_disasm: bool,
         want_metadata: bool,
     ) -> EmitResult<I>
     where
-        I: MachInstEmit,
+        I: VCodeInst,
     {
         // To write into disasm string.
         use core::fmt::Write;
@@ -790,7 +796,7 @@ impl<I: VCodeInst> VCode<I> {
         // We need to generate the prologue in order to get the ABI
         // object into the right state first. We'll emit it when we
         // hit the right block below.
-        let prologue_insts = self.abi.gen_prologue();
+        let prologue_insts = self.abi.gen_prologue(sigs);
 
         // Emit blocks.
         let mut cur_srcloc = None;

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -178,6 +178,8 @@ pub struct VCode<I: VCodeInst> {
 
     /// Value labels for debuginfo attached to vregs.
     debug_value_labels: Vec<(VReg, InsnIndex, InsnIndex, u32)>,
+
+    sigs: SigSet,
 }
 
 /// The result of `VCode::emit`. Contains all information computed
@@ -279,13 +281,14 @@ pub enum VCodeBuildDirection {
 impl<I: VCodeInst> VCodeBuilder<I> {
     /// Create a new VCodeBuilder.
     pub fn new(
+        sigs: SigSet,
         abi: Callee<I::ABIMachineSpec>,
         emit_info: I::Info,
         block_order: BlockLoweringOrder,
         constants: VCodeConstants,
         direction: VCodeBuildDirection,
     ) -> VCodeBuilder<I> {
-        let vcode = VCode::new(abi, emit_info, block_order, constants);
+        let vcode = VCode::new(sigs, abi, emit_info, block_order, constants);
 
         VCodeBuilder {
             vcode,
@@ -299,6 +302,10 @@ impl<I: VCodeInst> VCodeBuilder<I> {
         }
     }
 
+    pub fn init_abi(&mut self, temps: Vec<Writable<Reg>>) {
+        self.vcode.abi.init(&self.vcode.sigs, temps);
+    }
+
     /// Access the ABI object.
     pub fn abi(&self) -> &Callee<I::ABIMachineSpec> {
         &self.vcode.abi
@@ -307,6 +314,14 @@ impl<I: VCodeInst> VCodeBuilder<I> {
     /// Access the ABI object.
     pub fn abi_mut(&mut self) -> &mut Callee<I::ABIMachineSpec> {
         &mut self.vcode.abi
+    }
+
+    pub fn sigs(&self) -> &SigSet {
+        &self.vcode.sigs
+    }
+
+    pub fn sigs_mut(&mut self) -> &mut SigSet {
+        &mut self.vcode.sigs
     }
 
     /// Access to the BlockLoweringOrder object.
@@ -630,6 +645,7 @@ fn is_reftype(ty: Type) -> bool {
 impl<I: VCodeInst> VCode<I> {
     /// New empty VCode.
     fn new(
+        sigs: SigSet,
         abi: Callee<I::ABIMachineSpec>,
         emit_info: I::Info,
         block_order: BlockLoweringOrder,
@@ -637,6 +653,7 @@ impl<I: VCodeInst> VCode<I> {
     ) -> VCode<I> {
         let n_blocks = block_order.lowered_order().len();
         VCode {
+            sigs,
             vreg_types: vec![],
             have_ref_values: false,
             insts: Vec::with_capacity(10 * n_blocks),
@@ -748,7 +765,6 @@ impl<I: VCodeInst> VCode<I> {
     /// is consumed by the emission process.
     pub fn emit(
         mut self,
-        sigs: &SigSet,
         regalloc: &regalloc2::Output,
         want_disasm: bool,
         want_metadata: bool,
@@ -796,7 +812,7 @@ impl<I: VCodeInst> VCode<I> {
         // We need to generate the prologue in order to get the ABI
         // object into the right state first. We'll emit it when we
         // hit the right block below.
-        let prologue_insts = self.abi.gen_prologue(sigs);
+        let prologue_insts = self.abi.gen_prologue(&self.sigs);
 
         // Emit blocks.
         let mut cur_srcloc = None;

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -904,7 +904,7 @@
 ;;;; Helpers for generating calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Type to hold information about a function call signature.
-(type ABISig extern (enum))
+(type Sig extern (enum))
 
 ;; Information how to pass one argument or return value.
 (type ABIArg extern (enum))
@@ -934,36 +934,36 @@
 ))
 
 ;; Get the number of arguments expected.
-(decl abi_num_args (ABISig) usize)
+(decl abi_num_args (Sig) usize)
 (extern constructor abi_num_args abi_num_args)
 
 ;; Get information specifying how to pass one argument.
-(decl abi_get_arg (ABISig usize) ABIArg)
+(decl abi_get_arg (Sig usize) ABIArg)
 (extern constructor abi_get_arg abi_get_arg)
 
 ;; Get the number of return values expected.
-(decl abi_num_rets (ABISig) usize)
+(decl abi_num_rets (Sig) usize)
 (extern constructor abi_num_rets abi_num_rets)
 
 ;; Get information specifying how to pass one return value.
-(decl abi_get_ret (ABISig usize) ABIArg)
+(decl abi_get_ret (Sig usize) ABIArg)
 (extern constructor abi_get_ret abi_get_ret)
 
 ;; Get information specifying how to pass the implicit pointer
 ;; to the return-value area on the stack, if required.
-(decl abi_ret_arg (ABIArg) ABISig)
+(decl abi_ret_arg (ABIArg) Sig)
 (extern extractor abi_ret_arg abi_ret_arg)
 
 ;; Succeeds if no implicit return-value area pointer is required.
-(decl abi_no_ret_arg () ABISig)
+(decl abi_no_ret_arg () Sig)
 (extern extractor abi_no_ret_arg abi_no_ret_arg)
 
 ;; Size of the argument area.
-(decl abi_sized_stack_arg_space (ABISig) i64)
+(decl abi_sized_stack_arg_space (Sig) i64)
 (extern constructor abi_sized_stack_arg_space abi_sized_stack_arg_space)
 
 ;; Size of the return-value area.
-(decl abi_sized_stack_ret_space (ABISig) i64)
+(decl abi_sized_stack_ret_space (Sig) i64)
 (extern constructor abi_sized_stack_ret_space abi_sized_stack_ret_space)
 
 ;; StackSlot addr


### PR DESCRIPTION
This commit creates the `SigSet` type which interns and deduplicates the ABI
signatures that we create from `ir::Signature`s. The ABI signatures are now
referred to indirectly via a `Sig` (which is a `cranelift_entity` ID), and we
pass around a `SigSet` to anything that needs to access the actual underlying
`SigData` (which is what `ABISig` used to be).

I had to change a couple methods to return a `SmallInstVec` instead of emitting
directly to work around what would otherwise be shared and exclusive borrows of
the lowering context overlapping. I don't expect any of these to heap allocate
in practice.

This does not remove the often-unnecessary allocations caused by
`ensure_struct_return_ptr_is_returned`. That is left for follow up work.

This also opens the door for further shuffling of signature data into more
efficient representations in the future, now that we have `SigSet` to store it
all in one place and it is threaded through all the code. We could potentially
move each signature's parameter and return vectors into one big vector shared
between all signatures, for example, which could cut down on allocations and
shrink the size of `SigData` since those `SmallVec`s have pretty large inline
capacity.

Overall, this refactoring gives a 1-7% speedup for compilation on
`pulldown-cmark`:

```
compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm

  Δ = 8754213.66 ± 7526266.23 (confidence = 99%)

  dedupe.so is 1.01x to 1.07x faster than main.so!

  [191003295 234620642.20 280597986] dedupe.so
  [197626699 243374855.86 321816763] main.so

compilation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [170406200 194299792.68 253001201] dedupe.so
  [172071888 193230743.11 223608329] main.so

compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  No difference in performance.

  [3870997347 4437735062.59 5216007266] dedupe.so
  [4019924063 4424595349.24 4965088931] main.so
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
