### PR TITLE
wiggle: make wasmtime a mandatory dep, get rid of own Trap enum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,13 +173,6 @@ jobs:
       env:
         CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false
 
-    # Check whether `crates/wasi-common` cross-compiles to the following targets:
-    # * armv7-unknown-linux-gnueabihf
-    - run: |
-        rustup target add armv7-unknown-linux-gnueabihf
-        sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf
-    - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
-
   # Check whether `wasmtime` cross-compiles to aarch64-pc-windows-msvc
   # We don't build nor test it because it lacks trap handling.
   # Tracking issue: https://github.com/bytecodealliance/wasmtime/issues/4992

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,13 +174,10 @@ jobs:
         CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false
 
     # Check whether `crates/wasi-common` cross-compiles to the following targets:
-    # * wasm32-unknown-emscripten
     # * armv7-unknown-linux-gnueabihf
     - run: |
-        rustup target add wasm32-unknown-emscripten
         rustup target add armv7-unknown-linux-gnueabihf
         sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf
-    - run: cargo check --target wasm32-unknown-emscripten -p wasi-common
     - run: cargo check --target armv7-unknown-linux-gnueabihf -p wasi-common
 
   # Check whether `wasmtime` cross-compiles to aarch64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,6 +3149,7 @@ dependencies = [
  "rustix",
  "thiserror",
  "tracing",
+ "wasmtime",
  "wiggle",
  "windows-sys",
 ]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -20,7 +20,8 @@ links = "wasi-common-19"
 [dependencies]
 anyhow = { workspace = true }
 thiserror = "1.0"
-wiggle = { workspace = true, default-features = false }
+wiggle = { workspace = true }
+wasmtime = { workspace = true }
 tracing = "0.1.19"
 cap-std = { workspace = true }
 cap-rand = "0.26.0"

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -28,10 +28,10 @@ impl wiggle::GuestErrorType for types::Errno {
 }
 
 impl types::UserErrorConversion for WasiCtx {
-    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno, wiggle::Trap> {
+    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno, wasmtime::Trap> {
         debug!("Error: {:?}", e);
         e.try_into()
-            .map_err(|e| wiggle::Trap::String(format!("{:?}", e)))
+            .map_err(|e| wasmtime::Trap::new(format!("{:?}", e)))
     }
 }
 
@@ -932,7 +932,7 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         Ok(num_results.try_into().expect("results fit into memory"))
     }
 
