### PR TITLE
wasmtime-component-macro: struct and consts created for flags! must be pub

### DIFF
--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -1133,8 +1133,17 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
         impl #name {
             #constants
 
-            fn as_array(&self) -> [u32; #count] {
+            pub fn as_array(&self) -> [u32; #count] {
                 #as_array
+            }
+
+            pub fn empty() -> Self {
+                Self::default()
+            }
+
+            pub fn all() -> Self {
+                use std::ops::Not;
+                Self::default().not()
             }
         }
 

--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -1081,7 +1081,7 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
 
         let name = format_ident!("{}", name);
 
-        constants.extend(quote!(const #name: Self = Self { #fields };));
+        constants.extend(quote!(pub const #name: Self = Self { #fields };));
     }
 
     let generics = syn::Generics {
@@ -1128,7 +1128,7 @@ fn expand_flags(flags: &Flags) -> Result<TokenStream> {
 
     let expanded = quote! {
         #[derive(Copy, Clone, Default)]
-        struct #name { #fields }
+        pub struct #name { #fields }
 
         impl #name {
             #constants


### PR DESCRIPTION
Previously this created a private type, and private consts.

I also added `fn all() -> Self` and `fn empty() -> Self` constructors, because those are the two "most popular" functions from `bitflags` I stole for the sake of some tests. empty ends up being the same as Default, and all is `.empty().not()`, so these don't require any actual code generation.

Future work might consider adding the rest of the bitflags methods & impls, and putting the docs through the macro into rustdocs.