### PR TITLE
ISLE: Add the overlap_errors pragma

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1,5 +1,8 @@
 ;; x86-64 instruction selection and CLIF-to-MachInst lowering.
 
+;; Enable overlap checking for the x64 backend
+(pragma overlap_errors)
+
 ;; The main lowering constructor term: takes a clif `Inst` and returns the
 ;; register(s) within which the lowered instruction's result values live.
 (decl lower (Inst) InstOutput)

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -19,6 +19,5 @@ tempfile = "3"
 [features]
 default = []
 
-overlap-errors = []
 logging = ["log"]
 miette-errors = ["miette"]

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -17,6 +17,7 @@ pub struct Defs {
 /// One toplevel form in an ISLE file.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Def {
+    Pragma(Pragma),
     Type(Type),
     Rule(Rule),
     Extractor(Extractor),
@@ -28,6 +29,13 @@ pub enum Def {
 /// An identifier -- a variable, term symbol, or type.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ident(pub String, pub Pos);
+
+/// Pragmas parsed with the `(pragma <ident>)` syntax.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Pragma {
+    /// Enable overlap errors in the source.
+    OverlapErrors,
+}
 
 /// A declaration of a type.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/cranelift/isle/isle/src/overlap.rs
+++ b/cranelift/isle/isle/src/overlap.rs
@@ -11,7 +11,7 @@ use crate::sema::{self, Rule, RuleId, Sym, TermEnv, TermId, TermKind, TypeEnv, V
 /// Check for overlap.
 pub fn check(tyenv: &TypeEnv, termenv: &TermEnv) -> Result<()> {
     let mut errors = check_overlaps(termenv).report(tyenv, termenv);
-    if cfg!(feature = "overlap-errors") {
+    if termenv.overlap_errors {
         errors.sort_by_key(|err| match err {
             Error::OverlapError { rules, .. } => rules.first().unwrap().1.from,
             _ => Pos::default(),

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -137,6 +137,7 @@ impl<'a> Parser<'a> {
         self.lparen()?;
         let pos = self.pos();
         let def = match &self.symbol()?[..] {
+            "pragma" => Def::Pragma(self.parse_pragma()?),
             "type" => Def::Type(self.parse_type()?),
             "decl" => Def::Decl(self.parse_decl()?),
             "rule" => Def::Rule(self.parse_rule()?),
@@ -194,6 +195,14 @@ impl<'a> Parser<'a> {
                 pos,
                 "Not a constant identifier; must start with a '$'".to_string(),
             ))
+        }
+    }
+
+    fn parse_pragma(&mut self) -> Result<Pragma> {
+        let ident = self.parse_ident()?;
+        match ident.0.as_ref() {
+            "overlap_errors" => Ok(Pragma::OverlapErrors),
+            _ => Err(self.error(ident.1, format!("Unknown pragma '{}'", ident.0))),
         }
     }
 


### PR DESCRIPTION
Add the `(pragma ...)` syntax to ISLE, and introduce the `overlap_errors` pragma which raises errors for rule overlaps. Also mark the x64 backend with `overlap_errors` to ensure that we don't regress and introduce new overlaps.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