-    async fn proc_exit(&mut self, status: types::Exitcode) -> wiggle::Trap {
+    async fn proc_exit(&mut self, status: types::Exitcode) -> wasmtime::Trap {
         Snapshot1::proc_exit(self, status).await
     }
 

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -35,10 +35,10 @@ impl wiggle::GuestErrorType for types::Errno {
 }
 
 impl types::UserErrorConversion for WasiCtx {
-    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno, wiggle::Trap> {
+    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno, wasmtime::Trap> {
         debug!("Error: {:?}", e);
         e.try_into()
-            .map_err(|e| wiggle::Trap::String(format!("{:?}", e)))
+            .map_err(|e| wasmtime::Trap::new(format!("{:?}", e)))
     }
 }
 
@@ -1214,12 +1214,12 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         Ok(num_results.try_into().expect("results fit into memory"))
     }
 
-    async fn proc_exit(&mut self, status: types::Exitcode) -> wiggle::Trap {
+    async fn proc_exit(&mut self, status: types::Exitcode) -> wasmtime::Trap {
         // Check that the status is within WASI's range.
         if status < 126 {
-            wiggle::Trap::I32Exit(status as i32)
+            wasmtime::Trap::i32_exit(status as i32)
         } else {
-            wiggle::Trap::String("exit with invalid exit status outside of [0..126)".to_owned())
+            wasmtime::Trap::new("exit with invalid exit status outside of [0..126)")
         }
     }
 

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "LICENSE" ]
 [dependencies]
 wasi-common = { workspace = true }
 wasi-cap-std-sync = { workspace = true }
-wiggle = { workspace = true, features = ['wasmtime_integration'] }
+wiggle = { workspace = true }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
 cap-std = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 anyhow = { workspace = true }
 wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.5" }
 wasmtime = { workspace = true }
-wiggle = { workspace = true, default-features = true, features = ['wasmtime_integration'] }
+wiggle = { workspace = true }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -11,7 +11,10 @@ wiggle::from_witx!({
 use types::NnErrno;
 
 impl<'a> types::UserErrorConversion for WasiNnCtx {
-    fn nn_errno_from_wasi_nn_error(&mut self, e: WasiNnError) -> Result<NnErrno, wiggle::Trap> {
+    fn nn_errno_from_wasi_nn_error(
+        &mut self,
+        e: WasiNnError,
+    ) -> Result<NnErrno, wiggle::wasmtime_crate::Trap> {
         eprintln!("Host error: {:?}", e);
         match e {
             WasiNnError::BackendError(_) => unimplemented!(),

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 wasi-common = { workspace = true }
 wasi-cap-std-sync = { workspace = true, optional = true }
 wasi-tokio = { workspace = true, optional = true }
-wiggle = { workspace = true, default-features = false, features = ["wasmtime_integration"] }
+wiggle = { workspace = true }
 wasmtime = { workspace = true }
 anyhow = { workspace = true }
 

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -17,7 +17,7 @@ wiggle-macro = { workspace = true }
 tracing = "0.1.26"
 bitflags = "1.2"
 async-trait = "0.1.42"
-wasmtime = { workspace = true, optional = true }
+wasmtime = { workspace = true }
 anyhow = { workspace = true }
 
 [badges]
@@ -41,12 +41,12 @@ required-features = ["wasmtime_async", "wasmtime/wat"]
 [[test]]
 name = "wasmtime_sync"
 path = "tests/wasmtime_sync.rs"
-required-features = ["wasmtime_integration", "wasmtime/wat"]
+required-features = ["wasmtime/wat"]
 
 [[test]]
 name = "wasmtime_integration"
 path = "tests/wasmtime_integration.rs"
-required-features = ["wasmtime_integration", "wasmtime/wat"]
+required-features = ["wasmtime/wat"]
 
 
 [features]
@@ -62,9 +62,7 @@ wiggle_metadata = ['witx', "wiggle-macro/wiggle_metadata"]
 # the logs out of wiggle-generated libraries.
 tracing_log = [ "tracing/log" ]
 
-# Generate adapters for wasmtime, and expose the wasmtime_integration macro.
-wasmtime_integration = [ "wasmtime", "wiggle-macro/wasmtime" ]
 # Support for async in the wasmtime crates.
-wasmtime_async = [ "wasmtime_integration", "wasmtime/async" ]
+wasmtime_async = [ "wasmtime/async" ]
 
-default = ["wiggle_metadata", "wasmtime_integration" ]
+default = ["wiggle_metadata", "wasmtime_async" ]

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -91,7 +91,7 @@ fn _define_func(
                     ctx: &mut (impl #(#bounds)+*),
                     memory: &dyn #rt::GuestMemory,
                     #(#abi_params),*
-                ) -> Result<#abi_ret, #rt::Trap> {
+                ) -> Result<#abi_ret, #rt::wasmtime_crate::Trap> {
                     use std::convert::TryFrom as _;
                     #mk_span
                     _span.in_scope(|| {
@@ -109,7 +109,7 @@ fn _define_func(
                     ctx: &'a mut (impl #(#bounds)+*),
                     memory: &'a dyn #rt::GuestMemory,
                     #(#abi_params),*
-                ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::Trap>> + 'a {
+                ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::wasmtime_crate::Trap>> + 'a {
                     use std::convert::TryFrom as _;
                     use #rt::tracing::Instrument as _;
                     #mk_span

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -43,7 +43,7 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
         let abi_typename = names.type_ref(&errtype.abi_type(), anon_lifetime());
         let user_typename = errtype.typename();
         let methodname = names.user_error_conversion_method(&errtype);
-        quote!(fn #methodname(&mut self, e: super::#user_typename) -> Result<#abi_typename, #rt::Trap>;)
+        quote!(fn #methodname(&mut self, e: super::#user_typename) -> Result<#abi_typename, #rt::wasmtime_crate::Trap>;)
     });
     let user_error_conversion = quote! {
         pub trait UserErrorConversion {

--- a/crates/wiggle/generate/src/module_trait.rs
+++ b/crates/wiggle/generate/src/module_trait.rs
@@ -45,7 +45,7 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
         });
 
         let result = match f.results.len() {
-            0 if f.noreturn => quote!(#rt::Trap),
+            0 if f.noreturn => quote!(#rt::wasmtime_crate::Trap),
             0 => quote!(()),
             1 => {
                 let (ok, err) = match &**f.results[0].tref.type_() {

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -121,11 +121,7 @@ fn generate_func(
         let (mem , ctx) = mem.data_and_store_mut(&mut caller);
         let ctx = get_cx(ctx);
         let mem = #rt::wasmtime::WasmtimeGuestMemory::new(mem);
-        match #abi_func(ctx, &mem #(, #arg_names)*) #await_ {
-            Ok(r) => Ok(<#ret_ty>::from(r)),
-            Err(#rt::Trap::String(err)) => Err(#rt::wasmtime_crate::Trap::new(err)),
-            Err(#rt::Trap::I32Exit(err)) => Err(#rt::wasmtime_crate::Trap::i32_exit(err)),
-        }
+        Ok(<#ret_ty>::from(#abi_func(ctx, &mem #(, #arg_names)*) #await_ ?))
     };
 
     match asyncness {

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -30,5 +30,4 @@ proc-macro2 = "1.0"
 wiggle = { path = ".." }
 
 [features]
-wasmtime = []
 wiggle_metadata = []

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -152,7 +152,7 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         &config.errors,
         &config.async_,
         &doc,
-        cfg!(feature = "wasmtime") && config.wasmtime,
+        config.wasmtime,
     )
     .expect("validating codegen settings");
 
@@ -176,7 +176,6 @@ pub fn async_trait(attr: TokenStream, item: TokenStream) -> TokenStream {
     })
 }
 
-#[cfg(feature = "wasmtime")]
 /// Define the structs required to integrate a Wiggle implementation with Wasmtime.
 ///
 /// ## Arguments
@@ -190,13 +189,9 @@ pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
     let doc = config.c.load_document();
     let names = wiggle_generate::Names::new(quote!(wiggle));
 
-    let settings = wiggle_generate::CodegenSettings::new(
-        &config.c.errors,
-        &config.c.async_,
-        &doc,
-        cfg!(feature = "wasmtime"),
-    )
-    .expect("validating codegen settings");
+    let settings =
+        wiggle_generate::CodegenSettings::new(&config.c.errors, &config.c.async_, &doc, true)
+            .expect("validating codegen settings");
 
     let modules = doc.modules().map(|module| {
         wiggle_generate::wasmtime::link_module(&module, &names, Some(&config.target), &settings)

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -126,14 +126,14 @@ use syn::parse_macro_input;
 ///
 /// impl types::UserErrorConversion for YourCtxType {
 ///     fn errno_from_your_rich_error(&mut self, e: YourRichError)
-///         -> Result<types::Errno, wiggle::Trap>
+///         -> Result<types::Errno, wiggle::wasmtime_crate::Trap>
 ///     {
 ///         println!("Rich error: {:?}", e);
 ///         match e {
 ///             YourRichError::InvalidArg{..} => Ok(types::Errno::InvalidArg),
 ///             YourRichError::Io{..} => Ok(types::Errno::Io),
 ///             YourRichError::Overflow => Ok(types::Errno::Overflow),
-///             YourRichError::Trap(s) => Err(wiggle::Trap::String(s)),
+///             YourRichError::Trap(s) => Err(wiggle::wasmtime_crate::Trap::new(s)),
 ///         }
 ///     }
 /// }

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -909,22 +909,11 @@ impl Pointee for str {
     }
 }
 
-/// A runtime-independent way for Wiggle to terminate WebAssembly execution.
-/// Functions that are marked `(@witx noreturn)` will always return a Trap.
-/// Other functions that want to Trap can do so via their `UserErrorConversion`
-/// trait, which transforms the user's own error type into a `Result<abierror, Trap>`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Trap {
-    /// A Trap which indicates an i32 (posix-style) exit code. Runtimes may have a
-    /// special way of dealing with this for WASI embeddings and otherwise.
-    I32Exit(i32),
-    /// Any other Trap is just an unstructured String, for reporting and debugging.
-    String(String),
-}
-
-impl From<GuestError> for Trap {
-    fn from(err: GuestError) -> Trap {
-        Trap::String(err.to_string())
+impl From<GuestError> for wasmtime_crate::Trap {
+    fn from(err: GuestError) -> wasmtime_crate::Trap {
+        wasmtime_crate::Trap::from(
+            Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>
+        )
     }
 }
 

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 
 pub use wiggle_macro::{async_trait, from_witx};
 
-#[cfg(feature = "wasmtime")]
 pub use anyhow;
-#[cfg(feature = "wasmtime")]
 pub use wiggle_macro::wasmtime_integration;
 
 pub use bitflags;
@@ -30,10 +28,7 @@ pub mod async_trait_crate {
     pub use async_trait::*;
 }
 
-#[cfg(feature = "wasmtime")]
 pub mod wasmtime;
-
-#[cfg(feature = "wasmtime")]
 pub mod wasmtime_crate {
     pub use wasmtime::*;
 }
@@ -933,7 +928,6 @@ impl From<GuestError> for Trap {
     }
 }
 
-#[cfg(feature = "wasmtime")]
 pub fn run_in_dummy_executor<F: std::future::Future>(
     future: F,
 ) -> Result<F::Output, wasmtime_crate::Trap> {

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -86,19 +86,19 @@ fn main() {
 
     // Exercise each of the branches in `foo`.
     // Start with the success case:
-    let r0 = one_error_conversion::foo(&mut ctx, &host_memory, 0, 0, 8);
+    let r0 = one_error_conversion::foo(&mut ctx, &host_memory, 0, 0, 8).unwrap();
     assert_eq!(
         r0,
-        Ok(types::Errno::Ok as i32),
+        types::Errno::Ok as i32,
         "Expected return value for strike=0"
     );
     assert!(ctx.log.borrow().is_empty(), "No error log for strike=0");
 
     // First error case:
-    let r1 = one_error_conversion::foo(&mut ctx, &host_memory, 1, 0, 8);
+    let r1 = one_error_conversion::foo(&mut ctx, &host_memory, 1, 0, 8).unwrap();
     assert_eq!(
         r1,
-        Ok(types::Errno::PicketLine as i32),
+        types::Errno::PicketLine as i32,
         "Expected return value for strike=1"
     );
     assert_eq!(
@@ -108,10 +108,10 @@ fn main() {
     );
 
     // Second error case:
-    let r2 = one_error_conversion::foo(&mut ctx, &host_memory, 2, 0, 8);
+    let r2 = one_error_conversion::foo(&mut ctx, &host_memory, 2, 0, 8).unwrap();
     assert_eq!(
         r2,
-        Ok(types::Errno::InvalidArg as i32),
+        types::Errno::InvalidArg as i32,
         "Expected return value for strike=2"
     );
     assert_eq!(

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -32,7 +32,10 @@ impl_errno!(types::Errno);
 /// When the `errors` mapping in witx is non-empty, we need to impl the
 /// types::UserErrorConversion trait that wiggle generates from that mapping.
 impl<'a> types::UserErrorConversion for WasiCtx<'a> {
-    fn errno_from_rich_error(&mut self, e: RichError) -> Result<types::Errno, wiggle::Trap> {
+    fn errno_from_rich_error(
+        &mut self,
+        e: RichError,
+    ) -> Result<types::Errno, wiggle::wasmtime_crate::Trap> {
         wiggle::tracing::debug!(
             rich_error = wiggle::tracing::field::debug(&e),
             "error conversion"

--- a/crates/wiggle/tests/atoms.rs
+++ b/crates/wiggle/tests/atoms.rs
@@ -34,9 +34,10 @@ impl IntFloatExercise {
         let mut ctx = WasiCtx::new();
         let host_memory = HostMemory::new();
 
-        let e = atoms::int_float_args(&mut ctx, &host_memory, self.an_int as i32, self.an_float);
+        let e = atoms::int_float_args(&mut ctx, &host_memory, self.an_int as i32, self.an_float)
+            .unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "int_float_args error");
+        assert_eq!(e, types::Errno::Ok as i32, "int_float_args error");
     }
 
     pub fn strat() -> BoxedStrategy<Self> {
@@ -68,13 +69,14 @@ impl DoubleIntExercise {
             &host_memory,
             self.input as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
         let return_val = host_memory
             .ptr::<types::AliasToFloat>(self.return_loc.ptr)
             .read()
             .expect("failed to read return");
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "errno");
+        assert_eq!(e, types::Errno::Ok as i32, "errno");
         assert_eq!(return_val, (self.input as f32) * 2.0, "return val");
     }
 

--- a/crates/wiggle/tests/atoms_async.rs
+++ b/crates/wiggle/tests/atoms_async.rs
@@ -44,9 +44,10 @@ impl IntFloatExercise {
             &host_memory,
             self.an_int as i32,
             self.an_float,
-        ));
+        ))
+        .unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "int_float_args error");
+        assert_eq!(e, types::Errno::Ok as i32, "int_float_args error");
     }
 
     pub fn strat() -> BoxedStrategy<Self> {
@@ -78,13 +79,14 @@ impl DoubleIntExercise {
             &host_memory,
             self.input as i32,
             self.return_loc.ptr as i32,
-        ));
+        ))
+        .unwrap();
 
         let return_val = host_memory
             .ptr::<types::AliasToFloat>(self.return_loc.ptr)
             .read()
             .expect("failed to read return");
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "errno");
+        assert_eq!(e, types::Errno::Ok as i32, "errno");
         assert_eq!(return_val, (self.input as f32) * 2.0, "return val");
     }
 

--- a/crates/wiggle/tests/errors.rs
+++ b/crates/wiggle/tests/errors.rs
@@ -65,19 +65,19 @@ mod convert_just_errno {
 
         // Exercise each of the branches in `foo`.
         // Start with the success case:
-        let r0 = one_error_conversion::foo(&mut ctx, &host_memory, 0);
+        let r0 = one_error_conversion::foo(&mut ctx, &host_memory, 0).unwrap();
         assert_eq!(
             r0,
-            Ok(types::Errno::Ok as i32),
+            types::Errno::Ok as i32,
             "Expected return value for strike=0"
         );
         assert!(ctx.log.borrow().is_empty(), "No error log for strike=0");
 
         // First error case:
-        let r1 = one_error_conversion::foo(&mut ctx, &host_memory, 1);
+        let r1 = one_error_conversion::foo(&mut ctx, &host_memory, 1).unwrap();
         assert_eq!(
             r1,
-            Ok(types::Errno::PicketLine as i32),
+            types::Errno::PicketLine as i32,
             "Expected return value for strike=1"
         );
         assert_eq!(
@@ -87,10 +87,10 @@ mod convert_just_errno {
         );
 
         // Second error case:
-        let r2 = one_error_conversion::foo(&mut ctx, &host_memory, 2);
+        let r2 = one_error_conversion::foo(&mut ctx, &host_memory, 2).unwrap();
         assert_eq!(
             r2,
-            Ok(types::Errno::InvalidArg as i32),
+            types::Errno::InvalidArg as i32,
             "Expected return value for strike=2"
         );
         assert_eq!(

--- a/crates/wiggle/tests/errors.rs
+++ b/crates/wiggle/tests/errors.rs
@@ -31,7 +31,10 @@ mod convert_just_errno {
     /// When the `errors` mapping in witx is non-empty, we need to impl the
     /// types::UserErrorConversion trait that wiggle generates from that mapping.
     impl<'a> types::UserErrorConversion for WasiCtx<'a> {
-        fn errno_from_rich_error(&mut self, e: RichError) -> Result<types::Errno, wiggle::Trap> {
+        fn errno_from_rich_error(
+            &mut self,
+            e: RichError,
+        ) -> Result<types::Errno, wiggle::wasmtime_crate::Trap> {
             // WasiCtx can collect a Vec<String> log so we can test this. We're
             // logging the Display impl that `thiserror::Error` provides us.
             self.log.borrow_mut().push(e.to_string());
@@ -114,7 +117,7 @@ mod convert_multiple_error_types {
 
     // Just like the prior test, except that we have a second errno type. This should mean there
     // are two functions in UserErrorConversion.
-    // Additionally, test that the function "baz" marked noreturn always returns a wiggle::Trap.
+    // Additionally, test that the function "baz" marked noreturn always returns a wasmtime::Trap.
     wiggle::from_witx!({
         witx_literal: "
 (typename $errno (enum (@witx tag u8) $ok $invalid_arg $picket_line))
@@ -140,13 +143,16 @@ mod convert_multiple_error_types {
     // each member of the `errors` mapping.
     // Bodies elided.
     impl<'a> types::UserErrorConversion for WasiCtx<'a> {
-        fn errno_from_rich_error(&mut self, _e: RichError) -> Result<types::Errno, wiggle::Trap> {
+        fn errno_from_rich_error(
+            &mut self,
+            _e: RichError,
+        ) -> Result<types::Errno, wiggle::wasmtime_crate::Trap> {
             unimplemented!()
         }
         fn errno2_from_another_rich_error(
             &mut self,
             _e: AnotherRichError,
-        ) -> Result<types::Errno2, wiggle::Trap> {
+        ) -> Result<types::Errno2, wiggle::wasmtime_crate::Trap> {
             unimplemented!()
         }
     }
@@ -159,7 +165,7 @@ mod convert_multiple_error_types {
         fn bar(&mut self, _: u32) -> Result<(), AnotherRichError> {
             unimplemented!()
         }
-        fn baz(&mut self, _: u32) -> wiggle::Trap {
+        fn baz(&mut self, _: u32) -> wiggle::wasmtime_crate::Trap {
             unimplemented!()
         }
     }

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -77,8 +77,9 @@ impl ConfigureCarExercise {
             self.old_config.bits() as i32,
             self.other_config_by_ptr.ptr as i32,
             self.return_ptr_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "configure car errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "configure car errno");
 
         let res_config = host_memory
             .ptr::<types::CarConfig>(self.return_ptr_loc.ptr)

--- a/crates/wiggle/tests/handles.rs
+++ b/crates/wiggle/tests/handles.rs
@@ -34,9 +34,10 @@ impl HandleExercise {
         let mut ctx = WasiCtx::new();
         let host_memory = HostMemory::new();
 
-        let e = handle_examples::fd_create(&mut ctx, &host_memory, self.return_loc.ptr as i32);
+        let e =
+            handle_examples::fd_create(&mut ctx, &host_memory, self.return_loc.ptr as i32).unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "fd_create error");
+        assert_eq!(e, types::Errno::Ok as i32, "fd_create error");
 
         let h_got: u32 = host_memory
             .ptr(self.return_loc.ptr)
@@ -45,15 +46,15 @@ impl HandleExercise {
 
         assert_eq!(h_got, 123, "fd_create return val");
 
-        let e = handle_examples::fd_consume(&mut ctx, &host_memory, h_got as i32);
+        let e = handle_examples::fd_consume(&mut ctx, &host_memory, h_got as i32).unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "fd_consume error");
+        assert_eq!(e, types::Errno::Ok as i32, "fd_consume error");
 
-        let e = handle_examples::fd_consume(&mut ctx, &host_memory, h_got as i32 + 1);
+        let e = handle_examples::fd_consume(&mut ctx, &host_memory, h_got as i32 + 1).unwrap();
 
         assert_eq!(
             e,
-            Ok(types::Errno::InvalidArg as i32),
+            types::Errno::InvalidArg as i32,
             "fd_consume invalid error"
         );
     }

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -51,8 +51,9 @@ impl CookieCutterExercise {
             &host_memory,
             self.cookie as i64,
             self.return_ptr_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "cookie cutter errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "cookie cutter errno");
 
         let is_cookie_start = host_memory
             .ptr::<types::Bool>(self.return_ptr_loc.ptr)

--- a/crates/wiggle/tests/lists.rs
+++ b/crates/wiggle/tests/lists.rs
@@ -102,9 +102,10 @@ impl ReduceExcusesExcercise {
             self.array_ptr_loc.ptr as i32,
             self.excuse_ptr_locs.len() as i32,
             self.return_ptr_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "reduce excuses errno");
+        assert_eq!(res, types::Errno::Ok as i32, "reduce excuses errno");
 
         let expected = *self
             .excuse_values
@@ -181,8 +182,9 @@ impl PopulateExcusesExcercise {
             &host_memory,
             self.array_ptr_loc.ptr as i32,
             self.elements.len() as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "populate excuses errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "populate excuses errno");
 
         let arr: GuestPtr<'_, [GuestPtr<'_, types::Excuse>]> =
             host_memory.ptr((self.array_ptr_loc.ptr, self.elements.len() as u32));
@@ -307,8 +309,9 @@ impl SumElementsExercise {
             self.elements.len() as i32,
             self.start_ix as i32,
             self.return_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "sum_of_element errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "sum_of_element errno");
         let result_ptr = host_memory.ptr::<i32>(self.return_loc.ptr);
         let result = result_ptr.read().expect("read result");
 
@@ -326,10 +329,11 @@ impl SumElementsExercise {
             self.elements.len() as i32,
             self.elements.len() as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
         assert_eq!(
             res,
-            Ok(types::Errno::InvalidArg as i32),
+            types::Errno::InvalidArg as i32,
             "out of bounds sum_of_element errno"
         );
 
@@ -341,11 +345,12 @@ impl SumElementsExercise {
             self.start_ix as i32,
             self.end_ix as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
         if self.start_ix <= self.end_ix {
             assert_eq!(
                 res,
-                Ok(types::Errno::Ok as i32),
+                types::Errno::Ok as i32,
                 "expected ok sum_of_elements errno"
             );
             let result_ptr = host_memory.ptr::<i32>(self.return_loc.ptr);
@@ -366,7 +371,7 @@ impl SumElementsExercise {
         } else {
             assert_eq!(
                 res,
-                Ok(types::Errno::InvalidArg as i32),
+                types::Errno::InvalidArg as i32,
                 "expected error out-of-bounds sum_of_elements"
             );
         }
@@ -380,10 +385,11 @@ impl SumElementsExercise {
             self.start_ix as i32,
             self.elements.len() as i32 + 1,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
         assert_eq!(
             res,
-            Ok(types::Errno::InvalidArg as i32),
+            types::Errno::InvalidArg as i32,
             "out of bounds sum_of_elements errno"
         );
     }

--- a/crates/wiggle/tests/pointers.rs
+++ b/crates/wiggle/tests/pointers.rs
@@ -155,8 +155,9 @@ impl PointersAndEnumsExercise {
             self.input2_loc.ptr as i32,
             self.input3_loc.ptr as i32,
             self.input4_ptr_loc.ptr as i32,
-        );
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "errno");
+        )
+        .unwrap();
+        assert_eq!(e, types::Errno::Ok as i32, "errno");
 
         // Implementation of pointers_and_enums writes input3 to the input2_loc:
         let written_to_input2_loc: i32 = host_memory

--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -118,9 +118,10 @@ impl SumOfPairExercise {
             &host_memory,
             self.input_loc.ptr as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(sum_err, Ok(types::Errno::Ok as i32), "sum errno");
+        assert_eq!(sum_err, types::Errno::Ok as i32, "sum errno");
 
         let return_val: i64 = host_memory
             .ptr(self.return_loc.ptr)
@@ -216,13 +217,10 @@ impl SumPairPtrsExercise {
             &host_memory,
             self.input_struct_loc.ptr as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(
-            res,
-            Ok(types::Errno::Ok as i32),
-            "sum of pair of ptrs errno"
-        );
+        assert_eq!(res, types::Errno::Ok as i32, "sum of pair of ptrs errno");
 
         let doubled: i64 = host_memory
             .ptr(self.return_loc.ptr)
@@ -299,9 +297,10 @@ impl SumIntAndPtrExercise {
             &host_memory,
             self.input_struct_loc.ptr as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "sum of int and ptr errno");
+        assert_eq!(res, types::Errno::Ok as i32, "sum of int and ptr errno");
 
         let doubled: i64 = host_memory
             .ptr(self.return_loc.ptr)
@@ -338,9 +337,10 @@ impl ReturnPairInts {
         let mut ctx = WasiCtx::new();
         let host_memory = HostMemory::new();
 
-        let err = records::return_pair_ints(&mut ctx, &host_memory, self.return_loc.ptr as i32);
+        let err =
+            records::return_pair_ints(&mut ctx, &host_memory, self.return_loc.ptr as i32).unwrap();
 
-        assert_eq!(err, Ok(types::Errno::Ok as i32), "return struct errno");
+        assert_eq!(err, types::Errno::Ok as i32, "return struct errno");
 
         let return_struct: types::PairInts = host_memory
             .ptr(self.return_loc.ptr)
@@ -418,13 +418,10 @@ impl ReturnPairPtrsExercise {
             self.input_first_loc.ptr as i32,
             self.input_second_loc.ptr as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(
-            res,
-            Ok(types::Errno::Ok as i32),
-            "return pair of ptrs errno"
-        );
+        assert_eq!(res, types::Errno::Ok as i32, "return pair of ptrs errno");
 
         let ptr_pair_int_ptrs: types::PairIntPtrs<'_> = host_memory
             .ptr(self.return_loc.ptr)
@@ -529,10 +526,11 @@ impl SumArrayExercise {
             &host_memory,
             self.input_struct_loc.ptr as i32,
             self.output_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
         // should be no error - if hostcall did a GuestError it should eprintln it.
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "reduce excuses errno");
+        assert_eq!(res, types::Errno::Ok as i32, "reduce excuses errno");
 
         // Sum is inputs upcasted to u16
         let expected: u16 = self.inputs.iter().map(|v| *v as u16).sum();

--- a/crates/wiggle/tests/strings.rs
+++ b/crates/wiggle/tests/strings.rs
@@ -86,8 +86,9 @@ impl HelloStringExercise {
             self.string_ptr_loc.ptr as i32,
             self.test_word.len() as i32,
             self.return_ptr_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "hello string errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "hello string errno");
 
         let given = host_memory
             .ptr::<u32>(self.return_ptr_loc.ptr)
@@ -207,8 +208,9 @@ impl MultiStringExercise {
             self.sc_ptr_loc.ptr as i32,
             self.c.len() as i32,
             self.return_ptr_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "multi string errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "multi string errno");
 
         let given = host_memory
             .ptr::<u32>(self.return_ptr_loc.ptr)
@@ -285,8 +287,9 @@ impl OverlappingStringExercise {
             (self.sa_ptr_loc.ptr + self.offset_c) as i32,
             a_len - self.offset_c as i32,
             self.return_ptr_loc.ptr as i32,
-        );
-        assert_eq!(res, Ok(types::Errno::Ok as i32), "multi string errno");
+        )
+        .unwrap();
+        assert_eq!(res, types::Errno::Ok as i32, "multi string errno");
 
         let given = host_memory
             .ptr::<u32>(self.return_ptr_loc.ptr)

--- a/crates/wiggle/tests/variant.rs
+++ b/crates/wiggle/tests/variant.rs
@@ -134,9 +134,10 @@ impl GetTagExercise {
             &host_memory,
             self.input_loc.ptr as i32,
             self.return_loc.ptr as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "get_tag errno");
+        assert_eq!(e, types::Errno::Ok as i32, "get_tag errno");
 
         let return_val: types::Excuse = host_memory
             .ptr(self.return_loc.ptr)
@@ -218,9 +219,10 @@ impl ReasonMultExercise {
             &host_memory,
             self.input_loc.ptr as i32,
             self.multiply_by as i32,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(e, Ok(types::Errno::Ok as i32), "reason_mult errno");
+        assert_eq!(e, types::Errno::Ok as i32, "reason_mult errno");
 
         match self.input {
             types::Reason::DogAte(f) => {

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -314,7 +314,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("poll_oneoff")
     }
 
-    fn proc_exit(&mut self, _rval: types::Exitcode) -> wiggle::Trap {
+    fn proc_exit(&mut self, _rval: types::Exitcode) -> wiggle::wasmtime_crate::Trap {
         unimplemented!("proc_exit")
     }
 


### PR DESCRIPTION
Wiggle (& wasi-common) did a fair bit of cargo feature & other gymnastics to support Lucet and Wasmtime simultaneously. Supporting Lucet is no longer a concern, so I erased the cargo features that made wasmtime support optional in these crates, and got rid of the intermediate `wiggle::Trap` enum, using `wasmtime::Trap` directly instead.

Note this means wasi-common will no longer build for `wasm32-unknown-emscripten` nor `armv7-unknown-linux` because it depends on `wasmtime`. The emscripten used to build for that target to support a web polyfill, but we haven't maintained that polyfill in years and are fine with dropping that support. I have no idea what the armv7 target was used for. These targets were enforced in CI for a long time, and I deleted the CI job that checks for them.

We will be adding component support to wasi-common shortly, which will also incur a direct wasmtime dep in that crate, so those targets were going to be broken pretty soon anyway. I hope that this doesn't cause too much grief for anyone.