### PR TITLE
Remove the need for count_operands by restructuring emit in s390x

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -1395,7 +1395,7 @@ impl MachInstEmit for Inst {
         state: &mut EmitState,
     ) {
         let mut allocs = AllocationConsumer::new(allocs);
-        self.emit_consumer(&mut allocs, sink, emit_info, state)
+        self.emit_with_alloc_consumer(&mut allocs, sink, emit_info, state)
     }
 
     fn pretty_print_inst(&self, allocs: &[Allocation], state: &mut EmitState) -> String {
@@ -1405,7 +1405,7 @@ impl MachInstEmit for Inst {
 }
 
 impl Inst {
-    fn emit_consumer(
+    fn emit_with_alloc_consumer(
         &self,
         allocs: &mut AllocationConsumer<'_>,
         sink: &mut MachBuffer<Inst>,
@@ -2137,9 +2137,9 @@ impl Inst {
                                 target: done_label,
                                 cond: *cond,
                             };
-                            inst.emit_consumer(allocs, sink, emit_info, state);
+                            inst.emit_with_alloc_consumer(allocs, sink, emit_info, state);
                         }
-                        _ => inst.emit_consumer(allocs, sink, emit_info, state),
+                        _ => inst.emit_with_alloc_consumer(allocs, sink, emit_info, state),
                     };
                 }
 


### PR DESCRIPTION
Remove the need for `count_operands` by restructuring `emit` in the s390x backend to instead take the `AllocationConsumer` as an argument.

cc @uweigand 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
