### PR TITLE
Flatten `and` patterns in ISLE

### DIFF
--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -1514,7 +1514,12 @@ impl TermEnv {
                         /* is_root = */ false,
                     ));
                     expected_ty = expected_ty.or(Some(ty));
-                    children.push(subpat);
+
+                    // Normalize nested `And` nodes to a single vector of conjuncts.
+                    match subpat {
+                        Pattern::And(_, subpat_children) => children.extend(subpat_children),
+                        _ => children.push(subpat),
+                    }
                 }
                 if expected_ty.is_none() {
                     tyenv.report_error(pos, "No type for (and ...) form.".to_string());


### PR DESCRIPTION
Normalize `and` patterns in the ISLE front-end so that all `and` patterns are flattened into a single vector. For example, the following patterns will all have the same representation after normalization:

```lisp
(and (and x y) z)
(and x (and y z))
(and x y z)
```

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
