### PR TITLE
Remove function_alignment from ObjectBuilder

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -341,7 +341,9 @@ impl Module for ObjectModule {
         }
         *defined = true;
 
-        let align = alignment.max(self.isa.symbol_alignment());
+        let align = alignment
+            .max(self.isa.function_alignment())
+            .max(self.isa.symbol_alignment());
         let (section, offset) = if self.per_function_section {
             let symbol_name = self.object.symbol(symbol).name.clone();
             let (section, offset) =

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -342,7 +342,7 @@ impl Module for ObjectModule {
         *defined = true;
 
         let align = alignment
-            .max(self.isa.function_alignment())
+            .max(self.isa.function_alignment() as u64)
             .max(self.isa.symbol_alignment());
         let (section, offset) = if self.per_function_section {
             let symbol_name = self.object.symbol(symbol).name.clone();


### PR DESCRIPTION
Removes the `function_alignment` field from ObjectBuilder and ObjectModule. Alignment information is now provided either by the `Module` trait for minimum function alignment requirements, or on `FunctionInfo` for fucntion specific alignment requirements.

cc @bjorn3 
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
