### PR TITLE
fuzzgen: Disable verifier after NaN Canonicalization

### DIFF
--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -85,6 +85,10 @@ fuzz_target!(|testcase: TestCase| {
         let mut builder = settings::builder();
         // We need llvm ABI extensions for i128 values on x86
         builder.set("enable_llvm_abi_extensions", "true").unwrap();
+
+        // This is the default, but we should ensure that it wasn't accidentally turned off anywhere.
+        builder.set("enable_verifier", "true").unwrap();
+
         settings::Flags::new(builder)
     };
     let mut compiler = TestFileCompiler::with_host_isa(flags).unwrap();

--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -20,6 +20,10 @@ fuzz_target!(|func: SingleFunction| {
         let mut builder = settings::builder();
         // We need llvm ABI extensions for i128 values on x86
         builder.set("enable_llvm_abi_extensions", "true").unwrap();
+
+        // This is the default, but we should ensure that it wasn't accidentally turned off anywhere.
+        builder.set("enable_verifier", "true").unwrap();
+
         builder
     });
 


### PR DESCRIPTION
We are currently running the verifier twice, once after the nan canonicalization pass, and again when JIT compiling the code.

The verifier first runs in the NaN Canonicalization pass. If it fails it prevents us from getting a nice `cargo fuzz fmt` test case.

So disable the verifier there, but ensure its enabled when JIT compiling.

@jameysharp I think this solves the issue in this comment: https://github.com/bytecodealliance/wasmtime/pull/4896#pullrequestreview-1104415283

I also think it makes sense to keep NaN canonicalization in fuzzgen, otherwise the testcase reported in `fmt` is different than the one that is actually executed and that can be really confusing.
