### PR TITLE
Update to cap-std 0.26.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "438ca7f5bb15c799ea146429e4f8b7bfd25ff1eb05319024549a7728de45800c"
+checksum = "d6540a9d9002b6ec6fe5f1bbbfcded600a16018570c64fedbc5ccad0632b8edc"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba063daa90ed40882bb288ac4ecaa942d655d15cf74393d41d2267b5d7daf120"
+checksum = "591dbd5ace8712534c781367a16b46b620564153f88dfed85e7f609638f52e01"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "cap-rand"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c720808e249f0ae846ec647fe48cef3cea67e4e5026cf869c041c278b7dcae45"
+checksum = "d2832496b1552ea04fb9267a70f831697c67d4bf9656ada6b9f93d4640e78485"
 dependencies = [
  "ambient-authority",
  "rand 0.8.5",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3a603c9f3bd2181ed128ab3cd32fbde7cff76afc64a3576662701c4aee7e2b"
+checksum = "2a6652184ef93583621d582105885a82cc7c6f522662390a15658e6d098c833c"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d435f791da84cb800b98a1de48d145a08e70d8172d335e87446c79b17bfbf3"
+checksum = "cc76d2cf04cd69960421f484ac5a82802546fada52b26253e1e51a44fc318c34"
 dependencies = [
  "cap-std",
  "rand 0.8.5",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da76e64f3e46f8c8479e392a7fe3faa2e76b8c1cea4618bae445276fdec12082"
+checksum = "8cd90913f359a8baff03c1c8b8e5655d2a465da561344da85f052d5fa3091d8c"
 dependencies = [
  "cap-primitives",
  "once_cell",
@@ -1583,9 +1583,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.6"
+version = "0.35.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef258c11e17f5c01979a10543a30a4e12faef6aab217a74266e747eefa3aed88"
+checksum = "af895b90e5c071badc3136fc10ff0bcfc98747eadbaf43ed8f214e07ba8f8477"
 dependencies = [
  "bitflags",
  "errno",
@@ -2772,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa85f9e64bd72b222ced152d2694fd306c0ebe43670cb9d187701874b7b89008"
+checksum = "92adbaf536f5aff6986e1e62ba36cee72b1718c5153eee08b9e728ddde3f6029"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ once_cell = "1.12"
 listenfd = "1.0.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["mm", "param"] }
+rustix = { version = "0.35.10", features = ["mm", "param"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -25,7 +25,7 @@ wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
 wasmtime-wasi-nn = { path = "../wasi-nn", optional = true }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
-cap-std = "0.25.3"
+cap-std = "0.26.0"
 
 [dev-dependencies]
 wat = "1.0.45"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -29,7 +29,7 @@ wat = { version = "1.0.47", optional = true }
 # Optional dependencies for the `wasi` feature
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", optional = true }
 wasmtime-wasi = { path = "../wasi", optional = true }
-cap-std = { version = "0.25.3", optional = true }
+cap-std = { version = "0.26.0", optional = true }
 
 [features]
 default = ['jitdump', 'wat', 'wasi', 'cache', 'parallel-compilation', 'memory-init-cow']

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -27,7 +27,7 @@ features = [
 ]
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-rustix = { version = "0.35.6", features = ["process"] }
+rustix = { version = "0.35.10", features = ["process"] }
 
 [dev-dependencies]
 filetime = "0.2.7"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -17,7 +17,7 @@ links = "wasmtime-fiber-shims"
 cfg-if = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["mm", "param"] }
+rustix = { version = "0.35.10", features = ["mm", "param"] }
 wasmtime-asm-macros = { version = "=2.0.0", path = "../asm-macros" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = {version = "1.12.0", optional = true }
 object = { version = "0.29.0", default-features = false, features = ["std", "read_core"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.35.6", features = ["mm", "param", "time"], optional = true }
+rustix = { version = "0.35.10", features = ["mm", "param", "time"], optional = true }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -34,7 +34,7 @@ features = [
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rustix = { version = "0.35.6", features = ["process"] }
+rustix = { version = "0.35.10", features = ["process"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 ittapi = { version = "0.3.0", optional = true  }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -31,7 +31,7 @@ encoding_rs = { version = "0.8.31", optional = true }
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["mm"] }
+rustix = { version = "0.35.10", features = ["mm"] }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.36.0"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.1.0"
 os_pipe = "0.9"
 anyhow = "1.0.19"
 wat = "1.0.47"
-cap-std = "0.25.3"
+cap-std = "0.26.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 
 [features]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -22,12 +22,12 @@ anyhow = "1.0"
 thiserror = "1.0"
 wiggle = { path = "../wiggle", default-features = false, version = "=2.0.0" }
 tracing = "0.1.19"
-cap-std = "0.25.3"
-cap-rand = "0.25.3"
+cap-std = "0.26.0"
+cap-rand = "0.26.0"
 bitflags = "1.2"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.35.10", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 io-extras = "0.15.0"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -15,23 +15,23 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 wasi-common = { path = "../", version = "=2.0.0" }
 async-trait = "0.1"
 anyhow = "1.0"
-cap-std = "0.25.3"
-cap-fs-ext = "0.25.3"
-cap-time-ext = "0.25.3"
-cap-rand = "0.25.3"
+cap-std = "0.26.0"
+cap-fs-ext = "0.26.0"
+cap-time-ext = "0.26.0"
+cap-rand = "0.26.0"
 fs-set-times = "0.17.0"
-system-interface = { version = "0.22.0", features = ["cap_std_impls"] }
+system-interface = { version = "0.23.0", features = ["cap_std_impls"] }
 tracing = "0.1.19"
 io-lifetimes = { version = "0.7.0", default-features = false }
 is-terminal = "0.3.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.35.10", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1.12.0"
 io-extras = "0.15.0"
-rustix = { version = "0.35.6", features = ["net"] }
+rustix = { version = "0.35.10", features = ["net"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.0"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -15,12 +15,12 @@ wasi-common = { path = "../", version = "=2.0.0" }
 wasi-cap-std-sync = { path = "../cap-std-sync", version = "=2.0.0" }
 wiggle = { path = "../../wiggle", version = "=2.0.0" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
-cap-std = "0.25.3"
+cap-std = "0.26.0"
 anyhow = "1"
 io-lifetimes = { version = "0.7.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-rustix = { version = "0.35.6", features = ["fs"] }
+rustix = { version = "0.35.10", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 io-extras = "0.15.0"
@@ -29,4 +29,4 @@ io-extras = "0.15.0"
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
 anyhow = "1"
-cap-tempfile = "0.25.3"
+cap-tempfile = "0.26.0"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -47,37 +47,37 @@ notes = "I am the author of this crate."
 [[audits.cap-fs-ext]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-primitives]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-rand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-std]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-tempfile]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-run"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.cap-time-ext]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-version = "0.25.3"
+version = "0.26.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.cc]]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -185,7 +185,7 @@ notes = "I am the author of this crate."
 [[audits.system-interface]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
-version = "0.22.0"
+version = "0.23.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.wasm-encoder]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -431,7 +431,7 @@ version = "1.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.libc]]
-version = "0.2.126"
+version = "0.2.133"
 criteria = "safe-to-deploy"
 
 [[exemptions.libfuzzer-sys]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -787,7 +787,7 @@ version = "0.4.0"
 criteria = "safe-to-run"
 
 [[exemptions.rustix]]
-version = "0.35.6"
+version = "0.35.10"
 criteria = "safe-to-deploy"
 
 [[exemptions.rusty-fork]]


### PR DESCRIPTION
This is primarily to pull in bytecodealliance/cap-std#271, the fix for #4936, compilation on Rust nightly on Windows.

It also updates to rustix 0.35.10, to pull in bytecodealliance/rustix#403, the fix for bytecodealliance/rustix#402, compilation on newer versions of the libc crate, which changed a public function from `unsafe` to safe.

Fixes #4936.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
