### PR TITLE
Adjust fuel consumption to be empty when fuel is at 0 rather than 1

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -787,7 +787,8 @@ impl Drop for SignalOnDrop {
     }
 }
 
-fn set_fuel<T>(store: &mut Store<T>, fuel: u64) {
+/// Set the amount of fuel in a store to a given value
+pub fn set_fuel<T>(store: &mut Store<T>, fuel: u64) {
     // Determine the amount of fuel already within the store, if any, and
     // add/consume as appropriate to set the remaining amount to` fuel`.
     let remaining = store.consume_fuel(0).unwrap();

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1434,7 +1434,7 @@ impl StoreOpaque {
             .ok()
             .and_then(|fuel| consumed_ptr.checked_add(fuel))
         {
-            Some(consumed) if consumed < 0 => {
+            Some(consumed) if consumed <= 0 => {
                 *consumed_ptr = consumed;
                 Ok(u64::try_from(-consumed).unwrap())
             }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -138,10 +138,10 @@ fn manual_fuel() {
     assert_eq!(store.consume_fuel(999).unwrap(), 9_000);
     assert!(store.consume_fuel(10_000).is_err());
     assert_eq!(store.consume_fuel(8998).unwrap(), 2);
-    assert!(store.consume_fuel(2).is_err());
+    assert!(store.consume_fuel(3).is_err());
     assert_eq!(store.consume_fuel(1).unwrap(), 1);
-    assert!(store.consume_fuel(1).is_err());
-    assert_eq!(store.consume_fuel(0).unwrap(), 1);
+    assert_eq!(store.consume_fuel(1).unwrap(), 0);
+    assert_eq!(store.consume_fuel(0).unwrap(), 0);
 }
 
 #[test]
@@ -186,7 +186,6 @@ fn manual_edge_cases() {
     store.add_fuel(u64::MAX).unwrap();
     assert_eq!(store.fuel_consumed(), Some(0));
     assert!(store.consume_fuel(u64::MAX).is_err());
-    assert!(store.consume_fuel(i64::MAX as u64).is_err());
     assert!(store.consume_fuel(i64::MAX as u64 + 1).is_err());
-    assert_eq!(store.consume_fuel(i64::MAX as u64 - 1).unwrap(), 1);
+    assert_eq!(store.consume_fuel(i64::MAX as u64).unwrap(), 0);
 }


### PR DESCRIPTION
I ran into this when attempting to use `set_fuel` in a fuzz target (https://github.com/bytecodealliance/wasm-tools/pull/769). `set_fuel` calls `consume_fuel(0)` in order to get the current amount of fuel in a Store. However, `consume_fuel(0)` will return an out of fuel error if there is 0 fuel remaining, which is the case with a new Store.

Switching the `<` to a `<=` also has the effect of making this work:
```
...
let mut store = Store::new(&engine, ());
store.add_fuel(1).unwrap();
store.consume_fuel(1).unwrap();
```
previously this would have returned an "out of fuel" error, which doesn't seem correct, though maybe there's some nuance I'm missing?
