### PR TITLE
Bump crates to 1.0.0 and add the release notes for 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,7 +3098,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "cfg-if",
 ]
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap 3.2.8",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3493,11 +3493,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "0.41.0"
+version = "1.0.0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "object",
  "once_cell",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.41.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -21,15 +21,15 @@ path = "src/bin/wasmtime.rs"
 doc = false
 
 [dependencies]
-wasmtime = { path = "crates/wasmtime", version = "0.41.0", default-features = false, features = ['cache', 'cranelift'] }
-wasmtime-cache = { path = "crates/cache", version = "=0.41.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=0.41.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=0.41.0" }
-wasmtime-environ = { path = "crates/environ", version = "=0.41.0" }
-wasmtime-wast = { path = "crates/wast", version = "=0.41.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "0.41.0" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "0.41.0", optional = true }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "0.41.0", optional = true }
+wasmtime = { path = "crates/wasmtime", version = "1.0.0", default-features = false, features = ['cache', 'cranelift'] }
+wasmtime-cache = { path = "crates/cache", version = "=1.0.0" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=1.0.0" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=1.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=1.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=1.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "1.0.0" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "1.0.0", optional = true }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "1.0.0", optional = true }
 clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
@@ -43,7 +43,7 @@ rustix = { version = "0.35.6", features = ["mm", "param"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
-wasmtime = { path = "crates/wasmtime", version = "0.41.0", features = ['component-model'] }
+wasmtime = { path = "crates/wasmtime", version = "1.0.0", features = ['component-model'] }
 env_logger = "0.9.0"
 log = "0.4.8"
 filecheck = "0.5.0"
@@ -60,7 +60,7 @@ wat = "1.0.48"
 once_cell = "1.9.0"
 rayon = "1.5.0"
 component-macro-test = { path = "crates/misc/component-macro-test" }
-wasmtime-wast = { path = "crates/wast", version = "=0.41.0", features = ['component-model'] }
+wasmtime-wast = { path = "crates/wast", version = "=1.0.0", features = ['component-model'] }
 component-test-util = { path = "crates/misc/component-test-util" }
 wasmtime-component-util = { path = "crates/component-util" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,12 +1,167 @@
 --------------------------------------------------------------------------------
 
-## 0.41.0
+## 1.0.0
 
-Unreleased.
+Released 2022-09-20
+
+This release marks the official 1.0 release of Wasmtime and represents the
+culmination of the work amongst over 300 contributors. Wasmtime has been
+battle-tested in production through multiple embeddings for quite some time now
+and we're confident in releasing a 1.0 version to signify the stability and
+quality of the Wasmtime engine.
+
+More information about Wasmtime's 1.0 release is on the [Bytecode Alliance's
+blog][ba-blog] with separate posts on [Wasmtime's performance
+features][ba-perf], [Wasmtime's security story][ba-security], and [the 1.0
+release announcement][ba-1.0].
+
+As a reminder the 2.0 release of Wasmtime is scheduled for one month from now on
+October 20th. For more information see the [RFC on Wasmtime's 1.0
+release][rfc-1.0].
+
+[ba-blog]: https://bytecodealliance.org/articles/
+[ba-perf]: TODO
+[ba-security]: TODO
+[ba-1.0]: TODO
+[rfc-1.0]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-one-dot-oh.md
 
 ### Added
 
+* An incremental compilation cache for Cranelift has been added which can be
+  enabled with `Config::enable_incremental_compilation`, and this option is
+  disabled by default for now. The incremental compilation cache has been
+  measured to improve compile times for cold uncached modules as well due to
+  some wasm modules having similar-enough functions internally.
+  [#4551](https://github.com/bytecodealliance/wasmtime/pull/4551)
+
+* Source tarballs are now available as part of Wasmtime's release artifacts.
+  [#4294](https://github.com/bytecodealliance/wasmtime/pull/4294)
+
+* WASI APIs that specify the REALTIME clock are now supported.
+  [#4777](https://github.com/bytecodealliance/wasmtime/pull/4777)
+
+* WASI's socket functions are now fully implemented.
+  [#4776](https://github.com/bytecodealliance/wasmtime/pull/4776)
+
+* The native call stack for async-executed wasm functions are no longer
+  automatically reset to zero after the stack is returned to the pool when using
+  the pooling allocator. A `Config::async_stack_zeroing` option has been added
+  to restore the old behavior of zero-on-return-to-pool.
+  [#4813](https://github.com/bytecodealliance/wasmtime/pull/4813)
+
+* Inline stack probing has been implemented for the Cranelift x64 backend.
+  [#4747](https://github.com/bytecodealliance/wasmtime/pull/4747)
+
 ### Changed
+
+* Generating of native unwind information has moved from a
+  `Config::wasm_backtrace` option to a new `Config::native_unwind_info` option
+  and is enabled by default.
+  [#4643](https://github.com/bytecodealliance/wasmtime/pull/4643)
+
+* The `memory-init-cow` feature is now enabled by default in the C API.
+  [#4690](https://github.com/bytecodealliance/wasmtime/pull/4690)
+
+* Back-edge CFI is now enabled by default on AArch64 macOS.
+  [#4720](https://github.com/bytecodealliance/wasmtime/pull/4720)
+
+* WASI calls will no longer remove NOTCAPABLE in preparation for the removal of
+  the rights system from WASI.
+  [#4666](https://github.com/bytecodealliance/wasmtime/pull/4666)
+
+### Internal
+
+This section of the release notes shouldn't affect external users since no
+public-facing APIs are affected, but serves as a place to document larger
+changes internally within Wasmtime.
+
+* Differential fuzzing has been refactored and improved into one fuzzing target
+  which can execute against any of Wasmtime itself (configured differently),
+  wasmi, V8, or the spec interpreter. Fuzzing now executes each exported
+  function with fuzz-generated inputs and the contents of all of memory and each
+  exported global is compared after each execution. Additionally more
+  interesting shapes of modules are also possible to generate.
+  [#4515](https://github.com/bytecodealliance/wasmtime/pull/4515)
+  [#4735](https://github.com/bytecodealliance/wasmtime/pull/4735)
+  [#4737](https://github.com/bytecodealliance/wasmtime/pull/4737)
+  [#4739](https://github.com/bytecodealliance/wasmtime/pull/4739)
+  [#4774](https://github.com/bytecodealliance/wasmtime/pull/4774)
+  [#4773](https://github.com/bytecodealliance/wasmtime/pull/4773)
+  [#4845](https://github.com/bytecodealliance/wasmtime/pull/4845)
+  [#4672](https://github.com/bytecodealliance/wasmtime/pull/4672)
+  [#4674](https://github.com/bytecodealliance/wasmtime/pull/4674)
+
+* The x64 backend for Cranelift has been fully migrated to ISLE.
+  [#4619](https://github.com/bytecodealliance/wasmtime/pull/4619)
+  [#4625](https://github.com/bytecodealliance/wasmtime/pull/4625)
+  [#4645](https://github.com/bytecodealliance/wasmtime/pull/4645)
+  [#4650](https://github.com/bytecodealliance/wasmtime/pull/4650)
+  [#4684](https://github.com/bytecodealliance/wasmtime/pull/4684)
+  [#4704](https://github.com/bytecodealliance/wasmtime/pull/4704)
+  [#4718](https://github.com/bytecodealliance/wasmtime/pull/4718)
+  [#4726](https://github.com/bytecodealliance/wasmtime/pull/4726)
+  [#4722](https://github.com/bytecodealliance/wasmtime/pull/4722)
+  [#4729](https://github.com/bytecodealliance/wasmtime/pull/4729)
+  [#4730](https://github.com/bytecodealliance/wasmtime/pull/4730)
+  [#4741](https://github.com/bytecodealliance/wasmtime/pull/4741)
+  [#4763](https://github.com/bytecodealliance/wasmtime/pull/4763)
+  [#4772](https://github.com/bytecodealliance/wasmtime/pull/4772)
+  [#4780](https://github.com/bytecodealliance/wasmtime/pull/4780)
+  [#4787](https://github.com/bytecodealliance/wasmtime/pull/4787)
+  [#4793](https://github.com/bytecodealliance/wasmtime/pull/4793)
+  [#4809](https://github.com/bytecodealliance/wasmtime/pull/4809)
+
+* The AArch64 backend for Cranelift has seen significant progress in being
+  ported to ISLE.
+  [#4608](https://github.com/bytecodealliance/wasmtime/pull/4608)
+  [#4639](https://github.com/bytecodealliance/wasmtime/pull/4639)
+  [#4634](https://github.com/bytecodealliance/wasmtime/pull/4634)
+  [#4748](https://github.com/bytecodealliance/wasmtime/pull/4748)
+  [#4750](https://github.com/bytecodealliance/wasmtime/pull/4750)
+  [#4751](https://github.com/bytecodealliance/wasmtime/pull/4751)
+  [#4753](https://github.com/bytecodealliance/wasmtime/pull/4753)
+  [#4788](https://github.com/bytecodealliance/wasmtime/pull/4788)
+  [#4796](https://github.com/bytecodealliance/wasmtime/pull/4796)
+  [#4785](https://github.com/bytecodealliance/wasmtime/pull/4785)
+  [#4819](https://github.com/bytecodealliance/wasmtime/pull/4819)
+  [#4821](https://github.com/bytecodealliance/wasmtime/pull/4821)
+  [#4832](https://github.com/bytecodealliance/wasmtime/pull/4832)
+
+* The s390x backend has seen improvements and additions to fully support the
+  Cranelift backend for rustc.
+  [#4682](https://github.com/bytecodealliance/wasmtime/pull/4682)
+  [#4702](https://github.com/bytecodealliance/wasmtime/pull/4702)
+  [#4616](https://github.com/bytecodealliance/wasmtime/pull/4616)
+  [#4680](https://github.com/bytecodealliance/wasmtime/pull/4680)
+
+* Significant improvements have been made to Cranelift-based fuzzing with more
+  supported features and more instructions being fuzzed.
+  [#4589](https://github.com/bytecodealliance/wasmtime/pull/4589)
+  [#4591](https://github.com/bytecodealliance/wasmtime/pull/4591)
+  [#4665](https://github.com/bytecodealliance/wasmtime/pull/4665)
+  [#4670](https://github.com/bytecodealliance/wasmtime/pull/4670)
+  [#4590](https://github.com/bytecodealliance/wasmtime/pull/4590)
+  [#4375](https://github.com/bytecodealliance/wasmtime/pull/4375)
+  [#4519](https://github.com/bytecodealliance/wasmtime/pull/4519)
+  [#4696](https://github.com/bytecodealliance/wasmtime/pull/4696)
+  [#4700](https://github.com/bytecodealliance/wasmtime/pull/4700)
+  [#4703](https://github.com/bytecodealliance/wasmtime/pull/4703)
+  [#4602](https://github.com/bytecodealliance/wasmtime/pull/4602)
+  [#4713](https://github.com/bytecodealliance/wasmtime/pull/4713)
+  [#4738](https://github.com/bytecodealliance/wasmtime/pull/4738)
+  [#4667](https://github.com/bytecodealliance/wasmtime/pull/4667)
+  [#4782](https://github.com/bytecodealliance/wasmtime/pull/4782)
+  [#4783](https://github.com/bytecodealliance/wasmtime/pull/4783)
+  [#4800](https://github.com/bytecodealliance/wasmtime/pull/4800)
+
+* Optimization work on cranelift has continued across various dimensions for
+  some modest compile-time improvements.
+  [#4621](https://github.com/bytecodealliance/wasmtime/pull/4621)
+  [#4701](https://github.com/bytecodealliance/wasmtime/pull/4701)
+  [#4697](https://github.com/bytecodealliance/wasmtime/pull/4697)
+  [#4711](https://github.com/bytecodealliance/wasmtime/pull/4711)
+  [#4710](https://github.com/bytecodealliance/wasmtime/pull/4710)
+  [#4829](https://github.com/bytecodealliance/wasmtime/pull/4829)
 
 --------------------------------------------------------------------------------
 

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -16,7 +16,7 @@ wasmparser = { version = "0.89.0", default-features = false }
 cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
 cranelift-entity = { path = "../entity", version = "0.88.0" }
 cranelift-frontend = { path = "../frontend", version = "0.88.0", default-features = false }
-wasmtime-types = { path = "../../crates/types", version = "0.41.0" }
+wasmtime-types = { path = "../../crates/types", version = "1.0.0" }
 hashbrown = { version = "0.12", optional = true }
 itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }

--- a/crates/asm-macros/Cargo.toml
+++ b/crates/asm-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasmtime-asm-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.41.0"
+version = "1.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cache"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Support for automatic module caching with Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli-flags"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Exposes common CLI flags used for running Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 file-per-thread-logger = "0.1.1"
 pretty_env_logger = "0.4.0"
 rayon = "1.5.0"
-wasmtime = { path = "../wasmtime", version = "0.41.0", default-features = false }
+wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false }
 
 [features]
 default = [

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-component-macro"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Macros for deriving component interface types from Rust types"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -17,7 +17,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
-wasmtime-component-util = { path = "../component-util", version = "=0.41.0" }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.0" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/component-util/Cargo.toml
+++ b/crates/component-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-component-util"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Utility types and functions to support the component model in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cranelift"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Integration between Cranelift and Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-wasmtime-environ = { path = "../environ", version = "=0.41.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.0" }
 cranelift-wasm = { path = "../../cranelift/wasm", version = "0.88.0" }
 cranelift-codegen = { path = "../../cranelift/codegen", version = "0.88.0" }
 cranelift-frontend = { path = "../../cranelift/frontend", version = "0.88.0" }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 cranelift-entity = { path = "../../cranelift/entity", version = "0.88.0" }
-wasmtime-types = { path = "../types", version = "0.41.0" }
+wasmtime-types = { path = "../types", version = "1.0.0" }
 wasmparser = "0.89.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
@@ -24,7 +24,7 @@ object = { version = "0.29.0", default-features = false, features = ['read_core'
 target-lexicon = "0.12"
 wasm-encoder = { version = "0.16.0", optional = true }
 wasmprinter = { version = "0.2.39", optional = true }
-wasmtime-component-util = { path = "../component-util", version = "=0.41.0", optional = true }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.0", optional = true }
 
 [dev-dependencies]
 atty = "0.2.14"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-fiber"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Fiber support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -18,7 +18,7 @@ cfg-if = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.35.6", features = ["mm", "param"] }
-wasmtime-asm-macros = { version = "=0.41.0", path = "../asm-macros" }
+wasmtime-asm-macros = { version = "=1.0.0", path = "../asm-macros" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.1"

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit-debug"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT debug interfaces support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 documentation = "https://docs.rs/wasmtime-jit"
@@ -11,9 +11,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2021"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "=0.41.0" }
-wasmtime-jit-debug = { path = "../jit-debug", version = "=0.41.0", features = ["perf_jitdump"], optional = true }
-wasmtime-runtime = { path = "../runtime", version = "=0.41.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.0" }
+wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.0", features = ["perf_jitdump"], optional = true }
+wasmtime-runtime = { path = "../runtime", version = "=1.0.0" }
 thiserror = "1.0.4"
 target-lexicon = { version = "0.12.0", default-features = false }
 anyhow = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-runtime"
@@ -11,10 +11,10 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2021"
 
 [dependencies]
-wasmtime-asm-macros = { path = "../asm-macros", version = "=0.41.0" }
-wasmtime-environ = { path = "../environ", version = "=0.41.0" }
-wasmtime-fiber = { path = "../fiber", version = "=0.41.0", optional = true }
-wasmtime-jit-debug = { path = "../jit-debug", version = "=0.41.0", features = ["gdb_jit_int"] }
+wasmtime-asm-macros = { path = "../asm-macros", version = "=1.0.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.0" }
+wasmtime-fiber = { path = "../fiber", version = "=1.0.0", optional = true }
+wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.0", features = ["gdb_jit_int"] }
 libc = { version = "0.2.112", default-features = false }
 log = "0.4.8"
 memoffset = "0.6.0"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -11,10 +11,10 @@ license = "Apache-2.0 WITH LLVM-exception"
 cfg-if = "1.0"
 
 [dev-dependencies]
-wasi-common = { path = "../wasi-common", version = "0.41.0" }
-wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "0.41.0" }
-wasmtime = { path = "../wasmtime", version = "0.41.0" }
-wasmtime-wasi = { path = "../wasi", version = "0.41.0", features = ["tokio"] }
+wasi-common = { path = "../wasi-common", version = "1.0.0" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "1.0.0" }
+wasmtime = { path = "../wasmtime", version = "1.0.0" }
+wasmtime-wasi = { path = "../wasi", version = "1.0.0", features = ["tokio"] }
 target-lexicon = "0.12.0"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-types"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WebAssembly type definitions for Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -20,7 +20,7 @@ links = "wasi-common-19"
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0"
-wiggle = { path = "../wiggle", default-features = false, version = "=0.41.0" }
+wiggle = { path = "../wiggle", default-features = false, version = "=1.0.0" }
 tracing = "0.1.19"
 cap-std = "0.25.0"
 cap-rand = "0.25.0"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-cap-std-sync"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2021"
 include = ["src/**/*", "README.md", "LICENSE" ]
 
 [dependencies]
-wasi-common = { path = "../", version = "=0.41.0" }
+wasi-common = { path = "../", version = "=1.0.0" }
 async-trait = "0.1"
 anyhow = "1.0"
 cap-std = "0.25.0"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-tokio"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ edition = "2021"
 include = ["src/**/*", "LICENSE" ]
 
 [dependencies]
-wasi-common = { path = "../", version = "=0.41.0" }
-wasi-cap-std-sync = { path = "../cap-std-sync", version = "=0.41.0" }
-wiggle = { path = "../../wiggle", version = "=0.41.0" }
+wasi-common = { path = "../", version = "=1.0.0" }
+wasi-cap-std-sync = { path = "../cap-std-sync", version = "=1.0.0" }
+wiggle = { path = "../../wiggle", version = "=1.0.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
 cap-std = "0.25.0"
 anyhow = "1"

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-crypto"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-crypto API"
 documentation = "https://docs.rs/wasmtime-wasi-crypto"
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.5" }
-wasmtime = { path = "../wasmtime", version = "0.41.0", default-features = false }
-wiggle = { path = "../wiggle", version = "=0.41.0" }
+wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false }
+wiggle = { path = "../wiggle", version = "=1.0.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-nn"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-nn API"
 documentation = "https://docs.rs/wasmtime-wasi-nn"
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 # These dependencies are necessary for the witx-generation macros to work:
 anyhow = "1.0"
-wiggle = { path = "../wiggle", version = "=0.41.0" }
+wiggle = { path = "../wiggle", version = "=1.0.0" }
 
 # These dependencies are necessary for the wasi-nn implementation:
 openvino = { version = "0.4.1", features = ["runtime-linking"] }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,11 +13,11 @@ include = ["src/**/*", "README.md", "LICENSE", "build.rs"]
 build = "build.rs"
 
 [dependencies]
-wasi-common = { path = "../wasi-common", version = "=0.41.0" }
-wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "=0.41.0", optional = true }
-wasi-tokio = { path = "../wasi-common/tokio", version = "=0.41.0", optional = true }
-wiggle = { path = "../wiggle", default-features = false, version = "=0.41.0", features = ["wasmtime_integration"] }
-wasmtime = { path = "../wasmtime", default-features = false, version = "0.41.0" }
+wasi-common = { path = "../wasi-common", version = "=1.0.0" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "=1.0.0", optional = true }
+wasi-tokio = { path = "../wasi-common/tokio", version = "=1.0.0", optional = true }
+wiggle = { path = "../wiggle", default-features = false, version = "=1.0.0", features = ["wasmtime_integration"] }
+wasmtime = { path = "../wasmtime", default-features = false, version = "1.0.0" }
 anyhow = "1.0"
 
 [features]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 documentation = "https://docs.rs/wasmtime"
@@ -13,14 +13,14 @@ edition = "2021"
 rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime", version = "=0.41.0" }
-wasmtime-environ = { path = "../environ", version = "=0.41.0" }
-wasmtime-jit = { path = "../jit", version = "=0.41.0" }
-wasmtime-cache = { path = "../cache", version = "=0.41.0", optional = true }
-wasmtime-fiber = { path = "../fiber", version = "=0.41.0", optional = true }
-wasmtime-cranelift = { path = "../cranelift", version = "=0.41.0", optional = true }
-wasmtime-component-macro = { path = "../component-macro", version = "=0.41.0", optional = true }
-wasmtime-component-util = { path = "../component-util", version = "=0.41.0", optional = true }
+wasmtime-runtime = { path = "../runtime", version = "=1.0.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.0" }
+wasmtime-jit = { path = "../jit", version = "=1.0.0" }
+wasmtime-cache = { path = "../cache", version = "=1.0.0", optional = true }
+wasmtime-fiber = { path = "../fiber", version = "=1.0.0", optional = true }
+wasmtime-cranelift = { path = "../cranelift", version = "=1.0.0", optional = true }
+wasmtime-component-macro = { path = "../component-macro", version = "=1.0.0", optional = true }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.0", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
 wasmparser = "0.89.0"
 anyhow = "1.0.19"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmtime = { path = "../wasmtime", version = "0.41.0", default-features = false, features = ['cranelift'] }
+wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false, features = ['cranelift'] }
 wast = "46.0.0"
 log = "0.4"
 

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,11 +13,11 @@ include = ["src/**/*", "README.md", "LICENSE"]
 [dependencies]
 thiserror = "1"
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }
-wiggle-macro = { path = "macro", version = "=0.41.0" }
+wiggle-macro = { path = "macro", version = "=1.0.0" }
 tracing = "0.1.26"
 bitflags = "1.2"
 async-trait = "0.1.42"
-wasmtime = { path = "../wasmtime", version = "0.41.0", optional = true, default-features = false }
+wasmtime = { path = "../wasmtime", version = "1.0.0", optional = true, default-features = false }
 anyhow = "1.0"
 
 [badges]

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-generate"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2021"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-macro"
-version = "0.41.0"
+version = "1.0.0"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -21,7 +21,7 @@ test = false
 doctest = false
 
 [dependencies]
-wiggle-generate = { path = "../generate", version = "=0.41.0" }
+wiggle-generate = { path = "../generate", version = "=1.0.0" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"


### PR DESCRIPTION
The 1.0.0 release branch was created over the weekend, but I forgot to bump the version number ahead of time which means that a `release-0.41.0` branch was actually created instead. I've pushed the contents of that branch to a `release-1.0.0` branch and have updated all the version numbers of Wasmtime-related crates to 1.0.0 in this PR. I plan on deleting the `release-0.41.0` branch shortly since that release will not be made.

I've additionally added somewhat extensive release notes to this PR as well for 1.0. I opted to add an "internals" section which tries to go through and list PRs related to major efforts, but there's a fair number of PRs so I'm curious if others feel like it's too much or if I should remove the PR links.

Finally I've also left TODO entries for our three blog posts going out. We'll be able to update the URLs for two of them for sure but we may have to do some prediction to figure out the 1.0 one depending on how we want to order things.