### PR TITLE
Allow empty commits for the release

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -117,7 +117,7 @@ jobs:
           rustc ci/update-release-date.rs -o /tmp/update-release-date
           /tmp/update-release-date $(date +'%Y-%m-%d')
 
-          git commit -a -F-<<EOF
+          git commit --allow-empty -a -F-<<EOF
           Update release date of Wasmtime $cur
           EOF
           git push origin HEAD:ci/release-date-for-$cur
@@ -152,7 +152,7 @@ jobs:
           # released
           git reset --hard origin/release-$cur
           sed -i "s/^Unreleased/Released $(date +'%Y-%m-%d')/" RELEASES.md
-          git commit -a -F-<<EOF
+          git commit --allow-empty -a -F-<<EOF
           Release Wasmtime $cur
 
           [automatically-tag-and-release-this-commit]


### PR DESCRIPTION
The release process failed last night due to me filling out the dates in the release notes early (rather than leaving "Unreleased") which mean there were no changes for each commit. Switch to passing `--allow-empty` when making a commit to prevent this.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
