### PR TITLE
x64: remove `Inst::XmmLoadConst`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -246,12 +246,6 @@
                  (src Reg)
                  (dst SyntheticAmode))
 
-       ;; XMM (vector) unary op (to move a constant value into an xmm register):
-       ;; movups
-       (XmmLoadConst (src VCodeConstant)
-                     (dst WritableReg)
-                     (ty Type))
-
        ;; XMM (scalar) unary op (from xmm to integer reg): movd, movq,
        ;; cvtts{s,d}2si
        (XmmToGpr (op SseOpcode)
@@ -1716,9 +1710,7 @@
 ;; Load a constant into an XMM register.
 (decl x64_xmm_load_const (Type VCodeConstant) Xmm)
 (rule (x64_xmm_load_const ty const)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmLoadConst const dst ty))))
-        dst))
+      (x64_load ty (const_to_synthetic_amode const) (ExtKind.None)))
 
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -3856,6 +3848,8 @@
 (decl synthetic_amode_to_xmm_mem (SyntheticAmode) XmmMem)
 (rule (synthetic_amode_to_xmm_mem amode)
       (synthetic_amode_to_reg_mem amode))
+(decl const_to_synthetic_amode (VCodeConstant) SyntheticAmode)
+(extern constructor const_to_synthetic_amode const_to_synthetic_amode)
 
 ;; Helper for creating `MovPReg` instructions.
 (decl mov_preg (PReg) Reg)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -519,6 +519,12 @@ impl Into<SyntheticAmode> for Amode {
     }
 }
 
