### PR TITLE
Add an overlap checker to ISLE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,7 @@ version = "0.89.0"
 dependencies = [
  "log",
  "miette",
+ "rayon",
  "tempfile",
 ]
 

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -19,6 +19,6 @@ tempfile = "3"
 [features]
 default = []
 
-check-overlap = []
+overlap-errors = []
 logging = ["log"]
 miette-errors = ["miette"]

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.89.0"
 [dependencies]
 log = { version = "0.4", optional = true }
 miette = { version = "5.1.0", optional = true }
+rayon = "^1.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -18,5 +18,6 @@ tempfile = "3"
 [features]
 default = []
 
+check-overlap = []
 logging = ["log"]
 miette-errors = ["miette"]

--- a/cranelift/isle/isle/src/compile.rs
+++ b/cranelift/isle/isle/src/compile.rs
@@ -8,6 +8,8 @@ pub fn compile(defs: &ast::Defs, options: &codegen::CodegenOptions) -> Result<St
     let mut typeenv = sema::TypeEnv::from_ast(defs)?;
     let termenv = sema::TermEnv::from_ast(&mut typeenv, defs)?;
 
+    // As the overlap checker currently finds a lot of overlap errors in the lowerings, require it
+    // to be explicitly enabled while we work through them.
     #[cfg(feature = "check-overlap")]
     crate::overlap::check(&mut typeenv, &termenv)?;
 

--- a/cranelift/isle/isle/src/compile.rs
+++ b/cranelift/isle/isle/src/compile.rs
@@ -7,6 +7,10 @@ use crate::{ast, codegen, sema, trie};
 pub fn compile(defs: &ast::Defs, options: &codegen::CodegenOptions) -> Result<String> {
     let mut typeenv = sema::TypeEnv::from_ast(defs)?;
     let termenv = sema::TermEnv::from_ast(&mut typeenv, defs)?;
+
+    #[cfg(feature = "check-overlap")]
+    crate::overlap::check(&mut typeenv, &termenv)?;
+
     let tries = trie::build_tries(&typeenv, &termenv);
     Ok(codegen::codegen(&typeenv, &termenv, &tries, options))
 }

--- a/cranelift/isle/isle/src/compile.rs
+++ b/cranelift/isle/isle/src/compile.rs
@@ -7,12 +7,7 @@ use crate::{ast, codegen, sema, trie};
 pub fn compile(defs: &ast::Defs, options: &codegen::CodegenOptions) -> Result<String> {
     let mut typeenv = sema::TypeEnv::from_ast(defs)?;
     let termenv = sema::TermEnv::from_ast(&mut typeenv, defs)?;
-
-    // As the overlap checker currently finds a lot of overlap errors in the lowerings, require it
-    // to be explicitly enabled while we work through them.
-    #[cfg(feature = "check-overlap")]
     crate::overlap::check(&mut typeenv, &termenv)?;
-
     let tries = trie::build_tries(&typeenv, &termenv);
     Ok(codegen::codegen(&typeenv, &termenv, &tries, options))
 }

--- a/cranelift/isle/isle/src/error.rs
+++ b/cranelift/isle/isle/src/error.rs
@@ -42,12 +42,14 @@ pub enum Error {
         span: Span,
     },
 
-    /// The rules mentioned by the two spans overlap in the inputs they accept.
+    /// The rules mentioned overlap in the input they accept.
     OverlapError {
         /// The error message.
         msg: String,
 
-        /// The locations of all the rules that overlap.
+        /// The locations of all the rules that overlap. When there are more than two rules
+        /// present, the first rule is the one with the most overlaps (likely a fall-through
+        /// wildcard case).
         rules: Vec<(Source, Span)>,
     },
 

--- a/cranelift/isle/isle/src/error.rs
+++ b/cranelift/isle/isle/src/error.rs
@@ -42,6 +42,15 @@ pub enum Error {
         span: Span,
     },
 
+    /// The rules mentioned by the two spans overlap in the inputs they accept.
+    OverlapError {
+        /// The error message.
+        msg: String,
+
+        /// The locations of all the rules that overlap.
+        rules: Vec<(Source, Span)>,
+    },
+
     /// Multiple errors.
     Errors(Vec<Error>),
 }
@@ -108,6 +117,10 @@ impl std::fmt::Display for Error {
             #[cfg(feature = "miette-errors")]
             Error::TypeError { msg, .. } => write!(f, "type error: {}", msg),
 
+            Error::OverlapError { msg, rules, .. } => {
+                writeln!(f, "overlap error: {}\n{}", msg, OverlappingRules(&rules))
+            }
+
             Error::Errors(_) => write!(
                 f,
                 "found {} errors:\n\n{}",
@@ -123,6 +136,16 @@ impl std::fmt::Display for DisplayErrors<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for e in self.0 {
             writeln!(f, "{}", e)?;
+        }
+        Ok(())
+    }
+}
+
+struct OverlappingRules<'a>(&'a [(Source, Span)]);
+impl std::fmt::Display for OverlappingRules<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (src, span) in self.0 {
+            writeln!(f, "  {}", span.from.pretty_print_with_filename(&*src.name))?;
         }
         Ok(())
     }

