### PR TITLE
egraph opts: fix uextend-of-i32.

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -96,6 +96,11 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn u64_uextend_u32(&mut self, x: u64) -> Option<u64> {
+            Some(x & 0xffff_ffff)
+        }
+
+        #[inline]
         fn ty_bits(&mut self, ty: Type) -> Option<u8> {
             use std::convert::TryInto;
             Some(ty.bits().try_into().unwrap())

--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -7,8 +7,8 @@
 ;; can freely rewrite e.g. `x+y-y` to `x`.
 
 ;; uextend/sextend of a constant.
-(rule (simplify (uextend $I64 (iconst $I32 imm)))
-      (iconst $I64 imm))
+(rule (simplify (uextend $I64 (iconst $I32 (u64_from_imm64 imm))))
+      (iconst $I64 (imm64 (u64_uextend_u32 imm))))
 (rule (simplify (sextend $I64 (iconst $I32 (u64_from_imm64 imm))))
       (iconst $I64 (imm64 (u64_sextend_u32 imm))))
 

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -125,6 +125,9 @@
 (decl pure u64_sextend_u32 (u64) u64)
 (extern constructor u64_sextend_u32 u64_sextend_u32)
 
+(decl pure u64_uextend_u32 (u64) u64)
+(extern constructor u64_uextend_u32 u64_uextend_u32)
+
 (decl u64_is_zero (bool) u64)
 (extern extractor infallible u64_is_zero u64_is_zero)
 

--- a/cranelift/filetests/filetests/egraph/algebraic.clif
+++ b/cranelift/filetests/filetests/egraph/algebraic.clif
@@ -3,11 +3,20 @@ set opt_level=none
 set use_egraphs=true
 target x86_64
 
-function %f(i32) -> i32 {
+function %f0(i32) -> i32 {
 block0(v0: i32):
     v1 = iconst.i32 2
     v2 = imul v0, v1
     ; check: v1 = iadd v0, v0
     ; nextln: return v1
     return v2
+}
+
+function %f1() -> i64 {
+block0:
+  v0 = iconst.i32 0xffff_ffff_9876_5432
+  v1 = uextend.i64 v0
+  return v1
+  ; check: v0 = iconst.i64 0x9876_5432
+  ; nextln: return v0  ; v0 = 0x9876_5432
 }


### PR DESCRIPTION
This is a simple error in the const-prop rules: uextend was not masking iconst's u64 immediate when extending from i32 to i64. Arguably an iconst.i32 should not have nonzero bits in the upper 32 of its immediate, but that's a separate design question. For now, if our invariant is that the upper bits are ignored, then it is required to mask the bits when const-evaling a `uextend`.

Fixes #5047.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
