### PR TITLE
ISLE: merge trie edges across priority levels if possible.

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -919,9 +919,9 @@
 ;; Any amode can absorb an `iadd` by absorbing first the LHS of the
 ;; add, then the RHS.
 ;;
-;; Priority 2 to take this above fallbacks and ensure we traverse the
+;; Priority 4 to take this above fallbacks and ensure we traverse the
 ;; `iadd` tree fully.
-(rule 2 (amode_add amode (iadd x y))
+(rule 4 (amode_add amode (iadd x y))
       (let ((amode1 Amode (amode_add amode x))
             (amode2 Amode (amode_add amode1 y)))
         amode2))
@@ -930,7 +930,7 @@
 ;;
 ;; An Amode.ImmReg with invalid_reg (initial state) can absorb a
 ;; register as the base register.
-(rule (amode_add (Amode.ImmReg off (invalid_reg) flags) value)
+(rule 1 (amode_add (Amode.ImmReg off (invalid_reg) flags) value)
       (Amode.ImmReg off value flags))
 
 ;; -- Case 2 (adding a register to an Amode with a register already).

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -717,7 +717,7 @@ impl<'a> Codegen<'a> {
                 returned = true;
             }
 
-            &TrieNode::Decision { ref edges } => {
+            &TrieNode::Decision { ref edges, .. } => {
                 let subindent = format!("{}    ", indent);
                 // If this is a decision node, generate each match op
                 // in turn (in priority order). Gather together
@@ -732,11 +732,7 @@ impl<'a> Codegen<'a> {
                     let mut last = i;
                     let mut adjacent_variants = StableSet::new();
                     let mut adjacent_variant_input = None;
-                    log!(
-                        "edge: prio = {:?}, symbol = {:?}",
-                        edges[i].prio,
-                        edges[i].symbol
-                    );
+                    log!("edge: symbol = {:?}", edges[i].symbol);
                     while last < edges.len() {
                         match &edges[last].symbol {
                             &TrieSymbol::Match {

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -244,6 +244,10 @@ impl TrieNode {
             *last_prio = *cur_prio;
             *cur_prio = Some(PrioFrontier {
                 prio,
+                // This is `None` initially but will be updated below
+                // to at least the frontier, as we always reuse or
+                // insert an edge and that edge is always >=
+                // `last_prio.edge_idx`, if not `None`.
                 edge_idx: None,
             });
         }

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -249,9 +249,8 @@ impl TrieNode {
                 // insert an edge and that edge is always >=
                 // `last_prio.edge_idx`, if not `None`. It also needs
                 // to be `None` to distinguish the no-edges case from
-                // the one-edge-at-index-0 case so that if a new edge
-                // is inserted at index 0, we can do the appropriate
-                // update.
+                // the one-edge-at-index-0 case: see comment on
+                // frontier increment below.
                 edge_idx: None,
             });
         }
@@ -278,6 +277,13 @@ impl TrieNode {
                     .unwrap_err()
                     + first_after_prev_prio;
 
+                // If we inserted prior to the frontier for this
+                // priority, update the frontier index. Note that this
+                // check relies on the frontier being initially `None`
+                // for any given priority so this update does not
+                // occur (as distinguished from a single edge that
+                // existed at index 0, in which case we increment if
+                // we inserted prior to it).
                 if cur_prio.edge_idx.is_some() && insert_pos <= cur_prio.edge_idx.unwrap() {
                     *cur_prio.edge_idx.as_mut().unwrap() += 1;
                 }

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -247,7 +247,11 @@ impl TrieNode {
                 // This is `None` initially but will be updated below
                 // to at least the frontier, as we always reuse or
                 // insert an edge and that edge is always >=
-                // `last_prio.edge_idx`, if not `None`.
+                // `last_prio.edge_idx`, if not `None`. It also needs
+                // to be `None` to distinguish the no-edges case from
+                // the one-edge-at-index-0 case so that if a new edge
+                // is inserted at index 0, we can do the appropriate
+                // update.
                 edge_idx: None,
             });
         }

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -260,8 +260,9 @@ impl TrieNode {
         // Now find or insert the appropriate edge.
         let edge = edges
             .iter()
-            .enumerate()
-            .position(|(i, edge)| (start.is_none() || i >= start.unwrap()) && edge.symbol == op)
+            .skip(start.unwrap_or(0))
+            .position(|edge| edge.symbol == op)
+            .map(|pos| pos + start.unwrap_or(0))
             .unwrap_or_else(|| {
                 // Insert in a position among our allowed range
                 // (strictly after `start` now) that would be sorted


### PR DESCRIPTION
Previously, the ISLE trie-building process (which constructs the tree of match operations lowered into the generated Rust code) generated code for each priority level separately, for simplicity and to avoid subtle bugs in edge-ordering (see e.g. #4093, #4102 and #4117).

This PR implements a "priority frontier" approach that allows sharing a single match edge across rules of different priority levels, but in a fairly simple way: it builds the trie in rule-priority order (highest to lowest), and at each decision node, tracks the last edge that got an insertion at the previous priority level. Then a rule at the current priority level can be inserted into the subtree of any edge at or beyond that one, but not before it. This requires constant space per node and allows for significant flexibility. Within the range of possible insertion locations, we respect the sort order over trie symbols, as currently, so that matches on the same enum get placed adjacently to each other and can merge into `match` statements.

The advantage of this approach is that as we use more priority levels to break ties when rules overlap (as we are planning to do, for more semantic clarity), we do not regress compile-time performance by the use of more priority levels.

The generated code at least on AArch64 is actually almost unchanged (a few `let ... = arg0;` trivial arg-value match ops at the top become shared now), which indicates that our priority order already locked down the important tie-breaks and that this new trie-building mechanism otherwise respects the same ordering that we currently do.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
