### PR TITLE
Cranelift: Remove duplicate IR signature legalizations

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -773,8 +773,7 @@ impl SigSet {
         // `ir::Signature`.
         debug_assert!(!self.have_abi_sig_for_signature(&signature));
 
-        let legalized_signature = crate::machinst::ensure_struct_return_ptr_is_returned(&signature);
-        let sig_data = SigData::from_func_sig::<M>(&legalized_signature, flags)?;
+        let sig_data = SigData::from_func_sig::<M>(&signature, flags)?;
         let sig = self.sigs.push(sig_data);
         self.ir_signature_to_abi_sig.insert(signature, sig);
         Ok(sig)
@@ -793,8 +792,7 @@ impl SigSet {
             return Ok(sig);
         }
         let signature = &dfg.signatures[sig_ref];
-        let legalized_signature = crate::machinst::ensure_struct_return_ptr_is_returned(&signature);
-        let sig_data = SigData::from_func_sig::<M>(&legalized_signature, flags)?;
+        let sig_data = SigData::from_func_sig::<M>(signature, flags)?;
         let sig = self.sigs.push(sig_data);
         self.ir_sig_ref_to_abi_sig[sig_ref] = Some(sig);
         Ok(sig)


### PR DESCRIPTION
The `SigData::from_func_sig` constructor will already ensure that the struct return pointer is returned, so this is a purely unnecessary call.

Note that this is not a performance speed up, since `ensure_struct_return_ptr_is_returned` doesn't do any significant work if the signature is already legalized.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
