### PR TITLE
Don't reverse icmp nof/of

### DIFF
--- a/cranelift/codegen/src/ir/condcodes.rs
+++ b/cranelift/codegen/src/ir/condcodes.rs
@@ -24,7 +24,7 @@ pub trait CondCode: Copy {
     /// The reversed condition code produces the same result as swapping `x` and `y` in the
     /// comparison. That is, `cmp CC, x, y` is the same as `cmp CC.reverse(), y, x`.
     #[must_use]
-    fn reverse(self) -> Self;
+    fn reverse(self) -> Option<Self>;
 }
 
 /// Condition code for comparing integers.
@@ -80,21 +80,22 @@ impl CondCode for IntCC {
         }
     }
 
-    fn reverse(self) -> Self {
+    /// Returns the reversed condition code when that operation is defined.
+    fn reverse(self) -> Option<Self> {
         use self::IntCC::*;
         match self {
-            Equal => Equal,
-            NotEqual => NotEqual,
-            SignedGreaterThan => SignedLessThan,
-            SignedGreaterThanOrEqual => SignedLessThanOrEqual,
-            SignedLessThan => SignedGreaterThan,
-            SignedLessThanOrEqual => SignedGreaterThanOrEqual,
-            UnsignedGreaterThan => UnsignedLessThan,
-            UnsignedGreaterThanOrEqual => UnsignedLessThanOrEqual,
-            UnsignedLessThan => UnsignedGreaterThan,
-            UnsignedLessThanOrEqual => UnsignedGreaterThanOrEqual,
-            Overflow => Overflow,
-            NotOverflow => NotOverflow,
+            Equal => Some(Equal),
+            NotEqual => Some(NotEqual),
+            SignedGreaterThan => Some(SignedLessThan),
+            SignedGreaterThanOrEqual => Some(SignedLessThanOrEqual),
+            SignedLessThan => Some(SignedGreaterThan),
+            SignedLessThanOrEqual => Some(SignedGreaterThanOrEqual),
+            UnsignedGreaterThan => Some(UnsignedLessThan),
+            UnsignedGreaterThanOrEqual => Some(UnsignedLessThanOrEqual),
+            UnsignedLessThan => Some(UnsignedGreaterThan),
+            UnsignedLessThanOrEqual => Some(UnsignedGreaterThanOrEqual),
+            Overflow => None,
+            NotOverflow => None,
         }
     }
 }
@@ -287,9 +288,9 @@ impl CondCode for FloatCC {
             UnorderedOrGreaterThanOrEqual => LessThan,
         }
     }
-    fn reverse(self) -> Self {
+    fn reverse(self) -> Option<Self> {
         use self::FloatCC::*;
-        match self {
+        Some(match self {
             Ordered => Ordered,
             Unordered => Unordered,
             Equal => Equal,
@@ -304,7 +305,7 @@ impl CondCode for FloatCC {
             UnorderedOrLessThanOrEqual => UnorderedOrGreaterThanOrEqual,
             UnorderedOrGreaterThan => UnorderedOrLessThan,
             UnorderedOrGreaterThanOrEqual => UnorderedOrLessThanOrEqual,
-        }
+        })
     }
 }
 
@@ -374,8 +375,9 @@ mod tests {
     fn int_reverse() {
         for r in IntCC::all() {
             let cc = *r;
-            let rev = cc.reverse();
-            assert_eq!(rev.reverse(), cc);
+            if let Some(rev) = cc.reverse() {
+                assert_eq!(rev.reverse(), Some(cc));
+            }
         }
     }
 
@@ -402,8 +404,9 @@ mod tests {
     fn float_reverse() {
         for r in FloatCC::all() {
             let cc = *r;
-            let rev = cc.reverse();
-            assert_eq!(rev.reverse(), cc);
+            if let Some(rev) = cc.reverse() {
+                assert_eq!(rev.reverse(), Some(cc));
+            }
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1095,8 +1095,8 @@
 (decl cc_invert (CC) CC)
 (extern constructor cc_invert cc_invert)
 
-(decl intcc_reverse (IntCC) IntCC)
-(extern constructor intcc_reverse intcc_reverse)
+(decl intcc_reversed (IntCC) IntCC)
+(extern extractor intcc_reversed intcc_reversed)
 
 (decl floatcc_inverse (FloatCC) FloatCC)
 (extern constructor floatcc_inverse floatcc_inverse)
@@ -3451,9 +3451,9 @@
 ;; As a special case, reverse the arguments to the comparison when the LHS is a
 ;; constant. This ensures that we avoid moving the constant into a register when
 ;; performing the comparison.
-(rule (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
+(rule (emit_cmp (intcc_reversed cc) (and (simm32_from_value a) (value_type ty)) b)
       (let ((size OperandSize (raw_operand_size_of_type ty)))
-        (icmp_cond_result (x64_cmp size a b) (intcc_reverse cc))))
+        (icmp_cond_result (x64_cmp size a b) cc)))
 
 ;; For I128 values (held in two GPRs), the instruction sequences depend on what
 ;; kind of condition is tested.

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -663,7 +663,7 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
     }
 
     #[inline]
-    fn intcc_reverse(&mut self, cc: &IntCC) -> IntCC {
+    fn intcc_reversed(&mut self, cc: &IntCC) -> Option<IntCC> {
         cc.reverse()
     }
 

--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -16,3 +16,16 @@ block0(v0: i8):
 }
 ; run: %overflow_rhs_const(49) == true
 ; run: %overflow_rhs_const(-65) == false
+
+; This is a regression test for #4875, where we were considering the reverse of
+; `NotOverflow` to be `NotOverflow`. Both that operation and `Overflow` don't
+; appear to have reasonable reverse implementations, so the fix is to not
+; float constants right when they're involved in `icmp nof/of`.
+function %a() -> b1 {
+block0:
+    v0 = iconst.i8 193
+    v1 = iconst.i8 65
+    v2 = icmp.i8 nof v1, v0
+    return v2
+}
+; run: %a() == false


### PR DESCRIPTION
The implementation of `IntCC::reverse` considered the reverse of `NotOverflow` to be `NotOverflow`, but this isn't correct as the comparison does not commute. The solution here was to change the `reverse` function of the `CondCode` trait to return an `Option`, and then use the function as a fallible extractor in the isle rule that floats constants right in comparisons.

Fixes #4875
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
