### PR TITLE
Cherry-pick #4959 (aarch64 atomic_cas fix) to 1.0.0 release branch.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -726,8 +726,8 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_fixed_use(addr, xreg(25));
             collector.reg_fixed_use(expected, xreg(26));
             collector.reg_fixed_use(replacement, xreg(28));
-            collector.reg_fixed_def(oldval, xreg(24));
-            collector.reg_fixed_def(scratch, xreg(27));
+            collector.reg_fixed_def(oldval, xreg(27));
+            collector.reg_fixed_def(scratch, xreg(24));
         }
         &Inst::LoadAcquire { rt, rn, .. } => {
             collector.reg_use(rn);

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
@@ -1,0 +1,32 @@
+; Regression test for incorrect regalloc constraints introduced in #4830
+
+test compile precise-output
+target aarch64
+
+function u0:0(i64, i32, i32) -> i8 system_v {
+block0(v0: i64, v1: i32, v2: i32):
+    v6 = atomic_cas.i32 v0, v1, v2
+    v7 = icmp eq v6, v1
+    v8 = bint.i8 v7
+    return v8
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   str x28, [sp, #-16]!
+;   stp x26, x27, [sp, #-16]!
+;   stp x24, x25, [sp, #-16]!
+; block0:
+;   mov x25, x0
+;   mov x26, x1
+;   mov x28, x2
+;   atomic_cas_loop_32 addr=x25, expect=x26, replacement=x28, oldval=x27, scratch=x24
+;   subs wzr, w27, w26
+;   cset x8, eq
+;   and w0, w8, #1
+;   ldp x24, x25, [sp], #16
+;   ldp x26, x27, [sp], #16
+;   ldr x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
@@ -18,8 +18,9 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   stp x24, x25, [sp, #-16]!
 ; block0:
 ;   mov x25, x0
-;   mov x26, x1
+;   mov x9, x1
 ;   mov x28, x2
+;   mov x26, x9
 ;   atomic_cas_loop_32 addr=x25, expect=x26, replacement=x28, oldval=x27, scratch=x24
 ;   subs wzr, w27, w26
 ;   cset x8, eq


### PR DESCRIPTION
This PR cherry-picks #4959's fix onto the 1.0.0 release branch in order to facilitate a point-release. The bug affects `atomic_cas` usage on aarch64. This is not reachable from Wasmtime in the default configuration, but may affect other users of Cranelift (e.g. `cg_clif`) and any uses of Wasmtime with the atomic-operation extensions enabled.