### PR TITLE
Release Wasmtime 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -513,14 +513,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "arrayvec",
  "bincode",
@@ -545,18 +545,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.89.0"
+version = "0.89.1"
 
 [[package]]
 name = "cranelift-egraph"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-entity",
  "fxhash",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "serde",
 ]
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "log",
  "miette",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -661,7 +661,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -693,14 +693,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-preopt"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
 ]
 
 [[package]]
 name = "cranelift-reader"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "smallvec",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "clap 3.2.8",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.89.0"
+version = "0.89.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3091,7 +3091,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3354,14 +3354,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap 3.2.8",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3486,11 +3486,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "2.0.0"
+version = "2.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,53 +95,53 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 
 [workspace.dependencies]
-wasmtime = { path = "crates/wasmtime", version = "2.0.0", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=2.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=2.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=2.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=2.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=2.0.0" }
-wasmtime-types = { path = "crates/types", version = "2.0.0" }
-wasmtime-jit = { path = "crates/jit", version = "=2.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=2.0.0" }
-wasmtime-runtime = { path = "crates/runtime", version = "=2.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=2.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "2.0.0" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "2.0.0" }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "2.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=2.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=2.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=2.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "2.0.1", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=2.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=2.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=2.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=2.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=2.0.1" }
+wasmtime-types = { path = "crates/types", version = "2.0.1" }
+wasmtime-jit = { path = "crates/jit", version = "=2.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=2.0.1" }
+wasmtime-runtime = { path = "crates/runtime", version = "=2.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=2.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "2.0.1" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "2.0.1" }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "2.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=2.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=2.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=2.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=2.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=2.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=2.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=2.0.0" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=2.0.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=2.0.0" }
+wiggle = { path = "crates/wiggle", version = "=2.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=2.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=2.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=2.0.1" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=2.0.1" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=2.0.1" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.89.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.89.0" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.89.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.89.0" }
-cranelift-native = { path = "cranelift/native", version = "0.89.0" }
-cranelift-module = { path = "cranelift/module", version = "0.89.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.89.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.89.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.89.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.89.1" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.89.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.89.1" }
+cranelift-native = { path = "cranelift/native", version = "0.89.1" }
+cranelift-module = { path = "cranelift/module", version = "0.89.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.89.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.89.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.89.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.89.0" }
-cranelift-preopt = { path = "cranelift/preopt", version = "0.89.0" }
+cranelift-object = { path = "cranelift/object", version = "0.89.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.89.1" }
+cranelift-preopt = { path = "cranelift/preopt", version = "0.89.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.89.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.89.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.89.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.89.1" }
 
 target-lexicon = { version = "0.12.3", default-features = false }
 anyhow = "1.0.22"

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.89.0"
+version = "0.89.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.89.0"
+version = "0.89.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -15,7 +15,7 @@ edition.workspace = true
 [dependencies]
 arrayvec = "0.7"
 bumpalo = "3"
-cranelift-codegen-shared = { path = "./shared", version = "0.89.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.89.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 hashbrown = { workspace = true, optional = true }
@@ -37,8 +37,8 @@ sha2 = { version = "0.9.0", optional = true }
 criterion = "0.3"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.89.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.89.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.89.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.89.1" }
 miette = { version = "5.1.0", features = ["fancy"], optional = true }
 
 [features]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.89.0"
+version = "0.89.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -13,7 +13,7 @@ edition.workspace = true
 # rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.89.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.89.1" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.89.0"
+version = "0.89.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/egraph/Cargo.toml
+++ b/cranelift/egraph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-egraph"
-version = "0.89.0"
+version = "0.89.1"
 description = "acyclic-egraph (aegraph) implementation for Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-egraph"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.89.0"
+version = "0.89.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.89.0"
+version = "0.89.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.89.0"
+version = "0.89.1"
 
 [dependencies]
 log = { workspace = true, optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/preopt/Cargo.toml
+++ b/cranelift/preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.89.0"
+version = "0.89.1"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-preopt"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.89.0"
+version = "0.89.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.89.0"
+version = "0.89.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 2.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
