### PR TITLE
Tidy up the WASI `ErrorKind` enum.

### DIFF
--- a/crates/wasi-common/src/error.rs
+++ b/crates/wasi-common/src/error.rs
@@ -26,32 +26,27 @@
 pub use anyhow::{Context, Error};
 
 /// Internal error type for the `wasi-common` crate.
-/// Contains variants of the WASI `$errno` type are added according to what is actually used internally by
-/// the crate. Not all values are represented presently.
+///
+/// This Contains variants of the WASI `$errno` type that are used internally
+/// by the crate, and which aren't one-to-one with a `std::io::ErrorKind`
+/// error.
+///
+/// When the Rust [io_error_more] feature is stabilized, that will enable
+/// us to replace several more of these codes with `std::io::ErrorKind` codes.
+///
+/// [io_error_more]: https://doc.rust-lang.org/beta/unstable-book/library-features/io-error-more.html
 #[derive(Copy, Clone, Debug, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ErrorKind {
-    /// Errno::WouldBlk: Would block
-    #[error("WouldBlk: Would block")]
-    WouldBlk,
-    /// Errno::Noent: No such file or directory
-    #[error("Noent: No such file or directory")]
-    Noent,
     /// Errno::TooBig: Argument list too long
     #[error("TooBig: Argument list too long")]
     TooBig,
     /// Errno::Badf: Bad file descriptor
     #[error("Badf: Bad file descriptor")]
     Badf,
-    /// Errno::Exist: File exists
-    #[error("Exist: File exists")]
-    Exist,
     /// Errno::Ilseq: Illegal byte sequence
     #[error("Ilseq: Illegal byte sequence")]
     Ilseq,
-    /// Errno::Inval: Invalid argument
-    #[error("Inval: Invalid argument")]
-    Inval,
     /// Errno::Io: I/O error
     #[error("Io: I/O error")]
     Io,
@@ -76,9 +71,6 @@ pub enum ErrorKind {
     /// Errno::Perm: Permission denied
     #[error("Permission denied")]
     Perm,
-    /// Errno::NotCapable: Not capable
-    #[error("Not capable")]
-    NotCapable,
 }
 
 pub trait ErrorExt {
@@ -104,7 +96,7 @@ impl ErrorExt for Error {
         anyhow::anyhow!(msg.into())
     }
     fn not_found() -> Self {
-        ErrorKind::Noent.into()
+        std::io::Error::from(std::io::ErrorKind::NotFound).into()
     }
     fn too_big() -> Self {
         ErrorKind::TooBig.into()
@@ -113,13 +105,13 @@ impl ErrorExt for Error {
         ErrorKind::Badf.into()
     }
     fn exist() -> Self {
-        ErrorKind::Exist.into()
+        std::io::Error::from(std::io::ErrorKind::AlreadyExists).into()
     }
     fn illegal_byte_sequence() -> Self {
         ErrorKind::Ilseq.into()
     }
     fn invalid_argument() -> Self {
-        ErrorKind::Inval.into()
+        std::io::Error::from(std::io::ErrorKind::InvalidInput).into()
     }
     fn io() -> Self {
         ErrorKind::Io.into()

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -256,7 +256,7 @@ impl TryFrom<std::io::Error> for types::Errno {
                 std::io::ErrorKind::NotFound => Ok(types::Errno::Noent),
                 std::io::ErrorKind::PermissionDenied => Ok(types::Errno::Perm),
                 std::io::ErrorKind::AlreadyExists => Ok(types::Errno::Exist),
-                std::io::ErrorKind::InvalidInput => Ok(types::Errno::Ilseq),
+                std::io::ErrorKind::InvalidInput => Ok(types::Errno::Inval),
                 _ => Err(anyhow::anyhow!(err).context(format!("Unknown OS error"))),
             },
         }

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -69,13 +69,9 @@ impl From<ErrorKind> for types::Errno {
     fn from(e: ErrorKind) -> types::Errno {
         use types::Errno;
         match e {
-            ErrorKind::WouldBlk => Errno::Again,
-            ErrorKind::Noent => Errno::Noent,
             ErrorKind::TooBig => Errno::TooBig,
             ErrorKind::Badf => Errno::Badf,
-            ErrorKind::Exist => Errno::Exist,
             ErrorKind::Ilseq => Errno::Ilseq,
-            ErrorKind::Inval => Errno::Inval,
             ErrorKind::Io => Errno::Io,
             ErrorKind::Nametoolong => Errno::Nametoolong,
             ErrorKind::Notdir => Errno::Notdir,
@@ -83,7 +79,6 @@ impl From<ErrorKind> for types::Errno {
             ErrorKind::Overflow => Errno::Overflow,
             ErrorKind::Range => Errno::Range,
             ErrorKind::Spipe => Errno::Spipe,
-            ErrorKind::NotCapable => Errno::Notcapable,
             ErrorKind::Perm => Errno::Perm,
         }
     }


### PR DESCRIPTION
`ErrorKind` is an internal enum used in wasi-libc to represent WASI errors that aren't precisely represened by `std::io::ErrorKind` errors. Add a descriptive comment, and remove some codes that are no longer needed:

 - Remove `NotCapable`, which is no longer used.
 - Remove `WouldBlk`, `Exist`, `Noent`, and `Inval`, which have one-to-one correspondences with codes in `std::io::ErrorKind`.

This will simplify the error handling in #4947 and #4967, as it means the code will no longer have to check for two different forms of these errors.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
