### PR TITLE
Wasmtime: run all spec tests with Cranelift-with-egraphs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -102,8 +102,9 @@ fn test_directory(
 
     let testsuite = &extract_name(path);
     for entry in dir_entries.iter() {
-        write_testsuite_tests(out, entry, testsuite, strategy, false)?;
-        write_testsuite_tests(out, entry, testsuite, strategy, true)?;
+        write_testsuite_tests(out, entry, testsuite, strategy, false, false)?;
+        write_testsuite_tests(out, entry, testsuite, strategy, true, false)?;
+        write_testsuite_tests(out, entry, testsuite, strategy, false, true)?;
     }
 
     Ok(dir_entries.len())
@@ -141,6 +142,7 @@ fn write_testsuite_tests(
     testsuite: &str,
     strategy: &str,
     pooling: bool,
+    egraphs: bool,
 ) -> anyhow::Result<()> {
     let path = path.as_ref();
     let testname = extract_name(path);
@@ -155,15 +157,22 @@ fn write_testsuite_tests(
         out,
         "fn r#{}{}() {{",
         &testname,
-        if pooling { "_pooling" } else { "" }
+        if pooling {
+            "_pooling"
+        } else if egraphs {
+            "_egraphs"
+        } else {
+            ""
+        }
     )?;
     writeln!(out, "    let _ = env_logger::try_init();")?;
     writeln!(
         out,
-        "    crate::wast::run_wast(r#\"{}\"#, crate::wast::Strategy::{}, {}).unwrap();",
+        "    crate::wast::run_wast(r#\"{}\"#, crate::wast::Strategy::{}, {}, {}).unwrap();",
         path.display(),
         strategy,
-        pooling
+        pooling,
+        egraphs,
     )?;
     writeln!(out, "}}")?;
     writeln!(out)?;

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -12,7 +12,7 @@ include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
 // Each of the tests included from `wast_testsuite_tests` will call this
 // function which actually executes the `wast` test suite given the `strategy`
 // to compile it.
-fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()> {
+fn run_wast(wast: &str, strategy: Strategy, pooling: bool, egraphs: bool) -> anyhow::Result<()> {
     drop(env_logger::try_init());
 
     match strategy {
@@ -30,6 +30,11 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
         .wasm_threads(threads)
         .wasm_memory64(memory64)
         .cranelift_debug_verifier(true);
+    if egraphs {
+        unsafe {
+            cfg.cranelift_flag_enable("use_egraphs");
+        }
+    }
 
     cfg.wasm_component_model(feature_found(wast, "component-model"));
 


### PR DESCRIPTION
This change adds another variant of the spec-tests run as part of the `wasmtime-cli` crate's unit tests: Cranelift with egraph-based optimizations enabled.

We intend to test egraphs in various ways before turning the mechanism on by default. We will certainly fuzz differentially, but it is also useful to run our basic testsuite against the new compiler mid-end as part of normal CI. There is already precedent for running the spec tests with a variant of settings (the `_pooling` versions of each test). The actual spec testsuite execution does not contribute appreciably to CI time compared to the time to compile Wasmtime itself, so running an extra variant of the tests should not increase test cost significantly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
