### PR TITLE
Fix typo in examples-markdown.md

### DIFF
--- a/docs/examples-markdown.md
+++ b/docs/examples-markdown.md
@@ -34,7 +34,7 @@ To grant the capability to read in a directory using the Wasmtime CLI, we need t
 wasmtime --dir . my-wasi-program.wasm
 ```
 
-For this example, we will be passing a markdown file to our program called: `example-markdown.md`, that will exist in whatever our current directory (`./`) is. Our markdown file, `example-markdown.md`, will contain:
+For this example, we will be passing a markdown file to our program called: `example_markdown.md`, that will exist in whatever our current directory (`./`) is. Our markdown file, `example_markdown.md`, will contain:
 
 ```md
 # Hello!


### PR DESCRIPTION
Fixing a small typo in the name of the markdown file.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
