### PR TITLE
Add a CLI option for the maximum stack size

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -229,6 +229,11 @@ pub struct CommonOptions {
     #[cfg(feature = "pooling-allocator")]
     #[clap(long)]
     pub pooling_allocator: bool,
+
+    /// Maximum stack size, in bytes, that wasm is allowed to consumed before a
+    /// stack overflow is reported.
+    #[clap(long)]
+    pub max_wasm_stack: Option<usize>,
 }
 
 impl CommonOptions {
@@ -333,6 +338,10 @@ impl CommonOptions {
                     instance_limits,
                 });
             }
+        }
+
+        if let Some(max) = self.max_wasm_stack {
+            config.max_wasm_stack(max);
         }
 
         Ok(config)


### PR DESCRIPTION
This should allow either increasing or decreasing it for debugging and otherwise prodding at stack overflow behavior from the CLI.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
