### PR TITLE
Add missing `Win32_Foundation` feature

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -36,6 +36,7 @@ rustix = { workspace = true, features = ["mm"] }
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true
 features = [
+  "Win32_Foundation",
   "Win32_System_Kernel",
   "Win32_System_Memory",
   "Win32_System_Diagnostics_Debug",


### PR DESCRIPTION
This is necessary for the `wasmtime-runtime` crate to compile on Windows.

Resolves #5133

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #5133, or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [x] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
