### PR TITLE
Consolidate module definition in `wasmtime-jit`

### DIFF
--- a/crates/jit/src/unwind.rs
+++ b/crates/jit/src/unwind.rs
@@ -1,13 +1,10 @@
 cfg_if::cfg_if! {
-    if #[cfg(all(windows, target_arch = "x86_64"))] {
+    if #[cfg(all(windows, any(target_arch = "x86_64", target_arch = "aarch64")))] {
         mod winx64;
         pub use self::winx64::*;
     } else if #[cfg(all(windows, target_arch = "x86"))] {
         mod winx32;
         pub use self::winx32::*;
-    } else if #[cfg(all(windows, target_arch = "aarch64"))] {
-        mod winx64;
-        pub use self::winx64::*;
     } else if #[cfg(unix)] {
         mod systemv;
         pub use self::systemv::*;


### PR DESCRIPTION
Minor thing I noticed from #4990 but I stylistically prefer to keep the `mod foo;` definitions canonicalized to one location to emphasize how multiple targets can use the same definition.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
