### PR TITLE
ISLE: Overlap checker quality of life improvements

### DIFF
--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -5,12 +5,17 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use crate::error::{Error, Result, Source, Span};
+use crate::lexer::Pos;
 use crate::sema::{self, Rule, RuleId, Sym, TermEnv, TermId, TermKind, TypeEnv, VarId};
 
 /// Check for overlap.
 pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
     let mut errors = check_overlaps(termenv).report(tyenv, termenv);
     if cfg!(feature = "overlap-errors") {
+        errors.sort_by_key(|err| match err {
+            Error::OverlapError { rules, .. } => rules.first().unwrap().1.from,
+            _ => Pos::default(),
+        });
         match errors.len() {
             0 => Ok(()),
             1 => Err(errors.pop().unwrap()),


### PR DESCRIPTION
A small quality of life improvement for the overlap checker: sorting the errors to keep related overlaps together.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
