### PR TITLE
Cranelift: Derive `Copy` for `InstructionData`

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -71,17 +71,16 @@ fn gen_formats(formats: &[&InstructionFormat], fmt: &mut Formatter) {
 /// the SSA `Value` arguments.
 fn gen_instruction_data(formats: &[&InstructionFormat], fmt: &mut Formatter) {
     for (name, include_args) in &[("InstructionData", true), ("InstructionImms", false)] {
-        fmt.line("#[derive(Clone, Debug, PartialEq, Hash)]");
+        fmt.line("#[derive(Copy, Clone, Debug, PartialEq, Hash)]");
         if !include_args {
-            // `InstructionImms` gets some extra derives: it acts like
-            // a sort of extended opcode and we want to allow for
-            // hashconsing via Eq. `Copy` also turns out to be useful.
-            fmt.line("#[derive(Copy, Eq)]");
+            // `InstructionImms` gets some extra derives: it acts like a sort of
+            // extended opcode and we want to allow for hashconsing via `Eq`.
+            fmt.line("#[derive(Eq)]");
         }
         fmt.line(r#"#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]"#);
         fmt.line("#[allow(missing_docs)]");
-        // generate `enum InstructionData` or `enum InstructionImms`.
-        // (This comment exists so one can grep for `enum InstructionData`!)
+        // Generate `enum InstructionData` or `enum InstructionImms`. (This
+        // comment exists so one can grep for `enum InstructionData`!)
         fmtln!(fmt, "pub enum {} {{", name);
         fmt.indent(|fmt| {
             for format in formats {

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -386,7 +386,7 @@ impl FunctionStencil {
             .zip(self.dfg.inst_results(src))
             .all(|(a, b)| self.dfg.value_type(*a) == self.dfg.value_type(*b)));
 
-        self.dfg[dst] = self.dfg[src].clone();
+        self.dfg[dst] = self.dfg[src];
         self.layout.remove_inst(src);
     }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -762,6 +762,13 @@ mod tests {
     }
 
     #[test]
+    fn inst_data_size() {
+        // The size of `InstructionData` is performance sensitive, so make sure
+        // we don't regress it unintentionally.
+        assert_eq!(std::mem::size_of::<InstructionData>(), 16);
+    }
+
+    #[test]
     fn opcodes() {
         use core::mem;
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -756,6 +756,12 @@ mod tests {
     use alloc::string::ToString;
 
     #[test]
+    fn inst_data_is_copy() {
+        fn is_copy<T: Copy>() {}
+        is_copy::<InstructionData>();
+    }
+
+    #[test]
     fn opcodes() {
         use core::mem;
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -226,7 +226,7 @@ macro_rules! isle_lower_prelude_methods {
 
         #[inline]
         fn inst_data(&mut self, inst: Inst) -> InstructionData {
-            self.lower_ctx.dfg()[inst].clone()
+            self.lower_ctx.dfg()[inst]
         }
 
         #[inline]

--- a/cranelift/codegen/src/simple_gvn.rs
+++ b/cranelift/codegen/src/simple_gvn.rs
@@ -115,7 +115,7 @@ pub fn do_simple_gvn(func: &mut Function, domtree: &mut DominatorTree) {
 
             let ctrl_typevar = func.dfg.ctrl_typevar(inst);
             let key = HashKey {
-                inst: func.dfg[inst].clone(),
+                inst: func.dfg[inst],
                 ty: ctrl_typevar,
                 pos: &pos,
             };


### PR DESCRIPTION
And update `clone` calls to be copies.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
