### PR TITLE
Cherry-pick #4882 to 1.0.0 release branch: clean error on too-large input.

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -19,7 +19,7 @@ use crate::machinst::{
     LoweredBlock, MachLabel, Reg, SigSet, VCode, VCodeBuilder, VCodeConstant, VCodeConstantData,
     VCodeConstants, VCodeInst, ValueRegs, Writable,
 };
-use crate::{trace, CodegenResult};
+use crate::{trace, CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use regalloc2::VReg;
 use smallvec::{smallvec, SmallVec};
@@ -323,6 +323,10 @@ fn alloc_vregs<I: VCodeInst>(
     let v = *next_vreg;
     let (regclasses, tys) = I::rc_for_type(ty)?;
     *next_vreg += regclasses.len();
+    if *next_vreg >= VReg::MAX {
+        return Err(CodegenError::CodeTooLarge);
+    }
+
     let regs: ValueRegs<Reg> = match regclasses {
         &[rc0] => ValueRegs::one(VReg::new(v, rc0).into()),
         &[rc0, rc1] => ValueRegs::two(VReg::new(v, rc0).into(), VReg::new(v + 1, rc1).into()),


### PR DESCRIPTION
This is a cherry-pick of "Cranelift: add a vreg limit check to correctly return an error on too-large inputs. (#4882)"

This is a low-risk PR that provides a clean error on a too-large Wasm input, rather than panicking; this seems like
an important user-experience improvement for the upcoming release.

Previously, Cranelift panicked (via a a panic in regalloc2) when the virtual-register limit of 2M (2^21) was reached. This resulted in a perplexing and unhelpful failure when the user provided a too-large input (such as the Wasm module in #4865).

This PR adds an explicit check when allocating vregs that fails with a "code too large" error when the limit is hit, producing output such as (on the minimized testcase from #4865):

```
Error: failed to compile wasm function 3785 at offset 0xa3f3

Caused by:
    Compilation error: Code for function is too large
```

Fixes #4865.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
