### PR TITLE
Minor changes for components related to wit-bindgen support

### DIFF
--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -152,6 +152,7 @@ pub enum Export {
     ModuleStatic(StaticModuleIndex),
     ModuleImport(RuntimeImportIndex),
     Instance(IndexMap<String, Export>),
+    Type(TypeDef),
 }
 
 /// Same as `info::CoreDef`, except has an extra `Adapter` variant.
@@ -430,6 +431,7 @@ impl LinearizeDfg<'_> {
                     .map(|(name, export)| (name.clone(), self.export(export)))
                     .collect(),
             ),
+            Export::Type(def) => info::Export::Type(*def),
         }
     }
 

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -411,6 +411,9 @@ pub enum Export {
     /// A nested instance is being exported which has recursively defined
     /// `Export` items.
     Instance(IndexMap<String, Export>),
+    /// An exported type from a component or instance, currently only
+    /// informational.
+    Type(TypeDef),
 }
 
 /// Canonical ABI options associated with a lifted or lowered function.

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -471,7 +471,8 @@ impl ComponentTypesBuilder {
             wasmparser::ComponentTypeRef::Func(ty)
             | wasmparser::ComponentTypeRef::Type(_, ty)
             | wasmparser::ComponentTypeRef::Instance(ty)
-            | wasmparser::ComponentTypeRef::Component(ty) => {
+            | wasmparser::ComponentTypeRef::Component(ty)
+            | wasmparser::ComponentTypeRef::Type(wasmparser::TypeBounds::Eq, ty) => {
                 self.component_outer_type(0, ComponentTypeIndex::from_u32(*ty))
             }
             wasmparser::ComponentTypeRef::Value(..) => {

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -469,10 +469,9 @@ impl ComponentTypesBuilder {
                 self.core_outer_type(0, TypeIndex::from_u32(*ty))
             }
             wasmparser::ComponentTypeRef::Func(ty)
-            | wasmparser::ComponentTypeRef::Type(_, ty)
+            | wasmparser::ComponentTypeRef::Type(wasmparser::TypeBounds::Eq, ty)
             | wasmparser::ComponentTypeRef::Instance(ty)
-            | wasmparser::ComponentTypeRef::Component(ty)
-            | wasmparser::ComponentTypeRef::Type(wasmparser::TypeBounds::Eq, ty) => {
+            | wasmparser::ComponentTypeRef::Component(ty) => {
                 self.component_outer_type(0, ComponentTypeIndex::from_u32(*ty))
             }
             wasmparser::ComponentTypeRef::Value(..) => {

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -40,6 +40,13 @@ pub struct ModuleTranslation<'data> {
     /// Module information.
     pub module: Module,
 
+    /// The input wasm binary.
+    ///
+    /// This can be useful, for example, when modules are parsed from a
+    /// component and the embedder wants access to the raw wasm modules
+    /// themselves.
+    pub wasm: &'data [u8],
+
     /// References to the function bodies.
     pub function_body_inputs: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'data>>,
 
@@ -162,6 +169,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
         parser: Parser,
         data: &'data [u8],
     ) -> WasmResult<ModuleTranslation<'data>> {
+        self.result.wasm = data;
+
         for payload in parser.parse_all(data) {
             self.translate_payload(payload?)?;
         }

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -578,7 +578,7 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
                 func,
                 options,
             )),
-            Export::Module(_) | Export::Instance(_) => None,
+            Export::Module(_) | Export::Instance(_) | Export::Type(_) => None,
         }
     }
 


### PR DESCRIPTION
My [plan for wit-bindgen](https://github.com/bytecodealliance/wit-bindgen/issues/314) is to use the `wasmtime-environ` crate to parse an input component binary to generate host bindings. Leveraging `wasmtime-environ` should help offload almost all of the really complex handling of things like adapter modules, dataflow within a component, what exactly needs lifting/lowering where, etc. To that end though I have a few changes here for miscellaneous support in `wit-bindgen` of pieces required.