### PR TITLE
cranelift: update x64 inst_size_test

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -48,7 +48,7 @@ pub struct CallInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(48, std::mem::size_of::<Inst>());
+    assert_eq!(40, std::mem::size_of::<Inst>());
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {


### PR DESCRIPTION
Running `cargo test --all` on the latest main (3fa545bd8) fails on my x86_64 machine, in particular in the test. I am creating this PR to check my sanity. I expect that the CI for this PR fails.