### PR TITLE
Support writing riscv64 object files

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -29,6 +29,7 @@ pub struct ObjectBuilder {
     isa: Box<dyn TargetIsa>,
     binary_format: object::BinaryFormat,
     architecture: object::Architecture,
+    flags: object::FileFlags,
     endian: object::Endianness,
     name: Vec<u8>,
     libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
@@ -48,6 +49,7 @@ impl ObjectBuilder {
         name: V,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
     ) -> ModuleResult<Self> {
+        let mut file_flags = object::FileFlags::None;
         let binary_format = match isa.triple().binary_format {
             target_lexicon::BinaryFormat::Elf => object::BinaryFormat::Elf,
             target_lexicon::BinaryFormat::Coff => object::BinaryFormat::Coff,
@@ -72,7 +74,21 @@ impl ObjectBuilder {
             target_lexicon::Architecture::X86_64 => object::Architecture::X86_64,
             target_lexicon::Architecture::Arm(_) => object::Architecture::Arm,
             target_lexicon::Architecture::Aarch64(_) => object::Architecture::Aarch64,
-            target_lexicon::Architecture::Riscv64(_) => object::Architecture::Riscv64,
+            target_lexicon::Architecture::Riscv64(_) => {
+                if binary_format != object::BinaryFormat::Elf {
+                    return Err(ModuleError::Backend(anyhow!(
+                        "binary format {:?} is not supported for riscv64",
+                        binary_format,
+                    )));
+                }
+                // FIXME(#4994) get the right variant from the TargetIsa
+                file_flags = object::FileFlags::Elf {
+                    os_abi: object::elf::ELFOSABI_NONE,
+                    abi_version: 0,
+                    e_flags: object::elf::EF_RISCV_RVC | object::elf::EF_RISCV_FLOAT_ABI_DOUBLE,
+                };
+                object::Architecture::Riscv64
+            }
             target_lexicon::Architecture::S390x => object::Architecture::S390x,
             architecture => {
                 return Err(ModuleError::Backend(anyhow!(
@@ -89,6 +105,7 @@ impl ObjectBuilder {
             isa,
             binary_format,
             architecture,
+            flags: file_flags,
             endian,
             name: name.into(),
             libcall_names,
@@ -125,6 +142,7 @@ impl ObjectModule {
     /// Create a new `ObjectModule` using the given Cranelift target.
     pub fn new(builder: ObjectBuilder) -> Self {
         let mut object = Object::new(builder.binary_format, builder.architecture, builder.endian);
+        object.flags = builder.flags;
         object.add_file_symbol(builder.name);
         Self {
             isa: builder.isa,
@@ -686,6 +704,18 @@ impl ObjectModule {
                 );
                 (
                     RelocationKind::Elf(object::elf::R_390_TLS_GDCALL),
+                    RelocationEncoding::Generic,
+                    0,
+                )
+            }
+            Reloc::RiscvCall => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "RiscvCall is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_RISCV_CALL),
                     RelocationEncoding::Generic,
                     0,
                 )


### PR DESCRIPTION
Together with https://github.com/gimli-rs/object/pull/470 and a couple of small changes to cg_clif, this makes it possible to compile and run mini_core_hello_world modulo the tls test.

Depends on https://github.com/gimli-rs/object/pull/470
cc https://github.com/bytecodealliance/wasmtime/issues/4994