### PR TITLE
Cleanup cranelift-frontend

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -299,7 +299,6 @@ impl<'a> FunctionBuilder<'a> {
     pub fn create_block(&mut self) -> Block {
         let block = self.func.dfg.make_block();
         self.func_ctx.ssa.declare_block(block);
-        self.func_ctx.status[block] = BlockStatus::default();
         block
     }
 

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -714,13 +714,13 @@ impl<'a> FunctionBuilder<'a> {
 
     /// Returns `true` if and only if no instructions have been added since the last call to
     /// `switch_to_block`.
-    pub fn is_pristine(&self) -> bool {
+    fn is_pristine(&self) -> bool {
         self.func_ctx.blocks[self.position.unwrap()].pristine
     }
 
     /// Returns `true` if and only if a terminator instruction has been inserted since the
     /// last call to `switch_to_block`.
-    pub fn is_filled(&self) -> bool {
+    fn is_filled(&self) -> bool {
         self.func_ctx.blocks[self.position.unwrap()].filled
     }
 }


### PR DESCRIPTION
This PR eliminates most of the per-block state tracked by the `frontend` module in cranelift-frontend. I think I can eliminate the last bits of state while preserving all the debug-assertions, but I want to think about that more.

I tried to keep the individual commits well-separated so it may be worth reviewing them individually.

This saves a tiny bit of memory allocations and traffic, according to DHAT, but has basically no impact on performance.