### PR TITLE
Don't enable parallel compilation in the bench API by default

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 anyhow = "1.0"
 shuffling-allocator = { version = "1.1.1", optional = true }
 target-lexicon = "0.12"
-wasmtime = { path = "../wasmtime", default-features = true }
+wasmtime = { path = "../wasmtime", default-features = false, features = ["cranelift", "memory-init-cow"] }
 wasmtime-cli-flags = { path = "../cli-flags", default-features = true }
 wasmtime-wasi = { path = "../wasi" }
 wasmtime-wasi-crypto = { path = "../wasi-crypto", optional = true }
@@ -32,5 +32,6 @@ wat = "1.0.45"
 
 [features]
 default = ["shuffling-allocator"]
+parallel-compilation = ["wasmtime/parallel-compilation"]
 wasi-crypto = ["wasmtime-wasi-crypto"]
 wasi-nn = ["wasmtime-wasi-nn"]


### PR DESCRIPTION
And add a feature to turn it on if desired.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
