### PR TITLE
egraphs: fix fill-in-the-types logic for multiple projections of one value.

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -276,7 +276,7 @@ impl DataFlowGraph {
 
     /// Fill in the type of a value, only if currently invalid (as a placeholder).
     pub(crate) fn fill_in_value_type(&mut self, v: Value, ty: Type) {
-        debug_assert!(self.values[v].ty().is_invalid());
+        debug_assert!(self.values[v].ty().is_invalid() || self.values[v].ty() == ty);
         self.values[v].set_type(ty);
     }
 

--- a/cranelift/filetests/filetests/egraph/isplit.clif
+++ b/cranelift/filetests/filetests/egraph/isplit.clif
@@ -16,3 +16,14 @@ block0(v0: i128):
 }
 
 ; run: %a(871558149430564685057836279141) == 2147483647
+
+function %b(i128, i16) -> i16 {
+block0(v0: i128, v1: i16):
+    v2, v3 = isplit v0
+    v4 = rotr v1, v3
+    v5, v6 = isplit v0
+    v7 = rotr v4, v6
+    return v7
+}
+
+; run: %b(1234, 56) == 56


### PR DESCRIPTION
In particular, this was found to happen in #5099 because a `Result`
projection node was not deduplicating across two separate `isplit`s that
created it. (This is a separate issue we should also fix; `needs_dedup`
is I think overly conservative because `Result` can project out a single
value from a pure or impure node, but the projection itself should be
treated like any other pure operator.)

In any case, if we have a value `v0` and two separate
`Result { value: v0, result: N, ty }` nodes, each of these will fill in the
type `ty` for the `N`th output of `v0`, and the second will idempotently
overwrite the first; we should loosen the assert so that it allows this case.

Fixes #5099. Fixes #5100.