### PR TITLE
Cranelift: use iterators instead of indexing; clean up match expressions

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -397,21 +397,15 @@ impl ABIMachineSpec for S390xMachineDeps {
 
         // After all arguments are in their well-defined location,
         // allocate buffers for all StructArg or ImplicitPtrArg arguments.
-        for i in 0..args.args().len() {
-            match &mut args.args_mut()[i] {
-                &mut ABIArg::StructArg {
-                    ref mut offset,
-                    size,
-                    ..
-                } => {
+        for arg in args.args_mut() {
+            match arg {
+                ABIArg::StructArg { offset, size, .. } => {
                     *offset = next_stack as i64;
-                    next_stack += size;
+                    next_stack += *size;
                 }
-                &mut ABIArg::ImplicitPtrArg {
-                    ref mut offset, ty, ..
-                } => {
+                ABIArg::ImplicitPtrArg { offset, ty, .. } => {
                     *offset = next_stack as i64;
-                    next_stack += (ty_bits(ty) / 8) as u64;
+                    next_stack += (ty_bits(*ty) / 8) as u64;
                 }
                 _ => {}
             }


### PR DESCRIPTION
Missed a note from https://github.com/bytecodealliance/wasmtime/pull/5127

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
