### PR TITLE
cranelift: Static check out of bounds accesses to `heap_addr`'s

### DIFF
--- a/cranelift/filetests/filetests/alias/extends.clif
+++ b/cranelift/filetests/filetests/alias/extends.clif
@@ -11,7 +11,7 @@ function %f0(i64 vmctx, i32) -> i32, i32, i32, i64, i64, i64 {
     heap0 = static gv1, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i32
  
 block0(v0: i64, v1: i32):
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 16
 
     ;; Initial load. This will not be reused by anything below, even
     ;; though it does access the same address.

--- a/cranelift/filetests/filetests/alias/fence.clif
+++ b/cranelift/filetests/filetests/alias/fence.clif
@@ -11,7 +11,7 @@ function %f0(i64 vmctx, i32) -> i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
     heap0 = static gv1, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i32
  
 block0(v0: i64, v1: i32):
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 12
 
     v3 = load.i32 v2+8
     v4 = load.i32 vmctx v0+16

--- a/cranelift/filetests/filetests/alias/multiple-blocks.clif
+++ b/cranelift/filetests/filetests/alias/multiple-blocks.clif
@@ -11,7 +11,7 @@ function %f0(i64 vmctx, i32) -> i32 {
 
 
 block0(v0: i64, v1: i32):
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 12
     v3 = load.i32 v2+8
     brz v2, block1
     jump block2

--- a/cranelift/filetests/filetests/alias/partial-redundancy.clif
+++ b/cranelift/filetests/filetests/alias/partial-redundancy.clif
@@ -16,17 +16,17 @@ block0(v0: i64, v1: i32):
     jump block2
 
 block1:
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 68
     v3 = load.i32 v2+64
     jump block3(v3)
 
 block2:
-    v4 = heap_addr.i64 heap0, v1, 0
+    v4 = heap_addr.i64 heap0, v1, 132
     v5 = load.i32 v4+128
     jump block3(v5)
 
 block3(v6: i32):
-    v7 = heap_addr.i64 heap0, v1, 0
+    v7 = heap_addr.i64 heap0, v1, 68
     v8 = load.i32 v7+64
     ;; load should survive:
     ; check: v8 = load.i32 v7+64

--- a/cranelift/filetests/filetests/alias/simple-alias.clif
+++ b/cranelift/filetests/filetests/alias/simple-alias.clif
@@ -13,10 +13,10 @@ function %f0(i64 vmctx, i32) -> i32, i32, i32, i32 {
     fn0 = %g(i64 vmctx)
 
 block0(v0: i64, v1: i32):
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 12
     v3 = load.i32 v2+8
     ;; This should reuse the load above.
-    v4 = heap_addr.i64 heap0, v1, 0
+    v4 = heap_addr.i64 heap0, v1, 12
     v5 = load.i32 v4+8
     ; check: v5 -> v3
     
@@ -42,11 +42,11 @@ function %f1(i64 vmctx, i32) -> i32 {
     fn0 = %g(i64 vmctx)
 
 block0(v0: i64, v1: i32):
-    v2 = heap_addr.i64 heap0, v1, 0
+    v2 = heap_addr.i64 heap0, v1, 12
     store.i32 v1, v2+8
 
     ;; This load should pick up the store above.
-    v3 = heap_addr.i64 heap0, v1, 0
+    v3 = heap_addr.i64 heap0, v1, 12
     v4 = load.i32 v3+8
     ; check: v4 -> v1
     

--- a/cranelift/filetests/filetests/licm/load_readonly_notrap.clif
+++ b/cranelift/filetests/filetests/licm/load_readonly_notrap.clif
@@ -16,7 +16,7 @@ block0(v0: i32, v1: i64):
 
 block1(v2: i32, v3: i64):
     v4 = iconst.i32 1
-    v5 = heap_addr.i64 heap0, v4, 1
+    v5 = heap_addr.i64 heap0, v4, 4
     v6 = load.i32 notrap aligned readonly v5
     v7 = iadd v2, v6
     brz v2, block3(v2)
@@ -37,7 +37,7 @@ block3(v9: i32):
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
 ; nextln:    v4 = iconst.i32 1
-; nextln:    v5 = heap_addr.i64 heap0, v4, 1
+; nextln:    v5 = heap_addr.i64 heap0, v4, 4
 ; nextln:    v6 = load.i32 notrap aligned readonly v5
 ; nextln:    jump block1(v0, v1)
 ; nextln: 

--- a/cranelift/filetests/filetests/licm/reject_load_notrap.clif
+++ b/cranelift/filetests/filetests/licm/reject_load_notrap.clif
@@ -14,7 +14,7 @@ function %hoist_load(i32, i64 vmctx) -> i32 {
 
 block0(v0: i32, v1: i64):
     v4 = iconst.i32 1
-    v5 = heap_addr.i64 heap0, v4, 1
+    v5 = heap_addr.i64 heap0, v4, 4
     jump block1(v0, v1)
 
 block1(v2: i32, v3: i64):
@@ -38,7 +38,7 @@ block3(v9: i32):
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
 ; nextln:    v4 = iconst.i32 1
-; nextln:    v5 = heap_addr.i64 heap0, v4, 1
+; nextln:    v5 = heap_addr.i64 heap0, v4, 4
 ; nextln:    jump block1(v0, v1)
 ; nextln: 
 ; nextln: block1(v2: i32, v3: i64):

--- a/cranelift/filetests/filetests/licm/reject_load_readonly.clif
+++ b/cranelift/filetests/filetests/licm/reject_load_readonly.clif
@@ -17,7 +17,7 @@ block0(v0: i32, v1: i64):
 
 block1(v2: i32, v3: i64):
     v4 = iconst.i32 1
-    v5 = heap_addr.i64 heap0, v4, 1
+    v5 = heap_addr.i64 heap0, v4, 4
     v6 = load.i32 aligned readonly v5
     v7 = iadd v2, v6
     brz v2, block3(v2)
@@ -38,7 +38,7 @@ block3(v9: i32):
 ; nextln: 
 ; nextln: block0(v0: i32, v1: i64):
 ; nextln:    v4 = iconst.i32 1
-; nextln:    v5 = heap_addr.i64 heap0, v4, 1
+; nextln:    v5 = heap_addr.i64 heap0, v4, 4
 ; nextln:    jump block1(v0, v1)
 ; nextln: 
 ; nextln: block1(v2: i32, v3: i64):

--- a/cranelift/filetests/filetests/runtests/global_value.clif
+++ b/cranelift/filetests/filetests/runtests/global_value.clif
@@ -12,7 +12,7 @@ function %store_load(i64 vmctx, i64, i32) -> i32 {
     heap0 = static gv1, min 0x1000, bound 0x1_0000_0000, offset_guard 0, index_type i64
 
 block0(v0: i64, v1: i64, v2: i32):
-    v3 = heap_addr.i64 heap0, v1, 0
+    v3 = heap_addr.i64 heap0, v1, 4
     store.i32 v2, v3
 
     v4 = global_value.i64 gv1

--- a/cranelift/filetests/filetests/runtests/table_addr.clif
+++ b/cranelift/filetests/filetests/runtests/table_addr.clif
@@ -128,7 +128,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
     ; v1 - heap offset (bytes)
     ; v2 - table offset (elements)
     ; v3 - store/load value
-    v4 = heap_addr.i64 heap0, v1, 0
+    v4 = heap_addr.i64 heap0, v1, 8
     v5 = table_addr.i64 table0, v2, +2
 
     ; Store via heap, load via table

--- a/cranelift/filetests/filetests/simple_gvn/readonly.clif
+++ b/cranelift/filetests/filetests/simple_gvn/readonly.clif
@@ -9,8 +9,8 @@ function %eliminate_redundant_global_loads(i32, i64 vmctx) {
     heap0 = static gv1, min 0x1_0000, bound 0x1_0000_0000, offset_guard 0x8000_0000, index_type i32
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
-    v3 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 4
+    v3 = heap_addr.i64 heap0, v0, 4
 
     v4 = iconst.i32 0
     store.i32 notrap aligned v4, v2
@@ -18,7 +18,7 @@ block0(v0: i32, v1: i64):
 
     return
 }
-; check: v2 = heap_addr.i64 heap0, v0, 1
+; check: v2 = heap_addr.i64 heap0, v0, 4
 ; check: v3 -> v2
 ; check: v4 = iconst.i32 0
 ; check: store notrap aligned v4, v2

--- a/cranelift/filetests/filetests/simple_preopt/replace_branching_instructions_and_cfg_predecessors.clif
+++ b/cranelift/filetests/filetests/simple_preopt/replace_branching_instructions_and_cfg_predecessors.clif
@@ -7,7 +7,7 @@ function u0:2(i64 , i64) {
     heap0 = static gv1
     block0(v0: i64, v1: i64):
         v16 = iconst.i32 6
-        v17 = heap_addr.i64 heap0, v16, 1
+        v17 = heap_addr.i64 heap0, v16, 4
         v18 = load.i32 v17
         v19 = iconst.i32 4
         v20 = icmp ne v18, v19

--- a/cranelift/filetests/filetests/verifier/heap.clif
+++ b/cranelift/filetests/filetests/verifier/heap.clif
@@ -40,6 +40,6 @@ function %heap_addr_index_type(i64 vmctx, i64) {
     heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i32
 
 block0(v0: i64, v1: i64):
-    v2 = heap_addr.i64 heap0, v1, 0; error: index type i64 differs from heap index type i32
+    v2 = heap_addr.i64 heap0, v1, 4; error: index type i64 differs from heap index type i32
     return
 }

--- a/cranelift/filetests/filetests/verifier/heap_addr.clif
+++ b/cranelift/filetests/filetests/verifier/heap_addr.clif
@@ -1,0 +1,73 @@
+test verifier
+target x86_64
+
+
+function %heap_addr_zero(i64 vmctx, i64) {
+    gv0 = vmctx
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+
+block0(v0: i64, v1: i64):
+    ; Zero Sized `heap_addr`s are legal
+    ; See: https://github.com/bytecodealliance/wasmtime/pull/5167#issuecomment-1298908643
+    ; For discussions on this
+    v2 = heap_addr.i64 heap0, v1, 0
+    return
+}
+
+function %heap_addr_negative(i64 vmctx, i64) {
+    gv0 = vmctx
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+
+block0(v0: i64, v1: i64):
+    v2 = heap_addr.i64 heap0, v1, 2
+    
+    ; Negative offsets directly from a `heap_addr` are illegal
+    v3 = load.i8 v2-1 ; error: offset cannot be negative when referencing a heap_addr, got -1
+    return
+}
+
+function %heap_addr_invalid_size(i64 vmctx, i64) {
+    gv0 = vmctx
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+
+block0(v0: i64, v1: i64):
+    v2 = heap_addr.i64 heap0, v1, 2
+    
+    ; This is legal since we are loading 1 byte from a 2 byte space
+    v3 = load.i8 v2+0
+
+    ; This is legal since we are loading 1 byte from a 2 byte space with a offset of 1
+    v4 = load.i8 v2+1
+    
+    ; This is invalid since we are loading 1 byte past the allowed space
+    v5 = load.i8 v2+2 ; error: out of bounds access of 1 bytes past the value checked by the referenced heap_addr
+
+    return
+}
+
+function %heap_addr_partial_invalid_size(i64 vmctx, i64) {
+    gv0 = vmctx
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+
+block0(v0: i64, v1: i64):
+    v2 = heap_addr.i64 heap0, v1, 2
+    
+    ; Part of this load is outside of bounds
+    v3 = load.i32 v2+0 ; error: out of bounds access of 2 bytes past the value checked by the referenced heap_addr
+
+    return
+}
+
+
+function %heap_addr_uload8(i64 vmctx, i64) {
+    gv0 = vmctx
+    heap0 = static gv0, offset_guard 0x1000, bound 0x1_0000, index_type i64
+
+block0(v0: i64, v1: i64):
+    v2 = heap_addr.i64 heap0, v1, 1
+    
+    ; uload8 has a control type different than the amount of bytes it loads
+    ; this should not fail since it only accesses 1 byte of memory
+    v3 = uload8.i64 v2+0
+    return
+}

--- a/cranelift/filetests/filetests/wasm/f32-memory64.clif
+++ b/cranelift/filetests/filetests/wasm/f32-memory64.clif
@@ -11,7 +11,7 @@ function %f32_load(i32, i64 vmctx) -> f32 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 4
     v3 = load.f32 v2
     return v3
 }
@@ -21,7 +21,7 @@ function %f32_store(f32, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: f32, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 4
     store v0, v3
     return
 }

--- a/cranelift/filetests/filetests/wasm/f64-memory64.clif
+++ b/cranelift/filetests/filetests/wasm/f64-memory64.clif
@@ -11,7 +11,7 @@ function %f64_load(i32, i64 vmctx) -> f64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 8
     v3 = load.f64 v2
     return v3
 }
@@ -21,7 +21,7 @@ function %f64_store(f64, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: f64, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 8
     store v0, v3
     return
 }

--- a/cranelift/filetests/filetests/wasm/i32-memory64.clif
+++ b/cranelift/filetests/filetests/wasm/i32-memory64.clif
@@ -11,7 +11,7 @@ function %i32_load(i32, i64 vmctx) -> i32 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 4
     v3 = load.i32 v2
     return v3
 }
@@ -21,7 +21,7 @@ function %i32_store(i32, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 4
     store v0, v3
     return
 }
@@ -61,7 +61,7 @@ function %i32_load16_s(i32, i64 vmctx) -> i32 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 2
     v3 = sload16.i32 v2
     return v3
 }
@@ -71,7 +71,7 @@ function %i32_load16_u(i32, i64 vmctx) -> i32 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 2
     v3 = uload16.i32 v2
     return v3
 }
@@ -81,7 +81,7 @@ function %i32_store16(i32, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 2
     istore16 v0, v3
     return
 }

--- a/cranelift/filetests/filetests/wasm/i64-memory64.clif
+++ b/cranelift/filetests/filetests/wasm/i64-memory64.clif
@@ -11,7 +11,7 @@ function %i64_load(i32, i64 vmctx) -> i64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 8
     v3 = load.i64 v2
     return v3
 }
@@ -21,7 +21,7 @@ function %i64_store(i64, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i64, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 8
     store v0, v3
     return
 }
@@ -61,7 +61,7 @@ function %i64_load16_s(i32, i64 vmctx) -> i64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 2
     v3 = sload16.i64 v2
     return v3
 }
