### PR TITLE
fuzzgen: Panic on failed NaN Canonicalization pass

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -166,7 +166,7 @@ where
         Ok(inputs)
     }
 
-    fn run_func_passes(&self, func: Function) -> Result<Function> {
+    fn run_func_passes(&self, func: Function) -> Function {
         // Do a NaN Canonicalization pass on the generated function.
         //
         // Both IEEE754 and the Wasm spec are somewhat loose about what is allowed
@@ -189,16 +189,18 @@ where
         let flags = settings::Flags::new(settings::builder());
         let isa = builder_with_options(false)
             .expect("Unable to build a TargetIsa for the current host")
-            .finish(flags)?;
+            .finish(flags)
+            .expect("Failed to build TargetISA");
 
-        ctx.canonicalize_nans(isa.as_ref())?;
+        ctx.canonicalize_nans(isa.as_ref())
+            .expect("Failed validation after NaN canonicalization");
 
-        Ok(ctx.func)
+        ctx.func
     }
 
     fn generate_func(&mut self) -> Result<Function> {
         let func = FunctionGenerator::new(&mut self.u, &self.config).generate()?;
-        self.run_func_passes(func)
+        Ok(self.run_func_passes(func))
     }
 
     pub fn generate_test(mut self) -> Result<TestCase> {


### PR DESCRIPTION
This should never fail anyway, but it's good to know that we aren't accidentally ignoring an input

Ran about 60k fuzzer inputs on this and it didn't seem to panic, so I think we are good.

Thanks @jameysharp for the suggestion!