### PR TITLE
Backport stack trace panic fix to 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,6 +3443,7 @@ dependencies = [
  "humantime 2.1.0",
  "libc",
  "listenfd",
+ "log",
  "memchr",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ rustix = { version = "0.35.6", features = ["mm", "param"] }
 # depend again on wasmtime to activate its default features for tests
 wasmtime = { path = "crates/wasmtime", version = "0.40.0", features = ['component-model'] }
 env_logger = "0.9.0"
+log = "0.4.8"
 filecheck = "0.5.0"
 tempfile = "3.1.0"
 test-programs = { path = "crates/test-programs" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,17 @@
 --------------------------------------------------------------------------------
 
+## 0.40.1
+
+Released 2022-08-31.
+
+### Fixed
+
+* Fixed a potential panic when capturing a Wasm stack trace if there were
+  multiple Wasm activations on the stack from two different
+  stores. [#4779](https://github.com/bytecodealliance/wasmtime/pull/4779/)
+
+--------------------------------------------------------------------------------
+
 ## 0.40.0
 
 Released 2022-08-20.

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -103,7 +103,7 @@ impl TableElement {
     /// The same warnings as for `into_table_values()` apply.
     pub(crate) unsafe fn into_ref_asserting_initialized(self) -> usize {
         match self {
-            Self::FuncRef(e) => (e as usize),
+            Self::FuncRef(e) => e as usize,
             Self::ExternRef(e) => e.map_or(0, |e| e.into_raw() as usize),
             Self::UninitFunc => panic!("Uninitialized table element value outside of table slot"),
         }

--- a/crates/runtime/src/traphandlers/backtrace.rs
+++ b/crates/runtime/src/traphandlers/backtrace.rs
@@ -149,18 +149,18 @@ impl Backtrace {
             // trace through (since each `CallTheadState` saves the *previous*
             // call into Wasm's saved registers, and the youngest call into
             // Wasm's registers are saved in the `VMRuntimeLimits`)
-            if state.prev.get().is_null() {
-                debug_assert_eq!(state.old_last_wasm_exit_pc, 0);
-                debug_assert_eq!(state.old_last_wasm_exit_fp, 0);
-                debug_assert_eq!(state.old_last_wasm_entry_sp, 0);
+            if state.prev().is_null() {
+                debug_assert_eq!(state.old_last_wasm_exit_pc(), 0);
+                debug_assert_eq!(state.old_last_wasm_exit_fp(), 0);
+                debug_assert_eq!(state.old_last_wasm_entry_sp(), 0);
                 log::trace!("====== Done Capturing Backtrace ======");
                 return;
             }
 
             if let ControlFlow::Break(()) = Self::trace_through_wasm(
-                state.old_last_wasm_exit_pc,
-                state.old_last_wasm_exit_fp,
-                state.old_last_wasm_entry_sp,
+                state.old_last_wasm_exit_pc(),
+                state.old_last_wasm_exit_fp(),
+                state.old_last_wasm_entry_sp(),
                 &mut f,
             ) {
                 log::trace!("====== Done Capturing Backtrace ======");
@@ -266,7 +266,7 @@ impl Backtrace {
     }
 
     /// Iterate over the frames inside this backtrace.
-    pub fn frames<'a>(&'a self) -> impl Iterator<Item = &'a Frame> + 'a {
+    pub fn frames<'a>(&'a self) -> impl ExactSizeIterator<Item = &'a Frame> + 'a {
         self.0.iter()
     }
 }

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -482,6 +482,8 @@ async fn resume_separate_thread2() {
 
 #[tokio::test]
 async fn resume_separate_thread3() {
+    let _ = env_logger::try_init();
+
     // This test doesn't actually do anything with cross-thread polls, but
     // instead it deals with scheduling futures at "odd" times.
     //

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -753,3 +753,252 @@ fn traps_without_address_map() -> Result<()> {
     assert_eq!(trace[1].module_offset(), None);
     Ok(())
 }
+
+#[test]
+fn catch_trap_calling_across_stores() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let engine = Engine::default();
+
+    let mut child_store = Store::new(&engine, ());
+    let child_module = Module::new(
+        child_store.engine(),
+        r#"
+            (module $child
+              (func $trap (export "trap")
+                unreachable
+              )
+            )
+        "#,
+    )?;
+    let child_instance = Instance::new(&mut child_store, &child_module, &[])?;
+
+    struct ParentCtx {
+        child_store: Store<()>,
+        child_instance: Instance,
+    }
+
+    let mut linker = Linker::new(&engine);
+    linker.func_wrap(
+        "host",
+        "catch_child_trap",
+        move |mut caller: Caller<'_, ParentCtx>| {
+            let mut ctx = caller.as_context_mut();
+            let data = ctx.data_mut();
+            let func = data
+                .child_instance
+                .get_typed_func::<(), (), _>(&mut data.child_store, "trap")
+                .expect("trap function should be exported");
+
+            let trap = func
+                .call(&mut data.child_store, ())
+                .err()
+                .expect("should trap");
+            assert!(
+                trap.to_string().contains("unreachable"),
+                "trap should contain 'unreachable', got: {trap}"
+            );
+
+            let trace = trap.trace().unwrap();
+
+            assert_eq!(trace.len(), 1);
+            assert_eq!(trace[0].func_name(), Some("trap"));
+            // For now, we only get stack frames for Wasm in this store, not
+            // across all stores.
+            //
+            // assert_eq!(trace[1].func_name(), Some("run"));
+
+            Ok(())
+        },
+    )?;
+
+    let mut store = Store::new(
+        &engine,
+        ParentCtx {
+            child_store,
+            child_instance,
+        },
+    );
+
+    let parent_module = Module::new(
+        store.engine(),
+        r#"
+            (module $parent
+              (func $host.catch_child_trap (import "host" "catch_child_trap"))
+              (func $run (export "run")
+                call $host.catch_child_trap
+              )
+            )
+        "#,
+    )?;
+
+    let parent_instance = linker.instantiate(&mut store, &parent_module)?;
+
+    let func = parent_instance.get_typed_func::<(), (), _>(&mut store, "run")?;
+    func.call(store, ())?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn async_then_sync_trap() -> Result<()> {
+    // Test the trapping and capturing the stack with the following sequence of
+    // calls:
+    //
+    // a[async] ---> b[host] ---> c[sync]
+
+    drop(env_logger::try_init());
+
+    let wat = r#"
+        (module
+            (import "" "b" (func $b))
+            (func $a (export "a")
+                call $b
+            )
+            (func $c (export "c")
+                unreachable
+            )
+        )
+    "#;
+
+    let mut sync_store = Store::new(&Engine::default(), ());
+
+    let sync_module = Module::new(sync_store.engine(), wat)?;
+
+    let mut sync_linker = Linker::new(sync_store.engine());
+    sync_linker.func_wrap("", "b", |_caller: Caller<_>| unreachable!())?;
+
+    let sync_instance = sync_linker.instantiate(&mut sync_store, &sync_module)?;
+
+    struct AsyncCtx {
+        sync_instance: Instance,
+        sync_store: Store<()>,
+    }
+
+    let mut async_store = Store::new(
+        &Engine::new(Config::new().async_support(true)).unwrap(),
+        AsyncCtx {
+            sync_instance,
+            sync_store,
+        },
+    );
+
+    let async_module = Module::new(async_store.engine(), wat)?;
+
+    let mut async_linker = Linker::new(async_store.engine());
+    async_linker.func_wrap("", "b", move |mut caller: Caller<AsyncCtx>| {
+        log::info!("Called `b`...");
+        let sync_instance = caller.data().sync_instance;
+        let sync_store = &mut caller.data_mut().sync_store;
+
+        log::info!("Calling `c`...");
+        let c = sync_instance
+            .get_typed_func::<(), (), _>(&mut *sync_store, "c")
+            .unwrap();
+        c.call(sync_store, ())?;
+        Ok(())
+    })?;
+
+    let async_instance = async_linker
+        .instantiate_async(&mut async_store, &async_module)
+        .await?;
+
+    log::info!("Calling `a`...");
+    let a = async_instance
+        .get_typed_func::<(), (), _>(&mut async_store, "a")
+        .unwrap();
+    let trap = a.call_async(&mut async_store, ()).await.unwrap_err();
+
+    let trace = trap.trace().unwrap();
+    // We don't support cross-store or cross-engine symbolication currently, so
+    // the other frames are ignored.
+    assert_eq!(trace.len(), 1);
+    assert_eq!(trace[0].func_name(), Some("c"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn sync_then_async_trap() -> Result<()> {
+    // Test the trapping and capturing the stack with the following sequence of
+    // calls:
+    //
+    // a[sync] ---> b[host] ---> c[async]
+
+    drop(env_logger::try_init());
+
+    let wat = r#"
+        (module
+            (import "" "b" (func $b))
+            (func $a (export "a")
+                call $b
+            )
+            (func $c (export "c")
+                unreachable
+            )
+        )
+    "#;
+
+    let mut async_store = Store::new(&Engine::new(Config::new().async_support(true)).unwrap(), ());
+
+    let async_module = Module::new(async_store.engine(), wat)?;
+
+    let mut async_linker = Linker::new(async_store.engine());
+    async_linker.func_wrap("", "b", |_caller: Caller<_>| unreachable!())?;
+
+    let async_instance = async_linker
+        .instantiate_async(&mut async_store, &async_module)
+        .await?;
+
+    struct SyncCtx {
+        async_instance: Instance,
+        async_store: Store<()>,
+    }
+
+    let mut sync_store = Store::new(
+        &Engine::default(),
+        SyncCtx {
+            async_instance,
+            async_store,
+        },
+    );
+
+    let sync_module = Module::new(sync_store.engine(), wat)?;
+
+    let mut sync_linker = Linker::new(sync_store.engine());
+    sync_linker.func_wrap(
+        "",
+        "b",
+        move |mut caller: Caller<SyncCtx>| -> Result<(), Trap> {
+            log::info!("Called `b`...");
+            let async_instance = caller.data().async_instance;
+            let async_store = &mut caller.data_mut().async_store;
+
+            log::info!("Calling `c`...");
+            let c = async_instance
+                .get_typed_func::<(), (), _>(&mut *async_store, "c")
+                .unwrap();
+            tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current()
+                    .block_on(async move { c.call_async(async_store, ()).await })
+            })?;
+            Ok(())
+        },
+    )?;
+
+    let sync_instance = sync_linker.instantiate(&mut sync_store, &sync_module)?;
+
+    log::info!("Calling `a`...");
+    let a = sync_instance
+        .get_typed_func::<(), (), _>(&mut sync_store, "a")
+        .unwrap();
+    let trap = a.call(&mut sync_store, ()).unwrap_err();
+
+    let trace = trap.trace().unwrap();
+    // We don't support cross-store or cross-engine symbolication currently, so
+    // the other frames are ignored.
+    assert_eq!(trace.len(), 1);
+    assert_eq!(trace[0].func_name(), Some("c"));
+
+    Ok(())
+}


### PR DESCRIPTION
This backports ff0e84ecf (and a change to silence a build warning that could break CI) to the `release-0.40.0` branch.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
