### PR TITLE
Generate more fixed_nonallocatable constraints, and add debug assertions

### DIFF
--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -358,12 +358,22 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// Add a register use, at the start of the instruction (`Before`
     /// position).
     pub fn reg_use(&mut self, reg: Reg) {
-        self.add_operand(Operand::reg_use(reg.into()));
+        if let Some(rreg) = reg.to_real_reg() {
+            self.reg_fixed_nonallocatable(rreg.into());
+        } else {
+            debug_assert!(reg.is_virtual());
+            self.add_operand(Operand::reg_use(reg.into()));
+        }
     }
 
     /// Add a register use, at the end of the instruction (`After` position).
     pub fn reg_late_use(&mut self, reg: Reg) {
-        self.add_operand(Operand::reg_use_at_end(reg.into()));
+        if let Some(rreg) = reg.to_real_reg() {
+            self.reg_fixed_nonallocatable(rreg.into());
+        } else {
+            debug_assert!(reg.is_virtual());
+            self.add_operand(Operand::reg_use_at_end(reg.into()));
+        }
     }
 
     /// Add multiple register uses.
@@ -377,7 +387,12 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// position). Use only when this def will be written after all
     /// uses are read.
     pub fn reg_def(&mut self, reg: Writable<Reg>) {
-        self.add_operand(Operand::reg_def(reg.to_reg().into()));
+        if let Some(rreg) = reg.to_reg().to_real_reg() {
+            self.reg_fixed_nonallocatable(rreg.into());
+        } else {
+            debug_assert!(reg.to_reg().is_virtual());
+            self.add_operand(Operand::reg_def(reg.to_reg().into()));
+        }
     }
 
     /// Add multiple register defs.
@@ -392,20 +407,29 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// when the def may be written before all uses are read; the
     /// regalloc will ensure that it does not overwrite any uses.
     pub fn reg_early_def(&mut self, reg: Writable<Reg>) {
-        self.add_operand(Operand::reg_def_at_start(reg.to_reg().into()));
+        if let Some(rreg) = reg.to_reg().to_real_reg() {
+            self.reg_fixed_nonallocatable(rreg.into());
+        } else {
+            debug_assert!(reg.to_reg().is_virtual());
+            self.add_operand(Operand::reg_def_at_start(reg.to_reg().into()));
+        }
     }
 
     /// Add a register "fixed use", which ties a vreg to a particular
     /// RealReg at this point.
     pub fn reg_fixed_use(&mut self, reg: Reg, rreg: Reg) {
+        debug_assert!(reg.is_virtual());
         let rreg = rreg.to_real_reg().expect("fixed reg is not a RealReg");
+        debug_assert!(self.is_allocatable_preg(rreg.into()));
         self.add_operand(Operand::reg_fixed_use(reg.into(), rreg.into()));
     }
 
     /// Add a register "fixed def", which ties a vreg to a particular
     /// RealReg at this point.
     pub fn reg_fixed_def(&mut self, reg: Writable<Reg>, rreg: Reg) {
+        debug_assert!(reg.to_reg().is_virtual());
         let rreg = rreg.to_real_reg().expect("fixed reg is not a RealReg");
+        debug_assert!(self.is_allocatable_preg(rreg.into()));
         self.add_operand(Operand::reg_fixed_def(reg.to_reg().into(), rreg.into()));
     }
 
@@ -413,7 +437,8 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// allocation. The index of that earlier operand (relative to the
     /// current instruction's start of operands) must be known.
     pub fn reg_reuse_def(&mut self, reg: Writable<Reg>, idx: usize) {
-        if reg.to_reg().to_virtual_reg().is_some() {
+        if reg.to_reg().is_virtual() {
+            // TODO: assert that the reused operand is virtual or allocatable
             self.add_operand(Operand::reg_reuse_def(reg.to_reg().into(), idx));
         } else {
             // Sometimes destination registers that reuse a source are


### PR DESCRIPTION
Add assertions to the `OperandCollector` that show we're not using pinned vregs, and use `reg_fixed_nonallocatable` constraints when a real register is used with other constraint generation functions like `reg_use` etc.

I experimented with adding debug assertions that the reused operand referenced in `reg_reuse_def` constraints was compatible with the new constraint that would be generated. This didn't end up being possible as some backends will recursively process instructions when collecting operands, making it impossible without more invasive changes to tell where that operand is in the operand vector. Given that we would need to plumb through somewhat substantial changes to support adding debug assertions, I decided that rephrasing the existing warning comment about real registers would be good enough.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