+impl Into<SyntheticAmode> for VCodeConstant {
+    fn into(self) -> SyntheticAmode {
+        SyntheticAmode::ConstantOffset(self)
+    }
+}
+
 impl PrettyPrint for SyntheticAmode {
     fn pretty_print(&self, _size: u8, allocs: &mut AllocationConsumer<'_>) -> String {
         match self {
@@ -527,7 +533,7 @@ impl PrettyPrint for SyntheticAmode {
             SyntheticAmode::NominalSPOffset { simm32 } => {
                 format!("rsp({} + virtual offset)", *simm32 as i32)
             }
-            SyntheticAmode::ConstantOffset(c) => format!("const({:?})", c),
+            SyntheticAmode::ConstantOffset(c) => format!("const({})", c.as_u32()),
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2138,13 +2138,6 @@ pub(crate) fn emit(
             sink.put1(*imm);
         }
 
-        Inst::XmmLoadConst { src, dst, ty } => {
-            let dst = allocs.next(dst.to_reg());
-            let load_offset = Amode::rip_relative(sink.get_label_for_constant(*src));
-            let load = Inst::load(*ty, load_offset, Writable::from_reg(dst), ExtKind::None);
-            load.emit(&[], sink, info, state);
-        }
-
         Inst::XmmUninitializedValue { .. } => {
             // This instruction format only exists to declare a register as a `def`; no code is
             // emitted.

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -112,7 +112,6 @@ impl Inst {
             | Inst::VirtualSPOffsetAdj { .. }
             | Inst::XmmCmove { .. }
             | Inst::XmmCmpRmR { .. }
-            | Inst::XmmLoadConst { .. }
             | Inst::XmmMinMaxSeq { .. }
             | Inst::XmmUninitializedValue { .. }
             | Inst::ElfTlsGetAddr { .. }
@@ -1081,11 +1080,6 @@ impl PrettyPrint for Inst {
                 format!("{} {}", ljustify("uninit".into()), dst)
             }
 
-            Inst::XmmLoadConst { src, dst, .. } => {
-                let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
-                format!("load_const {:?}, {}", src, dst)
-            }
-
             Inst::XmmToGpr {
                 op,
                 src,
@@ -1830,7 +1824,6 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             }
         }
         Inst::XmmUninitializedValue { dst } => collector.reg_def(dst.to_writable_reg()),
-        Inst::XmmLoadConst { dst, .. } => collector.reg_def(*dst),
         Inst::XmmMinMaxSeq { lhs, rhs, dst, .. } => {
             collector.reg_use(rhs.to_reg());
             collector.reg_use(lhs.to_reg());

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -413,6 +413,11 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     #[inline]
+    fn const_to_synthetic_amode(&mut self, c: VCodeConstant) -> SyntheticAmode {
+        SyntheticAmode::ConstantOffset(c)
+    }
+
+    #[inline]
     fn writable_gpr_to_reg(&mut self, r: WritableGpr) -> WritableReg {
         r.to_writable_reg()
     }

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -170,9 +170,9 @@ block0(v0: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm3
+;   movdqu  const(0), %xmm3
 ;   unpcklps %xmm0, %xmm3, %xmm0
-;   load_const VCodeConstant(1), %xmm7
+;   movdqu  const(1), %xmm7
 ;   subpd   %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -19,15 +19,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %r10
-;   addq    %r10, const(VCodeConstant(0)), %r10
+;   addq    %r10, const(0), %r10
 ;   movq    %r10, 0(%rsi)
 ;   movq    %rdi, %r11
-;   subq    %r11, const(VCodeConstant(0)), %r11
+;   subq    %r11, const(0), %r11
 ;   movq    %r11, 0(%rsi)
 ;   movq    %rdi, %rax
-;   andq    %rax, const(VCodeConstant(0)), %rax
+;   andq    %rax, const(0), %rax
 ;   movq    %rax, 0(%rsi)
-;   orq     %rdi, const(VCodeConstant(0)), %rdi
+;   orq     %rdi, const(0), %rdi
 ;   movq    %rdi, 0(%rsi)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -42,7 +42,7 @@ block0(v0: f64x2):
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   cmppd   $0, %xmm5, %xmm0, %xmm5
-;   load_const VCodeConstant(0), %xmm6
+;   movupd  const(0), %xmm6
 ;   andps   %xmm5, %xmm6, %xmm5
 ;   minpd   %xmm0, %xmm5, %xmm0
 ;   cvttpd2dq %xmm0, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -13,7 +13,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm6
-;   load_const VCodeConstant(0), %xmm0
+;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm6, %xmm8
 ;   vpermi2b %xmm1, %xmm8, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
@@ -33,8 +33,8 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm9
-;   load_const VCodeConstant(1), %xmm0
-;   load_const VCodeConstant(0), %xmm8
+;   movdqu  const(1), %xmm0
+;   movdqu  const(0), %xmm8
 ;   movdqa  %xmm9, %xmm11
 ;   vpermi2b %xmm1, %xmm11, %xmm8, %xmm8
 ;   andps   %xmm0, %xmm8, %xmm0
@@ -52,7 +52,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm6
-;   load_const VCodeConstant(0), %xmm0
+;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm6, %xmm8
 ;   vpermi2b %xmm1, %xmm8, %xmm0, %xmm0
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -140,9 +140,9 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm0
-;   load_const VCodeConstant(0), %xmm2
-;   load_const VCodeConstant(0), %xmm6
+;   movdqu  const(0), %xmm0
+;   movdqu  const(0), %xmm2
+;   movdqu  const(0), %xmm6
 ;   pand    %xmm2, %xmm0, %xmm2
 ;   pandn   %xmm0, %xmm6, %xmm0
 ;   por     %xmm0, %xmm2, %xmm0
@@ -205,11 +205,11 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(1), %xmm0
+;   movdqu  const(1), %xmm0
 ;   andq    %rdi, $7, %rdi
 ;   movd    %edi, %xmm6
 ;   psllw   %xmm0, %xmm6, %xmm0
-;   lea     const(VCodeConstant(0)), %rax
+;   lea     const(0), %rax
 ;   shlq    $4, %rdi, %rdi
 ;   movdqu  0(%rax,%rdi,1), %xmm14
 ;   pand    %xmm0, %xmm14, %xmm0
@@ -228,12 +228,12 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(1), %xmm0
+;   movdqu  const(1), %xmm0
 ;   movl    $1, %r10d
 ;   andq    %r10, $7, %r10
 ;   movd    %r10d, %xmm6
 ;   psrlw   %xmm0, %xmm6, %xmm0
-;   lea     const(VCodeConstant(0)), %rdi
+;   lea     const(0), %rdi
 ;   shlq    $4, %r10, %r10
 ;   movdqu  0(%rdi,%r10,1), %xmm14
 ;   pand    %xmm0, %xmm14, %xmm0
@@ -251,7 +251,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm9
+;   movdqu  const(0), %xmm9
 ;   andq    %rdi, $7, %rdi
 ;   movdqa  %xmm9, %xmm0
 ;   punpcklbw %xmm0, %xmm9, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -15,11 +15,11 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(3), %xmm0
-;   load_const VCodeConstant(2), %xmm5
-;   load_const VCodeConstant(0), %xmm3
+;   movdqu  const(3), %xmm0
+;   movdqu  const(2), %xmm5
+;   movdqu  const(0), %xmm3
 ;   pshufb  %xmm0, %xmm3, %xmm0
-;   load_const VCodeConstant(1), %xmm7
+;   movdqu  const(1), %xmm7
 ;   pshufb  %xmm5, %xmm7, %xmm5
 ;   por     %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
@@ -36,8 +36,8 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(1), %xmm0
-;   load_const VCodeConstant(0), %xmm2
+;   movdqu  const(1), %xmm0
+;   movdqu  const(0), %xmm2
 ;   pshufb  %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -54,9 +54,9 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(1), %xmm0
-;   load_const VCodeConstant(1), %xmm3
-;   load_const VCodeConstant(0), %xmm4
+;   movdqu  const(1), %xmm0
+;   movdqu  const(1), %xmm3
+;   movdqu  const(0), %xmm4
 ;   paddusb %xmm3, %xmm4, %xmm3
 ;   pshufb  %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -13,7 +13,7 @@ block0(v0: i8x16):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
-;   load_const VCodeConstant(0), %xmm0
+;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm5, %xmm6
 ;   pmaddubsw %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
@@ -31,7 +31,7 @@ block0(v0: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm3
+;   movdqu  const(0), %xmm3
 ;   pmaddwd %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -48,7 +48,7 @@ block0(v0: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm3
+;   movdqu  const(0), %xmm3
 ;   pmaddubsw %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -65,11 +65,11 @@ block0(v0: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm3
+;   movdqu  const(0), %xmm3
 ;   pxor    %xmm0, %xmm3, %xmm0
-;   load_const VCodeConstant(1), %xmm7
+;   movdqu  const(1), %xmm7
 ;   pmaddwd %xmm0, %xmm7, %xmm0
-;   load_const VCodeConstant(2), %xmm11
+;   movdqu  const(2), %xmm11
 ;   paddd   %xmm0, %xmm11, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -10,10 +10,11 @@ block0(v0: i16x8, v1: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_const VCodeConstant(0), %xmm7
+;   movdqu  const(0), %xmm7
 ;   pmulhrsw %xmm0, %xmm1, %xmm0
 ;   pcmpeqw %xmm7, %xmm0, %xmm7
 ;   pxor    %xmm0, %xmm7, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -14,10 +14,10 @@ block0(v0: f64x2):
 ; block0:
 ;   xorpd   %xmm3, %xmm3, %xmm3
 ;   maxpd   %xmm0, %xmm3, %xmm0
-;   load_const VCodeConstant(0), %xmm7
+;   movupd  const(0), %xmm7
 ;   minpd   %xmm0, %xmm7, %xmm0
 ;   roundpd $3, %xmm0, %xmm0
-;   load_const VCodeConstant(1), %xmm13
+;   movupd  const(1), %xmm13
 ;   addpd   %xmm0, %xmm13, %xmm0
 ;   shufps  $136, %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp


### PR DESCRIPTION
This is a cherry-pick of a long-ago commit, 2d46637. The original
message reads:

> Now that `SyntheticAmode` can refer to constants, there is no longer a
> need for a separate instruction format--standard load instructions will
> work.

Since then, the transition to ISLE and the use of `XmmLoadConst` in many
more places makes this change a larger diff than the original. The basic
idea is the same, though: the extra indirection of `Inst::XMmLoadConst`
is removed and replaced by a direct use of `VCodeConstant` as a
`SyntheticAmode`. This has no effect on codegen, but the CLIF output is
now clearer in that the actual instruction is displayed (e.g., `movdqu`)
instead of a made-up instruction (`load_const`).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
