### PR TITLE
Throw out fewer fuzz inputs with differential fuzzer

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -38,11 +38,11 @@ impl Config {
 
         // Make it more likely that there are types available to generate a
         // function with.
-        config.min_types = 1;
+        config.min_types = config.min_types.max(1);
         config.max_types = config.max_types.max(1);
 
         // Generate at least one function
-        config.min_funcs = 1;
+        config.min_funcs = config.min_funcs.max(1);
         config.max_funcs = config.max_funcs.max(1);
 
         // Allow a memory to be generated, but don't let it get too large.
@@ -102,7 +102,7 @@ impl Config {
     /// to ensure termination; as doing so will add an additional global to the module,
     /// the pooling allocator, if configured, will also have its globals limit updated.
     pub fn generate(
-        &mut self,
+        &self,
         input: &mut Unstructured<'_>,
         default_fuel: Option<u32>,
     ) -> arbitrary::Result<wasm_smith::Module> {

--- a/crates/fuzzing/src/generators/single_inst_module.rs
+++ b/crates/fuzzing/src/generators/single_inst_module.rs
@@ -24,17 +24,7 @@ pub struct SingleInstModule<'a> {
 
 impl<'a> SingleInstModule<'a> {
     /// Choose a single-instruction module that matches `config`.
-    pub fn new(u: &mut Unstructured<'a>, config: &mut ModuleConfig) -> arbitrary::Result<&'a Self> {
-        // To avoid skipping modules unnecessarily during fuzzing, fix up the
-        // `ModuleConfig` to match the inherent limits of a single-instruction
-        // module.
-        config.config.min_funcs = 1;
-        config.config.max_funcs = 1;
-        config.config.min_tables = 0;
-        config.config.max_tables = 0;
-        config.config.min_memories = 0;
-        config.config.max_memories = 0;
-
+    pub fn new(u: &mut Unstructured<'a>, config: &ModuleConfig) -> arbitrary::Result<&'a Self> {
         // Only select instructions that match the `ModuleConfig`.
         let instructions = &INSTRUCTIONS
             .iter()

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -155,5 +155,5 @@ fn smoke() {
     if !wasm_spec_interpreter::support_compiled_in() {
         return;
     }
-    crate::oracles::engine::smoke_test_engine(|config| SpecInterpreter::new(&config.module_config))
+    crate::oracles::engine::smoke_test_engine(|_, config| Ok(SpecInterpreter::new(config)))
 }

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -320,5 +320,5 @@ fn get_diff_value(
 
 #[test]
 fn smoke() {
-    crate::oracles::engine::smoke_test_engine(|config| V8Engine::new(&config.module_config))
+    crate::oracles::engine::smoke_test_engine(|_, config| Ok(V8Engine::new(config)))
 }

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -208,5 +208,5 @@ impl Into<DiffValue> for wasmi::RuntimeValue {
 
 #[test]
 fn smoke() {
-    crate::oracles::engine::smoke_test_engine(|config| WasmiEngine::new(&config.module_config))
+    crate::oracles::engine::smoke_test_engine(|_, config| Ok(WasmiEngine::new(config)))
 }

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -227,5 +227,5 @@ impl Into<DiffValue> for Val {
 
 #[test]
 fn smoke() {
-    crate::oracles::engine::smoke_test_engine(|config| WasmtimeEngine::new(config))
+    crate::oracles::engine::smoke_test_engine(|u, config| WasmtimeEngine::new(u, config))
 }


### PR DESCRIPTION
Prior to this commit the differential fuzzer would generate a module and
then select an engine to execute the module against Wasmtime. This
meant, however, that the candidate list of engines were filtered against
the configuration used to generate the module to ensure that the
selected engine could run the generated module.

This commit inverts this logic and instead selects an engine first,
allowing the engine to then tweak the module configuration to ensure
that the generated module is compatible with the engine selected. This
means that fewer fuzz inputs are discarded because every fuzz input will
result in an engine being executed.

Internally the engine constructors have all been updated to update the
configuration to work instead of filtering the configuration. Some other
fixes were applied for the spec interpreter as well to work around #4852

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
