### PR TITLE
ISLE: More consistent use of `add_inst` in ir.rs

### DIFF
--- a/cranelift/isle/isle/src/ir.rs
+++ b/cranelift/isle/isle/src/ir.rs
@@ -262,8 +262,7 @@ impl PatternSequence {
     }
 
     fn add_arg(&mut self, index: usize, ty: TypeId) -> Value {
-        let inst = InstId(self.insts.len());
-        self.add_inst(PatternInst::Arg { index, ty });
+        let inst = self.add_inst(PatternInst::Arg { index, ty });
         Value::Pattern { inst, output: 0 }
     }
 
@@ -496,14 +495,12 @@ impl ExprSequence {
     }
 
     fn add_const_int(&mut self, ty: TypeId, val: i128) -> Value {
-        let inst = InstId(self.insts.len());
-        self.add_inst(ExprInst::ConstInt { ty, val });
+        let inst = self.add_inst(ExprInst::ConstInt { ty, val });
         Value::Expr { inst, output: 0 }
     }
 
     fn add_const_prim(&mut self, ty: TypeId, val: Sym) -> Value {
-        let inst = InstId(self.insts.len());
-        self.add_inst(ExprInst::ConstPrim { ty, val });
+        let inst = self.add_inst(ExprInst::ConstPrim { ty, val });
         Value::Expr { inst, output: 0 }
     }
 
@@ -513,9 +510,8 @@ impl ExprSequence {
         ty: TypeId,
         variant: VariantId,
     ) -> Value {
-        let inst = InstId(self.insts.len());
         let inputs = inputs.iter().cloned().collect();
-        self.add_inst(ExprInst::CreateVariant {
+        let inst = self.add_inst(ExprInst::CreateVariant {
             inputs,
             ty,
             variant,
@@ -531,9 +527,8 @@ impl ExprSequence {
         infallible: bool,
         multi: bool,
     ) -> Value {
-        let inst = InstId(self.insts.len());
         let inputs = inputs.iter().cloned().collect();
-        self.add_inst(ExprInst::Construct {
+        let inst = self.add_inst(ExprInst::Construct {
             inputs,
             ty,
             term,


### PR DESCRIPTION
Use the `InstId` returned by `add_inst` rather than creating it eagerly, when possible.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
