### PR TITLE
Increase attempts and timeout in publish script

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -156,7 +156,7 @@ fn main() {
             // publish in a loop and we remove crates once they're successfully
             // published. Failed-to-publish crates get enqueued for another try
             // later on.
-            for _ in 0..5 {
+            for _ in 0..10 {
                 crates.retain(|krate| !publish(krate));
 
                 if crates.is_empty() {
@@ -167,7 +167,7 @@ fn main() {
                     "{} crates failed to publish, waiting for a bit to retry",
                     crates.len(),
                 );
-                thread::sleep(Duration::from_secs(20));
+                thread::sleep(Duration::from_secs(40));
             }
 
             assert!(crates.is_empty(), "failed to publish all crates");


### PR DESCRIPTION
The 2.0.0 publication failed due to the index not being updated, so do more attempts and wait longer to try to get things working.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
