### PR TITLE
Tweak adapter cost of lists

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -514,12 +514,12 @@ impl Compiler<'_, '_> {
             InterfaceType::Char => 1,
 
             // This has a fair bit of code behind it depending on the
-            // strings/encodings in play, so arbitrarily assign it a cost a 5.
-            InterfaceType::String => 5,
+            // strings/encodings in play, so arbitrarily assign it this cost.
+            InterfaceType::String => 40,
 
             // Iteration of a loop is along the lines of the cost of a string
             // so give it the same cost
-            InterfaceType::List(_) => 5,
+            InterfaceType::List(_) => 40,
 
             InterfaceType::Flags(i) => {
                 let count = self.module.types[*i].names.len();


### PR DESCRIPTION
I noticed an oss-fuzz-based timeout that was reported for the
`component_api` fuzzer where the adapter module generated takes 1.5
seconds to compile the singular function in release mode (no fuzzing
enabled). The test case in question was a deeply recursive
list-of-list-of-etc and only one function was generated instead of
multiple. I updated the cost of strings/lists to cost more in the
approximate cost calculation which now forces the one giant function to
get split up and the large function is now split up into multiple
smaller function that take milliseconds to compile.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
