### PR TITLE
SSA-building cleanup

### DIFF
--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -19,6 +19,16 @@ where
     unused: PhantomData<K>,
 }
 
+impl<K: EntityRef> Default for EntitySet<K> {
+    fn default() -> Self {
+        Self {
+            elems: Vec::new(),
+            len: 0,
+            unused: PhantomData,
+        }
+    }
+}
+
 /// Shared `EntitySet` implementation for all value types.
 impl<K> EntitySet<K>
 where
@@ -26,11 +36,7 @@ where
 {
     /// Create a new empty set.
     pub fn new() -> Self {
-        Self {
-            elems: Vec::new(),
-            len: 0,
-            unused: PhantomData,
-        }
+        Self::default()
     }
 
     /// Creates a new empty set with the specified capacity.

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -15,13 +15,13 @@ use cranelift_codegen::ir::{
 };
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_codegen::packed_option::PackedOption;
-use std::convert::TryInto; // FIXME: Remove in edition2021
 
 /// Structure used for translating a series of functions into Cranelift IR.
 ///
 /// In order to reduce memory reallocations when compiling multiple functions,
 /// `FunctionBuilderContext` holds various data structures which are cleared between
 /// functions, rather than dropped, preserving the underlying allocations.
+#[derive(Default)]
 pub struct FunctionBuilderContext {
     ssa: SSABuilder,
     blocks: SecondaryMap<Block, BlockData>,
@@ -61,11 +61,7 @@ impl FunctionBuilderContext {
     /// Creates a FunctionBuilderContext structure. The structure is automatically cleared after
     /// each [`FunctionBuilder`](struct.FunctionBuilder.html) completes translating a function.
     pub fn new() -> Self {
-        Self {
-            ssa: SSABuilder::new(),
-            blocks: SecondaryMap::new(),
-            types: SecondaryMap::new(),
-        }
+        Self::default()
     }
 
     fn clear(&mut self) {

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -35,6 +35,7 @@ use smallvec::SmallVec;
 /// A basic block is said _filled_ if all the instruction that it contains have been translated,
 /// and it is said _sealed_ if all of its predecessors have been declared. Only filled predecessors
 /// can be declared.
+#[derive(Default)]
 pub struct SSABuilder {
     // TODO: Consider a sparse representation rather than SecondaryMap-of-SecondaryMap.
     /// Records for every variable and for every relevant block, the last definition of
@@ -143,18 +144,6 @@ impl SSABlockData {
 }
 
 impl SSABuilder {
-    /// Allocate a new blank SSA builder struct. Use the API function to interact with the struct.
-    pub fn new() -> Self {
-        Self {
-            variables: SecondaryMap::with_default(SecondaryMap::new()),
-            ssa_blocks: SecondaryMap::new(),
-            calls: Vec::new(),
-            results: Vec::new(),
-            side_effects: SideEffects::default(),
-            visited: EntitySet::new(),
-        }
-    }
-
     /// Clears a `SSABuilder` from all its data, letting it in a pristine state without
     /// deallocating memory.
     pub fn clear(&mut self) {

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -381,7 +381,10 @@ impl SSABuilder {
     /// No predecessors are declared here and the block is not sealed.
     /// Predecessors have to be added with `declare_block_predecessor`.
     pub fn declare_block(&mut self, block: Block) {
-        self.ssa_blocks[block] = SSABlockData::default();
+        // Ensure the block exists so seal_all_blocks will see it even if no predecessors or
+        // variables get declared for this block. But don't assign anything to it:
+        // SecondaryMap automatically sets all blocks to `default()`.
+        let _ = &mut self.ssa_blocks[block];
     }
 
     /// Declares a new predecessor for a `Block` and record the branch instruction

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -679,7 +679,7 @@ mod tests {
     #[test]
     fn simple_block() {
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         // Here is the pseudo-program we want to translate:
         // block0:
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn sequence_of_blocks() {
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
@@ -850,7 +850,7 @@ mod tests {
     #[test]
     fn program_with_loop() {
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
@@ -997,7 +997,7 @@ mod tests {
         // }
 
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
@@ -1083,7 +1083,7 @@ mod tests {
         //    jump block1;
         //
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         {
@@ -1154,7 +1154,7 @@ mod tests {
     fn undef() {
         // Use vars of various types which have not been defined.
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         ssa.declare_block(block0);
         ssa.seal_block(block0, &mut func);
@@ -1176,7 +1176,7 @@ mod tests {
         // Use a var which has not been defined. The search should hit the
         // top of the entry block, and then fall back to inserting an iconst.
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         ssa.declare_block(block0);
         ssa.seal_block(block0, &mut func);
@@ -1196,7 +1196,7 @@ mod tests {
         // until afterward. Before sealing, the SSA builder should insert an
         // block param; after sealing, it should be removed.
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         ssa.declare_block(block0);
         let x_var = Variable::new(0);
@@ -1220,7 +1220,7 @@ mod tests {
         //    brz x, block1;
         //    jump block1;
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         {
@@ -1273,7 +1273,7 @@ mod tests {
         // block2:
         //    jump block1;
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
@@ -1342,7 +1342,7 @@ mod tests {
         //    jump block1;
 
         let mut func = Function::new();
-        let mut ssa = SSABuilder::new();
+        let mut ssa = SSABuilder::default();
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();


### PR DESCRIPTION
This is a collection of all the cleanups I set aside while working on #4955 and #4966. According to DHAT and hyperfine, these patches together have almost no effect on performance. DHAT says this reduces total memory allocated, max heap size, and bytes written, while increasing instructions retired and bytes read, but all by tiny fractions of a percent.