### PR TITLE
Fix some egraph-related issues.

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -523,7 +523,7 @@ impl ValueDataPacked {
 
     #[inline(always)]
     fn set_type(&mut self, ty: Type) {
-        self.0 &= !((1 << Self::TYPE_BITS) - 1) << Self::TYPE_SHIFT;
+        self.0 &= !(((1 << Self::TYPE_BITS) - 1) << Self::TYPE_SHIFT);
         self.0 |= (ty.repr() as u64) << Self::TYPE_SHIFT;
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -114,7 +114,7 @@
 
 ;;;; Rules for `isplit` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $I64 (isplit x)))
+(rule (lower (isplit x @ (value_type $I128)))
       (let
           ((x_regs ValueRegs x)
            (x_lo ValueRegs (value_regs_get x_regs 0))

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -60,7 +60,7 @@
 
 ;;;; Rules for `isplit` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type (gpr64_ty ty) (isplit x)))
+(rule (lower (isplit x @ (value_type $I128)))
       (let ((x_reg Reg x)
             (x_hi Reg (vec_extract_lane $I64X2 x_reg 0 (zero_reg)))
             (x_lo Reg (vec_extract_lane $I64X2 x_reg 1 (zero_reg))))

--- a/cranelift/filetests/filetests/egraph/isplit.clif
+++ b/cranelift/filetests/filetests/egraph/isplit.clif
@@ -5,6 +5,7 @@ set use_egraphs=true
 set enable_llvm_abi_extensions=true
 target x86_64
 target aarch64
+target s390x
 
 function %a(i128) -> i32 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/egraph/isplit.clif
+++ b/cranelift/filetests/filetests/egraph/isplit.clif
@@ -1,0 +1,17 @@
+test interpret
+test run
+set opt_level=speed_and_size
+set use_egraphs=true
+set enable_llvm_abi_extensions=true
+target x86_64
+target aarch64
+
+function %a(i128) -> i32 {
+block0(v0: i128):
+  v1 = iconst.i32 -1
+  v2, v3 = isplit v0
+  v4 = ushr v1, v3
+  return v4
+}
+
+; run: %a(871558149430564685057836279141) == 2147483647


### PR DESCRIPTION
This fixes #5086 by addressing two separate issues:

- The `ValueDataPacked::set_type()` helper had an embarrassing bitfield-manipulation bug that would mangle the rest of a `ValueDef` when setting its type. This is not normally used, only when the egraph elaboration fills in types after-the-fact on a multi-value node.
- The lowering rules for `isplit` on aarch64 and s390x were dispatching on the first output type, rather than the input type. When only the second output is used (as in the example in #5086), the first output type actually remains `INVALID` (and this is fine because it's never used).