### PR TITLE
Allow WASI to open directories without `O_DIRECTORY`.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -65,11 +65,10 @@ unsafe fn exec_fd_readdir(fd: wasi::Fd, cookie: wasi::Dircookie) -> (Vec<DirEntr
     (dirs, eof)
 }
 
-unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
-    let stat = wasi::fd_filestat_get(dir_fd).expect("failed filestat");
+unsafe fn assert_empty_dir(fd: wasi::Fd) {
+    let stat = wasi::fd_filestat_get(fd).expect("failed filestat");
 
-    // Check the behavior in an empty directory
-    let (mut dirs, eof) = exec_fd_readdir(dir_fd, 0);
+    let (mut dirs, eof) = exec_fd_readdir(fd, 0);
     assert!(eof, "expected to read the entire directory");
     dirs.sort_by_key(|d| d.name.clone());
     assert_eq!(dirs.len(), 2, "expected two entries in an empty directory");
@@ -91,6 +90,11 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         dirs.next().is_none(),
         "the directory should be seen as empty"
     );
+}
+
+unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
+    // Check the behavior in an empty directory
+    assert_empty_dir(dir_fd);
 
     // Add a file and check the behavior
     let file_fd = wasi::path_open(
@@ -111,16 +115,33 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         "file descriptor range check",
     );
 
-    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
+    let file_stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
     wasi::fd_close(file_fd).expect("closing a file");
+
+    wasi::path_create_directory(dir_fd, "nested").expect("create a directory");
+    let nested_fd = wasi::path_open(
+        dir_fd,
+        0,
+        "nested",
+        0,
+        wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_READDIR | wasi::RIGHTS_FD_FILESTAT_GET,
+        0,
+        0,
+    )
+    .expect("failed to open nested directory");
+    assert!(
+        nested_fd > file_fd,
+        "nested directory file descriptor range check",
+    );
+    let nested_stat = wasi::fd_filestat_get(nested_fd).expect("failed filestat");
 
     // Execute another readdir
     let (mut dirs, eof) = exec_fd_readdir(dir_fd, 0);
     assert!(eof, "expected to read the entire directory");
-    assert_eq!(dirs.len(), 3, "expected three entries");
+    assert_eq!(dirs.len(), 4, "expected four entries");
     // Save the data about the last entry. We need to do it before sorting.
-    let lastfile_cookie = dirs[1].dirent.d_next;
-    let lastfile_name = dirs[2].name.clone();
+    let lastfile_cookie = dirs[2].dirent.d_next;
+    let lastfile_name = dirs[3].name.clone();
     dirs.sort_by_key(|d| d.name.clone());
     let mut dirs = dirs.into_iter();
 
@@ -136,7 +157,16 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
         wasi::FILETYPE_REGULAR_FILE,
         "type for the real file"
     );
-    assert_eq!(dir.dirent.d_ino, stat.ino);
+    assert_eq!(dir.dirent.d_ino, file_stat.ino);
+    let dir = dirs.next().expect("fourth entry is None");
+    // check the directory info
+    assert_eq!(dir.name, "nested", "nested directory name doesn't match");
+    assert_eq!(
+        dir.dirent.d_type,
+        wasi::FILETYPE_DIRECTORY,
+        "type for the nested directory"
+    );
+    assert_eq!(dir.dirent.d_ino, nested_stat.ino);
 
     // check if cookie works as expected
     let (dirs, eof) = exec_fd_readdir(dir_fd, lastfile_cookie);
@@ -144,7 +174,12 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
     assert_eq!(dirs.len(), 1, "expected one entry");
     assert_eq!(dirs[0].name, lastfile_name, "name of the only entry");
 
+    // check if nested directory shows up as empty
+    assert_empty_dir(nested_fd);
+    wasi::fd_close(nested_fd).expect("closing a nested directory");
+
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
+    wasi::path_remove_directory(dir_fd, "nested").expect("removing a nested directory");
 }
 
 unsafe fn test_fd_readdir_lots(dir_fd: wasi::Fd) {

--- a/crates/wasi-common/cap-std-sync/src/dir.rs
+++ b/crates/wasi-common/cap-std-sync/src/dir.rs
@@ -27,6 +27,9 @@ impl Dir {
     ) -> Result<File, Error> {
         use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 
+        // The current code assumes that directories are opened with `open_dir_`.
+        assert!(!oflags.contains(OFlags::DIRECTORY));
+
         let mut opts = cap_std::fs::OpenOptions::new();
 
         if oflags.contains(OFlags::CREATE | OFlags::EXCLUSIVE) {


### PR DESCRIPTION
`O_DIRECTORY` says that a directory is required, but `O_DIRECTORY` is not required for opening directories. To implement this on top of the current APIs, use `open_dir` to try to open a directory first, and then fall back to trying to open it as a file if that fails.

In the future, we may be able to simplify this code even more, using [`maybe_dir`], which is needed to allow Windows to be able to open a directory, though it needs bytecodealliance/cap-std#277 for Windows.

The testcase here is the testcase from #4947.

[`maybe_dir`]: https://docs.rs/cap-fs-ext/latest/cap_fs_ext/struct.OpenOptions.html#method.maybe_dir`

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
