### PR TITLE
Documentation: Fix broken WASI ABI link

### DIFF
--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -572,7 +572,7 @@ impl<T> Linker<T> {
     /// Ordinary modules which don't declare themselves to be either Commands
     /// or Reactors are treated as Reactors without any initialization calls.
     ///
-    /// [Commands and Reactors]: https://github.com/WebAssembly/WASI/blob/master/design/application-abi.md#current-unstable-abi
+    /// [Commands and Reactors]: https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Fixing a broken link I came across as I was reading the Linker documentation.