@@ -71,7 +71,7 @@ function %i64_load16_u(i32, i64 vmctx) -> i64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 2
     v3 = uload16.i64 v2
     return v3
 }
@@ -81,7 +81,7 @@ function %i64_store16(i64, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i64, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 2
     istore16 v0, v3
     return
 }
@@ -91,7 +91,7 @@ function %i64_load32_s(i32, i64 vmctx) -> i64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 4
     v3 = sload32.i64 v2
     return v3
 }
@@ -101,7 +101,7 @@ function %i64_load32_u(i32, i64 vmctx) -> i64 {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i32, v1: i64):
-    v2 = heap_addr.i64 heap0, v0, 1
+    v2 = heap_addr.i64 heap0, v0, 4
     v3 = uload32.i64 v2
     return v3
 }
@@ -111,7 +111,7 @@ function %i64_store32(i64, i32, i64 vmctx) {
     heap0 = static gv0, min 0x0001_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000
 
 block0(v0: i64, v1: i32, v2: i64):
-    v3 = heap_addr.i64 heap0, v1, 1
+    v3 = heap_addr.i64 heap0, v1, 4
     istore32 v0, v3
     return
 }


### PR DESCRIPTION
👋 Hey,

I don't know if we should merge this or not!

This PR started on https://github.com/bytecodealliance/wasmtime/pull/5155#discussion_r1009872167 where @jameysharp pointed out that it was a bit weird that the interpreter used a `saturating_sub` when calculating `heap_addr` sizes.

I added that because we do have some 0 sized `heap_addr`'s in runtests. However when fixing that, I added a verifier rule, and it turns out we have a **lot** of 0 sized `heap_addr`'s in our test suite. Are these legal?

The [instruction docs](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.heap_addr) state the following:
> Verify that the offset range `p .. p + Size - 1` is in bounds for the heap H, and generate an absolute address that is safe to dereference.

So it sounds like `Size` must always be larger than 1?

But it also says:

> If `p + Size` is not greater than the heap bound

Which would allow 0 as a `Size`.

So, lets make a decision about this! I don't have any preference for either, I'm just opening this as a PR because when I started fixing the interpreter I thought it would just be that one runtest that was wrong!

---

Also, there are some regressions in the x64 codegen that probably shouldn't be there.