### PR TITLE
Return `anyhow::Error` from host functions instead of `Trap`, redesign `Trap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,6 +3876,7 @@ dependencies = [
 name = "wiggle-test"
 version = "0.21.0"
 dependencies = [
+ "anyhow",
  "env_logger 0.9.0",
  "proptest",
  "thiserror",

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -473,7 +473,7 @@ impl FromStr for Offset32 {
 /// containing the bit pattern.
 ///
 /// We specifically avoid using a f32 here since some architectures may silently alter floats.
-/// See: https://github.com/bytecodealliance/wasmtime/pull/2251#discussion_r498508646
+/// See: <https://github.com/bytecodealliance/wasmtime/pull/2251#discussion_r498508646>
 ///
 /// The [PartialEq] and [Hash] implementations are over the underlying bit pattern, but
 /// [PartialOrd] respects IEEE754 semantics.
@@ -488,7 +488,7 @@ pub struct Ieee32(u32);
 /// containing the bit pattern.
 ///
 /// We specifically avoid using a f64 here since some architectures may silently alter floats.
-/// See: https://github.com/bytecodealliance/wasmtime/pull/2251#discussion_r498508646
+/// See: <https://github.com/bytecodealliance/wasmtime/pull/2251#discussion_r498508646>
 ///
 /// The [PartialEq] and [Hash] implementations are over the underlying bit pattern, but
 /// [PartialOrd] respects IEEE754 semantics.

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -3,7 +3,8 @@ use crate::{
     wasm_extern_t, wasm_functype_t, wasm_store_t, wasm_val_t, wasm_val_vec_t, wasmtime_error_t,
     wasmtime_extern_t, wasmtime_val_t, wasmtime_val_union, CStoreContext, CStoreContextMut,
 };
-use anyhow::Result;
+use anyhow::{Error, Result};
+use std::any::Any;
 use std::ffi::c_void;
 use std::mem::{self, MaybeUninit};
 use std::panic::{self, AssertUnwindSafe};
@@ -155,16 +156,20 @@ pub unsafe extern "C" fn wasm_func_call(
         }
         Ok(Err(err)) => Box::into_raw(Box::new(wasm_trap_t::new(err))),
         Err(panic) => {
-            let trap = if let Some(msg) = panic.downcast_ref::<String>() {
-                Trap::new(msg)
-            } else if let Some(msg) = panic.downcast_ref::<&'static str>() {
-                Trap::new(*msg)
-            } else {
-                Trap::new("rust panic happened")
-            };
-            let trap = Box::new(wasm_trap_t::new(trap.into()));
+            let err = error_from_panic(panic);
+            let trap = Box::new(wasm_trap_t::new(err));
             Box::into_raw(trap)
         }
+    }
+}
+
+fn error_from_panic(panic: Box<dyn Any + Send>) -> Error {
+    if let Some(msg) = panic.downcast_ref::<String>() {
+        Error::msg(msg.clone())
+    } else if let Some(msg) = panic.downcast_ref::<&'static str>() {
+        Error::msg(*msg)
+    } else {
+        Error::msg("rust panic happened")
     }
 }
 
@@ -346,22 +351,17 @@ pub unsafe extern "C" fn wasmtime_func_call(
             store.data_mut().wasm_val_storage = params;
             None
         }
-        Ok(Err(trap)) => match trap.downcast::<Trap>() {
-            Ok(trap) => {
-                *trap_ret = Box::into_raw(Box::new(wasm_trap_t::new(trap.into())));
+        Ok(Err(trap)) => {
+            if trap.is::<Trap>() {
+                *trap_ret = Box::into_raw(Box::new(wasm_trap_t::new(trap)));
                 None
-            }
-            Err(err) => Some(Box::new(wasmtime_error_t::from(err))),
-        },
-        Err(panic) => {
-            let trap = if let Some(msg) = panic.downcast_ref::<String>() {
-                Trap::new(msg)
-            } else if let Some(msg) = panic.downcast_ref::<&'static str>() {
-                Trap::new(*msg)
             } else {
-                Trap::new("rust panic happened")
-            };
-            *trap_ret = Box::into_raw(Box::new(wasm_trap_t::new(trap.into())));
+                Some(Box::new(wasmtime_error_t::from(trap)))
+            }
+        }
+        Err(panic) => {
+            let err = error_from_panic(panic);
+            *trap_ret = Box::into_raw(Box::new(wasm_trap_t::new(err)));
             None
         }
     }

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn wasm_instance_new(
         ))),
         Err(e) => {
             if let Some(ptr) = result {
-                *ptr = Box::into_raw(Box::new(wasm_trap_t::new(e.into())));
+                *ptr = Box::into_raw(Box::new(wasm_trap_t::new(e)));
             }
             None
         }
@@ -100,7 +100,7 @@ pub(crate) fn handle_instantiate(
         }
         Err(e) => match e.downcast::<Trap>() {
             Ok(trap) => {
-                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(trap)));
+                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(trap.into())));
                 None
             }
             Err(e) => Some(Box::new(e.into())),

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -52,7 +52,7 @@ pub extern "C" fn wasm_trap_new(
     }
     let message = String::from_utf8_lossy(&message[..message.len() - 1]);
     Box::new(wasm_trap_t {
-        error: Trap::new(message).into(),
+        error: Error::msg(message.into_owned()),
     })
 }
 
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn wasmtime_trap_new(message: *const u8, len: usize) -> Bo
     let bytes = crate::slice_from_raw_parts(message, len);
     let message = String::from_utf8_lossy(&bytes);
     Box::new(wasm_trap_t {
-        error: Trap::new(message).into(),
+        error: Error::msg(message.into_owned()),
     })
 }
 

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -142,6 +142,9 @@ pub extern "C" fn wasmtime_trap_exit_status(raw: &wasm_trap_t, status: &mut i32)
         return true;
     }
 
+    // Squash unused warnings in wasi-disabled builds.
+    drop((raw, status));
+
     false
 }
 

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -1,18 +1,30 @@
 use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
+use anyhow::{anyhow, Error};
 use once_cell::unsync::OnceCell;
 use wasmtime::{Trap, TrapCode};
 
 #[repr(C)]
-#[derive(Clone)]
 pub struct wasm_trap_t {
-    pub(crate) trap: Trap,
+    pub(crate) error: Error,
+}
+
+// This is currently only needed for the `wasm_trap_copy` API in the C API.
+//
+// For now the impl here is "fake it til you make it" since this is losing
+// context by only cloning the error string.
+impl Clone for wasm_trap_t {
+    fn clone(&self) -> wasm_trap_t {
+        wasm_trap_t {
+            error: anyhow!("{:?}", self.error),
+        }
+    }
 }
 
 wasmtime_c_api_macros::declare_ref!(wasm_trap_t);
 
 impl wasm_trap_t {
-    pub(crate) fn new(trap: Trap) -> wasm_trap_t {
-        wasm_trap_t { trap: trap }
+    pub(crate) fn new(error: Error) -> wasm_trap_t {
+        wasm_trap_t { error }
     }
 }
 
@@ -40,7 +52,7 @@ pub extern "C" fn wasm_trap_new(
     }
     let message = String::from_utf8_lossy(&message[..message.len() - 1]);
     Box::new(wasm_trap_t {
-        trap: Trap::new(message),
+        error: Trap::new(message).into(),
     })
 }
 
@@ -49,14 +61,14 @@ pub unsafe extern "C" fn wasmtime_trap_new(message: *const u8, len: usize) -> Bo
     let bytes = crate::slice_from_raw_parts(message, len);
     let message = String::from_utf8_lossy(&bytes);
     Box::new(wasm_trap_t {
-        trap: Trap::new(message),
+        error: Trap::new(message).into(),
     })
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t) {
     let mut buffer = Vec::new();
-    buffer.extend_from_slice(trap.trap.to_string().as_bytes());
+    buffer.extend_from_slice(format!("{:?}", trap.error).as_bytes());
     buffer.reserve_exact(1);
     buffer.push(0);
     out.set_buffer(buffer);
@@ -64,9 +76,13 @@ pub extern "C" fn wasm_trap_message(trap: &wasm_trap_t, out: &mut wasm_message_t
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t>> {
-    if raw.trap.trace().unwrap_or(&[]).len() > 0 {
+    let trap = match raw.error.downcast_ref::<Trap>() {
+        Some(trap) => trap,
+        None => return None,
+    };
+    if trap.trace().unwrap_or(&[]).len() > 0 {
         Some(Box::new(wasm_frame_t {
-            trap: raw.trap.clone(),
+            trap: trap.clone(),
             idx: 0,
             func_name: OnceCell::new(),
             module_name: OnceCell::new(),
@@ -78,10 +94,14 @@ pub extern "C" fn wasm_trap_origin(raw: &wasm_trap_t) -> Option<Box<wasm_frame_t
 
 #[no_mangle]
 pub extern "C" fn wasm_trap_trace(raw: &wasm_trap_t, out: &mut wasm_frame_vec_t) {
-    let vec = (0..raw.trap.trace().unwrap_or(&[]).len())
+    let trap = match raw.error.downcast_ref::<Trap>() {
+        Some(trap) => trap,
+        None => return out.set_buffer(Vec::new()),
+    };
+    let vec = (0..trap.trace().unwrap_or(&[]).len())
         .map(|idx| {
             Some(Box::new(wasm_frame_t {
-                trap: raw.trap.clone(),
+                trap: trap.clone(),
                 idx,
                 func_name: OnceCell::new(),
                 module_name: OnceCell::new(),
@@ -93,7 +113,11 @@ pub extern "C" fn wasm_trap_trace(raw: &wasm_trap_t, out: &mut wasm_frame_vec_t)
 
 #[no_mangle]
 pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut i32) -> bool {
-    match raw.trap.trap_code() {
+    let trap = match raw.error.downcast_ref::<Trap>() {
+        Some(trap) => trap,
+        None => return false,
+    };
+    match trap.trap_code() {
         Some(c) => {
             *code = match c {
                 TrapCode::StackOverflow => 0,
@@ -117,7 +141,11 @@ pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut i32) -> bool 
 
 #[no_mangle]
 pub extern "C" fn wasmtime_trap_exit_status(raw: &wasm_trap_t, status: &mut i32) -> bool {
-    match raw.trap.i32_exit_status() {
+    let trap = match raw.error.downcast_ref::<Trap>() {
+        Some(trap) => trap,
+        None => return false,
+    };
+    match trap.i32_exit_status() {
         Some(i) => {
             *status = i;
             true

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -141,17 +141,13 @@ pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut i32) -> bool 
 
 #[no_mangle]
 pub extern "C" fn wasmtime_trap_exit_status(raw: &wasm_trap_t, status: &mut i32) -> bool {
-    let trap = match raw.error.downcast_ref::<Trap>() {
-        Some(trap) => trap,
-        None => return false,
-    };
-    match trap.i32_exit_status() {
-        Some(i) => {
-            *status = i;
-            true
-        }
-        None => false,
+    #[cfg(feature = "wasi")]
+    if let Some(exit) = raw.error.downcast_ref::<wasmtime_wasi::I32Exit>() {
+        *status = exit.0;
+        return true;
     }
+
+    false
 }
 
 #[no_mangle]

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -19,7 +19,7 @@ impl wasm_name_t {
 macro_rules! declare_vecs {
     (
         $((
-            name: $name:ident,
+            name: $name:ident $(<$lt:tt>)?,
             ty: $elem_ty:ty,
             new: $new:ident,
             empty: $empty:ident,
@@ -29,12 +29,12 @@ macro_rules! declare_vecs {
         ))*
     ) => {$(
         #[repr(C)]
-        pub struct $name {
+        pub struct $name $(<$lt>)? {
             size: usize,
             data: *mut $elem_ty,
         }
 
-        impl $name {
+        impl$(<$lt>)? $name $(<$lt>)? {
             pub fn set_buffer(&mut self, buffer: Vec<$elem_ty>) {
                 let mut vec = buffer.into_boxed_slice();
                 self.size = vec.len();
@@ -79,13 +79,13 @@ macro_rules! declare_vecs {
             }
         }
 
-        impl Clone for $name {
+        impl$(<$lt>)? Clone for $name $(<$lt>)? {
             fn clone(&self) -> Self {
                 self.as_slice().to_vec().into()
             }
         }
 
-        impl From<Vec<$elem_ty>> for $name {
+        impl$(<$lt>)? From<Vec<$elem_ty>> for $name $(<$lt>)? {
             fn from(vec: Vec<$elem_ty>) -> Self {
                 let mut vec = vec.into_boxed_slice();
                 let result = $name {
@@ -97,7 +97,7 @@ macro_rules! declare_vecs {
             }
         }
 
-        impl Drop for $name {
+        impl$(<$lt>)? Drop for $name $(<$lt>)? {
             fn drop(&mut self) {
                 drop(self.take());
             }
@@ -115,8 +115,8 @@ macro_rules! declare_vecs {
         }
 
         #[no_mangle]
-        pub unsafe extern "C" fn $new(
-            out: &mut $name,
+        pub unsafe extern "C" fn $new $(<$lt>)? (
+            out: &mut $name $(<$lt>)?,
             size: usize,
             ptr: *const $elem_ty,
         ) {
@@ -125,12 +125,15 @@ macro_rules! declare_vecs {
         }
 
         #[no_mangle]
-        pub extern "C" fn $copy(out: &mut $name, src: &$name) {
+        pub extern "C" fn $copy $(<$lt>)? (
+            out: &mut $name $(<$lt>)?,
+            src: &$name $(<$lt>)?,
+        ) {
             out.set_buffer(src.as_slice().to_vec());
         }
 
         #[no_mangle]
-        pub extern "C" fn $delete(out: &mut $name) {
+        pub extern "C" fn $delete $(<$lt>)? (out: &mut $name $(<$lt>)?) {
             out.take();
         }
     )*};
@@ -228,8 +231,8 @@ declare_vecs! {
         delete: wasm_val_vec_delete,
     )
     (
-        name: wasm_frame_vec_t,
-        ty: Option<Box<wasm_frame_t>>,
+        name: wasm_frame_vec_t<'a>,
+        ty: Option<Box<wasm_frame_t<'a>>>,
         new: wasm_frame_vec_new,
         empty: wasm_frame_vec_new_empty,
         uninit: wasm_frame_vec_new_uninitialized,

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -374,8 +374,7 @@ pub fn differential(
         // falls through to checking the intermediate state otherwise.
         (Err(lhs), Err(rhs)) => {
             let err = rhs.downcast::<Trap>().expect("not a trap");
-            let poisoned = err.trap_code() == Some(TrapCode::StackOverflow)
-                || lhs_engine.is_stack_overflow(&lhs);
+            let poisoned = err == Trap::StackOverflow || lhs_engine.is_stack_overflow(&lhs);
 
             if poisoned {
                 return Ok(false);
@@ -675,11 +674,9 @@ pub fn table_ops(
             .downcast::<Trap>()
             .unwrap();
 
-        match trap.trap_code() {
-            Some(TrapCode::TableOutOfBounds) | Some(TrapCode::OutOfFuel) => {}
-            _ => {
-                panic!("unexpected trap: {}", trap);
-            }
+        match trap {
+            Trap::TableOutOfBounds | Trap::OutOfFuel => {}
+            _ => panic!("unexpected trap: {trap}"),
         }
 
         // Do a final GC after running the Wasm.

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -676,10 +676,7 @@ pub fn table_ops(
             .unwrap();
 
         match trap.trap_code() {
-            Some(TrapCode::TableOutOfBounds) => {}
-            None if trap
-                .to_string()
-                .contains("all fuel consumed by WebAssembly") => {}
+            Some(TrapCode::TableOutOfBounds) | Some(TrapCode::OutOfFuel) => {}
             _ => {
                 panic!("unexpected trap: {}", trap);
             }

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -5,7 +5,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Once;
 use wasmtime::Trap;
-use wasmtime::TrapCode;
 
 pub struct V8Engine {
     isolate: Rc<RefCell<v8::OwnedIsolate>>,
@@ -91,14 +90,14 @@ impl DiffEngine for V8Engine {
                 v8
             );
         };
-        match wasmtime.trap_code() {
-            Some(TrapCode::MemoryOutOfBounds) => {
+        match wasmtime {
+            Trap::MemoryOutOfBounds => {
                 return verify_v8(&[
                     "memory access out of bounds",
                     "data segment is out of bounds",
                 ])
             }
-            Some(TrapCode::UnreachableCodeReached) => {
+            Trap::UnreachableCodeReached => {
                 return verify_v8(&[
                     "unreachable",
                     // All the wasms we test use wasm-smith's
@@ -113,10 +112,10 @@ impl DiffEngine for V8Engine {
                     "Maximum call stack size exceeded",
                 ]);
             }
-            Some(TrapCode::IntegerDivisionByZero) => {
+            Trap::IntegerDivisionByZero => {
                 return verify_v8(&["divide by zero", "remainder by zero"])
             }
-            Some(TrapCode::StackOverflow) => {
+            Trap::StackOverflow => {
                 return verify_v8(&[
                     "call stack size exceeded",
                     // Similar to the above comment in `UnreachableCodeReached`
@@ -128,15 +127,15 @@ impl DiffEngine for V8Engine {
                     "unreachable",
                 ]);
             }
-            Some(TrapCode::IndirectCallToNull) => return verify_v8(&["null function"]),
-            Some(TrapCode::TableOutOfBounds) => {
+            Trap::IndirectCallToNull => return verify_v8(&["null function"]),
+            Trap::TableOutOfBounds => {
                 return verify_v8(&[
                     "table initializer is out of bounds",
                     "table index is out of bounds",
                 ])
             }
-            Some(TrapCode::BadSignature) => return verify_v8(&["function signature mismatch"]),
-            Some(TrapCode::IntegerOverflow) | Some(TrapCode::BadConversionToInteger) => {
+            Trap::BadSignature => return verify_v8(&["function signature mismatch"]),
+            Trap::IntegerOverflow | Trap::BadConversionToInteger => {
                 return verify_v8(&[
                     "float unrepresentable in integer range",
                     "divide result unrepresentable",

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -6,7 +6,7 @@ use crate::oracles::engine::DiffInstance;
 use crate::oracles::{compile_module, engine::DiffEngine, StoreLimits};
 use anyhow::{Context, Error, Result};
 use arbitrary::Unstructured;
-use wasmtime::{Extern, FuncType, Instance, Module, Store, Trap, TrapCode, Val};
+use wasmtime::{Extern, FuncType, Instance, Module, Store, Trap, Val};
 
 /// A wrapper for using Wasmtime as a [`DiffEngine`].
 pub struct WasmtimeEngine {
@@ -45,18 +45,12 @@ impl DiffEngine for WasmtimeEngine {
         let trap2 = err
             .downcast_ref::<Trap>()
             .expect(&format!("not a trap: {:?}", err));
-        assert_eq!(
-            trap.trap_code(),
-            trap2.trap_code(),
-            "{}\nis not equal to\n{}",
-            trap,
-            trap2
-        );
+        assert_eq!(trap, trap2, "{}\nis not equal to\n{}", trap, trap2);
     }
 
     fn is_stack_overflow(&self, err: &Error) -> bool {
         match err.downcast_ref::<Trap>() {
-            Some(trap) => trap.trap_code() == Some(TrapCode::StackOverflow),
+            Some(trap) => *trap == Trap::StackOverflow,
             None => false,
         }
     }

--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -27,7 +27,7 @@ pub fn check_stacks(stacks: Stacks) -> usize {
 
                 let fuel_left = fuel.get(&mut caller).unwrap_i32();
                 if fuel_left == 0 {
-                    bail!("out of fuel")
+                    bail!(Trap::OutOfFuel);
                 }
 
                 fuel.set(&mut caller, Val::I32(fuel_left - 1)).unwrap();
@@ -73,15 +73,10 @@ pub fn check_stacks(stacks: Stacks) -> usize {
                 .get_memory(&mut store, "memory")
                 .expect("should have `memory` export");
 
-            let (host_trace, code) = match trap.downcast_ref::<Trap>() {
-                Some(trap) => (trap.trace().unwrap(), trap.trap_code()),
-                None => (
-                    trap.downcast_ref::<BacktraceContext>().unwrap().frames(),
-                    None,
-                ),
-            };
+            let host_trace = trap.downcast_ref::<BacktraceContext>().unwrap().frames();
+            let trap = trap.downcast_ref::<Trap>().unwrap();
             max_stack_depth = max_stack_depth.max(host_trace.len());
-            assert_stack_matches(&mut store, memory, ptr, len, host_trace, code);
+            assert_stack_matches(&mut store, memory, ptr, len, host_trace, *trap);
         }
     }
     max_stack_depth
@@ -94,7 +89,7 @@ fn assert_stack_matches(
     ptr: u32,
     len: u32,
     host_trace: &[FrameInfo],
-    trap_code: Option<TrapCode>,
+    trap: Trap,
 ) {
     let mut data = vec![0; len as usize];
     memory
@@ -115,7 +110,7 @@ fn assert_stack_matches(
     // be able to see the exact function that triggered the stack overflow. In
     // this situation the host trace is asserted to be one larger and then the
     // top frame (first) of the host trace is discarded.
-    let host_trace = if trap_code == Some(TrapCode::StackOverflow) {
+    let host_trace = if trap == Trap::StackOverflow {
         assert_eq!(host_trace.len(), wasm_trace.len() + 1);
         &host_trace[1..]
     } else {

--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -73,7 +73,7 @@ pub fn check_stacks(stacks: Stacks) -> usize {
                 .get_memory(&mut store, "memory")
                 .expect("should have `memory` export");
 
-            let host_trace = trap.downcast_ref::<BacktraceContext>().unwrap().frames();
+            let host_trace = trap.downcast_ref::<WasmBacktrace>().unwrap().frames();
             let trap = trap.downcast_ref::<Trap>().unwrap();
             max_stack_depth = max_stack_depth.max(host_trace.len());
             assert_stack_matches(&mut store, memory, ptr, len, host_trace, *trap);

--- a/crates/wasi-common/src/error.rs
+++ b/crates/wasi-common/src/error.rs
@@ -24,6 +24,7 @@
 //! `anyhow::Result::context` to aid in debugging of errors.
 
 pub use anyhow::{Context, Error};
+use std::fmt;
 
 /// Internal error type for the `wasi-common` crate.
 ///
@@ -138,3 +139,18 @@ impl ErrorExt for Error {
         ErrorKind::Perm.into()
     }
 }
+
+/// An error returned from the `proc_exit` host syscall.
+///
+/// Embedders can test if an error returned from wasm is this error, in which
+/// case it may signal a non-fatal trap.
+#[derive(Debug)]
+pub struct I32Exit(pub i32);
+
+impl fmt::Display for I32Exit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Exited with i32 exit status {}", self.0)
+    }
+}
+
+impl std::error::Error for I32Exit {}

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -66,7 +66,7 @@ pub use cap_rand::RngCore;
 pub use clocks::{SystemTimeSpec, WasiClocks, WasiMonotonicClock, WasiSystemClock};
 pub use ctx::WasiCtx;
 pub use dir::WasiDir;
-pub use error::{Context, Error, ErrorExt, ErrorKind};
+pub use error::{Context, Error, ErrorExt, ErrorKind, I32Exit};
 pub use file::WasiFile;
 pub use sched::{Poll, WasiSched};
 pub use string_array::StringArrayError;

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     Error, ErrorExt, ErrorKind, SystemTimeSpec, WasiCtx,
 };
-use anyhow::Context;
+use anyhow::{Context, Result};
 use cap_std::time::{Duration, SystemClock};
 use std::convert::{TryFrom, TryInto};
 use std::io::{IoSlice, IoSliceMut};
@@ -35,10 +35,10 @@ impl wiggle::GuestErrorType for types::Errno {
 }
 
 impl types::UserErrorConversion for WasiCtx {
-    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno, wasmtime::Trap> {
+    fn errno_from_error(&mut self, e: Error) -> Result<types::Errno> {
         debug!("Error: {:?}", e);
-        e.try_into()
-            .map_err(|e| wasmtime::Trap::new(format!("{:?}", e)))
+        let errno = e.try_into()?;
+        Ok(errno)
     }
 }
 
@@ -1214,13 +1214,14 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         Ok(num_results.try_into().expect("results fit into memory"))
     }
 
-    async fn proc_exit(&mut self, status: types::Exitcode) -> wasmtime::Trap {
+    async fn proc_exit(&mut self, status: types::Exitcode) -> anyhow::Error {
         // Check that the status is within WASI's range.
-        if status < 126 {
-            wasmtime::Trap::i32_exit(status as i32)
+        let trap = if status < 126 {
+            wasmtime::Trap::i32_exit(status as i32).into()
         } else {
             wasmtime::Trap::new("exit with invalid exit status outside of [0..126)")
-        }
+        };
+        trap.into()
     }
 
     async fn proc_raise(&mut self, _sig: types::Signal) -> Result<(), Error> {

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -8,7 +8,7 @@ use crate::{
         subscription::{RwEventFlags, SubscriptionResult},
         Poll, Userdata,
     },
-    Error, ErrorExt, ErrorKind, SystemTimeSpec, WasiCtx,
+    Error, ErrorExt, ErrorKind, I32Exit, SystemTimeSpec, WasiCtx,
 };
 use anyhow::{Context, Result};
 use cap_std::time::{Duration, SystemClock};
@@ -1216,12 +1216,11 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
 
     async fn proc_exit(&mut self, status: types::Exitcode) -> anyhow::Error {
         // Check that the status is within WASI's range.
-        let trap = if status < 126 {
-            wasmtime::Trap::i32_exit(status as i32).into()
+        if status < 126 {
+            I32Exit(status as i32).into()
         } else {
-            wasmtime::Trap::new("exit with invalid exit status outside of [0..126)")
-        };
-        trap.into()
+            wasmtime::Trap::new("exit with invalid exit status outside of [0..126)").into()
+        }
     }
 
     async fn proc_raise(&mut self, _sig: types::Signal) -> Result<(), Error> {

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     Error, ErrorExt, ErrorKind, I32Exit, SystemTimeSpec, WasiCtx,
 };
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use cap_std::time::{Duration, SystemClock};
 use std::convert::{TryFrom, TryInto};
 use std::io::{IoSlice, IoSliceMut};
@@ -1219,7 +1219,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         if status < 126 {
             I32Exit(status as i32).into()
         } else {
-            wasmtime::Trap::new("exit with invalid exit status outside of [0..126)").into()
+            anyhow!("exit with invalid exit status outside of [0..126)")
         }
     }
 

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -1,6 +1,7 @@
 //! Contains the macro-generated implementation of wasi-nn from the its witx definition file.
 use crate::ctx::WasiNnCtx;
 use crate::ctx::WasiNnError;
+use anyhow::Result;
 
 // Generate the traits and types of wasi-nn in several Rust modules (e.g. `types`).
 wiggle::from_witx!({
@@ -11,10 +12,7 @@ wiggle::from_witx!({
 use types::NnErrno;
 
 impl<'a> types::UserErrorConversion for WasiNnCtx {
-    fn nn_errno_from_wasi_nn_error(
-        &mut self,
-        e: WasiNnError,
-    ) -> Result<NnErrno, wiggle::wasmtime_crate::Trap> {
+    fn nn_errno_from_wasi_nn_error(&mut self, e: WasiNnError) -> Result<NnErrno> {
         eprintln!("Host error: {:?}", e);
         match e {
             WasiNnError::BackendError(_) => unimplemented!(),

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -7,7 +7,7 @@
 //! Individual snapshots are available through
 //! `wasmtime_wasi::snapshots::preview_{0, 1}::Wasi::new(&Store, Rc<RefCell<WasiCtx>>)`.
 
-pub use wasi_common::{Error, WasiCtx, WasiDir, WasiFile};
+pub use wasi_common::{Error, I32Exit, WasiCtx, WasiDir, WasiFile};
 
 /// Re-export the commonly used wasi-cap-std-sync crate here. This saves
 /// consumers of this library from having to keep additional dependencies

--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -193,7 +193,7 @@ where
     // the component is disallowed, for example, when the `realloc` function
     // calls a canonical import.
     if !flags.may_leave() {
-        bail!("cannot leave component instance");
+        return Err(Trap::new("cannot leave component instance").into());
     }
 
     // There's a 2x2 matrix of whether parameters and results are stored on the
@@ -303,7 +303,7 @@ where
     // the component is disallowed, for example, when the `realloc` function
     // calls a canonical import.
     if !flags.may_leave() {
-        bail!("cannot leave component instance");
+        return Err(Trap::new("cannot leave component instance").into());
     }
 
     let args;

--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -193,7 +193,7 @@ where
     // the component is disallowed, for example, when the `realloc` function
     // calls a canonical import.
     if !flags.may_leave() {
-        return Err(Trap::new("cannot leave component instance").into());
+        bail!("cannot leave component instance");
     }
 
     // There's a 2x2 matrix of whether parameters and results are stored on the
@@ -303,7 +303,7 @@ where
     // the component is disallowed, for example, when the `realloc` function
     // calls a canonical import.
     if !flags.may_leave() {
-        return Err(Trap::new("cannot leave component instance").into());
+        bail!("cannot leave component instance");
     }
 
     let args;

--- a/crates/wasmtime/src/component/func/options.rs
+++ b/crates/wasmtime/src/component/func/options.rs
@@ -1,6 +1,5 @@
 use crate::store::{StoreId, StoreOpaque};
 use crate::StoreContextMut;
-use crate::Trap;
 use anyhow::{bail, Result};
 use std::ptr::NonNull;
 use wasmtime_environ::component::StringEncoding;
@@ -97,7 +96,7 @@ impl Options {
         };
 
         if result % old_align != 0 {
-            bail!(Trap::new("realloc return: result not aligned"));
+            bail!("realloc return: result not aligned");
         }
         let result = usize::try_from(result)?;
 
@@ -105,7 +104,7 @@ impl Options {
 
         let result_slice = match memory.get_mut(result..).and_then(|s| s.get_mut(..new_size)) {
             Some(end) => end,
-            None => bail!(Trap::new("realloc return: beyond end of memory")),
+            None => bail!("realloc return: beyond end of memory"),
         };
 
         Ok((result_slice, result))

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -464,7 +464,7 @@ impl Table {
             let table = Table::from_wasmtime_table(wasmtime_export, store);
             (*table.wasmtime_table(store, std::iter::empty()))
                 .fill(0, init, ty.minimum())
-                .map_err(|c| Trap::new_wasm(c, None))?;
+                .map_err(|c| Trap::from_env(c))?;
 
             Ok(table)
         }
@@ -653,7 +653,7 @@ impl Table {
         let src_table = src_table.wasmtime_table(store, src_range);
         unsafe {
             runtime::Table::copy(dst_table, src_table, dst_index, src_index, len)
-                .map_err(|c| Trap::new_wasm(c, None))?;
+                .map_err(|c| Trap::from_env(c))?;
         }
         Ok(())
     }
@@ -683,7 +683,7 @@ impl Table {
         unsafe {
             (*table)
                 .fill(dst, val, len)
-                .map_err(|c| Trap::new_wasm(c, None))?;
+                .map_err(|c| Trap::from_env(c))?;
         }
 
         Ok(())

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -68,6 +68,10 @@ where
     /// For more information, see the [`Func::typed`] and [`Func::call`]
     /// documentation.
     ///
+    /// # Errors
+    ///
+    /// For more information on errors see the documentation on [`Func::call`].
+    ///
     /// # Panics
     ///
     /// This function will panic if it is called when the underlying [`Func`] is
@@ -90,6 +94,10 @@ where
     ///
     /// For more information, see the [`Func::typed`] and [`Func::call_async`]
     /// documentation.
+    ///
+    /// # Errors
+    ///
+    /// For more information on errors see the documentation on [`Func::call`].
     ///
     /// # Panics
     ///

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -72,6 +72,8 @@ where
     ///
     /// This function will panic if it is called when the underlying [`Func`] is
     /// connected to an asynchronous store.
+    ///
+    /// [`Trap`]: crate::Trap
     pub fn call(&self, mut store: impl AsContextMut, params: Params) -> Result<Results> {
         let mut store = store.as_context_mut();
         assert!(
@@ -93,6 +95,8 @@ where
     ///
     /// This function will panic if it is called when the underlying [`Func`] is
     /// connected to a synchronous store.
+    ///
+    /// [`Trap`]: crate::Trap
     #[cfg(feature = "async")]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
     pub async fn call_async<T>(

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -1,6 +1,6 @@
 use super::{invoke_wasm_and_catch_traps, HostAbi};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
-use crate::{AsContextMut, ExternRef, Func, FuncType, StoreContextMut, Trap, ValRaw, ValType};
+use crate::{AsContextMut, ExternRef, Func, FuncType, StoreContextMut, ValRaw, ValType};
 use anyhow::{bail, Result};
 use std::marker;
 use std::mem::{self, MaybeUninit};
@@ -72,7 +72,7 @@ where
     ///
     /// This function will panic if it is called when the underlying [`Func`] is
     /// connected to an asynchronous store.
-    pub fn call(&self, mut store: impl AsContextMut, params: Params) -> Result<Results, Trap> {
+    pub fn call(&self, mut store: impl AsContextMut, params: Params) -> Result<Results> {
         let mut store = store.as_context_mut();
         assert!(
             !store.0.async_support(),
@@ -99,7 +99,7 @@ where
         &self,
         mut store: impl AsContextMut<Data = T>,
         params: Params,
-    ) -> Result<Results, Trap>
+    ) -> Result<Results>
     where
         T: Send,
     {
@@ -120,7 +120,7 @@ where
         store: &mut StoreContextMut<'_, T>,
         func: ptr::NonNull<VMCallerCheckedAnyfunc>,
         params: Params,
-    ) -> Result<Results, Trap> {
+    ) -> Result<Results> {
         // double-check that params/results match for this function's type in
         // debug mode.
         if cfg!(debug_assertions) {
@@ -150,9 +150,7 @@ where
             match params.into_abi(&mut store) {
                 Some(abi) => abi,
                 None => {
-                    return Err(Trap::new(
-                        "attempt to pass cross-`Store` value to Wasm as function argument",
-                    ))
+                    bail!("attempt to pass cross-`Store` value to Wasm as function argument")
                 }
             }
         };

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -324,7 +324,7 @@ impl Instance {
             )
             .map_err(|e| -> Error {
                 match e {
-                    InstantiationError::Trap(trap) => Trap::new_wasm(trap, None).into(),
+                    InstantiationError::Trap(trap) => Trap::from_env(trap).into(),
                     other => other.into(),
                 }
             })?;

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -88,7 +88,8 @@ impl Instance {
     ///
     /// When instantiation fails it's recommended to inspect the return value to
     /// see why it failed, or bubble it upwards. If you'd like to specifically
-    /// check for trap errors, you can use `error.downcast::<Trap>()`.
+    /// check for trap errors, you can use `error.downcast::<Trap>()`. For more
+    /// about error handling see the [`Trap`] documentation.
     ///
     /// # Panics
     ///
@@ -102,7 +103,7 @@ impl Instance {
         mut store: impl AsContextMut,
         module: &Module,
         imports: &[Extern],
-    ) -> Result<Instance, Error> {
+    ) -> Result<Instance> {
         let mut store = store.as_context_mut();
         let imports = Instance::typecheck_externs(store.0, module, imports)?;
         // Note that the unsafety here should be satisfied by the call to
@@ -134,7 +135,7 @@ impl Instance {
         mut store: impl AsContextMut<Data = T>,
         module: &Module,
         imports: &[Extern],
-    ) -> Result<Instance, Error>
+    ) -> Result<Instance>
     where
         T: Send,
     {

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -340,7 +340,7 @@
 //!     // module which called this host function.
 //!     let mem = match caller.get_export("memory") {
 //!         Some(Extern::Memory(mem)) => mem,
-//!         _ => return Err(Trap::new("failed to find host memory")),
+//!         _ => anyhow::bail!("failed to find host memory"),
 //!     };
 //!
 //!     // Use the `ptr` and `len` values to get a subslice of the wasm-memory
@@ -351,9 +351,9 @@
 //!     let string = match data {
 //!         Some(data) => match str::from_utf8(data) {
 //!             Ok(s) => s,
-//!             Err(_) => return Err(Trap::new("invalid utf-8")),
+//!             Err(_) => anyhow::bail!("invalid utf-8"),
 //!         },
-//!         None => return Err(Trap::new("pointer/length out of bounds")),
+//!         None => anyhow::bail!("pointer/length out of bounds"),
 //!     };
 //!     assert_eq!(string, "Hello, world!");
 //!     println!("{}", string);

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -3,7 +3,7 @@ use crate::instance::InstancePre;
 use crate::store::StoreOpaque;
 use crate::{
     AsContextMut, Caller, Engine, Extern, ExternType, Func, FuncType, ImportType, Instance,
-    IntoFunc, Module, StoreContextMut, Trap, Val, ValRaw,
+    IntoFunc, Module, StoreContextMut, Val, ValRaw,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use log::warn;
@@ -714,8 +714,7 @@ impl<T> Linker<T> {
                                     .unwrap()
                                     .into_func()
                                     .unwrap()
-                                    .call(&mut caller, params, results)
-                                    .map_err(|error| error.downcast::<Trap>().unwrap())?;
+                                    .call(&mut caller, params, results)?;
 
                                 Ok(())
                             },
@@ -781,8 +780,7 @@ impl<T> Linker<T> {
                                     .into_func()
                                     .unwrap()
                                     .call_async(&mut caller, params, results)
-                                    .await
-                                    .map_err(|error| error.downcast::<Trap>().unwrap())?;
+                                    .await?;
                                 Ok(())
                             })
                         },

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -149,7 +149,7 @@ macro_rules! generate_wrap_async_func {
                 let mut future = Pin::from(func(caller, $($args),*));
                 match unsafe { async_cx.block_on(future.as_mut()) } {
                     Ok(ret) => ret.into_fallible(),
-                    Err(e) => R::fallible_from_trap(e),
+                    Err(e) => R::fallible_from_error(e),
                 }
             })
         }
@@ -271,7 +271,7 @@ impl<T> Linker<T> {
                         import.name(),
                     );
                     self.func_new(import.module(), import.name(), func_ty, move |_, _, _| {
-                        Err(Trap::new(err_msg.clone()))
+                        bail!("{err_msg}")
                     })?;
                 }
             }
@@ -348,7 +348,7 @@ impl<T> Linker<T> {
         module: &str,
         name: &str,
         ty: FuncType,
-        func: impl Fn(Caller<'_, T>, &[Val], &mut [Val]) -> Result<(), Trap> + Send + Sync + 'static,
+        func: impl Fn(Caller<'_, T>, &[Val], &mut [Val]) -> Result<()> + Send + Sync + 'static,
     ) -> Result<&mut Self> {
         let func = HostFunc::new(&self.engine, ty, func);
         let key = self.import_key(module, Some(name));
@@ -366,7 +366,7 @@ impl<T> Linker<T> {
         module: &str,
         name: &str,
         ty: FuncType,
-        func: impl Fn(Caller<'_, T>, &mut [ValRaw]) -> Result<(), Trap> + Send + Sync + 'static,
+        func: impl Fn(Caller<'_, T>, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
     ) -> Result<&mut Self> {
         let func = HostFunc::new_unchecked(&self.engine, ty, func);
         let key = self.import_key(module, Some(name));
@@ -391,7 +391,7 @@ impl<T> Linker<T> {
                 Caller<'a, T>,
                 &'a [Val],
                 &'a mut [Val],
-            ) -> Box<dyn Future<Output = Result<(), Trap>> + Send + 'a>
+            ) -> Box<dyn Future<Output = Result<()>> + Send + 'a>
             + Send
             + Sync
             + 'static,

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -79,7 +79,7 @@
 use crate::linker::Definition;
 use crate::module::BareModuleInfo;
 use crate::{module::ModuleRegistry, Engine, Module, Trap, Val, ValRaw};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -219,11 +219,11 @@ enum ResourceLimiterInner<T> {
 pub trait CallHookHandler<T>: Send {
     /// A callback to run when wasmtime is about to enter a host call, or when about to
     /// exit the hostcall.
-    async fn handle_call_event(&self, t: &mut T, ch: CallHook) -> Result<(), crate::Trap>;
+    async fn handle_call_event(&self, t: &mut T, ch: CallHook) -> Result<()>;
 }
 
 enum CallHookInner<T> {
-    Sync(Box<dyn FnMut(&mut T, CallHook) -> Result<(), crate::Trap> + Send + Sync>),
+    Sync(Box<dyn FnMut(&mut T, CallHook) -> Result<()> + Send + Sync>),
     #[cfg(feature = "async")]
     Async(Box<dyn CallHookHandler<T> + Send + Sync>),
 }
@@ -331,8 +331,7 @@ pub struct StoreOpaque {
 
 #[cfg(feature = "async")]
 struct AsyncState {
-    current_suspend:
-        UnsafeCell<*const wasmtime_fiber::Suspend<Result<(), Trap>, (), Result<(), Trap>>>,
+    current_suspend: UnsafeCell<*const wasmtime_fiber::Suspend<Result<()>, (), Result<()>>>,
     current_poll_cx: UnsafeCell<*mut Context<'static>>,
 }
 
@@ -722,7 +721,7 @@ impl<T> Store<T> {
     /// to host or wasm code as the trap propagates to the root call.
     pub fn call_hook(
         &mut self,
-        hook: impl FnMut(&mut T, CallHook) -> Result<(), Trap> + Send + Sync + 'static,
+        hook: impl FnMut(&mut T, CallHook) -> Result<()> + Send + Sync + 'static,
     ) {
         self.inner.call_hook = Some(CallHookInner::Sync(Box::new(hook)));
     }
@@ -1094,7 +1093,7 @@ impl<T> StoreInner<T> {
         &mut self.data
     }
 
-    pub fn call_hook(&mut self, s: CallHook) -> Result<(), Trap> {
+    pub fn call_hook(&mut self, s: CallHook) -> Result<()> {
         match &mut self.call_hook {
             Some(CallHookInner::Sync(hook)) => hook(&mut self.data, s),
 
@@ -1103,7 +1102,7 @@ impl<T> StoreInner<T> {
                 Ok(self
                     .inner
                     .async_cx()
-                    .ok_or(Trap::new("couldn't grab async_cx for call hook"))?
+                    .ok_or_else(|| anyhow!("couldn't grab async_cx for call hook"))?
                     .block_on(handler.handle_call_event(&mut self.data, s).as_mut())??)
             },
 
@@ -1354,7 +1353,7 @@ impl StoreOpaque {
     /// This only works on async futures and stores, and assumes that we're
     /// executing on a fiber. This will yield execution back to the caller once.
     #[cfg(feature = "async")]
-    fn async_yield_impl(&mut self) -> Result<(), Trap> {
+    fn async_yield_impl(&mut self) -> Result<()> {
         // Small future that yields once and then returns ()
         #[derive(Default)]
         struct Yield {
@@ -1380,7 +1379,7 @@ impl StoreOpaque {
 
         let mut future = Yield::default();
 
-        // When control returns, we have a `Result<(), Trap>` passed
+        // When control returns, we have a `Result<()>` passed
         // in from the host fiber. If this finished successfully then
         // we were resumed normally via a `poll`, so keep going.  If
         // the future was dropped while we were yielded, then we need
@@ -1518,7 +1517,7 @@ impl<T> StoreContextMut<'_, T> {
     pub(crate) async fn on_fiber<R>(
         &mut self,
         func: impl FnOnce(&mut StoreContextMut<'_, T>) -> R + Send,
-    ) -> Result<R, Trap>
+    ) -> Result<R>
     where
         T: Send,
     {
@@ -1530,11 +1529,7 @@ impl<T> StoreContextMut<'_, T> {
         let future = {
             let current_poll_cx = self.0.async_state.current_poll_cx.get();
             let current_suspend = self.0.async_state.current_suspend.get();
-            let stack = self
-                .engine()
-                .allocator()
-                .allocate_fiber_stack()
-                .map_err(|e| Trap::from(anyhow::Error::from(e)))?;
+            let stack = self.engine().allocator().allocate_fiber_stack()?;
 
             let engine = self.engine().clone();
             let slot = &mut slot;
@@ -1558,8 +1553,7 @@ impl<T> StoreContextMut<'_, T> {
                     *slot = Some(func(self));
                     Ok(())
                 }
-            })
-            .map_err(|e| Trap::from(anyhow::Error::from(e)))?;
+            })?;
 
             // Once we have the fiber representing our synchronous computation, we
             // wrap that in a custom future implementation which does the
@@ -1575,7 +1569,7 @@ impl<T> StoreContextMut<'_, T> {
         return Ok(slot.unwrap());
 
         struct FiberFuture<'a> {
-            fiber: wasmtime_fiber::Fiber<'a, Result<(), Trap>, (), Result<(), Trap>>,
+            fiber: wasmtime_fiber::Fiber<'a, Result<()>, (), Result<()>>,
             current_poll_cx: *mut *mut Context<'static>,
             engine: Engine,
         }
@@ -1644,7 +1638,7 @@ impl<T> StoreContextMut<'_, T> {
         unsafe impl Send for FiberFuture<'_> {}
 
         impl Future for FiberFuture<'_> {
-            type Output = Result<(), Trap>;
+            type Output = Result<()>;
 
             fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
                 // We need to carry over this `cx` into our fiber's runtime
@@ -1699,7 +1693,7 @@ impl<T> StoreContextMut<'_, T> {
         impl Drop for FiberFuture<'_> {
             fn drop(&mut self) {
                 if !self.fiber.done() {
-                    let result = self.fiber.resume(Err(Trap::new("future dropped")));
+                    let result = self.fiber.resume(Err(anyhow!("future dropped")));
                     // This resumption with an error should always complete the
                     // fiber. While it's technically possible for host code to catch
                     // the trap and re-resume, we'd ideally like to signal that to
@@ -1719,7 +1713,7 @@ impl<T> StoreContextMut<'_, T> {
 
 #[cfg(feature = "async")]
 pub struct AsyncCx {
-    current_suspend: *mut *const wasmtime_fiber::Suspend<Result<(), Trap>, (), Result<(), Trap>>,
+    current_suspend: *mut *const wasmtime_fiber::Suspend<Result<()>, (), Result<()>>,
     current_poll_cx: *mut *mut Context<'static>,
 }
 
@@ -1748,7 +1742,7 @@ impl AsyncCx {
     pub unsafe fn block_on<U>(
         &self,
         mut future: Pin<&mut (dyn Future<Output = U> + Send)>,
-    ) -> Result<U, Trap> {
+    ) -> Result<U> {
         // Take our current `Suspend` context which was configured as soon as
         // our fiber started. Note that we must load it at the front here and
         // save it on our stack frame. While we're polling the future other
@@ -1895,15 +1889,16 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
     }
 
     fn out_of_gas(&mut self) -> Result<(), anyhow::Error> {
+        let trap = || anyhow::Error::from(Trap::new("all fuel consumed by WebAssembly"));
         return match &mut self.out_of_gas_behavior {
-            OutOfGas::Trap => Err(anyhow::Error::new(OutOfGasError)),
+            OutOfGas::Trap => Err(trap()),
             #[cfg(feature = "async")]
             OutOfGas::InjectFuel {
                 injection_count,
                 fuel_to_inject,
             } => {
                 if *injection_count == 0 {
-                    return Err(anyhow::Error::new(OutOfGasError));
+                    return Err(trap());
                 }
                 *injection_count -= 1;
                 let fuel = *fuel_to_inject;
@@ -1916,17 +1911,6 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
             #[cfg(not(feature = "async"))]
             OutOfGas::InjectFuel { .. } => unreachable!(),
         };
-
-        #[derive(Debug)]
-        struct OutOfGasError;
-
-        impl fmt::Display for OutOfGasError {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.write_str("all fuel consumed by WebAssembly")
-            }
-        }
-
-        impl std::error::Error for OutOfGasError {}
     }
 
     fn new_epoch(&mut self) -> Result<u64, anyhow::Error> {

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1890,14 +1890,14 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
 
     fn out_of_gas(&mut self) -> Result<(), anyhow::Error> {
         return match &mut self.out_of_gas_behavior {
-            OutOfGas::Trap => Err(Trap::out_of_fuel().into()),
+            OutOfGas::Trap => Err(Trap::OutOfFuel.into()),
             #[cfg(feature = "async")]
             OutOfGas::InjectFuel {
                 injection_count,
                 fuel_to_inject,
             } => {
                 if *injection_count == 0 {
-                    return Err(Trap::out_of_fuel().into());
+                    return Err(Trap::OutOfFuel.into());
                 }
                 *injection_count -= 1;
                 let fuel = *fuel_to_inject;
@@ -1914,10 +1914,7 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
 
     fn new_epoch(&mut self) -> Result<u64, anyhow::Error> {
         return match &mut self.epoch_deadline_behavior {
-            EpochDeadline::Trap => {
-                let trap = Trap::new_wasm(wasmtime_environ::TrapCode::Interrupt, None);
-                Err(anyhow::Error::from(trap))
-            }
+            EpochDeadline::Trap => Err(Trap::Interrupt.into()),
             EpochDeadline::Callback(callback) => {
                 let delta = callback(&mut self.data)?;
                 // Set a new deadline and return the new epoch deadline so

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1889,16 +1889,15 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
     }
 
     fn out_of_gas(&mut self) -> Result<(), anyhow::Error> {
-        let trap = || anyhow::Error::from(Trap::new("all fuel consumed by WebAssembly"));
         return match &mut self.out_of_gas_behavior {
-            OutOfGas::Trap => Err(trap()),
+            OutOfGas::Trap => Err(Trap::out_of_fuel().into()),
             #[cfg(feature = "async")]
             OutOfGas::InjectFuel {
                 injection_count,
                 fuel_to_inject,
             } => {
                 if *injection_count == 0 {
-                    return Err(trap());
+                    return Err(Trap::out_of_fuel().into());
                 }
                 *injection_count -= 1;
                 let fuel = *fuel_to_inject;

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -21,7 +21,7 @@ unsafe extern "C" fn stub_fn<F>(
     values_vec: *mut ValRaw,
     values_vec_len: usize,
 ) where
-    F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<(), Trap> + 'static,
+    F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<()> + 'static,
 {
     // Here we are careful to use `catch_unwind` to ensure Rust panics don't
     // unwind past us. The primary reason for this is that Rust considers it UB
@@ -105,7 +105,7 @@ pub fn create_function<F>(
     engine: &Engine,
 ) -> Result<(Box<VMHostFuncContext>, VMSharedSignatureIndex, VMTrampoline)>
 where
-    F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<(), Trap> + Send + Sync + 'static,
+    F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
 {
     let mut obj = engine.compiler().object()?;
     let (t1, t2) = engine.compiler().emit_trampoline_obj(

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -25,9 +25,6 @@ enum TrapReason {
     /// An error message describing a trap.
     Message(String),
 
-    /// An `i32` exit status describing an explicit program exit.
-    I32Exit(i32),
-
     /// A specific code for a trap triggered while executing WASM.
     InstructionTrap(TrapCode),
 }
@@ -133,13 +130,6 @@ impl Trap {
         Trap::new_with_trace(reason, None)
     }
 
-    /// Creates a new `Trap` representing an explicit program exit with a classic `i32`
-    /// exit status value.
-    #[cold] // see Trap::new
-    pub fn i32_exit(status: i32) -> Self {
-        Trap::new_with_trace(TrapReason::I32Exit(status), None)
-    }
-
     // Same safety requirements and caveats as
     // `wasmtime_runtime::raise_user_trap`.
     pub(crate) unsafe fn raise(error: anyhow::Error) -> ! {
@@ -229,15 +219,6 @@ impl Trap {
         }
     }
 
-    /// If the trap was the result of an explicit program exit with a classic
-    /// `i32` exit status value, return the value, otherwise return `None`.
-    pub fn i32_exit_status(&self) -> Option<i32> {
-        match self.inner.reason {
-            TrapReason::I32Exit(status) => Some(status),
-            _ => None,
-        }
-    }
-
     /// Displays the error reason for this trap.
     ///
     /// In particular, it differs from this struct's `Display` by *only*
@@ -321,7 +302,6 @@ impl fmt::Display for TrapReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TrapReason::Message(s) => write!(f, "{}", s),
-            TrapReason::I32Exit(status) => write!(f, "Exited with i32 exit status {}", status),
             TrapReason::InstructionTrap(code) => write!(f, "wasm trap: {}", code),
         }
     }

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -477,7 +477,7 @@ impl fmt::Display for TrapBacktrace {
             }
         }
         if self.hint_wasm_backtrace_details_env {
-            writeln!(f, "note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information")?;
+            write!(f, "\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information")?;
         }
         Ok(())
     }

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -101,7 +101,7 @@ fn _define_func(
                     ctx: &mut (impl #(#bounds)+*),
                     memory: &dyn #rt::GuestMemory,
                     #(#abi_params),*
-                ) -> Result<#abi_ret, #rt::wasmtime_crate::Trap> {
+                ) -> #rt::anyhow::Result<#abi_ret> {
                     use std::convert::TryFrom as _;
                     #traced_body
                 }
@@ -127,7 +127,7 @@ fn _define_func(
                     ctx: &'a mut (impl #(#bounds)+*),
                     memory: &'a dyn #rt::GuestMemory,
                     #(#abi_params),*
-                ) -> impl std::future::Future<Output = Result<#abi_ret, #rt::wasmtime_crate::Trap>> + 'a {
+                ) -> impl std::future::Future<Output = #rt::anyhow::Result<#abi_ret>> + 'a {
                     use std::convert::TryFrom as _;
                     #traced_body
                 }

--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -43,7 +43,7 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
         let abi_typename = names.type_ref(&errtype.abi_type(), anon_lifetime());
         let user_typename = errtype.typename();
         let methodname = names.user_error_conversion_method(&errtype);
-        quote!(fn #methodname(&mut self, e: super::#user_typename) -> Result<#abi_typename, #rt::wasmtime_crate::Trap>;)
+        quote!(fn #methodname(&mut self, e: super::#user_typename) -> #rt::anyhow::Result<#abi_typename>;)
     });
     let user_error_conversion = quote! {
         pub trait UserErrorConversion {

--- a/crates/wiggle/generate/src/module_trait.rs
+++ b/crates/wiggle/generate/src/module_trait.rs
@@ -45,7 +45,7 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
         });
 
         let result = match f.results.len() {
-            0 if f.noreturn => quote!(#rt::wasmtime_crate::Trap),
+            0 if f.noreturn => quote!(#rt::anyhow::Error),
             0 => quote!(()),
             1 => {
                 let (ok, err) = match &**f.results[0].tref.type_() {

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -114,9 +114,7 @@ fn generate_func(
     let body = quote! {
         let mem = match caller.get_export("memory") {
             Some(#rt::wasmtime_crate::Extern::Memory(m)) => m,
-            _ => {
-                return Err(#rt::wasmtime_crate::Trap::new("missing required memory export"));
-            }
+            _ => #rt::anyhow::bail!("missing required memory export"),
         };
         let (mem , ctx) = mem.data_and_store_mut(&mut caller);
         let ctx = get_cx(ctx);
@@ -143,7 +141,7 @@ fn generate_func(
                 linker.func_wrap(
                     #module_str,
                     #field_str,
-                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> Result<#ret_ty, #rt::wasmtime_crate::Trap> {
+                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> #rt::anyhow::Result<#ret_ty> {
                         let result = async { #body };
                         #rt::run_in_dummy_executor(result)?
                     },
@@ -156,7 +154,7 @@ fn generate_func(
                 linker.func_wrap(
                     #module_str,
                     #field_str,
-                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> Result<#ret_ty, #rt::wasmtime_crate::Trap> {
+                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> #rt::anyhow::Result<#ret_ty> {
                         #body
                     },
                 )?;

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -909,14 +909,6 @@ impl Pointee for str {
     }
 }
 
-impl From<GuestError> for wasmtime_crate::Trap {
-    fn from(err: GuestError) -> wasmtime_crate::Trap {
-        wasmtime_crate::Trap::from(
-            Box::new(err) as Box<dyn std::error::Error + Send + Sync + 'static>
-        )
-    }
-}
-
 pub fn run_in_dummy_executor<F: std::future::Future>(
     future: F,
 ) -> Result<F::Output, wasmtime_crate::Trap> {

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, Result};
 use std::fmt;
 use std::slice;
 use std::str;
@@ -909,9 +910,7 @@ impl Pointee for str {
     }
 }
 
-pub fn run_in_dummy_executor<F: std::future::Future>(
-    future: F,
-) -> Result<F::Output, wasmtime_crate::Trap> {
+pub fn run_in_dummy_executor<F: std::future::Future>(future: F) -> Result<F::Output> {
     use std::pin::Pin;
     use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
@@ -921,7 +920,7 @@ pub fn run_in_dummy_executor<F: std::future::Future>(
     match f.as_mut().poll(&mut cx) {
         Poll::Ready(val) => return Ok(val),
         Poll::Pending =>
-            return Err(wasmtime_crate::Trap::new("Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store"))
+            bail!("Cannot wait on pending future: must enable wiggle \"async\" future and execute on an async Store"),
     }
 
     fn dummy_waker() -> Waker {

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -16,6 +16,7 @@ proptest = "1.0.0"
 wiggle = { path = "..", features = ["tracing_log"] }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 thiserror = "1.0"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt'] }

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use wiggle_test::{impl_errno, HostMemory, WasiCtx};
 
 /// The `errors` argument to the wiggle gives us a hook to map a rich error
@@ -32,10 +33,7 @@ impl_errno!(types::Errno);
 /// When the `errors` mapping in witx is non-empty, we need to impl the
 /// types::UserErrorConversion trait that wiggle generates from that mapping.
 impl<'a> types::UserErrorConversion for WasiCtx<'a> {
-    fn errno_from_rich_error(
-        &mut self,
-        e: RichError,
-    ) -> Result<types::Errno, wiggle::wasmtime_crate::Trap> {
+    fn errno_from_rich_error(&mut self, e: RichError) -> Result<types::Errno> {
         wiggle::tracing::debug!(
             rich_error = wiggle::tracing::field::debug(&e),
             "error conversion"

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -314,7 +314,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         unimplemented!("poll_oneoff")
     }
 
-    fn proc_exit(&mut self, _rval: types::Exitcode) -> wiggle::wasmtime_crate::Trap {
+    fn proc_exit(&mut self, _rval: types::Exitcode) -> anyhow::Error {
         unimplemented!("proc_exit")
     }
 

--- a/crates/wiggle/tests/wasmtime_sync.rs
+++ b/crates/wiggle/tests/wasmtime_sync.rs
@@ -132,7 +132,7 @@ fn test_async_host_func_pending() {
         )
         .unwrap_err();
     assert!(
-        format!("{}", trap).contains("Cannot wait on pending future"),
+        format!("{:?}", trap).contains("Cannot wait on pending future"),
         "expected get a pending future Trap from dummy executor, got: {}",
         trap
     );

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -26,7 +26,11 @@ fn main() -> Result<()> {
     });
 
     println!("Entering infinite loop ...");
-    let trap = run.call(&mut store, ()).unwrap_err();
+    let trap = run
+        .call(&mut store, ())
+        .unwrap_err()
+        .downcast::<Trap>()
+        .unwrap();
 
     println!("trap received...");
     assert!(trap.trap_code().unwrap() == TrapCode::Interrupt);

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -26,14 +26,10 @@ fn main() -> Result<()> {
     });
 
     println!("Entering infinite loop ...");
-    let trap = run
-        .call(&mut store, ())
-        .unwrap_err()
-        .downcast::<Trap>()
-        .unwrap();
+    let err = run.call(&mut store, ()).unwrap_err();
 
     println!("trap received...");
-    assert!(trap.trap_code().unwrap() == TrapCode::Interrupt);
+    assert_eq!(err.downcast::<Trap>()?, Trap::Interrupt);
 
     Ok(())
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -15,6 +15,7 @@ use std::{
 use wasmtime::{Engine, Func, Linker, Module, Store, Trap, Val, ValType};
 use wasmtime_cli_flags::{CommonOptions, WasiModules};
 use wasmtime_wasi::sync::{ambient_authority, Dir, TcpListener, WasiCtxBuilder};
+use wasmtime_wasi::I32Exit;
 
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::WasiNnCtx;
@@ -211,24 +212,25 @@ impl RunCommand {
         {
             Ok(()) => (),
             Err(e) => {
-                // If the program exited because of a non-zero exit status, print
-                // a message and exit.
-                if let Some(trap) = e.downcast_ref::<Trap>() {
+                // If a specific WASI error code was requested then that's
+                // forwarded through to the process here without printing any
+                // extra error information.
+                if let Some(exit) = e.downcast_ref::<I32Exit>() {
                     // Print the error message in the usual way.
-                    if let Some(status) = trap.i32_exit_status() {
-                        // On Windows, exit status 3 indicates an abort (see below),
-                        // so return 1 indicating a non-zero status to avoid ambiguity.
-                        if cfg!(windows) && status >= 3 {
-                            process::exit(1);
-                        }
-                        process::exit(status);
+                    // On Windows, exit status 3 indicates an abort (see below),
+                    // so return 1 indicating a non-zero status to avoid ambiguity.
+                    if cfg!(windows) && exit.0 >= 3 {
+                        process::exit(1);
                     }
+                    process::exit(exit.0);
+                }
 
+                // If the program exited because of a trap, return an error code
+                // to the outside environment indicating a more severe problem
+                // than a simple failure.
+                if e.is::<Trap>() {
                     eprintln!("Error: {:?}", e);
 
-                    // If the program exited because of a trap, return an error code
-                    // to the outside environment indicating a more severe problem
-                    // than a simple failure.
                     if cfg!(unix) {
                         // On Unix, return the error code of an abort.
                         process::exit(128 + libc::SIGABRT);
@@ -238,6 +240,9 @@ impl RunCommand {
                         process::exit(3);
                     }
                 }
+
+                // Otherwise fall back on Rust's default error printing/return
+                // code.
                 return Err(e);
             }
         }

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -565,9 +565,8 @@ async fn recursive_async() -> Result<()> {
                 .call_async(&mut caller, ())
                 .await
                 .unwrap_err()
-                .downcast::<Trap>()
-                .unwrap();
-            assert_eq!(err.trap_code(), Some(TrapCode::StackOverflow));
+                .downcast::<Trap>()?;
+            assert_eq!(err, Trap::StackOverflow);
             Ok(())
         })
     });

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -252,11 +252,7 @@ fn exit125_wasi_snapshot1() -> Result<()> {
 fn exit126_wasi_snapshot0() -> Result<()> {
     let wasm = build_wasm("tests/all/cli_tests/exit126_wasi_snapshot0.wat")?;
     let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
-    if cfg!(windows) {
-        assert_eq!(output.status.code().unwrap(), 3);
-    } else {
-        assert_eq!(output.status.code().unwrap(), 128 + libc::SIGABRT);
-    }
+    assert_eq!(output.status.code().unwrap(), 1);
     assert!(output.stdout.is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("invalid exit status"));
     Ok(())
@@ -267,11 +263,7 @@ fn exit126_wasi_snapshot0() -> Result<()> {
 fn exit126_wasi_snapshot1() -> Result<()> {
     let wasm = build_wasm("tests/all/cli_tests/exit126_wasi_snapshot1.wat")?;
     let output = run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"])?;
-    if cfg!(windows) {
-        assert_eq!(output.status.code().unwrap(), 3);
-    } else {
-        assert_eq!(output.status.code().unwrap(), 128 + libc::SIGABRT);
-    }
+    assert_eq!(output.status.code().unwrap(), 1);
     assert!(output.stdout.is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("invalid exit status"));
     Ok(())

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use wasmtime::component::*;
-use wasmtime::{Store, StoreContextMut, Trap, TrapCode};
+use wasmtime::{Store, StoreContextMut, Trap};
 
 /// This is super::func::thunks, except with an async store.
 #[tokio::test]
@@ -38,7 +38,7 @@ async fn smoke() -> Result<()> {
         .call_async(&mut store, ())
         .await
         .unwrap_err();
-    assert!(err.downcast::<Trap>()?.trap_code() == Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(err.downcast::<Trap>()?, Trap::UnreachableCodeReached);
 
     Ok(())
 }

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use std::rc::Rc;
 use std::sync::Arc;
 use wasmtime::component::*;
-use wasmtime::{Store, StoreContextMut, Trap, TrapCode};
+use wasmtime::{Store, StoreContextMut, Trap};
 
 const CANON_32BIT_NAN: u32 = 0b01111111110000000000000000000000;
 const CANON_64BIT_NAN: u64 = 0b0111111111111000000000000000000000000000000000000000000000000000;
@@ -37,7 +37,7 @@ fn thunks() -> Result<()> {
         .get_typed_func::<(), (), _>(&mut store, "thunk-trap")?
         .call(&mut store, ())
         .unwrap_err();
-    assert!(err.downcast::<Trap>()?.trap_code() == Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(err.downcast::<Trap>()?, Trap::UnreachableCodeReached);
 
     Ok(())
 }
@@ -1099,7 +1099,7 @@ fn some_traps() -> Result<()> {
         .call(&mut store, (&[],))
         .unwrap_err()
         .downcast::<Trap>()?;
-    assert_eq!(err.trap_code(), Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(err, Trap::UnreachableCodeReached);
 
     // This should fail when calling the allocator function for the argument
     let err = instance(&mut store)?
@@ -1107,7 +1107,7 @@ fn some_traps() -> Result<()> {
         .call(&mut store, ("",))
         .unwrap_err()
         .downcast::<Trap>()?;
-    assert_eq!(err.trap_code(), Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(err, Trap::UnreachableCodeReached);
 
     // This should fail when calling the allocator function for the space
     // to store the arguments (before arguments are even lowered)
@@ -1119,7 +1119,7 @@ fn some_traps() -> Result<()> {
         .call(&mut store, ("", "", "", "", "", "", "", "", "", ""))
         .unwrap_err()
         .downcast::<Trap>()?;
-    assert_eq!(err.trap_code(), Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(err, Trap::UnreachableCodeReached);
 
     // Assert that when the base pointer returned by malloc is out of bounds
     // that errors are reported as such. Both empty and lists with contents
@@ -2375,8 +2375,8 @@ fn errors_that_poison_instance() -> Result<()> {
             Err(e) => e,
         };
         assert_eq!(
-            err.downcast::<Trap>().unwrap().trap_code(),
-            Some(TrapCode::UnreachableCodeReached)
+            err.downcast::<Trap>().unwrap(),
+            Trap::UnreachableCodeReached
         );
     }
 

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -733,16 +733,22 @@ fn bad_import_alignment() -> Result<()> {
         .instantiate(&mut store, &component)?
         .get_typed_func::<(), (), _>(&mut store, "unaligned-retptr")?
         .call(&mut store, ())
-        .unwrap_err()
-        .downcast::<Trap>()?;
-    assert!(trap.to_string().contains("pointer not aligned"), "{}", trap);
+        .unwrap_err();
+    assert!(
+        format!("{:?}", trap).contains("pointer not aligned"),
+        "{}",
+        trap
+    );
     let trap = linker
         .instantiate(&mut store, &component)?
         .get_typed_func::<(), (), _>(&mut store, "unaligned-argptr")?
         .call(&mut store, ())
-        .unwrap_err()
-        .downcast::<Trap>()?;
-    assert!(trap.to_string().contains("pointer not aligned"), "{}", trap);
+        .unwrap_err();
+    assert!(
+        format!("{:?}", trap).contains("pointer not aligned"),
+        "{}",
+        trap
+    );
 
     Ok(())
 }

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -2,7 +2,7 @@ use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use std::ops::Deref;
 use wasmtime::component::*;
-use wasmtime::{BacktraceContext, Store, StoreContextMut};
+use wasmtime::{Store, StoreContextMut, WasmBacktrace};
 
 #[test]
 fn can_compile() -> Result<()> {
@@ -262,7 +262,7 @@ fn attempt_to_leave_during_malloc() -> Result<()> {
         "bad trap: {trap:?}",
     );
 
-    let trace = trap.downcast_ref::<BacktraceContext>().unwrap().frames();
+    let trace = trap.downcast_ref::<WasmBacktrace>().unwrap().frames();
     assert_eq!(trace.len(), 4);
 
     // This was our entry point...

--- a/tests/all/component_model/post_return.rs
+++ b/tests/all/component_model/post_return.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use wasmtime::component::*;
-use wasmtime::{Store, StoreContextMut, Trap, TrapCode};
+use wasmtime::{Store, StoreContextMut, Trap};
 
 #[test]
 fn invalid_api() -> Result<()> {
@@ -284,7 +284,7 @@ fn trap_in_post_return_poisons_instance() -> Result<()> {
     let f = instance.get_typed_func::<(), (), _>(&mut store, "f")?;
     f.call(&mut store, ())?;
     let trap = f.post_return(&mut store).unwrap_err().downcast::<Trap>()?;
-    assert_eq!(trap.trap_code(), Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(trap, Trap::UnreachableCodeReached);
     let err = f.call(&mut store, ()).unwrap_err();
     assert!(
         err.to_string()

--- a/tests/all/component_model/strings.rs
+++ b/tests/all/component_model/strings.rs
@@ -1,7 +1,7 @@
 use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use wasmtime::component::{Component, Linker};
-use wasmtime::{Engine, Store, StoreContextMut, Trap, TrapCode};
+use wasmtime::{Engine, Store, StoreContextMut, Trap};
 
 const UTF16_TAG: u32 = 1 << 31;
 
@@ -248,7 +248,7 @@ fn test_ptr_out_of_bounds(engine: &Engine, src: &str, dst: &str) -> Result<()> {
             .err()
             .unwrap()
             .downcast::<Trap>()?;
-        assert_eq!(trap.trap_code(), Some(TrapCode::UnreachableCodeReached));
+        assert_eq!(trap, Trap::UnreachableCodeReached);
         Ok(())
     };
 
@@ -322,7 +322,7 @@ fn test_ptr_overflow(engine: &Engine, src: &str, dst: &str) -> Result<()> {
             .call(&mut store, (size,))
             .unwrap_err()
             .downcast::<Trap>()?;
-        assert_eq!(trap.trap_code(), Some(TrapCode::UnreachableCodeReached));
+        assert_eq!(trap, Trap::UnreachableCodeReached);
         Ok(())
     };
 
@@ -422,7 +422,7 @@ fn test_realloc_oob(engine: &Engine, src: &str, dst: &str) -> Result<()> {
     let instance = Linker::new(engine).instantiate(&mut store, &component)?;
     let func = instance.get_typed_func::<(), (), _>(&mut store, "f")?;
     let trap = func.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
-    assert_eq!(trap.trap_code(), Some(TrapCode::UnreachableCodeReached));
+    assert_eq!(trap, Trap::UnreachableCodeReached);
     Ok(())
 }
 

--- a/tests/all/component_model/strings.rs
+++ b/tests/all/component_model/strings.rs
@@ -498,9 +498,8 @@ fn test_invalid_string_encoding(
     let trap = test_raw_when_encoded(engine, src, dst, bytes, len)?.unwrap();
     let src = src.replace("latin1+", "");
     assert!(
-        trap.to_string()
-            .contains(&format!("invalid {src} encoding")),
-        "bad error: {}",
+        format!("{:?}", trap).contains(&format!("invalid {src} encoding")),
+        "bad error: {:?}",
         trap,
     );
     Ok(())
@@ -524,7 +523,7 @@ fn test_raw_when_encoded(
     dst: &str,
     bytes: &[u8],
     len: u32,
-) -> Result<Option<Trap>> {
+) -> Result<Option<anyhow::Error>> {
     let component = format!(
         r#"
 (component
@@ -574,6 +573,6 @@ fn test_raw_when_encoded(
     let func = instance.get_typed_func::<(&[u8], u32), (), _>(&mut store, "f")?;
     match func.call(&mut store, (bytes, len)) {
         Ok(_) => Ok(None),
-        Err(e) => Ok(Some(e.downcast()?)),
+        Err(e) => Ok(Some(e)),
     }
 }

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -170,12 +170,7 @@ mod tests {
             let trap = invoke_export(&mut store, instance, "read_out_of_bounds")
                 .unwrap_err()
                 .downcast::<Trap>()?;
-            assert!(
-                trap.to_string()
-                    .contains("wasm trap: out of bounds memory access"),
-                "bad trap message: {:?}",
-                trap.to_string()
-            );
+            assert_eq!(trap, Trap::MemoryOutOfBounds);
         }
 
         // these invoke wasmtime_call_trampoline from callable.rs
@@ -192,10 +187,11 @@ mod tests {
             let read_out_of_bounds_func =
                 instance.get_typed_func::<(), i32, _>(&mut store, "read_out_of_bounds")?;
             println!("calling read_out_of_bounds...");
-            let trap = read_out_of_bounds_func.call(&mut store, ()).unwrap_err();
-            assert!(trap
-                .to_string()
-                .contains("wasm trap: out of bounds memory access"));
+            let trap = read_out_of_bounds_func
+                .call(&mut store, ())
+                .unwrap_err()
+                .downcast::<Trap>()?;
+            assert_eq!(trap, Trap::MemoryOutOfBounds);
         }
         Ok(())
     }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -117,7 +117,7 @@ fn iloop() {
         store.add_fuel(10_000).unwrap();
         let error = Instance::new(&mut store, &module, &[]).err().unwrap();
         assert!(
-            error.to_string().contains("all fuel consumed"),
+            format!("{:?}", error).contains("all fuel consumed"),
             "bad error: {}",
             error
         );
@@ -173,8 +173,11 @@ fn host_function_consumes_all() {
     let export = instance
         .get_typed_func::<(), (), _>(&mut store, "")
         .unwrap();
-    let trap = export.call(&mut store, ()).err().unwrap().to_string();
-    assert!(trap.contains("all fuel consumed"), "bad error: {}", trap);
+    let trap = export.call(&mut store, ()).unwrap_err();
+    assert!(
+        format!("{trap:?}").contains("all fuel consumed"),
+        "bad error: {trap:?}"
+    );
 }
 
 #[test]

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -228,7 +228,6 @@ fn trap_smoke() -> Result<()> {
         .unwrap_err()
         .downcast::<Trap>()?;
     assert!(err.to_string().contains("test"));
-    assert!(err.i32_exit_status().is_none());
     Ok(())
 }
 

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -31,7 +31,7 @@ fn loops_interruptable() -> anyhow::Result<()> {
     let instance = Instance::new(&mut store, &module, &[])?;
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
     store.engine().increment_epoch();
-    let trap = iloop.call(&mut store, ()).unwrap_err();
+    let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
     assert!(
         trap.trap_code().unwrap() == TrapCode::Interrupt,
         "bad message: {}",
@@ -48,7 +48,7 @@ fn functions_interruptable() -> anyhow::Result<()> {
     let instance = Instance::new(&mut store, &module, &[func.into()])?;
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
     store.engine().increment_epoch();
-    let trap = iloop.call(&mut store, ()).unwrap_err();
+    let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
     assert!(
         trap.trap_code().unwrap() == TrapCode::Interrupt,
         "{}",
@@ -98,7 +98,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
-    let trap = iloop.call(&mut store, ()).unwrap_err();
+    let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
     STOP.store(true, SeqCst);
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);
@@ -138,7 +138,7 @@ fn function_interrupt_from_afar() -> anyhow::Result<()> {
     // Enter the infinitely looping function and assert that our interrupt
     // handle does indeed actually interrupt the function.
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
-    let trap = iloop.call(&mut store, ()).unwrap_err();
+    let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
     STOP.store(true, SeqCst);
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -32,11 +32,7 @@ fn loops_interruptable() -> anyhow::Result<()> {
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
     store.engine().increment_epoch();
     let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
-    assert!(
-        trap.trap_code().unwrap() == TrapCode::Interrupt,
-        "bad message: {}",
-        trap
-    );
+    assert_eq!(trap, Trap::Interrupt);
     Ok(())
 }
 
@@ -49,11 +45,7 @@ fn functions_interruptable() -> anyhow::Result<()> {
     let iloop = instance.get_typed_func::<(), (), _>(&mut store, "loop")?;
     store.engine().increment_epoch();
     let trap = iloop.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
-    assert!(
-        trap.trap_code().unwrap() == TrapCode::Interrupt,
-        "{}",
-        trap.to_string()
-    );
+    assert_eq!(trap, Trap::Interrupt);
     Ok(())
 }
 
@@ -102,11 +94,7 @@ fn loop_interrupt_from_afar() -> anyhow::Result<()> {
     STOP.store(true, SeqCst);
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);
-    assert!(
-        trap.trap_code().unwrap() == TrapCode::Interrupt,
-        "bad message: {}",
-        trap.to_string()
-    );
+    assert_eq!(trap, Trap::Interrupt);
     Ok(())
 }
 
@@ -142,10 +130,6 @@ fn function_interrupt_from_afar() -> anyhow::Result<()> {
     STOP.store(true, SeqCst);
     thread.join().unwrap();
     assert!(HITS.load(SeqCst) > NUM_HITS);
-    assert!(
-        trap.trap_code().unwrap() == TrapCode::Interrupt,
-        "bad message: {}",
-        trap.to_string()
-    );
+    assert_eq!(trap, Trap::Interrupt);
     Ok(())
 }

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -82,10 +82,7 @@ fn test_returns_incorrect_type() -> Result<()> {
     let mut result = [Val::I32(0)];
     let trap = run_func
         .call(&mut store, &[], &mut result)
-        .expect_err("the execution should fail")
-        .downcast::<Trap>()?;
-    assert!(trap
-        .to_string()
-        .contains("function attempted to return an incompatible value"));
+        .expect_err("the execution should fail");
+    assert!(format!("{:?}", trap).contains("function attempted to return an incompatible value"));
     Ok(())
 }

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -32,7 +32,7 @@ fn link_twice_bad() -> Result<()> {
     linker.func_wrap("f", "", || {})?;
     assert!(linker.func_wrap("f", "", || {}).is_err());
     assert!(linker
-        .func_wrap("f", "", || -> Result<(), Trap> { loop {} })
+        .func_wrap("f", "", || -> Result<()> { loop {} })
         .is_err());
 
     // globals

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -167,20 +167,32 @@ fn memory_guard_page_trap() -> Result<()> {
         let m = instance.get_memory(&mut store, "m").unwrap();
         let f = instance.get_typed_func::<i32, (), _>(&mut store, "f")?;
 
-        let trap = f.call(&mut store, 0).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
+        let trap = f
+            .call(&mut store, 0)
+            .expect_err("function should trap")
+            .downcast::<Trap>()?;
+        assert_eq!(trap, Trap::MemoryOutOfBounds);
 
-        let trap = f.call(&mut store, 1).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
+        let trap = f
+            .call(&mut store, 1)
+            .expect_err("function should trap")
+            .downcast::<Trap>()?;
+        assert_eq!(trap, Trap::MemoryOutOfBounds);
 
         m.grow(&mut store, 1).expect("memory should grow");
         f.call(&mut store, 0).expect("function should not trap");
 
-        let trap = f.call(&mut store, 65536).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
+        let trap = f
+            .call(&mut store, 65536)
+            .expect_err("function should trap")
+            .downcast::<Trap>()?;
+        assert_eq!(trap, Trap::MemoryOutOfBounds);
 
-        let trap = f.call(&mut store, 65537).expect_err("function should trap");
-        assert!(trap.to_string().contains("out of bounds"));
+        let trap = f
+            .call(&mut store, 65537)
+            .expect_err("function should trap")
+            .downcast::<Trap>()?;
+        assert_eq!(trap, Trap::MemoryOutOfBounds);
 
         m.grow(&mut store, 1).expect("memory should grow");
         f.call(&mut store, 65536).expect("function should not trap");

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -28,12 +28,8 @@ fn host_always_has_some_stack() -> anyhow::Result<()> {
 
     // Make sure that our function traps and the trap says that the call stack
     // has been exhausted.
-    let trap = foo.call(&mut store, ()).unwrap_err();
-    assert!(
-        trap.to_string().contains("call stack exhausted"),
-        "{}",
-        trap.to_string()
-    );
+    let trap = foo.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::StackOverflow);
 
     // Additionally, however, and this is the crucial test, make sure that the
     // host function actually completed. If HITS is 1 then we entered but didn't

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -337,7 +337,7 @@ wasm backtrace:
     0:   0x23 - m!die
     1:   0x27 - m!<wasm function 1>
     2:   0x2c - m!foo
-    3:   0x31 - m!<wasm function 3>
+    3:   0x31 - m!<wasm function 3>\
 "
     );
     Ok(())
@@ -384,7 +384,7 @@ wasm backtrace:
     2:   0x2c - a!foo
     3:   0x31 - a!<wasm function 3>
     4:   0x29 - b!middle
-    5:   0x2e - b!<wasm function 2>
+    5:   0x2e - b!<wasm function 2>\
 "
     );
     Ok(())
@@ -634,7 +634,7 @@ wasm backtrace:
     0:   0x1d - m!die
     1:   0x21 - m!<wasm function 1>
     2:   0x26 - m!foo
-    3:   0x2b - m!start
+    3:   0x2b - m!start\
 "
     );
     Ok(())
@@ -794,7 +794,7 @@ fn no_hint_even_with_dwarf_info() -> Result<()> {
         "\
 wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
-    0:   0x1a - <unknown>!start
+    0:   0x1a - <unknown>!start\
 "
     );
     Ok(())
@@ -829,7 +829,7 @@ fn hint_with_dwarf_info() -> Result<()> {
 wasm trap: wasm `unreachable` instruction executed
 wasm backtrace:
     0:   0x1a - <unknown>!start
-note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information
+note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information\
 "
     );
     Ok(())


### PR DESCRIPTION
This series of commits is a large refactoring of how `Trap` works and is used in Wasmtime. Individual commits have more details but at a high-level the changes implemented here are:

* All functions in Wasmtime now work with `Result<T>` instead of some working with `Result<T, Trap>`. For example `TypedFunc::call` reutrns `Result<T>` now, in addition to the host-provided closure to `Func::wrap`.
* Instances of `anyhow::Error` are threaded around as-is, so if the host returns a specific error that error pops out the other end.
* The `Trap::i32_exit` function has been removed in favor of a concrete `wasi_common::I32Exit` error type
* The `Trap::new` function has been removed in favor of `anyhow::Error` constructors like `bail!`
* The `Trap` type has been removed and replaced with `TrapCode`. It's now just a simple `enum`
* Wasm backtraces are modeled through a new `WasmBacktrace` type that's attached with `.context(...)` to `anyhow::Error` errors.

This is a large refactoring of how traps work in Wasmtime where the main goal is to pare down the responsibility of `Trap` and instead let `anyhow` do all the heavy lifting. Embedders which handle various kinds of traps various ways will need to be adjusted accordingly.