### PR TITLE
fuzzgen: Mostly Forward Branching

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     pub static_stack_slots_per_function: RangeInclusive<usize>,
     /// Size in bytes
     pub static_stack_slot_size: RangeInclusive<usize>,
+
+    /// Determines how often we generate a backwards branch
+    /// Backwards branches are prone to infinite loops, and thus cause timeouts.
+    pub backwards_branch_ratio: (usize, usize),
 }
 
 impl Default for Config {
@@ -55,6 +59,9 @@ impl Default for Config {
             funcrefs_per_function: 0..=8,
             static_stack_slots_per_function: 0..=8,
             static_stack_slot_size: 0..=128,
+            // 0.1% allows us to explore this, while not causing enough timeouts to significantly
+            // impact execs/s
+            backwards_branch_ratio: (1, 1000),
         }
     }
 }

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -747,6 +747,10 @@ struct Resources {
 impl Resources {
     /// Returns [JumpTable]'s where all blocks are forward of `block`
     fn forward_jump_tables(&self, builder: &FunctionBuilder, block: Block) -> Vec<JumpTable> {
+        // TODO: We can avoid allocating a Vec here by sorting self.jump_tables based
+        // on the minimum block and returning a slice based on that.
+        // See https://github.com/bytecodealliance/wasmtime/pull/4894#discussion_r971241430 for more details
+
         // Unlike with the blocks below jump table targets are not ordered, thus we do need
         // to allocate a Vec here.
         let jump_tables = &builder.func.jump_tables;

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1038,6 +1038,11 @@ where
     }
 
     fn generate_jumptables(&mut self, builder: &mut FunctionBuilder) -> Result<()> {
+        // We shouldn't try to generate jumptables if we don't have any valid targets!
+        if self.resources.blocks_without_params.is_empty() {
+            return Ok(());
+        }
+
         for _ in 0..self.param(&self.config.jump_tables_per_function)? {
             let mut jt_data = JumpTableData::new();
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -644,10 +644,9 @@ fn insert_bricmp(
     source_block: Block,
 ) -> Result<()> {
     let (block, args) = fgen.generate_target_block(builder, source_block)?;
-    let cond = *fgen.u.choose(IntCC::all())?;
 
-    let bricmp_types = [I8, I16, I32, I64, I128];
-    let _type = *fgen.u.choose(&bricmp_types[..])?;
+    let cc = *fgen.u.choose(IntCC::all())?;
+    let _type = *fgen.u.choose(&[I8, I16, I32, I64, I128])?;
 
     let lhs_var = fgen.get_variable_of_type(_type)?;
     let lhs_val = builder.use_var(lhs_var);
@@ -657,7 +656,7 @@ fn insert_bricmp(
 
     builder
         .ins()
-        .br_icmp(cond, lhs_val, rhs_val, block, &args[..]);
+        .br_icmp(cc, lhs_val, rhs_val, block, &args[..]);
 
     // After bricmp's we must generate a jump
     insert_jump(fgen, builder, source_block)?;


### PR DESCRIPTION
👋 Hey,

This PR addresses some of the issues found in #3050 regarding the performance of fuzzgen. We found that we had an outsized number of timeouts during execution of the fuzzer. This is mostly due to generating a bunch of infinite loops.

This changes our branching strategy. Instead of choosing blocks at random, we always choose a block ahead of the current block. This makes it so that we always make forward progress and don't time out very often. I still think backwards branches are important to generate, so we make those a configurable option (0.1% of branches).

Additionally it looks like not having valid target branches was also an issue. 27.3% of our invalid `Arbitrary::choice` failures were due to us trying to select a block that we didn't have. Such as for example trying to select a block that does not have params when all of them do.
We are now smarter about which terminators we allow to be inserted avoiding these issues.

cc: @jameysharp 

## Benchmarks

<details>
<summary><h3>Baseline</h3></summary>

Statistics:
```
#49967  NEW    cov: 31776 ft: 183224 corp: 4225/5444Kb lim: 394895 exec/s: 23 rss: 966Mb L: 2106/373965 MS: 2 ShuffleBytes-CopyPart-
== FuzzGen Statistics  ====================
Total Inputs: 50000
Valid Inputs: 18378 (36.8%)
Total Runs: 62769
Successful Runs: 48229 (76.8% of Total Runs)
Timed out Runs: 10440 (16.6% of Total Runs)
Traps:
        user code: int_divz: 4100 (6.5% of Total Runs)
        user code: bad_sig: 0 (0.0% of Total Runs)
        user debug: 0 (0.0% of Total Runs)
        user code: icall_null: 0 (0.0% of Total Runs)
        user code: heap_oob: 0 (0.0% of Total Runs)
        user code: int_ovf: 0 (0.0% of Total Runs)
        user code: bad_toint: 0 (0.0% of Total Runs)
        user code: interrupt: 0 (0.0% of Total Runs)
        user code: stk_ovf: 0 (0.0% of Total Runs)
        user code: table_oob: 0 (0.0% of Total Runs)
        user code: heap_misaligned: 0 (0.0% of Total Runs)
        user code: unreachable: 0 (0.0% of Total Runs)
        resumable: 0 (0.0% of Total Runs)

```

`Arbitrary::choice` failures:
```
Loaded 20139 stacks

First Line duplicates
5.9 - Count: 1181 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::generate_br_table
8.3 - Count: 1679 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::generate_jumptables
1.4 - Count: 282 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::generate_switch
11.7 - Count: 2355 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::generate_target_block
29.9 - Count: 6014 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::get_variable_of_type
29.7 - Count: 5991 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::stack_slot_with_size
13.1 - Count: 2637 - Line:    0: cranelift_fuzzgen::function_generator::insert_call
```

</details>

<details>
<summary><h3>This PR</h3></summary>

Statistics:
```
#49979  NEW    cov: 31503 ft: 178604 corp: 3520/7374Kb lim: 1048576 exec/s: 48 rss: 1054Mb L: 2702/1048576 MS: 1 CMP- DE: "\x01\x00\x00\x00\x00\x00\x00\x05"-
== FuzzGen Statistics  ====================
Total Inputs: 50000
Valid Inputs: 21036 (42.1%)
Total Runs: 724599
Successful Runs: 719276 (99.3% of Total Runs)
Timed out Runs: 32 (0.0% of Total Runs)
Traps:
        user code: stk_ovf: 0 (0.0% of Total Runs)
        user code: heap_misaligned: 0 (0.0% of Total Runs)
        user code: bad_sig: 0 (0.0% of Total Runs)
        user code: table_oob: 0 (0.0% of Total Runs)
        user code: bad_toint: 0 (0.0% of Total Runs)
        user code: heap_oob: 0 (0.0% of Total Runs)
        user debug: 0 (0.0% of Total Runs)
        resumable: 0 (0.0% of Total Runs)
        user code: icall_null: 0 (0.0% of Total Runs)
        user code: int_ovf: 0 (0.0% of Total Runs)
        user code: int_divz: 5291 (0.7% of Total Runs)
        user code: unreachable: 0 (0.0% of Total Runs)
        user code: interrupt: 0 (0.0% of Total Runs)
```

`Arbitrary::choice` failures:
```
Loaded 14367 stacks

First Line duplicates
41.3 - Count: 5936 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::get_variable_of_type
37.6 - Count: 5395 - Line:    0: cranelift_fuzzgen::function_generator::FunctionGenerator::stack_slot_with_size
21.1 - Count: 3036 - Line:    0: cranelift_fuzzgen::function_generator::insert_call
```
</details>

This improves execs/s by 108% (23 -> 48) which is nice. It also eliminates all invalid choices regarding block terminators so we reject fewer inputs as well. 