### PR TITLE
Release Wasmtime 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -517,14 +517,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "arrayvec",
  "bincode",
@@ -549,18 +549,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.88.0"
+version = "0.88.1"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "serde",
 ]
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "log",
  "miette",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -685,14 +685,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-preopt"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
 ]
 
 [[package]]
 name = "cranelift-reader"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "smallvec",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "clap 3.2.8",
  "cranelift-codegen",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.88.0"
+version = "0.88.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3098,7 +3098,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cfg-if",
 ]
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap 3.2.8",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3493,11 +3493,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3516,7 +3516,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Command-line interface for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -21,15 +21,15 @@ path = "src/bin/wasmtime.rs"
 doc = false
 
 [dependencies]
-wasmtime = { path = "crates/wasmtime", version = "1.0.0", default-features = false, features = ['cache', 'cranelift'] }
-wasmtime-cache = { path = "crates/cache", version = "=1.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=1.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=1.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=1.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=1.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "1.0.0" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "1.0.0", optional = true }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "1.0.0", optional = true }
+wasmtime = { path = "crates/wasmtime", version = "1.0.1", default-features = false, features = ['cache', 'cranelift'] }
+wasmtime-cache = { path = "crates/cache", version = "=1.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=1.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=1.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=1.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=1.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "1.0.1" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "1.0.1", optional = true }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "1.0.1", optional = true }
 clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 anyhow = "1.0.19"
 target-lexicon = { version = "0.12.0", default-features = false }
@@ -43,7 +43,7 @@ rustix = { version = "0.35.6", features = ["mm", "param"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
-wasmtime = { path = "crates/wasmtime", version = "1.0.0", features = ['component-model'] }
+wasmtime = { path = "crates/wasmtime", version = "1.0.1", features = ['component-model'] }
 env_logger = "0.9.0"
 log = "0.4.8"
 filecheck = "0.5.0"
@@ -60,7 +60,7 @@ wat = "1.0.48"
 once_cell = "1.9.0"
 rayon = "1.5.0"
 component-macro-test = { path = "crates/misc/component-macro-test" }
-wasmtime-wast = { path = "crates/wast", version = "=1.0.0", features = ['component-model'] }
+wasmtime-wast = { path = "crates/wast", version = "=1.0.1", features = ['component-model'] }
 component-test-util = { path = "crates/misc/component-test-util" }
 wasmtime-component-util = { path = "crates/component-util" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,24 @@
 --------------------------------------------------------------------------------
 
+## 1.0.1
+
+Released 2022-09-26
+
+This is a patch release that incorporates a fix for a miscompilation of an
+atomic-CAS operator on aarch64. The instruction is not usable from Wasmtime
+with default settings, but may be used if the Wasm atomics extension is
+enabled. The bug may also be reachable via other uses of Cranelift. Thanks to
+@bjorn3 for reporting and debugging this issue!
+
+### Fixed
+
+* Fixed a miscompilation of `atomic_cas` on aarch64. The output register was
+  swapped with a temporary register in the register-allocator constraints.
+  [#4959](https://github.com/bytecodealliance/wasmtime/pull/4959)
+  [#4960](https://github.com/bytecodealliance/wasmtime/pull/4960)
+
+--------------------------------------------------------------------------------
+
 ## 1.0.0
 
 Released 2022-09-20

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -20,19 +20,19 @@ harness = false
 
 [dependencies]
 cfg-if = "1.0"
-cranelift-codegen = { path = "codegen", version = "0.88.0" }
-cranelift-entity = { path = "entity", version = "0.88.0" }
-cranelift-interpreter = { path = "interpreter", version = "0.88.0" }
-cranelift-reader = { path = "reader", version = "0.88.0" }
-cranelift-frontend = { path = "frontend", version = "0.88.0" }
-cranelift-wasm = { path = "wasm", version = "0.88.0", optional = true }
-cranelift-native = { path = "native", version = "0.88.0" }
+cranelift-codegen = { path = "codegen", version = "0.88.1" }
+cranelift-entity = { path = "entity", version = "0.88.1" }
+cranelift-interpreter = { path = "interpreter", version = "0.88.1" }
+cranelift-reader = { path = "reader", version = "0.88.1" }
+cranelift-frontend = { path = "frontend", version = "0.88.1" }
+cranelift-wasm = { path = "wasm", version = "0.88.1", optional = true }
+cranelift-native = { path = "native", version = "0.88.1" }
 cranelift-filetests = { path = "filetests", version = "0.73.0" }
-cranelift-module = { path = "module", version = "0.88.0" }
-cranelift-object = { path = "object", version = "0.88.0" }
-cranelift-jit = { path = "jit", version = "0.88.0" }
-cranelift-preopt = { path = "preopt", version = "0.88.0" }
-cranelift = { path = "umbrella", version = "0.88.0" }
+cranelift-module = { path = "module", version = "0.88.1" }
+cranelift-object = { path = "object", version = "0.88.1" }
+cranelift-jit = { path = "jit", version = "0.88.1" }
+cranelift-preopt = { path = "preopt", version = "0.88.1" }
+cranelift = { path = "umbrella", version = "0.88.1" }
 filecheck = "0.5.0"
 log = "0.4.8"
 termcolor = "1.1.2"

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.88.0"
+version = "0.88.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"
@@ -12,7 +12,7 @@ keywords = ["btree", "forest", "set", "map"]
 edition = "2021"
 
 [dependencies]
-cranelift-entity = { path = "../entity", version = "0.88.0", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.88.1", default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.88.0"
+version = "0.88.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -15,9 +15,9 @@ edition = "2021"
 [dependencies]
 arrayvec = "0.7"
 bumpalo = "3"
-cranelift-codegen-shared = { path = "./shared", version = "0.88.0" }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
-cranelift-bforest = { path = "../bforest", version = "0.88.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.88.1" }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
+cranelift-bforest = { path = "../bforest", version = "0.88.1" }
 hashbrown = { version = "0.12", optional = true }
 target-lexicon = "0.12"
 log = { version = "0.4.6", default-features = false }
@@ -37,8 +37,8 @@ sha2 = { version = "0.9.0", optional = true }
 criterion = "0.3"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.88.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.88.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.88.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.88.1" }
 miette = { version = "5.1.0", features = ["fancy"], optional = true }
 
 [features]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.88.0"
+version = "0.88.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -13,7 +13,7 @@ edition = "2021"
 # rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.88.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.88.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.88.0"
+version = "0.88.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.88.0"
+version = "0.88.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", features = ["testing_hooks"] }
-cranelift-frontend = { path = "../frontend", version = "0.88.0" }
-cranelift-interpreter = { path = "../interpreter", version = "0.88.0" }
-cranelift-native = { path = "../native", version = "0.88.0" }
-cranelift-reader = { path = "../reader", version = "0.88.0" }
-cranelift-preopt = { path = "../preopt", version = "0.88.0" }
-cranelift-jit = { path = "../jit", version = "0.88.0" }
-cranelift-module = { path = "../module", version = "0.88.0" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", features = ["testing_hooks"] }
+cranelift-frontend = { path = "../frontend", version = "0.88.1" }
+cranelift-interpreter = { path = "../interpreter", version = "0.88.1" }
+cranelift-native = { path = "../native", version = "0.88.1" }
+cranelift-reader = { path = "../reader", version = "0.88.1" }
+cranelift-preopt = { path = "../preopt", version = "0.88.1" }
+cranelift-jit = { path = "../jit", version = "0.88.1" }
+cranelift-module = { path = "../module", version = "0.88.1" }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"
 gimli = { version = "0.26.0", default-features = false, features = ["read"] }

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.88.0"
+version = "0.88.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
 target-lexicon = "0.12"
 log = { version = "0.4.6", default-features = false }
 hashbrown = { version = "0.12", optional = true }

--- a/cranelift/fuzzgen/Cargo.toml
+++ b/cranelift/fuzzgen/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 
 
 [dependencies]
-cranelift = { path = "../umbrella", version = "0.88.0" }
-cranelift-native = { path = "../native", version = "0.88.0" }
+cranelift = { path = "../umbrella", version = "0.88.1" }
+cranelift-native = { path = "../native", version = "0.88.1" }
 
 anyhow = "1.0.19"
 arbitrary = "1.0.0"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0" }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1" }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
 log = { version = "0.4.8", default-features = false }
 smallvec = "1.6.1"
 thiserror = "1.0.15"
@@ -21,8 +21,8 @@ thiserror = "1.0.15"
 libm = "0.2.4"
 
 [dev-dependencies]
-cranelift-frontend = { path = "../frontend", version = "0.88.0" }
-cranelift-reader = { path = "../reader", version = "0.88.0" }
+cranelift-frontend = { path = "../frontend", version = "0.88.1" }
+cranelift-reader = { path = "../reader", version = "0.88.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.88.0"
+version = "0.88.1"
 
 [dependencies]
 log = { version = "0.4", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.88.0" }
-cranelift-native = { path = "../native", version = "0.88.0" }
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false, features = ["std"] }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
+cranelift-module = { path = "../module", version = "0.88.1" }
+cranelift-native = { path = "../native", version = "0.88.1" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false, features = ["std"] }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
 anyhow = "1.0"
 region = "2.2.0"
 libc = { version = "0.2.42" }
@@ -34,9 +34,9 @@ selinux-fix = ['memmap2']
 default = []
 
 [dev-dependencies]
-cranelift = { path = "../umbrella", version = "0.88.0" }
-cranelift-frontend = { path = "../frontend", version = "0.88.0" }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
+cranelift = { path = "../umbrella", version = "0.88.1" }
+cranelift-frontend = { path = "../frontend", version = "0.88.1" }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
 hashbrown = { version = "0.12", optional = true }
 anyhow = "1.0"
 

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
 target-lexicon = "0.12"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -10,16 +10,16 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-module = { path = "../module", version = "0.88.0" }
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false, features = ["std"] }
+cranelift-module = { path = "../module", version = "0.88.1" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false, features = ["std"] }
 object = { version = "0.29.0", default-features = false, features = ["write"] }
 target-lexicon = "0.12"
 anyhow = "1.0"
 log = { version = "0.4.6", default-features = false }
 
 [dev-dependencies]
-cranelift-frontend = { path = "../frontend", version = "0.88.0" }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
+cranelift-frontend = { path = "../frontend", version = "0.88.1" }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/preopt/Cargo.toml
+++ b/cranelift/preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.88.0"
+version = "0.88.1"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-preopt"
@@ -12,7 +12,7 @@ keywords = ["optimize", "compile", "compiler", "jit"]
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.88.0"
+version = "0.88.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1" }
 smallvec = "1.6.1"
 target-lexicon = "0.12"
 

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -16,8 +16,8 @@ path = "src/clif-json.rs"
 [dependencies]
 clap = { version = "3.2.0", features = ["derive"] }
 serde_json = "1.0.26"
-cranelift-codegen = { path = "../codegen", version = "0.88.0", features = ["enable-serde"] }
-cranelift-reader = { path = "../reader", version = "0.88.0" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", features = ["enable-serde"] }
+cranelift-reader = { path = "../reader", version = "0.88.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.88.0"
+version = "0.88.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"
@@ -12,8 +12,8 @@ keywords = ["compile", "compiler", "jit"]
 edition = "2021"
 
 [dependencies]
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
-cranelift-frontend = { path = "../frontend", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
+cranelift-frontend = { path = "../frontend", version = "0.88.1", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.88.0"
+version = "0.88.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"
@@ -13,10 +13,10 @@ edition = "2021"
 
 [dependencies]
 wasmparser = { version = "0.89.0", default-features = false }
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
-cranelift-entity = { path = "../entity", version = "0.88.0" }
-cranelift-frontend = { path = "../frontend", version = "0.88.0", default-features = false }
-wasmtime-types = { path = "../../crates/types", version = "1.0.0" }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
+cranelift-entity = { path = "../entity", version = "0.88.1" }
+cranelift-frontend = { path = "../frontend", version = "0.88.1", default-features = false }
+wasmtime-types = { path = "../../crates/types", version = "1.0.1" }
 hashbrown = { version = "0.12", optional = true }
 itertools = "0.10.0"
 log = { version = "0.4.6", default-features = false }
@@ -26,7 +26,7 @@ smallvec = "1.6.1"
 [dev-dependencies]
 wat = "1.0.47"
 target-lexicon = "0.12"
-cranelift-codegen = { path = "../codegen", version = "0.88.0", default-features = false }
+cranelift-codegen = { path = "../codegen", version = "0.88.1", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/asm-macros/Cargo.toml
+++ b/crates/asm-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasmtime-asm-macros"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "1.0.0"
+version = "1.0.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cache"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Support for automatic module caching with Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cli-flags"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Exposes common CLI flags used for running Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 file-per-thread-logger = "0.1.1"
 pretty_env_logger = "0.4.0"
 rayon = "1.5.0"
-wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false }
+wasmtime = { path = "../wasmtime", version = "1.0.1", default-features = false }
 
 [features]
 default = [

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-component-macro"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Macros for deriving component interface types from Rust types"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -17,7 +17,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }
-wasmtime-component-util = { path = "../component-util", version = "=1.0.0" }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.1" }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/crates/component-util/Cargo.toml
+++ b/crates/component-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-component-util"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Utility types and functions to support the component model in Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-cranelift"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Integration between Cranelift and Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,12 +13,12 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-wasmtime-environ = { path = "../environ", version = "=1.0.0" }
-cranelift-wasm = { path = "../../cranelift/wasm", version = "0.88.0" }
-cranelift-codegen = { path = "../../cranelift/codegen", version = "0.88.0" }
-cranelift-frontend = { path = "../../cranelift/frontend", version = "0.88.0" }
-cranelift-entity = { path = "../../cranelift/entity", version = "0.88.0" }
-cranelift-native = { path = "../../cranelift/native", version = "0.88.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.1" }
+cranelift-wasm = { path = "../../cranelift/wasm", version = "0.88.1" }
+cranelift-codegen = { path = "../../cranelift/codegen", version = "0.88.1" }
+cranelift-frontend = { path = "../../cranelift/frontend", version = "0.88.1" }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.88.1" }
+cranelift-native = { path = "../../cranelift/native", version = "0.88.1" }
 wasmparser = "0.89.0"
 target-lexicon = "0.12"
 gimli = { version = "0.26.0", default-features = false, features = ['read', 'std'] }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-environ"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Standalone environment support for WebAsssembly code in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,8 +12,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../../cranelift/entity", version = "0.88.0" }
-wasmtime-types = { path = "../types", version = "1.0.0" }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.88.1" }
+wasmtime-types = { path = "../types", version = "1.0.1" }
 wasmparser = "0.89.0"
 indexmap = { version = "1.0.2", features = ["serde-1"] }
 thiserror = "1.0.4"
@@ -24,7 +24,7 @@ object = { version = "0.29.0", default-features = false, features = ['read_core'
 target-lexicon = "0.12"
 wasm-encoder = { version = "0.16.0", optional = true }
 wasmprinter = { version = "0.2.39", optional = true }
-wasmtime-component-util = { path = "../component-util", version = "=1.0.0", optional = true }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.1", optional = true }
 
 [dev-dependencies]
 atty = "0.2.14"

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-fiber"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Fiber support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -18,7 +18,7 @@ cfg-if = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { version = "0.35.6", features = ["mm", "param"] }
-wasmtime-asm-macros = { version = "=1.0.0", path = "../asm-macros" }
+wasmtime-asm-macros = { version = "=1.0.1", path = "../asm-macros" }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.36.1"

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit-debug"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT debug interfaces support for Wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-jit"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "JIT-style execution for WebAsssembly code in Cranelift"
 documentation = "https://docs.rs/wasmtime-jit"
@@ -11,9 +11,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2021"
 
 [dependencies]
-wasmtime-environ = { path = "../environ", version = "=1.0.0" }
-wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.0", features = ["perf_jitdump"], optional = true }
-wasmtime-runtime = { path = "../runtime", version = "=1.0.0" }
+wasmtime-environ = { path = "../environ", version = "=1.0.1" }
+wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.1", features = ["perf_jitdump"], optional = true }
+wasmtime-runtime = { path = "../runtime", version = "=1.0.1" }
 thiserror = "1.0.4"
 target-lexicon = { version = "0.12.0", default-features = false }
 anyhow = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-runtime"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Runtime library support for Wasmtime"
 documentation = "https://docs.rs/wasmtime-runtime"
@@ -11,10 +11,10 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition = "2021"
 
 [dependencies]
-wasmtime-asm-macros = { path = "../asm-macros", version = "=1.0.0" }
-wasmtime-environ = { path = "../environ", version = "=1.0.0" }
-wasmtime-fiber = { path = "../fiber", version = "=1.0.0", optional = true }
-wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.0", features = ["gdb_jit_int"] }
+wasmtime-asm-macros = { path = "../asm-macros", version = "=1.0.1" }
+wasmtime-environ = { path = "../environ", version = "=1.0.1" }
+wasmtime-fiber = { path = "../fiber", version = "=1.0.1", optional = true }
+wasmtime-jit-debug = { path = "../jit-debug", version = "=1.0.1", features = ["gdb_jit_int"] }
 libc = { version = "0.2.112", default-features = false }
 log = "0.4.8"
 memoffset = "0.6.0"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -11,10 +11,10 @@ license = "Apache-2.0 WITH LLVM-exception"
 cfg-if = "1.0"
 
 [dev-dependencies]
-wasi-common = { path = "../wasi-common", version = "1.0.0" }
-wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "1.0.0" }
-wasmtime = { path = "../wasmtime", version = "1.0.0" }
-wasmtime-wasi = { path = "../wasi", version = "1.0.0", features = ["tokio"] }
+wasi-common = { path = "../wasi-common", version = "1.0.1" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "1.0.1" }
+wasmtime = { path = "../wasmtime", version = "1.0.1" }
+wasmtime-wasi = { path = "../wasi", version = "1.0.1", features = ["tokio"] }
 target-lexicon = "0.12.0"
 pretty_env_logger = "0.4.0"
 tempfile = "3.1.0"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-types"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WebAssembly type definitions for Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasmtime-types"
 edition = "2021"
 
 [dependencies]
-cranelift-entity = { path = "../../cranelift/entity", version = "0.88.0", features = ['enable-serde'] }
+cranelift-entity = { path = "../../cranelift/entity", version = "0.88.1", features = ['enable-serde'] }
 serde = { version = "1.0.94", features = ["derive"] }
 thiserror = "1.0.4"
 wasmparser = { version = "0.89.0", default-features = false }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-common"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -20,7 +20,7 @@ links = "wasi-common-19"
 [dependencies]
 anyhow = "1.0"
 thiserror = "1.0"
-wiggle = { path = "../wiggle", default-features = false, version = "=1.0.0" }
+wiggle = { path = "../wiggle", default-features = false, version = "=1.0.1" }
 tracing = "0.1.19"
 cap-std = "0.25.0"
 cap-rand = "0.25.0"

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-cap-std-sync"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -12,7 +12,7 @@ edition = "2021"
 include = ["src/**/*", "README.md", "LICENSE" ]
 
 [dependencies]
-wasi-common = { path = "../", version = "=1.0.0" }
+wasi-common = { path = "../", version = "=1.0.1" }
 async-trait = "0.1"
 anyhow = "1.0"
 cap-std = "0.25.0"

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-tokio"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ edition = "2021"
 include = ["src/**/*", "LICENSE" ]
 
 [dependencies]
-wasi-common = { path = "../", version = "=1.0.0" }
-wasi-cap-std-sync = { path = "../cap-std-sync", version = "=1.0.0" }
-wiggle = { path = "../../wiggle", version = "=1.0.0" }
+wasi-common = { path = "../", version = "=1.0.1" }
+wasi-cap-std-sync = { path = "../cap-std-sync", version = "=1.0.1" }
+wiggle = { path = "../../wiggle", version = "=1.0.1" }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
 cap-std = "0.25.0"
 anyhow = "1"

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-crypto"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-crypto API"
 documentation = "https://docs.rs/wasmtime-wasi-crypto"
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.5" }
-wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false }
-wiggle = { path = "../wiggle", version = "=1.0.0" }
+wasmtime = { path = "../wasmtime", version = "1.0.1", default-features = false }
+wiggle = { path = "../wiggle", version = "=1.0.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-nn"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Wasmtime implementation of the wasi-nn API"
 documentation = "https://docs.rs/wasmtime-wasi-nn"
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 # These dependencies are necessary for the witx-generation macros to work:
 anyhow = "1.0"
-wiggle = { path = "../wiggle", version = "=1.0.0" }
+wiggle = { path = "../wiggle", version = "=1.0.1" }
 
 # These dependencies are necessary for the wasi-nn implementation:
 openvino = { version = "0.4.1", features = ["runtime-linking"] }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "WASI implementation in Rust"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,11 +13,11 @@ include = ["src/**/*", "README.md", "LICENSE", "build.rs"]
 build = "build.rs"
 
 [dependencies]
-wasi-common = { path = "../wasi-common", version = "=1.0.0" }
-wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "=1.0.0", optional = true }
-wasi-tokio = { path = "../wasi-common/tokio", version = "=1.0.0", optional = true }
-wiggle = { path = "../wiggle", default-features = false, version = "=1.0.0", features = ["wasmtime_integration"] }
-wasmtime = { path = "../wasmtime", default-features = false, version = "1.0.0" }
+wasi-common = { path = "../wasi-common", version = "=1.0.1" }
+wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync", version = "=1.0.1", optional = true }
+wasi-tokio = { path = "../wasi-common/tokio", version = "=1.0.1", optional = true }
+wiggle = { path = "../wiggle", default-features = false, version = "=1.0.1", features = ["wasmtime_integration"] }
+wasmtime = { path = "../wasmtime", default-features = false, version = "1.0.1" }
 anyhow = "1.0"
 
 [features]

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "High-level API to expose the Wasmtime runtime"
 documentation = "https://docs.rs/wasmtime"
@@ -13,14 +13,14 @@ edition = "2021"
 rustdoc-args = ["--cfg", "nightlydoc"]
 
 [dependencies]
-wasmtime-runtime = { path = "../runtime", version = "=1.0.0" }
-wasmtime-environ = { path = "../environ", version = "=1.0.0" }
-wasmtime-jit = { path = "../jit", version = "=1.0.0" }
-wasmtime-cache = { path = "../cache", version = "=1.0.0", optional = true }
-wasmtime-fiber = { path = "../fiber", version = "=1.0.0", optional = true }
-wasmtime-cranelift = { path = "../cranelift", version = "=1.0.0", optional = true }
-wasmtime-component-macro = { path = "../component-macro", version = "=1.0.0", optional = true }
-wasmtime-component-util = { path = "../component-util", version = "=1.0.0", optional = true }
+wasmtime-runtime = { path = "../runtime", version = "=1.0.1" }
+wasmtime-environ = { path = "../environ", version = "=1.0.1" }
+wasmtime-jit = { path = "../jit", version = "=1.0.1" }
+wasmtime-cache = { path = "../cache", version = "=1.0.1", optional = true }
+wasmtime-fiber = { path = "../fiber", version = "=1.0.1", optional = true }
+wasmtime-cranelift = { path = "../cranelift", version = "=1.0.1", optional = true }
+wasmtime-component-macro = { path = "../component-macro", version = "=1.0.1", optional = true }
+wasmtime-component-util = { path = "../component-util", version = "=1.0.1", optional = true }
 target-lexicon = { version = "0.12.0", default-features = false }
 wasmparser = "0.89.0"
 anyhow = "1.0.19"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wast"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["The Wasmtime Project Developers"]
 description = "wast testing support for wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.19"
-wasmtime = { path = "../wasmtime", version = "1.0.0", default-features = false, features = ['cranelift'] }
+wasmtime = { path = "../wasmtime", version = "1.0.1", default-features = false, features = ['cranelift'] }
 wast = "46.0.0"
 log = "0.4"
 

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkonk@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,11 +13,11 @@ include = ["src/**/*", "README.md", "LICENSE"]
 [dependencies]
 thiserror = "1"
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }
-wiggle-macro = { path = "macro", version = "=1.0.0" }
+wiggle-macro = { path = "macro", version = "=1.0.1" }
 tracing = "0.1.26"
 bitflags = "1.2"
 async-trait = "0.1.42"
-wasmtime = { path = "../wasmtime", version = "1.0.0", optional = true, default-features = false }
+wasmtime = { path = "../wasmtime", version = "1.0.1", optional = true, default-features = false }
 anyhow = "1.0"
 
 [badges]

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-generate"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2021"

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wiggle-macro"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Pat Hickey <phickey@fastly.com>", "Jakub Konka <kubkon@jakubkonka.com>", "Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -21,7 +21,7 @@ test = false
 doctest = false
 
 [dependencies]
-wiggle-generate = { path = "../generate", version = "=1.0.0" }
+wiggle-generate = { path = "../generate", version = "=1.0.1" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 1.0.1, requested by @cfallin.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
