### PR TITLE
Switch to `x64_rbp` to avoid the use of a pinned register

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2853,7 +2853,7 @@
 
 (rule (lower (get_return_address))
       (x64_load $I64
-                (Amode.ImmReg 8 (preg_rbp) (mem_flags_trusted))
+                (Amode.ImmReg 8 (x64_rbp) (mem_flags_trusted))
                 (ExtKind.None)))
 
 ;; Rules for `jump` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
@@ -39,7 +39,9 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    8(%rbp), %rax
+;   movq    %rbp, %rdi
+;   movq    8(%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+


### PR DESCRIPTION
Avoid a use of `preg_rpb` in the x64 backend, using `x64_rbp` instead.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
