### PR TITLE
Fall back to alternative membarrier command on aarch64 to support older kernels.

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -60,6 +60,8 @@ impl CodeMemory {
             rustix::process::membarrier(
                 rustix::process::MembarrierCommand::RegisterPrivateExpeditedSyncCore,
             )
+            // Fallback for older kernels that don't support the above command.
+            .or_else(|_| rustix::process::membarrier(rustix::process::MembarrierCommand::Global))
             .unwrap();
         }
 


### PR DESCRIPTION
This is an attempt to fix #4972 by adding a fallback syscall that older kernels should support. The fallback is invoked only if the more specific membarrier fails.