### PR TITLE
Cranelift: use `.enumerate()` to avoid indexing in s390x backend

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -245,9 +245,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             next_gpr += 1;
         }
 
-        for i in 0..params.len() {
-            let mut param = params[i];
-
+        for (i, mut param) in params.iter().copied().enumerate() {
             let intreg = in_int_reg(param.value_type);
             let fltreg = in_flt_reg(param.value_type);
             let vecreg = in_vec_reg(param.value_type);


### PR DESCRIPTION
This can help rustc/llvm avoid bounds checks, but more importantly I will have future changes here that remove indexing of params, and instead hand them out as an iterator.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
