### PR TITLE
ISLE: Stabilize the overlap error order

### DIFF
--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -65,7 +65,11 @@ impl Errors {
             (src, span)
         };
 
-        while let Some((&id, _)) = self.nodes.iter().max_by_key(|(_, edges)| edges.len()) {
+        while let Some((&id, _)) = self
+            .nodes
+            .iter()
+            .max_by_key(|(id, edges)| (edges.len(), *id))
+        {
             let node = self.nodes.remove(&id).unwrap();
             for other in node.iter() {
                 if let Entry::Occupied(mut entry) = self.nodes.entry(*other) {


### PR DESCRIPTION
We were finding rules with the most overlap errors by traversing a hash map, but weren't doing anything to prevent the unstable order of the hash map elements from affecting the error output order. This PR includes the rule id when looking for rules that have the largest number of overlaps, to break ties predictably.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
