### PR TITLE
Memoize `can_optimize_var_lookup`

### DIFF
--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -21,7 +21,7 @@ use cranelift_codegen::ir::{
 };
 use cranelift_codegen::packed_option::PackedOption;
 use smallvec::SmallVec;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Structure containing the data relevant the construction of SSA for a given function.
 ///
@@ -57,6 +57,11 @@ pub struct SSABuilder {
     /// Reused allocation for blocks we've already visited in the
     /// `can_optimize_var_lookup` method.
     visited: HashSet<Block>,
+
+    /// If a block B has chain up single predecessors leading to a block B' in
+    /// this map, then the value in the map indicates whether variable lookups
+    /// can be optimized in block B.
+    successors_can_optimize_var_lookup: HashMap<Block, bool>,
 }
 
 /// Side effects of a `use_var` or a `seal_block` method call.
@@ -134,6 +139,7 @@ impl SSABuilder {
             results: Vec::new(),
             side_effects: SideEffects::new(),
             visited: Default::default(),
+            successors_can_optimize_var_lookup: Default::default(),
         }
     }
 
@@ -142,9 +148,11 @@ impl SSABuilder {
     pub fn clear(&mut self) {
         self.variables.clear();
         self.ssa_blocks.clear();
+        self.successors_can_optimize_var_lookup.clear();
         debug_assert!(self.calls.is_empty());
         debug_assert!(self.results.is_empty());
         debug_assert!(self.side_effects.is_empty());
+        debug_assert!(self.successors_can_optimize_var_lookup.is_empty());
     }
 
     /// Tests whether an `SSABuilder` is in a cleared state.
@@ -154,6 +162,7 @@ impl SSABuilder {
             && self.calls.is_empty()
             && self.results.is_empty()
             && self.side_effects.is_empty()
+            && self.successors_can_optimize_var_lookup.is_empty()
     }
 }
 
@@ -291,31 +300,47 @@ impl SSABuilder {
         // Check that the initial block only has one predecessor. This is only a requirement
         // for the first block.
         if self.predecessors(block).len() != 1 {
+            // Skip insertion into `successors_can_optimize_var_lookup` because
+            // the condition is different for the first block.
             return false;
         }
 
         self.visited.clear();
         let mut current = block;
         loop {
+            if let Some(can_optimize) = self
+                .successors_can_optimize_var_lookup
+                .get(&current)
+                .copied()
+            {
+                self.successors_can_optimize_var_lookup
+                    .insert(block, can_optimize);
+                return can_optimize;
+            }
+
             let predecessors = self.predecessors(current);
 
             // We haven't found the original block and we have either reached the entry
             // block, or we found the end of this line of dead blocks, either way we are
             // safe to optimize this line of lookups.
             if predecessors.len() == 0 {
+                self.successors_can_optimize_var_lookup.insert(block, true);
                 return true;
             }
 
             // We can stop the search here, the algorithm can handle these cases, even if they are
             // in an undefined island.
             if predecessors.len() > 1 {
+                self.successors_can_optimize_var_lookup.insert(block, true);
                 return true;
             }
 
             let next_current = predecessors[0].block;
             if !self.visited.insert(current) {
+                self.successors_can_optimize_var_lookup.insert(block, false);
                 return false;
             }
+
             current = next_current;
         }
     }

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -21,7 +21,6 @@ use cranelift_codegen::ir::{
 };
 use cranelift_codegen::packed_option::PackedOption;
 use smallvec::SmallVec;
-use std::collections::HashSet;
 
 /// Structure containing the data relevant the construction of SSA for a given function.
 ///
@@ -56,7 +55,7 @@ pub struct SSABuilder {
 
     /// Reused allocation for blocks we've already visited in the
     /// `can_optimize_var_lookup` method.
-    visited: HashSet<Block>,
+    visited: SecondaryMap<Block, bool>,
 
     /// If a block B has chain up single predecessors leading to a block B' in
     /// this map, then the value in the map indicates whether variable lookups
@@ -331,10 +330,11 @@ impl SSABuilder {
             }
 
             let next_current = predecessors[0].block;
-            if !self.visited.insert(current) {
+            if self.visited[current] {
                 self.successors_can_optimize_var_lookup[block] = Some(false);
                 return false;
             }
+            self.visited[current] = true;
 
             current = next_current;
         }


### PR DESCRIPTION
This fixes issue https://github.com/bytecodealliance/wasmtime/issues/4923.

`can_optimize_var_lookup` can have quadratic behavior if there is a chain of blocks each containing a local.get instruction because each run can walk up the entire chain. This change memoizes the results of `can_optimize_var_lookup` so that we can stop following the chain of predecessors when we hit a block that has previously been handled (making the operation linear again).

For the example wasm in issue https://github.com/bytecodealliance/wasmtime/issues/4923 this reduces the compile time from 2.4 seconds to 80 milliseconds on my machine.

I haven't added any test cases because this is an optimization, but happy to add some if needed.

Running this on the `bz2`, `spidermonkey`, and `pulldown-cmark` benchmarks in `sightglass` showed a slight slowdown on `spidermonkey` and no change on the others. But after I switched the `visited` field from a `HashSet` to `SecondaryMap` there's no regression overall:

```
     Running `target/debug/sightglass-cli benchmark --stop-after compilation --engine /tmp/wasmtime_main.so --engine /tmp/wasmtime_all_secondarymap.so -- benchmarks/bz2/benchmark.wasm benchmarks/pulldown-cmark/benchmark.wasm benchmarks/spidermonkey/benchmark.wasm`

compilation :: cycles :: benchmarks/spidermonkey/benchmark.wasm

  Δ = 760212555.60 ± 294917212.14 (confidence = 99%)

  all_secondarymap.so is 1.01x to 1.03x faster than main.so!

  [28814332410 35120475949.50 36287395200] all_secondarymap.so
  [34284188130 35880688505.10 36647154330] main.so

compilation :: cycles :: benchmarks/bz2/benchmark.wasm

  No difference in performance.

  [505446060 603389897.40 1110277230] all_secondarymap.so
  [476744010 579360685.20 853570110] main.so

compilation :: cycles :: benchmarks/pulldown-cmark/benchmark.wasm

  No difference in performance.

  [1189612080 1520043626.70 2771829660] all_secondarymap.so
  [1347713850 1514585763.90 1904475450] main.so

```