--- a/cranelift/isle/isle/src/error_miette.rs
+++ b/cranelift/isle/isle/src/error_miette.rs
@@ -45,12 +45,14 @@ impl miette::Diagnostic for Error {
                     .into_iter(),
                 ))
             }
+
             _ => None,
         }
     }
     fn source_code(&self) -> std::option::Option<&dyn miette::SourceCode> {
         match self {
             Self::ParseError { src, .. } | Self::TypeError { src, .. } => Some(src),
+
             _ => None,
         }
     }

--- a/cranelift/isle/isle/src/error_miette.rs
+++ b/cranelift/isle/isle/src/error_miette.rs
@@ -45,14 +45,12 @@ impl miette::Diagnostic for Error {
                     .into_iter(),
                 ))
             }
-
             _ => None,
         }
     }
     fn source_code(&self) -> std::option::Option<&dyn miette::SourceCode> {
         match self {
             Self::ParseError { src, .. } | Self::TypeError { src, .. } => Some(src),
-
             _ => None,
         }
     }

--- a/cranelift/isle/isle/src/lib.rs
+++ b/cranelift/isle/isle/src/lib.rs
@@ -98,6 +98,7 @@ pub mod error;
 pub mod ir;
 pub mod lexer;
 mod log;
+pub mod overlap;
 pub mod parser;
 pub mod sema;
 pub mod trie;

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -289,7 +289,6 @@ enum Pattern {
     /// Enum variant constructors.
     Variant {
         id: TermId,
-        single_case: bool,
         pats: Vec<Pattern>,
     },
 
@@ -369,19 +368,14 @@ impl Pattern {
             sema::Pattern::ConstInt(_, value) => Pattern::Int { value: *value },
             sema::Pattern::ConstPrim(_, name) => Pattern::Const { name: *name },
 
-            sema::Pattern::Term(ty, id, pats) => {
+            sema::Pattern::Term(_, id, pats) => {
                 let pats = pats
                     .iter()
                     .map(|pat| Pattern::from_sema(env, binds, pat))
                     .collect();
 
                 match &env.get_term(*id).kind {
-                    TermKind::EnumVariant { .. } => Pattern::Variant {
-                        id: *id,
-                        single_case: env.is_single_constructor_enum(*ty),
-                        pats,
-                    },
-
+                    TermKind::EnumVariant { .. } => Pattern::Variant { id: *id, pats },
                     TermKind::Decl { .. } => Pattern::Extractor { id: *id, pats },
                 }
             }

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -100,9 +100,16 @@ impl Errors {
             .copied()
             .max_by_key(|id| self.nodes[id].edges.len())
         {
-            let node = self.remove_edges(id);
+            let node = self.nodes.remove(&id).unwrap();
+
             if node.edges.is_empty() {
                 break;
+            }
+
+            for other in node.edges.iter() {
+                if let Some(other) = self.nodes.get_mut(&other) {
+                    other.remove_edge(id);
+                }
             }
 
             // build the real error
@@ -117,20 +124,6 @@ impl Errors {
         }
 
         errors
-    }
-
-    /// Remove all the edges for this rule in the graph, returning the original `Node` contents for
-    /// further processing.
-    fn remove_edges(&mut self, id: RuleId) -> Node {
-        let node = self.nodes.remove(&id).unwrap();
-
-        for other in node.edges.iter() {
-            if let Some(other) = self.nodes.get_mut(&other) {
-                other.remove_edge(id);
-            }
-        }
-
-        node
     }
 
     /// Add a bidirectional edge between two rules in the graph.

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -1,0 +1,808 @@
+//! Overlap detection for rules in ISLE.
+
+use std::collections::HashSet;
+
+use crate::error::{Error, Result, Source, Span};
+use crate::sema::{
+    self, ConstructorKind, Rule, RuleId, Sym, Term, TermEnv, TermId, TermKind, Type, TypeEnv,
+    TypeId, VarId,
+};
+
+/// Check for overlap.
+pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
+
+
+    let env = Env::new(tyenv, termenv);
+    let mut errors = Errors::new(termenv.rules.len());
+    for term in termenv.terms.iter() {
+        // The only isle declaration that currently produces overlap is constructors whose
+        // definition is entirely in isle.
+        if !env.is_internal_constructor(term.id) {
+            continue;
+        }
+
+        check_overlap_groups(&mut errors, &env, term);
+    }
+
+
+    if !errors.is_empty() {
+        let mut errors = errors.report(&env);
+        return match errors.len() {
+            1 => Err(errors.pop().unwrap()),
+            _ => Err(Error::Errors(std::mem::take(&mut errors))),
+        };
+    }
+
+    Ok(())
+}
+
+struct Node {
+    degree: usize,
+    edges: Vec<bool>,
+}
+
+impl Node {
+    fn new(len: usize) -> Self {
+        let mut edges = Vec::with_capacity(len);
+        edges.resize(len, false);
+        Self { degree: 0, edges }
+    }
+
+    fn add_edge(&mut self, other: RuleId) {
+        if self.edges[other.0] {
+            return;
+        }
+
+        self.degree += 1;
+        self.edges[other.0] = true;
+    }
+
+    fn remove_edge(&mut self, other: RuleId) {
+        if !self.edges[other.0] {
+            return;
+        }
+
+        self.degree -= 1;
+        self.edges[other.0] = false;
+    }
+}
+
+struct Errors {
+    /// Edges between rules indicating overlap. As the edges are not directed, the edges are
+    /// normalized by ordering the rule ids.
+    nodes: Vec<Node>,
+}
+
+impl Errors {
+    fn new(len: usize) -> Self {
+        let mut nodes = Vec::with_capacity(len);
+        nodes.resize_with(len, || Node::new(len));
+        Self { nodes }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.nodes.iter().all(|node| node.degree == 0)
+    }
+
+    fn report(&mut self, env: &Env) -> Vec<Error> {
+        let mut rules: Vec<usize> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter_map(|(id, node)| {
+                if node.degree == 0 {
+                    None
+                } else {
+                    Some(id)
+                }
+            })
+            .collect();
+
+        rules.sort_by_cached_key(|id| self.nodes[*id].degree);
+
+        let mut errors = Vec::new();
+
+        let get_info = |id| {
+            let rule = env.get_rule(id);
+
+            let src = env.get_source(rule.pos.file);
+            let span = Span::new_single(rule.pos);
+            (src, span)
+        };
+
+        // Work backwards through the ids to find the nodes with the largest conflict first.
+        for id in rules.into_iter().rev() {
+            let node = self.remove_node(RuleId(id));
+            if node.degree == 0 {
+                continue;
+            }
+
+            // build the real error
+            let mut rules = vec![get_info(RuleId(id))];
+
+            rules.extend(node.edges.into_iter().enumerate().filter_map(|(ix, present)| {
+                if present {
+                    Some(get_info(RuleId(ix)))
+                } else {
+                    None
+                }
+            }));
+
+            errors.push(Error::OverlapError {
+                msg: String::from("rules are overlapping"),
+                rules,
+            });
+        }
+
+        errors
+    }
+
+    fn remove_node(&mut self, id: RuleId) -> Node {
+        let mut node = Node::new(self.nodes.len());
+        std::mem::swap(&mut self.nodes[id.0], &mut node);
+
+        for (ix, other) in node.edges.iter().copied().enumerate() {
+            if other {
+                self.nodes[ix].remove_edge(id);
+            }
+        }
+
+        node
+    }
+
+    fn add_edge(&mut self, a: RuleId, b: RuleId) {
+        // edges are undirected
+        self.nodes[a.0].add_edge(b);
+        self.nodes[b.0].add_edge(a);
+    }
+}
+
+fn overlap_error(errs: &mut Errors, matrix: Matrix) {
+    for (ix, rule) in matrix.rows.iter().enumerate() {
+        for other in &matrix.rows[ix + 1..] {
+            errs.add_edge(rule.rule, other.rule);
+        }
+    }
+}
+
+fn check_overlap_groups(errs: &mut Errors, env: &Env, term: &Term) {
+    for matrix in Matrix::from_priority_groups(env, term.id) {
+        check_overlap(errs, env, matrix);
+    }
+}
+
+fn check_overlap(errs: &mut Errors, env: &Env, mut matrix: Matrix) {
+    if matrix.is_unique() {
+        return;
+    }
+
+    matrix.normalize();
+    if matrix.cols_empty() {
+        overlap_error(errs, matrix);
+        return;
+    }
+
+    let mut work = Vec::new();
+    work.push(matrix);
+
+    while let Some(mut matrix) = work.pop() {
+        let pat = matrix.leading_pattern();
+        let remainder = matrix.specialize(env, &pat);
+
+        if !remainder.is_empty() && !remainder.is_unique() {
+            if remainder.cols_empty() {
+                overlap_error(errs, remainder);
+            } else if !remainder.is_unique() {
+                work.push(remainder);
+            }
+        }
+
+        if !matrix.is_empty() && !matrix.is_unique() {
+            if matrix.cols_empty() {
+                overlap_error(errs, matrix);
+            } else if !matrix.is_unique() {
+                work.push(matrix);
+            }
+        }
+    }
+}
+
+struct Env<'a> {
+    tyenv: &'a TypeEnv,
+    termenv: &'a TermEnv,
+}
+
+impl<'a> Env<'a> {
+    /// Construct a new [`Env`].
+    fn new(tyenv: &'a TypeEnv, termenv: &'a TermEnv) -> Self {
+        Self { tyenv, termenv }
+    }
+
+    /// Fetch the string associated with a symbol.
+    fn get_sym(&self, id: Sym) -> &str {
+        &self.tyenv.syms[id.0]
+    }
+
+    /// Fetch the rule associated with this id.
+    fn get_rule(&self, id: RuleId) -> &Rule {
+        &self.termenv.rules[id.0]
+    }
+
+    /// Fetch the term associated with this id.
+    fn get_term(&self, id: TermId) -> &Term {
+        &self.termenv.terms[id.0]
+    }
+
+    /// Fetch the tyep associated with this id.
+    fn get_type(&self, id: TypeId) -> &Type {
+        &self.tyenv.types[id.0]
+    }
+
+    fn get_source(&self, file: usize) -> Source {
+        Source::new(
+            self.tyenv.filenames[file].clone(),
+            self.tyenv.file_texts[file].clone(),
+        )
+    }
+
+    /// True when this term represents a constructor implemented in isle.
+    fn is_internal_constructor(&self, id: TermId) -> bool {
+        match self.get_term(id).kind {
+            TermKind::Decl {
+                constructor_kind: Some(ConstructorKind::InternalConstructor),
+                ..
+            } => true,
+            _ => false,
+        }
+    }
+
+    /// The ids of all [`Rule`]s defined for this term.
+    fn rules_for_term(&self, id: TermId) -> Vec<RuleId> {
+        self.termenv
+            .rules
+            .iter()
+            .filter_map(|rule| {
+                if let sema::Pattern::Term(_, tid, _) = rule.lhs {
+                    if tid == id {
+                        return Some(rule.id);
+                    }
+                }
+                None
+            })
+            .collect()
+    }
+
+    /// Returns true when this type is an enum with only a single constructor.
+    fn is_single_constructor_enum(&self, ty: TypeId) -> bool {
+        match self.get_type(ty) {
+            Type::Primitive(_, _, _) => false,
+            Type::Enum { variants, .. } => variants.len() == 1,
+        }
+    }
+}
+
+/// A version of [`sema::Pattern`] with some simplifications to make overlap checking easier.
+/// TODO: location information for reporting errors.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+enum Pattern {
+    Int {
+        value: i128,
+    },
+
+    Const {
+        name: Sym,
+    },
+
+    Variant {
+        id: TermId,
+        single_case: bool,
+        pats: Vec<Pattern>,
+    },
+
+    And {
+        pats: Vec<Pattern>,
+    },
+
+    Extractor {
+        id: TermId,
+        pats: Vec<Pattern>,
+    },
+
+    Wildcard,
+}
+
+impl Pattern {
+    /// Create a [`Pattern`] from a [`sema::Pattern`]. The major differences between these two
+    /// representations are as follows:
+    /// 1. Variable bindings are removed and turned into wildcards
+    /// 2. Equality constraints are removed and turned into inlined versions of the patterns they
+    ///    would have introduced equalities with
+    /// 3. [`sema::Pattern::Term`] instances are turned into either [`Pattern::Variant`] or
+    ///    [`Pattern::Extractor`] cases depending on their term kind.
+    fn from_sema(env: &Env, binds: &mut Vec<(VarId, Pattern)>, pat: &sema::Pattern) -> Self {
+        match pat {
+            sema::Pattern::BindPattern(_, id, pat) => {
+                let pat = Self::from_sema(env, binds, pat);
+                binds.push((*id, pat.clone()));
+                pat
+            }
+
+            sema::Pattern::Var(_, id) => {
+                for (vid, pat) in binds.iter().rev() {
+                    if vid == id {
+                        // TODO: explain why we inline equality constraint
+                        return pat.clone();
+                    }
+                }
+
+                binds.push((*id, Pattern::Wildcard));
+                Pattern::Wildcard
+            }
+
+            sema::Pattern::ConstInt(_, value) => Pattern::Int { value: *value },
+            sema::Pattern::ConstPrim(_, name) => Pattern::Const { name: *name },
+
+            sema::Pattern::Term(ty, id, pats) => {
+                let pats = pats
+                    .iter()
+                    .map(|pat| Pattern::from_sema(env, binds, pat))
+                    .collect();
+
+                match &env.get_term(*id).kind {
+                    TermKind::EnumVariant { .. } => Pattern::Variant {
+                        id: *id,
+                        single_case: env.is_single_constructor_enum(*ty),
+                        pats,
+                    },
+
+                    TermKind::Decl { .. } => Pattern::Extractor { id: *id, pats },
+                }
+            }
+
+            sema::Pattern::Wildcard(_) => Pattern::Wildcard,
+
+            sema::Pattern::And(_, pats) => {
+                let mut pats: Vec<Pattern> = pats
+                    .iter()
+                    .map(|pat| Pattern::from_sema(env, binds, pat))
+                    .collect();
+
+                if pats.len() == 1 {
+                    pats.pop().unwrap()
+                } else {
+                    pats.sort_unstable();
+                    Pattern::And { pats }
+                }
+            }
+        }
+    }
+
+    fn is_wildcard(&self) -> bool {
+        match self {
+            Pattern::Wildcard => true,
+            _ => false,
+        }
+    }
+
+    fn is_extractor(&self) -> Option<TermId> {
+        match self {
+            Pattern::Extractor { id, .. } => Some(*id),
+            _ => None,
+        }
+    }
+
+    fn is_and(&self) -> bool {
+        match self {
+            Pattern::And { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// For `Variant` and `Extractor`, the number of arguments.
+    fn arity(&self) -> usize {
+        match self {
+            Pattern::Variant { pats, .. } => pats.len(),
+            Pattern::Extractor { pats, .. } => pats.len(),
+            _ => 1,
+        }
+    }
+
+    /// Returns `true` for `Variant` or `Extractor`.
+    fn can_expand(&self) -> bool {
+        match self {
+            Pattern::Variant { .. } => true,
+            Pattern::Extractor { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this pattern could match one of the concrete patterns specified by
+    /// `other`.
+    fn match_concrete(&self, other: &Pattern) -> bool {
+        match (self, other) {
+            // these are the cases where we know enough to say definitively yes or no
+            (Pattern::Int { value: left }, Pattern::Int { value: right }) => left == right,
+            (Pattern::Const { name: left }, Pattern::Const { name: right }) => left == right,
+            (Pattern::Variant { id: left, .. }, Pattern::Variant { id: right, .. }) => {
+                left == right
+            }
+
+            (Pattern::Extractor { id: left, .. }, Pattern::Extractor { id: right, .. }) => {
+                left == right
+            }
+
+            (Pattern::And { pats }, _) => pats.iter().rev().any(|pat| pat.match_concrete(other)),
+
+            _ => false,
+        }
+    }
+
+    /// Extracts the that matches the template from this pattern, assuming that it's an `And`.
+    /// Updates the `And` to no longer include the pattern.
+    fn extract_matching(&mut self, template: &Pattern) -> Option<Pattern> {
+        if let Pattern::And { pats } = self {
+            for i in 0..pats.len() {
+                if pats[i].match_concrete(template) {
+                    let res = pats.remove(i);
+
+                    // if the and has only a single element left, collapse it
+                    if pats.len() == 1 {
+                        *self = pats.remove(0);
+                    }
+
+                    return Some(res);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// A single row in the pattern matrix.
+#[derive(Debug, Clone)]
+struct Row {
+    pats: Vec<Pattern>,
+    rule: RuleId,
+}
+
+impl Row {
+    fn from_rule(env: &Env, rule: RuleId) -> Row {
+        if let sema::Pattern::Term(_, _, vars) = &env.get_rule(rule).lhs {
+            let mut binds = Vec::new();
+            Self {
+                // NOTE: the patterns are reversed so that it's easier to manipulate the leading
+                // column of the row.
+                pats: vars
+                    .iter()
+                    .rev()
+                    .map(|pat| Pattern::from_sema(env, &mut binds, pat))
+                    .collect(),
+                rule,
+            }
+        } else {
+            panic!("Constructing a Row from a malformed rule")
+        }
+    }
+
+    /// A row is empty when its pattern vector is empty.
+    fn is_empty(&self) -> bool {
+        self.pats.is_empty()
+    }
+
+    /// The pattern from the first column of this row.
+    fn front(&self) -> &Pattern {
+        assert!(!self.pats.is_empty());
+        self.pats.last().unwrap()
+    }
+
+    /// A mutable reference to the pattern from the first column of this row.
+    fn front_mut(&mut self) -> &mut Pattern {
+        assert!(!self.pats.is_empty());
+        self.pats.last_mut().unwrap()
+    }
+
+    /// Push a new pattern on the front of this row.
+    fn push(&mut self, pat: Pattern) {
+        self.pats.push(pat);
+    }
+
+    /// Pop the pattern from the front of the row.
+    fn pop(&mut self) -> Pattern {
+        assert!(!self.pats.is_empty());
+        self.pats.pop().unwrap()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Matrix {
+    rows: Vec<Row>,
+
+    /// The term that this matrix represents.
+    term: TermId,
+
+    /// The priority of this group of rules matrix.
+    prio: i64,
+}
+
+impl Matrix {
+    fn new(term: TermId, prio: i64, rows: Vec<Row>) -> Self {
+        Self { rows, prio, term }
+    }
+
+    fn from_priority_groups(env: &Env, term: TermId) -> Vec<Self> {
+        let mut matrices = Vec::new();
+
+        let mut rules: Vec<(i64, RuleId)> = env
+            .rules_for_term(term)
+            .into_iter()
+            .map(|id| (env.get_rule(id).prio.unwrap_or(0), id))
+            .collect();
+
+        if rules.is_empty() {
+            return matrices;
+        }
+
+        rules.sort_by_key(|(prio, _)| *prio);
+
+        let mut current = {
+            let (prio, _) = rules.first().unwrap();
+            matrices.push(Matrix::new(term, *prio, Vec::new()));
+            matrices.last_mut().unwrap()
+        };
+
+        for (p, id) in rules {
+            if p != current.prio {
+                matrices.push(Matrix::new(term, p, Vec::new()));
+                current = matrices.last_mut().unwrap();
+            }
+            current.rows.push(Row::from_rule(env, id));
+        }
+
+        matrices
+    }
+
+    /// Normalizing the matrix by removing leading columns that consist of only wildcards, and then
+    /// sorting the remaining rows to put those with fallible leading patterns first.
+    fn normalize(&mut self) {
+        while !self.cols_empty() && self.rows.iter().all(|row| row.front().is_wildcard()) {
+            self.drop_leading();
+        }
+
+        if !self.cols_empty() {
+            self.rows.sort_unstable_by(|a, b| a.front().cmp(b.front()));
+        }
+    }
+
+    /// Returns true if there are no rows in the matrix.
+    fn is_empty(&self) -> bool {
+        self.rows.first().is_none()
+    }
+
+    /// Returns true if there are no rows, or those that exist have no columns.
+    fn cols_empty(&self) -> bool {
+        self.rows.first().map_or(true, |row| row.is_empty())
+    }
+
+    /// Returns true if there is exactly one row.
+    fn is_unique(&self) -> bool {
+        self.rows.len() == 1
+    }
+
+    /// Specialize the matrix according to the pattern in the first column of the first row. This
+    /// assumes that the matrix has already been normalized.
+    fn specialize(&mut self, env: &Env, pat: &Pattern) -> Self {
+        assert!(!self.cols_empty());
+
+        let spec_extractor = pat.is_extractor();
+
+        // we start by specializing and patterns, so that we don't have to consider them when
+        // deciding which rows go to which matrix.
+        self.specialize_and_patterns(&pat);
+
+        // remove rows from self that we know couldn't possibly match this pattern
+        let mut other = Matrix::new(self.term, self.prio, Vec::new());
+        let mut i = 0;
+        while i < self.rows.len() {
+            let row = &mut self.rows[i];
+            match row.front() {
+                Pattern::Wildcard => {
+                    // wildcards always match, and go into both matrices as a result
+                    other.rows.push(row.clone());
+                    i += 1;
+                }
+
+                Pattern::Extractor { id, .. } => {
+                    // if we're specializing on this extractor then it shouldn't be duplicated over
+                    // to the other matrix. otherwise, we copy the row over to the other matrix and
+                    // rewrite this one to a wildcard to model the fact that we can't determine if
+                    // the extractor will actually match.
+                    if spec_extractor != Some(*id) {
+                        other.rows.push(row.clone());
+                        *row.front_mut() = Pattern::Wildcard;
+                    }
+
+                    i += 1;
+                }
+
+                // rows that don't match this pattern get moved to the other matrix
+                col if !col.match_concrete(&pat) => {
+                    other.rows.push(self.rows.swap_remove(i));
+                    // note that we don't increment the index here
+                }
+
+                // and all other rows stay in this matrix
+                _ => i += 1,
+            }
+        }
+
+        if pat.can_expand() {
+            self.expand_leading(env, &pat);
+        } else {
+            self.drop_leading();
+        }
+
+        self.normalize();
+        other.normalize();
+        other
+    }
+
+    /// Returns a copy of the first pattern for the first row of the matrix, as a candidate for
+    /// specialization.
+    fn leading_pattern(&self) -> Pattern {
+        assert!(
+            !self.cols_empty(),
+            "leading_pattern called on a matrix with no patterns"
+        );
+
+        match self.rows[0].front() {
+            Pattern::And { pats } => pats.first().unwrap().clone(),
+            pat => pat.clone(),
+        }
+    }
+
+    /// If there are any `and` patterns in the leading column, extract out the sub-pattern that
+    /// matches `pat` and leave the rest in a fresh column. Insert wildcards for other columns
+    /// that have no `and` patterns.
+    fn specialize_and_patterns(&mut self, template: &Pattern) {
+        if !self.rows.iter().any(|row| row.front().is_and()) {
+            return;
+        }
+
+        for row in self.rows.iter_mut() {
+            let mut pat = row.pop();
+            if let Some(p) = pat.extract_matching(template) {
+                row.push(pat);
+                row.push(p);
+            } else {
+                row.push(Pattern::Wildcard);
+                row.push(pat);
+            }
+        }
+    }
+
+    /// Expand leading patterns.
+    fn expand_leading(&mut self, env: &Env, template: &Pattern) {
+        let arity = template.arity();
+        for row in self.rows.iter_mut() {
+            let pat = row.pop();
+            match pat {
+                Pattern::Variant { pats, .. } | Pattern::Extractor { pats, .. }
+                    if pat.match_concrete(template) =>
+                {
+                    row.pats.extend(pats.into_iter().rev())
+                }
+
+                Pattern::Wildcard => row
+                    .pats
+                    .extend(std::iter::repeat(Pattern::Wildcard).take(arity)),
+
+                _ => panic!(
+                    "incorrect leading expansion:\nfound: {}\n expected: {}",
+                    WithEnv::new(env, &pat),
+                    WithEnv::new(env, template)
+                ),
+            }
+        }
+    }
+
+    // Drop leading column from the matrix.
+    fn drop_leading(&mut self) {
+        for row in self.rows.iter_mut() {
+            row.pop();
+        }
+    }
+}
+
+struct WithEnv<'env, T> {
+    env: &'env Env<'env>,
+    value: T,
+}
+
+impl<'env, T> WithEnv<'env, T> {
+    fn new(env: &'env Env, value: T) -> Self {
+        Self { env, value }
+    }
+
+    fn with_value<U>(&self, value: U) -> WithEnv<'env, U> {
+        WithEnv {
+            env: self.env,
+            value,
+        }
+    }
+}
+
+impl std::fmt::Display for WithEnv<'_, &Pattern> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value {
+            Pattern::Int { value } => write!(f, "{}", value),
+
+            Pattern::Const { name } => write!(f, "${}", self.env.get_sym(*name)),
+
+            Pattern::Variant { id, pats, .. } => {
+                write!(f, "({}", self.env.get_sym(self.env.get_term(*id).name))?;
+                for pat in pats {
+                    write!(f, " {}", self.with_value(pat))?;
+                }
+                write!(f, ")")
+            }
+
+            Pattern::And { pats } => {
+                write!(f, "(and")?;
+                for pat in pats {
+                    write!(f, " {}", self.with_value(pat))?;
+                }
+                write!(f, ")")
+            }
+
+            Pattern::Extractor { id, pats } => {
+                write!(f, "({}", self.env.get_sym(self.env.get_term(*id).name))?;
+                for pat in pats {
+                    write!(f, " {}", self.with_value(pat))?;
+                }
+                write!(f, ")")
+            }
+
+            Pattern::Wildcard => write!(f, "_"),
+        }
+    }
+}
+
+impl std::fmt::Display for WithEnv<'_, &Matrix> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.value.rows.is_empty() {
+            return writeln!(f, "<empty>");
+        }
+
+        let mut lens = vec![0; self.value.rows.first().unwrap().pats.len()];
+        let mut rows: Vec<(RuleId, Vec<String>)> = Vec::with_capacity(self.value.rows.len());
+
+        for row in self.value.rows.iter() {
+            rows.push((
+                row.rule,
+                row.pats
+                    .iter()
+                    .rev()
+                    .enumerate()
+                    .map(|(col, pat)| {
+                        let str = format!("{}", self.with_value(pat));
+                        lens[col] = lens[col].max(str.len());
+                        str
+                    })
+                    .collect(),
+            ));
+        }
+
+        for (rule, row) in rows.into_iter() {
+            write!(f, "[")?;
+            let mut sep = "";
+            for (col, width) in row.into_iter().zip(lens.iter()) {
+                write!(f, "{} {:width$} ", sep, col)?;
+                sep = "|";
+            }
+            writeln!(f, "] = {}", rule.0)?
+        }
+
+        Ok(())
+    }
+}

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -235,18 +235,18 @@ enum Pattern {
     /// Enum variant constructors.
     Variant {
         id: TermId,
-        pats: Vec<Pattern>,
+        pats: Box<[Pattern]>,
     },
 
     /// Conjunctions of patterns.
     And {
-        pats: Vec<Pattern>,
+        pats: Box<[Pattern]>,
     },
 
     /// Extractor uses (both fallible and infallible).
     Extractor {
         id: TermId,
-        pats: Vec<Pattern>,
+        pats: Box<[Pattern]>,
     },
 
     Wildcard,

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -74,12 +74,7 @@ impl Errors {
             (src, span)
         };
 
-        while let Some(id) = self
-            .nodes
-            .keys()
-            .copied()
-            .max_by_key(|id| self.nodes[id].edges.len())
-        {
+        while let Some((&id, _)) = self.nodes.iter().max_by_key(|(_, node)| node.edges.len()) {
             let node = self.nodes.remove(&id).unwrap();
             for other in node.edges.iter() {
                 if let Entry::Occupied(mut entry) = self.nodes.entry(*other) {

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -26,11 +26,22 @@ pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
         })
         .reduce(Errors::default, Errors::union);
 
-    let mut errors = errors.report(&env);
-    match errors.len() {
-        0 => Ok(()),
-        1 => Err(errors.pop().unwrap()),
-        _ => Err(Error::Errors(errors)),
+    #[cfg(feature = "overlap-errors")]
+    {
+        let mut errors = errors.report(&env);
+        match errors.len() {
+            0 => Ok(()),
+            1 => Err(errors.pop().unwrap()),
+            _ => Err(Error::Errors(errors)),
+        }
+    }
+
+
+    #[cfg(not(feature = "overlap-errors"))]
+    {
+        use crate::log;
+        log!("found {} overlap errors", errors.report(&env).len());
+        Ok(())
     }
 }
 

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -171,7 +171,7 @@ fn check_overlap_groups(env: &Env, term: &Term) -> Errors {
         .reduce(Errors::default, Errors::union)
 }
 
-/// Check for overlapping rules within a single prioirty group.
+/// Check for overlapping rules within a single priority group.
 fn check_overlap(env: &Env, mut left: Row, mut right: Row) -> bool {
     while !left.is_empty() {
         // drop leading wildcards from both
@@ -478,7 +478,7 @@ impl Pattern {
         }
     }
 
-    /// Assuming that this is an and-pattern, extract the sub-pattern that matches the template and
+    /// If this pattern is an and-pattern, extract the sub-pattern that matches the template and
     /// remove it from `self`. This operation is used when specializing columns that contain
     /// and-patterns to another pattern, leaning on the assumption that the and-pattern matches if
     /// any of its sub-patterns also match.

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -506,16 +506,16 @@ impl Row {
     fn from_rule(env: &Env, rule: RuleId) -> Row {
         if let sema::Pattern::Term(_, _, vars) = &env.get_rule(rule).lhs {
             let mut binds = Vec::new();
-            Self {
-                // NOTE: the patterns are reversed so that it's easier to manipulate the leading
-                // column of the row by pushing/popping the pats vector.
-                pats: vars
-                    .iter()
-                    .rev()
-                    .map(|pat| Pattern::from_sema(env, &mut binds, pat))
-                    .collect(),
-                rule,
-            }
+            let mut pats: Vec<_> = vars
+                .iter()
+                .map(|pat| Pattern::from_sema(env, &mut binds, pat))
+                .collect();
+
+            // NOTE: the patterns are reversed so that it's easier to manipulate the leading
+            // column of the row by pushing/popping the pats vector.
+            pats.reverse();
+
+            Self { pats, rule }
         } else {
             panic!("Constructing a Row from a malformed rule")
         }

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -36,7 +36,6 @@ pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
         }
     }
 
-
     #[cfg(not(feature = "overlap-errors"))]
     {
         use crate::log;

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -131,7 +131,7 @@ impl Errors {
 
 /// Check for overlapping rules within individual priority groups.
 fn check_overlap_groups(errs: &mut Errors, env: &Env, term: &Term) {
-    let rows: Vec<Row> = env
+    let rows: Vec<_> = env
         .rules_for_term(term.id)
         .into_iter()
         .map(|id| Row::from_rule(env, id))
@@ -164,7 +164,9 @@ fn check_overlap_groups(errs: &mut Errors, env: &Env, term: &Term) {
 
     // Process conflicts sequentially.
     for (l, r) in conflicts {
-        errs.add_edge(l, r);
+        if env.get_rule(l).prio == env.get_rule(r).prio {
+            errs.add_edge(l, r);
+        }
     }
 }
 

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -23,17 +23,13 @@ pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
         check_overlap_groups(&mut errors, &env, term);
     }
 
-    if !errors.is_empty() {
-        errors.graphviz(&env);
-        panic!("");
-        let mut errors = errors.report(&env);
-        return match errors.len() {
-            1 => Err(errors.pop().unwrap()),
-            _ => Err(Error::Errors(std::mem::take(&mut errors))),
-        };
+    errors.graphviz(&env);
+    let mut errors = errors.report(&env);
+    match errors.len() {
+        0 => Ok(()),
+        1 => Err(errors.pop().unwrap()),
+        _ => Err(Error::Errors(errors)),
     }
-
-    Ok(())
 }
 
 /// A node in the error graph.
@@ -143,11 +139,6 @@ impl Errors {
         }
 
         components
-    }
-
-    /// True when there are no edges in the graph.
-    fn is_empty(&self) -> bool {
-        self.nodes.is_empty()
     }
 
     /// Condense the overlap information down into individual errors.


### PR DESCRIPTION
Introduce overlap checking for ISLE as the start of addressing #4717.

The overlap checker detects cases where ISLE rules could fire for the same input. Consider the following example from the x64 lowerings (line numbers added for clarity):

```lisp
13: (rule (sse_xor_op $F32X4) (SseOpcode.Xorps))
14: (rule (sse_xor_op $F64X2) (SseOpcode.Xorpd))
15: (rule (sse_xor_op (multi_lane _bits _lanes)) (SseOpcode.Pxor))
```

Rule 15 overlaps separately with rules 13 and 14, but rules 13 and 14 don't overlap with each other. With overlap checking enabled this will be reported as an overlap of all three rules, where the rule on line 15 will be identified as the source of the overlap (error messages could definitely be improved here). In this case the overlap can be resolved by setting a lower priority for rule 3.

```
Error:
  × overlap error: rules are overlapping
  │   ../x64.isle:15:0
  │   ../x64.isle:13:0
  │   ../x64.isle:14:0
```

For another example, consider the following:

```lisp
1: (rule (example $F32 25) ...)
2: (rule (example $F32 (fallible_extractor y)) ...)
3: (rule (example $F64 _) ...)
```

In this case, only the rules on lines 1 and 2 overlap, as we don't know that the fallible extractor won't fire successfully on the input `25`. As the rule on line 3 has a different leading pattern (`$F64`) it won't be part of  the overlap group generated.

However, if the example looks instead like the following:

```lisp
1: (rule (example $F32 (fallible_extractor 25)) ...)
2: (rule (example $F32 (fallible_extractor 31)) ...)
3: (rule (example $F64 _) ...)
```

We consider there to be no overlap in the rules as fallible extractors are expected to be pure.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
