### PR TITLE
Revert "Disable wasi-nn CI tests due to breakage (404'ing package repository). (#5028)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -342,6 +342,21 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
+  # Build and test the wasi-nn module.
+  test_wasi_nn:
+    name: Test wasi-nn module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: ./.github/actions/install-rust
+      - run: rustup target add wasm32-wasi
+      - uses: abrown/install-openvino-action@v3
+      - run: ./ci/run-wasi-nn-example.sh
+        env:
+          RUST_BACKTRACE: 1
+
   # Build and test the wasi-crypto module.
   test_wasi_crypto:
     name: Test wasi-crypto module


### PR DESCRIPTION
This reverts commit 4f8b94163c2d22771a7f350c7b83c3200c842479. The APT repository for OpenVINO should be restored to its original state.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
