### PR TITLE
cranelift: Remove const_addr instruction (fixes #2398)

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1455,21 +1455,6 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
-    let constant =
-        &Operand::new("constant", &imm.pool_constant).with_doc("A constant in the constant pool");
-    let address = &Operand::new("address", iAddr);
-    ig.push(
-        Inst::new(
-            "const_addr",
-            r#"
-        Calculate the base address of a value in the constant pool.
-        "#,
-            &formats.unary_const,
-        )
-        .operands_in(vec![constant])
-        .operands_out(vec![address]),
-    );
-
     let mask = &Operand::new("mask", &imm.uimm128)
         .with_doc("The 16 immediate bytes used for selecting the elements to shuffle");
     let Tx16 = &TypeVar::new(

--- a/cranelift/codegen/src/isa/aarch64/lower_inst.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower_inst.rs
@@ -471,7 +471,7 @@ pub(crate) fn lower_insn_to_regs(
 
         Opcode::ExtractVector => implemented_in_isle(ctx),
 
-        Opcode::ConstAddr | Opcode::Vconcat | Opcode::Vsplit => {
+        Opcode::Vconcat | Opcode::Vsplit => {
             return Err(CodegenError::Unsupported(format!(
                 "Unimplemented lowering: {}",
                 op

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -200,8 +200,7 @@ impl LowerBackend for S390xBackend {
                 )
             }
 
-            Opcode::ConstAddr
-            | Opcode::GetPinnedReg
+            Opcode::GetPinnedReg
             | Opcode::SetPinnedReg
             | Opcode::Vsplit
             | Opcode::Vconcat

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -503,8 +503,6 @@ fn lower_insn_to_regs(
 
         Opcode::Trueif | Opcode::Trueff => unimplemented!("trueif / trueff not implemented"),
 
-        Opcode::ConstAddr => unimplemented!("ConstAddr not implemented"),
-
         Opcode::Vsplit | Opcode::Vconcat => {
             unimplemented!("Vector split/concat ops not implemented.");
         }

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -533,7 +533,6 @@ where
         Opcode::F64const => assign(imm()),
         Opcode::Bconst => assign(imm()),
         Opcode::Vconst => assign(imm()),
-        Opcode::ConstAddr => unimplemented!("ConstAddr"),
         Opcode::Null => unimplemented!("Null"),
         Opcode::Nop => ControlFlow::Continue,
         Opcode::Select => choose(arg(0)?.into_bool()?, arg(1)?, arg(2)?),


### PR DESCRIPTION
Per discussion in #2398, this PR removes the `const_addr` instruction from Cranelift.