### PR TITLE
Increase the `sigaltstack` stack size

### DIFF
--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -286,7 +286,14 @@ pub fn lazy_per_thread_init() {
 
     /// The size of the sigaltstack (not including the guard, which will be
     /// added). Make this large enough to run our signal handlers.
-    const MIN_STACK_SIZE: usize = 16 * 4096;
+    ///
+    /// The main current requirement of the signal handler in terms of stack
+    /// space is that `malloc`/`realloc` are called to create a `Backtrace` of
+    /// wasm frames.
+    ///
+    /// Historically this was 16k. Turns out jemalloc requires more than 16k of
+    /// stack space in debug mode, so this was bumped to 64k.
+    const MIN_STACK_SIZE: usize = 64 * 4096;
 
     struct Stack {
         mmap_ptr: *mut libc::c_void,


### PR DESCRIPTION
This commit updates the `MIN_STACK_SIZE` constant for Unix platforms when allocating a sigaltstack from 16k to 64k. The signal handler captures a wasm `Backtrace` which involves memory allocations and it was recently discovered that, at least in debug mode, jemalloc can take up to 16k of stack space for an allocation. To allow running the sigaltstack size is increased here.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
