### PR TITLE
Fix StructReturn handling: properly mark the clobber, and offset actual rets.

### DIFF
--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1212,7 +1212,11 @@ macro_rules! isle_prelude_method_helpers {
             let mut outputs = InstOutput::new();
             let mut retval_insts: crate::machinst::abi::SmallInstVec<_> = smallvec::smallvec![];
             for i in 0..num_rets {
-                let ret = self.lower_ctx.sigs()[abi].get_ret(i);
+                // We take the *last* `num_rets` returns of the sig:
+                // this skips a StructReturn, if any, that is present.
+                let sigdata = &self.lower_ctx.sigs()[abi];
+                let idx = (sigdata.num_rets() - num_rets) + i;
+                let ret = sigdata.get_ret(idx);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();
                 retval_insts.extend(
                     caller

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1217,6 +1217,9 @@ macro_rules! isle_prelude_method_helpers {
             let sigdata = &self.lower_ctx.sigs()[abi];
             debug_assert!(num_rets <= sigdata.num_rets());
             for i in (sigdata.num_rets() - num_rets)..sigdata.num_rets() {
+                // Borrow `sigdata` again so we don't hold a `self`
+                // borrow across the `&mut self` arg to
+                // `abi_arg_slot_regs()` below.
                 let sigdata = &self.lower_ctx.sigs()[abi];
                 let ret = sigdata.get_ret(i);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1206,17 +1206,19 @@ macro_rules! isle_prelude_method_helpers {
                     self.lower_ctx.emit(inst);
                 }
             }
+
             // Handle retvals prior to emitting call, so the
             // constraints are on the call instruction; but buffer the
             // instructions till after the call.
             let mut outputs = InstOutput::new();
             let mut retval_insts: crate::machinst::abi::SmallInstVec<_> = smallvec::smallvec![];
-            for i in 0..num_rets {
-                // We take the *last* `num_rets` returns of the sig:
-                // this skips a StructReturn, if any, that is present.
+            // We take the *last* `num_rets` returns of the sig:
+            // this skips a StructReturn, if any, that is present.
+            let sigdata = &self.lower_ctx.sigs()[abi];
+            debug_assert!(num_rets <= sigdata.num_rets());
+            for i in (sigdata.num_rets() - num_rets)..sigdata.num_rets() {
                 let sigdata = &self.lower_ctx.sigs()[abi];
-                let idx = (sigdata.num_rets() - num_rets) + i;
-                let ret = sigdata.get_ret(idx);
+                let ret = sigdata.get_ret(i);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();
                 retval_insts.extend(
                     caller

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -475,7 +475,6 @@ block0(v0: i64):
 ;   mov x8, x0
 ;   ldr x4, 8 ; b 12 ; data TestCase(%g) + 0
 ;   blr x4
-;   mov x0, x8
 ;   ldp fp, lr, [sp], #16
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -33,6 +33,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsi, %rdi
 ;   load_ext_name %f2+0, %r8
 ;   call    *%r8
+;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -47,10 +48,15 @@ block0(v0: i64):
 
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %r15, 0(%rsp)
 ; block0:
-;   movq    %rdi, %rax
+;   movq    %rdi, %r15
 ;   load_ext_name %f4+0, %rdx
 ;   call    *%rdx
+;   movq    %r15, %rax
+;   movq    0(%rsp), %r15
+;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
The legalization of `StructReturn` was causing issues in the new call-handling code: the `StructReturn` ret was included in the `SigData` as if it were an actual CLIF-level return value, but it is not.

Prior to using regalloc constraints for return values, we unconditionally included rax (or the architecture's usual return register) as a def, so it would be properly handled as "clobbered" by the regalloc. With the new scheme, we include defs on the call only for CLIF-level outputs. Callees with `StructReturn` args were thus not known to clobber the return-value register, and values might be corrupted.

This PR updates the code to include a `StructReturn` ret as a clobber rather than a returned value in the relevant spots. I observed it causing saves/restores of rax in some CLIF that @bjorn3 provided me, but I was having difficulty minimizing this into a test-case that I would be comfortable including as a precise-output case (including the whole thing verbatim would lock down a bunch of other irrelevant details and cause test-update noise later). If we can find a more minimized example I'm happy to include it as a filetest.

Fixes? #5018 (cc @bjorn3 to confirm?).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
