### PR TITLE
Cranelift: Use a single, shared vector allocation for all `ABIArg`s

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -345,7 +345,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 ));
                 next_stack += 8;
             }
-            Some(args.len() - 1)
+            Some(args.args().len() - 1)
         } else {
             None
         };

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -177,7 +177,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 args.push(arg);
                 next_stack += 8;
             }
-            Some(args.len() - 1)
+            Some(args.args().len() - 1)
         } else {
             None
         };

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -390,15 +390,15 @@ impl ABIMachineSpec for S390xMachineDeps {
                 ));
                 next_stack += 8;
             }
-            Some(args.len() - 1)
+            Some(args.args().len() - 1)
         } else {
             None
         };
 
         // After all arguments are in their well-defined location,
         // allocate buffers for all StructArg or ImplicitPtrArg arguments.
-        for i in 0..args.len() {
-            match &mut args[i] {
+        for i in 0..args.args().len() {
+            match &mut args.args_mut()[i] {
                 &mut ABIArg::StructArg {
                     ref mut offset,
                     size,

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -129,7 +129,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
         for i in 0..self.lower_ctx.sigs()[*abi].num_rets() {
             if let &ABIArg::Slots {
                 ref slots, purpose, ..
-            } = &self.lower_ctx.sigs()[*abi].get_ret(i)
+            } = &self.lower_ctx.sigs()[*abi].get_ret(self.lower_ctx.sigs(), i)
             {
                 if purpose == ArgumentPurpose::StructReturn {
                     continue;
@@ -192,7 +192,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
         defs: &CallRetList,
         opcode: &Opcode,
     ) -> BoxCallInfo {
-        let clobbers = self.lower_ctx.sigs()[*abi].call_clobbers::<S390xMachineDeps>();
+        let clobbers =
+            self.lower_ctx.sigs()[*abi].call_clobbers::<S390xMachineDeps>(self.lower_ctx.sigs());
         Box::new(CallInfo {
             dest: name.clone(),
             uses: uses.clone(),
@@ -213,7 +214,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
         defs: &CallRetList,
         opcode: &Opcode,
     ) -> BoxCallIndInfo {
-        let clobbers = self.lower_ctx.sigs()[*abi].call_clobbers::<S390xMachineDeps>();
+        let clobbers =
+            self.lower_ctx.sigs()[*abi].call_clobbers::<S390xMachineDeps>(self.lower_ctx.sigs());
         Box::new(CallIndInfo {
             rn: target,
             uses: uses.clone(),

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -87,7 +87,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         params: I,
         args_or_rets: ArgsOrRets,
         add_ret_area_ptr: bool,
-    ) -> CodegenResult<(ABIArgVec, i64, Option<usize>)>
+        mut args: ArgsAccumulator<'_>,
+    ) -> CodegenResult<(i64, Option<usize>)>
     where
         I: IntoIterator<Item = &'a ir::AbiParam>,
     {
@@ -97,7 +98,6 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         let mut next_vreg = 0;
         let mut next_stack: u64 = 0;
         let mut next_param_idx = 0; // Fastcall cares about overall param index
-        let mut ret = ABIArgVec::new();
 
         if args_or_rets == ArgsOrRets::Args && is_fastcall {
             // Fastcall always reserves 32 bytes of shadow space corresponding to
@@ -114,7 +114,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 let size = size as u64;
                 assert!(size % 8 == 0, "StructArgument size is not properly aligned");
                 next_stack += size;
-                ret.push(ABIArg::StructArg {
+                args.push(ABIArg::StructArg {
                     pointer: None,
                     offset,
                     size,
@@ -216,7 +216,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 }
             }
 
-            ret.push(ABIArg::Slots {
+            args.push(ABIArg::Slots {
                 slots,
                 purpose: param.purpose,
             });
@@ -225,14 +225,14 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         let extra_arg = if add_ret_area_ptr {
             debug_assert!(args_or_rets == ArgsOrRets::Args);
             if let Some(reg) = get_intreg_for_arg(&call_conv, next_gpr, next_param_idx) {
-                ret.push(ABIArg::reg(
+                args.push(ABIArg::reg(
                     reg.to_real_reg().unwrap(),
                     types::I64,
                     ir::ArgumentExtension::None,
                     ir::ArgumentPurpose::Normal,
                 ));
             } else {
-                ret.push(ABIArg::stack(
+                args.push(ABIArg::stack(
                     next_stack as i64,
                     types::I64,
                     ir::ArgumentExtension::None,
@@ -240,7 +240,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 ));
                 next_stack += 8;
             }
-            Some(ret.len() - 1)
+            Some(args.len() - 1)
         } else {
             None
         };
@@ -252,7 +252,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             return Err(CodegenError::ImplLimitExceeded);
         }
 
-        Ok((ret, next_stack as i64, extra_arg))
+        Ok((next_stack as i64, extra_arg))
     }
 
     fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -240,7 +240,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                 ));
                 next_stack += 8;
             }
-            Some(args.len() - 1)
+            Some(args.args().len() - 1)
         } else {
             None
         };

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -327,20 +327,14 @@ impl<'a> ArgsAccumulator<'a> {
     pub fn push(&mut self, arg: ABIArg) {
         self.sig_set_abi_args.push(arg)
     }
-}
-
-impl std::ops::Deref for ArgsAccumulator<'_> {
-    type Target = [ABIArg];
 
     #[inline]
-    fn deref(&self) -> &Self::Target {
+    pub fn args(&self) -> &[ABIArg] {
         &self.sig_set_abi_args[self.start..]
     }
-}
 
-impl std::ops::DerefMut for ArgsAccumulator<'_> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
+    pub fn args_mut(&mut self) -> &mut [ABIArg] {
         &mut self.sig_set_abi_args[self.start..]
     }
 }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -439,7 +439,7 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         fn abi_get_arg(&mut self, abi: &Sig, idx: usize) -> ABIArg {
-            self.lower_ctx.sigs()[*abi].get_arg(idx)
+            self.lower_ctx.sigs()[*abi].get_arg(self.lower_ctx.sigs(), idx)
         }
 
         fn abi_num_rets(&mut self, abi: &Sig) -> usize {
@@ -447,15 +447,15 @@ macro_rules! isle_lower_prelude_methods {
         }
 
         fn abi_get_ret(&mut self, abi: &Sig, idx: usize) -> ABIArg {
-            self.lower_ctx.sigs()[*abi].get_ret(idx)
+            self.lower_ctx.sigs()[*abi].get_ret(self.lower_ctx.sigs(), idx)
         }
 
         fn abi_ret_arg(&mut self, abi: &Sig) -> Option<ABIArg> {
-            self.lower_ctx.sigs()[*abi].get_ret_arg()
+            self.lower_ctx.sigs()[*abi].get_ret_arg(self.lower_ctx.sigs())
         }
 
         fn abi_no_ret_arg(&mut self, abi: &Sig) -> Option<()> {
-            if let Some(_) = self.lower_ctx.sigs()[*abi].get_ret_arg() {
+            if let Some(_) = self.lower_ctx.sigs()[*abi].get_ret_arg(self.lower_ctx.sigs()) {
                 None
             } else {
                 Some(())
@@ -709,7 +709,7 @@ macro_rules! isle_prelude_method_helpers {
                 // borrow across the `&mut self` arg to
                 // `abi_arg_slot_regs()` below.
                 let sigdata = &self.lower_ctx.sigs()[abi];
-                let ret = sigdata.get_ret(i);
+                let ret = sigdata.get_ret(self.lower_ctx.sigs(), i);
                 let retval_regs = self.abi_arg_slot_regs(&ret).unwrap();
                 retval_insts.extend(
                     caller


### PR DESCRIPTION
Instead of two (large!!) `SmallVec`s per `SigData`.

Unfortunately, I haven't measured any perf benefits from this, but we did shrink the size of `SigData` from 632 bytes to 56 bytes! It could probably get even smaller still, but I'm going to hold off on that until I get some new DHAT, `perf`, and `cachegrind` profiles that show whether `SigData` is still important to spend time on or not.

Before:

```
struct cranelift_codegen::machinst::abi::SigData
    size: 632
    members:
        0[296]   args: struct smallvec::SmallVec<[cranelift_codegen::machinst::abi::ABIArg; 6]>
        296[296] rets: struct smallvec::SmallVec<[cranelift_codegen::machinst::abi::ABIArg; 6]>
        592[8]   sized_stack_arg_space: i64
        600[8]   sized_stack_ret_space: i64
        608[16]  stack_ret_arg: struct core::option::Option<usize>
        624[1]   call_conv: enum cranelift_codegen::isa::call_conv::CallConv
        625[7]   <padding>

```

After:

```
struct cranelift_codegen::machinst::abi::SigData
    size: 56
    members:
        0[8]   sized_stack_arg_space: i64
        8[8]   sized_stack_ret_space: i64
        16[16] stack_ret_arg: struct core::option::Option<usize>
        32[8]  arg_indices: struct core::ops::range::Range<u32>
        40[8]  ret_indices: struct core::ops::range::Range<u32>
        48[1]  call_conv: enum cranelift_codegen::isa::call_conv::CallConv
        49[7]  <padding>
```