### PR TITLE
Fix push tag workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -162,7 +162,7 @@ jobs:
             body="${body//'%'/'%25'}"
             body="${body//$'\n'/'%0A'}"
             body="${body//$'\r'/'%0D'}"
-            echo "::set-output name=body::$body"
+            echo "body=$body" >> $GITHUB_OUTPUT
 
       - name: Publish Results
         run: |

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -24,16 +24,16 @@ jobs:
       - name: Test if tag is needed
         run: |
           git log ${{ github.event.before }}...${{ github.event.after }} | tee main.log
-          version=$(grep 'version =' Cargo.toml | head -n 1 | sed 's/.*"\(.*\)"/\1/')
+          version=$(grep '^version =' Cargo.toml | head -n 1 | sed 's/.*"\(.*\)"/\1/')
           echo "version: $version"
-          echo "::set-output name=version::$version"
-          echo "::set-output name=sha::$(git rev-parse HEAD)"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
           if grep -q "automatically-tag-and-release-this-commit" main.log; then
             echo push-tag
-            echo "::set-output name=push_tag::yes"
+            echo "push_tag=yes" >> $GITHUB_OUTPUT
           else
             echo no-push-tag
-            echo "::set-output name=push_tag::no"
+            echo "push_tag=no" >> $GITHUB_OUTPUT
           fi
         id: tag
       - name: Push the tag


### PR DESCRIPTION
This commit fixes the `push-tag.yml` workflow to work with the new `Cargo.toml` manifest since workspace inheritance was added. This additionally fixes some warnings coming up on CI about our usage of deprecated features on github actions.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
