### PR TITLE
feat: improve wasi_common::ErrorKind derives

### DIFF
--- a/crates/wasi-common/src/error.rs
+++ b/crates/wasi-common/src/error.rs
@@ -28,7 +28,8 @@ pub use anyhow::{Context, Error};
 /// Internal error type for the `wasi-common` crate.
 /// Contains variants of the WASI `$errno` type are added according to what is actually used internally by
 /// the crate. Not all values are represented presently.
-#[derive(Debug, thiserror::Error)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Errno::WouldBlk: Would block
     #[error("WouldBlk: Would block")]


### PR DESCRIPTION
Besides the standard traits (Copy, Clone, PartialEq and Eq), we also mark the trait as non-exhaustive so that we can add errors in the future without breaking API.
