### PR TITLE
Add --disable-parallel-compilation CLI flag

### DIFF
--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -22,6 +22,7 @@ default = [
     "wasmtime/cranelift",
     "wasmtime/jitdump",
     "wasmtime/vtune",
+    "wasmtime/parallel-compilation",
 ]
 pooling-allocator = []
 memory-init-cow = []

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -124,6 +124,10 @@ pub struct CommonOptions {
     #[clap(long)]
     pub disable_cache: bool,
 
+    /// Disable parallel compilation
+    #[clap(long)]
+    pub disable_parallel_compilation: bool,
+
     /// Enables or disables WebAssembly features
     #[clap(long, value_name = "FEATURE,FEATURE,...", parse(try_from_str = parse_wasm_features))]
     pub wasm_features: Option<WasmFeatures>,
@@ -290,6 +294,10 @@ impl CommonOptions {
                     config.cache_config_load_default()?;
                 }
             }
+        }
+
+        if self.disable_parallel_compilation {
+            config.parallel_compilation(false);
         }
 
         if let Some(max) = self.static_memory_maximum_size {


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Closes #4910. This PR adds `--disable-parallel-compilation` CLI flag to `wasmtime`, for use cases when parallel compilation is not desirable.