### PR TITLE
ISLE: Always default the priority to 0

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -866,28 +866,28 @@
 ;; `i64` and smaller.
 
 ;; Multiply two registers.
-(rule -4 (lower (has_type (fits_in_64 ty) (imul x y)))
+(rule -5 (lower (has_type (fits_in_64 ty) (imul x y)))
       (x64_mul ty x y))
 
 ;; Multiply a register and an immediate.
 
-(rule -2 (lower (has_type (fits_in_64 ty)
+(rule -3 (lower (has_type (fits_in_64 ty)
                        (imul x (simm32_from_value y))))
       (x64_mul ty x y))
 
-(rule -3 (lower (has_type (fits_in_64 ty)
+(rule -4 (lower (has_type (fits_in_64 ty)
                        (imul (simm32_from_value x) y)))
       (x64_mul ty y x))
 
 ;; Multiply a register and a memory load.
 
-(rule -1 (lower (has_type (fits_in_64 ty)
+(rule -2 (lower (has_type (fits_in_64 ty)
                        (imul x (sinkable_load y))))
       (x64_mul ty
            x
            (sink_load_to_gpr_mem_imm y)))
 
-(rule 0 (lower (has_type (fits_in_64 ty)
+(rule -1 (lower (has_type (fits_in_64 ty)
                        (imul (sinkable_load x) y)))
       (x64_mul ty y
            (sink_load_to_gpr_mem_imm x)))

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -431,8 +431,8 @@ pub struct Rule {
     /// The right-hand side expression that this rule evaluates upon successful
     /// match.
     pub rhs: Expr,
-    /// The priority of this rule, if any.
-    pub prio: Option<i64>,
+    /// The priority of this rule, defaulted to 0 if it was missing in the source.
+    pub prio: i64,
     /// The source position where this rule is defined.
     pub pos: Pos,
 }
@@ -1394,7 +1394,7 @@ impl TermEnv {
                         lhs,
                         iflets,
                         rhs,
-                        prio: rule.prio,
+                        prio: rule.prio.unwrap_or(0),
                         pos,
                     });
                 }

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -337,7 +337,7 @@ impl<'a> TermFunctionsBuilder<'a> {
     fn build(&mut self) {
         for rule in 0..self.termenv.rules.len() {
             let rule = RuleId(rule);
-            let prio = self.termenv.rules[rule.index()].prio.unwrap_or(0);
+            let prio = self.termenv.rules[rule.index()].prio;
 
             let (pattern, expr) = lower_rule(self.typeenv, self.termenv, rule);
             let root_term = self.termenv.rules[rule.index()].lhs.root_term().unwrap();


### PR DESCRIPTION
Make the priority field of the `sema::Rule` struct an `i64` instead of an `Option<i64>`. As this value was always defaulted to `0` when used, this change removes a source of footguns when comparing priority values of different rules.

Additionally, fix a hidden overlap error in the x64 backend, where rules with no priority were seen to be written at a different priority level from those at priority `0`.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
