### PR TITLE
Shrink all SmallVecs by 8 bytes

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -24,7 +24,7 @@ log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { version = "0.26.0", default-features = false, features = ["write"], optional = true }
-smallvec = { version = "1.6.1" }
+smallvec = { version = "1.6.1", features = ["union"] }
 regalloc2 = { version = "0.4.1", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.9.0", optional = true }

--- a/cranelift/egraph/Cargo.toml
+++ b/cranelift/egraph/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 cranelift-entity = { path = "../entity", version = "0.89.0" }
 log = { version = "0.4.6", default-features = false }
-smallvec = { version = "1.6.1" }
+smallvec = { version = "1.6.1", features = ["union"] }
 indexmap = { version = "1.9.1" }
 hashbrown = { version = "0.12.2", features = ["raw"] }
 fxhash = "0.2.1"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-codegen = { path = "../codegen", version = "0.89.0", default-features 
 target-lexicon = "0.12"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.12", optional = true }
-smallvec = { version = "1.6.1" }
+smallvec = { version = "1.6.1", features = ["union"] }
 
 [features]
 default = ["std"]

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 cranelift-codegen = { path = "../codegen", version = "0.89.0" }
 cranelift-entity = { path = "../entity", version = "0.89.0" }
 log = { version = "0.4.8", default-features = false }
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 thiserror = "1.0.15"
 
 [target.x86_64-pc-windows-gnu.dependencies]

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 cranelift-codegen = { path = "../codegen", version = "0.89.0" }
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 target-lexicon = "0.12"
 
 [badges]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -21,7 +21,7 @@ hashbrown = { version = "0.12", optional = true }
 itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 
 [dev-dependencies]
 wat = "1.0.47"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ cranelift-interpreter = { path = "../cranelift/interpreter" }
 cranelift-fuzzgen = { path = "../cranelift/fuzzgen" }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 target-lexicon = "0.12"
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 wasmtime = { path = "../crates/wasmtime" }
 wasmtime-fuzzing = { path = "../crates/fuzzing" }
 component-test-util = { path = "../crates/misc/component-test-util" }


### PR DESCRIPTION
We weren't using the "union" cargo feature for the smallvec crate, which reduces the size of a SmallVec by one machine word. This feature requires Rust 1.49 but we already require much newer versions.

I also reduced ABIArgSlot::Stack::offset from i64 to i32, so it fits in the same space as ABIArgSlot::Reg::reg. This eliminates all padding from ABIArgSlot, saving 8 bytes there. Without that change, ABIArg wouldn't shrink even though it contains a SmallVec.

When using Wasmtime to compile pulldown-cmark from Sightglass, this saves a decent amount of memory allocations and writes. According to `valgrind --tool=dhat`:

- 6.3MiB (3.78%) less memory allocated over the program's lifetime
- 0.5MiB (4.16%) less memory allocated at maximum heap size
- 5.6MiB (1.94%) fewer bytes written to
- 0.5% fewer instructions executed

Reducing the size of SmallVecs also shrinks other types by varying amounts. Here are some types that shrink by quite a bit but aren't allocated often:

- 264 bytes: cranelift_codegen::machinst::buffer::MachBuffer
- 112 bytes: cranelift_codegen::machinst::abi::SigData
- 64 bytes: wasmtime_cranelift::compiler::CompilerContext
- 56 bytes: cranelift_codegen::context::Context

Here are some types which don't shrink by a lot, but are allocated very often:

- 16 bytes: cranelift_codegen::isa::x64::inst::CallInfo
- 16 bytes: cranelift_codegen::machinst::abi::Caller
- 8 bytes: cranelift_codegen::machinst::buffer::MachBranch
- 8 bytes: cranelift_frontend::ssa::SSABlockData
- 8 bytes: regalloc2::ion::data_structures::LiveBundle
- 8 bytes: regalloc2::ion::data_structures::LiveRange
- 8 bytes: regalloc2::ion::data_structures::SpillSet
- 8 bytes: regalloc2::ion::data_structures::SpillSlotList
- 8 bytes: regalloc2::ion::data_structures::VRegData
- 8 bytes: regalloc2::ion::process::AllocRegResult
- 8 bytes: regalloc2::moves::MoveVecWithScratch
- 8 bytes: regalloc2::moves::ParallelMoves

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
