### PR TITLE
fuzzgen: Generate compiler flags

### DIFF
--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -98,6 +98,26 @@ fn gen_iterator(group: &SettingGroup, fmt: &mut Formatter) {
     fmtln!(fmt, "}");
 }
 
+/// Generates a `all()` function with all options for this enum
+fn gen_enum_all(name: &str, values: &[&'static str], fmt: &mut Formatter) {
+    fmtln!(
+        fmt,
+        "/// Returns a slice with all possible [{}] values.",
+        name
+    );
+    fmtln!(fmt, "pub fn all() -> &'static [{}] {{", name);
+    fmt.indent(|fmt| {
+        fmtln!(fmt, "&[");
+        fmt.indent(|fmt| {
+            for v in values.iter() {
+                fmtln!(fmt, "Self::{},", camel_case(v));
+            }
+        });
+        fmtln!(fmt, "]");
+    });
+    fmtln!(fmt, "}");
+}
+
 /// Emit Display and FromStr implementations for enum settings.
 fn gen_to_and_from_str(name: &str, values: &[&'static str], fmt: &mut Formatter) {
     fmtln!(fmt, "impl fmt::Display for {} {{", name);
@@ -155,6 +175,12 @@ fn gen_enum_types(group: &SettingGroup, fmt: &mut Formatter) {
                 fmt.doc_comment(format!("`{}`.", v));
                 fmtln!(fmt, "{},", camel_case(v));
             }
+        });
+        fmtln!(fmt, "}");
+
+        fmtln!(fmt, "impl {} {{", name);
+        fmt.indent(|fmt| {
+            gen_enum_all(&name, values, fmt);
         });
         fmtln!(fmt, "}");
 

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -364,5 +364,7 @@ pub(crate) fn define() -> SettingGroup {
         false,
     );
 
+    // When adding new settings please check if they can also be added
+    // in cranelift/fuzzgen/src/lib.rs for fuzzing.
     settings.build()
 }

--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 
 /// Holds the range of acceptable values to use during the generation of testcases
@@ -51,6 +52,11 @@ pub struct Config {
     /// We insert a checking sequence to guarantee that those inputs never make
     /// it to the instruction, but sometimes we want to allow them.
     pub allowed_fcvt_traps_ratio: (usize, usize),
+
+    /// Some flags really impact compile performance, we still want to test
+    /// them, but probably at a lower rate, so that overall execution time isn't
+    /// impacted as much
+    pub compile_flag_ratio: HashMap<&'static str, (usize, usize)>,
 }
 
 impl Default for Config {
@@ -75,6 +81,7 @@ impl Default for Config {
             backwards_branch_ratio: (1, 1000),
             allowed_int_divz_ratio: (1, 1_000_000),
             allowed_fcvt_traps_ratio: (1, 1_000_000),
+            compile_flag_ratio: [("regalloc_checker", (1usize, 1000))].into_iter().collect(),
         }
     }
 }

