### PR TITLE
fuzzgen: Continue execution on traps

### DIFF
--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -104,15 +104,18 @@ fuzz_target!(|testcase: TestCase| {
         match int_res {
             RunResult::Success(_) => {}
             RunResult::Trap(_) => {
-                // We currently ignore inputs that trap the interpreter
+                // If this input traps, skip it and continue trying other inputs
+                // for this function. We've already compiled it anyway.
+                //
                 // We could catch traps in the host run and compare them to the
                 // interpreter traps, but since we already test trap cases with
                 // wasm tests and wasm-level fuzzing, the amount of effort does
                 // not justify implementing it again here.
-                return;
+                continue;
             }
             RunResult::Timeout => {
-                // We probably generated an infinite loop, we can ignore this
+                // We probably generated an infinite loop, we should drop this entire input.
+                // We could `continue` like we do on traps, but timeouts are *really* expensive.
                 return;
             }
             RunResult::Error(_) => panic!("interpreter failed: {:?}", int_res),


### PR DESCRIPTION
👋 Hey,

This PR changes how we deal with traps in fuzzgen. Instead of discarding the entire function outright we continue onto the next function input and test those as well. Maybe they won't trap! We do not try to run these inputs on the host machine.

I haven't done any benchmarking on this, but it also didn't seem to decrease execs/s in any meaningful way when I tested it locally.

Thanks @jameysharp for the suggestion!