### PR TITLE
cranelift-frontend: Replace Vecs with ListPools

### DIFF
--- a/cranelift/entity/src/list.rs
+++ b/cranelift/entity/src/list.rs
@@ -104,6 +104,12 @@ impl<T: core::hash::Hash + EntityRef + ReservedValue> core::hash::Hash for ListP
     }
 }
 
+impl<T: EntityRef + ReservedValue> Default for ListPool<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Lists are allocated in sizes that are powers of two, starting from 4.
 /// Each power of two is assigned a size class number, so the size is `4 << SizeClass`.
 type SizeClass = u8;

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1822,24 +1822,24 @@ block0:
             builder.switch_to_block(block0);
 
             assert_eq!(
-                builder.try_use_var(Variable::with_u32(0)),
-                Err(UseVariableError::UsedBeforeDeclared(Variable::with_u32(0)))
+                builder.try_use_var(Variable::from_u32(0)),
+                Err(UseVariableError::UsedBeforeDeclared(Variable::from_u32(0)))
             );
 
             let value = builder.ins().iconst(cranelift_codegen::ir::types::I32, 0);
 
             assert_eq!(
-                builder.try_def_var(Variable::with_u32(0), value),
-                Err(DefVariableError::DefinedBeforeDeclared(Variable::with_u32(
+                builder.try_def_var(Variable::from_u32(0), value),
+                Err(DefVariableError::DefinedBeforeDeclared(Variable::from_u32(
                     0
                 )))
             );
 
-            builder.declare_var(Variable::with_u32(0), cranelift_codegen::ir::types::I32);
+            builder.declare_var(Variable::from_u32(0), cranelift_codegen::ir::types::I32);
             assert_eq!(
-                builder.try_declare_var(Variable::with_u32(0), cranelift_codegen::ir::types::I32),
+                builder.try_declare_var(Variable::from_u32(0), cranelift_codegen::ir::types::I32),
                 Err(DeclareVariableError::DeclaredMultipleTimes(
-                    Variable::with_u32(0)
+                    Variable::from_u32(0)
                 ))
             );
         }

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -135,11 +135,10 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                         {
                             // Call `declare_block_predecessor` instead of `declare_successor` for
                             // avoiding the borrow checker.
-                            self.builder.func_ctx.ssa.declare_block_predecessor(
-                                *dest_block,
-                                self.builder.position.unwrap(),
-                                inst,
-                            );
+                            self.builder
+                                .func_ctx
+                                .ssa
+                                .declare_block_predecessor(*dest_block, inst);
                         }
                         self.builder.declare_successor(destination, inst);
                     }
@@ -688,11 +687,9 @@ impl<'a> FunctionBuilder<'a> {
         let old_dest = self.func.dfg[inst]
             .branch_destination_mut()
             .expect("you want to change the jump destination of a non-jump instruction");
-        let pred = self.func_ctx.ssa.remove_block_predecessor(*old_dest, inst);
+        self.func_ctx.ssa.remove_block_predecessor(*old_dest, inst);
         *old_dest = new_dest;
-        self.func_ctx
-            .ssa
-            .declare_block_predecessor(new_dest, pred, inst);
+        self.func_ctx.ssa.declare_block_predecessor(new_dest, inst);
     }
 
     /// Returns `true` if and only if the current `Block` is sealed and has no predecessors declared.
@@ -1083,7 +1080,7 @@ impl<'a> FunctionBuilder<'a> {
     fn declare_successor(&mut self, dest_block: Block, jump_inst: Inst) {
         self.func_ctx
             .ssa
-            .declare_block_predecessor(dest_block, self.position.unwrap(), jump_inst);
+            .declare_block_predecessor(dest_block, jump_inst);
     }
 
     fn handle_ssa_side_effects(&mut self, side_effects: SideEffects) {

--- a/cranelift/frontend/src/variable.rs
+++ b/cranelift/frontend/src/variable.rs
@@ -9,27 +9,18 @@
 //! starting at `0`.
 
 use core::u32;
-use cranelift_codegen::entity::EntityRef;
+use cranelift_codegen::entity::entity_impl;
 
 /// An opaque reference to a variable.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Variable(u32);
+
+entity_impl!(Variable, "var");
 
 impl Variable {
     /// Create a new Variable with the given index.
+    #[deprecated = "Use Variable::from_u32 instead"]
     pub fn with_u32(index: u32) -> Self {
-        debug_assert!(index < u32::MAX);
-        Self(index)
-    }
-}
-
-impl EntityRef for Variable {
-    fn new(index: usize) -> Self {
-        debug_assert!(index < (u32::MAX as usize));
-        Self(index as u32)
-    }
-
-    fn index(self) -> usize {
-        self.0 as usize
+        Variable::from_u32(index)
     }
 }

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -125,7 +125,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
          *  disappear in the Cranelift Code
          ***********************************************************************************/
         Operator::LocalGet { local_index } => {
-            let val = builder.use_var(Variable::with_u32(*local_index));
+            let val = builder.use_var(Variable::from_u32(*local_index));
             state.push1(val);
             let label = ValueLabel::from_u32(*local_index);
             builder.set_val_label(val, label);
@@ -139,7 +139,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 val = optionally_bitcast_vector(val, I8X16, builder);
             }
 
-            builder.def_var(Variable::with_u32(*local_index), val);
+            builder.def_var(Variable::from_u32(*local_index), val);
             let label = ValueLabel::from_u32(*local_index);
             builder.set_val_label(val, label);
         }
@@ -152,7 +152,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 val = optionally_bitcast_vector(val, I8X16, builder);
             }
 
-            builder.def_var(Variable::with_u32(*local_index), val);
+            builder.def_var(Variable::from_u32(*local_index), val);
             let label = ValueLabel::from_u32(*local_index);
             builder.set_val_label(val, label);
         }


### PR DESCRIPTION
There are three main themes in this PR:

1. Replace the `Vec` and `SmallVec` in `SSABlockData` with `EntityList`s using `ListPool`s kept in the `SSABuilder`.
2. Both of those vectors stored pairs, which `EntityList` doesn't easily support. But in both cases I was able to remove one element of the pair because it was uniquely determined by other information.
3. Determining the removed `Block` ID from a branch `Inst` is slower than just storing the block together with the branch, but I was able to remove most of those lookups.

According to DHAT, compared with main, overal this PR uses 0.3% less memory at max heap, reads 0.6% fewer bytes, and writes 0.2% fewer bytes. It also executes fewer instructions and allocates less memory in total, by less than 0.1% each.

According to Hyperfine, this PR is "1.01 ± 0.01 times faster" than main when compiling Spidermonkey. On the other hand, Sightglass says main is 1.01x faster than this PR on the same benchmark by CPU cycles. In short, actual effects are too small to measure reliably.

By coincidence, the diff adds exactly as many lines as it removes, but a larger fraction of those lines are comments now.