--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -3,7 +3,11 @@ use std::ops::RangeInclusive;
 
 /// Holds the range of acceptable values to use during the generation of testcases
 pub struct Config {
-    pub test_case_inputs: RangeInclusive<usize>,
+    /// Maximum allowed test case inputs.
+    /// We build test case inputs from the rest of the bytes that the fuzzer provides us
+    /// so we allow the fuzzer to control this by feeding us more or less bytes.
+    /// The upper bound here is to prevent too many inputs that cause long test times
+    pub max_test_case_inputs: usize,
     pub signature_params: RangeInclusive<usize>,
     pub signature_rets: RangeInclusive<usize>,
     pub instructions_per_block: RangeInclusive<usize>,
@@ -62,7 +66,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            test_case_inputs: 1..=10,
+            max_test_case_inputs: 100,
             signature_params: 0..=16,
             signature_rets: 0..=16,
             instructions_per_block: 0..=64,

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -230,8 +230,7 @@ where
     fn generate_flags(&mut self) -> Result<Flags> {
         let mut builder = settings::builder();
 
-        let opt_levels = [OptLevel::None, OptLevel::Speed, OptLevel::SpeedAndSize];
-        let opt = self.u.choose(&opt_levels)?;
+        let opt = self.u.choose(OptLevel::all())?;
         builder.set("opt_level", &format!("{}", opt)[..])?;
 
         // Boolean flags

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -257,6 +257,7 @@ where
             "enable_incremental_compilation_cache_checks",
             "regalloc_checker",
             "enable_llvm_abi_extensions",
+            "use_egraphs",
         ];
         for flag_name in bool_settings {
             let enabled = self

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -256,7 +256,14 @@ where
             "enable_llvm_abi_extensions",
         ];
         for flag_name in bool_settings {
-            let value = format!("{}", bool::arbitrary(self.u)?);
+            let enabled = self
+                .config
+                .compile_flag_ratio
+                .get(&flag_name)
+                .map(|&(num, denum)| self.u.ratio(num, denum))
+                .unwrap_or_else(|| bool::arbitrary(self.u))?;
+
+            let value = format!("{}", enabled);
             builder.set(flag_name, value.as_str())?;
         }
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -245,13 +245,9 @@ where
         //   aarch64: https://github.com/bytecodealliance/wasmtime/issues/2735
         let bool_settings = [
             "enable_alias_analysis",
-            "enable_simd",
-            "enable_float",
-            "enable_atomics",
             "enable_safepoints",
             "unwind_info",
             "preserve_frame_pointers",
-            "machine_code_cfg_info",
             "enable_jump_tables",
             "enable_heap_access_spectre_mitigation",
             "enable_table_access_spectre_mitigation",
@@ -282,6 +278,16 @@ where
 
         // This is the default, but we should ensure that it wasn't accidentally turned off anywhere.
         builder.enable("enable_verifier")?;
+
+        // These settings just panic when they're not enabled and we try to use their respective functionality
+        // so they aren't very interesting to be automatically generated.
+        builder.enable("enable_atomics")?;
+        builder.enable("enable_float")?;
+        builder.enable("enable_simd")?;
+
+        // `machine_code_cfg_info` generates additional metadata for the embedder but this doesn't feed back
+        // into compilation anywhere, we leave it on unconditionally to make sure the generation doesn't panic.
+        builder.enable("machine_code_cfg_info")?;
 
         Ok(Flags::new(builder))
     }

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -58,6 +58,7 @@ impl fmt::Debug for TestCase {
 
         writeln!(f, "target aarch64")?;
         writeln!(f, "target s390x")?;
+        writeln!(f, "target riscv64")?;
         writeln!(f, "target x86_64\n")?;
 
         writeln!(f, "{}", self.func)?;

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -148,7 +148,10 @@ where
     fn generate_test_inputs(mut self, signature: &Signature) -> Result<Vec<TestCaseInput>> {
         let mut inputs = Vec::new();
 
-        loop {
+        // Generate up to "max_test_case_inputs" inputs, we need an upper bound here since
+        // the fuzzer at some point starts trying to feed us way too many inputs. (I found one
+        // test case with 130k inputs!)
+        for _ in 0..self.config.max_test_case_inputs {
             let last_len = self.u.len();
 
             let test_args = signature


### PR DESCRIPTION
👋 Hey,

This PR allows fuzzgen to generate compiler flags and test using those. We only allow compiler flags that shouldn't change the behaviour of the code.

I wanted to submit this now so that we could fuzz PR's such as #4953 and #5004 that require optimizations enabled.

However, when testing this it has found an issue with one of the passes (I haven't yet narrowed it down), but I don't want to start fixing it if we are going to change pretty much everything once #4953 lands. I'm opening this as a draft, and lets re test this once #4953 lands.

<details>
<summary>The actual bug manifests as following:</summary>

Fails with:
```
target/aarch64-unknown-linux-gnu/release/cranelift-fuzzgen: Running 1 inputs 1 time(s) each.
Running: fuzz/artifacts/cranelift-fuzzgen/crash-00e37c2858c35c573ed85d618ea5d0c75ae06fda
thread '<unnamed>' panicked at 'assertion failed: `(left != right)`
  left: `v137`,
 right: `v137`: Aliasing v137 to v134 would create a loop', cranelift/codegen/src/ir/dfg.rs:322:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


And I cannot reproduce via the CLIF file since that runs into https://github.com/bytecodealliance/wasmtime/issues/4875#issuecomment-1239314171 (which I kinda forgot about 😅 ). But I'm going to try and investigate that one in the mean time.
</details>


This also enables regalloc_checker as we discussed in #4979.


cc: @jameysharp