### PR TITLE
ISLE: add support for multi-extractors and multi-constructors.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle/generated_code.rs
@@ -4,6 +4,6 @@
 // mod generated_code;` trick either.
 #![allow(dead_code, unreachable_code, unreachable_patterns)]
 #![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]
-#![allow(irrefutable_let_patterns)]
+#![allow(irrefutable_let_patterns, unused_assignments, non_camel_case_types)]
 
 include!(concat!(env!("ISLE_DIR"), "/isle_aarch64.rs"));

--- a/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle/generated_code.rs
@@ -4,6 +4,6 @@
 // mod generated_code;` trick either.
 #![allow(dead_code, unreachable_code, unreachable_patterns)]
 #![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]
-#![allow(irrefutable_let_patterns)]
+#![allow(irrefutable_let_patterns, unused_assignments, non_camel_case_types)]
 
 include!(concat!(env!("ISLE_DIR"), "/isle_s390x.rs"));

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -4,6 +4,6 @@
 // mod generated_code;` trick either.
 #![allow(dead_code, unreachable_code, unreachable_patterns)]
 #![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]
-#![allow(irrefutable_let_patterns)]
+#![allow(irrefutable_let_patterns, unused_assignments, non_camel_case_types)]
 
 include!(concat!(env!("ISLE_DIR"), "/isle_x64.rs"));

--- a/cranelift/isle/isle/isle_examples/fail/multi_internal_etor.isle
+++ b/cranelift/isle/isle/isle_examples/fail/multi_internal_etor.isle
@@ -1,0 +1,4 @@
+(type u32 (primitive u32))
+
+(decl multi A (u32) u32)
+(extractor (A x) x)

--- a/cranelift/isle/isle/isle_examples/link/multi_constructor.isle
+++ b/cranelift/isle/isle/isle_examples/link/multi_constructor.isle
@@ -1,0 +1,15 @@
+(type u32 (primitive u32))
+
+(decl multi A (u32) u32)
+(decl multi B (u32) u32)
+(decl multi C (u32) u32)
+(decl multi D (u32) u32)
+
+(extern constructor B ctor_B)
+(extern extractor C etor_C)
+
+(rule (A x)
+      (B x))
+
+(rule (D (C x))
+      (B x))

--- a/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
@@ -1,0 +1,42 @@
+mod multi_constructor;
+
+pub(crate) type ConstructorVec<T> = Vec<T>;
+
+struct Context;
+
+struct It {
+    i: u32,
+    limit: u32,
+}
+
+impl multi_constructor::ContextIter for It {
+    type Context = Context;
+    type Output = u32;
+    fn next(&mut self, _ctx: &mut Self::Context) -> Option<u32> {
+        if self.i >= self.limit {
+            None
+        } else {
+            let i = self.i;
+            self.i += 1;
+            Some(i)
+        }
+    }
+}
+
+impl multi_constructor::Context for Context {
+    type etor_C_iter = It;
+    fn etor_C(&mut self, value: u32) -> Option<It> {
+        Some(It { i: 0, limit: value })
+    }
+
+    fn ctor_B(&mut self, value: u32) -> Option<Vec<u32>> {
+        Some((0..value).rev().collect())
+    }
+}
+
+fn main() {
+    let mut ctx = Context;
+    let l1 = multi_constructor::constructor_A(&mut ctx, 10).unwrap();
+    let l2 = multi_constructor::constructor_D(&mut ctx, 5).unwrap();
+    println!("l1 = {:?} l2 = {:?}", l1, l2);
+}

--- a/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
@@ -29,8 +29,21 @@ impl multi_constructor::Context for Context {
         Some(It { i: 0, limit: value })
     }
 
