### PR TITLE
fix: check filetype in `path_open`

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -65,11 +65,10 @@ unsafe fn exec_fd_readdir(fd: wasi::Fd, cookie: wasi::Dircookie) -> (Vec<DirEntr
     (dirs, eof)
 }
 
-unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
-    let stat = wasi::fd_filestat_get(dir_fd).expect("failed filestat");
+unsafe fn assert_empty_dir(fd: wasi::Fd) {
+    let stat = wasi::fd_filestat_get(fd).expect("failed filestat");
 
-    // Check the behavior in an empty directory
-    let (mut dirs, eof) = exec_fd_readdir(dir_fd, 0);
+    let (mut dirs, eof) = exec_fd_readdir(fd, 0);
     assert!(eof, "expected to read the entire directory");
     dirs.sort_by_key(|d| d.name.clone());
     assert_eq!(dirs.len(), 2, "expected two entries in an empty directory");
@@ -91,6 +90,11 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         dirs.next().is_none(),
         "the directory should be seen as empty"
     );
+}
+
+unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
+    // Check the behavior in an empty directory
+    assert_empty_dir(dir_fd);
 
     // Add a file and check the behavior
     let file_fd = wasi::path_open(
@@ -111,16 +115,33 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         "file descriptor range check",
     );
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
+    let file_stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
     wasi::fd_close(file_fd).expect("closing a file");
+
+    wasi::path_create_directory(dir_fd, "nested").expect("create a directory");
+    let nested_fd = wasi::path_open(
+        dir_fd,
+        0,
+        "nested",
+        0,
+        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_READDIR | wasi::RIGHTS_FD_FILESTAT_GET,
+        0,
+        0,
+    )
+    .expect("failed to open nested directory");
+    assert!(
+        nested_fd > file_fd,
+        "nested directory file descriptor range check",
+    );
+    let nested_stat = wasi::fd_filestat_get(nested_fd).expect("failed filestat");
 
     // Execute another readdir
     let (mut dirs, eof) = exec_fd_readdir(dir_fd, 0);
     assert!(eof, "expected to read the entire directory");
-    assert_eq!(dirs.len(), 3, "expected three entries");
+    assert_eq!(dirs.len(), 4, "expected four entries");
     // Save the data about the last entry. We need to do it before sorting.
-    let lastfile_cookie = dirs[1].dirent.d_next;
-    let lastfile_name = dirs[2].name.clone();
+    let lastfile_cookie = dirs[2].dirent.d_next;
+    let lastfile_name = dirs[3].name.clone();
     dirs.sort_by_key(|d| d.name.clone());
     let mut dirs = dirs.into_iter();
 
@@ -136,7 +157,16 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         wasi::FILETYPE_REGULAR_FILE,
         "type for the real file"
     );
-    assert_eq!(dir.dirent.d_ino, stat.ino);
+    assert_eq!(dir.dirent.d_ino, file_stat.ino);
+    let dir = dirs.next().expect("fourth entry is None");
+    // check the directory info
+    assert_eq!(dir.name, "nested", "nested directory name doesn't match");
+    assert_eq!(
+        dir.dirent.d_type,
+        wasi::FILETYPE_DIRECTORY,
+        "type for the nested directory"
+    );
+    assert_eq!(dir.dirent.d_ino, nested_stat.ino);
 
     // check if cookie works as expected
     let (dirs, eof) = exec_fd_readdir(dir_fd, lastfile_cookie);
@@ -144,7 +174,12 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
     assert_eq!(dirs.len(), 1, "expected one entry");
     assert_eq!(dirs[0].name, lastfile_name, "name of the only entry");
 
+    // check if nested directory shows up as empty
+    assert_empty_dir(nested_fd);
+    wasi::fd_close(nested_fd).expect("closing a nested directory");
+
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasi::path_remove_directory(dir_fd, "nested").expect("removing a nested directory");
 }
 
 unsafe fn test_fd_readdir_lots(dir_fd: wasi::Fd) {

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -890,45 +890,67 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         }
         let dir_entry = table.get_dir(dirfd)?;
 
+        let oflags = OFlags::from(&oflags);
+
+        // OFlags that are not supported for directories
+        let non_dir_oflags = oflags.contains(OFlags::CREATE)
+            || oflags.contains(OFlags::EXCLUSIVE)
+            || oflags.contains(OFlags::TRUNCATE);
+
+        if oflags.contains(OFlags::DIRECTORY) && non_dir_oflags {
+            return Err(Error::invalid_argument().context("incompatible oflag combination"));
+        }
+
+        let mut required_caps = DirCaps::OPEN;
+        if oflags.contains(OFlags::CREATE) {
+            required_caps = required_caps | DirCaps::CREATE_FILE;
+        }
+        let dir = dir_entry.get_cap(required_caps)?;
+
         let symlink_follow = dirflags.contains(types::Lookupflags::SYMLINK_FOLLOW);
 
