### PR TITLE
Optimize the WASI `random_get` implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1aa052bd5af24e9d1ad26db37c4bed43e45494366a03321f05beeafaf99bdb"
+checksum = "c720808e249f0ae846ec647fe48cef3cea67e4e5026cf869c041c278b7dcae45"
 dependencies = [
  "ambient-authority",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "337ddae0c23990d98099a34db274fda588a3ddf89e1961aa2d3ae08d4572b746"
+checksum = "438ca7f5bb15c799ea146429e4f8b7bfd25ff1eb05319024549a7728de45800c"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -246,12 +246,11 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c13977868250c3102a1737c766c0fe0abea4c9d64b60566b55e3df084a46eb6"
+checksum = "ba063daa90ed40882bb288ac4ecaa942d655d15cf74393d41d2267b5d7daf120"
 dependencies = [
  "ambient-authority",
- "errno",
  "fs-set-times",
  "io-extras",
  "io-lifetimes",
@@ -275,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc3bec032b93533630adb5cd0e05f4eac5475bf3e9edafc562ccbc44fd5db06"
+checksum = "0e3a603c9f3bd2181ed128ab3cd32fbde7cff76afc64a3576662701c4aee7e2b"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -288,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e19d4852b4185065d0744d225fb961a79165f5a6dedfee9175457fbfd1a9bbb"
+checksum = "86d435f791da84cb800b98a1de48d145a08e70d8172d335e87446c79b17bfbf3"
 dependencies = [
  "cap-std",
  "rand 0.8.5",
@@ -300,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.25.0"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486425152c6e3e45528baa8edff1c37e82056cb2105a82836989679b6509326"
+checksum = "da76e64f3e46f8c8479e392a7fe3faa2e76b8c1cea4618bae445276fdec12082"
 dependencies = [
  "cap-primitives",
  "once_cell",

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.25.0"
+cap-std = "0.25.3"
 
 [dev-dependencies]
 wat = "1.0.45"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -29,7 +29,7 @@ wat = { version = "1.0.47", optional = true }
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.25.0", optional = true }
+cap-std = { version = "0.25.3", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache', 'parallel-compilation', 'memory-init-cow']

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.47"
-cap-std = "0.25.0"
+cap-std = "0.25.3"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,8 +22,8 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "=2.0.0" }
 tracing = "0.1.19"
-cap-std = "0.25.0"
-cap-rand = "0.25.0"
+cap-std = "0.25.3"
+cap-rand = "0.25.3"
 bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 cap-std = "0.25.0"
 cap-fs-ext = "0.25.0"
 cap-time-ext = "0.25.0"
-cap-rand = "0.25.0"
+cap-rand = "0.25.3"
 fs-set-times = "0.17.0"
 system-interface = { version = "0.22.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,9 +15,9 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "=2.0.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.25.0"
-cap-fs-ext = "0.25.0"
-cap-time-ext = "0.25.0"
+cap-std = "0.25.3"
+cap-fs-ext = "0.25.3"
+cap-time-ext = "0.25.3"
 cap-rand = "0.25.3"
 fs-set-times = "0.17.0"
 system-interface = { version = "0.22.0", features = ["cap_std_impls"] }

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -141,5 +141,5 @@ impl WasiCtxBuilder {
 }
 
 pub fn random_ctx() -> Box<dyn RngCore + Send + Sync> {
-    Box::new(cap_rand::rngs::OsRng::default(ambient_authority()))
+    Box::new(cap_rand::std_rng_from_entropy(cap_rand::ambient_authority()))
 }

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,7 +15,7 @@ wasi-common = { path = "../", version = "=2.0.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "=2.0.0" }
 wiggle = { path = "../../wiggle", version = "=2.0.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.25.0"
+cap-std = "0.25.3"
 anyhow = "1"
 io-lifetimes = { version = "0.7.0", default-features = false }
 
@@ -29,4 +29,4 @@ io-extras = "0.15.0"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.25.0"
+cap-tempfile = "0.25.3"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -44,16 +44,40 @@ criteria = "safe-to-deploy"
 version = "3.9.1"
 notes = "I am the author of this crate."
 
+[[audits.cap-fs-ext]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.cap-primitives]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.cap-std]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.cap-tempfile]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-run"
+version = "0.25.3"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.cap-rand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.25.0"
+version = "0.25.3"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-time-ext]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.25.0"
+version = "0.25.3"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.cc]]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -56,6 +56,12 @@ criteria = "safe-to-deploy"
 version = "0.25.3"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.cap-rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.25.3"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.cap-std]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
@@ -65,12 +71,6 @@ notes = "The Bytecode Alliance is the author of this crate"
 [[audits.cap-tempfile]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-run"
-version = "0.25.3"
-notes = "The Bytecode Alliance is the author of this crate"
-
-[[audits.cap-rand]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
 version = "0.25.3"
 notes = "The Bytecode Alliance is the author of this crate"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -90,22 +90,6 @@ criteria = "safe-to-deploy"
 version = "1.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.cap-fs-ext]]
-version = "0.25.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.cap-primitives]]
-version = "0.25.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.cap-std]]
-version = "0.25.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.cap-tempfile]]
-version = "0.25.0"
-criteria = "safe-to-run"
-
 [[exemptions.capstone]]
 version = "0.9.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Use `StdRng` instead of the `OsRng` in the default implementation of `random_get`. This uses a userspace CSPRNG, making `random_get` 3x faster in simple benchmarks.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
