### PR TITLE
Add a missing compilation feature for `windows-sys`

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -42,6 +42,7 @@ features = [
   "Win32_System_SystemInformation",
   "Win32_Storage_FileSystem",
   "Win32_Security",
+  "Win32_Foundation",
 ]
 
 [build-dependencies]


### PR DESCRIPTION
This fixes a compilation error on Windows when just the `wasmtime` crate is compiled. If the `async` feature and `wasi-common` are omitted then otherwise this feature was accidentally not included. This was not caught on our CI only performs these minimal build checks on Linux, not on Windows as well.

Closes #5133

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