-        let oflags = OFlags::from(&oflags);
-        let fdflags = FdFlags::from(fdflags);
         let path = path.as_str()?;
-        if oflags.contains(OFlags::DIRECTORY) {
-            if oflags.contains(OFlags::CREATE)
-                || oflags.contains(OFlags::EXCLUSIVE)
-                || oflags.contains(OFlags::TRUNCATE)
-            {
-                return Err(Error::invalid_argument().context("directory oflags"));
-            }
-            let dir_caps = dir_entry.child_dir_caps(DirCaps::from(&fs_rights_base));
-            let file_caps = dir_entry.child_file_caps(FileCaps::from(&fs_rights_inheriting));
-            let dir = dir_entry.get_cap(DirCaps::OPEN)?;
-            let child_dir = dir.open_dir(symlink_follow, path.deref()).await?;
-            drop(dir);
-            let fd = table.push(Box::new(DirEntry::new(
-                dir_caps, file_caps, None, child_dir,
-            )))?;
-            Ok(types::Fd::from(fd))
-        } else {
-            let mut required_caps = DirCaps::OPEN;
-            if oflags.contains(OFlags::CREATE) {
-                required_caps = required_caps | DirCaps::CREATE_FILE;
+        let path = path.deref();
+        match dir.get_path_filestat(path, symlink_follow).await {
+            Ok(Filestat {
+                filetype: FileType::Directory,
+                ..
+            }) if non_dir_oflags => {
+                Err(Error::invalid_argument().context("oflags not applicable to a directory"))
             }
 
-            let file_caps = dir_entry.child_file_caps(FileCaps::from(&fs_rights_base));
-            let dir = dir_entry.get_cap(required_caps)?;
-            let read = file_caps.contains(FileCaps::READ);
-            let write = file_caps.contains(FileCaps::WRITE)
-                || file_caps.contains(FileCaps::ALLOCATE)
-                || file_caps.contains(FileCaps::FILESTAT_SET_SIZE);
-            let file = dir
-                .open_file(symlink_follow, path.deref(), oflags, read, write, fdflags)
-                .await?;
-            drop(dir);
-            let fd = table.push(Box::new(FileEntry::new(file_caps, file)))?;
-            Ok(types::Fd::from(fd))
+            Ok(Filestat {
+                filetype: FileType::Directory,
+                ..
+            }) => {
+                let dir_caps = dir_entry.child_dir_caps(DirCaps::from(&fs_rights_base));
+                let file_caps = dir_entry.child_file_caps(FileCaps::from(&fs_rights_inheriting));
+                let child_dir = dir.open_dir(symlink_follow, path).await?;
+                drop(dir);
+                let fd = table.push(Box::new(DirEntry::new(
+                    dir_caps, file_caps, None, child_dir,
+                )))?;
+                Ok(types::Fd::from(fd))
+            }
+
+            Ok(_) if oflags.contains(OFlags::DIRECTORY) => {
+                Err(Error::not_dir().context("directory requested"))
+            }
+
+            _ => {
+                let file_caps = dir_entry.child_file_caps(FileCaps::from(&fs_rights_base));
+                let read = file_caps.contains(FileCaps::READ);
+                let write = file_caps.contains(FileCaps::WRITE)
+                    || file_caps.contains(FileCaps::ALLOCATE)
+                    || file_caps.contains(FileCaps::FILESTAT_SET_SIZE);
+                let fdflags = FdFlags::from(fdflags);
+                let file = dir
+                    .open_file(symlink_follow, path, oflags, read, write, fdflags)
+                    .await?;
+                drop(dir);
+                let fd = table.push(Box::new(FileEntry::new(file_caps, file)))?;
+                Ok(types::Fd::from(fd))
+            }
         }
     }
 


### PR DESCRIPTION
Using the `directory` [open flag] to determine whether the entity being opened is a directory or a file is undefined behavior, since that means that the only way to acquire a usable directory is to specify the flag.

Instead of relying on the [open flag] value to determine the filetype, issue `get_path_filestat` first to determine it and then perform appropriate operation depending on the value.

~Note that this also slightly changes the behavior, where `create` [open flag] is not dropped anymore, but rather passed through to the `open_dir` call.~

@pchickey seems to be the last person making any significant changes in this method, so assigning him for review

[open flag]: https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#-oflags-record

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
