### PR TITLE
cranelift-fuzzgen: Consume all trailing fuzz input

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -137,11 +137,12 @@ where
         })
     }
 
-    fn generate_test_inputs(&mut self, signature: &Signature) -> Result<Vec<TestCaseInput>> {
-        let num_tests = self.u.int_in_range(self.config.test_case_inputs.clone())?;
-        let mut inputs = Vec::with_capacity(num_tests);
+    fn generate_test_inputs(mut self, signature: &Signature) -> Result<Vec<TestCaseInput>> {
+        let mut inputs = Vec::new();
 
-        for _ in 0..num_tests {
+        loop {
+            let last_len = self.u.len();
+
             let test_args = signature
                 .params
                 .iter()
@@ -149,6 +150,17 @@ where
                 .collect::<Result<TestCaseInput>>()?;
 
             inputs.push(test_args);
+
+            // Continue generating input as long as we just consumed some of self.u. Otherwise
+            // we'll generate the same test input again and again, forever. Note that once self.u
+            // becomes empty we obviously can't consume any more of it, so this check is more
+            // general. Also note that we need to generate at least one input or the fuzz target
+            // won't actually test anything, so checking at the end of the loop is good, even if
+            // self.u is empty from the start and we end up with all zeros in test_args.
+            assert!(self.u.len() <= last_len);
+            if self.u.len() == last_len {
+                break;
+            }
         }
 
         Ok(inputs)


### PR DESCRIPTION
But don't keep going once we've consumed it all.

I got tired of having a bunch of copies of the same all-zeros test inputs at the end. This version always produces exactly one all-zeros test input at the end, which I feel okay about. I could remove that by explicitly checking for `self.u.is_empty()` but, eh, testing an all-zeros input could be useful.

This uses less of the fuzz input too since it doesn't need to come up with a count of how many test inputs to generate.

This changes the input format for this fuzz target, so I figure I'll bundle it together with #4824 and merge both sometime next week.

cc: @afonso360 