### PR TITLE
Cranelift: Make `Opcode` represented as a `u8` instead of `u16` and remove vestigial conversion impls

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -405,7 +405,7 @@ fn gen_opcodes(all_inst: &AllInstructions, fmt: &mut Formatter) {
         All instructions from all supported ISAs are present.
     "#,
     );
-    fmt.line("#[repr(u16)]");
+    fmt.line("#[repr(u8)]");
     fmt.line("#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]");
     fmt.line(
         r#"#[cfg_attr(
@@ -573,11 +573,11 @@ fn gen_opcodes(all_inst: &AllInstructions, fmt: &mut Formatter) {
 }
 
 fn gen_try_from(all_inst: &AllInstructions, fmt: &mut Formatter) {
-    fmt.line("impl core::convert::TryFrom<u16> for Opcode {");
+    fmt.line("impl core::convert::TryFrom<u8> for Opcode {");
     fmt.indent(|fmt| {
         fmt.line("type Error = ();");
         fmt.line("#[inline]");
-        fmt.line("fn try_from(x: u16) -> Result<Self, ()> {");
+        fmt.line("fn try_from(x: u8) -> Result<Self, ()> {");
         fmt.indent(|fmt| {
             fmtln!(fmt, "if 0 < x && x <= {} {{", all_inst.len());
             fmt.indent(|fmt| fmt.line("Ok(unsafe { core::mem::transmute(x) })"));

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -572,24 +572,6 @@ fn gen_opcodes(all_inst: &AllInstructions, fmt: &mut Formatter) {
     fmt.empty_line();
 }
 
-fn gen_try_from(all_inst: &AllInstructions, fmt: &mut Formatter) {
-    fmt.line("impl core::convert::TryFrom<u8> for Opcode {");
-    fmt.indent(|fmt| {
-        fmt.line("type Error = ();");
-        fmt.line("#[inline]");
-        fmt.line("fn try_from(x: u8) -> Result<Self, ()> {");
-        fmt.indent(|fmt| {
-            fmtln!(fmt, "if 0 < x && x <= {} {{", all_inst.len());
-            fmt.indent(|fmt| fmt.line("Ok(unsafe { core::mem::transmute(x) })"));
-            fmt.line("} else {");
-            fmt.indent(|fmt| fmt.line("Err(())"));
-            fmt.line("}");
-        });
-        fmt.line("}");
-    });
-    fmt.line("}");
-}
-
 /// Get the value type constraint for an SSA value operand, where
 /// `ctrl_typevar` is the controlling type variable.
 ///
@@ -1420,8 +1402,6 @@ pub(crate) fn generate(
     gen_opcodes(all_inst, &mut fmt);
     fmt.empty_line();
     gen_type_constraints(all_inst, &mut fmt);
-    fmt.empty_line();
-    gen_try_from(all_inst, &mut fmt);
     fmt.update_file(opcode_filename, out_dir)?;
 
     // ISLE DSL.

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -82,7 +82,7 @@ impl TryFrom<NonZeroU32> for Opcode {
 
     #[inline]
     fn try_from(x: NonZeroU32) -> Result<Self, ()> {
-        let x: u16 = x.get().try_into().map_err(|_| ())?;
+        let x: u8 = x.get().try_into().map_err(|_| ())?;
         Self::try_from(x)
     }
 }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -7,9 +7,7 @@
 //! directory.
 
 use alloc::vec::Vec;
-use core::convert::{TryFrom, TryInto};
 use core::fmt::{self, Display, Formatter};
-use core::num::NonZeroU32;
 use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
 
@@ -74,24 +72,6 @@ impl Opcode {
             Opcode::ResumableTrap | Opcode::ResumableTrapnz => true,
             _ => false,
         }
-    }
-}
-
-impl TryFrom<NonZeroU32> for Opcode {
-    type Error = ();
-
-    #[inline]
-    fn try_from(x: NonZeroU32) -> Result<Self, ()> {
-        let x: u8 = x.get().try_into().map_err(|_| ())?;
-        Self::try_from(x)
-    }
-}
-
-impl From<Opcode> for NonZeroU32 {
-    #[inline]
-    fn from(op: Opcode) -> NonZeroU32 {
-        let x = op as u8;
-        NonZeroU32::new(x as u32).unwrap()
     }
 }
 


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
