### PR TITLE
Add egraphs option to Wasmtime config, and add it to fuzzing config generation.

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -163,6 +163,7 @@ impl Config {
             .native_unwind_info(self.wasmtime.native_unwind_info)
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)
             .cranelift_opt_level(self.wasmtime.opt_level.to_wasmtime())
+            .cranelift_use_egraphs(self.wasmtime.use_egraphs)
             .consume_fuel(self.wasmtime.consume_fuel)
             .epoch_interruption(self.wasmtime.epoch_interruption)
             .memory_init_cow(self.wasmtime.memory_init_cow)
@@ -369,6 +370,7 @@ impl<'a> Arbitrary<'a> for Config {
 #[derive(Arbitrary, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WasmtimeConfig {
     opt_level: OptLevel,
+    use_egraphs: bool,
     debug_info: bool,
     canonicalize_nans: bool,
     interruptable: bool,

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -304,9 +304,10 @@ impl Config {
         // Don't propagate these errors to prevent them from accidentally being
         // interpreted as invalid wasm, these should never fail on a
         // well-behaved host system.
-        let file = tempfile::NamedTempFile::new().unwrap();
-        std::fs::write(file.path(), module.serialize().unwrap()).unwrap();
-        unsafe { Ok(Module::deserialize_file(engine, file.path()).unwrap()) }
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("module.wasm");
+        std::fs::write(&file, module.serialize().unwrap()).unwrap();
+        unsafe { Ok(Module::deserialize_file(engine, &file).unwrap()) }
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -853,6 +853,27 @@ impl Config {
         self
     }
 
+    /// Configures the Cranelift code generator to use its
+    /// "egraph"-based mid-end optimizer.
+    ///
+    /// This optimizer is intended to replace the compiler's more
+    /// traditional pipeline of optimization passes with a unified
+    /// code-rewriting system. It is not yet on by default, but it is
+    /// intended to become the default in a future version. It may
+    /// result in faster code, at the cost of slightly more
+    /// compilation-time work.
+    ///
+    /// The default value for this is `false`.
+    #[cfg(compiler)]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
+    pub fn cranelift_use_egraphs(&mut self, enable: bool) -> &mut Self {
+        let val = if enable { "true" } else { "false" };
+        self.compiler_config
+            .settings
+            .insert("use_egraphs".to_string(), val.to_string());
+        self
+    }
+
     /// Configures whether Cranelift should perform a NaN-canonicalization pass.
     ///
     /// When Cranelift is used as a code generation backend this will configure


### PR DESCRIPTION
This PR adds a wrapper method for Cranelift's `use_egraphs` setting to Wasmtime's `Config`, named `cranelift_use_egraphs` analogously to its existing `cranelift_opt_level`.

Eventually this should become a no-op as egraph-based optimization becomes the default, but until then it makes sense to expose this as another kind of optimization option.

This PR then adds the option to the `Arbitrary`-based config generation for fuzzing, so compilation with egraphs will be fuzzed (on its own and against other configurations and oracles).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
