### PR TITLE
rebased wiggle: allow disable tracing in Wiggle-generated code #5087

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -25,7 +25,7 @@ wiggle::from_witx!({
     // keeping that set the same in this macro and the wasmtime_wiggle / lucet_wiggle macros is
     // tedious, and there is no cost to having a sync function be async in this case.
     async: *,
-    wasmtime: false
+    wasmtime: false,
 });
 
 impl wiggle::GuestErrorType for types::Errno {

--- a/crates/wiggle/generate/src/codegen_settings.rs
+++ b/crates/wiggle/generate/src/codegen_settings.rs
@@ -12,6 +12,10 @@ pub struct CodegenSettings {
     pub errors: ErrorTransform,
     pub async_: AsyncConf,
     pub wasmtime: bool,
+    // Disabling this feature makes it possible to remove all of the tracing
+    // code emitted in the Wiggle-generated code; this can be helpful while
+    // inspecting the code (e.g., with `cargo expand`).
+    pub tracing: bool,
 }
 impl CodegenSettings {
     pub fn new(
@@ -19,12 +23,14 @@ impl CodegenSettings {
         async_: &AsyncConf,
         doc: &Document,
         wasmtime: bool,
+        tracing: bool,
     ) -> Result<Self, Error> {
         let errors = ErrorTransform::new(error_conf, doc)?;
         Ok(Self {
             errors,
             async_: async_.clone(),
             wasmtime,
+            tracing,
         })
     }
     pub fn get_async(&self, module: &Module, func: &InterfaceFunc) -> Asyncness {

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -153,6 +153,7 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         &config.async_,
         &doc,
         config.wasmtime,
+        config.tracing,
     )
     .expect("validating codegen settings");
 
@@ -189,9 +190,14 @@ pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
     let doc = config.c.load_document();
     let names = wiggle_generate::Names::new(quote!(wiggle));
 
-    let settings =
-        wiggle_generate::CodegenSettings::new(&config.c.errors, &config.c.async_, &doc, true)
-            .expect("validating codegen settings");
+    let settings = wiggle_generate::CodegenSettings::new(
+        &config.c.errors,
+        &config.c.async_,
+        &doc,
+        true,
+        config.c.tracing,
+    )
+    .expect("validating codegen settings");
 
     let modules = doc.modules().map(|module| {
         wiggle_generate::wasmtime::link_module(&module, &names, Some(&config.target), &settings)


### PR DESCRIPTION
Wiggle generates code that instruments APIs with tracing code. This is handy for diagnosing issues at runtime, but when inspecting the output of Wiggle, it can make the generated code difficult for a human to decipher. This change makes tracing a default but optional feature, allowing users to avoid tracing code with commands like `cargo expand --no-default-features`. This should be no change for current crates depending on `wiggle`, `wiggle-macro`, and `wiggle-generate`.

review: add 'tracing' feature to wasi-common

review: switch to using macro configuration parsing

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
