### PR TITLE
Fix accidental infinite loop in fuzz targets

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -53,10 +53,10 @@ fuzz_target!(|data: &[u8]| {
 
     // Errors in `run` have to do with not enough input in `data`, which we
     // ignore here since it doesn't affect how we'd like to fuzz.
-    drop(run(&data));
+    drop(execute_one(&data));
 });
 
-fn run(data: &[u8]) -> Result<()> {
+fn execute_one(data: &[u8]) -> Result<()> {
     STATS.bump_attempts();
 
     let mut u = Unstructured::new(data);

--- a/fuzz/fuzz_targets/instantiate-many.rs
+++ b/fuzz/fuzz_targets/instantiate-many.rs
@@ -12,10 +12,10 @@ const MAX_MODULES: usize = 5;
 fuzz_target!(|data: &[u8]| {
     // errors in `run` have to do with not enough input in `data`, which we
     // ignore here since it doesn't affect how we'd like to fuzz.
-    drop(run(data));
+    drop(execute_one(data));
 });
 
-fn run(data: &[u8]) -> Result<()> {
+fn execute_one(data: &[u8]) -> Result<()> {
     let mut u = Unstructured::new(data);
     let mut config: generators::Config = u.arbitrary()?;
 


### PR DESCRIPTION
The `libfuzzer-sys` update in #5068 included some changes to the `fuzz_target!` macro which caused a bare `run` function to be shadowed by the macro-defined `run` function (changed in
rust-fuzz/libfuzzer#95) which meant that some of our fuzz targets were infinite looping or stack overflowing as the same function was called indefinitely. This renames the top-level `run` function to something else in the meantime.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
