### PR TITLE
Fix wasmtime-bench-api build

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -430,9 +430,11 @@ impl BenchState {
         execution_end: extern "C" fn(*mut u8),
         make_wasi_cx: impl FnMut() -> Result<WasiCtx> + 'static,
     ) -> Result<Self> {
-        let config = options
-            .map(|o| o.config(Some(&Triple::host().to_string()))?)
-            .unwrap_or(Config::new());
+        let config = if let Some(o) = &options {
+            o.config(Some(&Triple::host().to_string()))?
+        } else {
+            Config::new()
+        };
         // NB: do not configure a code cache.
         let engine = Engine::new(&config)?;
         let mut linker = Linker::<HostState>::new(&engine);


### PR DESCRIPTION
This fixes a compile-time error introduced in #4207. The `?` operator doesn't work inside `Option::map` because it tries to return from the inner closure, not the outer function.

Apparently our CI doesn't build wasmtime-bench-api so it didn't catch this issue.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
