### PR TITLE
Allocate less while constructing cranelift-fuzzgen tests

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -864,7 +864,12 @@ impl DataFlowGraph {
             self.value_type(
                 self[inst]
                     .typevar_operand(&self.value_lists)
-                    .expect("Instruction format doesn't have a designated operand, bad opcode."),
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Instruction format for {:?} doesn't have a designated operand",
+                            self[inst]
+                        )
+                    }),
             )
         } else {
             self.value_type(self.first_result(inst))

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -563,7 +563,6 @@ where
     blocks_without_params: Vec<Block>,
     jump_tables: Vec<JumpTable>,
     func_refs: Vec<(Signature, FuncRef)>,
-    next_func_index: u32,
     static_stack_slots: Vec<(StackSlot, StackSize)>,
 }
 
@@ -581,7 +580,6 @@ where
             jump_tables: vec![],
             func_refs: vec![],
             static_stack_slots: vec![],
-            next_func_index: 0,
         }
     }
 
@@ -915,10 +913,9 @@ where
     }
 
     fn generate_funcrefs(&mut self, builder: &mut FunctionBuilder) -> Result<()> {
-        for _ in 0..self.param(&self.config.funcrefs_per_function)? {
+        let count = self.param(&self.config.funcrefs_per_function)?;
+        for func_index in 0..count.try_into().unwrap() {
             let (ext_name, sig) = if self.u.arbitrary::<bool>()? {
-                let func_index = self.next_func_index;
-                self.next_func_index = self.next_func_index.wrapping_add(1);
                 let user_func_ref = builder
                     .func
                     .declare_imported_user_function(UserExternalName {


### PR DESCRIPTION
These are some steps I was taking toward a bigger refactoring of cranelift-fuzzgen, but this is as far as I got finished before other things came up. I think these are still improvements even without the bigger changes I wanted to make, so I'd like to get them merged.

I believe this PR should not change the input format for cranelift-fuzzgen or cranelift-icache and so should be fine to merge at any time.

cc: @afonso360

edit: I believe this will have merge conflicts with #4824. I'd probably prefer to merge that first and then fix this up rather than the other way around.