### PR TITLE
s390x: Fix handling of sret arguments

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -3511,6 +3511,9 @@
 (decl abi_sig (SigRef) Sig)
 (extern constructor abi_sig abi_sig)
 
+(decl abi_first_ret (SigRef Sig) usize)
+(extern constructor abi_first_ret abi_first_ret)
+
 (decl abi_call_info (Sig ExternalName CallArgList CallRetList Opcode) BoxCallInfo)
 (extern constructor abi_call_info abi_call_info)
 

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3892,7 +3892,8 @@
             (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args))
             (defs CallRetList (defs_init abi))
             (_ InstOutput (side_effect (abi_call abi name uses defs (Opcode.Call)))))
-        (lower_call_rets abi defs (range 0 (abi_num_rets abi)) (output_builder_new))))
+        (lower_call_rets abi defs (range (abi_first_ret sig_ref abi)
+                                         (abi_num_rets abi)) (output_builder_new))))
 
 ;; Direct call to an out-of-range function (implicitly via pointer).
 (rule (lower (call (func_ref_data sig_ref name _) args))
@@ -3902,7 +3903,8 @@
             (defs CallRetList (defs_init abi))
             (target Reg (load_symbol_reloc (SymbolReloc.Absolute name 0)))
             (_ InstOutput (side_effect (abi_call_ind abi target uses defs (Opcode.Call)))))
-        (lower_call_rets abi defs (range 0 (abi_num_rets abi)) (output_builder_new))))
+        (lower_call_rets abi defs (range (abi_first_ret sig_ref abi)
+                                         (abi_num_rets abi)) (output_builder_new))))
 
 ;; Indirect call.
 (rule (lower (call_indirect sig_ref ptr args))
@@ -3912,7 +3914,8 @@
             (uses CallArgList (lower_call_args abi (range 0 (abi_num_args abi)) args))
             (defs CallRetList (defs_init abi))
             (_ InstOutput (side_effect (abi_call_ind abi target uses defs (Opcode.CallIndirect)))))
-        (lower_call_rets abi defs (range 0 (abi_num_rets abi)) (output_builder_new))))
+        (lower_call_rets abi defs (range (abi_first_ret sig_ref abi)
+                                         (abi_num_rets abi)) (output_builder_new))))
 
 ;; Lower function arguments.
 (decl lower_call_args (Sig Range ValueSlice) CallArgList)

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -165,6 +165,13 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
         self.lower_ctx.sigs().abi_sig_for_sig_ref(sig_ref)
     }
 
+    fn abi_first_ret(&mut self, sig_ref: SigRef, abi: &Sig) -> usize {
+        // Return the index of the first actual return value, excluding
+        // any StructReturn that might have been added to Sig.
+        let sig = &self.lower_ctx.dfg().signatures[sig_ref];
+        self.lower_ctx.sigs()[*abi].num_rets() - sig.returns.len()
+    }
+
     fn abi_lane_order(&mut self, abi: &Sig) -> LaneOrder {
         lane_order_for_call_conv(self.lower_ctx.sigs()[*abi].call_conv())
     }

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -220,3 +220,21 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
 ;   vst %v17, 0(%r2)
 ;   br %r14
 
+
+function %call_sret() -> i64 {
+    fn0 = colocated %g(i64 sret)
+
+block0:
+    v1 = iconst.i64 0
+    call fn0(v1)
+    trap user0
+}
+
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -160
+;   virtual_sp_offset_adjust 160
+; block0:
+;   lghi %r2, 0
+;   brasl %r14, %g
+;   trap
+


### PR DESCRIPTION
Skip synthetic StructReturn entries in the return value list. Fixes https://github.com/bytecodealliance/wasmtime/issues/5089

CC @cfallin 

This mirrors the implementation in `gen_call_common`, and does fix the actual crash.  I still think this could be improved further:
- It's unfortunate that whether or not a synthetic `StructReturn` was added cannot be discovered solely from looking at the `Sig` (or `SigData`) - at the moment you always have to look at the `SigRef` as well.
- There appears to be a discrepancy between `call_clobbers`, which considers *all* `StructReturn` return values as clobbers, and `gen_call_common`, which only skips those `StructReturn`s that were added by `missing_struct_return`.   Shouldn't these two be in sync?   (OTOH does any code ever actually have a `StructReturn` on the *return* list that isn't added by `missing_struct_return`?)
- This whole mechanism probably should be platform-specific anyway.  The fact that the incoming return-buffer address needs to be preserved in a return register is a property of the *Intel* ABI only - AFAIK none of the other ABIs we support have that requirement (s390x certainly does not).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