-    fn ctor_B(&mut self, value: u32) -> Option<Vec<u32>> {
-        Some((0..value).rev().collect())
+    type ctor_B_iter = multi_constructor::ContextIterWrapper<u32, std::vec::IntoIter<u32>, Context>;
+    fn ctor_B(&mut self, value: u32) -> Option<Self::ctor_B_iter> {
+        Some((0..value).rev().collect::<Vec<_>>().into_iter().into())
+    }
+}
+
+struct IterWithContext<'a, Item, I: multi_constructor::ContextIter<Output = Item, Context = Context>> {
+    ctx: &'a mut Context,
+    it: I,
+}
+
+impl<'a, Item, I: multi_constructor::ContextIter<Output = Item, Context = Context>> Iterator for IterWithContext<'a, Item, I> {
+    type Item = Item;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next(self.ctx)
     }
 }
 
@@ -38,5 +51,7 @@ fn main() {
     let mut ctx = Context;
     let l1 = multi_constructor::constructor_A(&mut ctx, 10).unwrap();
     let l2 = multi_constructor::constructor_D(&mut ctx, 5).unwrap();
+    let l1 = IterWithContext { ctx: &mut ctx, it: l1 }.collect::<Vec<_>>();
+    let l2 = IterWithContext { ctx: &mut ctx, it: l2 }.collect::<Vec<_>>();
     println!("l1 = {:?} l2 = {:?}", l1, l2);
 }

--- a/cranelift/isle/isle/isle_examples/link/multi_extractor.isle
+++ b/cranelift/isle/isle/isle_examples/link/multi_extractor.isle
@@ -1,0 +1,14 @@
+(type u32 (primitive u32))
+(type A extern (enum (B) (C)))
+
+(decl multi E1 (A u32) u32)
+
+(extern extractor E1 e1_etor)
+
+(decl Rule (u32) u32)
+
+(rule (Rule (E1 a idx))
+      (if-let (A.B) a)
+      idx)
+(rule (Rule _)
+      32)

--- a/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
@@ -1,0 +1,46 @@
+mod multi_extractor;
+
+#[derive(Clone)]
+pub enum A {
+    B,
+    C,
+}
+
+struct It {
+    i: u32,
+    arg: u32,
+}
+
+impl multi_extractor::ContextIter for It {
+    type Context = Context;
+    type Output = (A, u32);
+    fn next(&mut self, _ctx: &mut Self::Context) -> Option<Self::Output> {
+        if self.i >= 32 {
+            None
+        } else {
+            let idx = self.i;
+            self.i += 1;
+            let a = if self.arg & (1u32 << idx) != 0 {
+                A::B
+            } else {
+                A::C
+            };
+            Some((a, idx))
+        }
+    }
+}
+
+struct Context;
+impl multi_extractor::Context for Context {
+    type e1_etor_iter = It;
+    fn e1_etor(&mut self, arg0: u32) -> Option<It> {
+        Some(It { i: 0, arg: arg0 })
+    }
+}
+
+fn main() {
+    let mut ctx = Context;
+    let x = multi_extractor::constructor_Rule(&mut ctx, 0xf0);
+    let y = multi_extractor::constructor_Rule(&mut ctx, 0);
+    println!("x = {:?} y = {:?}", x, y);
+}

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -72,6 +72,13 @@ pub struct Decl {
     pub ret_ty: Ident,
     /// Whether this term's constructor is pure.
     pub pure: bool,
+    /// Whether this term can exist with some multiplicity. For an
+    /// extractor, this implies an ABI with an extra `&mut usize`
+    /// parameter (a lazy or "pull") approach to get all the
+    /// terms. For a constructor, this implies an ABI where the return
+    /// value is a `SmallVec` (an eager or "push") approach to return
+    /// all the terms.
+    pub multi: bool,
     pub pos: Pos,
 }
 

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -72,12 +72,9 @@ pub struct Decl {
     pub ret_ty: Ident,
     /// Whether this term's constructor is pure.
     pub pure: bool,
-    /// Whether this term can exist with some multiplicity. For an
-    /// extractor, this implies an ABI with an extra `&mut usize`
-    /// parameter (a lazy or "pull") approach to get all the
-    /// terms. For a constructor, this implies an ABI where the return
-    /// value is a `SmallVec` (an eager or "push") approach to return
-    /// all the terms.
+    /// Whether this term can exist with some multiplicity: an
+    /// extractor or a constructor that matches multiple times, or
+    /// produces multiple values.
     pub multi: bool,
     pub pos: Pos,
 }

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -3,7 +3,7 @@
 use crate::ir::{ExprInst, InstId, PatternInst, Value};
 use crate::log;
 use crate::sema::ExternalSig;
