### PR TITLE
cranelift: Added `bitcast.f32` for i32, `bitcast.f64` for i64 to interpreter.

### DIFF
--- a/cranelift/filetests/filetests/runtests/float-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitcast.clif
@@ -15,16 +15,16 @@ block0(v0: i32):
 ; run: %bcast_i32_f32_i32_convert(0x12345678) == 0x12345678
 ; run: %bcast_i32_f32_i32_convert(0x0) == 0x0
 
-function %bcast_i64_f64_f64_convert(i64) -> i64 {
+function %bcast_i64_f64_i64_convert(i64) -> i64 {
 block0(v0: i64):
     v1 = bitcast.f64 v0
     v2 = bitcast.i64 v1
     return v2
 }
 
-; run: %bcast_i64_f64_f64_convert(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
-; run: %bcast_i64_f64_f64_convert(0x1234567812345678) == 0x1234567812345678
-; run: %bcast_i64_f64_f64_convert(0x0) == 0x0
+; run: %bcast_i64_f64_i64_convert(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
+; run: %bcast_i64_f64_i64_convert(0x1234567812345678) == 0x1234567812345678
+; run: %bcast_i64_f64_i64_convert(0x0) == 0x0
 
 function %bcast_i32_to_f32(i32) -> f32 {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/runtests/float-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitcast.clif
@@ -4,24 +4,44 @@ target x86_64
 target aarch64
 target s390x
 
-function %bcast_i32_to_f32(i32) -> i32 {
+function %bcast_i32_f32_i32_convert(i32) -> i32 {
 block0(v0: i32):
     v1 = bitcast.f32 v0
     v2 = bitcast.i32 v1
     return v2
 }
 
-; run: %bcast_i32_to_f32(0xFFFFFFFF) == 0xFFFFFFFF
-; run: %bcast_i32_to_f32(0x12345678) == 0x12345678
-; run: %bcast_i32_to_f32(0x0) == 0x0
+; run: %bcast_i32_f32_i32_convert(0xFFFFFFFF) == 0xFFFFFFFF
+; run: %bcast_i32_f32_i32_convert(0x12345678) == 0x12345678
+; run: %bcast_i32_f32_i32_convert(0x0) == 0x0
 
-function %bcast_i64_to_f64(i64) -> i64 {
+function %bcast_i64_f64_f64_convert(i64) -> i64 {
 block0(v0: i64):
     v1 = bitcast.f64 v0
     v2 = bitcast.i64 v1
     return v2
 }
 
-; run: %bcast_i64_to_f64(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
-; run: %bcast_i64_to_f64(0x1234567812345678) == 0x1234567812345678
-; run: %bcast_i64_to_f64(0x0) == 0x0
+; run: %bcast_i64_f64_f64_convert(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
+; run: %bcast_i64_f64_f64_convert(0x1234567812345678) == 0x1234567812345678
+; run: %bcast_i64_f64_f64_convert(0x0) == 0x0
+
+function %bcast_i32_to_f32(i32) -> f32 {
+block0(v0: i32):
+    v1 = bitcast.f32 v0
+    return v1
+}
+
+; run: %bcast_i32_to_f32(0xFFFFFFFF) == -NaN:0x3fffff
+; run: %bcast_i32_to_f32(0x12345678) == 0x1.68acf0p-91
+; run: %bcast_i32_to_f32(0x0) == 0x0.0
+
+function %bcast_i64_to_f64(i64) -> f64 {
+block0(v0: i64):
+    v1 = bitcast.f64 v0
+    return v1
+}
+
+; run: %bcast_i64_to_f64(0xFFFFFFFFFFFFFFFF) == -NaN:0x7ffffffffffff
+; run: %bcast_i64_to_f64(0x1234567812345678) == 0x1.4567812345678p-732
+; run: %bcast_i64_to_f64(0x0) == 0x0.0

--- a/cranelift/filetests/filetests/runtests/float-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitcast.clif
@@ -1,0 +1,27 @@
+test interpret
+test run
+target x86_64
+target aarch64
+target s390x
+
+function %bcast_i32_to_f32(i32) -> i32 {
+block0(v0: i32):
+    v1 = bitcast.f32 v0
+    v2 = bitcast.i32 v1
+    return v2
+}
+
+; run: %bcast_i32_to_f32(0xFFFFFFFF) == 0xFFFFFFFF
+; run: %bcast_i32_to_f32(0x12345678) == 0x12345678
+; run: %bcast_i32_to_f32(0x0) == 0x0
+
+function %bcast_i64_to_f64(i64) -> i64 {
+block0(v0: i64):
+    v1 = bitcast.f64 v0
+    v2 = bitcast.i64 v1
+    return v2
+}
+
+; run: %bcast_i64_to_f64(0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
+; run: %bcast_i64_to_f64(0x1234567812345678) == 0x1234567812345678
+; run: %bcast_i64_to_f64(0x0) == 0x0

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -309,6 +309,8 @@ impl Value for DataValue {
                 }
                 (DataValue::F32(n), types::I32) => DataValue::I32(n.bits() as i32),
                 (DataValue::F64(n), types::I64) => DataValue::I64(n.bits() as i64),
+                (DataValue::I32(n), types::F32) => DataValue::F32(Ieee32::with_bits(n as u32)),
+                (DataValue::I64(n), types::F64) => DataValue::F64(Ieee64::with_bits(n as u64)),
                 (DataValue::B(b), t) if t.is_bool() => DataValue::B(b),
                 (DataValue::B(b), t) if t.is_int() => {
                     // Bools are represented in memory as all 1's


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

@afonso360 
Related to https://github.com/bytecodealliance/wasmtime/pull/4920