### PR TITLE
s390x: Fix regalloc checker error

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -539,7 +539,9 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
         } => {
             collector.reg_def(rd);
             collector.reg_use(rn);
-            collector.reg_use(shift_reg);
+            if shift_reg != zero_reg() {
+                collector.reg_use(shift_reg);
+            }
         }
         &Inst::RxSBG { rd, rn, .. } => {
             collector.reg_mod(rd);
@@ -744,7 +746,9 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
         } => {
             collector.reg_def(rd);
             collector.reg_use(rn);
-            collector.reg_use(shift_reg);
+            if shift_reg != zero_reg() {
+                collector.reg_use(shift_reg);
+            }
         }
         &Inst::VecSelect { rd, rn, rm, ra, .. } => {
             collector.reg_def(rd);


### PR DESCRIPTION
For ShiftRR and VecShiftRR, if shift_reg is zero_reg(), the instruction does not actually use any register value.

Fixes https://github.com/bytecodealliance/wasmtime/issues/4969

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
