### PR TITLE
fuzzgen: Avoid `int_divz` traps

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -39,6 +39,14 @@ pub struct Config {
     /// Determines how often we generate a backwards branch
     /// Backwards branches are prone to infinite loops, and thus cause timeouts.
     pub backwards_branch_ratio: (usize, usize),
+
+    /// How often should we allow integer division by zero traps.
+    ///
+    /// Some instructions such as Srem and Udiv can cause a `int_divz` trap
+    /// under some inputs. We almost always insert a sequence of instructions
+    /// that avoids these issues. However we can allow some `int_divz` traps
+    /// by controlling this config.
+    pub allowed_int_divz_ratio: (usize, usize),
 }
 
 impl Default for Config {
@@ -62,6 +70,7 @@ impl Default for Config {
             // 0.1% allows us to explore this, while not causing enough timeouts to significantly
             // impact execs/s
             backwards_branch_ratio: (1, 1000),
+            allowed_int_divz_ratio: (1, 1_000_000),
         }
     }
 }

--- a/cranelift/fuzzgen/src/pass.rs
+++ b/cranelift/fuzzgen/src/pass.rs
@@ -30,10 +30,10 @@ pub fn do_int_divz_pass(fuzz: &mut FuzzGen, func: &mut Function) -> Result<()> {
 fn can_int_divz(pos: &FuncCursor, inst: Inst) -> bool {
     let opcode = pos.func.dfg[inst].opcode();
 
-    opcode == Opcode::Sdiv
-        || opcode == Opcode::Udiv
-        || opcode == Opcode::Srem
-        || opcode == Opcode::Urem
+    matches!(
+        opcode,
+        Opcode::Sdiv | Opcode::Udiv | Opcode::Srem | Opcode::Urem
+    )
 }
 
 /// Prepend instructions to inst to avoid `int_divz` traps
@@ -49,7 +49,7 @@ fn insert_int_divz_sequence(pos: &mut FuncCursor, inst: Inst) {
     let one = pos.ins().iconst(ty, 1);
     let denominator_is_zero = pos.ins().icmp(IntCC::Equal, rhs, zero);
 
-    let replace_denominator = if opcode == Opcode::Srem || opcode == Opcode::Sdiv {
+    let replace_denominator = if matches!(opcode, Opcode::Srem | Opcode::Sdiv) {
         // Srem and Sdiv can also trap on INT_MIN / -1. So we need to check for the second one
 
         // 1 << (ty bits - 1) to get INT_MIN

--- a/cranelift/fuzzgen/src/pass.rs
+++ b/cranelift/fuzzgen/src/pass.rs
@@ -1,0 +1,78 @@
+use crate::FuzzGen;
+use anyhow::Result;
+use cranelift::codegen::cursor::{Cursor, FuncCursor};
+use cranelift::codegen::ir::{Function, Inst, Opcode};
+use cranelift::prelude::{InstBuilder, IntCC};
+
+pub fn do_int_divz_pass(fuzz: &mut FuzzGen, func: &mut Function) -> Result<()> {
+    // Insert this per function, otherwise the actual rate of int_divz doesn't go down that much
+    // Experimentally if we decide this per instruction with a 0.1% allow rate, we get 4.4% of runs
+    // trapping. Doing this per function decreases the number of runs that trap. It also consumes
+    // fewer fuzzer input bytes which is nice.
+    let ratio = fuzz.config.allowed_int_divz_ratio;
+    let insert_seq = !fuzz.u.ratio(ratio.0, ratio.1)?;
+    if !insert_seq {
+        return Ok(());
+    }
+
+    let mut pos = FuncCursor::new(func);
+    while let Some(_block) = pos.next_block() {
+        while let Some(inst) = pos.next_inst() {
+            if can_int_divz(&pos, inst) {
+                insert_int_divz_sequence(&mut pos, inst);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Returns true/false if this instruction can cause a `int_divz` trap
+fn can_int_divz(pos: &FuncCursor, inst: Inst) -> bool {
+    let opcode = pos.func.dfg[inst].opcode();
+
+    opcode == Opcode::Sdiv
+        || opcode == Opcode::Udiv
+        || opcode == Opcode::Srem
+        || opcode == Opcode::Urem
+}
+
+/// Prepend instructions to inst to avoid `int_divz` traps
+fn insert_int_divz_sequence(pos: &mut FuncCursor, inst: Inst) {
+    let opcode = pos.func.dfg[inst].opcode();
+    let inst_args = pos.func.dfg.inst_args(inst);
+    let (lhs, rhs) = (inst_args[0], inst_args[1]);
+    assert_eq!(pos.func.dfg.value_type(lhs), pos.func.dfg.value_type(rhs));
+    let ty = pos.func.dfg.value_type(lhs);
+
+    // All of these instructions can trap if the denominator is zero
+    let zero = pos.ins().iconst(ty, 0);
+    let one = pos.ins().iconst(ty, 1);
+    let denominator_is_zero = pos.ins().icmp(IntCC::Equal, rhs, zero);
+
+    let replace_denominator = if opcode == Opcode::Srem || opcode == Opcode::Sdiv {
+        // Srem and Sdiv can also trap on INT_MIN / -1. So we need to check for the second one
+
+        // 1 << (ty bits - 1) to get INT_MIN
+        let int_min = pos.ins().ishl_imm(one, ty.lane_bits() as i64 - 1);
+
+        // Get a -1 const
+        // TODO: A iconst -1 would be clearer, but #2906 makes this impossible for i128
+        let neg_one = pos.ins().isub(zero, one);
+
+        let lhs_check = pos.ins().icmp(IntCC::Equal, lhs, int_min);
+        let rhs_check = pos.ins().icmp(IntCC::Equal, rhs, neg_one);
+        let is_invalid = pos.ins().band(lhs_check, rhs_check);
+
+        // These also crash if the denominator is zero, so we still need to check for that.
+        pos.ins().bor(denominator_is_zero, is_invalid)
+    } else {
+        denominator_is_zero
+    };
+
+    // If we have a trap we replace the denominator with a 1
+    let new_rhs = pos.ins().select(replace_denominator, one, rhs);
+
+    // Replace the previous rhs with the new one
+    let args = pos.func.dfg.inst_args_mut(inst);
+    args[1] = new_rhs;
+}


### PR DESCRIPTION
👋 Hey,

This avoids `int_divz` traps generated by fuzzgen by doing a pass over generated code and inserting additional instructions if a particular opcode can cause a `int_divz` trap.

Currently we decide per function if we are going to avoid all `int_divz`'s. However I ran into something a bit unexpected. Even with one in a million inputs being allowed to trap, we still get a somewhat big amount of runs trapping (~2-3%). I'm not quite sure why this happens (if anyone has any ideas, let me know!).

I suspect this is somehow related to a single input generating a bunch of runs and them all failing and inflating those numbers, or maybe the fuzzer really likes to explore the inputs where we allow `int_divz`'s? I'm not sure.

I also did a sanity check run where I always inserted the `int_divz` check, and predictably got 0%.

Here are the benchmarks:

<details>
<summary><h3>Baseline:</h3></summary>

```
#49977  NEW    cov: 31759 ft: 183553 corp: 4114/8186Kb lim: 393599 exec/s: 29 rss: 979Mb L: 2926/316258 MS: 1 EraseBytes-
== FuzzGen Statistics  ====================
Total Inputs: 50000
Valid Inputs: 26348 (52.7%)
Total Runs: 656246
Successful Runs: 539632 (82.2% of Total Runs)
Timed out Runs: 155 (0.0% of Total Runs)
Traps:
        user code: bad_sig: 0 (0.0% of Total Runs)
        user code: int_ovf: 8 (0.0% of Total Runs)
        user code: int_divz: 116451 (17.7% of Total Runs)
        user code: unreachable: 0 (0.0% of Total Runs)
        user code: heap_misaligned: 0 (0.0% of Total Runs)
        user code: interrupt: 0 (0.0% of Total Runs)
        user code: stk_ovf: 0 (0.0% of Total Runs)
        user code: table_oob: 0 (0.0% of Total Runs)
        user debug: 0 (0.0% of Total Runs)
        user code: bad_toint: 0 (0.0% of Total Runs)
        user code: heap_oob: 0 (0.0% of Total Runs)
        resumable: 0 (0.0% of Total Runs)
        user code: icall_null: 0 (0.0% of Total Runs)
```

</details>



<details>
<summary><h3>This PR:</h3></summary>

```
#49982  NEW    cov: 32009 ft: 184999 corp: 3984/8155Kb lim: 393599 exec/s: 25 rss: 975Mb L: 5077/393581 MS: 1 CopyPart-
== FuzzGen Statistics  ====================
Total Inputs: 50000
Valid Inputs: 25940 (51.9%)
Total Runs: 660751
Successful Runs: 639007 (96.7% of Total Runs)
Timed out Runs: 125 (0.0% of Total Runs)
Traps:
        user code: bad_sig: 0 (0.0% of Total Runs)
        user code: int_ovf: 0 (0.0% of Total Runs)
        user debug: 0 (0.0% of Total Runs)
        user code: int_divz: 21619 (3.3% of Total Runs)
        user code: bad_toint: 0 (0.0% of Total Runs)
        resumable: 0 (0.0% of Total Runs)
        user code: unreachable: 0 (0.0% of Total Runs)
        user code: icall_null: 0 (0.0% of Total Runs)
        user code: heap_oob: 0 (0.0% of Total Runs)
        user code: table_oob: 0 (0.0% of Total Runs)
        user code: interrupt: 0 (0.0% of Total Runs)
        user code: stk_ovf: 0 (0.0% of Total Runs)
        user code: heap_misaligned: 0 (0.0% of Total Runs)
```

</details>


<details>
<summary><h3>This PR with 100% insertion rate:</h3></summary>

```

#49907  NEW    cov: 31943 ft: 184612 corp: 4012/8336Kb lim: 393599 exec/s: 24 rss: 1060Mb L: 687/393581 MS: 2 ChangeByte-ChangeASCIIInt-
== FuzzGen Statistics  ====================
Total Inputs: 50000
Valid Inputs: 25911 (51.8%)
Total Runs: 834983
Successful Runs: 834813 (100.0% of Total Runs)
Timed out Runs: 170 (0.0% of Total Runs)
Traps:
        resumable: 0 (0.0% of Total Runs)
        user code: table_oob: 0 (0.0% of Total Runs)
        user code: interrupt: 0 (0.0% of Total Runs)
        user code: bad_sig: 0 (0.0% of Total Runs)
        user code: icall_null: 0 (0.0% of Total Runs)
        user debug: 0 (0.0% of Total Runs)
        user code: heap_misaligned: 0 (0.0% of Total Runs)
        user code: int_ovf: 0 (0.0% of Total Runs)
        user code: bad_toint: 0 (0.0% of Total Runs)
        user code: stk_ovf: 0 (0.0% of Total Runs)
        user code: heap_oob: 0 (0.0% of Total Runs)
        user code: int_divz: 0 (0.0% of Total Runs)
        user code: unreachable: 0 (0.0% of Total Runs)
```

</details>

CC: @jameysharp 