### PR TITLE
cranelift: Fix i128 iconst on AArch64 with egraphs

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -16,8 +16,13 @@
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type ty (iconst (u64_from_imm64 n))))
+(rule (lower (has_type (fits_in_64 ty) (iconst (u64_from_imm64 n))))
       (imm ty (ImmExtend.Zero) n))
+
+(rule 1 (lower (has_type $I128 (iconst (u64_from_imm64 n))))
+      (value_regs
+            (imm $I64 (ImmExtend.Zero) n)
+            (imm $I64 (ImmExtend.Zero) 0)))
 
 ;;;; Rules for `bconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/runtests/i128-const-egraphs.clif
+++ b/cranelift/filetests/filetests/runtests/i128-const-egraphs.clif
@@ -1,0 +1,16 @@
+test interpret
+test run
+set enable_llvm_abi_extensions=true
+set opt_level=speed_and_size
+set use_egraphs=true
+target aarch64
+target s390x
+target x86_64
+target riscv64
+
+function %i128_const_0() -> i128 {
+block0:
+    v1 = iconst.i128 0
+    return v1
+}
+; run: %i128_const_0() == 0


### PR DESCRIPTION
👋 Hey,

This is the first of the bugs that the fuzzer found in the new egraph work. On AArch64 `iconst.i128` is not implemented. This PR implements it for values that fit in a u64, which is (I think) all the values that can be passed in by the frontend.

We've had discussions in the past about removing `iconst.i128` (I can't find the link), and I think I've previously disagreed with this, but maybe we can restrict `iconst` to `i64` and add a helper method to the frontend that does the right thing? so, for example for -1 we can lower it to `iconst.i64 -1` + `sextend`, or `iconst` + `iconst` + `iconcat` for other values etc..

What do you guys think about that?

cc: @cfallin 