-use crate::sema::{TermEnv, TermId, Type, TypeEnv, TypeId, Variant};
+use crate::sema::{MultiMode, TermEnv, TermId, Type, TypeEnv, TypeId, Variant};
 use crate::trie::{TrieEdge, TrieNode, TrieSymbol};
 use crate::{StableMap, StableSet};
 use std::collections::BTreeMap;
@@ -87,35 +87,66 @@ impl<'a> Codegen<'a> {
                 "#![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]"
             )
             .unwrap();
-            writeln!(code, "#![allow(irrefutable_let_patterns)]").unwrap();
+            writeln!(
+                code,
+                "#![allow(irrefutable_let_patterns, unused_assignments, non_camel_case_types)]"
+            )
+            .unwrap();
         }
 
         writeln!(code, "\nuse super::*;  // Pulls in all external types.").unwrap();
     }
 
     fn generate_trait_sig(&self, code: &mut String, indent: &str, sig: &ExternalSig) {
-        writeln!(
-            code,
-            "{indent}fn {name}(&mut self, {params}) -> {opt_start}{open_paren}{rets}{close_paren}{opt_end};",
-            indent = indent,
-            name = sig.func_name,
-            params = sig.param_tys
-                .iter()
-                .enumerate()
-                .map(|(i, &ty)| format!("arg{}: {}", i, self.type_name(ty, /* by_ref = */ true)))
-                .collect::<Vec<_>>()
-                .join(", "),
-            opt_start = if sig.infallible { "" } else { "Option<" },
+        let ret_tuple = format!(
+            "{open_paren}{rets}{close_paren}",
             open_paren = if sig.ret_tys.len() != 1 { "(" } else { "" },
-            rets = sig.ret_tys
+            rets = sig
+                .ret_tys
                 .iter()
                 .map(|&ty| self.type_name(ty, /* by_ref = */ false))
                 .collect::<Vec<_>>()
                 .join(", "),
             close_paren = if sig.ret_tys.len() != 1 { ")" } else { "" },
-            opt_end = if sig.infallible { "" } else { ">" },
+        );
+
+        let ret_ty = match (sig.multi, sig.infallible) {
+            (MultiMode::None, false) => format!("Option<{}>", ret_tuple),
+            (MultiMode::None, true) => format!("{}", ret_tuple),
+            (MultiMode::Vec, false) => format!("Option<ConstructorVec<{}>>", ret_tuple.clone()),
+            (MultiMode::Iter, false) => format!("Option<Self::{}_iter>", sig.func_name),
+            _ => panic!(
+                "Unsupported multiplicity/infallible combo: {:?}, {}",
+                sig.multi, sig.infallible
+            ),
+        };
+
+        writeln!(
+            code,
+            "{indent}fn {name}(&mut self, {params}) -> {ret_ty};",
+            indent = indent,
+            name = sig.func_name,
+            params = sig
+                .param_tys
+                .iter()
+                .enumerate()
+                .map(|(i, &ty)| format!("arg{}: {}", i, self.type_name(ty, /* by_ref = */ true)))
+                .collect::<Vec<_>>()
+                .join(", "),
+            ret_ty = ret_ty,
         )
         .unwrap();
+
+        if sig.multi == MultiMode::Iter {
+            writeln!(
+                code,
+                "{indent}type {name}_iter: ContextIter<Context = Self, Output = {output}>;",
+                indent = indent,
+                name = sig.func_name,
+                output = ret_tuple,
+            )
+            .unwrap();
+        }
     }
 
     fn generate_ctx_trait(&self, code: &mut String) {
@@ -146,6 +177,15 @@ impl<'a> Codegen<'a> {
                 self.generate_trait_sig(code, "    ", &ext_sig);
             }
         }
+        writeln!(code, "}}").unwrap();
+        writeln!(code, "pub trait ContextIter {{").unwrap();
+        writeln!(code, "    type Context;").unwrap();
+        writeln!(code, "    type Output;").unwrap();
+        writeln!(
+            code,
+            "    fn next(&mut self, ctx: &mut Self::Context) -> Option<Self::Output>;"
+        )
+        .unwrap();
         writeln!(code, "}}").unwrap();
     }
 
