### PR TITLE
ABI: implement register arguments with constraints.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -387,12 +387,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
-    fn gen_args(
-        _isa_flags: &aarch64_settings::Flags,
-        defs: Vec<Writable<Reg>>,
-        pregs: Vec<Reg>,
-    ) -> Inst {
-        let args = Box::new(ArgInfo { defs, pregs });
+    fn gen_args(_isa_flags: &aarch64_settings::Flags, args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -387,6 +387,15 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
+    fn gen_args(
+        _isa_flags: &aarch64_settings::Flags,
+        defs: Vec<Writable<Reg>>,
+        pregs: Vec<Reg>,
+    ) -> Inst {
+        let args = Box::new(ArgInfo { defs, pregs });
+        Inst::Args { args }
+    }
+
     fn gen_ret(setup_frame: bool, isa_flags: &aarch64_settings::Flags, rets: Vec<Reg>) -> Inst {
         if isa_flags.sign_return_address() && (setup_frame || isa_flags.sign_return_address_all()) {
             let key = if isa_flags.sign_return_address_with_bkey() {

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -779,6 +779,10 @@
        (CallInd
         (info BoxCallIndInfo))
 
+       ;; A pseudo-instruction that captures register arguments in vregs.
+       (Args
+        (args BoxArgInfo))
+
        ;; ---- branches (exactly one must appear at end of BB) ----
 
        ;; A machine return instruction.

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -781,7 +781,7 @@
 
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
-        (args BoxArgInfo))
+        (args VecArgPair))
 
        ;; ---- branches (exactly one must appear at end of BB) ----
 

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3015,6 +3015,10 @@ impl MachInstEmit for Inst {
                 // Emit the jump itself.
                 sink.put4(enc_jump26(0b000101, dest.as_offset26_or_zero()));
             }
+            &Inst::Args { .. } => {
+                // Nothing: this is a pseudoinstruction that serves
+                // only to constrain registers at a certain point.
+            }
             &Inst::Ret { .. } => {
                 sink.put4(0xd65f03c0);
             }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1016,8 +1016,8 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(rn);
         }
         &Inst::Args { ref args } => {
-            for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
-                collector.reg_fixed_def(def, preg);
+            for arg in args {
+                collector.reg_fixed_def(arg.vreg, arg.preg);
             }
         }
         &Inst::Ret { ref rets } | &Inst::AuthenticatedRet { ref rets, .. } => {
@@ -2632,10 +2632,10 @@ impl Inst {
             }
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
-                for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                for arg in args {
                     use std::fmt::Write;
-                    let preg = pretty_print_reg(preg, &mut empty_allocs);
-                    let def = pretty_print_reg(def.to_reg(), allocs);
+                    let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
+                    let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
                 }
                 s

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -31,7 +31,7 @@ use crate::{
     isa::aarch64::inst::args::{ShiftOp, ShiftOpShiftImm},
     isa::unwind::UnwindInst,
     machinst::{
-        abi::ArgInfo, ty_bits, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData,
+        abi::ArgPair, ty_bits, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData,
     },
 };
 use regalloc2::PReg;
@@ -45,7 +45,7 @@ type BoxCallIndInfo = Box<CallIndInfo>;
 type VecMachLabel = Vec<MachLabel>;
 type BoxJTSequenceInfo = Box<JTSequenceInfo>;
 type BoxExternalName = Box<ExternalName>;
-type BoxArgInfo = Box<ArgInfo>;
+type VecArgPair = Vec<ArgPair>;
 
 /// The main entry point for lowering with ISLE.
 pub(crate) fn lower(

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -30,7 +30,9 @@ use crate::{
     isa::aarch64::abi::AArch64Caller,
     isa::aarch64::inst::args::{ShiftOp, ShiftOpShiftImm},
     isa::unwind::UnwindInst,
-    machinst::{ty_bits, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData},
+    machinst::{
+        abi::ArgInfo, ty_bits, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData,
+    },
 };
 use regalloc2::PReg;
 use std::boxed::Box;
@@ -43,6 +45,7 @@ type BoxCallIndInfo = Box<CallIndInfo>;
 type VecMachLabel = Vec<MachLabel>;
 type BoxJTSequenceInfo = Box<JTSequenceInfo>;
 type BoxExternalName = Box<ExternalName>;
+type BoxArgInfo = Box<ArgInfo>;
 
 /// The main entry point for lowering with ISLE.
 pub(crate) fn lower(

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -82,6 +82,7 @@ use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use regalloc2::{PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
+use std::boxed::Box;
 use std::convert::TryFrom;
 
 // We use a generic implementation that factors out ABI commonalities.
@@ -457,6 +458,15 @@ impl ABIMachineSpec for S390xMachineDeps {
             from_bits,
             to_bits,
         }
+    }
+
+    fn gen_args(
+        _isa_flags: &s390x_settings::Flags,
+        defs: Vec<Writable<Reg>>,
+        pregs: Vec<Reg>,
+    ) -> Inst {
+        let args = Box::new(ArgInfo { defs, pregs });
+        Inst::Args { args }
     }
 
     fn gen_ret(_setup_frame: bool, _isa_flags: &s390x_settings::Flags, rets: Vec<Reg>) -> Inst {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -82,7 +82,6 @@ use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use regalloc2::{PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::boxed::Box;
 use std::convert::TryFrom;
 
 // We use a generic implementation that factors out ABI commonalities.
@@ -460,12 +459,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
     }
 
-    fn gen_args(
-        _isa_flags: &s390x_settings::Flags,
-        defs: Vec<Writable<Reg>>,
-        pregs: Vec<Reg>,
-    ) -> Inst {
-        let args = Box::new(ArgInfo { defs, pregs });
+    fn gen_args(_isa_flags: &s390x_settings::Flags, args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -860,6 +860,10 @@
     (CallInd
       (link WritableReg)
       (info BoxCallIndInfo))
+    
+    ;; A pseudo-instruction that captures register arguments in vregs.
+    (Args
+      (args BoxArgInfo))
 
     ;; ---- branches (exactly one must appear at end of BB) ----
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -863,7 +863,7 @@
     
     ;; A pseudo-instruction that captures register arguments in vregs.
     (Args
-      (args BoxArgInfo))
+      (args VecArgPair))
 
     ;; ---- branches (exactly one must appear at end of BB) ----
 

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3319,6 +3319,7 @@ impl MachInstEmit for Inst {
                     sink.add_call_site(info.opcode);
                 }
             }
+            &Inst::Args { .. } => {}
             &Inst::Ret { link, .. } => {
                 let link = allocs.next(link);
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -937,8 +937,8 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             collector.reg_clobbers(info.clobbers);
         }
         &Inst::Args { ref args } => {
-            for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
-                collector.reg_fixed_def(def, preg);
+            for arg in args {
+                collector.reg_fixed_def(arg.vreg, arg.preg);
             }
         }
         &Inst::Ret { link, ref rets } => {
@@ -3085,10 +3085,10 @@ impl Inst {
             }
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
-                for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                for arg in args {
                     use std::fmt::Write;
-                    let preg = pretty_print_reg(preg, &mut empty_allocs);
-                    let def = pretty_print_reg(def.to_reg(), allocs);
+                    let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
+                    let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
                 }
                 s

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -208,6 +208,7 @@ impl Inst {
             | Inst::VecReplicateLane { .. }
             | Inst::Call { .. }
             | Inst::CallInd { .. }
+            | Inst::Args { .. }
             | Inst::Ret { .. }
             | Inst::Jump { .. }
             | Inst::CondBr { .. }
@@ -935,6 +936,11 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             collector.reg_defs(&*info.defs);
             collector.reg_clobbers(info.clobbers);
         }
+        &Inst::Args { ref args } => {
+            for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                collector.reg_fixed_def(def, preg);
+            }
+        }
         &Inst::Ret { link, ref rets } => {
             collector.reg_use(link);
             collector.reg_uses(&rets[..]);
@@ -1008,6 +1014,13 @@ impl MachInst for Inst {
             &Inst::Call { ref info, .. } => info.caller_callconv != info.callee_callconv,
             &Inst::CallInd { ref info, .. } => info.caller_callconv != info.callee_callconv,
             _ => true,
+        }
+    }
+
+    fn is_args(&self) -> bool {
+        match self {
+            Self::Args { .. } => true,
+            _ => false,
         }
     }
 
@@ -3069,6 +3082,16 @@ impl Inst {
                 let link = pretty_print_reg(link.to_reg(), allocs);
                 let rn = pretty_print_reg(info.rn, allocs);
                 format!("basr {}, {}", link, rn)
+            }
+            &Inst::Args { ref args } => {
+                let mut s = "args".to_string();
+                for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                    use std::fmt::Write;
+                    let preg = pretty_print_reg(preg, &mut empty_allocs);
+                    let def = pretty_print_reg(def.to_reg(), allocs);
+                    write!(&mut s, " {}={}", def, preg).unwrap();
+                }
+                s
             }
             &Inst::Ret { link, .. } => {
                 let link = pretty_print_reg(link, allocs);

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -22,7 +22,7 @@ use crate::{
     isa::unwind::UnwindInst,
     isa::CallConv,
     machinst::abi::ABIMachineSpec,
-    machinst::{InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData},
+    machinst::{ArgInfo, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData},
 };
 use regalloc2::PReg;
 use smallvec::{smallvec, SmallVec};
@@ -45,6 +45,7 @@ type BoxExternalName = Box<ExternalName>;
 type BoxSymbolReloc = Box<SymbolReloc>;
 type VecMInst = Vec<MInst>;
 type VecMInstBuilder = Cell<Vec<MInst>>;
+type BoxArgInfo = Box<ArgInfo>;
 
 /// The main entry point for lowering with ISLE.
 pub(crate) fn lower(

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -22,7 +22,7 @@ use crate::{
     isa::unwind::UnwindInst,
     isa::CallConv,
     machinst::abi::ABIMachineSpec,
-    machinst::{ArgInfo, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData},
+    machinst::{ArgPair, InsnOutput, Lower, MachInst, VCodeConstant, VCodeConstantData},
 };
 use regalloc2::PReg;
 use smallvec::{smallvec, SmallVec};
@@ -45,7 +45,7 @@ type BoxExternalName = Box<ExternalName>;
 type BoxSymbolReloc = Box<SymbolReloc>;
 type VecMInst = Vec<MInst>;
 type VecMInstBuilder = Cell<Vec<MInst>>;
-type BoxArgInfo = Box<ArgInfo>;
+type VecArgPair = Vec<ArgPair>;
 
 /// The main entry point for lowering with ISLE.
 pub(crate) fn lower(

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -297,6 +297,15 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
     }
 
+    fn gen_args(
+        _isa_flags: &x64_settings::Flags,
+        defs: Vec<Writable<Reg>>,
+        pregs: Vec<Reg>,
+    ) -> Inst {
+        let args = Box::new(ArgInfo { defs, pregs });
+        Inst::Args { args }
+    }
+
     fn gen_ret(_setup_frame: bool, _isa_flags: &x64_settings::Flags, rets: Vec<Reg>) -> Self::I {
         Inst::ret(rets)
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -297,12 +297,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
     }
 
-    fn gen_args(
-        _isa_flags: &x64_settings::Flags,
-        defs: Vec<Writable<Reg>>,
-        pregs: Vec<Reg>,
-    ) -> Inst {
-        let args = Box::new(ArgInfo { defs, pregs });
+    fn gen_args(_isa_flags: &x64_settings::Flags, args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -323,6 +323,10 @@
        (CallUnknown (dest RegMem)
                     (info BoxCallInfo))
 
+       ;; A pseudo-instruction that captures register arguments in vregs.
+       (Args
+        (args BoxArgInfo))
+
        ;; Return.
        (Ret (rets VecReg))
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -325,7 +325,7 @@
 
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
-        (args BoxArgInfo))
+        (args VecArgPair))
 
        ;; Return.
        (Ret (rets VecReg))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1406,6 +1406,8 @@ pub(crate) fn emit(
             }
         }
 
+        Inst::Args { .. } => {}
+
         Inst::Ret { .. } => sink.put1(0xC3),
 
         Inst::JmpKnown { dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -101,6 +101,7 @@ impl Inst {
             | Inst::Pop64 { .. }
             | Inst::Push64 { .. }
             | Inst::StackProbeLoop { .. }
+            | Inst::Args { .. }
             | Inst::Ret { .. }
             | Inst::Setcc { .. }
             | Inst::ShiftR { .. }
@@ -1452,6 +1453,17 @@ impl PrettyPrint for Inst {
                 format!("{} *{}", ljustify("call".to_string()), dest)
             }
 
+            Inst::Args { args } => {
+                let mut s = "args".to_string();
+                for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                    use std::fmt::Write;
+                    let preg = regs::show_reg(preg);
+                    let def = pretty_print_reg(def.to_reg(), 8, allocs);
+                    write!(&mut s, " {}={}", def, preg).unwrap();
+                }
+                s
+            }
+
             Inst::Ret { .. } => "ret".to_string(),
 
             Inst::JmpKnown { dst } => {
@@ -2037,6 +2049,12 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             mem.get_operands_late(collector)
         }
 
+        Inst::Args { args } => {
+            for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                collector.reg_fixed_def(def, preg);
+            }
+        }
+
         Inst::Ret { rets } => {
             // The return value(s) are live-out; we represent this
             // with register uses on the return instruction.
@@ -2131,6 +2149,13 @@ impl MachInst for Inst {
                 }
             }
             _ => None,
+        }
+    }
+
+    fn is_args(&self) -> bool {
+        match self {
+            Self::Args { .. } => true,
+            _ => false,
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1455,10 +1455,10 @@ impl PrettyPrint for Inst {
 
             Inst::Args { args } => {
                 let mut s = "args".to_string();
-                for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
+                for arg in args {
                     use std::fmt::Write;
-                    let preg = regs::show_reg(preg);
-                    let def = pretty_print_reg(def.to_reg(), 8, allocs);
+                    let preg = regs::show_reg(arg.preg);
+                    let def = pretty_print_reg(arg.vreg.to_reg(), 8, allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
                 }
                 s
@@ -2050,8 +2050,8 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
         }
 
         Inst::Args { args } => {
-            for (&def, &preg) in args.defs.iter().zip(args.pregs.iter()) {
-                collector.reg_fixed_def(def, preg);
+            for arg in args {
+                collector.reg_fixed_def(arg.vreg, arg.preg);
             }
         }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -30,7 +30,7 @@ use crate::{
         },
     },
     machinst::{
-        isle::*, valueregs, ArgInfo, InsnInput, InsnOutput, Lower, MachAtomicRmwOp, MachInst,
+        isle::*, valueregs, ArgPair, InsnInput, InsnOutput, Lower, MachAtomicRmwOp, MachInst,
         VCodeConstant, VCodeConstantData,
     },
 };
@@ -44,7 +44,7 @@ use target_lexicon::Triple;
 type BoxCallInfo = Box<CallInfo>;
 type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 type MachLabelSlice = [MachLabel];
-type BoxArgInfo = Box<ArgInfo>;
+type VecArgPair = Vec<ArgPair>;
 
 pub struct SinkableLoad {
     inst: Inst,

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -30,8 +30,8 @@ use crate::{
         },
     },
     machinst::{
-        isle::*, valueregs, InsnInput, InsnOutput, Lower, MachAtomicRmwOp, MachInst, VCodeConstant,
-        VCodeConstantData,
+        isle::*, valueregs, ArgInfo, InsnInput, InsnOutput, Lower, MachAtomicRmwOp, MachInst,
+        VCodeConstant, VCodeConstantData,
     },
 };
 use alloc::vec::Vec;
@@ -44,6 +44,7 @@ use target_lexicon::Triple;
 type BoxCallInfo = Box<CallInfo>;
 type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
 type MachLabelSlice = [MachLabel];
+type BoxArgInfo = Box<ArgInfo>;
 
 pub struct SinkableLoad {
     inst: Inst,

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -124,6 +124,17 @@ use std::mem;
 /// a small fixed sequence implementing one operation.
 pub type SmallInstVec<I> = SmallVec<[I; 4]>;
 
+/// A type used by backends to track argument-binding info in the
+/// "args" pseudoinst.
+#[derive(Clone, Debug)]
+pub struct ArgInfo {
+    /// vregs that are defined at the top of the function with
+    /// register-argument values.
+    pub defs: Vec<Writable<Reg>>,
+    /// pregs that constrain these vregs to ABI-defined locations.
+    pub pregs: Vec<Reg>,
+}
+
 /// A location for (part of) an argument or return value. These "storage slots"
 /// are specified for each register-sized part of an argument.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -358,6 +369,10 @@ pub trait ABIMachineSpec {
         from_bits: u8,
         to_bits: u8,
     ) -> Self::I;
+
+    /// Generate an "args" pseudo-instruction to capture input args in
+    /// registers.
+    fn gen_args(isa_flags: &Self::F, defs: Vec<Writable<Reg>>, pregs: Vec<Reg>) -> Self::I;
 
     /// Generate a return instruction.
     fn gen_ret(setup_frame: bool, isa_flags: &Self::F, rets: Vec<Reg>) -> Self::I;
@@ -851,6 +866,10 @@ pub struct Callee<M: ABIMachineSpec> {
     stackslots_size: u32,
     /// Stack size to be reserved for outgoing arguments.
     outgoing_args_size: u32,
+    /// Register-argument defs, to be provided to the `args` pseudo-inst.
+    reg_arg_defs: Vec<Writable<Reg>>,
+    /// Register-argument pregs, to be used as constraints on the `args` pseudo-inst.
+    reg_arg_pregs: Vec<Reg>,
     /// Clobbered registers, from regalloc.
     clobbered: Vec<Writable<RealReg>>,
     /// Total number of spillslots, including for 'dynamic' types, from regalloc.
@@ -1007,6 +1026,8 @@ impl<M: ABIMachineSpec> Callee<M> {
             sized_stackslots,
             stackslots_size,
             outgoing_args_size: 0,
+            reg_arg_defs: vec![],
+            reg_arg_pregs: vec![],
             clobbered: vec![],
             spillslots: None,
             fixed_frame_storage_size: 0,
@@ -1274,7 +1295,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Generate an instruction which copies an argument to a destination
     /// register.
     pub fn gen_copy_arg_to_regs(
-        &self,
+        &mut self,
         sigs: &SigSet,
         idx: usize,
         into_regs: ValueRegs<Writable<Reg>>,
@@ -1282,10 +1303,13 @@ impl<M: ABIMachineSpec> Callee<M> {
         let mut insts = smallvec![];
         let mut copy_arg_slot_to_reg = |slot: &ABIArgSlot, into_reg: &Writable<Reg>| {
             match slot {
-                &ABIArgSlot::Reg { reg, ty, .. } => {
-                    // Extension mode doesn't matter (we're copying out, not in; we
-                    // ignore high bits by convention).
-                    insts.push(M::gen_move(*into_reg, reg.into(), ty));
+                &ABIArgSlot::Reg { reg, .. } => {
+                    // Add a preg -> def pair to the eventual `args`
+                    // instruction.  Extension mode doesn't matter
+                    // (we're copying out, not in; we ignore high bits
+                    // by convention).
+                    self.reg_arg_defs.push(*into_reg);
+                    self.reg_arg_pregs.push(reg.into());
                 }
                 &ABIArgSlot::Stack {
                     offset,
@@ -1472,17 +1496,21 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// values or an otherwise large return value that must be passed on the
     /// stack; typically the ABI specifies an extra hidden argument that is a
     /// pointer to that memory.
-    pub fn gen_retval_area_setup(&self, sigs: &SigSet) -> Option<M::I> {
+    pub fn gen_retval_area_setup(&mut self, sigs: &SigSet) -> Option<M::I> {
         if let Some(i) = sigs[self.sig].stack_ret_arg {
             let insts =
                 self.gen_copy_arg_to_regs(sigs, i, ValueRegs::one(self.ret_area_ptr.unwrap()));
-            let inst = insts.into_iter().next().unwrap();
-            trace!(
-                "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
-                inst,
-                self.ret_area_ptr.unwrap().to_reg()
-            );
-            Some(inst)
+            if insts.is_empty() {
+                None
+            } else {
+                let inst = insts.into_iter().next().unwrap();
+                trace!(
+                    "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
+                    inst,
+                    self.ret_area_ptr.unwrap().to_reg()
+                );
+                Some(inst)
+            }
         } else {
             trace!("gen_retval_area_setup: not needed");
             None
@@ -1563,6 +1591,24 @@ impl<M: ABIMachineSpec> Callee<M> {
         trace!("store_spillslot: slot {:?} -> sp_off {}", slot, sp_off);
 
         gen_store_stack_multi::<M>(StackAMode::NominalSPOffset(sp_off, ty), from_regs, ty)
+    }
+
+    /// Get an `args` pseudo-inst, if any, that should appear at the
+    /// very top of the function body prior to regalloc.
+    pub fn take_args(&mut self) -> Option<M::I> {
+        if self.reg_arg_defs.len() > 0 {
+            // Very first instruction is an `args` pseudo-inst that
+            // establishes live-ranges for in-register arguments and
+            // constrains them at the start of the function to the
+            // locations defined by the ABI.
+            Some(M::gen_args(
+                &self.isa_flags,
+                std::mem::take(&mut self.reg_arg_defs),
+                std::mem::take(&mut self.reg_arg_pregs),
+            ))
+        } else {
+            None
+        }
     }
 }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1501,17 +1501,14 @@ impl<M: ABIMachineSpec> Callee<M> {
         if let Some(i) = sigs[self.sig].stack_ret_arg {
             let insts =
                 self.gen_copy_arg_to_regs(sigs, i, ValueRegs::one(self.ret_area_ptr.unwrap()));
-            if insts.is_empty() {
-                None
-            } else {
-                let inst = insts.into_iter().next().unwrap();
+            insts.into_iter().next().map(|inst| {
                 trace!(
                     "gen_retval_area_setup: inst {:?}; ptr reg is {:?}",
                     inst,
                     self.ret_area_ptr.unwrap().to_reg()
                 );
-                Some(inst)
-            }
+                inst
+            })
         } else {
             trace!("gen_retval_area_setup: not needed");
             None

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -617,8 +617,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 self.emit(insn);
             }
 
-            // The `args` instruction below must come first. Finish the
-            // current "IR inst" and continue the scan backward.
+            // The `args` instruction below must come first. Finish
+            // the current "IR inst" (with a default source location,
+            // as for other special instructions inserted during
+            // lowering) and continue the scan backward.
             self.finish_ir_inst(Default::default());
 
             if let Some(insn) = self.vcode.vcode.abi.take_args() {

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -582,8 +582,9 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 let regs = writable_value_regs(self.value_regs[*param]);
                 for insn in self
                     .vcode
-                    .abi()
-                    .gen_copy_arg_to_regs(self.sigs(), i, regs)
+                    .vcode
+                    .abi
+                    .gen_copy_arg_to_regs(&self.vcode.vcode.sigs, i, regs)
                     .into_iter()
                 {
                     self.emit(insn);
@@ -607,7 +608,20 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                     ));
                 }
             }
-            if let Some(insn) = self.vcode.abi().gen_retval_area_setup(self.sigs()) {
+            if let Some(insn) = self
+                .vcode
+                .vcode
+                .abi
+                .gen_retval_area_setup(&self.vcode.vcode.sigs)
+            {
+                self.emit(insn);
+            }
+
+            // The below must come first. Finish the current "IR inst"
+            // and continue the scan backward.
+            self.finish_ir_inst(Default::default());
+
+            if let Some(insn) = self.vcode.vcode.abi.take_args() {
                 self.emit(insn);
             }
         }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -617,8 +617,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 self.emit(insn);
             }
 
-            // The below must come first. Finish the current "IR inst"
-            // and continue the scan backward.
+            // The `args` instruction below must come first. Finish the
+            // current "IR inst" and continue the scan backward.
             self.finish_ir_inst(Default::default());
 
             if let Some(insn) = self.vcode.vcode.abi.take_args() {

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -100,6 +100,9 @@ pub trait MachInst: Clone + Debug {
     /// (ret/uncond/cond) and target if applicable.
     fn is_term(&self) -> MachTerminator;
 
+    /// Is this an "args" pseudoinst?
+    fn is_args(&self) -> bool;
+
     /// Should this instruction be included in the clobber-set?
     fn is_included_in_clobbers(&self) -> bool {
         true

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -158,7 +158,7 @@ pub struct VCode<I: VCodeInst> {
     block_order: BlockLoweringOrder,
 
     /// ABI object.
-    abi: Callee<I::ABIMachineSpec>,
+    pub(crate) abi: Callee<I::ABIMachineSpec>,
 
     /// Constant information used during code emission. This should be
     /// immutable across function compilations within the same module.
@@ -179,7 +179,7 @@ pub struct VCode<I: VCodeInst> {
     /// Value labels for debuginfo attached to vregs.
     debug_value_labels: Vec<(VReg, InsnIndex, InsnIndex, u32)>,
 
-    sigs: SigSet,
+    pub(crate) sigs: SigSet,
 }
 
 /// The result of `VCode::emit`. Contains all information computed
@@ -244,7 +244,7 @@ pub struct EmitResult<I: VCodeInst> {
 /// terminator instructions with successor blocks.)
 pub struct VCodeBuilder<I: VCodeInst> {
     /// In-progress VCode.
-    vcode: VCode<I>,
+    pub(crate) vcode: VCode<I>,
 
     /// In what direction is the build occuring?
     direction: VCodeBuildDirection,
@@ -860,7 +860,7 @@ impl<I: VCodeInst> VCode<I> {
                            disasm: &mut String,
                            buffer: &mut MachBuffer<I>,
                            state: &mut I::State| {
-                if want_disasm {
+                if want_disasm && !inst.is_args() {
                     let mut s = state.clone();
                     writeln!(disasm, "  {}", inst.pretty_print_inst(allocs, &mut s)).unwrap();
                 }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -212,7 +212,7 @@
 (type ExternalName (primitive ExternalName))
 (type BoxExternalName (primitive BoxExternalName))
 (type RelocDistance (primitive RelocDistance))
-(type BoxArgInfo extern (enum))
+(type VecArgPair extern (enum))
 
 ;;;; Primitive Type Conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -212,6 +212,7 @@
 (type ExternalName (primitive ExternalName))
 (type BoxExternalName (primitive BoxExternalName))
 (type RelocDistance (primitive RelocDistance))
+(type BoxArgInfo extern (enum))
 
 ;;;; Primitive Type Conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -36,8 +36,8 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   mov w5, w0
-;   ldr w0, [x5, w1, UXTW]
+;   mov w4, w0
+;   ldr w0, [x4, w1, UXTW]
 ;   ret
 
 function %f8(i64, i32) -> i32 {
@@ -52,10 +52,10 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   add x5, x0, #68
-;   add x5, x5, x0
-;   add x5, x5, x1, SXTW
-;   ldr w0, [x5, w1, SXTW]
+;   add x4, x0, #68
+;   add x4, x4, x0
+;   add x4, x4, x1, SXTW
+;   ldr w0, [x4, w1, SXTW]
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -85,10 +85,10 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movz x7, #4100
-;   add x7, x7, x1
-;   add x7, x7, x2
-;   ldr w0, [x7, x0]
+;   movz x5, #4100
+;   add x5, x5, x1
+;   add x5, x5, x2
+;   ldr w0, [x5, x0]
 ;   ret
 
 function %f10() -> i32 {
@@ -166,8 +166,8 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   sxtw x5, w0
-;   ldr w0, [x5, w1, SXTW]
+;   sxtw x4, w0
+;   ldr w0, [x4, w1, SXTW]
 ;   ret
 
 function %f18(i64, i64, i64) -> i32 {
@@ -179,8 +179,8 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movn w7, #4097
-;   ldrsh x0, [x7]
+;   movn w5, #4097
+;   ldrsh x0, [x5]
 ;   ret
 
 function %f19(i64, i64, i64) -> i32 {
@@ -192,8 +192,8 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movz x7, #4098
-;   ldrsh x0, [x7]
+;   movz x5, #4098
+;   ldrsh x0, [x5]
 ;   ret
 
 function %f20(i64, i64, i64) -> i32 {
@@ -205,9 +205,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movn w7, #4097
-;   sxtw x9, w7
-;   ldrsh x0, [x9]
+;   movn w5, #4097
+;   sxtw x7, w5
+;   ldrsh x0, [x7]
 ;   ret
 
 function %f21(i64, i64, i64) -> i32 {
@@ -219,9 +219,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movz x7, #4098
-;   sxtw x9, w7
-;   ldrsh x0, [x9]
+;   movz x5, #4098
+;   sxtw x7, w5
+;   ldrsh x0, [x7]
 ;   ret
 
 function %i128(i64) -> i128 {
@@ -327,13 +327,13 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   mov x8, x0
-;   add x8, x8, x1, SXTW
-;   ldp x10, x11, [x8, #24]
+;   mov x7, x0
+;   add x7, x7, x1, SXTW
+;   ldp x9, x10, [x7, #24]
 ;   add x0, x0, x1, SXTW
-;   mov x15, x10
-;   mov x1, x11
-;   stp x15, x1, [x0, #24]
-;   mov x0, x10
+;   mov x14, x9
+;   mov x1, x10
+;   stp x14, x1, [x0, #24]
+;   mov x0, x9
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -109,8 +109,8 @@ block0(v0: i64, v1: i64):
 
 ; block0:
 ;   cbnz x1, 8 ; udf
-;   sdiv x6, x0, x1
-;   msub x0, x6, x1, x0
+;   sdiv x5, x0, x1
+;   msub x0, x5, x1, x0
 ;   ret
 
 function %f11(i64, i64) -> i64 {
@@ -121,8 +121,8 @@ block0(v0: i64, v1: i64):
 
 ; block0:
 ;   cbnz x1, 8 ; udf
-;   udiv x6, x0, x1
-;   msub x0, x6, x1, x0
+;   udiv x5, x0, x1
+;   msub x0, x5, x1, x0
 ;   ret
 
 function %f12(i32, i32) -> i32 {
@@ -132,13 +132,13 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   sxtw x5, w0
-;   sxtw x7, w1
-;   cbnz x7, 8 ; udf
-;   adds wzr, w7, #1
-;   ccmp w5, #1, #nzcv, eq
+;   sxtw x4, w0
+;   sxtw x6, w1
+;   cbnz x6, 8 ; udf
+;   adds wzr, w6, #1
+;   ccmp w4, #1, #nzcv, eq
 ;   b.vc 8 ; udf
-;   sdiv x0, x5, x7
+;   sdiv x0, x4, x6
 ;   ret
 
 function %f13(i32) -> i32 {
@@ -161,10 +161,10 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   mov w5, w0
-;   mov w7, w1
-;   cbnz x7, 8 ; udf
-;   udiv x0, x5, x7
+;   mov w4, w0
+;   mov w6, w1
+;   cbnz x6, 8 ; udf
+;   udiv x0, x4, x6
 ;   ret
 
 function %f15(i32) -> i32 {
@@ -187,11 +187,11 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   sxtw x5, w0
-;   sxtw x7, w1
-;   cbnz x7, 8 ; udf
-;   sdiv x10, x5, x7
-;   msub x0, x10, x7, x5
+;   sxtw x4, w0
+;   sxtw x6, w1
+;   cbnz x6, 8 ; udf
+;   sdiv x9, x4, x6
+;   msub x0, x9, x6, x4
 ;   ret
 
 function %f17(i32, i32) -> i32 {
@@ -201,11 +201,11 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   mov w5, w0
-;   mov w7, w1
-;   cbnz x7, 8 ; udf
-;   udiv x10, x5, x7
-;   msub x0, x10, x7, x5
+;   mov w4, w0
+;   mov w6, w1
+;   cbnz x6, 8 ; udf
+;   udiv x9, x4, x6
+;   msub x0, x9, x6, x4
 ;   ret
 
 function %f18(i64, i64) -> i64 {
@@ -379,9 +379,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   umulh x10, x0, x2
-;   madd x12, x0, x3, x10
-;   madd x1, x1, x2, x12
+;   umulh x7, x0, x2
+;   madd x9, x0, x3, x7
+;   madd x1, x1, x2, x9
 ;   madd x0, x0, x2, xzr
 ;   ret
 
@@ -437,8 +437,8 @@ block0(v0: i32, v1: i32, v2: i32):
 }
 
 ; block0:
-;   madd w8, w1, w2, wzr
-;   sub w0, w8, w0
+;   madd w6, w1, w2, wzr
+;   sub w0, w6, w0
 ;   ret
 
 function %imul_sub_i64(i64, i64, i64) -> i64 {
@@ -449,8 +449,8 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   madd x8, x1, x2, xzr
-;   sub x0, x8, x0
+;   madd x6, x1, x2, xzr
+;   sub x0, x6, x0
 ;   ret
 
 function %srem_const (i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
@@ -8,7 +8,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldaddal x1, x4, [x0]
+;   ldaddal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_add_i32(i64, i32) {
@@ -18,7 +18,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldaddal w1, w4, [x0]
+;   ldaddal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_add_i16(i64, i16) {
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldaddalh w1, w4, [x0]
+;   ldaddalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_add_i8(i64, i8) {
@@ -38,7 +38,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldaddalb w1, w4, [x0]
+;   ldaddalb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_sub_i64(i64, i64) {
@@ -48,8 +48,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   sub x4, xzr, x1
-;   ldaddal x4, x6, [x0]
+;   sub x3, xzr, x1
+;   ldaddal x3, x5, [x0]
 ;   ret
 
 function %atomic_rmw_sub_i32(i64, i32) {
@@ -59,8 +59,8 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   sub w4, wzr, w1
-;   ldaddal w4, w6, [x0]
+;   sub w3, wzr, w1
+;   ldaddal w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_sub_i16(i64, i16) {
@@ -70,8 +70,8 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   sub w4, wzr, w1
-;   ldaddalh w4, w6, [x0]
+;   sub w3, wzr, w1
+;   ldaddalh w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_sub_i8(i64, i8) {
@@ -81,8 +81,8 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   sub w4, wzr, w1
-;   ldaddalb w4, w6, [x0]
+;   sub w3, wzr, w1
+;   ldaddalb w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_and_i64(i64, i64) {
@@ -92,8 +92,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   eon x4, x1, xzr
-;   ldclral x4, x6, [x0]
+;   eon x3, x1, xzr
+;   ldclral x3, x5, [x0]
 ;   ret
 
 function %atomic_rmw_and_i32(i64, i32) {
@@ -103,8 +103,8 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   eon w4, w1, wzr
-;   ldclral w4, w6, [x0]
+;   eon w3, w1, wzr
+;   ldclral w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_and_i16(i64, i16) {
@@ -114,8 +114,8 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   eon w4, w1, wzr
-;   ldclralh w4, w6, [x0]
+;   eon w3, w1, wzr
+;   ldclralh w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_and_i8(i64, i8) {
@@ -125,8 +125,8 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   eon w4, w1, wzr
-;   ldclralb w4, w6, [x0]
+;   eon w3, w1, wzr
+;   ldclralb w3, w5, [x0]
 ;   ret
 
 function %atomic_rmw_nand_i64(i64, i64) {
@@ -220,7 +220,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldsetal x1, x4, [x0]
+;   ldsetal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_or_i32(i64, i32) {
@@ -230,7 +230,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldsetal w1, w4, [x0]
+;   ldsetal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_or_i16(i64, i16) {
@@ -240,7 +240,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldsetalh w1, w4, [x0]
+;   ldsetalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_or_i8(i64, i8) {
@@ -250,7 +250,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldsetalb w1, w4, [x0]
+;   ldsetalb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_xor_i64(i64, i64) {
@@ -260,7 +260,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldeoral x1, x4, [x0]
+;   ldeoral x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_xor_i32(i64, i32) {
@@ -270,7 +270,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldeoral w1, w4, [x0]
+;   ldeoral w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_xor_i16(i64, i16) {
@@ -280,7 +280,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldeoralh w1, w4, [x0]
+;   ldeoralh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_xor_i8(i64, i8) {
@@ -290,7 +290,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldeoralb w1, w4, [x0]
+;   ldeoralb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smax_i64(i64, i64) {
@@ -300,7 +300,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldsmaxal x1, x4, [x0]
+;   ldsmaxal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_smax_i32(i64, i32) {
@@ -310,7 +310,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldsmaxal w1, w4, [x0]
+;   ldsmaxal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smax_i16(i64, i16) {
@@ -320,7 +320,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldsmaxalh w1, w4, [x0]
+;   ldsmaxalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smax_i8(i64, i8) {
@@ -330,7 +330,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldsmaxalb w1, w4, [x0]
+;   ldsmaxalb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umax_i64(i64, i64) {
@@ -340,7 +340,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldumaxal x1, x4, [x0]
+;   ldumaxal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_umax_i32(i64, i32) {
@@ -350,7 +350,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldumaxal w1, w4, [x0]
+;   ldumaxal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umax_i16(i64, i16) {
@@ -360,7 +360,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldumaxalh w1, w4, [x0]
+;   ldumaxalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umax_i8(i64, i8) {
@@ -370,7 +370,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldumaxalb w1, w4, [x0]
+;   ldumaxalb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smin_i64(i64, i64) {
@@ -380,7 +380,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldsminal x1, x4, [x0]
+;   ldsminal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_smin_i32(i64, i32) {
@@ -390,7 +390,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   ldsminal w1, w4, [x0]
+;   ldsminal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smin_i16(i64, i16) {
@@ -400,7 +400,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   ldsminalh w1, w4, [x0]
+;   ldsminalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_smin_i8(i64, i8) {
@@ -410,7 +410,7 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   ldsminalb w1, w4, [x0]
+;   ldsminalb w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umin_i64(i64, i64) {
@@ -420,7 +420,7 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   lduminal x1, x4, [x0]
+;   lduminal x1, x3, [x0]
 ;   ret
 
 function %atomic_rmw_umin_i32(i64, i32) {
@@ -430,7 +430,7 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   lduminal w1, w4, [x0]
+;   lduminal w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umin_i16(i64, i16) {
@@ -440,7 +440,7 @@ block0(v0: i64, v1: i16):
 }
 
 ; block0:
-;   lduminalh w1, w4, [x0]
+;   lduminalh w1, w3, [x0]
 ;   ret
 
 function %atomic_rmw_umin_i8(i64, i8) {
@@ -450,6 +450,6 @@ block0(v0: i64, v1: i8):
 }
 
 ; block0:
-;   lduminalb w1, w4, [x0]
+;   lduminalb w1, w3, [x0]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitops.clif
@@ -51,9 +51,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   rbit x6, x0
+;   rbit x5, x0
 ;   rbit x0, x1
-;   mov x1, x6
+;   mov x1, x5
 ;   ret
 
 function %b(i8) -> i8 {
@@ -107,10 +107,10 @@ block0(v0: i128):
 }
 
 ; block0:
-;   clz x6, x1
-;   clz x8, x0
-;   lsr x10, x6, #6
-;   madd x0, x8, x10, x6
+;   clz x5, x1
+;   clz x7, x0
+;   lsr x9, x5, #6
+;   madd x0, x7, x9, x5
 ;   movz w1, #0
 ;   ret
 
@@ -165,14 +165,14 @@ block0(v0: i128):
 }
 
 ; block0:
-;   cls x6, x0
-;   cls x8, x1
-;   eon x10, x1, x0
-;   lsr x12, x10, #63
-;   madd x14, x6, x12, x12
-;   subs xzr, x8, #63
-;   csel x1, x14, xzr, eq
-;   add x0, x1, x8
+;   cls x5, x0
+;   cls x7, x1
+;   eon x9, x1, x0
+;   lsr x11, x9, #63
+;   madd x13, x5, x11, x11
+;   subs xzr, x7, #63
+;   csel x0, x13, xzr, eq
+;   add x0, x0, x7
 ;   movz w1, #0
 ;   ret
 
@@ -229,12 +229,12 @@ block0(v0: i128):
 }
 
 ; block0:
-;   rbit x6, x0
-;   rbit x8, x1
-;   clz x10, x6
-;   clz x12, x8
-;   lsr x14, x10, #6
-;   madd x0, x12, x14, x10
+;   rbit x5, x0
+;   rbit x7, x1
+;   clz x9, x5
+;   clz x11, x7
+;   lsr x13, x9, #6
+;   madd x0, x11, x13, x9
 ;   movz w1, #0
 ;   ret
 
@@ -245,11 +245,11 @@ block0(v0: i128):
 }
 
 ; block0:
-;   fmov d7, x0
-;   mov v7.d[1], v7.d[1], x1
-;   cnt v18.16b, v7.16b
-;   addv b20, v18.16b
-;   umov w0, v20.b[0]
+;   fmov d6, x0
+;   mov v6.d[1], v6.d[1], x1
+;   cnt v17.16b, v6.16b
+;   addv b19, v17.16b
+;   umov w0, v19.b[0]
 ;   movz w1, #0
 ;   ret
 
@@ -821,15 +821,15 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   lsl x8, x0, x2
-;   lsl x10, x1, x2
-;   orn w12, wzr, w2
-;   lsr x14, x0, #1
-;   lsr x0, x14, x12
-;   orr x3, x10, x0
+;   lsl x6, x0, x2
+;   lsl x8, x1, x2
+;   orn w10, wzr, w2
+;   lsr x12, x0, #1
+;   lsr x14, x12, x10
+;   orr x1, x8, x14
 ;   ands xzr, x2, #64
-;   csel x0, xzr, x8, ne
-;   csel x1, x8, x3, ne
+;   csel x0, xzr, x6, ne
+;   csel x1, x6, x1, ne
 ;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
@@ -839,15 +839,15 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   lsl x10, x0, x2
-;   lsl x12, x1, x2
-;   orn w14, wzr, w2
-;   lsr x0, x0, #1
-;   lsr x3, x0, x14
-;   orr x4, x12, x3
+;   lsl x7, x0, x2
+;   lsl x9, x1, x2
+;   orn w11, wzr, w2
+;   lsr x13, x0, #1
+;   lsr x15, x13, x11
+;   orr x1, x9, x15
 ;   ands xzr, x2, #64
-;   csel x0, xzr, x10, ne
-;   csel x1, x10, x4, ne
+;   csel x0, xzr, x7, ne
+;   csel x1, x7, x1, ne
 ;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
@@ -857,15 +857,15 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   lsr x8, x0, x2
-;   lsr x10, x1, x2
-;   orn w12, wzr, w2
-;   lsl x14, x1, #1
-;   lsl x0, x14, x12
-;   orr x3, x8, x0
+;   lsr x6, x0, x2
+;   lsr x8, x1, x2
+;   orn w10, wzr, w2
+;   lsl x12, x1, #1
+;   lsl x14, x12, x10
+;   orr x0, x6, x14
 ;   ands xzr, x2, #64
-;   csel x0, x10, x3, ne
-;   csel x1, xzr, x10, ne
+;   csel x0, x8, x0, ne
+;   csel x1, xzr, x8, ne
 ;   ret
 
 function %ushr_i128_i128(i128, i128) -> i128 {
@@ -875,15 +875,15 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   lsr x10, x0, x2
-;   lsr x12, x1, x2
-;   orn w14, wzr, w2
-;   lsl x0, x1, #1
-;   lsl x3, x0, x14
-;   orr x4, x10, x3
+;   lsr x7, x0, x2
+;   lsr x9, x1, x2
+;   orn w11, wzr, w2
+;   lsl x13, x1, #1
+;   lsl x15, x13, x11
+;   orr x1, x7, x15
 ;   ands xzr, x2, #64
-;   csel x0, x12, x4, ne
-;   csel x1, xzr, x12, ne
+;   csel x0, x9, x1, ne
+;   csel x1, xzr, x9, ne
 ;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
@@ -893,16 +893,16 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   lsr x8, x0, x2
-;   asr x10, x1, x2
-;   orn w12, wzr, w2
-;   lsl x14, x1, #1
-;   lsl x0, x14, x12
-;   asr x3, x1, #63
-;   orr x4, x8, x0
+;   lsr x6, x0, x2
+;   asr x8, x1, x2
+;   orn w10, wzr, w2
+;   lsl x12, x1, #1
+;   lsl x14, x12, x10
+;   asr x1, x1, #63
+;   orr x3, x6, x14
 ;   ands xzr, x2, #64
-;   csel x0, x10, x4, ne
-;   csel x1, x3, x10, ne
+;   csel x0, x8, x3, ne
+;   csel x1, x1, x8, ne
 ;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
@@ -912,14 +912,15 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   lsr x10, x0, x2
-;   asr x12, x1, x2
-;   orn w14, wzr, w2
-;   lsl x0, x1, #1
-;   lsl x3, x0, x14
-;   asr x4, x1, #63
-;   orr x6, x10, x3
+;   lsr x7, x0, x2
+;   asr x9, x1, x2
+;   orn w11, wzr, w2
+;   lsl x13, x1, #1
+;   lsl x15, x13, x11
+;   asr x1, x1, #63
+;   orr x3, x7, x15
 ;   ands xzr, x2, #64
-;   csel x0, x12, x6, ne
-;   csel x1, x4, x12, ne
+;   csel x0, x9, x3, ne
+;   csel x1, x1, x9, ne
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -105,8 +105,8 @@ block0(v0: i8):
 }
 
 ; block0:
-;   mov x14, x0
-;   mov x8, x1
+;   mov x15, x0
+;   mov x13, x1
 ;   movz x0, #42
 ;   movz x1, #42
 ;   movz x2, #42
@@ -115,7 +115,7 @@ block0(v0: i8):
 ;   movz x5, #42
 ;   movz x6, #42
 ;   movz x7, #42
-;   strb w14, [x8]
+;   strb w15, [x13]
 ;   ret
 
 function %f8() {
@@ -376,18 +376,18 @@ block0(v0: i128, v1: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   mov x14, x2
+;   mov x11, x2
 ;   sub sp, sp, #16
 ;   virtual_sp_offset_adjust 16
-;   mov x13, x0
-;   mov x15, x1
-;   mov x2, x13
-;   mov x3, x15
-;   mov x4, x13
-;   mov x5, x15
-;   mov x6, x14
-;   str x13, [sp]
-;   str x15, [sp, #8]
+;   mov x10, x0
+;   mov x12, x1
+;   mov x2, x10
+;   mov x3, x12
+;   mov x4, x10
+;   mov x5, x12
+;   mov x6, x11
+;   str x10, [sp]
+;   str x12, [sp, #8]
 ;   ldr x7, 8 ; b 12 ; data TestCase(%f14) + 0
 ;   blr x7
 ;   add sp, sp, #16
@@ -419,18 +419,18 @@ block0(v0: i128, v1: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   mov x14, x2
+;   mov x11, x2
 ;   sub sp, sp, #16
 ;   virtual_sp_offset_adjust 16
-;   mov x13, x0
-;   mov x15, x1
-;   mov x2, x13
-;   mov x3, x15
-;   mov x4, x13
-;   mov x5, x15
-;   mov x6, x14
-;   str x13, [sp]
-;   str x15, [sp, #8]
+;   mov x10, x0
+;   mov x12, x1
+;   mov x2, x10
+;   mov x3, x12
+;   mov x4, x10
+;   mov x5, x12
+;   mov x6, x11
+;   str x10, [sp]
+;   str x12, [sp, #8]
 ;   ldr x7, 8 ; b 12 ; data TestCase(%f15) + 0
 ;   blr x7
 ;   add sp, sp, #16

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -45,10 +45,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, lo
+;   cset x8, lo
 ;   subs xzr, x1, x3
-;   cset x14, lt
-;   csel x0, x11, x14, eq
+;   cset x11, lt
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_ult_i128(i128, i128) -> b1 {
@@ -59,10 +59,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, lo
+;   cset x8, lo
 ;   subs xzr, x1, x3
-;   cset x14, lo
-;   csel x0, x11, x14, eq
+;   cset x11, lo
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_sle_i128(i128, i128) -> b1 {
@@ -73,10 +73,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, ls
+;   cset x8, ls
 ;   subs xzr, x1, x3
-;   cset x14, le
-;   csel x0, x11, x14, eq
+;   cset x11, le
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_ule_i128(i128, i128) -> b1 {
@@ -87,10 +87,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, ls
+;   cset x8, ls
 ;   subs xzr, x1, x3
-;   cset x14, ls
-;   csel x0, x11, x14, eq
+;   cset x11, ls
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_sgt_i128(i128, i128) -> b1 {
@@ -101,10 +101,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, hi
+;   cset x8, hi
 ;   subs xzr, x1, x3
-;   cset x14, gt
-;   csel x0, x11, x14, eq
+;   cset x11, gt
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_ugt_i128(i128, i128) -> b1 {
@@ -115,10 +115,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, hi
+;   cset x8, hi
 ;   subs xzr, x1, x3
-;   cset x14, hi
-;   csel x0, x11, x14, eq
+;   cset x11, hi
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_sge_i128(i128, i128) -> b1 {
@@ -129,10 +129,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, hs
+;   cset x8, hs
 ;   subs xzr, x1, x3
-;   cset x14, ge
-;   csel x0, x11, x14, eq
+;   cset x11, ge
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %icmp_uge_i128(i128, i128) -> b1 {
@@ -143,10 +143,10 @@ block0(v0: i128, v1: i128):
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x11, hs
+;   cset x8, hs
 ;   subs xzr, x1, x3
-;   cset x14, hs
-;   csel x0, x11, x14, eq
+;   cset x11, hs
+;   csel x0, x8, x11, eq
 ;   ret
 
 function %f(i64, i64) -> i64 {
@@ -207,8 +207,8 @@ block1:
 }
 
 ; block0:
-;   orr x4, x0, x1
-;   cbz x4, label1 ; b label2
+;   orr x3, x0, x1
+;   cbz x3, label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -227,8 +227,8 @@ block1:
 }
 
 ; block0:
-;   orr x4, x0, x1
-;   cbnz x4, label1 ; b label2
+;   orr x3, x0, x1
+;   cbnz x3, label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -287,11 +287,11 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, lo
+;   cset x6, lo
 ;   subs xzr, x1, x3
-;   cset x12, lt
-;   csel x9, x9, x12, eq
-;   subs xzr, xzr, x9
+;   cset x9, lt
+;   csel x6, x6, x9, eq
+;   subs xzr, xzr, x6
 ;   b.lt label1 ; b label2
 ; block1:
 ;   b label3
@@ -311,11 +311,11 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, lo
+;   cset x6, lo
 ;   subs xzr, x1, x3
-;   cset x12, lo
-;   csel x9, x9, x12, eq
-;   subs xzr, xzr, x9
+;   cset x9, lo
+;   csel x6, x6, x9, eq
+;   subs xzr, xzr, x6
 ;   b.lo label1 ; b label2
 ; block1:
 ;   b label3
@@ -335,12 +335,12 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, ls
+;   cset x6, ls
 ;   subs xzr, x1, x3
-;   cset x12, le
-;   csel x9, x9, x12, eq
-;   movz x12, #1
-;   subs xzr, x12, x9
+;   cset x9, le
+;   csel x6, x6, x9, eq
+;   movz x9, #1
+;   subs xzr, x9, x6
 ;   b.le label1 ; b label2
 ; block1:
 ;   b label3
@@ -360,12 +360,12 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, ls
+;   cset x6, ls
 ;   subs xzr, x1, x3
-;   cset x12, ls
-;   csel x9, x9, x12, eq
-;   movz x12, #1
-;   subs xzr, x12, x9
+;   cset x9, ls
+;   csel x6, x6, x9, eq
+;   movz x9, #1
+;   subs xzr, x9, x6
 ;   b.ls label1 ; b label2
 ; block1:
 ;   b label3
@@ -385,11 +385,11 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, hi
+;   cset x6, hi
 ;   subs xzr, x1, x3
-;   cset x12, gt
-;   csel x9, x9, x12, eq
-;   subs xzr, x9, xzr
+;   cset x9, gt
+;   csel x6, x6, x9, eq
+;   subs xzr, x6, xzr
 ;   b.gt label1 ; b label2
 ; block1:
 ;   b label3
@@ -409,11 +409,11 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, hi
+;   cset x6, hi
 ;   subs xzr, x1, x3
-;   cset x12, hi
-;   csel x9, x9, x12, eq
-;   subs xzr, x9, xzr
+;   cset x9, hi
+;   csel x6, x6, x9, eq
+;   subs xzr, x6, xzr
 ;   b.hi label1 ; b label2
 ; block1:
 ;   b label3
@@ -433,12 +433,12 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, hs
+;   cset x6, hs
 ;   subs xzr, x1, x3
-;   cset x12, ge
-;   csel x9, x9, x12, eq
-;   movz x12, #1
-;   subs xzr, x9, x12
+;   cset x9, ge
+;   csel x6, x6, x9, eq
+;   movz x9, #1
+;   subs xzr, x6, x9
 ;   b.ge label1 ; b label2
 ; block1:
 ;   b label3
@@ -458,12 +458,12 @@ block1:
 
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x9, hs
+;   cset x6, hs
 ;   subs xzr, x1, x3
-;   cset x12, hs
-;   csel x9, x9, x12, eq
-;   movz x12, #1
-;   subs xzr, x9, x12
+;   cset x9, hs
+;   csel x6, x6, x9, eq
+;   movz x9, #1
+;   subs xzr, x6, x9
 ;   b.hs label1 ; b label2
 ; block1:
 ;   b label3
@@ -471,4 +471,3 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-

--- a/cranelift/filetests/filetests/isa/aarch64/condops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condops.clif
@@ -11,8 +11,8 @@ block0(v0: i8, v1: i64, v2: i64):
 }
 
 ; block0:
-;   uxtb w8, w0
-;   subs wzr, w8, #42
+;   uxtb w6, w0
+;   subs wzr, w6, #42
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -37,9 +37,9 @@ block0(v0: i8, v1: i8, v2: i8):
 }
 
 ; block0:
-;   and w7, w1, w0
-;   bic w9, w2, w0
-;   orr w0, w7, w9
+;   and w5, w1, w0
+;   bic w7, w2, w0
+;   orr w0, w5, w7
 ;   ret
 
 function %i(b1, i8, i8) -> i8 {
@@ -49,8 +49,8 @@ block0(v0: b1, v1: i8, v2: i8):
 }
 
 ; block0:
-;   and w8, w0, #1
-;   subs wzr, w8, wzr
+;   and w6, w0, #1
+;   subs wzr, w6, wzr
 ;   csel x0, x1, x2, ne
 ;   ret
 
@@ -74,8 +74,8 @@ block0(v0: b1, v1: i128, v2: i128):
 }
 
 ; block0:
-;   and w14, w0, #1
-;   subs wzr, w14, wzr
+;   and w10, w0, #1
+;   subs wzr, w10, wzr
 ;   csel x0, x2, x4, ne
 ;   csel x1, x3, x5, ne
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
@@ -14,9 +14,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   dup v16.16b, w0
-;   dup v17.16b, w1
-;   add v0.16b, v16.16b, v17.16b
+;   dup v7.16b, w0
+;   dup v16.16b, w1
+;   add v0.16b, v7.16b, v16.16b
 ;   ret
 
 function %i16x8_splat_add(i16, i16) -> i16x8 {
@@ -32,9 +32,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   dup v16.8h, w0
-;   dup v17.8h, w1
-;   add v0.8h, v16.8h, v17.8h
+;   dup v7.8h, w0
+;   dup v16.8h, w1
+;   add v0.8h, v7.8h, v16.8h
 ;   ret
 
 function %i32x4_splat_mul(i32, i32) -> i32x4 {
@@ -50,9 +50,9 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   dup v16.4s, w0
-;   dup v17.4s, w1
-;   mul v0.4s, v16.4s, v17.4s
+;   dup v7.4s, w0
+;   dup v16.4s, w1
+;   mul v0.4s, v7.4s, v16.4s
 ;   ret
 
 function %i64x2_splat_sub(i64, i64) -> i64x2 {
@@ -68,9 +68,9 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   dup v16.2d, x0
-;   dup v17.2d, x1
-;   sub v0.2d, v16.2d, v17.2d
+;   dup v7.2d, x0
+;   dup v16.2d, x1
+;   sub v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f32x4_splat_add(f32, f32) -> f32x4 {
@@ -86,9 +86,9 @@ block0(v0: f32, v1: f32):
 }
 
 ; block0:
-;   dup v16.4s, v0.s[0]
-;   dup v17.4s, v1.s[0]
-;   fadd v0.4s, v16.4s, v17.4s
+;   dup v7.4s, v0.s[0]
+;   dup v16.4s, v1.s[0]
+;   fadd v0.4s, v7.4s, v16.4s
 ;   ret
 
 function %f64x2_splat_sub(f64, f64) -> f64x2 {
@@ -104,9 +104,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v16.2d, v0.d[0]
-;   dup v17.2d, v1.d[0]
-;   fsub v0.2d, v16.2d, v17.2d
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fsub v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f64x2_splat_mul(f64, f64) -> f64x2 {
@@ -122,9 +122,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v16.2d, v0.d[0]
-;   dup v17.2d, v1.d[0]
-;   fmul v0.2d, v16.2d, v17.2d
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fmul v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f64x2_splat_div(f64, f64) -> f64x2 {
@@ -140,9 +140,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v16.2d, v0.d[0]
-;   dup v17.2d, v1.d[0]
-;   fdiv v0.2d, v16.2d, v17.2d
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fdiv v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f64x2_splat_min(f64, f64) -> f64x2 {
@@ -158,9 +158,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v16.2d, v0.d[0]
-;   dup v17.2d, v1.d[0]
-;   fmin v0.2d, v16.2d, v17.2d
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fmin v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f64x2_splat_max(f64, f64) -> f64x2 {
@@ -176,9 +176,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v16.2d, v0.d[0]
-;   dup v17.2d, v1.d[0]
-;   fmax v0.2d, v16.2d, v17.2d
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fmax v0.2d, v7.2d, v16.2d
 ;   ret
 
 function %f64x2_splat_min_pseudo(f64, f64) -> f64x2 {
@@ -194,10 +194,10 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v17.2d, v0.d[0]
-;   dup v18.2d, v1.d[0]
-;   fcmgt v0.2d, v17.2d, v18.2d
-;   bsl v0.16b, v0.16b, v18.16b, v17.16b
+;   dup v16.2d, v0.d[0]
+;   dup v17.2d, v1.d[0]
+;   fcmgt v0.2d, v16.2d, v17.2d
+;   bsl v0.16b, v0.16b, v17.16b, v16.16b
 ;   ret
 
 function %f64x2_splat_max_pseudo(f64, f64) -> f64x2 {
@@ -213,9 +213,9 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   dup v17.2d, v0.d[0]
-;   dup v18.2d, v1.d[0]
-;   fcmgt v0.2d, v18.2d, v17.2d
-;   bsl v0.16b, v0.16b, v18.16b, v17.16b
+;   dup v16.2d, v0.d[0]
+;   dup v17.2d, v1.d[0]
+;   fcmgt v0.2d, v17.2d, v16.2d
+;   bsl v0.16b, v0.16b, v17.16b, v16.16b
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
@@ -109,15 +109,15 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 }
 
 ; block0:
-;   uxtb w0, w0
-;   ucvtf s26, w0
-;   uxth w0, w1
-;   ucvtf s27, w0
-;   ucvtf s25, w2
-;   ucvtf s28, x3
-;   fadd s26, s26, s27
-;   fadd s25, s26, s25
-;   fadd s0, s25, s28
+;   uxtb w13, w0
+;   ucvtf s23, w13
+;   uxth w13, w1
+;   ucvtf s24, w13
+;   ucvtf s22, w2
+;   ucvtf s25, x3
+;   fadd s23, s23, s24
+;   fadd s22, s23, s22
+;   fadd s0, s22, s25
 ;   ret
 
 function %f11(i32x4) -> f64x2 {

--- a/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
@@ -309,8 +309,8 @@ block0(v0: f32, v1: f32):
 }
 
 ; block0:
-;   ushr v6.2s, v1.2s, #31
-;   sli v0.2s, v0.2s, v6.2s, #31
+;   ushr v5.2s, v1.2s, #31
+;   sli v0.2s, v0.2s, v5.2s, #31
 ;   ret
 
 function %f32(f64, f64) -> f64 {
@@ -320,8 +320,8 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   ushr d6, d1, #63
-;   sli d0, d0, d6, #63
+;   ushr d5, d1, #63
+;   sli d0, d0, d5, #63
 ;   ret
 
 function %f33(f32) -> i32 {
@@ -951,8 +951,8 @@ block0(v0: f32x2, v1: f32x2):
 }
 
 ; block0:
-;   ushr v6.2s, v1.2s, #31
-;   sli v0.2s, v0.2s, v6.2s, #31
+;   ushr v5.2s, v1.2s, #31
+;   sli v0.2s, v0.2s, v5.2s, #31
 ;   ret
 
 function %f82(f32x4, f32x4) -> f32x4 {
@@ -962,8 +962,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   ushr v6.4s, v1.4s, #31
-;   sli v0.4s, v0.4s, v6.4s, #31
+;   ushr v5.4s, v1.4s, #31
+;   sli v0.4s, v0.4s, v5.4s, #31
 ;   ret
 
 function %f83(f64x2, f64x2) -> f64x2 {
@@ -973,7 +973,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   ushr v6.2d, v1.2d, #63
-;   sli v0.2d, v0.2d, v6.2d, #63
+;   ushr v5.2d, v1.2d, #63
+;   sli v0.2d, v0.2d, v5.2d, #63
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/heap_addr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/heap_addr.clif
@@ -14,16 +14,16 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   mov w10, w1
-;   ldr x11, [x0]
-;   mov x11, x11
-;   subs xzr, x10, x11
+;   mov w9, w1
+;   ldr x10, [x0]
+;   mov x10, x10
+;   subs xzr, x9, x10
 ;   b.ls label1 ; b label2
 ; block1:
-;   add x12, x0, x1, UXTW
-;   subs xzr, x10, x11
-;   movz x13, #0
-;   csel x0, x13, x12, hi
+;   add x11, x0, x1, UXTW
+;   subs xzr, x9, x10
+;   movz x12, #0
+;   csel x0, x12, x11, hi
 ;   csdb
 ;   ret
 ; block2:
@@ -39,15 +39,16 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   mov w8, w1
-;   subs xzr, x8, #65536
+;   mov w7, w1
+;   subs xzr, x7, #65536
 ;   b.ls label1 ; b label2
 ; block1:
-;   add x10, x0, x1, UXTW
-;   subs xzr, x8, #65536
-;   movz x11, #0
-;   csel x0, x11, x10, hi
+;   add x9, x0, x1, UXTW
+;   subs xzr, x7, #65536
+;   movz x10, #0
+;   csel x0, x10, x9, hi
 ;   csdb
 ;   ret
 ; block2:
 ;   udf #0xc11f
+

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -69,28 +69,28 @@ block3(v7: r64, v8: r64):
 ; block0:
 ;   str x1, [sp, #16]
 ;   str x0, [sp, #8]
-;   ldr x2, 8 ; b 12 ; data TestCase(%f) + 0
-;   blr x2
-;   mov x4, sp
-;   ldr x11, [sp, #8]
-;   str x11, [x4]
-;   and w5, w0, #1
-;   cbz x5, label1 ; b label3
+;   ldr x1, 8 ; b 12 ; data TestCase(%f) + 0
+;   blr x1
+;   mov x3, sp
+;   ldr x9, [sp, #8]
+;   str x9, [x3]
+;   and w4, w0, #1
+;   cbz x4, label1 ; b label3
 ; block1:
 ;   b label2
 ; block2:
-;   mov x1, x11
+;   mov x1, x9
 ;   ldr x0, [sp, #16]
 ;   b label5
 ; block3:
 ;   b label4
 ; block4:
-;   mov x0, x11
+;   mov x0, x9
 ;   ldr x1, [sp, #16]
 ;   b label5
 ; block5:
-;   mov x6, sp
-;   ldr x2, [x6]
+;   mov x5, sp
+;   ldr x2, [x5]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
@@ -13,28 +13,28 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   orr x10, xzr, #128
-;   sub x12, x10, x2
-;   lsr x14, x0, x2
-;   lsr x3, x1, x2
-;   orn w4, wzr, w2
-;   lsl x5, x1, #1
-;   lsl x6, x5, x4
-;   orr x8, x14, x6
+;   orr x7, xzr, #128
+;   sub x9, x7, x2
+;   lsr x11, x0, x2
+;   lsr x13, x1, x2
+;   orn w15, wzr, w2
+;   lsl x3, x1, #1
+;   lsl x3, x3, x15
+;   orr x5, x11, x3
 ;   ands xzr, x2, #64
-;   csel x11, x3, x8, ne
-;   csel x13, xzr, x3, ne
-;   lsl x15, x0, x12
-;   lsl x1, x1, x12
-;   orn w3, wzr, w12
-;   lsr x5, x0, #1
-;   lsr x7, x5, x3
-;   orr x9, x1, x7
-;   ands xzr, x12, #64
-;   csel x12, xzr, x15, ne
-;   csel x14, x15, x9, ne
-;   orr x1, x13, x14
-;   orr x0, x11, x12
+;   csel x8, x13, x5, ne
+;   csel x10, xzr, x13, ne
+;   lsl x12, x0, x9
+;   lsl x14, x1, x9
+;   orn w1, wzr, w9
+;   lsr x2, x0, #1
+;   lsr x4, x2, x1
+;   orr x6, x14, x4
+;   ands xzr, x9, #64
+;   csel x9, xzr, x12, ne
+;   csel x11, x12, x6, ne
+;   orr x1, x10, x11
+;   orr x0, x8, x9
 ;   ret
 
 function %f0(i64, i64) -> i64 {
@@ -64,13 +64,13 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   uxth w5, w0
-;   and w7, w1, #15
-;   sub w9, w7, #16
-;   sub w11, wzr, w9
-;   lsr w13, w5, w7
-;   lsl w15, w5, w11
-;   orr w0, w15, w13
+;   uxth w4, w0
+;   and w6, w1, #15
+;   sub w8, w6, #16
+;   sub w10, wzr, w8
+;   lsr w12, w4, w6
+;   lsl w14, w4, w10
+;   orr w0, w14, w12
 ;   ret
 
 function %f3(i8, i8) -> i8 {
@@ -80,13 +80,13 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   uxtb w5, w0
-;   and w7, w1, #7
-;   sub w9, w7, #8
-;   sub w11, wzr, w9
-;   lsr w13, w5, w7
-;   lsl w15, w5, w11
-;   orr w0, w15, w13
+;   uxtb w4, w0
+;   and w6, w1, #7
+;   sub w8, w6, #8
+;   sub w10, wzr, w8
+;   lsr w12, w4, w6
+;   lsl w14, w4, w10
+;   orr w0, w14, w12
 ;   ret
 
 function %i128_rotl(i128, i128) -> i128 {
@@ -96,28 +96,28 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   orr x10, xzr, #128
-;   sub x12, x10, x2
-;   lsl x14, x0, x2
-;   lsl x3, x1, x2
-;   orn w4, wzr, w2
-;   lsr x5, x0, #1
-;   lsr x6, x5, x4
-;   orr x8, x3, x6
+;   orr x7, xzr, #128
+;   sub x9, x7, x2
+;   lsl x11, x0, x2
+;   lsl x13, x1, x2
+;   orn w15, wzr, w2
+;   lsr x3, x0, #1
+;   lsr x3, x3, x15
+;   orr x5, x13, x3
 ;   ands xzr, x2, #64
+;   csel x8, xzr, x11, ne
+;   csel x10, x11, x5, ne
+;   lsr x12, x0, x9
+;   lsr x14, x1, x9
+;   orn w0, wzr, w9
+;   lsl x2, x1, #1
+;   lsl x4, x2, x0
+;   orr x6, x12, x4
+;   ands xzr, x9, #64
+;   csel x9, x14, x6, ne
 ;   csel x11, xzr, x14, ne
-;   csel x13, x14, x8, ne
-;   lsr x15, x0, x12
-;   lsr x2, x1, x12
-;   orn w3, wzr, w12
-;   lsl x5, x1, #1
-;   lsl x7, x5, x3
-;   orr x9, x15, x7
-;   ands xzr, x12, #64
-;   csel x12, x2, x9, ne
-;   csel x14, xzr, x2, ne
-;   orr x0, x11, x12
-;   orr x1, x13, x14
+;   orr x0, x8, x9
+;   orr x1, x10, x11
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -127,8 +127,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   sub x5, xzr, x1
-;   ror x0, x0, x5
+;   sub x4, xzr, x1
+;   ror x0, x0, x4
 ;   ret
 
 function %f5(i32, i32) -> i32 {
@@ -138,8 +138,8 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   sub w5, wzr, w1
-;   ror w0, w0, w5
+;   sub w4, wzr, w1
+;   ror w0, w0, w4
 ;   ret
 
 function %f6(i16, i16) -> i16 {
@@ -149,14 +149,14 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   sub w5, wzr, w1
-;   uxth w7, w0
-;   and w9, w5, #15
-;   sub w11, w9, #16
-;   sub w13, wzr, w11
-;   lsr w15, w7, w9
-;   lsl w1, w7, w13
-;   orr w0, w1, w15
+;   sub w4, wzr, w1
+;   uxth w6, w0
+;   and w8, w4, #15
+;   sub w10, w8, #16
+;   sub w12, wzr, w10
+;   lsr w14, w6, w8
+;   lsl w0, w6, w12
+;   orr w0, w0, w14
 ;   ret
 
 function %f7(i8, i8) -> i8 {
@@ -166,14 +166,14 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   sub w5, wzr, w1
-;   uxtb w7, w0
-;   and w9, w5, #7
-;   sub w11, w9, #8
-;   sub w13, wzr, w11
-;   lsr w15, w7, w9
-;   lsl w1, w7, w13
-;   orr w0, w1, w15
+;   sub w4, wzr, w1
+;   uxtb w6, w0
+;   and w8, w4, #7
+;   sub w10, w8, #8
+;   sub w12, wzr, w10
+;   lsr w14, w6, w8
+;   lsl w0, w6, w12
+;   orr w0, w0, w14
 ;   ret
 
 function %f8(i64, i64) -> i64 {
@@ -203,9 +203,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   uxth w5, w0
-;   and w7, w1, #15
-;   lsr w0, w5, w7
+;   uxth w4, w0
+;   and w6, w1, #15
+;   lsr w0, w4, w6
 ;   ret
 
 function %f11(i8, i8) -> i8 {
@@ -215,9 +215,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   uxtb w5, w0
-;   and w7, w1, #7
-;   lsr w0, w5, w7
+;   uxtb w4, w0
+;   and w6, w1, #7
+;   lsr w0, w4, w6
 ;   ret
 
 function %f12(i64, i64) -> i64 {
@@ -247,8 +247,8 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   and w5, w1, #15
-;   lsl w0, w0, w5
+;   and w4, w1, #15
+;   lsl w0, w0, w4
 ;   ret
 
 function %f15(i8, i8) -> i8 {
@@ -258,8 +258,8 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   and w5, w1, #7
-;   lsl w0, w0, w5
+;   and w4, w1, #7
+;   lsl w0, w0, w4
 ;   ret
 
 function %f16(i64, i64) -> i64 {
@@ -289,9 +289,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   sxth w5, w0
-;   and w7, w1, #15
-;   asr w0, w5, w7
+;   sxth w4, w0
+;   and w6, w1, #15
+;   asr w0, w4, w6
 ;   ret
 
 function %f19(i8, i8) -> i8 {
@@ -301,9 +301,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   sxtb w5, w0
-;   and w7, w1, #7
-;   asr w0, w5, w7
+;   sxtb w4, w0
+;   and w6, w1, #7
+;   asr w0, w4, w6
 ;   ret
 
 function %f20(i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
@@ -69,13 +69,13 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   movz x6, #1
-;   dup v6.2d, x6
-;   orr v17.16b, v0.16b, v1.16b
-;   and v19.16b, v17.16b, v6.16b
-;   ushr v21.2d, v0.2d, #1
-;   ushr v23.2d, v1.2d, #1
-;   add v25.2d, v21.2d, v23.2d
-;   add v0.2d, v19.2d, v25.2d
+;   movz x5, #1
+;   dup v5.2d, x5
+;   orr v16.16b, v0.16b, v1.16b
+;   and v18.16b, v16.16b, v5.16b
+;   ushr v20.2d, v0.2d, #1
+;   ushr v22.2d, v1.2d, #1
+;   add v24.2d, v20.2d, v22.2d
+;   add v0.2d, v18.2d, v24.2d
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
@@ -191,11 +191,11 @@ block0(v0: i8x16, v1: i32):
 }
 
 ; block0:
-;   movz x5, #3
-;   and w7, w5, #7
-;   sub x9, xzr, x7
-;   dup v19.16b, w9
-;   sshl v0.16b, v0.16b, v19.16b
+;   movz x4, #3
+;   and w6, w4, #7
+;   sub x8, xzr, x6
+;   dup v18.16b, w8
+;   sshl v0.16b, v0.16b, v18.16b
 ;   ret
 
 function %sshr_i64x2(i64x2, i32) -> i64x2 {
@@ -205,9 +205,9 @@ block0(v0: i64x2, v1: i32):
 }
 
 ; block0:
-;   and w5, w0, #63
-;   sub x7, xzr, x5
-;   dup v17.2d, x7
-;   sshl v0.2d, v0.2d, v17.2d
+;   and w4, w0, #63
+;   sub x6, xzr, x4
+;   dup v16.2d, x6
+;   sshl v0.2d, v0.2d, v16.2d
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -86,9 +86,9 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldrb w8, [x0]
+;   ldrb w7, [x0]
 ;   ld1r { v0.16b }, [x1]
-;   dup v1.16b, w8
+;   dup v1.16b, w7
 ;   ret
 
 function %f8(i64, i64) -> i8x16, i8x16 {
@@ -100,9 +100,9 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   ldrb w8, [x0]
-;   dup v0.16b, w8
-;   dup v1.16b, w8
+;   ldrb w7, [x0]
+;   dup v0.16b, w7
+;   dup v1.16b, w7
 ;   ret
 
 function %f9() -> i32x2 {

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -442,8 +442,8 @@ block0(v0: i128):
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   mov x5, sp
-;   stp x0, x1, [x5]
+;   mov x4, sp
+;   stp x0, x1, [x4]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -461,8 +461,8 @@ block0(v0: i128):
 ;   mov fp, sp
 ;   sub sp, sp, #32
 ; block0:
-;   add x5, sp, #32
-;   stp x0, x1, [x5]
+;   add x4, sp, #32
+;   stp x0, x1, [x4]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -482,8 +482,8 @@ block0(v0: i128):
 ;   movk w16, w16, #1, LSL #16
 ;   sub sp, sp, x16, UXTX
 ; block0:
-;   mov x5, sp
-;   stp x0, x1, [x5]
+;   mov x4, sp
+;   stp x0, x1, [x4]
 ;   movz w16, #34480
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -227,8 +227,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   ar %r2, %r4
+;   llc %r3, 0(%r3)
+;   ar %r2, %r3
 ;   br %r14
 
 function %iadd_i64(i64, i64) -> i64 {
@@ -271,8 +271,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   lg %r4, 0(%r3)
-;   algr %r2, %r4
+;   lg %r3, 0(%r3)
+;   algr %r2, %r3
 ;   br %r14
 
 function %iadd_i64_mem_ext32(i64, i64) -> i64 {
@@ -283,8 +283,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   llgf %r4, 0(%r3)
-;   algr %r2, %r4
+;   llgf %r3, 0(%r3)
+;   algr %r2, %r3
 ;   br %r14
 
 function %iadd_i32(i32, i32) -> i32 {
@@ -316,8 +316,8 @@ block0(v0: i32, v1: i64):
 }
 
 ; block0:
-;   l %r4, 0(%r3)
-;   alr %r2, %r4
+;   l %r3, 0(%r3)
+;   alr %r2, %r3
 ;   br %r14
 
 function %iadd_i32_memoff(i32, i64) -> i32 {
@@ -328,8 +328,8 @@ block0(v0: i32, v1: i64):
 }
 
 ; block0:
-;   ly %r4, 4096(%r3)
-;   alr %r2, %r4
+;   ly %r3, 4096(%r3)
+;   alr %r2, %r3
 ;   br %r14
 
 function %isub_i128(i128, i128) -> i128 {
@@ -558,8 +558,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   sr %r2, %r4
+;   llc %r3, 0(%r3)
+;   sr %r2, %r3
 ;   br %r14
 
 function %iabs_i128(i128) -> i128 {
@@ -923,8 +923,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   msr %r2, %r4
+;   llc %r3, 0(%r3)
+;   msr %r2, %r3
 ;   br %r14
 
 function %umulhi_i64(i64, i64) -> i64 {
@@ -946,12 +946,10 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   llgfr %r3, %r2
-;   lgr %r2, %r4
-;   llgfr %r5, %r2
-;   msgr %r3, %r5
-;   srlg %r2, %r3, 32
+;   llgfr %r2, %r2
+;   llgfr %r4, %r3
+;   msgr %r2, %r4
+;   srlg %r2, %r2, 32
 ;   br %r14
 
 function %umulhi_i16(i16, i16) -> i16 {
@@ -961,12 +959,10 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   llhr %r3, %r2
-;   lgr %r2, %r4
-;   llhr %r5, %r2
-;   msr %r3, %r5
-;   srlk %r2, %r3, 16
+;   llhr %r2, %r2
+;   llhr %r4, %r3
+;   msr %r2, %r4
+;   srlk %r2, %r2, 16
 ;   br %r14
 
 function %umulhi_i8(i8, i8) -> i8 {
@@ -976,12 +972,10 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   llcr %r3, %r2
-;   lgr %r2, %r4
-;   llcr %r5, %r2
-;   msr %r3, %r5
-;   srlk %r2, %r3, 8
+;   llcr %r2, %r2
+;   llcr %r4, %r3
+;   msr %r2, %r4
+;   srlk %r2, %r2, 8
 ;   br %r14
 
 function %smulhi_i64(i64, i64) -> i64 {
@@ -1002,12 +996,10 @@ block0(v0: i32, v1: i32):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   lgfr %r3, %r2
-;   lgr %r2, %r4
-;   lgfr %r5, %r2
-;   msgr %r3, %r5
-;   srag %r2, %r3, 32
+;   lgfr %r2, %r2
+;   lgfr %r4, %r3
+;   msgr %r2, %r4
+;   srag %r2, %r2, 32
 ;   br %r14
 
 function %smulhi_i16(i16, i16) -> i16 {
@@ -1017,12 +1009,10 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   lhr %r3, %r2
-;   lgr %r2, %r4
-;   lhr %r5, %r2
-;   msr %r3, %r5
-;   srak %r2, %r3, 16
+;   lhr %r2, %r2
+;   lhr %r4, %r3
+;   msr %r2, %r4
+;   srak %r2, %r2, 16
 ;   br %r14
 
 function %smulhi_i8(i8, i8) -> i8 {
@@ -1032,12 +1022,10 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   lgr %r4, %r3
-;   lbr %r3, %r2
-;   lgr %r2, %r4
-;   lbr %r5, %r2
-;   msr %r3, %r5
-;   srak %r2, %r3, 8
+;   lbr %r2, %r2
+;   lbr %r4, %r3
+;   msr %r2, %r4
+;   srak %r2, %r2, 8
 ;   br %r14
 
 function %sdiv_i64(i64, i64) -> i64 {
@@ -1050,9 +1038,9 @@ block0(v0: i64, v1: i64):
 ;   lgr %r1, %r2
 ;   llihf %r4, 2147483647
 ;   iilf %r4, 4294967295
-;   xgr %r4, %r1
-;   ngrk %r5, %r4, %r3
-;   cgite %r5, -1
+;   xgrk %r2, %r4, %r1
+;   ngrk %r4, %r2, %r3
+;   cgite %r4, -1
 ;   dsgr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
@@ -1080,8 +1068,8 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lgfr %r1, %r2
 ;   iilf %r4, 2147483647
-;   xrk %r2, %r4, %r1
-;   nrk %r4, %r2, %r3
+;   xrk %r5, %r4, %r1
+;   nrk %r4, %r5, %r3
 ;   cite %r4, -1
 ;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
@@ -1109,12 +1097,12 @@ block0(v0: i16, v1: i16):
 
 ; block0:
 ;   lghr %r1, %r2
-;   lhr %r4, %r3
-;   lhi %r2, 32767
-;   xrk %r5, %r2, %r1
-;   nrk %r2, %r5, %r4
-;   cite %r2, -1
-;   dsgfr %r0, %r4
+;   lhr %r3, %r3
+;   lhi %r5, 32767
+;   xrk %r4, %r5, %r1
+;   nrk %r5, %r4, %r3
+;   cite %r5, -1
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -1140,12 +1128,12 @@ block0(v0: i8, v1: i8):
 
 ; block0:
 ;   lgbr %r1, %r2
-;   lbr %r4, %r3
-;   lhi %r2, 127
-;   xrk %r5, %r2, %r1
-;   nrk %r2, %r5, %r4
-;   cite %r2, -1
-;   dsgfr %r0, %r4
+;   lbr %r3, %r3
+;   lhi %r5, 127
+;   xrk %r4, %r5, %r1
+;   nrk %r5, %r4, %r3
+;   cite %r5, -1
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -1228,8 +1216,8 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   lhi %r0, 0
 ;   llhr %r1, %r2
-;   llhr %r5, %r3
-;   dlr %r0, %r5
+;   llhr %r4, %r3
+;   dlr %r0, %r4
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -1257,8 +1245,8 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   lhi %r0, 0
 ;   llcr %r1, %r2
-;   llcr %r5, %r3
-;   dlr %r0, %r5
+;   llcr %r4, %r3
+;   dlr %r0, %r4
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -1311,8 +1299,8 @@ block0(v0: i16, v1: i16):
 
 ; block0:
 ;   lghr %r1, %r2
-;   lhr %r4, %r3
-;   dsgfr %r0, %r4
+;   lhr %r3, %r3
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -1324,8 +1312,8 @@ block0(v0: i8, v1: i8):
 
 ; block0:
 ;   lgbr %r1, %r2
-;   lbr %r4, %r3
-;   dsgfr %r0, %r4
+;   lbr %r3, %r3
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -1364,8 +1352,8 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   lhi %r0, 0
 ;   llhr %r1, %r2
-;   llhr %r5, %r3
-;   dlr %r0, %r5
+;   llhr %r4, %r3
+;   dlr %r0, %r4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -1378,8 +1366,8 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   lhi %r0, 0
 ;   llcr %r1, %r2
-;   llcr %r5, %r3
-;   dlr %r0, %r5
+;   llcr %r4, %r3
+;   dlr %r0, %r4
 ;   lgr %r2, %r0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
@@ -12,10 +12,10 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r2
-;   lrvgr %r3, %r3
-;   csg %r5, %r3, 0(%r4)
-;   lrvgr %r2, %r5
+;   lrvgr %r2, %r2
+;   lrvgr %r5, %r3
+;   csg %r2, %r5, 0(%r4)
+;   lrvgr %r2, %r2
 ;   br %r14
 
 function %atomic_cas_i32(i32, i32, i64) -> i32 {
@@ -25,10 +25,10 @@ block0(v0: i32, v1: i32, v2: i64):
 }
 
 ; block0:
-;   lrvr %r5, %r2
-;   lrvr %r3, %r3
-;   cs %r5, %r3, 0(%r4)
-;   lrvr %r2, %r5
+;   lrvr %r2, %r2
+;   lrvr %r5, %r3
+;   cs %r2, %r5, 0(%r4)
+;   lrvr %r2, %r2
 ;   br %r14
 
 function %atomic_cas_i16(i64, i16, i16, i64) -> i16 {
@@ -37,19 +37,19 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
   return v4
 }
 
-;   stmg %r13, %r15, 104(%r15)
+;   stmg %r9, %r15, 72(%r15)
 ; block0:
-;   lgr %r13, %r3
-;   sllk %r3, %r5, 3
+;   lgr %r9, %r4
+;   sllk %r4, %r5, 3
 ;   nill %r5, 65532
-;   lgr %r2, %r13
-;   lrvr %r2, %r2
-;   lrvr %r4, %r4
+;   lrvr %r2, %r3
+;   lgr %r3, %r9
+;   lrvr %r3, %r3
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 16(%r3) ; rxsbg %r1, %r2, 176, 64, 48 ; jglh 1f ; risbgn %r1, %r4, 48, 64, 48 ; rll %r1, %r1, 16(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r3)
-;   lrvr %r2, %r2
-;   lmg %r13, %r15, 104(%r15)
+;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r2, 176, 64, 48 ; jglh 1f ; risbgn %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r3, %r0, 0(%r4)
+;   lrvr %r2, %r3
+;   lmg %r9, %r15, 72(%r15)
 ;   br %r14
 
 function %atomic_cas_i8(i64, i8, i8, i64) -> i8 {
@@ -58,14 +58,15 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
   return v4
 }
 
-;   stmg %r11, %r15, 88(%r15)
+;   stmg %r12, %r15, 96(%r15)
 ; block0:
-;   sllk %r2, %r5, 3
+;   lgr %r12, %r4
+;   sllk %r4, %r5, 3
 ;   nill %r5, 65532
-;   lcr %r11, %r2
+;   lcr %r2, %r4
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r11) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r2)
-;   lmg %r11, %r15, 88(%r15)
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
+;   lmg %r12, %r15, 96(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
@@ -32,11 +32,12 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 }
 
 ; block0:
-;   sllk %r2, %r5, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r5, 3
 ;   nill %r5, 65532
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r3, 160, 48, 16 ; jglh 1f ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r2)
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 48, 16 ; jglh 1f ; risbgn %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_cas_i8(i64, i8, i8, i64) -> i8 {
@@ -45,14 +46,15 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
   return v4
 }
 
-;   stmg %r11, %r15, 88(%r15)
+;   stmg %r12, %r15, 96(%r15)
 ; block0:
-;   sllk %r2, %r5, 3
+;   lgr %r12, %r4
+;   sllk %r4, %r5, 3
 ;   nill %r5, 65532
-;   lcr %r11, %r2
+;   lcr %r2, %r4
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r11) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r2)
-;   lmg %r11, %r15, 88(%r15)
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
+;   lmg %r12, %r15, 96(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
@@ -61,9 +61,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
+;   lrvgr %r4, %r4
 ;   lg %r0, 0(%r3)
-;   0: nngrk %r1, %r0, %r5 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: nngrk %r1, %r0, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -74,9 +74,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
+;   lrvr %r4, %r4
 ;   l %r0, 0(%r3)
-;   0: nnrk %r1, %r0, %r5 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: nnrk %r1, %r0, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -87,13 +87,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; rnsbg %r1, %r2, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r5, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
@@ -12,9 +12,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
+;   lrvgr %r4, %r4
 ;   lg %r0, 0(%r3)
-;   0: csg %r0, %r5, 0(%r3) ; jglh 0b ; 1:
+;   0: csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -25,9 +25,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
+;   lrvr %r4, %r4
 ;   l %r0, 0(%r3)
-;   0: cs %r0, %r5, 0(%r3) ; jglh 0b ; 1:
+;   0: cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -38,13 +38,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; risbgn %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; risbgn %r1, %r5, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_xchg_i8(i64, i64, i8) -> i8 {
@@ -93,13 +94,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; ar %r1, %r2 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; ar %r1, %r5 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_add_i8(i64, i64, i8) -> i8 {
@@ -109,13 +111,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; ar %r1, %r2 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; ar %r1, %r5 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_sub_i64(i64, i64, i64) -> i64 {
@@ -149,13 +152,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; sr %r1, %r2 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; sr %r1, %r5 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_sub_i8(i64, i64, i8) -> i8 {
@@ -165,13 +169,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; sr %r1, %r2 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; sr %r1, %r5 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_and_i64(i64, i64, i64) -> i64 {
@@ -181,9 +186,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
-;   lang %r3, %r5, 0(%r3)
-;   lrvgr %r2, %r3
+;   lrvgr %r4, %r4
+;   lang %r5, %r4, 0(%r3)
+;   lrvgr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_and_i32(i64, i64, i32) -> i32 {
@@ -193,9 +198,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
-;   lan %r3, %r5, 0(%r3)
-;   lrvr %r2, %r3
+;   lrvr %r4, %r4
+;   lan %r5, %r4, 0(%r3)
+;   lrvr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_and_i16(i64, i64, i16) -> i16 {
@@ -205,13 +210,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; rnsbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r5, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_and_i8(i64, i64, i8) -> i8 {
@@ -236,9 +242,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
-;   laog %r3, %r5, 0(%r3)
-;   lrvgr %r2, %r3
+;   lrvgr %r4, %r4
+;   laog %r5, %r4, 0(%r3)
+;   lrvgr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_or_i32(i64, i64, i32) -> i32 {
@@ -248,9 +254,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
-;   lao %r3, %r5, 0(%r3)
-;   lrvr %r2, %r3
+;   lrvr %r4, %r4
+;   lao %r5, %r4, 0(%r3)
+;   lrvr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_or_i16(i64, i64, i16) -> i16 {
@@ -260,13 +266,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; rosbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; rosbg %r1, %r5, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_or_i8(i64, i64, i8) -> i8 {
@@ -291,9 +298,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
-;   laxg %r3, %r5, 0(%r3)
-;   lrvgr %r2, %r3
+;   lrvgr %r4, %r4
+;   laxg %r5, %r4, 0(%r3)
+;   lrvgr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_xor_i32(i64, i64, i32) -> i32 {
@@ -303,9 +310,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
-;   lax %r3, %r5, 0(%r3)
-;   lrvr %r2, %r3
+;   lrvr %r4, %r4
+;   lax %r5, %r4, 0(%r3)
+;   lrvr %r2, %r5
 ;   br %r14
 
 function %atomic_rmw_xor_i16(i64, i64, i16) -> i16 {
@@ -315,13 +322,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; rxsbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r5, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_xor_i8(i64, i64, i8) -> i8 {
@@ -346,9 +354,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   lrvgr %r5, %r4
+;   lrvgr %r4, %r4
 ;   lg %r0, 0(%r3)
-;   0: ngrk %r1, %r0, %r5 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: ngrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -359,9 +367,9 @@ block0(v0: i64, v1: i64, v2: i32):
 }
 
 ; block0:
-;   lrvr %r5, %r4
+;   lrvr %r4, %r4
 ;   l %r0, 0(%r3)
-;   0: nrk %r1, %r0, %r5 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: nrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -372,13 +380,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   lrvr %r2, %r4
+;   lrvr %r5, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; rnsbg %r1, %r2, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r5, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {
@@ -427,13 +436,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_smin_i8(i64, i64, i8) -> i8 {
@@ -443,13 +453,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_smax_i64(i64, i64, i64) -> i64 {
@@ -483,13 +494,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_smax_i8(i64, i64, i8) -> i8 {
@@ -499,13 +511,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_umin_i64(i64, i64, i64) -> i64 {
@@ -539,13 +552,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_umin_i8(i64, i64, i8) -> i8 {
@@ -555,13 +569,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_umax_i64(i64, i64, i64) -> i64 {
@@ -595,13 +610,14 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r5, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r5) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 0(%r5)
-;   lrvr %r2, %r2
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r4, %r0, 0(%r4)
+;   lrvr %r2, %r4
 ;   br %r14
 
 function %atomic_rmw_umax_i8(i64, i64, i8) -> i8 {
@@ -611,12 +627,13 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
@@ -85,12 +85,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; ar %r1, %r2 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; ar %r1, %r5 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_add_i8(i64, i64, i8) -> i8 {
@@ -100,13 +101,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; ar %r1, %r2 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; ar %r1, %r5 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_sub_i64(i64, i64) -> i64 {
@@ -138,12 +140,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; sr %r1, %r2 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; sr %r1, %r5 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_sub_i8(i64, i64, i8) -> i8 {
@@ -153,13 +156,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; sr %r1, %r2 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; sr %r1, %r5 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_and_i64(i64, i64) -> i64 {
@@ -393,12 +397,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_smin_i8(i64, i64, i8) -> i8 {
@@ -408,13 +413,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_smax_i64(i64, i64, i64) -> i64 {
@@ -448,12 +454,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_smax_i8(i64, i64, i8) -> i8 {
@@ -463,13 +470,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; cr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_umin_i64(i64, i64, i64) -> i64 {
@@ -503,12 +511,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_umin_i8(i64, i64, i8) -> i8 {
@@ -518,13 +527,14 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnl 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 
 function %atomic_rmw_umax_i64(i64, i64, i64) -> i64 {
@@ -558,12 +568,13 @@ block0(v0: i64, v1: i64, v2: i16):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r2, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 16
+;   sllk %r5, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 16(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 
 function %atomic_rmw_umax_i8(i64, i64, i8) -> i8 {
@@ -573,12 +584,13 @@ block0(v0: i64, v1: i64, v2: i8):
 }
 
 ; block0:
-;   sllk %r5, %r3, 3
+;   lgr %r5, %r4
+;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
-;   sllk %r2, %r4, 24
-;   lcr %r4, %r5
+;   sllk %r5, %r5, 24
+;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
-;   rll %r2, %r0, 8(%r5)
+;   0: rll %r1, %r0, 0(%r4) ; clr %r5, %r1 ; jgnh 1f ; risbgn %r1, %r5, 32, 40, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
@@ -173,9 +173,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   ngrk %r5, %r3, %r2
-;   ncgrk %r3, %r4, %r2
-;   ogrk %r2, %r3, %r5
+;   ngr %r3, %r2
+;   ncgrk %r5, %r4, %r2
+;   ogrk %r2, %r5, %r3
 ;   br %r14
 
 function %bitselect_i32(i32, i32, i32) -> i32 {
@@ -185,9 +185,9 @@ block0(v0: i32, v1: i32, v2: i32):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
-;   ncrk %r3, %r4, %r2
-;   ork %r2, %r3, %r5
+;   nr %r3, %r2
+;   ncrk %r5, %r4, %r2
+;   ork %r2, %r5, %r3
 ;   br %r14
 
 function %bitselect_i16(i16, i16, i16) -> i16 {
@@ -197,9 +197,9 @@ block0(v0: i16, v1: i16, v2: i16):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
-;   ncrk %r3, %r4, %r2
-;   ork %r2, %r3, %r5
+;   nr %r3, %r2
+;   ncrk %r5, %r4, %r2
+;   ork %r2, %r5, %r3
 ;   br %r14
 
 function %bitselect_i8(i8, i8, i8) -> i8 {
@@ -209,8 +209,8 @@ block0(v0: i8, v1: i8, v2: i8):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
-;   ncrk %r3, %r4, %r2
-;   ork %r2, %r3, %r5
+;   nr %r3, %r2
+;   ncrk %r5, %r4, %r2
+;   ork %r2, %r5, %r3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -88,8 +88,8 @@ block0(v0: i16, v1: i64):
 }
 
 ; block0:
-;   llh %r4, 0(%r3)
-;   nr %r2, %r4
+;   llh %r3, 0(%r3)
+;   nr %r2, %r3
 ;   br %r14
 
 function %band_i8(i8, i8) -> i8 {
@@ -110,8 +110,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   nr %r2, %r4
+;   llc %r3, 0(%r3)
+;   nr %r2, %r3
 ;   br %r14
 
 function %bor_i128(i128, i128) -> i128 {
@@ -198,8 +198,8 @@ block0(v0: i16, v1: i64):
 }
 
 ; block0:
-;   llh %r4, 0(%r3)
-;   or %r2, %r4
+;   llh %r3, 0(%r3)
+;   or %r2, %r3
 ;   br %r14
 
 function %bor_i8(i8, i8) -> i8 {
@@ -220,8 +220,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   or %r2, %r4
+;   llc %r3, 0(%r3)
+;   or %r2, %r3
 ;   br %r14
 
 function %bxor_i128(i128, i128) -> i128 {
@@ -308,8 +308,8 @@ block0(v0: i16, v1: i64):
 }
 
 ; block0:
-;   llh %r4, 0(%r3)
-;   xr %r2, %r4
+;   llh %r3, 0(%r3)
+;   xr %r2, %r3
 ;   br %r14
 
 function %bxor_i8(i8, i8) -> i8 {
@@ -330,8 +330,8 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   llc %r4, 0(%r3)
-;   xr %r2, %r4
+;   llc %r3, 0(%r3)
+;   xr %r2, %r3
 ;   br %r14
 
 function %band_not_i128(i128, i128) -> i128 {
@@ -582,11 +582,11 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   ngrk %r5, %r3, %r2
+;   ngr %r3, %r2
 ;   xilf %r2, 4294967295
 ;   xihf %r2, 4294967295
-;   ngrk %r2, %r4, %r2
-;   ogr %r2, %r5
+;   ngr %r4, %r2
+;   ogrk %r2, %r4, %r3
 ;   br %r14
 
 function %bitselect_i32(i32, i32, i32) -> i32 {
@@ -596,10 +596,10 @@ block0(v0: i32, v1: i32, v2: i32):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
+;   nr %r3, %r2
 ;   xilf %r2, 4294967295
-;   nrk %r2, %r4, %r2
-;   or %r2, %r5
+;   nr %r4, %r2
+;   ork %r2, %r4, %r3
 ;   br %r14
 
 function %bitselect_i16(i16, i16, i16) -> i16 {
@@ -609,10 +609,10 @@ block0(v0: i16, v1: i16, v2: i16):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
+;   nr %r3, %r2
 ;   xilf %r2, 4294967295
-;   nrk %r2, %r4, %r2
-;   or %r2, %r5
+;   nr %r4, %r2
+;   ork %r2, %r4, %r3
 ;   br %r14
 
 function %bitselect_i8(i8, i8, i8) -> i8 {
@@ -622,9 +622,9 @@ block0(v0: i8, v1: i8, v2: i8):
 }
 
 ; block0:
-;   nrk %r5, %r3, %r2
+;   nr %r3, %r2
 ;   xilf %r2, 4294967295
-;   nrk %r2, %r4, %r2
-;   or %r2, %r5
+;   nr %r4, %r2
+;   ork %r2, %r4, %r3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -150,37 +150,39 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
     return v27
 }
 
-;   stmg %r7, %r15, 56(%r15)
+;   stmg %r6, %r15, 48(%r15)
 ;   aghi %r15, -16
 ; block0:
-;   stg %r4, 8(%r15)
-;   lgr %r10, %r5
+;   stg %r2, 0(%r15)
+;   lgr %r10, %r6
 ;   lg %r11, 176(%r15)
 ;   lg %r12, 184(%r15)
 ;   llgc %r13, 199(%r15)
-;   lg %r8, 200(%r15)
-;   lg %r7, 208(%r15)
-;   llgfr %r4, %r3
-;   lg %r5, 8(%r15)
-;   llgfr %r5, %r5
-;   lgr %r3, %r10
-;   llgfr %r3, %r3
-;   llghr %r9, %r6
-;   llghr %r10, %r11
-;   llghr %r11, %r12
-;   llgcr %r12, %r13
-;   llgcr %r8, %r8
-;   llgcr %r13, %r7
-;   agrk %r4, %r2, %r4
-;   agr %r5, %r3
-;   agrk %r2, %r9, %r10
-;   agrk %r3, %r11, %r12
-;   agr %r8, %r13
-;   agr %r4, %r5
-;   agrk %r5, %r2, %r3
-;   agrk %r4, %r8, %r4
-;   agrk %r2, %r5, %r4
-;   lmg %r7, %r15, 72(%r15)
+;   lg %r6, 200(%r15)
+;   lg %r2, 208(%r15)
+;   stg %r2, 8(%r15)
+;   llgfr %r2, %r3
+;   llgfr %r9, %r4
+;   llgfr %r7, %r5
+;   lgr %r4, %r10
+;   llghr %r8, %r4
+;   llghr %r5, %r11
+;   llghr %r10, %r12
+;   llgcr %r4, %r13
+;   llgcr %r13, %r6
+;   lg %r3, 8(%r15)
+;   llgcr %r3, %r3
+;   lg %r11, 0(%r15)
+;   agrk %r2, %r11, %r2
+;   agrk %r6, %r9, %r7
+;   agrk %r5, %r8, %r5
+;   agrk %r4, %r10, %r4
+;   agrk %r3, %r13, %r3
+;   agr %r2, %r6
+;   agrk %r4, %r5, %r4
+;   agrk %r5, %r3, %r2
+;   agrk %r2, %r4, %r5
+;   lmg %r6, %r15, 64(%r15)
 ;   br %r14
 
 function %incoming_args_i128(i128, i128, i128, i128, i128, i128, i128, i128) -> i128 {
@@ -200,14 +202,14 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
 ;   vl %v1, 0(%r4)
 ;   vl %v2, 0(%r5)
 ;   vl %v3, 0(%r6)
-;   lg %r3, 160(%r15)
-;   vl %v4, 0(%r3)
+;   lg %r4, 160(%r15)
+;   vl %v4, 0(%r4)
 ;   lg %r3, 168(%r15)
 ;   vl %v5, 0(%r3)
-;   lg %r5, 176(%r15)
-;   vl %v6, 0(%r5)
-;   lg %r4, 184(%r15)
-;   vl %v7, 0(%r4)
+;   lg %r3, 176(%r15)
+;   vl %v6, 0(%r3)
+;   lg %r5, 184(%r15)
+;   vl %v7, 0(%r5)
 ;   vaq %v17, %v0, %v1
 ;   vaq %v18, %v2, %v3
 ;   vaq %v19, %v4, %v5

--- a/cranelift/filetests/filetests/isa/s390x/concat-split.clif
+++ b/cranelift/filetests/filetests/isa/s390x/concat-split.clif
@@ -8,8 +8,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   vlvgp %v7, %r4, %r3
-;   vst %v7, 0(%r2)
+;   vlvgp %v5, %r4, %r3
+;   vst %v5, 0(%r2)
 ;   br %r14
 
 function %isplit_i128(i128) -> i64, i64 {

--- a/cranelift/filetests/filetests/isa/s390x/condops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condops.clif
@@ -52,9 +52,9 @@ block0(v0: i32, v1: i8x16, v2: i8x16):
 }
 
 ; block0:
-;   vlr %v20, %v24
+;   vlr %v16, %v24
 ;   clfi %r2, 42
 ;   vlr %v24, %v25
-;   jne 10 ; vlr %v24, %v20
+;   jne 10 ; vlr %v24, %v16
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -8,9 +8,9 @@ block0(v0: i64):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vlvgg %v5, %r3, 1
-;   vst %v5, 0(%r2)
+;   vgbm %v4, 0
+;   vlvgg %v4, %r3, 1
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %uextend_i32_i128(i32) -> i128 {
@@ -20,9 +20,9 @@ block0(v0: i32):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vlvgf %v5, %r3, 3
-;   vst %v5, 0(%r2)
+;   vgbm %v4, 0
+;   vlvgf %v4, %r3, 3
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %uextend_i32_i64(i32) -> i64 {
@@ -42,9 +42,9 @@ block0(v0: i16):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vlvgh %v5, %r3, 7
-;   vst %v5, 0(%r2)
+;   vgbm %v4, 0
+;   vlvgh %v4, %r3, 7
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %uextend_i16_i64(i16) -> i64 {
@@ -74,9 +74,9 @@ block0(v0: i8):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vlvgb %v5, %r3, 15
-;   vst %v5, 0(%r2)
+;   vgbm %v4, 0
+;   vlvgb %v4, %r3, 15
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %uextend_i8_i64(i8) -> i64 {
@@ -117,8 +117,8 @@ block0(v0: i64):
 
 ; block0:
 ;   srag %r4, %r3, 63
-;   vlvgp %v7, %r4, %r3
-;   vst %v7, 0(%r2)
+;   vlvgp %v6, %r4, %r3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %sextend_i32_i128(i32) -> i128 {
@@ -129,9 +129,9 @@ block0(v0: i32):
 
 ; block0:
 ;   lgfr %r3, %r3
-;   srag %r5, %r3, 63
-;   vlvgp %v17, %r5, %r3
-;   vst %v17, 0(%r2)
+;   srag %r4, %r3, 63
+;   vlvgp %v16, %r4, %r3
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %sextend_i32_i64(i32) -> i64 {
@@ -152,9 +152,9 @@ block0(v0: i16):
 
 ; block0:
 ;   lghr %r3, %r3
-;   srag %r5, %r3, 63
-;   vlvgp %v17, %r5, %r3
-;   vst %v17, 0(%r2)
+;   srag %r4, %r3, 63
+;   vlvgp %v16, %r4, %r3
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %sextend_i16_i64(i16) -> i64 {
@@ -185,9 +185,9 @@ block0(v0: i8):
 
 ; block0:
 ;   lgbr %r3, %r3
-;   srag %r5, %r3, 63
-;   vlvgp %v17, %r5, %r3
-;   vst %v17, 0(%r2)
+;   srag %r4, %r3, 63
+;   vlvgp %v16, %r4, %r3
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %sextend_i8_i64(i8) -> i64 {
@@ -331,8 +331,8 @@ block0(v0: b64):
 }
 
 ; block0:
-;   vlvgp %v5, %r3, %r3
-;   vst %v5, 0(%r2)
+;   vlvgp %v4, %r3, %r3
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %bextend_b32_b128(b32) -> b128 {
@@ -343,8 +343,8 @@ block0(v0: b32):
 
 ; block0:
 ;   lgfr %r3, %r3
-;   vlvgp %v7, %r3, %r3
-;   vst %v7, 0(%r2)
+;   vlvgp %v6, %r3, %r3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %bextend_b32_b64(b32) -> b64 {
@@ -365,8 +365,8 @@ block0(v0: b16):
 
 ; block0:
 ;   lghr %r3, %r3
-;   vlvgp %v7, %r3, %r3
-;   vst %v7, 0(%r2)
+;   vlvgp %v6, %r3, %r3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %bextend_b16_b64(b16) -> b64 {
@@ -397,8 +397,8 @@ block0(v0: b8):
 
 ; block0:
 ;   lgbr %r3, %r3
-;   vlvgp %v7, %r3, %r3
-;   vst %v7, 0(%r2)
+;   vlvgp %v6, %r3, %r3
+;   vst %v6, 0(%r2)
 ;   br %r14
 
 function %bextend_b8_b64(b8) -> b64 {
@@ -439,9 +439,9 @@ block0(v0: b1):
 
 ; block0:
 ;   sllg %r3, %r3, 63
-;   srag %r5, %r3, 63
-;   vlvgp %v17, %r5, %r5
-;   vst %v17, 0(%r2)
+;   srag %r4, %r3, 63
+;   vlvgp %v16, %r4, %r4
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %bextend_b1_b64(b1) -> b64 {
@@ -705,8 +705,8 @@ block0(v0: b64, v1: b64):
 }
 
 ; block0:
-;   vlvgp %v7, %r4, %r4
-;   vst %v7, 0(%r2)
+;   vlvgp %v5, %r4, %r4
+;   vst %v5, 0(%r2)
 ;   br %r14
 
 function %bmask_b64_i64(b64, b64) -> i64 {
@@ -756,9 +756,9 @@ block0(v0: b32, v1: b32):
 }
 
 ; block0:
-;   lgfr %r5, %r4
-;   vlvgp %v17, %r5, %r5
-;   vst %v17, 0(%r2)
+;   lgfr %r3, %r4
+;   vlvgp %v7, %r3, %r3
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bmask_b32_i64(b32, b32) -> i64 {
@@ -808,9 +808,9 @@ block0(v0: b16, v1: b16):
 }
 
 ; block0:
-;   lghr %r5, %r4
-;   vlvgp %v17, %r5, %r5
-;   vst %v17, 0(%r2)
+;   lghr %r3, %r4
+;   vlvgp %v7, %r3, %r3
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bmask_b16_i64(b16, b16) -> i64 {
@@ -860,9 +860,9 @@ block0(v0: b8, v1: b8):
 }
 
 ; block0:
-;   lgbr %r5, %r4
-;   vlvgp %v17, %r5, %r5
-;   vst %v17, 0(%r2)
+;   lgbr %r3, %r4
+;   vlvgp %v7, %r3, %r3
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bmask_b8_i64(b8, b8) -> i64 {
@@ -912,10 +912,10 @@ block0(v0: b1, v1: b1):
 }
 
 ; block0:
-;   sllg %r5, %r4, 63
-;   srag %r3, %r5, 63
-;   vlvgp %v19, %r3, %r3
-;   vst %v19, 0(%r2)
+;   sllg %r3, %r4, 63
+;   srag %r5, %r3, 63
+;   vlvgp %v17, %r5, %r5
+;   vst %v17, 0(%r2)
 ;   br %r14
 
 function %bmask_b1_i64(b1, b1) -> i64 {
@@ -925,8 +925,8 @@ block0(v0: b1, v1: b1):
 }
 
 ; block0:
-;   sllg %r3, %r3, 63
-;   srag %r2, %r3, 63
+;   sllg %r2, %r3, 63
+;   srag %r2, %r2, 63
 ;   br %r14
 
 function %bmask_b1_i32(b1, b1) -> i32 {
@@ -936,8 +936,8 @@ block0(v0: b1, v1: b1):
 }
 
 ; block0:
-;   sllk %r3, %r3, 31
-;   srak %r2, %r3, 31
+;   sllk %r2, %r3, 31
+;   srak %r2, %r2, 31
 ;   br %r14
 
 function %bmask_b1_i16(b1, b1) -> i16 {
@@ -947,8 +947,8 @@ block0(v0: b1, v1: b1):
 }
 
 ; block0:
-;   sllk %r3, %r3, 31
-;   srak %r2, %r3, 31
+;   sllk %r2, %r3, 31
+;   srak %r2, %r2, 31
 ;   br %r14
 
 function %bmask_b1_i8(b1, b1) -> i8 {
@@ -958,8 +958,8 @@ block0(v0: b1, v1: b1):
 }
 
 ; block0:
-;   sllk %r3, %r3, 31
-;   srak %r2, %r3, 31
+;   sllk %r2, %r3, 31
+;   srak %r2, %r2, 31
 ;   br %r14
 
 function %bint_b128_i128(b128) -> i128 {
@@ -1031,9 +1031,9 @@ block0(v0: b64):
 
 ; block0:
 ;   nill %r3, 1
-;   vgbm %v16, 0
-;   vlvgb %v16, %r3, 15
-;   vst %v16, 0(%r2)
+;   vgbm %v7, 0
+;   vlvgb %v7, %r3, 15
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bint_b64_i64(b64) -> i64 {
@@ -1085,9 +1085,9 @@ block0(v0: b32):
 
 ; block0:
 ;   nill %r3, 1
-;   vgbm %v16, 0
-;   vlvgb %v16, %r3, 15
-;   vst %v16, 0(%r2)
+;   vgbm %v7, 0
+;   vlvgb %v7, %r3, 15
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bint_b32_i64(b32) -> i64 {
@@ -1139,9 +1139,9 @@ block0(v0: b16):
 
 ; block0:
 ;   nill %r3, 1
-;   vgbm %v16, 0
-;   vlvgb %v16, %r3, 15
-;   vst %v16, 0(%r2)
+;   vgbm %v7, 0
+;   vlvgb %v7, %r3, 15
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bint_b16_i64(b16) -> i64 {
@@ -1193,9 +1193,9 @@ block0(v0: b8):
 
 ; block0:
 ;   nill %r3, 1
-;   vgbm %v16, 0
-;   vlvgb %v16, %r3, 15
-;   vst %v16, 0(%r2)
+;   vgbm %v7, 0
+;   vlvgb %v7, %r3, 15
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bint_b8_i64(b8) -> i64 {
@@ -1247,9 +1247,9 @@ block0(v0: b1):
 
 ; block0:
 ;   nill %r3, 1
-;   vgbm %v16, 0
-;   vlvgb %v16, %r3, 15
-;   vst %v16, 0(%r2)
+;   vgbm %v7, 0
+;   vlvgb %v7, %r3, 15
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %bint_b1_i64(b1) -> i64 {

--- a/cranelift/filetests/filetests/isa/s390x/div-traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/div-traps.clif
@@ -15,11 +15,11 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lgr %r1, %r2
 ;   cgite %r3, 0
-;   llihf %r5, 2147483647
-;   iilf %r5, 4294967295
-;   xgrk %r4, %r5, %r1
-;   ngrk %r2, %r4, %r3
-;   cgite %r2, -1
+;   llihf %r4, 2147483647
+;   iilf %r4, 4294967295
+;   xgr %r4, %r1
+;   ngrk %r5, %r4, %r3
+;   cgite %r5, -1
 ;   dsgr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
@@ -47,10 +47,10 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lgfr %r1, %r2
 ;   cite %r3, 0
-;   iilf %r5, 2147483647
-;   xrk %r4, %r5, %r1
-;   nrk %r5, %r4, %r3
-;   cite %r5, -1
+;   iilf %r4, 2147483647
+;   xrk %r2, %r4, %r1
+;   nrk %r4, %r2, %r3
+;   cite %r4, -1
 ;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
@@ -77,13 +77,13 @@ block0(v0: i16, v1: i16):
 
 ; block0:
 ;   lghr %r1, %r2
-;   lhr %r4, %r3
-;   cite %r4, 0
-;   lhi %r3, 32767
-;   xrk %r5, %r3, %r1
-;   nrk %r3, %r5, %r4
-;   cite %r3, -1
-;   dsgfr %r0, %r4
+;   lhr %r3, %r3
+;   cite %r3, 0
+;   lhi %r2, 32767
+;   xrk %r4, %r2, %r1
+;   nrk %r2, %r4, %r3
+;   cite %r2, -1
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -109,13 +109,13 @@ block0(v0: i8, v1: i8):
 
 ; block0:
 ;   lgbr %r1, %r2
-;   lbr %r4, %r3
-;   cite %r4, 0
-;   lhi %r3, 127
-;   xrk %r5, %r3, %r1
-;   nrk %r3, %r5, %r4
-;   cite %r3, -1
-;   dsgfr %r0, %r4
+;   lbr %r3, %r3
+;   cite %r3, 0
+;   lhi %r2, 127
+;   xrk %r4, %r2, %r1
+;   nrk %r2, %r4, %r3
+;   cite %r2, -1
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -200,9 +200,9 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   lhi %r0, 0
 ;   llhr %r1, %r2
-;   llhr %r5, %r3
-;   cite %r5, 0
-;   dlr %r0, %r5
+;   llhr %r4, %r3
+;   cite %r4, 0
+;   dlr %r0, %r4
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -230,9 +230,9 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   lhi %r0, 0
 ;   llcr %r1, %r2
-;   llcr %r5, %r3
-;   cite %r5, 0
-;   dlr %r0, %r5
+;   llcr %r4, %r3
+;   cite %r4, 0
+;   dlr %r0, %r4
 ;   lgr %r2, %r1
 ;   br %r14
 
@@ -287,9 +287,9 @@ block0(v0: i16, v1: i16):
 
 ; block0:
 ;   lghr %r1, %r2
-;   lhr %r4, %r3
-;   cite %r4, 0
-;   dsgfr %r0, %r4
+;   lhr %r3, %r3
+;   cite %r3, 0
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -301,9 +301,9 @@ block0(v0: i8, v1: i8):
 
 ; block0:
 ;   lgbr %r1, %r2
-;   lbr %r4, %r3
-;   cite %r4, 0
-;   dsgfr %r0, %r4
+;   lbr %r3, %r3
+;   cite %r3, 0
+;   dsgfr %r0, %r3
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -344,9 +344,9 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   lhi %r0, 0
 ;   llhr %r1, %r2
-;   llhr %r5, %r3
-;   cite %r5, 0
-;   dlr %r0, %r5
+;   llhr %r4, %r3
+;   cite %r4, 0
+;   dlr %r0, %r4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -359,9 +359,9 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   lhi %r0, 0
 ;   llcr %r1, %r2
-;   llcr %r5, %r3
-;   cite %r5, 0
-;   dlr %r0, %r5
+;   llcr %r4, %r3
+;   cite %r4, 0
+;   dlr %r0, %r4
 ;   lgr %r2, %r0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -395,8 +395,8 @@ block0(v0: f32, v1: f32):
 }
 
 ; block0:
-;   bras %r1, 8 ; data.f32 NaN ; le %f5, 0(%r1)
-;   vsel %v0, %v0, %v2, %v5
+;   bras %r1, 8 ; data.f32 NaN ; le %f4, 0(%r1)
+;   vsel %v0, %v0, %v2, %v4
 ;   br %r14
 
 function %fcopysign_f64(f64, f64) -> f64 {
@@ -406,8 +406,8 @@ block0(v0: f64, v1: f64):
 }
 
 ; block0:
-;   bras %r1, 12 ; data.f64 NaN ; ld %f5, 0(%r1)
-;   vsel %v0, %v0, %v2, %v5
+;   bras %r1, 12 ; data.f64 NaN ; ld %f4, 0(%r1)
+;   vsel %v0, %v0, %v2, %v4
 ;   br %r14
 
 function %fcvt_to_uint_f32_i8(f32) -> i8 {

--- a/cranelift/filetests/filetests/isa/s390x/fpmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem.clif
@@ -70,8 +70,8 @@ block0(v0: f64, v1: i64):
 }
 
 ; block0:
-;   lgdr %r3, %f0
-;   strvg %r3, 0(%r2)
+;   lgdr %r5, %f0
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %store_f32_little(f32, i64) {
@@ -81,7 +81,7 @@ block0(v0: f32, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v0, 0
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v0, 0
+;   strv %r5, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/heap_addr.clif
+++ b/cranelift/filetests/filetests/isa/s390x/heap_addr.clif
@@ -12,16 +12,16 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   llgfr %r4, %r3
-;   lg %r5, 0(%r2)
-;   aghi %r5, 0
-;   clgr %r4, %r5
+;   llgfr %r3, %r3
+;   lg %r4, 0(%r2)
+;   aghi %r4, 0
+;   clgr %r3, %r4
 ;   jgnh label1 ; jg label2
 ; block1:
-;   agr %r2, %r4
-;   lghi %r3, 0
-;   clgr %r4, %r5
-;   locgrh %r2, %r3
+;   agr %r2, %r3
+;   lghi %r5, 0
+;   clgr %r3, %r4
+;   locgrh %r2, %r5
 ;   br %r14
 ; block2:
 ;   trap
@@ -36,14 +36,14 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   llgfr %r3, %r3
-;   clgfi %r3, 65536
+;   llgfr %r5, %r3
+;   clgfi %r5, 65536
 ;   jgnh label1 ; jg label2
 ; block1:
-;   agr %r2, %r3
-;   lghi %r4, 0
-;   clgfi %r3, 65536
-;   locgrh %r2, %r4
+;   agr %r2, %r5
+;   lghi %r3, 0
+;   clgfi %r5, 65536
+;   locgrh %r2, %r3
 ;   br %r14
 ; block2:
 ;   trap

--- a/cranelift/filetests/filetests/isa/s390x/icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp.clif
@@ -263,10 +263,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   lhr %r3, %r2
-;   lhr %r5, %r5
-;   cr %r3, %r5
+;   lhr %r2, %r2
+;   lhr %r4, %r3
+;   cr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -293,8 +292,8 @@ block0(v0: i16, v1: i64):
 }
 
 ; block0:
-;   lhr %r4, %r2
-;   ch %r4, 0(%r3)
+;   lhr %r2, %r2
+;   ch %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -322,10 +321,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   lbr %r3, %r2
-;   lbr %r5, %r5
-;   cr %r3, %r5
+;   lbr %r2, %r2
+;   lbr %r4, %r3
+;   cr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -352,10 +350,9 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   lbr %r3, %r2
-;   lb %r5, 0(%r5)
-;   cr %r3, %r5
+;   lbr %r2, %r2
+;   lb %r4, 0(%r3)
+;   cr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -462,8 +459,8 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   llgh %r4, 0(%r3)
-;   clgr %r2, %r4
+;   llgh %r3, 0(%r3)
+;   clgr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -557,8 +554,8 @@ block0(v0: i32, v1: i64):
 }
 
 ; block0:
-;   llh %r4, 0(%r3)
-;   clr %r2, %r4
+;   llh %r3, 0(%r3)
+;   clr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -585,10 +582,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   llhr %r3, %r2
-;   llhr %r5, %r5
-;   clr %r3, %r5
+;   llhr %r2, %r2
+;   llhr %r4, %r3
+;   clr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -615,10 +611,9 @@ block0(v0: i16, v1: i64):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   llhr %r3, %r2
-;   llh %r5, 0(%r5)
-;   clr %r3, %r5
+;   llhr %r2, %r2
+;   llh %r4, 0(%r3)
+;   clr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -646,10 +641,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   llcr %r3, %r2
-;   llcr %r5, %r5
-;   clr %r3, %r5
+;   llcr %r2, %r2
+;   llcr %r4, %r3
+;   clr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -676,10 +670,9 @@ block0(v0: i8, v1: i64):
 }
 
 ; block0:
-;   lgr %r5, %r3
-;   llcr %r3, %r2
-;   llc %r5, 0(%r5)
-;   clr %r3, %r5
+;   llcr %r2, %r2
+;   llc %r4, 0(%r3)
+;   clr %r2, %r4
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -71,29 +71,28 @@ block3(v7: r64, v8: r64):
 ; block0:
 ;   stg %r3, 176(%r15)
 ;   stg %r2, 168(%r15)
-;   bras %r1, 12 ; data %f + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   la %r3, 160(%r15)
-;   lg %r5, 168(%r15)
-;   stg %r5, 0(%r3)
-;   llcr %r3, %r2
-;   chi %r3, 0
+;   bras %r1, 12 ; data %f + 0 ; lg %r3, 0(%r1)
+;   basr %r14, %r3
+;   la %r5, 160(%r15)
+;   lg %r3, 168(%r15)
+;   stg %r3, 0(%r5)
+;   llcr %r2, %r2
+;   chi %r2, 0
 ;   jgnlh label1 ; jg label3
 ; block1:
 ;   jg label2
 ; block2:
-;   lgr %r3, %r5
 ;   lg %r2, 176(%r15)
 ;   jg label5
 ; block3:
 ;   jg label4
 ; block4:
-;   lgr %r2, %r5
+;   lgr %r2, %r3
 ;   lg %r3, 176(%r15)
 ;   jg label5
 ; block5:
-;   la %r5, 160(%r15)
-;   lg %r4, 0(%r5)
+;   la %r4, 160(%r15)
+;   lg %r4, 0(%r4)
 ;   lmg %r14, %r15, 296(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -28,15 +28,15 @@ block0(v0: i128, v1: i64):
 
 ; block0:
 ;   vl %v0, 0(%r3)
-;   vlvgb %v7, %r4, 0
-;   vrepb %v17, %v7, 0
-;   vlcb %v19, %v17
-;   vslb %v21, %v0, %v19
-;   vsl %v23, %v21, %v19
-;   vsrlb %v25, %v0, %v17
-;   vsrl %v27, %v25, %v17
-;   vo %v29, %v23, %v27
-;   vst %v29, 0(%r2)
+;   vlvgb %v6, %r4, 0
+;   vrepb %v16, %v6, 0
+;   vlcb %v18, %v16
+;   vslb %v20, %v0, %v18
+;   vsl %v22, %v20, %v18
+;   vsrlb %v24, %v0, %v16
+;   vsrl %v26, %v24, %v16
+;   vo %v28, %v22, %v26
+;   vst %v28, 0(%r2)
 ;   br %r14
 
 function %rotr_i128_imm(i128) -> i128 {
@@ -153,13 +153,13 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   llhr %r4, %r2
-;   lcr %r5, %r3
+;   llhr %r2, %r2
+;   lcr %r4, %r3
 ;   nill %r3, 15
-;   nill %r5, 15
-;   sllk %r5, %r4, 0(%r5)
-;   srlk %r3, %r4, 0(%r3)
-;   ork %r2, %r5, %r3
+;   nill %r4, 15
+;   sllk %r4, %r2, 0(%r4)
+;   srlk %r2, %r2, 0(%r3)
+;   ork %r2, %r4, %r2
 ;   br %r14
 
 function %rotr_i16_imm(i16) -> i16 {
@@ -201,13 +201,13 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   llcr %r4, %r2
-;   lcr %r5, %r3
+;   llcr %r2, %r2
+;   lcr %r4, %r3
 ;   nill %r3, 7
-;   nill %r5, 7
-;   sllk %r5, %r4, 0(%r5)
-;   srlk %r3, %r4, 0(%r3)
-;   ork %r2, %r5, %r3
+;   nill %r4, 7
+;   sllk %r4, %r2, 0(%r4)
+;   srlk %r2, %r2, 0(%r3)
+;   ork %r2, %r4, %r2
 ;   br %r14
 
 function %rotr_i8_imm(i8) -> i8 {
@@ -251,15 +251,15 @@ block0(v0: i128, v1: i64):
 
 ; block0:
 ;   vl %v0, 0(%r3)
-;   vlvgb %v7, %r4, 0
-;   vrepb %v17, %v7, 0
-;   vlcb %v19, %v17
-;   vslb %v21, %v0, %v17
-;   vsl %v23, %v21, %v17
-;   vsrlb %v25, %v0, %v19
-;   vsrl %v27, %v25, %v19
-;   vo %v29, %v23, %v27
-;   vst %v29, 0(%r2)
+;   vlvgb %v6, %r4, 0
+;   vrepb %v16, %v6, 0
+;   vlcb %v18, %v16
+;   vslb %v20, %v0, %v16
+;   vsl %v22, %v20, %v16
+;   vsrlb %v24, %v0, %v18
+;   vsrl %v26, %v24, %v18
+;   vo %v28, %v22, %v26
+;   vst %v28, 0(%r2)
 ;   br %r14
 
 function %rotl_i128_imm(i128) -> i128 {
@@ -372,13 +372,13 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   llhr %r4, %r2
-;   lcr %r5, %r3
+;   llhr %r2, %r2
+;   lcr %r4, %r3
 ;   nill %r3, 15
-;   nill %r5, 15
-;   sllk %r2, %r4, 0(%r3)
-;   srlk %r3, %r4, 0(%r5)
-;   or %r2, %r3
+;   nill %r4, 15
+;   sllk %r5, %r2, 0(%r3)
+;   srlk %r2, %r2, 0(%r4)
+;   ork %r2, %r5, %r2
 ;   br %r14
 
 function %rotl_i16_imm(i16) -> i16 {
@@ -420,13 +420,13 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   llcr %r4, %r2
-;   lcr %r5, %r3
+;   llcr %r2, %r2
+;   lcr %r4, %r3
 ;   nill %r3, 7
-;   nill %r5, 7
-;   sllk %r2, %r4, 0(%r3)
-;   srlk %r3, %r4, 0(%r5)
-;   or %r2, %r3
+;   nill %r4, 7
+;   sllk %r5, %r2, 0(%r3)
+;   srlk %r2, %r2, 0(%r4)
+;   ork %r2, %r5, %r2
 ;   br %r14
 
 function %rotr_i8_imm(i8) -> i8 {
@@ -466,11 +466,11 @@ block0(v0: i128, v1: i64):
 
 ; block0:
 ;   vl %v0, 0(%r3)
-;   vlvgb %v7, %r4, 0
-;   vrepb %v17, %v7, 0
-;   vsrlb %v19, %v0, %v17
-;   vsrl %v21, %v19, %v17
-;   vst %v21, 0(%r2)
+;   vlvgb %v6, %r4, 0
+;   vrepb %v16, %v6, 0
+;   vsrlb %v18, %v0, %v16
+;   vsrl %v20, %v18, %v16
+;   vst %v20, 0(%r2)
 ;   br %r14
 
 function %ushr_i128_imm(i128) -> i128 {
@@ -577,9 +577,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   llhr %r4, %r2
+;   llhr %r2, %r2
 ;   nill %r3, 15
-;   srlk %r2, %r4, 0(%r3)
+;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ushr_i16_imm(i16) -> i16 {
@@ -615,9 +615,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   llcr %r4, %r2
+;   llcr %r2, %r2
 ;   nill %r3, 7
-;   srlk %r2, %r4, 0(%r3)
+;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ushr_i8_imm(i8) -> i8 {
@@ -655,11 +655,11 @@ block0(v0: i128, v1: i64):
 
 ; block0:
 ;   vl %v0, 0(%r3)
-;   vlvgb %v7, %r4, 0
-;   vrepb %v17, %v7, 0
-;   vslb %v19, %v0, %v17
-;   vsl %v21, %v19, %v17
-;   vst %v21, 0(%r2)
+;   vlvgb %v6, %r4, 0
+;   vrepb %v16, %v6, 0
+;   vslb %v18, %v0, %v16
+;   vsl %v20, %v18, %v16
+;   vst %v20, 0(%r2)
 ;   br %r14
 
 function %ishl_i128_imm(i128) -> i128 {
@@ -838,11 +838,11 @@ block0(v0: i128, v1: i64):
 
 ; block0:
 ;   vl %v0, 0(%r3)
-;   vlvgb %v7, %r4, 0
-;   vrepb %v17, %v7, 0
-;   vsrab %v19, %v0, %v17
-;   vsra %v21, %v19, %v17
-;   vst %v21, 0(%r2)
+;   vlvgb %v6, %r4, 0
+;   vrepb %v16, %v6, 0
+;   vsrab %v18, %v0, %v16
+;   vsra %v20, %v18, %v16
+;   vst %v20, 0(%r2)
 ;   br %r14
 
 function %sshr_i128_imm(i128) -> i128 {
@@ -949,9 +949,9 @@ block0(v0: i16, v1: i16):
 }
 
 ; block0:
-;   lhr %r4, %r2
+;   lhr %r2, %r2
 ;   nill %r3, 15
-;   srak %r2, %r4, 0(%r3)
+;   srak %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %sshr_i16_imm(i16) -> i16 {
@@ -987,9 +987,9 @@ block0(v0: i8, v1: i8):
 }
 
 ; block0:
-;   lbr %r4, %r2
+;   lbr %r2, %r2
 ;   nill %r3, 7
-;   srak %r2, %r4, 0(%r3)
+;   srak %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %sshr_i8_imm(i8) -> i8 {

--- a/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
@@ -20,9 +20,9 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   llc %r5, 0(%r3)
-;   llc %r2, 0(%r2)
-;   ark %r2, %r5, %r2
+;   llc %r4, 0(%r3)
+;   llc %r5, 0(%r2)
+;   ark %r2, %r4, %r5
 ;   br %r14
 
 function u0:2(i64) -> i8 system_v {
@@ -70,9 +70,9 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   llc %r5, 0(%r2)
-;   llc %r2, 0(%r3)
-;   ark %r2, %r5, %r2
+;   llc %r4, 0(%r2)
+;   llc %r5, 0(%r3)
+;   ark %r2, %r4, %r5
 ;   br %r14
 
 function u0:5(i64, i64, i64) -> i8 system_v {

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -13,8 +13,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
 ; block0:
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r3, 0(%r1)
-;   basr %r14, %r3
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
 
@@ -39,19 +39,19 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   std %f15, 216(%r15)
 ; block0:
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v20, %v25, %v25, 4
-;   verllg %v25, %v20, 32
-;   vpdi %v26, %v26, %v26, 4
-;   verllg %v28, %v26, 32
-;   verllf %v26, %v28, 16
-;   vpdi %v0, %v27, %v27, 4
-;   verllg %v2, %v0, 32
-;   verllf %v4, %v2, 16
-;   verllh %v27, %v4, 8
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r3, 0(%r1)
-;   basr %r14, %r3
-;   vpdi %v22, %v24, %v24, 4
-;   verllg %v24, %v22, 32
+;   vpdi %v17, %v25, %v25, 4
+;   verllg %v25, %v17, 32
+;   vpdi %v22, %v26, %v26, 4
+;   verllg %v26, %v22, 32
+;   verllf %v26, %v26, 16
+;   vpdi %v29, %v27, %v27, 4
+;   verllg %v31, %v29, 32
+;   verllf %v1, %v31, 16
+;   verllh %v27, %v1, 8
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v19, %v24, %v24, 4
+;   verllg %v24, %v19, 32
 ;   ld %f8, 160(%r15)
 ;   ld %f9, 168(%r15)
 ;   ld %f10, 176(%r15)
@@ -84,19 +84,19 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   std %f15, 216(%r15)
 ; block0:
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v20, %v25, %v25, 4
-;   verllg %v25, %v20, 32
-;   vpdi %v26, %v26, %v26, 4
-;   verllg %v28, %v26, 32
-;   verllf %v26, %v28, 16
-;   vpdi %v0, %v27, %v27, 4
-;   verllg %v2, %v0, 32
-;   verllf %v4, %v2, 16
-;   verllh %v27, %v4, 8
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r3, 0(%r1)
-;   basr %r14, %r3
-;   vpdi %v22, %v24, %v24, 4
-;   verllg %v24, %v22, 32
+;   vpdi %v17, %v25, %v25, 4
+;   verllg %v25, %v17, 32
+;   vpdi %v22, %v26, %v26, 4
+;   verllg %v26, %v22, 32
+;   verllf %v26, %v26, 16
+;   vpdi %v29, %v27, %v27, 4
+;   verllg %v31, %v29, 32
+;   verllf %v1, %v31, 16
+;   verllh %v27, %v1, 8
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v19, %v24, %v24, 4
+;   verllg %v24, %v19, 32
 ;   ld %f8, 160(%r15)
 ;   ld %f9, 168(%r15)
 ;   ld %f10, 176(%r15)
@@ -120,8 +120,8 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
 ; block0:
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r3, 0(%r1)
-;   basr %r14, %r3
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
@@ -368,9 +368,9 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vag %v5, %v24, %v25
-;   vchlg %v7, %v24, %v5
-;   vo %v24, %v5, %v7
+;   vag %v4, %v24, %v25
+;   vchlg %v6, %v24, %v4
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %uadd_sat32x4(i32x4, i32x4) -> i32x4 {
@@ -380,9 +380,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vaf %v5, %v24, %v25
-;   vchlf %v7, %v24, %v5
-;   vo %v24, %v5, %v7
+;   vaf %v4, %v24, %v25
+;   vchlf %v6, %v24, %v4
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %uadd_sat16x8(i16x8, i16x8) -> i16x8 {
@@ -392,9 +392,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vah %v5, %v24, %v25
-;   vchlh %v7, %v24, %v5
-;   vo %v24, %v5, %v7
+;   vah %v4, %v24, %v25
+;   vchlh %v6, %v24, %v4
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %uadd_sat8x16(i8x16, i8x16) -> i8x16 {
@@ -404,9 +404,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vab %v5, %v24, %v25
-;   vchlb %v7, %v24, %v5
-;   vo %v24, %v5, %v7
+;   vab %v4, %v24, %v25
+;   vchlb %v6, %v24, %v4
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %sadd_sat32x4(i32x4, i32x4) -> i32x4 {
@@ -416,13 +416,13 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vuphf %v5, %v24
-;   vuphf %v7, %v25
-;   vag %v17, %v5, %v7
-;   vuplf %v19, %v24
-;   vuplf %v21, %v25
-;   vag %v23, %v19, %v21
-;   vpksg %v24, %v17, %v23
+;   vuphf %v4, %v24
+;   vuphf %v6, %v25
+;   vag %v16, %v4, %v6
+;   vuplf %v18, %v24
+;   vuplf %v20, %v25
+;   vag %v22, %v18, %v20
+;   vpksg %v24, %v16, %v22
 ;   br %r14
 
 function %sadd_sat16x8(i16x8, i16x8) -> i16x8 {
@@ -432,13 +432,13 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vuphh %v5, %v24
-;   vuphh %v7, %v25
-;   vaf %v17, %v5, %v7
-;   vuplh %v19, %v24
-;   vuplh %v21, %v25
-;   vaf %v23, %v19, %v21
-;   vpksf %v24, %v17, %v23
+;   vuphh %v4, %v24
+;   vuphh %v6, %v25
+;   vaf %v16, %v4, %v6
+;   vuplh %v18, %v24
+;   vuplh %v20, %v25
+;   vaf %v22, %v18, %v20
+;   vpksf %v24, %v16, %v22
 ;   br %r14
 
 function %sadd_sat8x16(i8x16, i8x16) -> i8x16 {
@@ -448,13 +448,13 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vuphb %v5, %v24
-;   vuphb %v7, %v25
-;   vah %v17, %v5, %v7
-;   vuplb %v19, %v24
-;   vuplb %v21, %v25
-;   vah %v23, %v19, %v21
-;   vpksh %v24, %v17, %v23
+;   vuphb %v4, %v24
+;   vuphb %v6, %v25
+;   vah %v16, %v4, %v6
+;   vuplb %v18, %v24
+;   vuplb %v20, %v25
+;   vah %v22, %v18, %v20
+;   vpksh %v24, %v16, %v22
 ;   br %r14
 
 function %usub_sat64x2(i64x2, i64x2) -> i64x2 {
@@ -464,9 +464,9 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vsg %v5, %v24, %v25
-;   vchlg %v7, %v24, %v25
-;   vn %v24, %v5, %v7
+;   vsg %v4, %v24, %v25
+;   vchlg %v6, %v24, %v25
+;   vn %v24, %v4, %v6
 ;   br %r14
 
 function %usub_sat32x4(i32x4, i32x4) -> i32x4 {
@@ -476,9 +476,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vsf %v5, %v24, %v25
-;   vchlf %v7, %v24, %v25
-;   vn %v24, %v5, %v7
+;   vsf %v4, %v24, %v25
+;   vchlf %v6, %v24, %v25
+;   vn %v24, %v4, %v6
 ;   br %r14
 
 function %usub_sat16x8(i16x8, i16x8) -> i16x8 {
@@ -488,9 +488,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vsh %v5, %v24, %v25
-;   vchlh %v7, %v24, %v25
-;   vn %v24, %v5, %v7
+;   vsh %v4, %v24, %v25
+;   vchlh %v6, %v24, %v25
+;   vn %v24, %v4, %v6
 ;   br %r14
 
 function %usub_sat8x16(i8x16, i8x16) -> i8x16 {
@@ -500,9 +500,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vsb %v5, %v24, %v25
-;   vchlb %v7, %v24, %v25
-;   vn %v24, %v5, %v7
+;   vsb %v4, %v24, %v25
+;   vchlb %v6, %v24, %v25
+;   vn %v24, %v4, %v6
 ;   br %r14
 
 function %ssub_sat32x4(i32x4, i32x4) -> i32x4 {
@@ -512,13 +512,13 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vuphf %v5, %v24
-;   vuphf %v7, %v25
-;   vsg %v17, %v5, %v7
-;   vuplf %v19, %v24
-;   vuplf %v21, %v25
-;   vsg %v23, %v19, %v21
-;   vpksg %v24, %v17, %v23
+;   vuphf %v4, %v24
+;   vuphf %v6, %v25
+;   vsg %v16, %v4, %v6
+;   vuplf %v18, %v24
+;   vuplf %v20, %v25
+;   vsg %v22, %v18, %v20
+;   vpksg %v24, %v16, %v22
 ;   br %r14
 
 function %ssub_sat16x8(i16x8, i16x8) -> i16x8 {
@@ -528,13 +528,13 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vuphh %v5, %v24
-;   vuphh %v7, %v25
-;   vsf %v17, %v5, %v7
-;   vuplh %v19, %v24
-;   vuplh %v21, %v25
-;   vsf %v23, %v19, %v21
-;   vpksf %v24, %v17, %v23
+;   vuphh %v4, %v24
+;   vuphh %v6, %v25
+;   vsf %v16, %v4, %v6
+;   vuplh %v18, %v24
+;   vuplh %v20, %v25
+;   vsf %v22, %v18, %v20
+;   vpksf %v24, %v16, %v22
 ;   br %r14
 
 function %ssub_sat8x16(i8x16, i8x16) -> i8x16 {
@@ -544,13 +544,13 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vuphb %v5, %v24
-;   vuphb %v7, %v25
-;   vsh %v17, %v5, %v7
-;   vuplb %v19, %v24
-;   vuplb %v21, %v25
-;   vsh %v23, %v19, %v21
-;   vpksh %v24, %v17, %v23
+;   vuphb %v4, %v24
+;   vuphb %v6, %v25
+;   vsh %v16, %v4, %v6
+;   vuplb %v18, %v24
+;   vuplb %v20, %v25
+;   vsh %v22, %v18, %v20
+;   vpksh %v24, %v16, %v22
 ;   br %r14
 
 function %iadd_pairwise_i32x4_be(i32x4, i32x4) -> i32x4 {
@@ -560,12 +560,12 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepib %v5, 32
-;   vsrlb %v7, %v24, %v5
-;   vaf %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vaf %v21, %v25, %v19
-;   vpkg %v24, %v17, %v21
+;   vrepib %v4, 32
+;   vsrlb %v6, %v24, %v4
+;   vaf %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vaf %v20, %v25, %v18
+;   vpkg %v24, %v16, %v20
 ;   br %r14
 
 function %iadd_pairwise_i16x8_be(i16x8, i16x8) -> i16x8 {
@@ -575,12 +575,12 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vrepib %v5, 16
-;   vsrlb %v7, %v24, %v5
-;   vah %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vah %v21, %v25, %v19
-;   vpkf %v24, %v17, %v21
+;   vrepib %v4, 16
+;   vsrlb %v6, %v24, %v4
+;   vah %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vah %v20, %v25, %v18
+;   vpkf %v24, %v16, %v20
 ;   br %r14
 
 function %iadd_pairwise_i8x16_be(i8x16, i8x16) -> i8x16 {
@@ -590,12 +590,12 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepib %v5, 8
-;   vsrlb %v7, %v24, %v5
-;   vab %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vab %v21, %v25, %v19
-;   vpkh %v24, %v17, %v21
+;   vrepib %v4, 8
+;   vsrlb %v6, %v24, %v4
+;   vab %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vab %v20, %v25, %v18
+;   vpkh %v24, %v16, %v20
 ;   br %r14
 
 function %iadd_pairwise_i32x4_le(i32x4, i32x4) -> i32x4 wasmtime_system_v {
@@ -605,12 +605,12 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepib %v5, 32
-;   vsrlb %v7, %v24, %v5
-;   vaf %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vaf %v21, %v25, %v19
-;   vpkg %v24, %v21, %v17
+;   vrepib %v4, 32
+;   vsrlb %v6, %v24, %v4
+;   vaf %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vaf %v20, %v25, %v18
+;   vpkg %v24, %v20, %v16
 ;   br %r14
 
 function %iadd_pairwise_i16x8_le(i16x8, i16x8) -> i16x8 wasmtime_system_v {
@@ -620,12 +620,12 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vrepib %v5, 16
-;   vsrlb %v7, %v24, %v5
-;   vah %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vah %v21, %v25, %v19
-;   vpkf %v24, %v21, %v17
+;   vrepib %v4, 16
+;   vsrlb %v6, %v24, %v4
+;   vah %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vah %v20, %v25, %v18
+;   vpkf %v24, %v20, %v16
 ;   br %r14
 
 function %iadd_pairwise_i8x16_le(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -635,12 +635,12 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepib %v5, 8
-;   vsrlb %v7, %v24, %v5
-;   vab %v17, %v24, %v7
-;   vsrlb %v19, %v25, %v5
-;   vab %v21, %v25, %v19
-;   vpkh %v24, %v21, %v17
+;   vrepib %v4, 8
+;   vsrlb %v6, %v24, %v4
+;   vab %v16, %v24, %v6
+;   vsrlb %v18, %v25, %v4
+;   vab %v20, %v25, %v18
+;   vpkh %v24, %v20, %v16
 ;   br %r14
 
 function %imul_i64x2(i64x2, i64x2) -> i64x2 {
@@ -650,13 +650,13 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   vlgvg %r5, %v25, 0
-;   msgr %r3, %r5
-;   vlgvg %r5, %v24, 1
-;   vlgvg %r4, %v25, 1
-;   msgr %r5, %r4
-;   vlvgp %v24, %r3, %r5
+;   vlgvg %r2, %v24, 0
+;   vlgvg %r4, %v25, 0
+;   msgr %r2, %r4
+;   vlgvg %r4, %v24, 1
+;   vlgvg %r3, %v25, 1
+;   msgr %r4, %r3
+;   vlvgp %v24, %r2, %r4
 ;   br %r14
 
 function %imul_i32x4(i32x4, i32x4) -> i32x4 {
@@ -696,14 +696,14 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
+;   vlgvg %r2, %v24, 0
 ;   vlgvg %r1, %v25, 0
-;   mlgr %r0, %r3
-;   lgr %r2, %r0
-;   vlgvg %r3, %v24, 1
+;   mlgr %r0, %r2
+;   lgr %r3, %r0
+;   vlgvg %r2, %v24, 1
 ;   vlgvg %r1, %v25, 1
-;   mlgr %r0, %r3
-;   vlvgp %v24, %r2, %r0
+;   mlgr %r0, %r2
+;   vlvgp %v24, %r3, %r0
 ;   br %r14
 
 function %umulhi_i32x4(i32x4, i32x4) -> i32x4 {
@@ -743,15 +743,15 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   vlgvg %r5, %v25, 0
-;   mgrk %r0, %r3, %r5
-;   lgr %r3, %r0
-;   vlgvg %r2, %v24, 1
-;   vlgvg %r4, %v25, 1
+;   vlgvg %r2, %v24, 0
+;   vlgvg %r4, %v25, 0
 ;   mgrk %r0, %r2, %r4
-;   lgr %r4, %r3
-;   vlvgp %v24, %r4, %r0
+;   lgr %r2, %r0
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v25, 1
+;   mgrk %r0, %r5, %r3
+;   lgr %r5, %r2
+;   vlvgp %v24, %r5, %r0
 ;   br %r14
 
 function %smulhi_i32x4(i32x4, i32x4) -> i32x4 {
@@ -791,9 +791,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vmeh %v5, %v24, %v25
-;   vmoh %v7, %v24, %v25
-;   vaf %v24, %v5, %v7
+;   vmeh %v4, %v24, %v25
+;   vmoh %v6, %v24, %v25
+;   vaf %v24, %v4, %v6
 ;   br %r14
 
 function %sqmul_round_sat(i16x8, i16x8) -> i16x8 {
@@ -803,19 +803,19 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vuphh %v5, %v24
-;   vuphh %v7, %v25
-;   vmlf %v17, %v5, %v7
-;   vgmf %v19, 17, 17
-;   vaf %v21, %v17, %v19
-;   vesraf %v23, %v21, 15
-;   vuplh %v26, %v24
-;   vuplh %v27, %v25
-;   vmlf %v29, %v26, %v27
-;   vgmf %v31, 17, 17
-;   vaf %v1, %v29, %v31
-;   vesraf %v3, %v1, 15
-;   vpksf %v24, %v23, %v3
+;   vuphh %v4, %v24
+;   vuphh %v6, %v25
+;   vmlf %v16, %v4, %v6
+;   vgmf %v18, 17, 17
+;   vaf %v20, %v16, %v18
+;   vesraf %v22, %v20, 15
+;   vuplh %v24, %v24
+;   vuplh %v26, %v25
+;   vmlf %v28, %v24, %v26
+;   vgmf %v30, 17, 17
+;   vaf %v0, %v28, %v30
+;   vesraf %v2, %v0, 15
+;   vpksf %v24, %v22, %v2
 ;   br %r14
 
 function %sqmul_round_sat(i32x4, i32x4) -> i32x4 {
@@ -825,30 +825,30 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vuphf %v5, %v24
-;   vuphf %v7, %v25
-;   lgdr %r3, %f5
-;   lgdr %r5, %f7
-;   msgr %r3, %r5
-;   vlgvg %r5, %v5, 1
-;   vlgvg %r4, %v7, 1
-;   msgr %r5, %r4
-;   vlvgp %v29, %r3, %r5
-;   vgmg %v31, 33, 33
-;   vag %v1, %v29, %v31
-;   vesrag %v3, %v1, 31
-;   vuplf %v5, %v24
-;   vuplf %v7, %v25
-;   lgdr %r3, %f5
-;   lgdr %r5, %f7
-;   msgr %r3, %r5
-;   vlgvg %r5, %v5, 1
-;   vlgvg %r4, %v7, 1
-;   msgr %r5, %r4
-;   vlvgp %v29, %r3, %r5
-;   vgmg %v31, 33, 33
-;   vag %v1, %v29, %v31
-;   vesrag %v4, %v1, 31
-;   vpksg %v24, %v3, %v4
+;   vuphf %v4, %v24
+;   vuphf %v6, %v25
+;   lgdr %r2, %f4
+;   lgdr %r4, %f6
+;   msgr %r2, %r4
+;   vlgvg %r4, %v4, 1
+;   vlgvg %r3, %v6, 1
+;   msgr %r4, %r3
+;   vlvgp %v28, %r2, %r4
+;   vgmg %v30, 33, 33
+;   vag %v0, %v28, %v30
+;   vesrag %v2, %v0, 31
+;   vuplf %v4, %v24
+;   vuplf %v6, %v25
+;   lgdr %r2, %f4
+;   lgdr %r4, %f6
+;   msgr %r2, %r4
+;   vlgvg %r4, %v4, 1
+;   vlgvg %r3, %v6, 1
+;   msgr %r4, %r3
+;   vlvgp %v28, %r2, %r4
+;   vgmg %v30, 33, 33
+;   vag %v0, %v28, %v30
+;   vesrag %v3, %v0, 31
+;   vpksg %v24, %v2, %v3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
@@ -38,10 +38,10 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxg %v7, %v24, %v5
-;   vmxg %v17, %v25, %v5
-;   vpklsg %v24, %v17, %v7
+;   vgbm %v4, 0
+;   vmxg %v6, %v24, %v4
+;   vmxg %v16, %v25, %v4
+;   vpklsg %v24, %v16, %v6
 ;   br %r14
 
 function %unarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 wasmtime_system_v {
@@ -51,10 +51,10 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxf %v7, %v24, %v5
-;   vmxf %v17, %v25, %v5
-;   vpklsf %v24, %v17, %v7
+;   vgbm %v4, 0
+;   vmxf %v6, %v24, %v4
+;   vmxf %v16, %v25, %v4
+;   vpklsf %v24, %v16, %v6
 ;   br %r14
 
 function %unarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 wasmtime_system_v {
@@ -64,10 +64,10 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxh %v7, %v24, %v5
-;   vmxh %v17, %v25, %v5
-;   vpklsh %v24, %v17, %v7
+;   vgbm %v4, 0
+;   vmxh %v6, %v24, %v4
+;   vmxh %v16, %v25, %v4
+;   vpklsh %v24, %v16, %v6
 ;   br %r14
 
 function %uunarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 wasmtime_system_v {

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
@@ -38,10 +38,10 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxg %v7, %v24, %v5
-;   vmxg %v17, %v25, %v5
-;   vpklsg %v24, %v7, %v17
+;   vgbm %v4, 0
+;   vmxg %v6, %v24, %v4
+;   vmxg %v16, %v25, %v4
+;   vpklsg %v24, %v6, %v16
 ;   br %r14
 
 function %unarrow_i32x4_i16x8(i32x4, i32x4) -> i16x8 {
@@ -51,10 +51,10 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxf %v7, %v24, %v5
-;   vmxf %v17, %v25, %v5
-;   vpklsf %v24, %v7, %v17
+;   vgbm %v4, 0
+;   vmxf %v6, %v24, %v4
+;   vmxf %v16, %v25, %v4
+;   vpklsf %v24, %v6, %v16
 ;   br %r14
 
 function %unarrow_i16x8_i8x16(i16x8, i16x8) -> i8x16 {
@@ -64,10 +64,10 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vmxh %v7, %v24, %v5
-;   vmxh %v17, %v25, %v5
-;   vpklsh %v24, %v7, %v17
+;   vgbm %v4, 0
+;   vmxh %v6, %v24, %v4
+;   vmxh %v16, %v25, %v4
+;   vpklsh %v24, %v6, %v16
 ;   br %r14
 
 function %uunarrow_i64x2_i32x4(i64x2, i64x2) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
@@ -18,8 +18,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfcedb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfcedb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_gt_f64x2(f64x2, f64x2) -> b64x2 {
@@ -69,9 +69,9 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdb %v5, %v24, %v25
-;   vfchdb %v7, %v25, %v24
-;   vno %v24, %v5, %v7
+;   vfchdb %v4, %v24, %v25
+;   vfchdb %v6, %v25, %v24
+;   vno %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_one_f64x2(f64x2, f64x2) -> b64x2 {
@@ -81,9 +81,9 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdb %v5, %v24, %v25
-;   vfchdb %v7, %v25, %v24
-;   vo %v24, %v5, %v7
+;   vfchdb %v4, %v24, %v25
+;   vfchdb %v6, %v25, %v24
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_ugt_f64x2(f64x2, f64x2) -> b64x2 {
@@ -93,8 +93,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vfchedb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ult_f64x2(f64x2, f64x2) -> b64x2 {
@@ -104,8 +104,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfchedb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_uge_f64x2(f64x2, f64x2) -> b64x2 {
@@ -115,8 +115,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vfchdb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ule_f64x2(f64x2, f64x2) -> b64x2 {
@@ -126,8 +126,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfchdb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ord_f64x2(f64x2, f64x2) -> b64x2 {
@@ -137,9 +137,9 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedb %v5, %v24, %v25
-;   vfchedb %v7, %v25, %v24
-;   vo %v24, %v5, %v7
+;   vfchedb %v4, %v24, %v25
+;   vfchedb %v6, %v25, %v24
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_uno_f64x2(f64x2, f64x2) -> b64x2 {
@@ -149,9 +149,9 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedb %v5, %v24, %v25
-;   vfchedb %v7, %v25, %v24
-;   vno %v24, %v5, %v7
+;   vfchedb %v4, %v24, %v25
+;   vfchedb %v6, %v25, %v24
+;   vno %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_eq_f32x4(f32x4, f32x4) -> b32x4 {
@@ -171,8 +171,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfcesb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfcesb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_gt_f32x4(f32x4, f32x4) -> b32x4 {
@@ -222,9 +222,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchsb %v5, %v24, %v25
-;   vfchsb %v7, %v25, %v24
-;   vno %v24, %v5, %v7
+;   vfchsb %v4, %v24, %v25
+;   vfchsb %v6, %v25, %v24
+;   vno %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_one_f32x4(f32x4, f32x4) -> b32x4 {
@@ -234,9 +234,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchsb %v5, %v24, %v25
-;   vfchsb %v7, %v25, %v24
-;   vo %v24, %v5, %v7
+;   vfchsb %v4, %v24, %v25
+;   vfchsb %v6, %v25, %v24
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_ugt_f32x4(f32x4, f32x4) -> b32x4 {
@@ -246,8 +246,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchesb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vfchesb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ult_f32x4(f32x4, f32x4) -> b32x4 {
@@ -257,8 +257,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchesb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfchesb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_uge_f32x4(f32x4, f32x4) -> b32x4 {
@@ -268,8 +268,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchsb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vfchsb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ule_f32x4(f32x4, f32x4) -> b32x4 {
@@ -279,8 +279,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchsb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vfchsb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %fcmp_ord_f32x4(f32x4, f32x4) -> b32x4 {
@@ -290,9 +290,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchesb %v5, %v24, %v25
-;   vfchesb %v7, %v25, %v24
-;   vo %v24, %v5, %v7
+;   vfchesb %v4, %v24, %v25
+;   vfchesb %v6, %v25, %v24
+;   vo %v24, %v4, %v6
 ;   br %r14
 
 function %fcmp_uno_f32x4(f32x4, f32x4) -> b32x4 {
@@ -302,8 +302,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vfchesb %v5, %v24, %v25
-;   vfchesb %v7, %v25, %v24
-;   vno %v24, %v5, %v7
+;   vfchesb %v4, %v24, %v25
+;   vfchesb %v6, %v25, %v24
+;   vno %v24, %v4, %v6
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
@@ -436,8 +436,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vgmf %v5, 1, 31
-;   vsel %v24, %v24, %v25, %v5
+;   vgmf %v4, 1, 31
+;   vsel %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %fcopysign_f64x2(f64x2, f64x2) -> f64x2 {
@@ -447,8 +447,8 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vgmg %v5, 1, 63
-;   vsel %v24, %v24, %v25, %v5
+;   vgmg %v4, 1, 63
+;   vsel %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %fcvt_from_uint_i32x4_f32x4(i32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
@@ -18,8 +18,8 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vceqg %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vceqg %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sgt_i64x2(i64x2, i64x2) -> b64x2 {
@@ -49,8 +49,8 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchg %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchg %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sle_i64x2(i64x2, i64x2) -> b64x2 {
@@ -60,8 +60,8 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchg %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchg %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ugt_i64x2(i64x2, i64x2) -> b64x2 {
@@ -91,8 +91,8 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlg %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchlg %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ule_i64x2(i64x2, i64x2) -> b64x2 {
@@ -102,8 +102,8 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlg %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchlg %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_eq_i32x4(i32x4, i32x4) -> b32x4 {
@@ -123,8 +123,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vceqf %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vceqf %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sgt_i32x4(i32x4, i32x4) -> b32x4 {
@@ -154,8 +154,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vchf %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchf %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sle_i32x4(i32x4, i32x4) -> b32x4 {
@@ -165,8 +165,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vchf %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchf %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ugt_i32x4(i32x4, i32x4) -> b32x4 {
@@ -196,8 +196,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vchlf %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchlf %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ule_i32x4(i32x4, i32x4) -> b32x4 {
@@ -207,8 +207,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vchlf %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchlf %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_eq_i16x8(i16x8, i16x8) -> b16x8 {
@@ -228,8 +228,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vceqh %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vceqh %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sgt_i16x8(i16x8, i16x8) -> b16x8 {
@@ -259,8 +259,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vchh %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchh %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sle_i16x8(i16x8, i16x8) -> b16x8 {
@@ -270,8 +270,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vchh %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchh %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ugt_i16x8(i16x8, i16x8) -> b16x8 {
@@ -301,8 +301,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vchlh %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchlh %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ule_i16x8(i16x8, i16x8) -> b16x8 {
@@ -312,8 +312,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vchlh %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchlh %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_eq_i8x16(i8x16, i8x16) -> b8x16 {
@@ -333,8 +333,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vceqb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vceqb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sgt_i8x16(i8x16, i8x16) -> b8x16 {
@@ -364,8 +364,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vchb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_sle_i8x16(i8x16, i8x16) -> b8x16 {
@@ -375,8 +375,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vchb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ugt_i8x16(i8x16, i8x16) -> b8x16 {
@@ -406,8 +406,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vchlb %v5, %v25, %v24
-;   vno %v24, %v5, %v5
+;   vchlb %v4, %v25, %v24
+;   vno %v24, %v4, %v4
 ;   br %r14
 
 function %icmp_ule_i8x16(i8x16, i8x16) -> b8x16 {
@@ -417,7 +417,7 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vchlb %v5, %v24, %v25
-;   vno %v24, %v5, %v5
+;   vchlb %v4, %v24, %v25
+;   vno %v24, %v4, %v4
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
@@ -117,8 +117,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 1
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
 ;   br %r14
 
 function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 wasmtime_system_v {
@@ -129,8 +129,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i32x4_0(i32x4, i32) -> i32x4 wasmtime_system_v {
@@ -183,8 +183,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 15
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 15
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i32x4_lane_0_3(i32x4, i32x4) -> i32x4 wasmtime_system_v {
@@ -195,9 +195,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 3
-;   vgbm %v7, 61440
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 3
+;   vgbm %v6, 61440
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i32x4_lane_3_0(i32x4, i32x4) -> i32x4 wasmtime_system_v {
@@ -208,9 +208,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i32x4_lane_3_3(i32x4, i32x4) -> i32x4 wasmtime_system_v {
@@ -221,8 +221,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -255,8 +255,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 3
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -267,8 +267,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i16x8_0(i16x8, i16) -> i16x8 wasmtime_system_v {
@@ -321,8 +321,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 3
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 3
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i16x8_lane_0_7(i16x8, i16x8) -> i16x8 wasmtime_system_v {
@@ -333,9 +333,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vreph %v5, %v25, 7
-;   vgbm %v7, 49152
-;   vsel %v24, %v5, %v24, %v7
+;   vreph %v4, %v25, 7
+;   vgbm %v6, 49152
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i16x8_lane_7_0(i16x8, i16x8) -> i16x8 wasmtime_system_v {
@@ -346,9 +346,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vreph %v5, %v25, 0
-;   vgbm %v7, 3
-;   vsel %v24, %v5, %v24, %v7
+;   vreph %v4, %v25, 0
+;   vgbm %v6, 3
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i16x8_lane_7_7(i16x8, i16x8) -> i16x8 wasmtime_system_v {
@@ -359,8 +359,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 49152
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 49152
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 wasmtime_system_v {
@@ -393,8 +393,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   lrvh %r3, 0(%r2)
-;   vlvgh %v24, %r3, 7
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 7
 ;   br %r14
 
 function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 wasmtime_system_v {
@@ -405,8 +405,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   lrvh %r3, 0(%r2)
-;   vlvgh %v24, %r3, 0
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i8x16_0(i8x16, i8) -> i8x16 wasmtime_system_v {
@@ -459,8 +459,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 1
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 1
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i8x16_lane_0_15(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -471,9 +471,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepb %v5, %v25, 15
-;   vgbm %v7, 32768
-;   vsel %v24, %v5, %v24, %v7
+;   vrepb %v4, %v25, 15
+;   vgbm %v6, 32768
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i8x16_lane_15_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -484,9 +484,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepb %v5, %v25, 0
-;   vgbm %v7, 1
-;   vsel %v24, %v5, %v24, %v7
+;   vrepb %v4, %v25, 0
+;   vgbm %v6, 1
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i8x16_lane_15_15(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -497,8 +497,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 32768
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 32768
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -639,8 +639,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 1
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
 ;   br %r14
 
 function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 wasmtime_system_v {
@@ -651,8 +651,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_f32x4_0(f32x4, f32) -> f32x4 wasmtime_system_v {
@@ -662,9 +662,9 @@ block0(v0: f32x4, v1: f32):
 }
 
 ; block0:
-;   vrepf %v5, %v0, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v0, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_3(f32x4, f32) -> f32x4 wasmtime_system_v {
@@ -674,8 +674,8 @@ block0(v0: f32x4, v1: f32):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v0, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v0, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_lane_0_0(f32x4, f32x4) -> f32x4 wasmtime_system_v {
@@ -686,8 +686,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vgbm %v5, 15
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 15
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_lane_0_3(f32x4, f32x4) -> f32x4 wasmtime_system_v {
@@ -698,9 +698,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 3
-;   vgbm %v7, 61440
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 3
+;   vgbm %v6, 61440
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_lane_3_0(f32x4, f32x4) -> f32x4 wasmtime_system_v {
@@ -711,9 +711,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_lane_3_3(f32x4, f32x4) -> f32x4 wasmtime_system_v {
@@ -724,8 +724,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 wasmtime_system_v {
@@ -758,8 +758,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 3
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -770,8 +770,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
 ;   br %r14
 
 function %extractlane_i64x2_0(i64x2) -> i64 wasmtime_system_v {
@@ -824,8 +824,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i64x2_mem_little_1(i64x2, i64) wasmtime_system_v {
@@ -836,8 +836,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i32x4_0(i32x4) -> i32 wasmtime_system_v {
@@ -890,8 +890,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 3
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i32x4_mem_little_3(i32x4, i64) wasmtime_system_v {
@@ -902,8 +902,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 0
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i16x8_0(i16x8) -> i16 wasmtime_system_v {
@@ -956,8 +956,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vlgvh %r3, %v24, 7
-;   strvh %r3, 0(%r2)
+;   vlgvh %r5, %v24, 7
+;   strvh %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i16x8_mem_little_7(i16x8, i64) wasmtime_system_v {
@@ -968,8 +968,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vlgvh %r3, %v24, 0
-;   strvh %r3, 0(%r2)
+;   vlgvh %r5, %v24, 0
+;   strvh %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i8x16_0(i8x16) -> i8 wasmtime_system_v {
@@ -1086,8 +1086,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f64x2_mem_little_1(f64x2, i64) wasmtime_system_v {
@@ -1098,8 +1098,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f32x4_0(f32x4) -> f32 wasmtime_system_v {
@@ -1152,8 +1152,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 3
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f32x4_mem_little_3(f32x4, i64) wasmtime_system_v {
@@ -1164,8 +1164,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 0
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %splat_i64x2(i64) -> i64x2 wasmtime_system_v {

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
@@ -117,8 +117,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 {
@@ -129,8 +129,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 1
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
 ;   br %r14
 
 function %insertlane_i32x4_0(i32x4, i32) -> i32x4 {
@@ -183,8 +183,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i32x4_lane_0_3(i32x4, i32x4) -> i32x4 {
@@ -195,9 +195,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i32x4_lane_3_0(i32x4, i32x4) -> i32x4 {
@@ -208,9 +208,9 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 3
-;   vgbm %v7, 61440
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 3
+;   vgbm %v6, 61440
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i32x4_lane_3_3(i32x4, i32x4) -> i32x4 {
@@ -221,8 +221,8 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; block0:
-;   vgbm %v5, 15
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 15
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 {
@@ -255,8 +255,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 {
@@ -267,8 +267,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 3
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
 ;   br %r14
 
 function %insertlane_i16x8_0(i16x8, i16) -> i16x8 {
@@ -321,8 +321,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 49152
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 49152
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i16x8_lane_0_7(i16x8, i16x8) -> i16x8 {
@@ -333,9 +333,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vreph %v5, %v25, 0
-;   vgbm %v7, 3
-;   vsel %v24, %v5, %v24, %v7
+;   vreph %v4, %v25, 0
+;   vgbm %v6, 3
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i16x8_lane_7_0(i16x8, i16x8) -> i16x8 {
@@ -346,9 +346,9 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vreph %v5, %v25, 7
-;   vgbm %v7, 49152
-;   vsel %v24, %v5, %v24, %v7
+;   vreph %v4, %v25, 7
+;   vgbm %v6, 49152
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i16x8_lane_7_7(i16x8, i16x8) -> i16x8 {
@@ -359,8 +359,8 @@ block0(v0: i16x8, v1: i16x8):
 }
 
 ; block0:
-;   vgbm %v5, 3
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 3
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 {
@@ -393,8 +393,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   lrvh %r3, 0(%r2)
-;   vlvgh %v24, %r3, 0
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 {
@@ -405,8 +405,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   lrvh %r3, 0(%r2)
-;   vlvgh %v24, %r3, 7
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 7
 ;   br %r14
 
 function %insertlane_i8x16_0(i8x16, i8) -> i8x16 {
@@ -459,8 +459,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 32768
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 32768
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i8x16_lane_0_15(i8x16, i8x16) -> i8x16 {
@@ -471,9 +471,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepb %v5, %v25, 0
-;   vgbm %v7, 1
-;   vsel %v24, %v5, %v24, %v7
+;   vrepb %v4, %v25, 0
+;   vgbm %v6, 1
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i8x16_lane_15_0(i8x16, i8x16) -> i8x16 {
@@ -484,9 +484,9 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepb %v5, %v25, 15
-;   vgbm %v7, 32768
-;   vsel %v24, %v5, %v24, %v7
+;   vrepb %v4, %v25, 15
+;   vgbm %v6, 32768
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_i8x16_lane_15_15(i8x16, i8x16) -> i8x16 {
@@ -497,8 +497,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 1
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 1
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 {
@@ -639,8 +639,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 {
@@ -651,8 +651,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   lrvg %r3, 0(%r2)
-;   vlvgg %v24, %r3, 1
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
 ;   br %r14
 
 function %insertlane_f32x4_0(f32x4, f32) -> f32x4 {
@@ -662,8 +662,8 @@ block0(v0: f32x4, v1: f32):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v0, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v0, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_3(f32x4, f32) -> f32x4 {
@@ -673,9 +673,9 @@ block0(v0: f32x4, v1: f32):
 }
 
 ; block0:
-;   vrepf %v5, %v0, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v0, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_lane_0_0(f32x4, f32x4) -> f32x4 {
@@ -686,8 +686,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vgbm %v5, 61440
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 61440
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_lane_0_3(f32x4, f32x4) -> f32x4 {
@@ -698,9 +698,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 0
-;   vgbm %v7, 15
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 0
+;   vgbm %v6, 15
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_lane_3_0(f32x4, f32x4) -> f32x4 {
@@ -711,9 +711,9 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vrepf %v5, %v25, 3
-;   vgbm %v7, 61440
-;   vsel %v24, %v5, %v24, %v7
+;   vrepf %v4, %v25, 3
+;   vgbm %v6, 61440
+;   vsel %v24, %v4, %v24, %v6
 ;   br %r14
 
 function %insertlane_f32x4_lane_3_3(f32x4, f32x4) -> f32x4 {
@@ -724,8 +724,8 @@ block0(v0: f32x4, v1: f32x4):
 }
 
 ; block0:
-;   vgbm %v5, 15
-;   vsel %v24, %v25, %v24, %v5
+;   vgbm %v4, 15
+;   vsel %v24, %v25, %v24, %v4
 ;   br %r14
 
 function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 {
@@ -758,8 +758,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 {
@@ -770,8 +770,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   lrv %r3, 0(%r2)
-;   vlvgf %v24, %r3, 3
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
 ;   br %r14
 
 function %extractlane_i64x2_0(i64x2) -> i64 {
@@ -824,8 +824,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i64x2_mem_little_1(i64x2, i64) {
@@ -836,8 +836,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i32x4_0(i32x4) -> i32 {
@@ -890,8 +890,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 0
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i32x4_mem_little_3(i32x4, i64) {
@@ -902,8 +902,8 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 3
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i16x8_0(i16x8) -> i16 {
@@ -956,8 +956,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vlgvh %r3, %v24, 0
-;   strvh %r3, 0(%r2)
+;   vlgvh %r5, %v24, 0
+;   strvh %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i16x8_mem_little_7(i16x8, i64) {
@@ -968,8 +968,8 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vlgvh %r3, %v24, 7
-;   strvh %r3, 0(%r2)
+;   vlgvh %r5, %v24, 7
+;   strvh %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_i8x16_0(i8x16) -> i8 {
@@ -1086,8 +1086,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 0
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f64x2_mem_little_1(f64x2, i64) {
@@ -1098,8 +1098,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   strvg %r3, 0(%r2)
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f32x4_0(f32x4) -> f32 {
@@ -1152,8 +1152,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 0
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %extractlane_f32x4_mem_little_3(f32x4, i64) {
@@ -1164,8 +1164,8 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvf %r3, %v24, 3
-;   strv %r3, 0(%r2)
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
 ;   br %r14
 
 function %splat_i64x2(i64) -> i64x2 {

--- a/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
@@ -113,7 +113,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vceqgs %v5, %v24, %v25
+;   vceqgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -126,7 +126,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vceqgs %v5, %v24, %v25
+;   vceqgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -139,7 +139,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v24, %v25
+;   vchgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -152,7 +152,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v24, %v25
+;   vchgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -165,7 +165,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v25, %v24
+;   vchgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -178,7 +178,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v25, %v24
+;   vchgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -191,7 +191,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v24, %v25
+;   vchlgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -204,7 +204,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v24, %v25
+;   vchlgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -217,7 +217,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v25, %v24
+;   vchlgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -230,7 +230,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v25, %v24
+;   vchlgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -243,7 +243,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfcedbs %v5, %v24, %v25
+;   vfcedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -256,7 +256,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfcedbs %v5, %v24, %v25
+;   vfcedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -269,7 +269,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v24, %v25
+;   vfchdbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -282,7 +282,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v24, %v25
+;   vfchdbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -295,7 +295,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v24, %v25
+;   vfchedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -308,7 +308,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v24, %v25
+;   vfchedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -321,7 +321,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v25, %v24
+;   vfchdbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -334,7 +334,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v25, %v24
+;   vfchdbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -347,7 +347,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v25, %v24
+;   vfchedbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
@@ -360,7 +360,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v25, %v24
+;   vfchedbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -373,7 +373,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vceqgs %v5, %v24, %v25
+;   vceqgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -386,7 +386,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vceqgs %v5, %v24, %v25
+;   vceqgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -399,7 +399,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v24, %v25
+;   vchgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -412,7 +412,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v24, %v25
+;   vchgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -425,7 +425,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v25, %v24
+;   vchgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -438,7 +438,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchgs %v5, %v25, %v24
+;   vchgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -451,7 +451,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v24, %v25
+;   vchlgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -464,7 +464,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v24, %v25
+;   vchlgs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -477,7 +477,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v25, %v24
+;   vchlgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -490,7 +490,7 @@ block0(v0: i64x2, v1: i64x2):
 }
 
 ; block0:
-;   vchlgs %v5, %v25, %v24
+;   vchlgs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -503,7 +503,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfcedbs %v5, %v24, %v25
+;   vfcedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -516,7 +516,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfcedbs %v5, %v24, %v25
+;   vfcedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -529,7 +529,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v24, %v25
+;   vfchdbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -542,7 +542,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v24, %v25
+;   vfchdbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -555,7 +555,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v24, %v25
+;   vfchedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -568,7 +568,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v24, %v25
+;   vfchedbs %v4, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -581,7 +581,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v25, %v24
+;   vfchdbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -594,7 +594,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchdbs %v5, %v25, %v24
+;   vfchdbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
@@ -607,7 +607,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v25, %v24
+;   vfchedbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -620,7 +620,7 @@ block0(v0: f64x2, v1: f64x2):
 }
 
 ; block0:
-;   vfchedbs %v5, %v25, %v24
+;   vfchedbs %v4, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -8,11 +8,11 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vrepib %v7, 239
-;   vno %v17, %v25, %v25
-;   vmxlb %v19, %v7, %v17
-;   vperm %v24, %v5, %v24, %v19
+;   vgbm %v4, 0
+;   vrepib %v6, 239
+;   vno %v16, %v25, %v25
+;   vmxlb %v18, %v6, %v16
+;   vperm %v24, %v4, %v24, %v18
 ;   br %r14
 
 function %shuffle_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -22,8 +22,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vrepib %v5, 15
-;   vperm %v24, %v24, %v25, %v5
+;   vrepib %v4, 15
+;   vperm %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %shuffle_1(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -33,8 +33,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   bras %r1, 20 ; data.u128 0x0a1e000d0b1702180403090b15100f0c ; vl %v5, 0(%r1)
-;   vperm %v24, %v24, %v25, %v5
+;   bras %r1, 20 ; data.u128 0x0a1e000d0b1702180403090b15100f0c ; vl %v4, 0(%r1)
+;   vperm %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %shuffle_2(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -44,10 +44,10 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 1
-;   bras %r1, 20 ; data.u128 0x8080808080808080808080808080800f ; vl %v7, 0(%r1)
-;   vperm %v17, %v24, %v25, %v7
-;   vn %v24, %v5, %v17
+;   vgbm %v4, 1
+;   bras %r1, 20 ; data.u128 0x8080808080808080808080808080800f ; vl %v6, 0(%r1)
+;   vperm %v16, %v24, %v25, %v6
+;   vn %v24, %v4, %v16
 ;   br %r14
 
 function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 wasmtime_system_v {

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
@@ -8,10 +8,10 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vrepib %v7, 16
-;   vmnlb %v17, %v7, %v25
-;   vperm %v24, %v24, %v5, %v17
+;   vgbm %v4, 0
+;   vrepib %v6, 16
+;   vmnlb %v16, %v6, %v25
+;   vperm %v24, %v24, %v4, %v16
 ;   br %r14
 
 function %shuffle_0(i8x16, i8x16) -> i8x16 {
@@ -21,8 +21,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 0
-;   vperm %v24, %v24, %v25, %v5
+;   vgbm %v4, 0
+;   vperm %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %shuffle_1(i8x16, i8x16) -> i8x16 {
@@ -32,8 +32,8 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   bras %r1, 20 ; data.u128 0x03001f1a04060c0b170d1804020f1105 ; vl %v5, 0(%r1)
-;   vperm %v24, %v24, %v25, %v5
+;   bras %r1, 20 ; data.u128 0x03001f1a04060c0b170d1804020f1105 ; vl %v4, 0(%r1)
+;   vperm %v24, %v24, %v25, %v4
 ;   br %r14
 
 function %shuffle_2(i8x16, i8x16) -> i8x16 {
@@ -43,10 +43,10 @@ block0(v0: i8x16, v1: i8x16):
 }
 
 ; block0:
-;   vgbm %v5, 32768
-;   bras %r1, 20 ; data.u128 0x00808080808080808080808080808080 ; vl %v7, 0(%r1)
-;   vperm %v17, %v24, %v25, %v7
-;   vn %v24, %v5, %v17
+;   vgbm %v4, 32768
+;   bras %r1, 20 ; data.u128 0x00808080808080808080808080808080 ; vl %v6, 0(%r1)
+;   vperm %v16, %v24, %v25, %v6
+;   vn %v24, %v4, %v16
 ;   br %r14
 
 function %shuffle_vmrhg_xy(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
@@ -8,8 +8,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   lcr %r3, %r2
-;   verllg %v24, %v24, 0(%r3)
+;   lcr %r2, %r2
+;   verllg %v24, %v24, 0(%r2)
 ;   br %r14
 
 function %rotr_i64x4_imm(i64x2) -> i64x2 {
@@ -30,8 +30,8 @@ block0(v0: i32x4, v1: i32):
 }
 
 ; block0:
-;   lcr %r3, %r2
-;   verllf %v24, %v24, 0(%r3)
+;   lcr %r2, %r2
+;   verllf %v24, %v24, 0(%r2)
 ;   br %r14
 
 function %rotr_i32x4_imm(i32x4) -> i32x4 {
@@ -52,8 +52,8 @@ block0(v0: i16x8, v1: i16):
 }
 
 ; block0:
-;   lcr %r3, %r2
-;   verllh %v24, %v24, 0(%r3)
+;   lcr %r2, %r2
+;   verllh %v24, %v24, 0(%r2)
 ;   br %r14
 
 function %rotr_i16x8_imm(i16x8) -> i16x8 {
@@ -74,8 +74,8 @@ block0(v0: i8x16, v1: i8):
 }
 
 ; block0:
-;   lcr %r3, %r2
-;   verllb %v24, %v24, 0(%r3)
+;   lcr %r2, %r2
+;   verllb %v24, %v24, 0(%r2)
 ;   br %r14
 
 function %rotr_i8x16_imm(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
@@ -114,8 +114,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   vl %v5, 0(%r3)
-;   vst %v5, 0(%r2)
+;   vl %v4, 0(%r3)
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %load_f32x4_big(i64) -> f32x4 {
@@ -326,8 +326,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   vlbrq %v5, 0(%r3)
-;   vst %v5, 0(%r2)
+;   vlbrq %v4, 0(%r3)
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %load_f32x4_little(i64) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
@@ -153,10 +153,10 @@ block0(v0: i8x16, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_i16x8_big(i16x8, i64) wasmtime_system_v {
@@ -166,10 +166,10 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   verllf %v16, %v6, 16
-;   vst %v16, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   verllf %v7, %v5, 16
+;   vst %v7, 0(%r2)
 ;   br %r14
 
 function %store_i32x4_big(i32x4, i64) wasmtime_system_v {
@@ -179,9 +179,9 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   vst %v6, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   vst %v5, 0(%r2)
 ;   br %r14
 
 function %store_i64x2_big(i64x2, i64) wasmtime_system_v {
@@ -191,8 +191,8 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   vst %v4, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   vst %v3, 0(%r2)
 ;   br %r14
 
 function %store_f32x4_big(f32x4, i64) wasmtime_system_v {
@@ -202,9 +202,9 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   vst %v6, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   vst %v5, 0(%r2)
 ;   br %r14
 
 function %store_f64x2_big(f64x2, i64) wasmtime_system_v {
@@ -214,8 +214,8 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   vst %v4, 0(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   vst %v3, 0(%r2)
 ;   br %r14
 
 function %uload8x8_little(i64) -> i16x8 wasmtime_system_v {
@@ -394,10 +394,10 @@ block0(v0: i8x16, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_i16x8_little(i16x8, i64) wasmtime_system_v {
@@ -407,10 +407,10 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_i32x4_little(i32x4, i64) wasmtime_system_v {
@@ -420,10 +420,10 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_i64x2_little(i64x2, i64) wasmtime_system_v {
@@ -433,10 +433,10 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_f32x4_little(f32x4, i64) wasmtime_system_v {
@@ -446,10 +446,10 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_f64x2_little(f64x2, i64) wasmtime_system_v {
@@ -459,10 +459,10 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_f64x2_sum_little(f64x2, i64, i64) wasmtime_system_v {
@@ -486,9 +486,9 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vlgvg %r3, %v24, 1
-;   vlgvg %r4, %v24, 0
-;   strvg %r3, 128(%r2)
-;   strvg %r4, 136(%r2)
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 128(%r2)
+;   strvg %r3, 136(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -114,8 +114,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   vl %v5, 0(%r3)
-;   vst %v5, 0(%r2)
+;   vl %v4, 0(%r3)
+;   vst %v4, 0(%r2)
 ;   br %r14
 
 function %load_f32x4_big(i64) -> f32x4 {
@@ -342,8 +342,8 @@ block0(v0: i64):
 ; block0:
 ;   lrvg %r4, 0(%r3)
 ;   lrvg %r5, 8(%r3)
-;   vlvgp %v17, %r5, %r4
-;   vst %v17, 0(%r2)
+;   vlvgp %v16, %r5, %r4
+;   vst %v16, 0(%r2)
 ;   br %r14
 
 function %load_f32x4_little(i64) -> f32x4 {
@@ -383,8 +383,8 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lrvg %r4, 0(%r3,%r2)
 ;   lrvg %r5, 8(%r3,%r2)
-;   vlvgp %v17, %r5, %r4
-;   vpdi %v24, %v17, %v17, 4
+;   vlvgp %v16, %r5, %r4
+;   vpdi %v24, %v16, %v16, 4
 ;   br %r14
 
 function %load_f64x2_off_little(i64) -> f64x2 {
@@ -417,13 +417,13 @@ block0(v0: i16x8, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   verllf %v16, %v6, 16
-;   vlgvg %r4, %v16, 1
-;   vlgvg %r3, %v16, 0
-;   strvg %r4, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   verllf %v7, %v5, 16
+;   vlgvg %r3, %v7, 1
+;   lgdr %r5, %f7
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
 ;   br %r14
 
 function %store_i32x4_little(i32x4, i64) {
@@ -433,12 +433,12 @@ block0(v0: i32x4, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   vlgvg %r3, %v6, 1
-;   lgdr %r4, %f6
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   vlgvg %r5, %v5, 1
+;   lgdr %r3, %f5
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_i64x2_little(i64x2, i64) {
@@ -448,11 +448,11 @@ block0(v0: i64x2, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   vlgvg %r4, %v4, 1
-;   lgdr %r3, %f4
-;   strvg %r4, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
 ;   br %r14
 
 function %store_i128_little(i128, i64) {
@@ -476,12 +476,12 @@ block0(v0: f32x4, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   verllg %v6, %v4, 32
-;   vlgvg %r3, %v6, 1
-;   lgdr %r4, %f6
-;   strvg %r3, 0(%r2)
-;   strvg %r4, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 32
+;   vlgvg %r5, %v5, 1
+;   lgdr %r3, %f5
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
 ;   br %r14
 
 function %store_f64x2_little(f64x2, i64) {
@@ -491,11 +491,11 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   vlgvg %r4, %v4, 1
-;   lgdr %r3, %f4
-;   strvg %r4, 0(%r2)
-;   strvg %r3, 8(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
 ;   br %r14
 
 function %store_f64x2_sum_little(f64x2, i64, i64) {
@@ -506,9 +506,9 @@ block0(v0: f64x2, v1: i64, v2: i64):
 }
 
 ; block0:
-;   vpdi %v6, %v24, %v24, 4
-;   vlgvg %r5, %v6, 1
-;   lgdr %r4, %f6
+;   vpdi %v4, %v24, %v24, 4
+;   vlgvg %r5, %v4, 1
+;   lgdr %r4, %f4
 ;   strvg %r5, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
 ;   br %r14
@@ -520,10 +520,10 @@ block0(v0: f64x2, v1: i64):
 }
 
 ; block0:
-;   vpdi %v4, %v24, %v24, 4
-;   vlgvg %r4, %v4, 1
-;   lgdr %r3, %f4
-;   strvg %r4, 128(%r2)
-;   strvg %r3, 136(%r2)
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 128(%r2)
+;   strvg %r5, 136(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -132,8 +132,8 @@ block0(v0: i64, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    %esi, %r8d
-;   movq    -1(%rdi,%r8,8), %rax
+;   movl    %esi, %edx
+;   movq    -1(%rdi,%rdx,8), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -36,20 +36,20 @@ block0(v0: i32, v1: f32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r11
+;   movq    %rdi, %r10
 ;   movdqa  %xmm0, %xmm6
 ;   subq    %rsp, $32, %rsp
 ;   virtual_sp_offset_adjust 32
-;   movq    %r11, %rcx
+;   movq    %r10, %rcx
 ;   movdqa  %xmm6, %xmm1
-;   movq    %r11, %rdi
+;   movq    %r10, %rdi
 ;   movdqa  %xmm1, %xmm6
 ;   call    *%rdi
 ;   addq    %rsp, $32, %rsp
 ;   virtual_sp_offset_adjust -32
-;   movq    %rdi, %r11
+;   movq    %rdi, %r10
 ;   movdqa  %xmm6, %xmm0
-;   call    *%r11
+;   call    *%r10
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -129,17 +129,13 @@ block0(
 
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $64, %rsp
-;   movq    %rbx, 32(%rsp)
-;   movq    %r13, 40(%rsp)
-;   movq    %r14, 48(%rsp)
-;   movq    %r15, 56(%rsp)
 ; block0:
-;   movq    %rsi, %rbx
-;   movq    %rdx, %r14
-;   movq    %rcx, %rax
-;   movq    %r8, %r13
-;   movq    %r9, %r15
+;   movq    %rdx, %r10
+;   movq    %rsi, %rdx
+;   movq    %r8, %rsi
+;   movq    %r10, %r8
+;   movq    %r9, %rax
+;   movq    %rcx, %r9
 ;   movq    16(%rbp), %r11
 ;   movq    24(%rbp), %r10
 ;   movss   32(%rbp), %xmm9
@@ -147,12 +143,8 @@ block0(
 ;   subq    %rsp, $144, %rsp
 ;   virtual_sp_offset_adjust 144
 ;   movq    %rdi, %rcx
-;   movq    %rbx, %rdx
-;   movq    %r14, %r8
-;   movq    %rax, %r9
-;   movq    %r13, %rsi
 ;   movq    %rsi, 32(%rsp)
-;   movq    %r15, %rsi
+;   movq    %rax, %rsi
 ;   movq    %rsi, 40(%rsp)
 ;   movsd   %xmm0, 48(%rsp)
 ;   movsd   %xmm1, 56(%rsp)
@@ -169,11 +161,6 @@ block0(
 ;   call    *%rdi
 ;   addq    %rsp, $144, %rsp
 ;   virtual_sp_offset_adjust -144
-;   movq    32(%rsp), %rbx
-;   movq    40(%rsp), %r13
-;   movq    48(%rsp), %r14
-;   movq    56(%rsp), %r15
-;   addq    %rsp, $64, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -193,18 +180,15 @@ block0(v0: i64, v1:i64, v2:i64, v3:i64, v4:i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %rdx, %rax
-;   movq    %rcx, %r11
 ;   movq    %r8, %r10
+;   movq    %rdx, %r8
+;   movq    %rcx, %rax
 ;   subq    %rsp, $48, %rsp
 ;   virtual_sp_offset_adjust 48
 ;   movq    %rdi, %rcx
-;   movq    %r9, %rdx
-;   movq    %rax, %r8
-;   movq    %r11, %r9
-;   movq    %r10, %rsi
-;   movq    %rsi, 32(%rsp)
+;   movq    %rsi, %rdx
+;   movq    %rax, %r9
+;   movq    %r10, 32(%rsp)
 ;   call    *%rdi
 ;   addq    %rsp, $48, %rsp
 ;   virtual_sp_offset_adjust -48
@@ -222,24 +206,21 @@ block0(v0: i32, v1: f32, v2: i64, v3: f64, v4: i32, v5: i32, v6: i32, v7: f32, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm6
-;   movq    %rsi, %r10
-;   movdqa  %xmm1, %xmm14
-;   movq    %rcx, %r11
+;   movq    %rcx, %r10
 ;   movq    %r8, %r9
-;   movdqa  %xmm3, %xmm15
+;   movdqa  %xmm1, %xmm6
+;   movdqa  %xmm3, %xmm8
 ;   subq    %rsp, $96, %rsp
 ;   virtual_sp_offset_adjust 96
 ;   movq    %rdi, %rcx
-;   movdqa  %xmm6, %xmm1
-;   movq    %r10, %r8
-;   movdqa  %xmm14, %xmm3
+;   movdqa  %xmm0, %xmm1
+;   movq    %rsi, %r8
+;   movdqa  %xmm6, %xmm3
 ;   movl    %edx, 32(%rsp)
-;   movq    %r11, %r10
 ;   movl    %r10d, 40(%rsp)
 ;   movl    %r9d, 48(%rsp)
 ;   movss   %xmm2, 56(%rsp)
-;   movsd   %xmm15, 64(%rsp)
+;   movsd   %xmm8, 64(%rsp)
 ;   movss   %xmm4, 72(%rsp)
 ;   movsd   %xmm5, 80(%rsp)
 ;   call    *%rdi
@@ -399,12 +380,12 @@ block0(v0: f32, v1: i64, v2: i32, v3: f32):
 ;   movq    %rbx, 0(%rsp)
 ; block0:
 ;   movq    %rdx, %rbx
-;   movl    $1, %r8d
-;   call    *%r8
-;   movq    %rbx, %r10
-;   movq    %rax, 0(%r10)
-;   movl    %edx, 8(%r10)
-;   movss   %xmm1, 12(%r10)
+;   movl    $1, %eax
+;   call    *%rax
+;   movq    %rbx, %rcx
+;   movq    %rax, 0(%rcx)
+;   movl    %edx, 8(%rcx)
+;   movss   %xmm1, 12(%rcx)
 ;   movq    0(%rsp), %rbx
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -13,11 +13,11 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    0(%rsi), %rcx
-;   cmpq    %rcx, %rdi
+;   movq    0(%rsi), %r11
+;   cmpq    %r11, %rdi
 ;   setz    %al
 ;   andq    %rax, $1, %rax
-;   cmpq    %rcx, %rdi
+;   cmpq    %r11, %rdi
 ;   cmovzq  %rdi, %rsi, %rsi
 ;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
@@ -36,16 +36,19 @@ block0(v0: f64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movsd   0(%rdi), %xmm12
-;   ucomisd %xmm12, %xmm0
+;   movsd   0(%rdi), %xmm11
+;   ucomisd %xmm11, %xmm0
 ;   setnp   %al
-;   setz    %dl
-;   andl    %eax, %edx, %eax
+;   setz    %cl
+;   andl    %eax, %ecx, %eax
 ;   andq    %rax, $1, %rax
-;   ucomisd %xmm0, %xmm12
-;   movdqa  %xmm0, %xmm5
-;   mov z, sd; j%xmm5 $next; mov%xmm0 %xmm0, %xmm0; $next: 
-;   mov np, sd; j%xmm5 $next; mov%xmm0 %xmm0, %xmm0; $next: 
+;   ucomisd %xmm0, %xmm11
+;   movdqa  %xmm0, %xmm12
+;   mov z, sd; j%xmm0 $next; mov%xmm12 %xmm12, %xmm12; $next: 
+;   movdqa  %xmm12, %xmm4
+;   mov np, sd; j%xmm0 $next; mov%xmm4 %xmm4, %xmm4; $next: 
+;   movdqa  %xmm4, %xmm12
+;   movdqa  %xmm12, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -1,4 +1,4 @@
-test compile
+test compile precise-output
 set avoid_div_traps=false
 target x86_64
 
@@ -10,47 +10,76 @@ target x86_64
 function %i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
   v2 = srem.i8 v0, v1
-; check:  xorl    %r11d, %r11d, %r11d
-; nextln: movq    %rdi, %rax
-; nextln: movq    %r11, %rdx
-; nextln: srem_seq %al, %dl, %sil, %al, %dl, tmp=(none)
-; nextln: shrq    $$8, %rax, %rax
 
   return v2
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorl    %r10d, %r10d, %r10d
+;   movq    %rdi, %rax
+;   movq    %r10, %rdx
+;   srem_seq %al, %dl, %sil, %al, %dl, tmp=(none)
+;   shrq    $8, %rax, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
   v2 = srem.i16 v0, v1
-; check:  xorl    %r11d, %r11d, %r11d
-; nextln: movq    %rdi, %rax
-; nextln: movq    %r11, %rdx
-; nextln: srem_seq %ax, %dx, %si, %ax, %dx, tmp=(none)
-; nextln: movq    %rdx, %rax
 
   return v2
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorl    %r10d, %r10d, %r10d
+;   movq    %rdi, %rax
+;   movq    %r10, %rdx
+;   srem_seq %ax, %dx, %si, %ax, %dx, tmp=(none)
+;   movq    %rdx, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
   v2 = srem.i32 v0, v1
-; check:  xorl    %r11d, %r11d, %r11d
-; nextln: movq    %rdi, %rax
-; nextln: movq    %r11, %rdx
-; nextln: srem_seq %eax, %edx, %esi, %eax, %edx, tmp=(none)
-; nextln: movq    %rdx, %rax
 
   return v2
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorl    %r10d, %r10d, %r10d
+;   movq    %rdi, %rax
+;   movq    %r10, %rdx
+;   srem_seq %eax, %edx, %esi, %eax, %edx, tmp=(none)
+;   movq    %rdx, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
   v2 = srem.i64 v0, v1
-; check:  xorl    %r11d, %r11d, %r11d
-; nextln: movq    %rdi, %rax
-; nextln: movq    %r11, %rdx
-; nextln: srem_seq %rax, %rdx, %rsi, %rax, %rdx, tmp=(none)
-; nextln: movq    %rdx, %rax
 
   return v2
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorl    %r10d, %r10d, %r10d
+;   movq    %rdi, %rax
+;   movq    %r10, %rdx
+;   srem_seq %rax, %rdx, %rsi, %rax, %rdx, tmp=(none)
+;   movq    %rdx, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -10,13 +10,13 @@ block0(v0: f32, v1: f32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $-2147483648, %r8d
-;   movd    %r8d, %xmm9
-;   movdqa  %xmm0, %xmm14
-;   movdqa  %xmm9, %xmm0
-;   andnps  %xmm0, %xmm14, %xmm0
-;   andps   %xmm9, %xmm1, %xmm9
-;   orps    %xmm0, %xmm9, %xmm0
+;   movl    $-2147483648, %edx
+;   movd    %edx, %xmm8
+;   movdqa  %xmm0, %xmm11
+;   movdqa  %xmm8, %xmm0
+;   andnps  %xmm0, %xmm11, %xmm0
+;   andps   %xmm8, %xmm1, %xmm8
+;   orps    %xmm0, %xmm8, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -30,13 +30,13 @@ block0(v0: f64, v1: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movabsq $-9223372036854775808, %r8
-;   movq    %r8, %xmm9
-;   movdqa  %xmm0, %xmm14
-;   movdqa  %xmm9, %xmm0
-;   andnpd  %xmm0, %xmm14, %xmm0
-;   andpd   %xmm9, %xmm1, %xmm9
-;   orpd    %xmm0, %xmm9, %xmm0
+;   movabsq $-9223372036854775808, %rdx
+;   movq    %rdx, %xmm8
+;   movdqa  %xmm0, %xmm11
+;   movdqa  %xmm8, %xmm0
+;   andnpd  %xmm0, %xmm11, %xmm0
+;   andpd   %xmm8, %xmm1, %xmm8
+;   orpd    %xmm0, %xmm8, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -146,16 +146,16 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbq  %dil, %rdi
-;   cvtsi2ss %rdi, %xmm0
-;   movzwq  %si, %rdi
-;   cvtsi2ss %rdi, %xmm5
-;   movl    %edx, %edi
-;   cvtsi2ss %rdi, %xmm6
-;   u64_to_f32_seq %rcx, %xmm2, %rdi, %rax
-;   addss   %xmm0, %xmm5, %xmm0
-;   addss   %xmm0, %xmm6, %xmm0
+;   movzbq  %dil, %r10
+;   cvtsi2ss %r10, %xmm0
+;   movzwq  %si, %r10
+;   cvtsi2ss %r10, %xmm2
+;   movl    %edx, %r10d
+;   cvtsi2ss %r10, %xmm3
+;   u64_to_f32_seq %rcx, %xmm15, %r10, %r11
 ;   addss   %xmm0, %xmm2, %xmm0
+;   addss   %xmm0, %xmm3, %xmm0
+;   addss   %xmm0, %xmm15, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -10,8 +10,8 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %FmaF32+0, %rax
-;   call    *%rax
+;   load_ext_name %FmaF32+0, %rsi
+;   call    *%rsi
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -25,8 +25,8 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %FmaF64+0, %rax
-;   call    *%rax
+;   load_ext_name %FmaF64+0, %rsi
+;   call    *%rsi
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
@@ -34,6 +34,9 @@ block0(v0: i32, v1: i64):
 ; block2:
 ;   ud2 heap_oob
 
+;; For a static memory with no Spectre mitigations, we observe a smaller amount
+;; of bounds checking: the offset check (`cmp + jbe + j`) and the offset
+;; calculation (`add`)--4 instructions.
 function %f(i64 vmctx, i32) -> i64 system_v {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0

--- a/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
@@ -20,11 +20,11 @@ block0(v0: i32, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %edi, %eax
-;   movq    8(%rsi), %r11
-;   movq    %rax, %rdi
-;   addq    %rdi, $32768, %rdi
+;   movq    8(%rsi), %r10
+;   movq    %rax, %r11
+;   addq    %r11, $32768, %r11
 ;   jnb ; ud2 heap_oob ;
-;   cmpq    %r11, %rdi
+;   cmpq    %r10, %r11
 ;   jbe     label1; j label2
 ; block1:
 ;   addq    %rax, 0(%rsi), %rax
@@ -34,9 +34,6 @@ block0(v0: i32, v1: i64):
 ; block2:
 ;   ud2 heap_oob
 
-;; For a static memory with no Spectre mitigations, we observe a smaller amount
-;; of bounds checking: the offset check (`cmp + jbe + j`) and the offset
-;; calculation (`add`)--4 instructions.
 function %f(i64 vmctx, i32) -> i64 system_v {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -82,6 +82,9 @@ block0(v0: i64, v1: i32):
 ; block2:
 ;   ud2 heap_oob
 
+;; When a static memory is the "right" size (4GB memory, 2GB guard regions), the
+;; Spectre mitigation is not present. Cranelift relies on the memory permissions
+;; and emits no bounds checking, simply `add`--a single instruction.
 function %f(i64 vmctx, i32) -> i64 system_v {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -67,24 +67,21 @@ block0(v0: i64, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    %esi, %r11d
-;   cmpq    $4096, %r11
+;   movl    %esi, %r10d
+;   cmpq    $4096, %r10
 ;   jbe     label1; j label2
 ; block1:
-;   movq    %r11, %rax
+;   movq    %r10, %rax
 ;   addq    %rax, 0(%rdi), %rax
-;   xorq    %rsi, %rsi, %rsi
-;   cmpq    $4096, %r11
-;   cmovnbeq %rsi, %rax, %rax
+;   xorq    %r11, %r11, %r11
+;   cmpq    $4096, %r10
+;   cmovnbeq %r11, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
 ;   ud2 heap_oob
 
-;; When a static memory is the "right" size (4GB memory, 2GB guard regions), the
-;; Spectre mitigation is not present. Cranelift relies on the memory permissions
-;; and emits no bounds checking, simply `add`--a single instruction.
 function %f(i64 vmctx, i32) -> i64 system_v {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -113,18 +113,18 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r9
-;   imulq   %r9, %rcx, %r9
+;   movq    %rdi, %r8
+;   imulq   %r8, %rcx, %r8
 ;   imulq   %rsi, %rdx, %rsi
-;   movq    %r9, %r8
-;   addq    %r8, %rsi, %r8
 ;   movq    %r8, %r9
+;   addq    %r9, %rsi, %r9
+;   movq    %r9, %r8
 ;   movq    %rdi, %rax
 ;   mul     %rax, %rdx, %rax, %rdx
-;   movq    %r9, %r11
-;   addq    %r11, %rdx, %r11
-;   movq    %r11, %r9
-;   movq    %r9, %rdx
+;   movq    %r8, %rdi
+;   addq    %rdi, %rdx, %rdi
+;   movq    %rdi, %r8
+;   movq    %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -193,11 +193,11 @@ block0(v0: i128, v1: i128):
 ;   movq    %r15, 48(%rsp)
 ; block0:
 ;   cmpq    %rdx, %rdi
-;   setz    %al
+;   setz    %r10b
 ;   cmpq    %rcx, %rsi
-;   setz    %r8b
-;   andq    %rax, %r8, %rax
-;   testq   $1, %rax
+;   setz    %r11b
+;   andq    %r10, %r11, %r10
+;   testq   $1, %r10
 ;   setnz   %al
 ;   cmpq    %rdx, %rdi
 ;   setnz   %r8b
@@ -205,90 +205,90 @@ block0(v0: i128, v1: i128):
 ;   setnz   %r9b
 ;   orq     %r8, %r9, %r8
 ;   testq   $1, %r8
-;   setnz   %r8b
-;   movq    %r8, rsp(0 + virtual offset)
-;   cmpq    %rcx, %rsi
-;   setl    %r10b
-;   setz    %r11b
-;   cmpq    %rdx, %rdi
-;   setb    %r9b
-;   andq    %r11, %r9, %r11
-;   orq     %r10, %r11, %r10
-;   testq   $1, %r10
-;   setnz   %r9b
-;   cmpq    %rcx, %rsi
-;   setl    %r10b
-;   setz    %r11b
-;   cmpq    %rdx, %rdi
-;   setbe   %r14b
-;   andq    %r11, %r14, %r11
-;   orq     %r10, %r11, %r10
-;   testq   $1, %r10
 ;   setnz   %r10b
+;   movq    %r10, rsp(0 + virtual offset)
 ;   cmpq    %rcx, %rsi
-;   setnle  %r11b
-;   setz    %bl
+;   setl    %r8b
+;   setz    %r9b
 ;   cmpq    %rdx, %rdi
-;   setnbe  %r12b
-;   andq    %rbx, %r12, %rbx
-;   orq     %r11, %rbx, %r11
-;   testq   $1, %r11
+;   setb    %r11b
+;   andq    %r9, %r11, %r9
+;   orq     %r8, %r9, %r8
+;   testq   $1, %r8
 ;   setnz   %r11b
 ;   cmpq    %rcx, %rsi
-;   setnle  %r14b
-;   setz    %r15b
+;   setl    %r8b
+;   setz    %r9b
 ;   cmpq    %rdx, %rdi
-;   setnb   %bl
-;   andq    %r15, %rbx, %r15
-;   orq     %r14, %r15, %r14
-;   testq   $1, %r14
-;   setnz   %r12b
+;   setbe   %bl
+;   andq    %r9, %rbx, %r9
+;   orq     %r8, %r9, %r8
+;   testq   $1, %r8
+;   setnz   %r9b
 ;   cmpq    %rcx, %rsi
-;   setb    %r13b
-;   setz    %r14b
+;   setnle  %r8b
+;   setz    %r13b
 ;   cmpq    %rdx, %rdi
-;   setb    %r15b
-;   andq    %r14, %r15, %r14
-;   orq     %r13, %r14, %r13
-;   testq   $1, %r13
-;   setnz   %r13b
+;   setnbe  %r14b
+;   andq    %r13, %r14, %r13
+;   orq     %r8, %r13, %r8
+;   testq   $1, %r8
+;   setnz   %r8b
 ;   cmpq    %rcx, %rsi
-;   setb    %r15b
-;   setz    %bl
+;   setnle  %bl
+;   setz    %r12b
 ;   cmpq    %rdx, %rdi
-;   setbe   %r14b
-;   andq    %rbx, %r14, %rbx
-;   orq     %r15, %rbx, %r15
-;   testq   $1, %r15
+;   setnb   %r13b
+;   andq    %r12, %r13, %r12
+;   orq     %rbx, %r12, %rbx
+;   testq   $1, %rbx
 ;   setnz   %r14b
 ;   cmpq    %rcx, %rsi
-;   setnbe  %r15b
+;   setb    %r15b
 ;   setz    %bl
 ;   cmpq    %rdx, %rdi
-;   setnbe  %r8b
-;   andq    %rbx, %r8, %rbx
+;   setb    %r12b
+;   andq    %rbx, %r12, %rbx
 ;   orq     %r15, %rbx, %r15
 ;   testq   $1, %r15
 ;   setnz   %r15b
 ;   cmpq    %rcx, %rsi
-;   setnbe  %cl
-;   setz    %sil
+;   setb    %r12b
+;   setz    %r13b
 ;   cmpq    %rdx, %rdi
-;   setnb   %dl
-;   andq    %rsi, %rdx, %rsi
-;   orq     %rcx, %rsi, %rcx
-;   testq   $1, %rcx
+;   setbe   %bl
+;   andq    %r13, %rbx, %r13
+;   orq     %r12, %r13, %r12
+;   testq   $1, %r12
+;   setnz   %bl
+;   cmpq    %rcx, %rsi
+;   setnbe  %r12b
+;   setz    %r13b
+;   cmpq    %rdx, %rdi
+;   setnbe  %r10b
+;   andq    %r13, %r10, %r13
+;   orq     %r12, %r13, %r12
+;   testq   $1, %r12
+;   setnz   %r12b
+;   cmpq    %rcx, %rsi
+;   setnbe  %sil
+;   setz    %cl
+;   cmpq    %rdx, %rdi
+;   setnb   %dil
+;   andq    %rcx, %rdi, %rcx
+;   orq     %rsi, %rcx, %rsi
+;   testq   $1, %rsi
 ;   setnz   %sil
 ;   movq    rsp(0 + virtual offset), %rdx
 ;   andl    %eax, %edx, %eax
-;   andl    %r9d, %r10d, %r9d
-;   andl    %r11d, %r12d, %r11d
-;   andl    %r13d, %r14d, %r13d
-;   andl    %r15d, %esi, %r15d
-;   andl    %eax, %r9d, %eax
-;   andl    %r11d, %r13d, %r11d
+;   andl    %r11d, %r9d, %r11d
+;   andl    %r8d, %r14d, %r8d
+;   andl    %r15d, %ebx, %r15d
+;   andl    %r12d, %esi, %r12d
 ;   andl    %eax, %r11d, %eax
-;   andl    %eax, %r15d, %eax
+;   andl    %r8d, %r15d, %r8d
+;   andl    %eax, %r8d, %eax
+;   andl    %eax, %r12d, %eax
 ;   movq    16(%rsp), %rbx
 ;   movq    24(%rsp), %r12
 ;   movq    32(%rsp), %r13
@@ -317,10 +317,10 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
-;   setz    %r11b
+;   setz    %r10b
 ;   cmpq    $0, %rsi
-;   setz    %al
-;   testb   %r11b, %al
+;   setz    %dil
+;   testb   %r10b, %dil
 ;   jnz     label1; j label2
 ; block1:
 ;   movl    $1, %eax
@@ -351,10 +351,10 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
-;   setz    %r11b
+;   setz    %r10b
 ;   cmpq    $0, %rsi
-;   setz    %al
-;   testb   %r11b, %al
+;   setz    %dil
+;   testb   %r10b, %dil
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
@@ -482,43 +482,43 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r8
-;   shrq    $1, %r8, %r8
-;   movabsq $8608480567731124087, %r11
-;   andq    %r8, %r11, %r8
-;   subq    %rdi, %r8, %rdi
-;   shrq    $1, %r8, %r8
-;   andq    %r8, %r11, %r8
-;   subq    %rdi, %r8, %rdi
-;   shrq    $1, %r8, %r8
-;   andq    %r8, %r11, %r8
-;   subq    %rdi, %r8, %rdi
+;   movq    %rdi, %rdx
+;   shrq    $1, %rdx, %rdx
+;   movabsq $8608480567731124087, %r10
+;   andq    %rdx, %r10, %rdx
+;   subq    %rdi, %rdx, %rdi
+;   shrq    $1, %rdx, %rdx
+;   andq    %rdx, %r10, %rdx
+;   subq    %rdi, %rdx, %rdi
+;   shrq    $1, %rdx, %rdx
+;   andq    %rdx, %r10, %rdx
+;   subq    %rdi, %rdx, %rdi
 ;   movq    %rdi, %rax
 ;   shrq    $4, %rax, %rax
 ;   addq    %rax, %rdi, %rax
 ;   movabsq $1085102592571150095, %rcx
 ;   andq    %rax, %rcx, %rax
-;   movabsq $72340172838076673, %r10
-;   imulq   %rax, %r10, %rax
+;   movabsq $72340172838076673, %r9
+;   imulq   %rax, %r9, %rax
 ;   shrq    $56, %rax, %rax
 ;   movq    %rsi, %rcx
 ;   shrq    $1, %rcx, %rcx
-;   movabsq $8608480567731124087, %r9
-;   andq    %rcx, %r9, %rcx
+;   movabsq $8608480567731124087, %r8
+;   andq    %rcx, %r8, %rcx
 ;   subq    %rsi, %rcx, %rsi
 ;   shrq    $1, %rcx, %rcx
-;   andq    %rcx, %r9, %rcx
+;   andq    %rcx, %r8, %rcx
 ;   subq    %rsi, %rcx, %rsi
 ;   shrq    $1, %rcx, %rcx
-;   andq    %rcx, %r9, %rcx
+;   andq    %rcx, %r8, %rcx
 ;   subq    %rsi, %rcx, %rsi
 ;   movq    %rsi, %rcx
 ;   shrq    $4, %rcx, %rcx
 ;   addq    %rcx, %rsi, %rcx
-;   movabsq $1085102592571150095, %rdi
-;   andq    %rcx, %rdi, %rcx
-;   movabsq $72340172838076673, %r8
-;   imulq   %rcx, %r8, %rcx
+;   movabsq $1085102592571150095, %rsi
+;   andq    %rcx, %rsi, %rcx
+;   movabsq $72340172838076673, %rdx
+;   imulq   %rcx, %rdx, %rcx
 ;   shrq    $56, %rcx, %rcx
 ;   addq    %rax, %rcx, %rax
 ;   xorq    %rdx, %rdx, %rdx
@@ -535,88 +535,88 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movabsq $6148914691236517205, %r9
-;   movq    %rsi, %r10
-;   andq    %r10, %r9, %r10
+;   movabsq $6148914691236517205, %r8
+;   movq    %rsi, %r9
+;   andq    %r9, %r8, %r9
 ;   shrq    $1, %rsi, %rsi
-;   andq    %rsi, %r9, %rsi
-;   shlq    $1, %r10, %r10
-;   orq     %r10, %rsi, %r10
-;   movabsq $3689348814741910323, %rsi
-;   movq    %r10, %rax
-;   andq    %rax, %rsi, %rax
-;   shrq    $2, %r10, %r10
-;   andq    %r10, %rsi, %r10
-;   shlq    $2, %rax, %rax
-;   orq     %rax, %r10, %rax
-;   movabsq $1085102592571150095, %rcx
-;   movq    %rax, %rdx
-;   andq    %rdx, %rcx, %rdx
-;   shrq    $4, %rax, %rax
+;   andq    %rsi, %r8, %rsi
+;   shlq    $1, %r9, %r9
+;   orq     %r9, %rsi, %r9
+;   movabsq $3689348814741910323, %r11
+;   movq    %r9, %rsi
+;   andq    %rsi, %r11, %rsi
+;   shrq    $2, %r9, %r9
+;   andq    %r9, %r11, %r9
+;   shlq    $2, %rsi, %rsi
+;   orq     %rsi, %r9, %rsi
+;   movabsq $1085102592571150095, %rax
+;   movq    %rsi, %rcx
+;   andq    %rcx, %rax, %rcx
+;   shrq    $4, %rsi, %rsi
+;   andq    %rsi, %rax, %rsi
+;   shlq    $4, %rcx, %rcx
+;   orq     %rcx, %rsi, %rcx
+;   movabsq $71777214294589695, %r8
+;   movq    %rcx, %r9
+;   andq    %r9, %r8, %r9
+;   shrq    $8, %rcx, %rcx
+;   andq    %rcx, %r8, %rcx
+;   shlq    $8, %r9, %r9
+;   orq     %r9, %rcx, %r9
+;   movabsq $281470681808895, %rsi
+;   movq    %r9, %r11
+;   andq    %r11, %rsi, %r11
+;   shrq    $16, %r9, %r9
+;   andq    %r9, %rsi, %r9
+;   shlq    $16, %r11, %r11
+;   orq     %r11, %r9, %r11
+;   movabsq $4294967295, %rcx
+;   movq    %r11, %rax
 ;   andq    %rax, %rcx, %rax
-;   shlq    $4, %rdx, %rdx
-;   orq     %rdx, %rax, %rdx
-;   movabsq $71777214294589695, %r9
+;   shrq    $32, %r11, %r11
+;   shlq    $32, %rax, %rax
+;   orq     %rax, %r11, %rax
+;   movabsq $6148914691236517205, %rcx
+;   movq    %rdi, %rdx
+;   andq    %rdx, %rcx, %rdx
+;   shrq    $1, %rdi, %rdi
+;   andq    %rdi, %rcx, %rdi
+;   shlq    $1, %rdx, %rdx
+;   orq     %rdx, %rdi, %rdx
+;   movabsq $3689348814741910323, %r9
 ;   movq    %rdx, %r10
 ;   andq    %r10, %r9, %r10
-;   shrq    $8, %rdx, %rdx
+;   shrq    $2, %rdx, %rdx
 ;   andq    %rdx, %r9, %rdx
-;   shlq    $8, %r10, %r10
+;   shlq    $2, %r10, %r10
 ;   orq     %r10, %rdx, %r10
-;   movabsq $281470681808895, %rax
-;   movq    %r10, %rsi
-;   andq    %rsi, %rax, %rsi
-;   shrq    $16, %r10, %r10
-;   andq    %r10, %rax, %r10
-;   shlq    $16, %rsi, %rsi
-;   orq     %rsi, %r10, %rsi
-;   movabsq $4294967295, %rcx
-;   movq    %rsi, %rax
-;   andq    %rax, %rcx, %rax
-;   shrq    $32, %rsi, %rsi
-;   shlq    $32, %rax, %rax
-;   orq     %rax, %rsi, %rax
-;   movabsq $6148914691236517205, %rdx
-;   movq    %rdi, %r8
-;   andq    %r8, %rdx, %r8
-;   shrq    $1, %rdi, %rdi
-;   andq    %rdi, %rdx, %rdi
-;   shlq    $1, %r8, %r8
-;   orq     %r8, %rdi, %r8
-;   movabsq $3689348814741910323, %r10
-;   movq    %r8, %r11
-;   andq    %r11, %r10, %r11
-;   shrq    $2, %r8, %r8
-;   andq    %r8, %r10, %r8
-;   shlq    $2, %r11, %r11
-;   orq     %r11, %r8, %r11
-;   movabsq $1085102592571150095, %rdi
-;   movq    %r11, %rcx
-;   andq    %rcx, %rdi, %rcx
-;   shrq    $4, %r11, %r11
-;   andq    %r11, %rdi, %r11
-;   shlq    $4, %rcx, %rcx
-;   orq     %rcx, %r11, %rcx
-;   movabsq $71777214294589695, %rdx
-;   movq    %rcx, %r8
-;   andq    %r8, %rdx, %r8
-;   shrq    $8, %rcx, %rcx
-;   andq    %rcx, %rdx, %rcx
-;   shlq    $8, %r8, %r8
-;   orq     %r8, %rcx, %r8
-;   movabsq $281470681808895, %r11
-;   movq    %r8, %r10
-;   andq    %r10, %r11, %r10
-;   shrq    $16, %r8, %r8
-;   andq    %r8, %r11, %r8
-;   shlq    $16, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   movabsq $4294967295, %rdi
-;   movq    %r10, %rdx
-;   andq    %rdx, %rdi, %rdx
-;   shrq    $32, %r10, %r10
+;   movabsq $1085102592571150095, %rsi
+;   movq    %r10, %rdi
+;   andq    %rdi, %rsi, %rdi
+;   shrq    $4, %r10, %r10
+;   andq    %r10, %rsi, %r10
+;   shlq    $4, %rdi, %rdi
+;   orq     %rdi, %r10, %rdi
+;   movabsq $71777214294589695, %rcx
+;   movq    %rdi, %rdx
+;   andq    %rdx, %rcx, %rdx
+;   shrq    $8, %rdi, %rdi
+;   andq    %rdi, %rcx, %rdi
+;   shlq    $8, %rdx, %rdx
+;   orq     %rdx, %rdi, %rdx
+;   movabsq $281470681808895, %r10
+;   movq    %rdx, %r9
+;   andq    %r9, %r10, %r9
+;   shrq    $16, %rdx, %rdx
+;   andq    %rdx, %r10, %rdx
+;   shlq    $16, %r9, %r9
+;   orq     %r9, %rdx, %r9
+;   movabsq $4294967295, %rsi
+;   movq    %r9, %rdx
+;   andq    %rdx, %rsi, %rdx
+;   shrq    $32, %r9, %r9
 ;   shlq    $32, %rdx, %rdx
-;   orq     %rdx, %r10, %rdx
+;   orq     %rdx, %r9, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -676,20 +676,20 @@ block2(v6: i128):
 ; block1:
 ;   xorq    %rax, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movl    $1, %ecx
-;   xorq    %r8, %r8, %r8
-;   addq    %rax, %rcx, %rax
-;   adcq    %rdx, %r8, %rdx
+;   movl    $1, %esi
+;   xorq    %rcx, %rcx, %rcx
+;   addq    %rax, %rsi, %rax
+;   adcq    %rdx, %rcx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
 ;   xorq    %rax, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movl    $2, %r10d
-;   xorq    %rsi, %rsi, %rsi
-;   addq    %rax, %r10, %rax
-;   adcq    %rdx, %rsi, %rdx
+;   movl    $2, %r8d
+;   xorq    %r10, %r10, %r10
+;   addq    %rax, %r8, %rax
+;   adcq    %rdx, %r10, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -708,31 +708,32 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $32, %rsp
-;   movq    %r13, 16(%rsp)
-;   movq    %r15, 24(%rsp)
+;   subq    %rsp, $16, %rsp
+;   movq    %rbx, 0(%rsp)
+;   movq    %r13, 8(%rsp)
 ; block0:
-;   movq    %rdx, rsp(0 + virtual offset)
-;   movq    16(%rbp), %r10
+;   movq    16(%rbp), %rbx
 ;   movq    24(%rbp), %rax
-;   movq    32(%rbp), %rdx
-;   movq    40(%rbp), %r15
-;   movq    48(%rbp), %r11
-;   movq    rsp(0 + virtual offset), %r13
-;   addq    %rdi, %r13, %rdi
-;   adcq    %rsi, %rcx, %rsi
-;   xorq    %rcx, %rcx, %rcx
+;   movq    32(%rbp), %r10
+;   movq    %r10, %r13
+;   movq    40(%rbp), %r11
+;   movq    48(%rbp), %r10
+;   addq    %rdi, %rdx, %rdi
+;   movq    %rcx, %rdx
+;   adcq    %rsi, %rdx, %rsi
+;   xorq    %rdx, %rdx, %rdx
 ;   addq    %r9, %r8, %r9
-;   adcq    %r10, %rcx, %r10
-;   addq    %rax, %r15, %rax
-;   adcq    %rdx, %r11, %rdx
+;   adcq    %rbx, %rdx, %rbx
+;   addq    %rax, %r11, %rax
+;   movq    %r13, %rdx
+;   adcq    %rdx, %r10, %rdx
 ;   addq    %rdi, %r9, %rdi
-;   adcq    %rsi, %r10, %rsi
+;   adcq    %rsi, %rbx, %rsi
 ;   addq    %rax, %rdi, %rax
 ;   adcq    %rdx, %rsi, %rdx
-;   movq    16(%rsp), %r13
-;   movq    24(%rsp), %r15
-;   addq    %rsp, $32, %rsp
+;   movq    0(%rsp), %rbx
+;   movq    8(%rsp), %r13
+;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -747,31 +748,34 @@ block0(v0: i128):
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $32, %rsp
 ;   movq    %rbx, 0(%rsp)
-;   movq    %r13, 8(%rsp)
+;   movq    %r12, 8(%rsp)
 ;   movq    %r14, 16(%rsp)
+;   movq    %r15, 24(%rsp)
 ; block0:
-;   movq    %rdx, %r14
+;   movq    %rdx, %r12
 ;   movq    %rdi, %rax
 ;   movq    %rsi, %rdx
-;   movq    %rdi, %rbx
-;   movq    %rsi, %r13
+;   movq    %rdi, %r14
+;   movq    %rsi, %rbx
 ;   movq    %rdi, %r11
-;   movq    %rsi, %r10
-;   movq    %rdi, %r9
-;   movq    %rdi, %rcx
-;   movq    %rsi, %r8
-;   movq    %rbx, 0(%r14)
-;   movq    %r13, 8(%r14)
-;   movq    %r11, 16(%r14)
-;   movq    %r10, 24(%r14)
-;   movq    %r9, 32(%r14)
-;   movq    %rcx, 40(%r14)
-;   movq    %r8, 48(%r14)
-;   movq    %rdi, 56(%r14)
-;   movq    %rsi, 64(%r14)
+;   movq    %rsi, %r9
+;   movq    %rdi, %r10
+;   movq    %rdi, %r8
+;   movq    %rsi, %rcx
+;   movq    %r12, %r15
+;   movq    %r14, 0(%r15)
+;   movq    %rbx, 8(%r15)
+;   movq    %r11, 16(%r15)
+;   movq    %r9, 24(%r15)
+;   movq    %r10, 32(%r15)
+;   movq    %r8, 40(%r15)
+;   movq    %rcx, 48(%r15)
+;   movq    %rdi, 56(%r15)
+;   movq    %rsi, 64(%r15)
 ;   movq    0(%rsp), %rbx
-;   movq    8(%rsp), %r13
+;   movq    8(%rsp), %r12
 ;   movq    16(%rsp), %r14
+;   movq    24(%rsp), %r15
 ;   addq    %rsp, $32, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -793,15 +797,15 @@ block0(v0: i128, v1: i128):
 ;   subq    %rsp, $16, %rsp
 ;   virtual_sp_offset_adjust 16
 ;   lea     0(%rsp), %r8
-;   load_ext_name %g+0, %r9
-;   call    *%r9
-;   movq    0(%rsp), %rcx
-;   movq    8(%rsp), %r8
+;   load_ext_name %g+0, %rax
+;   call    *%rax
+;   movq    0(%rsp), %r11
+;   movq    8(%rsp), %rdi
 ;   addq    %rsp, $16, %rsp
 ;   virtual_sp_offset_adjust -16
-;   movq    %r12, %r9
-;   movq    %rcx, 0(%r9)
-;   movq    %r8, 8(%r9)
+;   movq    %r12, %r8
+;   movq    %r11, 0(%r8)
+;   movq    %rdi, 8(%r8)
 ;   movq    0(%rsp), %r12
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
@@ -817,19 +821,19 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   movabsq $-1, %r8
+;   bsrq    %rsi, %r11
+;   cmovzq  %r8, %r11, %r11
+;   movl    $63, %ecx
+;   subq    %rcx, %r11, %rcx
 ;   movabsq $-1, %r9
-;   bsrq    %rsi, %rsi
+;   bsrq    %rdi, %rsi
 ;   cmovzq  %r9, %rsi, %rsi
-;   movl    $63, %edx
-;   subq    %rdx, %rsi, %rdx
-;   movabsq $-1, %r10
-;   bsrq    %rdi, %rdi
-;   cmovzq  %r10, %rdi, %rdi
 ;   movl    $63, %eax
-;   subq    %rax, %rdi, %rax
+;   subq    %rax, %rsi, %rax
 ;   addq    %rax, $64, %rax
-;   cmpq    $64, %rdx
-;   cmovnzq %rdx, %rax, %rax
+;   cmpq    $64, %rcx
+;   cmovnzq %rcx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -844,15 +848,15 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $64, %r9d
+;   movl    $64, %r8d
 ;   bsfq    %rdi, %rax
-;   cmovzq  %r9, %rax, %rax
+;   cmovzq  %r8, %rax, %rax
 ;   movl    $64, %ecx
-;   bsfq    %rsi, %r10
-;   cmovzq  %rcx, %r10, %r10
-;   addq    %r10, $64, %r10
+;   bsfq    %rsi, %r9
+;   cmovzq  %rcx, %r9, %r9
+;   addq    %r9, $64, %r9
 ;   cmpq    $64, %rax
-;   cmovzq  %r10, %rax, %rax
+;   cmovzq  %r9, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -884,20 +888,20 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %rax
-;   movq    %rax, %rcx
+;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
+;   movq    %rcx, %rax
 ;   movl    $64, %ecx
-;   movq    %rax, %r11
-;   subq    %rcx, %r11, %rcx
+;   movq    %rax, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r11
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r11
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -913,17 +917,17 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %r9
-;   movq    %r9, %rcx
+;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r8
 ;   shrq    %cl, %r8, %r8
 ;   movl    $64, %ecx
+;   movq    %rdx, %r9
 ;   subq    %rcx, %r9, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
+;   xorq    %r11, %r11, %r11
 ;   testq   $127, %r9
-;   cmovzq  %rax, %rsi, %rsi
+;   cmovzq  %r11, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
 ;   testq   $64, %r9
@@ -943,22 +947,22 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %r8
-;   movq    %r8, %rcx
+;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %rdx
 ;   sarq    %cl, %rdx, %rdx
+;   movq    %rcx, %rax
 ;   movl    $64, %ecx
-;   movq    %r8, %r9
-;   subq    %rcx, %r9, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r9
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   movq    %rax, %r8
+;   subq    %rcx, %r8, %rcx
+;   movq    %rsi, %r11
+;   shlq    %cl, %r11, %r11
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %r8
+;   cmovzq  %rax, %r11, %r11
+;   orq     %rdi, %r11, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r9
+;   testq   $64, %r8
 ;   movq    %rdx, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
@@ -976,14 +980,13 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %r11
-;   movq    %r11, %rcx
+;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   movq    %rsi, %r9
 ;   shlq    %cl, %r9, %r9
+;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r11, %r10
 ;   subq    %rcx, %r10, %rcx
 ;   movq    %rdi, %r8
 ;   shrq    %cl, %r8, %r8
@@ -995,27 +998,26 @@ block0(v0: i128, v1: i128):
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r8, %rdx, %rdx
 ;   movl    $128, %ecx
-;   movq    %r11, %r9
-;   subq    %rcx, %r9, %rcx
+;   movq    %r10, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r8
-;   shrq    %cl, %r8, %r8
-;   movq    %rcx, %r9
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
+;   movq    %rcx, %r8
 ;   movl    $64, %ecx
-;   movq    %r9, %r10
-;   subq    %rcx, %r10, %rcx
+;   subq    %rcx, %r8, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %r9, %r9, %r9
-;   testq   $127, %r10
-;   cmovzq  %r9, %rsi, %rsi
+;   xorq    %r10, %r10, %r10
+;   testq   $127, %r8
+;   cmovzq  %r10, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
-;   xorq    %rdi, %rdi, %rdi
-;   testq   $64, %r10
-;   movq    %r8, %rcx
-;   cmovzq  %rsi, %rcx, %rcx
-;   cmovzq  %r8, %rdi, %rdi
-;   orq     %rax, %rcx, %rax
-;   orq     %rdx, %rdi, %rdx
+;   xorq    %r10, %r10, %r10
+;   testq   $64, %r8
+;   movq    %r11, %rdi
+;   cmovzq  %rsi, %rdi, %rdi
+;   cmovzq  %r11, %r10, %r10
+;   orq     %rax, %rdi, %rax
+;   orq     %rdx, %r10, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1029,45 +1031,47 @@ block0(v0: i128, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %r11
-;   movq    %r11, %rcx
-;   movq    %rdi, %rax
-;   shrq    %cl, %rax, %rax
+;   movq    %rdx, %rcx
+;   movq    %rdi, %r10
+;   shrq    %cl, %r10, %r10
 ;   movq    %rsi, %r8
 ;   shrq    %cl, %r8, %r8
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r11, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %r11, %rax
+;   subq    %rcx, %rax, %rcx
 ;   movq    %rsi, %r9
 ;   shlq    %cl, %r9, %r9
+;   xorq    %r11, %r11, %r11
+;   testq   $127, %rax
+;   cmovzq  %r11, %r9, %r9
+;   orq     %r9, %r10, %r9
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %r10
-;   cmovzq  %rdx, %r9, %r9
-;   orq     %r9, %rax, %r9
-;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r10
+;   testq   $64, %rax
+;   movq    %rax, %r11
 ;   movq    %r8, %rax
 ;   cmovzq  %r9, %rax, %rax
 ;   cmovzq  %r8, %rdx, %rdx
 ;   movl    $128, %ecx
-;   subq    %rcx, %r10, %rcx
-;   movq    %rdi, %r8
-;   shlq    %cl, %r8, %r8
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
+;   movq    %rdi, %r11
+;   shlq    %cl, %r11, %r11
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %r9
+;   movq    %rcx, %r8
 ;   movl    $64, %ecx
-;   movq    %r9, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %r8, %r9
+;   subq    %rcx, %r9, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   xorq    %r9, %r9, %r9
-;   testq   $127, %r10
-;   cmovzq  %r9, %rdi, %rdi
+;   xorq    %r8, %r8, %r8
+;   testq   $127, %r9
+;   cmovzq  %r8, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r10
-;   cmovzq  %r8, %r9, %r9
-;   cmovzq  %rdi, %r8, %r8
-;   orq     %rax, %r9, %rax
-;   orq     %rdx, %r8, %rdx
+;   testq   $64, %r9
+;   cmovzq  %r11, %r8, %r8
+;   cmovzq  %rdi, %r11, %r11
+;   orq     %rax, %r8, %rax
+;   orq     %rdx, %r11, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -18,15 +18,15 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   movq    %rdi, %r9
+;   addq    %r9, const(0), %r9
+;   movq    %r9, 0(%rsi)
 ;   movq    %rdi, %r10
-;   addq    %r10, const(0), %r10
+;   subq    %r10, const(0), %r10
 ;   movq    %r10, 0(%rsi)
 ;   movq    %rdi, %r11
-;   subq    %r11, const(0), %r11
+;   andq    %r11, const(0), %r11
 ;   movq    %r11, 0(%rsi)
-;   movq    %rdi, %rax
-;   andq    %rax, const(0), %rax
-;   movq    %rax, 0(%rsi)
 ;   orq     %rdi, const(0), %rdi
 ;   movq    %rdi, 0(%rsi)
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -21,16 +21,16 @@ block0(v0: i128, v1: i8):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %rax
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r10
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r10
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -50,16 +50,16 @@ block0(v0: i128, v1: i64):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %rax
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r9
-;   subq    %rcx, %r9, %rcx
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r9
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r9
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -79,16 +79,16 @@ block0(v0: i128, v1: i32):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %rax
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r9
-;   subq    %rcx, %r9, %rcx
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r9
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r9
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -108,16 +108,16 @@ block0(v0: i128, v1: i16):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %rax
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r9
-;   subq    %rcx, %r9, %rcx
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r9
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r9
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -137,16 +137,16 @@ block0(v0: i128, v1: i8):
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
 ;   shlq    %cl, %rsi, %rsi
-;   movq    %rcx, %rax
+;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r9
-;   subq    %rcx, %r9, %rcx
+;   movq    %r11, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %r9
+;   testq   $127, %r8
 ;   cmovzq  %rax, %rdi, %rdi
 ;   orq     %rdi, %rsi, %rdi
-;   testq   $64, %r9
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
@@ -162,8 +162,7 @@ block0(v0: i64, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   shlq    %cl, %rdi, %rdi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
@@ -179,8 +178,7 @@ block0(v0: i32, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   shll    %cl, %edi, %edi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -56,6 +56,9 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+;; test narrow loads: 8-bit load should not merge because the `addl` is 32 bits
+;; and would load 32 bits from memory, which may go beyond the end of the heap.
+
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -1,48 +1,85 @@
-test compile
+test compile precise-output
 target x86_64
 
 function %add_from_mem_u32_1(i64, i32) -> i32 {
 block0(v0: i64, v1: i32):
   v2 = load.i32 v0
   v3 = iadd.i32 v2, v1
-  ; check: addl    %esi, 0(%rdi), %esi
   return v3
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addl    %esi, 0(%rdi), %esi
+;   movq    %rsi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %add_from_mem_u32_2(i64, i32) -> i32 {
 block0(v0: i64, v1: i32):
   v2 = load.i32 v0
   v3 = iadd.i32 v1, v2
-  ; check: addl    %esi, 0(%rdi), %esi
   return v3
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addl    %esi, 0(%rdi), %esi
+;   movq    %rsi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %add_from_mem_u64_1(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
   v2 = load.i64 v0
   v3 = iadd.i64 v2, v1
-  ; check: addq    %rsi, 0(%rdi), %rsi
   return v3
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addq    %rsi, 0(%rdi), %rsi
+;   movq    %rsi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %add_from_mem_u64_2(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
   v2 = load.i64 v0
   v3 = iadd.i64 v1, v2
-  ; check: addq    %rsi, 0(%rdi), %rsi
   return v3
 }
 
-; test narrow loads: 8-bit load should not merge because the `addl` is 32 bits
-; and would load 32 bits from memory, which may go beyond the end of the heap.
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   addq    %rsi, 0(%rdi), %rsi
+;   movq    %rsi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
 function %add_from_mem_not_narrow(i64, i8) -> i8 {
 block0(v0: i64, v1: i8):
   v2 = load.i8 v0
   v3 = iadd.i8 v2, v1
-  ; check: movzbq  0(%rdi), %rax
-  ; nextln: addl    %eax, %esi, %eax
   return v3
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movzbq  0(%rdi), %rax
+;   addl    %eax, %esi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %no_merge_if_lookback_use(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -51,23 +88,39 @@ block0(v0: i64, v1: i64):
   store.i64 v3, v1
   v4 = load.i64 v3
   return v4
-  ; check:  movq    0(%rdi), %r10
-  ; nextln: movq    %r10, %r11
-  ; nextln: addq    %r11, %rdi, %r11
-  ; nextln: movq    %r11, 0(%rsi)
-  ; nextln: movq    0(%r10,%rdi,1), %rax
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    0(%rdi), %r9
+;   movq    %r9, %r10
+;   addq    %r10, %rdi, %r10
+;   movq    %r10, 0(%rsi)
+;   movq    0(%r9,%rdi,1), %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %merge_scalar_to_vector(i64) -> i32x4 {
 block0(v0: i64):
   v1 = load.i32 v0
   v2 = scalar_to_vector.i32x4 v1
-  ; check: movss   0(%rdi), %xmm0
 
   jump block1
 block1:
   return v2
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm0
+;   jmp     label1
+; block1:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
 
 function %cmp_mem(i64) -> i64 {
 block0(v0: i64):
@@ -75,7 +128,15 @@ block0(v0: i64):
   v2 = icmp eq v0, v1
   v3 = bint.i64 v2
   return v3
-
-  ; check:  cmpq    0(%rdi), %rdi
-  ; nextln: setz    %al
 }
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   cmpq    0(%rdi), %rdi
+;   setz    %al
+;   andq    %rax, $1, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   movq    %rdi, %rax
 ;   cbw %al, %al
-;   movq    %rax, %rdi
+;   movq    %rax, %r11
 ;   idiv    %al, (none), %sil, %al, (none)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -29,7 +29,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   movq    %rdi, %rax
 ;   cwd %ax, %dx
-;   movq    %rdx, %r8
+;   movq    %rdx, %rcx
 ;   idiv    %ax, %dx, %si, %ax, %dx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -46,7 +46,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   movq    %rdi, %rax
 ;   cdq %eax, %edx
-;   movq    %rdx, %r8
+;   movq    %rdx, %rcx
 ;   idiv    %eax, %edx, %esi, %eax, %edx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -63,7 +63,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   movq    %rdi, %rax
 ;   cqo %rax, %rdx
-;   movq    %rdx, %r8
+;   movq    %rdx, %rcx
 ;   idiv    %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -14,8 +14,8 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   movdqa  %xmm0, %xmm6
 ;   movdqu  const(0), %xmm0
-;   movdqa  %xmm6, %xmm8
-;   vpermi2b %xmm1, %xmm8, %xmm0, %xmm0
+;   movdqa  %xmm6, %xmm7
+;   vpermi2b %xmm1, %xmm7, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -32,12 +32,12 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm9
+;   movdqa  %xmm0, %xmm8
 ;   movdqu  const(1), %xmm0
-;   movdqu  const(0), %xmm8
-;   movdqa  %xmm9, %xmm11
-;   vpermi2b %xmm1, %xmm11, %xmm8, %xmm8
-;   andps   %xmm0, %xmm8, %xmm0
+;   movdqu  const(0), %xmm7
+;   movdqa  %xmm8, %xmm10
+;   vpermi2b %xmm1, %xmm10, %xmm7, %xmm7
+;   andps   %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -53,8 +53,8 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   movdqa  %xmm0, %xmm6
 ;   movdqu  const(0), %xmm0
-;   movdqa  %xmm6, %xmm8
-;   vpermi2b %xmm1, %xmm8, %xmm0, %xmm0
+;   movdqa  %xmm6, %xmm7
+;   vpermi2b %xmm1, %xmm7, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -274,19 +274,19 @@ block0(v0: i8x16, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $3, %esi
-;   andq    %rsi, $7, %rsi
-;   movdqa  %xmm0, %xmm15
-;   punpcklbw %xmm15, %xmm0, %xmm15
-;   movdqa  %xmm15, %xmm13
+;   movl    $3, %r11d
+;   andq    %r11, $7, %r11
+;   movdqa  %xmm0, %xmm14
+;   punpcklbw %xmm14, %xmm0, %xmm14
+;   movdqa  %xmm14, %xmm13
 ;   punpckhbw %xmm0, %xmm0, %xmm0
-;   movdqa  %xmm0, %xmm7
-;   addl    %esi, $8, %esi
-;   movd    %esi, %xmm15
+;   movdqa  %xmm0, %xmm6
+;   addl    %r11d, $8, %r11d
+;   movd    %r11d, %xmm14
 ;   movdqa  %xmm13, %xmm0
-;   psraw   %xmm0, %xmm15, %xmm0
-;   psraw   %xmm7, %xmm15, %xmm7
-;   packsswb %xmm0, %xmm7, %xmm0
+;   psraw   %xmm0, %xmm14, %xmm0
+;   psraw   %xmm6, %xmm14, %xmm6
+;   packsswb %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -300,15 +300,14 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   pextrd.w $0, %xmm0, %r10
-;   pextrd.w $1, %xmm0, %rsi
-;   movq    %rax, %rcx
-;   sarq    %cl, %r10, %r10
-;   sarq    %cl, %rsi, %rsi
+;   pextrd.w $0, %xmm0, %r9
+;   pextrd.w $1, %xmm0, %r11
+;   movq    %rdi, %rcx
+;   sarq    %cl, %r9, %r9
+;   sarq    %cl, %r11, %r11
 ;   uninit  %xmm0
-;   pinsrd.w $0, %xmm0, %r10, %xmm0
-;   pinsrd.w $1, %xmm0, %rsi, %xmm0
+;   pinsrd.w $0, %xmm0, %r9, %xmm0
+;   pinsrd.w $1, %xmm0, %r11, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -12,8 +12,8 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm0, %xmm1, %xmm0
-;   pcmpeqd %xmm7, %xmm7, %xmm7
-;   pxor    %xmm0, %xmm7, %xmm0
+;   pcmpeqd %xmm6, %xmm6, %xmm6
+;   pxor    %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -29,8 +29,8 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   pmaxud  %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm0, %xmm1, %xmm0
-;   pcmpeqd %xmm9, %xmm9, %xmm9
-;   pxor    %xmm0, %xmm9, %xmm0
+;   pcmpeqd %xmm8, %xmm8, %xmm8
+;   pxor    %xmm0, %xmm8, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -44,9 +44,9 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm5
-;   pmaxsw  %xmm5, %xmm1, %xmm5
-;   pcmpeqw %xmm0, %xmm5, %xmm0
+;   movdqa  %xmm0, %xmm4
+;   pmaxsw  %xmm4, %xmm1, %xmm4
+;   pcmpeqw %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -60,9 +60,9 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm5
-;   pmaxub  %xmm5, %xmm1, %xmm5
-;   pcmpeqb %xmm0, %xmm5, %xmm0
+;   movdqa  %xmm0, %xmm4
+;   pmaxub  %xmm4, %xmm1, %xmm4
+;   pcmpeqb %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -10,10 +10,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqu  const(0), %xmm7
+;   movdqu  const(0), %xmm6
 ;   pmulhrsw %xmm0, %xmm1, %xmm0
-;   pcmpeqw %xmm7, %xmm0, %xmm7
-;   pxor    %xmm0, %xmm7, %xmm0
+;   pcmpeqw %xmm6, %xmm0, %xmm6
+;   pxor    %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -10,9 +10,9 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorl    %r11d, %r11d, %r11d
+;   xorl    %r10d, %r10d, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   srem_seq %al, %dl, %sil, %al, %dl, tmp=(none)
 ;   shrq    $8, %rax, %rax
 ;   movq    %rbp, %rsp
@@ -28,9 +28,9 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorl    %r11d, %r11d, %r11d
+;   xorl    %r10d, %r10d, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   srem_seq %ax, %dx, %si, %ax, %dx, tmp=(none)
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -46,9 +46,9 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorl    %r11d, %r11d, %r11d
+;   xorl    %r10d, %r10d, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   srem_seq %eax, %edx, %esi, %eax, %edx, tmp=(none)
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -64,9 +64,9 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   xorl    %r11d, %r11d, %r11d
+;   xorl    %r10d, %r10d, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   srem_seq %rax, %rdx, %rsi, %rax, %rdx, tmp=(none)
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -22,16 +22,16 @@ block0(v0: i128, v1: i8):
 ;   sarq    %cl, %rdx, %rdx
 ;   movq    %rcx, %rax
 ;   movl    $64, %ecx
-;   movq    %rax, %r11
-;   subq    %rcx, %r11, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r11
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   movq    %rax, %r8
+;   subq    %rcx, %r8, %rcx
+;   movq    %rsi, %r11
+;   shlq    %cl, %r11, %r11
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %r8
+;   cmovzq  %rax, %r11, %r11
+;   orq     %rdi, %r11, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r11
+;   testq   $64, %r8
 ;   movq    %rdx, %rax
 ;   cmovzq  %rdi, %rax, %rax
 ;   cmovzq  %rdx, %rsi, %rsi
@@ -51,23 +51,21 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %rdx
-;   sarq    %cl, %rdx, %rdx
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   sarq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r10
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   subq    %rcx, %rdx, %rcx
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r10, %r10
+;   orq     %rdi, %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r10
-;   movq    %rdx, %rax
+;   testq   $64, %rdx
+;   movq    %r11, %rax
 ;   cmovzq  %rdi, %rax, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmovzq  %r11, %rsi, %rsi
 ;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -84,23 +82,21 @@ block0(v0: i128, v1: i32):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %rdx
-;   sarq    %cl, %rdx, %rdx
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   sarq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r10
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   subq    %rcx, %rdx, %rcx
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r10, %r10
+;   orq     %rdi, %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r10
-;   movq    %rdx, %rax
+;   testq   $64, %rdx
+;   movq    %r11, %rax
 ;   cmovzq  %rdi, %rax, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmovzq  %r11, %rsi, %rsi
 ;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -117,23 +113,21 @@ block0(v0: i128, v1: i16):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %rdx
-;   sarq    %cl, %rdx, %rdx
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   sarq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r10
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   subq    %rcx, %rdx, %rcx
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r10, %r10
+;   orq     %rdi, %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r10
-;   movq    %rdx, %rax
+;   testq   $64, %rdx
+;   movq    %r11, %rax
 ;   cmovzq  %rdi, %rax, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmovzq  %r11, %rsi, %rsi
 ;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -150,23 +144,21 @@ block0(v0: i128, v1: i8):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %rdx
-;   sarq    %cl, %rdx, %rdx
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   sarq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
-;   movq    %rsi, %rax
-;   shlq    %cl, %rax, %rax
-;   xorq    %r8, %r8, %r8
-;   testq   $127, %r10
-;   cmovzq  %r8, %rax, %rax
-;   orq     %rdi, %rax, %rdi
+;   subq    %rcx, %rdx, %rcx
+;   movq    %rsi, %r10
+;   shlq    %cl, %r10, %r10
+;   xorq    %rax, %rax, %rax
+;   testq   $127, %rdx
+;   cmovzq  %rax, %r10, %r10
+;   orq     %rdi, %r10, %rdi
 ;   sarq    $63, %rsi, %rsi
-;   testq   $64, %r10
-;   movq    %rdx, %rax
+;   testq   $64, %rdx
+;   movq    %r11, %rax
 ;   cmovzq  %rdi, %rax, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmovzq  %r11, %rsi, %rsi
 ;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -181,8 +173,7 @@ block0(v0: i64, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   sarq    %cl, %rdi, %rdi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
@@ -198,8 +189,7 @@ block0(v0: i32, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   sarl    %cl, %edi, %edi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -125,8 +125,8 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq    %rbx, 0(%rsp)
 ;   movq    %r14, 8(%rsp)
 ; block0:
-;   movq    %rdi, %r14
 ;   movq    %rdx, %rbx
+;   movq    %rdi, %r14
 ;   subq    %rsp, $192, %rsp
 ;   virtual_sp_offset_adjust 192
 ;   lea     0(%rsp), %rdi

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -31,8 +31,8 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rdi
-;   load_ext_name %f2+0, %r9
-;   call    *%r9
+;   load_ext_name %f2+0, %r8
+;   call    *%r8
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -19,16 +19,16 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    8(%rdx), %eax
-;   cmpl    %eax, %edi
+;   movl    8(%rdx), %r11d
+;   cmpl    %r11d, %edi
 ;   jb      label1; j label2
 ; block1:
-;   movl    %edi, %r8d
-;   movq    0(%rdx), %rcx
-;   movq    %rcx, %rdx
-;   addq    %rdx, %r8, %rdx
-;   cmpl    %eax, %edi
-;   cmovnbq %rcx, %rdx, %rdx
+;   movl    %edi, %ecx
+;   movq    0(%rdx), %rax
+;   movq    %rax, %rdx
+;   addq    %rdx, %rcx, %rdx
+;   cmpl    %r11d, %edi
+;   cmovnbq %rax, %rdx, %rdx
 ;   movq    %rsi, 0(%rdx)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -10,8 +10,8 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %r10d
-;   movq    %r10, %rax
+;   movzbl  %dil, %r9d
+;   movq    %r9, %rax
 ;   div     %al, (none), %sil, %al, (none)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -26,9 +26,9 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %ax, %dx, %si, %ax, %dx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -43,9 +43,9 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %eax, %edx, %esi, %eax, %edx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -60,9 +60,9 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -11,9 +11,9 @@ block0(v1: i32, v2: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    0(%rsi), %r9d
-;   cmpl    %edi, %r9d
-;   cmovnbl %r9d, %edi, %edi
+;   movl    0(%rsi), %r8d
+;   cmpl    %edi, %r8d
+;   cmovnbl %r8d, %edi, %edi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -10,8 +10,8 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movzbl  %dil, %r10d
-;   movq    %r10, %rax
+;   movzbl  %dil, %r9d
+;   movq    %r9, %rax
 ;   div     %al, (none), %sil, %al, (none)
 ;   shrq    $8, %rax, %rax
 ;   movq    %rbp, %rsp
@@ -27,9 +27,9 @@ block0(v0: i16, v1: i16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %ax, %dx, %si, %ax, %dx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -45,9 +45,9 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %eax, %edx, %esi, %eax, %edx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
@@ -63,9 +63,9 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $0, %r11d
+;   movl    $0, %r10d
 ;   movq    %rdi, %rax
-;   movq    %r11, %rdx
+;   movq    %r10, %rdx
 ;   div     %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -21,15 +21,15 @@ block0(v0: i128, v1: i8):
 ;   shrq    %cl, %r8, %r8
 ;   movq    %rcx, %rax
 ;   movl    $64, %ecx
-;   movq    %rax, %r11
-;   subq    %rcx, %r11, %rcx
+;   movq    %rax, %r9
+;   subq    %rcx, %r9, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
-;   testq   $127, %r11
-;   cmovzq  %rax, %rsi, %rsi
+;   xorq    %r11, %r11, %r11
+;   testq   $127, %r9
+;   cmovzq  %r11, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r11
+;   testq   $64, %r9
 ;   movq    %r8, %rax
 ;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r8, %rdx, %rdx
@@ -48,22 +48,21 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r8
-;   shrq    %cl, %r8, %r8
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %rdx, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
-;   testq   $127, %r10
-;   cmovzq  %rax, %rsi, %rsi
+;   xorq    %r10, %r10, %r10
+;   testq   $127, %r8
+;   cmovzq  %r10, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r10
-;   movq    %r8, %rax
+;   testq   $64, %r8
+;   movq    %r11, %rax
 ;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r8, %rdx, %rdx
+;   cmovzq  %r11, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -79,22 +78,21 @@ block0(v0: i128, v1: i32):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r8
-;   shrq    %cl, %r8, %r8
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %rdx, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
-;   testq   $127, %r10
-;   cmovzq  %rax, %rsi, %rsi
+;   xorq    %r10, %r10, %r10
+;   testq   $127, %r8
+;   cmovzq  %r10, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r10
-;   movq    %r8, %rax
+;   testq   $64, %r8
+;   movq    %r11, %rax
 ;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r8, %rdx, %rdx
+;   cmovzq  %r11, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -110,22 +108,21 @@ block0(v0: i128, v1: i16):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r8
-;   shrq    %cl, %r8, %r8
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %rdx, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
-;   testq   $127, %r10
-;   cmovzq  %rax, %rsi, %rsi
+;   xorq    %r10, %r10, %r10
+;   testq   $127, %r8
+;   cmovzq  %r10, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r10
-;   movq    %r8, %rax
+;   testq   $64, %r8
+;   movq    %r11, %rax
 ;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r8, %rdx, %rdx
+;   cmovzq  %r11, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -141,22 +138,21 @@ block0(v0: i128, v1: i8):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   shrq    %cl, %rdi, %rdi
-;   movq    %rsi, %r8
-;   shrq    %cl, %r8, %r8
-;   movq    %rcx, %rax
+;   movq    %rsi, %r11
+;   shrq    %cl, %r11, %r11
 ;   movl    $64, %ecx
-;   movq    %rax, %r10
-;   subq    %rcx, %r10, %rcx
+;   movq    %rdx, %r8
+;   subq    %rcx, %r8, %rcx
 ;   shlq    %cl, %rsi, %rsi
-;   xorq    %rax, %rax, %rax
-;   testq   $127, %r10
-;   cmovzq  %rax, %rsi, %rsi
+;   xorq    %r10, %r10, %r10
+;   testq   $127, %r8
+;   cmovzq  %r10, %rsi, %rsi
 ;   orq     %rsi, %rdi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $64, %r10
-;   movq    %r8, %rax
+;   testq   $64, %r8
+;   movq    %r11, %rax
 ;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r8, %rdx, %rdx
+;   cmovzq  %r11, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -170,8 +166,7 @@ block0(v0: i64, v1: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   shrq    %cl, %rdi, %rdi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp
@@ -188,8 +183,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r9
-;   movq    %r9, %rcx
+;   movq    %rsi, %rcx
 ;   shrl    %cl, %edi, %edi
 ;   movq    %rdi, %rax
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -11,9 +11,9 @@ block0(v0: i64, v2: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqu  80(%rdi), %xmm5
-;   palignr $8, %xmm5, %xmm5, %xmm5
-;   pmovzxbw %xmm5, %xmm0
+;   movdqu  80(%rdi), %xmm4
+;   palignr $8, %xmm4, %xmm4, %xmm4
+;   pmovzxbw %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
Currently, Cranelift's ABI code emits a sequence of moves from physical
registers into vregs at the top of the function body, one for every
register-carried argument.

For a number of reasons, we want to move to operand constraints instead,
and remove the use of explicitly-named "pinned vregs"; this allows for
better regalloc in theory, as it removes the need to "reverse-engineer"
the sequence of moves.

This PR alters the ABI code so that it generates a single "args"
pseudo-instruction as the first instruction in the function body. This
pseudo-inst defs all register arguments, and constrains them to the
appropriate registers at the def-point. Subsequently the regalloc can
move them wherever it needs to.

Some care was taken not to have this pseudo-inst show up in
post-regalloc disassemblies, but the change did cause a general regalloc
"shift" in many tests, so the precise-output updates are a bit noisy.
Sorry about that!

A subsequent PR will handle the other half of the ABI code, namely, the
callsite case, with a similar preg-to-constraint conversion.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
