### PR TITLE
Misc cleanups

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -191,32 +191,21 @@ impl Context {
     /// If available, return information about the code layout in the
     /// final machine code: the offsets (in bytes) of each basic-block
     /// start, and all basic-block edges.
+    #[deprecated = "use CompiledCode::get_code_bb_layout"]
     pub fn get_code_bb_layout(&self) -> Option<(Vec<usize>, Vec<(usize, usize)>)> {
-        if let Some(result) = self.compiled_code.as_ref() {
-            Some((
-                result.bb_starts.iter().map(|&off| off as usize).collect(),
-                result
-                    .bb_edges
-                    .iter()
-                    .map(|&(from, to)| (from as usize, to as usize))
-                    .collect(),
-            ))
-        } else {
-            None
-        }
+        self.compiled_code().map(CompiledCode::get_code_bb_layout)
     }
 
     /// Creates unwind information for the function.
     ///
     /// Returns `None` if the function has no unwind information.
     #[cfg(feature = "unwind")]
+    #[deprecated = "use CompiledCode::create_unwind_info"]
     pub fn create_unwind_info(
         &self,
         isa: &dyn TargetIsa,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
-        let unwind_info_kind = isa.unwind_info_kind();
-        let result = self.compiled_code.as_ref().unwrap();
-        isa.emit_unwind_info(result, unwind_info_kind)
+        self.compiled_code().unwrap().create_unwind_info(isa)
     }
 
     /// Run the verifier on the function.

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -119,10 +119,7 @@ impl Context {
         mem: &mut Vec<u8>,
     ) -> CompileResult<&CompiledCode> {
         let compiled_code = self.compile(isa)?;
-        let code_info = compiled_code.code_info();
-        let old_len = mem.len();
-        mem.resize(old_len + code_info.total_size as usize, 0);
-        mem[old_len..].copy_from_slice(compiled_code.code_buffer());
+        mem.extend_from_slice(compiled_code.code_buffer());
         Ok(compiled_code)
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -91,9 +91,9 @@ mod tests {
             Some(StackSlotData::new(StackSlotKind::ExplicitSlot, 64)),
         ));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {
@@ -130,9 +130,9 @@ mod tests {
 
         let mut context = Context::for_function(create_multi_return_function(CallConv::SystemV));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -56,7 +56,7 @@ use crate::CodegenResult;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
-use target_lexicon::{triple, Architecture, OperatingSystem, PointerWidth, Triple};
+use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 
 // This module is made public here for benchmarking purposes. No guarantees are
 // made regarding API stability.
@@ -358,18 +358,6 @@ impl<'a> dyn TargetIsa + 'a {
         TargetFrontendConfig {
             default_call_conv: self.default_call_conv(),
             pointer_width: self.pointer_width(),
-        }
-    }
-
-    /// Returns the flavor of unwind information emitted for this target.
-    pub(crate) fn unwind_info_kind(&self) -> UnwindInfoKind {
-        match self.triple().operating_system {
-            #[cfg(feature = "unwind")]
-            OperatingSystem::Windows => UnwindInfoKind::Windows,
-            #[cfg(feature = "unwind")]
-            _ => UnwindInfoKind::SystemV,
-            #[cfg(not(feature = "unwind"))]
-            _ => UnwindInfoKind::None,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
@@ -89,9 +89,9 @@ mod tests {
             Some(StackSlotData::new(StackSlotKind::ExplicitSlot, 64)),
         ));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {
@@ -129,9 +129,9 @@ mod tests {
 
         let mut context = Context::for_function(create_multi_return_function(CallConv::SystemV));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -122,9 +122,9 @@ mod tests {
             Some(StackSlotData::new(StackSlotKind::ExplicitSlot, 64)),
         ));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {
@@ -164,9 +164,9 @@ mod tests {
             Some(StackSlotData::new(StackSlotKind::ExplicitSlot, 64)),
         ));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -118,9 +118,9 @@ mod tests {
             Some(StackSlotData::new(StackSlotKind::ExplicitSlot, 64)),
         ));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {
@@ -157,9 +157,9 @@ mod tests {
 
         let mut context = Context::for_function(create_multi_return_function(CallConv::SystemV));
 
-        context.compile(&*isa).expect("expected compilation");
+        let code = context.compile(&*isa).expect("expected compilation");
 
-        let fde = match context
+        let fde = match code
             .create_unwind_info(isa.as_ref())
             .expect("can create unwind info")
         {

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -39,10 +39,10 @@ impl SubTest for TestUnwind {
         let isa = context.isa.expect("unwind needs an ISA");
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
-        comp_ctx.compile(isa).expect("failed to compile function");
+        let code = comp_ctx.compile(isa).expect("failed to compile function");
 
         let mut text = String::new();
-        match comp_ctx.create_unwind_info(isa).expect("unwind info") {
+        match code.create_unwind_info(isa).expect("unwind info") {
             Some(UnwindInfo::WindowsX64(info)) => {
                 let mut mem = vec![0; info.emit_size()];
                 info.emit(&mut mem);

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -165,7 +165,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The signature `sig_ref` was previously created by `make_indirect_sig()`.
     ///
     /// Return the call instruction whose results are the WebAssembly return values.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
+    #[allow(clippy::too_many_arguments)]
     fn translate_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,

--- a/cranelift/wasm/src/func_translator.rs
+++ b/cranelift/wasm/src/func_translator.rs
@@ -94,12 +94,11 @@ impl FuncTranslator {
         debug_assert_eq!(func.dfg.num_blocks(), 0, "Function must be empty");
         debug_assert_eq!(func.dfg.num_insts(), 0, "Function must be empty");
 
-        // This clears the `FunctionBuilderContext`.
         let mut builder = FunctionBuilder::new(func, &mut self.func_ctx);
         builder.set_srcloc(cur_srcloc(&reader));
         let entry_block = builder.create_block();
         builder.append_block_params_for_function_params(entry_block);
-        builder.switch_to_block(entry_block); // This also creates values for the arguments.
+        builder.switch_to_block(entry_block);
         builder.seal_block(entry_block); // Declare all predecessors known.
 
         // Make sure the entry block is inserted in the layout before we make any callbacks to
@@ -183,7 +182,7 @@ fn parse_local_decls<FE: FuncEnvironment + ?Sized>(
 
 /// Declare `count` local variables of the same type, starting from `next_local`.
 ///
-/// Fail of too many locals are declared in the function, or if the type is not valid for a local.
+/// Fail if too many locals are declared in the function, or if the type is not valid for a local.
 fn declare_locals<FE: FuncEnvironment + ?Sized>(
     builder: &mut FunctionBuilder,
     count: u32,

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -298,7 +298,7 @@ impl wasmtime_environ::Compiler for Compiler {
         let stack_maps = mach_stack_maps_to_stack_maps(compiled_code.buffer.stack_maps());
 
         let unwind_info = if isa.flags().unwind_info() {
-            context
+            compiled_code
                 .create_unwind_info(isa)
                 .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
         } else {
@@ -835,7 +835,7 @@ impl Compiler {
             .collect::<Vec<_>>();
 
         let unwind_info = if isa.flags().unwind_info() {
-            context
+            compiled_code
                 .create_unwind_info(isa)
                 .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
         } else {

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -496,10 +496,10 @@ mod incremental_cache {
         isa: &dyn TargetIsa,
         cache_ctx: Option<&mut IncrementalCacheContext>,
     ) -> Result<(&'a CompiledCode, Vec<u8>), CompileError> {
-        let mut code_buf = Vec::new();
         let cache_ctx = match cache_ctx {
             Some(ctx) => ctx,
             None => {
+                let mut code_buf = Vec::new();
                 let compiled_code =
                     context
                         .compile_and_emit(isa, &mut code_buf)
@@ -521,10 +521,7 @@ mod incremental_cache {
             cache_ctx.num_cached += 1;
         }
 
-        code_buf.resize(compiled_code.code_info().total_size as _, 0);
-        code_buf.copy_from_slice(compiled_code.code_buffer());
-
-        Ok((compiled_code, code_buf))
+        Ok((compiled_code, compiled_code.code_buffer().to_vec()))
     }
 }
 


### PR DESCRIPTION
Here's an assortment of unrelated cleanups I put together while trying to understand wasmtime-cranelift.

- 0e6333ec4 Replace resize+copy_from_slice with extend_from_slice
- f4f2d07e2 Move helpers from Context to CompiledCode
- 36a55c439 Remove some incremental-cache code duplication
- dfdff805e Remove an unnecessary #[cfg_attr]
- 7b167e776 Fix a few comments
- b76e9af86 wasmtime-cranelift: Misc cleanups