### PR TITLE
Ignore when components export type definitions

### DIFF
--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -469,15 +469,13 @@ impl ComponentTypesBuilder {
                 self.core_outer_type(0, TypeIndex::from_u32(*ty))
             }
             wasmparser::ComponentTypeRef::Func(ty)
+            | wasmparser::ComponentTypeRef::Type(_, ty)
             | wasmparser::ComponentTypeRef::Instance(ty)
             | wasmparser::ComponentTypeRef::Component(ty) => {
                 self.component_outer_type(0, ComponentTypeIndex::from_u32(*ty))
             }
             wasmparser::ComponentTypeRef::Value(..) => {
                 unimplemented!("references to value types");
-            }
-            wasmparser::ComponentTypeRef::Type(..) => {
-                unimplemented!("references to types");
             }
         }
     }

--- a/crates/wasmtime/src/component/matching.rs
+++ b/crates/wasmtime/src/component/matching.rs
@@ -72,6 +72,12 @@ impl TypeChecker<'_> {
         // the actual type. It's ok, though, to have extra exports in the actual
         // type.
         for (name, expected) in expected.exports.iter() {
+            // Interface types may be exported from a component in order to give them a name, but
+            // they don't have a definition in the sense that this search is interested in, so
+            // ignore them.
+            if let TypeDef::Interface(_) = expected {
+                continue;
+            }
             let actual = self
                 .strings
                 .lookup(name)

--- a/tests/misc_testsuite/component-model/instance.wast
+++ b/tests/misc_testsuite/component-model/instance.wast
@@ -181,6 +181,12 @@
 
 (component
   (import "host" (instance $i
+    (type $rec (record (field "x" (record)) (field "y" string)))
+    (export "some-record" (type (eq $rec)))))
+)
+
+(component
+  (import "host" (instance $i
     (export "nested" (instance
       (export "return-four" (func (result u32)))
     ))


### PR DESCRIPTION
As of https://github.com/bytecodealliance/wit-bindgen/pull/369, wit-component will export interface types in order to give them names.

We now accept type for mapping to a component TypeDef in wasmtime-environ.

Type exports do not have definitions which Wasmtime can match to a `Definition`, so we now skip inspecting them in the component/matching.rs file.

A test case has been added to component-model/instance.wast.