### PR TITLE
Remove a debug utility in the publish script

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -323,9 +323,6 @@ fn bump_version(krate: &Crate, crates: &[Crate], patch: bool) {
 /// releases. This may end up getting tweaked as we stabilize crates and start
 /// doing more minor/patch releases, but for now this should do the trick.
 fn bump(version: &str, patch_bump: bool) -> String {
-    if version == "0.41.0" {
-        return String::from("2.0.0");
-    }
     let mut iter = version.split('.').map(|s| s.parse::<u32>().unwrap());
     let major = iter.next().expect("major version");
     let minor = iter.next().expect("minor version");


### PR DESCRIPTION
This was something I used for a one-time bump to 2.0, but is no longer necessary. I didn't mean to commit this but I forgot to back it out.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
