### PR TITLE
Update Rust lang doc for 1.0.0 dependency

### DIFF
--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -43,7 +43,7 @@ dependency in `Cargo.toml`:
 
 ```toml
 [dependencies]
-wasmtime = "0.33.0"
+wasmtime = "1.0.0"
 ```
 
 Next up let's write the code that we need to execute this wasm file. The


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Update for Rust `wasmtime="1.0.0"` dependency. If you want to just put this one line change at part of another PR/commit, feel free to close.
