### PR TITLE
Limit linear memories when fuzzing with pooling

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -349,6 +349,11 @@ impl<'a> Arbitrary<'a> for Config {
                 }
             };
 
+            // Don't allow too many linear memories per instance since massive
+            // virtual mappings can fail to get allocated.
+            cfg.min_memories = cfg.min_memories.min(10);
+            cfg.max_memories = cfg.max_memories.min(10);
+
             // Force this pooling allocator to always be able to accommodate the
             // module that may be generated.
             limits.memories = cfg.max_memories as u32;


### PR DESCRIPTION
This commit limits the maximum number of linear memories when the pooling allocator is used to ensure that the virtual memory mapping for the pooling allocator itself can succeed. Currently there are a number of crashes in the differential fuzzer where the pooling allocator can't allocate its mapping because the maximum specified number of linear memories times the number of instances exceeds the address space presumably.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
