### PR TITLE
fuzzgen: Always generate reachable blocks

### DIFF
--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -33,6 +33,10 @@ impl JumpTableData {
             table: Vec::with_capacity(capacity),
         }
     }
+    /// Create a new jump table with the provided blocks
+    pub fn with_blocks(table: Vec<Block>) -> Self {
+        Self { table }
+    }
 
     /// Get the number of table entries.
     pub fn len(&self) -> usize {

--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -16,10 +16,7 @@ pub struct Config {
     /// This value does not apply to block0 which takes the function params
     /// and is thus governed by `signature_params`
     pub block_signature_params: RangeInclusive<usize>,
-    /// Max number of jump tables generated per function
-    /// Note, the actual number of jump tables may be larger if the Switch interface
-    /// decides to insert more.
-    pub jump_tables_per_function: RangeInclusive<usize>,
+    /// Max number of jump tables entries to generate
     pub jump_table_entries: RangeInclusive<usize>,
 
     /// The Switch API specializes either individual blocks or contiguous ranges.
@@ -66,7 +63,6 @@ impl Default for Config {
             vars_per_function: 0..=16,
             blocks_per_function: 0..=16,
             block_signature_params: 0..=16,
-            jump_tables_per_function: 0..=4,
             jump_table_entries: 0..=16,
             switch_cases: 0..=64,
             // Ranges smaller than 2 don't make sense.

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1209,6 +1209,9 @@ where
                     .forward_blocks_without_params(block)
                     .contains(&next_block);
 
+                // BrTable and the Switch interface only allow targeting blocks without params
+                // thus we can only target them if we have some blocks that were generated without
+                // params.
                 if has_paramless_targets && next_block_is_paramless {
                     // BrTable
                     // At least one of the options must be the next block

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -24,9 +24,7 @@ fn arbitrary_vec<T: Clone>(
     len: usize,
     options: &[T],
 ) -> arbitrary::Result<Vec<T>> {
-    (0..len)
-        .map(|_| u.choose(options).cloned())
-        .collect()
+    (0..len).map(|_| u.choose(options).cloned()).collect()
 }
 
 type BlockSignature = Vec<Type>;

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1187,10 +1187,9 @@ where
             .map(|&(block, _)| {
                 let next_block = Block::with_number(block.as_u32() + 1).unwrap();
                 let forward_blocks = self.resources.forward_blocks(block);
-                let forward_blocks_without_params =
-                    self.resources.forward_blocks_without_params(block);
-                let has_paramless_targets = !forward_blocks_without_params.is_empty();
-                let next_block_is_paramless = forward_blocks_without_params.contains(&next_block);
+                let paramless_targets = self.resources.forward_blocks_without_params(block);
+                let has_paramless_targets = !paramless_targets.is_empty();
+                let next_block_is_paramless = paramless_targets.contains(&next_block);
 
                 let mut valid_terminators = vec![];
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -25,7 +25,7 @@ fn arbitrary_vec<T: Clone>(
     options: &[T],
 ) -> arbitrary::Result<Vec<T>> {
     (0..len)
-        .map(|_| u.choose(options).map(Clone::clone))
+        .map(|_| u.choose(options).cloned())
         .collect()
 }
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1209,8 +1209,8 @@ where
                 }
 
                 // BrTable and the Switch interface only allow targeting blocks without params
-                // thus we can only target them if we have some blocks that were generated without
-                // params.
+                // we also need to ensure that the next block has no params, since that one is
+                // guaranteed to be picked in either case.
                 if has_paramless_targets && next_block_is_paramless {
                     valid_terminators.extend_from_slice(&[
                         BlockTerminatorKind::BrTable,


### PR DESCRIPTION
👋 Hey,

This PR alters fuzzgen to always generate reachable blocks. See #5022 for context.

We do this by making sure that whenever we insert terminators at least one of the edges points to the next block. 

Another thing this PR does is separate the CFG construction from block terminator insertion.

This fuzzed ok individually, but I'm now also testing with #5020 on top to see if it finds anything else.

cc: @jameysharp 