@@ -299,6 +339,11 @@ impl<'a> Codegen<'a> {
                 .join(", ");
             assert_eq!(sig.ret_tys.len(), 1);
             let ret = self.type_name(sig.ret_tys[0], false);
+            let ret = match sig.multi {
+                MultiMode::Vec => format!("ConstructorVec<{}>", ret),
+                MultiMode::Iter => unimplemented!(),
+                MultiMode::None => ret,
+            };
 
             writeln!(
                 code,
@@ -313,11 +358,31 @@ impl<'a> Codegen<'a> {
             )
             .unwrap();
 
+            let is_multi = match sig.multi {
+                MultiMode::Vec => true,
+                MultiMode::None => false,
+                MultiMode::Iter => unimplemented!(),
+            };
+
+            if is_multi {
+                writeln!(code, "let mut returns = ConstructorVec::new();").unwrap();
+            }
+
             let mut body_ctx: BodyContext = Default::default();
-            let returned =
-                self.generate_body(code, /* depth = */ 0, trie, "    ", &mut body_ctx);
+            let returned = self.generate_body(
+                code,
+                /* depth = */ 0,
+                trie,
+                "    ",
+                &mut body_ctx,
+                is_multi,
+            );
             if !returned {
-                writeln!(code, "    return None;").unwrap();
+                if is_multi {
+                    writeln!(code, "    return Some(returns);").unwrap();
+                } else {
+                    writeln!(code, "    return None;").unwrap();
+                }
             }
 
             writeln!(code, "}}").unwrap();
@@ -332,8 +397,9 @@ impl<'a> Codegen<'a> {
         indent: &str,
         ctx: &mut BodyContext,
         returns: &mut Vec<(usize, String)>,
-    ) {
+    ) -> bool {
         log!("generate_expr_inst: {:?}", inst);
+        let mut new_scope = false;
         match inst {
             &ExprInst::ConstInt { ty, val } => {
                 let value = Value::Expr {
@@ -422,6 +488,7 @@ impl<'a> Codegen<'a> {
                 ref inputs,
                 term,
                 infallible,
+                multi,
                 ..
             } => {
                 let mut input_exprs = vec![];
@@ -442,17 +509,35 @@ impl<'a> Codegen<'a> {
                 let termdata = &self.termenv.terms[term.index()];
                 let sig = termdata.constructor_sig(self.typeenv).unwrap();
                 assert_eq!(input_exprs.len(), sig.param_tys.len());
-                let fallible_try = if infallible { "" } else { "?" };
-                writeln!(
-                    code,
-                    "{}let {} = {}(ctx, {}){};",
-                    indent,
-                    outputname,
-                    sig.full_name,
-                    input_exprs.join(", "),
-                    fallible_try,
-                )
-                .unwrap();
+
+                match multi {
+                    MultiMode::None => {
+                        let fallible_try = if infallible { "" } else { "?" };
+                        writeln!(
+                            code,
+                            "{}let {} = {}(ctx, {}){};",
+                            indent,
+                            outputname,
+                            sig.full_name,
+                            input_exprs.join(", "),
+                            fallible_try,
+                        )
+                        .unwrap();
+                    }
+                    MultiMode::Vec => {
+                        writeln!(
+                            code,
+                            "{}for {} in {}(ctx, {})? {{",
+                            indent,
+                            outputname,
+                            sig.full_name,
+                            input_exprs.join(", "),
+                        )
+                        .unwrap();
+                        new_scope = true;
+                    }
+                    MultiMode::Iter => unimplemented!(),
+                }
                 self.define_val(&output, ctx, /* is_ref = */ false, termdata.ret_ty);
             }
             &ExprInst::Return {
@@ -462,6 +547,8 @@ impl<'a> Codegen<'a> {
                 returns.push((index, value_expr));
             }
         }
+
+        new_scope
     }
 
     fn match_variant_binders(
@@ -489,7 +576,7 @@ impl<'a> Codegen<'a> {
     }
 
     /// Returns a `bool` indicating whether this pattern inst is
-    /// infallible.
+    /// infallible, and the number of scopes opened.
     fn generate_pattern_inst(
         &self,
         code: &mut String,
@@ -497,7 +584,7 @@ impl<'a> Codegen<'a> {
         inst: &PatternInst,
         indent: &str,
         ctx: &mut BodyContext,
-    ) -> bool {
+    ) -> (bool, usize) {
         match inst {
             &PatternInst::Arg { index, ty } => {
                 let output = Value::Pattern {
@@ -519,13 +606,13 @@ impl<'a> Codegen<'a> {
                     is_ref,
                     ty,
                 );
-                true
+                (true, 0)
             }
             &PatternInst::MatchEqual { ref a, ref b, .. } => {
                 let a = self.value_by_ref(a, ctx);
                 let b = self.value_by_ref(b, ctx);
                 writeln!(code, "{}if {} == {} {{", indent, a, b).unwrap();
-                false
+                (false, 1)
             }
             &PatternInst::MatchInt {
                 ref input,
@@ -536,13 +623,13 @@ impl<'a> Codegen<'a> {
                 let int_val = self.const_int(int_val, ty);
                 let input = self.value_by_val(input, ctx);
                 writeln!(code, "{}if {} == {}  {{", indent, input, int_val).unwrap();
-                false
+                (false, 1)
             }
             &PatternInst::MatchPrim { ref input, val, .. } => {
                 let input = self.value_by_val(input, ctx);
                 let sym = &self.typeenv.syms[val.index()];
                 writeln!(code, "{}if {} == {} {{", indent, input, sym).unwrap();
-                false
+                (false, 1)
             }
             &PatternInst::MatchVariant {
                 ref input,
@@ -570,13 +657,14 @@ impl<'a> Codegen<'a> {
                     indent, ty_name, variantname, args, input
                 )
                 .unwrap();
-                false
+                (false, 1)
             }
             &PatternInst::Extract {
                 ref inputs,
                 ref output_tys,
                 term,
                 infallible,
+                multi,
                 ..
             } => {
                 let termdata = &self.termenv.terms[term.index()];
@@ -599,32 +687,62 @@ impl<'a> Codegen<'a> {
                     })
                     .collect::<Vec<_>>();
 
-                if infallible {
-                    writeln!(
-                        code,
-                        "{indent}let {open_paren}{vars}{close_paren} = {name}(ctx, {args});",
-                        indent = indent,
-                        open_paren = if output_binders.len() == 1 { "" } else { "(" },
-                        vars = output_binders.join(", "),
-                        close_paren = if output_binders.len() == 1 { "" } else { ")" },
-                        name = sig.full_name,
-                        args = input_values.join(", "),
-                    )
-                    .unwrap();
-                    true
-                } else {
-                    writeln!(
-                        code,
-                        "{indent}if let Some({open_paren}{vars}{close_paren}) = {name}(ctx, {args}) {{",
-                        indent = indent,
-                        open_paren = if output_binders.len() == 1 { "" } else { "(" },
-                        vars = output_binders.join(", "),
-                        close_paren = if output_binders.len() == 1 { "" } else { ")" },
-                        name = sig.full_name,
-                        args = input_values.join(", "),
-                    )
-                    .unwrap();
-                    false
+                let bind_pattern = format!(
+                    "{open_paren}{vars}{close_paren}",
+                    open_paren = if output_binders.len() == 1 { "" } else { "(" },
+                    vars = output_binders.join(", "),
+                    close_paren = if output_binders.len() == 1 { "" } else { ")" }
+                );
+                let etor_call = format!(
+                    "{name}(ctx, {args})",
+                    name = sig.full_name,
+                    args = input_values.join(", ")
+                );
+
+                match (infallible, multi) {
+                    (_, MultiMode::Vec) => unimplemented!(),
+                    (_, MultiMode::Iter) => {
+                        writeln!(
+                            code,
+                            "{indent}if let Some(mut iter) = {etor_call} {{",
+                            indent = indent,
+                            etor_call = etor_call,
+                        )
+                        .unwrap();
+                        writeln!(
+                            code,
+                            "{indent}    while let Some({bind_pattern}) = iter.next(ctx) {{",
+                            indent = indent,
+                            bind_pattern = bind_pattern,
+                        )
+                        .unwrap();
+
+                        (false, 2)
+                    }
+                    (false, MultiMode::None) => {
+                        writeln!(
+                            code,
+                            "{indent}if let Some({bind_pattern}) = {etor_call} {{",
+                            indent = indent,
+                            bind_pattern = bind_pattern,
+                            etor_call = etor_call,
+                        )
+                        .unwrap();
+
+                        (false, 1)
+                    }
+                    (true, MultiMode::None) => {
+                        writeln!(
+                            code,
+                            "{indent}let {bind_pattern} = {etor_call};",
+                            indent = indent,
+                            bind_pattern = bind_pattern,
+                            etor_call = etor_call,
+                        )
+                        .unwrap();
+
+                        (true, 0)
+                    }
                 }
             }
             &PatternInst::Expr {
@@ -646,7 +764,7 @@ impl<'a> Codegen<'a> {
                 )
                 .unwrap();
                 self.define_val(&output, ctx, /* is_ref = */ false, ty);
-                true
+                (true, 0)
             }
             &PatternInst::Expr {
                 ref seq, output_ty, ..
@@ -658,7 +776,15 @@ impl<'a> Codegen<'a> {
                 let mut returns = vec![];
                 for (id, inst) in seq.insts.iter().enumerate() {
                     let id = InstId(id);
-                    self.generate_expr_inst(code, id, inst, &subindent, &mut subctx, &mut returns);
+                    let new_scope = self.generate_expr_inst(
+                        code,
+                        id,
+                        inst,
+                        &subindent,
+                        &mut subctx,
+                        &mut returns,
+                    );
+                    assert!(!new_scope);
                 }
                 assert_eq!(returns.len(), 1);
                 writeln!(code, "{}return Some({});", subindent, returns[0].1).unwrap();
@@ -678,7 +804,7 @@ impl<'a> Codegen<'a> {
                 .unwrap();
                 self.define_val(&output, ctx, /* is_ref = */ false, output_ty);
 
-                false
+                (false, 1)
             }
         }
     }
@@ -690,6 +816,7 @@ impl<'a> Codegen<'a> {
         trie: &TrieNode,
         indent: &str,
         ctx: &mut BodyContext,
+        is_multi: bool,
     ) -> bool {
         log!("generate_body:\n{}", trie.pretty());
         let mut returned = false;
@@ -704,21 +831,37 @@ impl<'a> Codegen<'a> {
                     output.pos.pretty_print_line(&self.typeenv.filenames[..])
                 )
                 .unwrap();
+
                 // If this is a leaf node, generate the ExprSequence and return.
                 let mut returns = vec![];
+                let mut scopes = 0;
+                let mut indent = indent.to_string();
+                let orig_indent = indent.clone();
                 for (id, inst) in output.insts.iter().enumerate() {
                     let id = InstId(id);
-                    self.generate_expr_inst(code, id, inst, indent, ctx, &mut returns);
+                    let new_scope =
+                        self.generate_expr_inst(code, id, inst, &indent[..], ctx, &mut returns);
+                    if new_scope {
+                        scopes += 1;
+                        indent.push_str("    ");
+                    }
                 }
 
                 assert_eq!(returns.len(), 1);
-                writeln!(code, "{}return Some({});", indent, returns[0].1).unwrap();
+                if is_multi {
+                    writeln!(code, "{}returns.push({});", indent, returns[0].1).unwrap();
+                } else {
+                    writeln!(code, "{}return Some({});", indent, returns[0].1).unwrap();
+                }
 
-                returned = true;
+                for _ in 0..scopes {
+                    writeln!(code, "{}}}", orig_indent).unwrap();
+                }
+
+                returned = !is_multi;
             }
 
             &TrieNode::Decision { ref edges } => {
-                let subindent = format!("{}    ", indent);
                 // If this is a decision node, generate each match op
                 // in turn (in priority order). Gather together
                 // adjacent MatchVariant ops with the same input and
@@ -764,7 +907,14 @@ impl<'a> Codegen<'a> {
                     // (possibly an empty one). Only use a `match` form if there
                     // are at least two adjacent options.
                     if last - i > 1 {
-                        self.generate_body_matches(code, depth, &edges[i..last], indent, ctx);
+                        self.generate_body_matches(
+                            code,
+                            depth,
+                            &edges[i..last],
+                            indent,
+                            ctx,
+                            is_multi,
+                        );
                         i = last;
                         continue;
                     } else {
@@ -777,16 +927,32 @@ impl<'a> Codegen<'a> {
 
                         match symbol {
                             &TrieSymbol::EndOfMatch => {
-                                returned = self.generate_body(code, depth + 1, node, indent, ctx);
+                                returned = self.generate_body(
+                                    code,
+                                    depth + 1,
+                                    node,
+                                    indent,
+                                    ctx,
+                                    is_multi,
+                                );
                             }
                             &TrieSymbol::Match { ref op } => {
                                 let id = InstId(depth);
-                                let infallible =
+                                let (infallible, new_scopes) =
                                     self.generate_pattern_inst(code, id, op, indent, ctx);
-                                let i = if infallible { indent } else { &subindent[..] };
-                                let sub_returned =
-                                    self.generate_body(code, depth + 1, node, i, ctx);
-                                if !infallible {
+                                let mut subindent = indent.to_string();
+                                for _ in 0..new_scopes {
+                                    subindent.push_str("    ");
+                                }
+                                let sub_returned = self.generate_body(
+                                    code,
+                                    depth + 1,
+                                    node,
+                                    &subindent[..],
+                                    ctx,
+                                    is_multi,
+                                );
+                                for _ in 0..new_scopes {
                                     writeln!(code, "{}}}", indent).unwrap();
                                 }
                                 if infallible && sub_returned {
@@ -810,6 +976,7 @@ impl<'a> Codegen<'a> {
         edges: &[TrieEdge],
         indent: &str,
         ctx: &mut BodyContext,
+        is_multi: bool,
     ) {
         let (input, input_ty) = match &edges[0].symbol {
             &TrieSymbol::Match {
@@ -874,12 +1041,12 @@ impl<'a> Codegen<'a> {
             )
             .unwrap();
             let subindent = format!("{}        ", indent);
-            self.generate_body(code, depth + 1, node, &subindent, ctx);
+            self.generate_body(code, depth + 1, node, &subindent, ctx, is_multi);
             writeln!(code, "{}    }}", indent).unwrap();
         }
 
         // Always add a catchall, because we don't do exhaustiveness
-        // checking on the MatcHVariants.
+        // checking on the MatchVariants.
         writeln!(code, "{}    _ => {{}}", indent).unwrap();
 
         writeln!(code, "{}}}", indent).unwrap();

--- a/cranelift/isle/isle/src/ir.rs
+++ b/cranelift/isle/isle/src/ir.rs
@@ -105,8 +105,8 @@ pub enum PatternInst {
         output_tys: Vec<TypeId>,
         /// This extractor's term.
         term: TermId,
-        /// The mode in which we handle multiplicity.
-        multi: MultiMode,
+        /// Is this a multi-extractor?
+        multi: bool,
     },
 
     // NB: This has to go last, since it is infallible, so that when we sort
@@ -164,8 +164,8 @@ pub enum ExprInst {
         term: TermId,
         /// Whether this constructor is infallible or not.
         infallible: bool,
-        /// The mode in which we handle multiplicity.
-        multi: MultiMode,
+        /// Is this a multi-constructor?
+        multi: bool,
     },
 
     /// Set the Nth return value. Produces no values.
@@ -309,7 +309,7 @@ impl PatternSequence {
         output_tys: Vec<TypeId>,
         term: TermId,
         infallible: bool,
-        multi: MultiMode,
+        multi: bool,
     ) -> Vec<Value> {
         let inst = InstId(self.insts.len());
         let mut outs = vec![];
@@ -529,7 +529,7 @@ impl ExprSequence {
         ty: TypeId,
         term: TermId,
         infallible: bool,
-        multi: MultiMode,
+        multi: bool,
     ) -> Value {
         let inst = InstId(self.insts.len());
         let inputs = inputs.iter().cloned().collect();
@@ -599,11 +599,7 @@ impl ExprSequence {
                             ty,
                             term,
                             /* infallible = */ false,
-                            if *multi {
-                                MultiMode::Vec
-                            } else {
-                                MultiMode::None
-                            },
+                            *multi,
                         )
                     }
                     TermKind::Decl {
@@ -617,11 +613,7 @@ impl ExprSequence {
                             ty,
                             term,
                             /* infallible = */ !pure,
-                            if *multi {
-                                MultiMode::Vec
-                            } else {
-                                MultiMode::None
-                            },
+                            *multi,
                         )
                     }
                     TermKind::Decl {

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -290,6 +290,12 @@ impl<'a> Parser<'a> {
         } else {
             false
         };
+        let multi = if self.is_sym_str("multi") {
+            self.symbol()?;
+            true
+        } else {
+            false
+        };
 
         let term = self.parse_ident()?;
 
@@ -307,6 +313,7 @@ impl<'a> Parser<'a> {
             arg_tys,
             ret_ty,
             pure,
+            multi,
             pos,
         })
     }

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -292,23 +292,9 @@ pub struct ExternalSig {
     pub ret_tys: Vec<TypeId>,
     /// Whether this signature is infallible or not.
     pub infallible: bool,
-    /// "Multiplicity" mode: iterator, vec-return, or none.
-    pub multi: MultiMode,
-}
-
-/// The mode by which a term (extractor or constructor) returns
-/// multiple values.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum MultiMode {
-    /// Function (constructor or extractor) logically returns only one
-    /// result (or none).
-    None,
-    /// Function logically returns multiple results, and returns these
-    /// as an iterator that implements a custom iterator trait.
-    Iter,
-    /// Function logically returns multiple results, and returns these
-    /// as a vector.
-    Vec,
+    /// "Multiplicity": does the function return multiple values (via
+    /// an iterator)?
+    pub multi: bool,
 }
 
 impl Term {
@@ -384,11 +370,7 @@ impl Term {
                 param_tys: vec![self.ret_ty],
                 ret_tys: self.arg_tys.clone(),
                 infallible: *infallible && !*multi,
-                multi: if *multi {
-                    MultiMode::Iter
-                } else {
-                    MultiMode::None
-                },
+                multi: *multi,
             }),
             _ => None,
         }
@@ -408,11 +390,7 @@ impl Term {
                 param_tys: self.arg_tys.clone(),
                 ret_tys: vec![self.ret_ty],
                 infallible: !pure && !*multi,
-                multi: if *multi {
-                    MultiMode::Vec
-                } else {
-                    MultiMode::None
-                },
+                multi: *multi,
             }),
             TermKind::Decl {
                 constructor_kind: Some(ConstructorKind::InternalConstructor { .. }),
@@ -430,11 +408,7 @@ impl Term {
                     // matching at the toplevel (an entry point can
                     // fail to rewrite).
                     infallible: false,
-                    multi: if *multi {
-                        MultiMode::Vec
-                    } else {
-                        MultiMode::None
-                    },
+                    multi: *multi,
                 })
             }
             _ => None,


### PR DESCRIPTION
This support allows for rules that process multiple matching values per extractor call on the left-hand side, and as a result, can produce multiple values from the constructor whose body they define.

This is useful in situations where we are matching on an input data structure that can have multiple "nodes" for a given value or ID, for example in an e-graph.

This is the first piece of the implementation of bytecodealliance/rfcs#27.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
