### PR TITLE
Avoid quadratic behavior in `can_optimize_var_lookup`

### DIFF
--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -126,6 +126,7 @@ impl SSABlockData {
     }
 }
 
+#[derive(Eq, PartialEq)]
 enum Action {
     Add,
     Remove,
@@ -383,12 +384,12 @@ impl SSABuilder {
         let will_have_one_pred = match block_ref.predecessors.as_slice() {
             // None: `pred` might reach `block` in a cycle. There'll be one predecessor afterward
             // if we're adding `pred`.
-            [] => matches!(action, Action::Add),
+            [] => action == Action::Add,
             // One: the other predecessor might reach `block` in a cycle. There'll be one
             // predecessor afterward if we're removing `pred`.
             [other] => {
                 pred = other.block;
-                matches!(action, Action::Remove)
+                action == Action::Remove
             }
             // Two or more: there is definitely no cycle through `block`, either before or after.
             _ => {


### PR DESCRIPTION
This fixes #4938/#4923, with a different take on #4924.

I think this maybe introduces worst-case quadratic behavior in `declare_block_predecessor` instead, though I think it would happen much less often. I'd appreciate any performance insights during review.

I want to work some more on the comments before merging this, because it was hard to get right and involves subtle invariants. But it does pass the test suite now and I think it's correct.