### PR TITLE
cranelift: improve syscall error/oom handling in JIT module

### DIFF
--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -244,7 +244,7 @@ impl TestFileCompiler {
         // Finalize the functions which we just defined, which resolves any
         // outstanding relocations (patching in addresses, now that they're
         // available).
-        self.module.finalize_definitions();
+        self.module.finalize_definitions()?;
 
         Ok(CompiledTestFile {
             module: Some(self.module),

--- a/cranelift/jit/examples/jit-minimal.rs
+++ b/cranelift/jit/examples/jit-minimal.rs
@@ -78,7 +78,7 @@ fn main() {
     module.clear_context(&mut ctx);
 
     // Perform linking.
-    module.finalize_definitions();
+    module.finalize_definitions().unwrap();
 
     // Get a raw pointer to the generated code.
     let code_b = module.get_finalized_function(func_b);

--- a/cranelift/jit/src/memory.rs
+++ b/cranelift/jit/src/memory.rs
@@ -1,3 +1,5 @@
+use cranelift_module::{ModuleError, ModuleResult};
+
 #[cfg(feature = "selinux-fix")]
 use memmap2::MmapMut;
 
@@ -56,10 +58,14 @@ impl PtrLen {
         // Safety: We assert that the size is non-zero above.
         let ptr = unsafe { alloc::alloc(layout) };
 
-        Ok(Self {
-            ptr,
-            len: alloc_size,
-        })
+        if !ptr.is_null() {
+            Ok(Self {
+                ptr,
+                len: alloc_size,
+            })
+        } else {
+            Err(io::Error::last_os_error())
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -168,7 +174,7 @@ impl Memory {
     }
 
     /// Set all memory allocated in this `Memory` up to now as readable and executable.
-    pub(crate) fn set_readable_and_executable(&mut self) {
+    pub(crate) fn set_readable_and_executable(&mut self) -> ModuleResult<()> {
         self.finish_current();
 
         // Clear all the newly allocated code from cache if the processor requires it
@@ -182,7 +188,7 @@ impl Memory {
             };
         }
 
-        let set_region_readable_and_executable = |ptr, len| {
+        let set_region_readable_and_executable = |ptr, len| -> ModuleResult<()> {
             if self.branch_protection == BranchProtection::BTI {
                 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
                 if std::arch::is_aarch64_feature_detected!("bti") {
@@ -190,42 +196,66 @@ impl Memory {
 
                     unsafe {
                         if libc::mprotect(ptr as *mut libc::c_void, len, prot) < 0 {
-                            panic!("unable to make memory readable+executable");
+                            return Err(ModuleError::Syscall {
+                                message: "unable to make memory readable+executable",
+                                err: io::Error::last_os_error(),
+                            });
                         }
                     }
 
-                    return;
+                    return Ok(());
                 }
             }
 
             unsafe {
-                region::protect(ptr, len, region::Protection::READ_EXECUTE)
-                    .expect("unable to make memory readable+executable");
+                region::protect(ptr, len, region::Protection::READ_EXECUTE).map_err(
+                    |e| match e {
+                        region::Error::SystemCall(error) => ModuleError::Syscall {
+                            message: "unable to make memory readable+executable",
+                            err: error,
+                        },
+                        _ => ModuleError::Backend(anyhow::anyhow!(
+                            "unable to make memory readable+executable: {}",
+                            e
+                        )),
+                    },
+                )?;
             }
+            Ok(())
         };
 
         for &PtrLen { ptr, len, .. } in self.non_protected_allocations_iter() {
-            set_region_readable_and_executable(ptr, len);
+            set_region_readable_and_executable(ptr, len)?;
         }
 
         // Flush any in-flight instructions from the pipeline
         icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");
 
         self.already_protected = self.allocations.len();
+        Ok(())
     }
 
     /// Set all memory allocated in this `Memory` up to now as readonly.
-    pub(crate) fn set_readonly(&mut self) {
+    pub(crate) fn set_readonly(&mut self) -> ModuleResult<()> {
         self.finish_current();
 
         for &PtrLen { ptr, len, .. } in self.non_protected_allocations_iter() {
             unsafe {
-                region::protect(ptr, len, region::Protection::READ)
-                    .expect("unable to make memory readonly");
+                region::protect(ptr, len, region::Protection::READ).map_err(|e| match e {
+                    region::Error::SystemCall(error) => ModuleError::Syscall {
+                        message: "unable to make memory readonly",
+                        err: error,
+                    },
+                    _ => ModuleError::Backend(anyhow::anyhow!(
+                        "unable to make memory readonly: {}",
+                        e
+                    )),
+                })?;
             }
         }
 
         self.already_protected = self.allocations.len();
+        Ok(())
     }
 
     /// Iterates non protected memory allocations that are of not zero bytes in size.

--- a/cranelift/jit/src/memory.rs
+++ b/cranelift/jit/src/memory.rs
@@ -64,7 +64,7 @@ impl PtrLen {
                 len: alloc_size,
             })
         } else {
-            Err(io::Error::last_os_error())
+            Err(io::Error::from(io::ErrorKind::OutOfMemory))
         }
     }
 

--- a/cranelift/jit/tests/basic.rs
+++ b/cranelift/jit/tests/basic.rs
@@ -209,5 +209,5 @@ fn libcall_function() {
 
     module.define_function(func_id, &mut ctx).unwrap();
 
-    module.finalize_definitions();
+    module.finalize_definitions().unwrap();
 }

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -237,14 +237,6 @@ pub enum ModuleError {
         err: std::io::Error,
     },
 
-    /// Syscall failure from a backend
-    Syscall {
-        /// Tell what the syscall was for
-        message: &'static str,
-        /// Io error the syscall failed with
-        err: std::io::Error,
-    },
-
     /// Wraps a generic error from a backend
     Backend(anyhow::Error),
 }
@@ -267,7 +259,6 @@ impl std::error::Error for ModuleError {
             | Self::InvalidImportDefinition { .. } => None,
             Self::Compilation(source) => Some(source),
             Self::Allocation { err: source, .. } => Some(source),
-            Self::Syscall { err: source, .. } => Some(source),
             Self::Backend(source) => Some(&**source),
         }
     }
@@ -304,9 +295,6 @@ impl std::fmt::Display for ModuleError {
             }
             Self::Allocation { message, err } => {
                 write!(f, "Allocation error: {}: {}", message, err)
-            }
-            Self::Syscall { message, err } => {
-                write!(f, "Syscall error: {}: {}", message, err)
             }
             Self::Backend(err) => write!(f, "Backend error: {}", err),
         }

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -229,6 +229,22 @@ pub enum ModuleError {
     /// Wraps a `cranelift-codegen` error
     Compilation(CodegenError),
 
+    /// Memory allocation failure from a backend
+    Allocation {
+        /// Tell where the allocation came from
+        message: &'static str,
+        /// Io error the allocation failed with
+        err: std::io::Error,
+    },
+
+    /// Syscall failure from a backend
+    Syscall {
+        /// Tell what the syscall was for
+        message: &'static str,
+        /// Io error the syscall failed with
+        err: std::io::Error,
+    },
+
     /// Wraps a generic error from a backend
     Backend(anyhow::Error),
 }
@@ -250,6 +266,8 @@ impl std::error::Error for ModuleError {
             | Self::DuplicateDefinition { .. }
             | Self::InvalidImportDefinition { .. } => None,
             Self::Compilation(source) => Some(source),
+            Self::Allocation { err: source, .. } => Some(source),
+            Self::Syscall { err: source, .. } => Some(source),
             Self::Backend(source) => Some(&**source),
         }
     }
@@ -283,6 +301,12 @@ impl std::fmt::Display for ModuleError {
             }
             Self::Compilation(err) => {
                 write!(f, "Compilation error: {}", err)
+            }
+            Self::Allocation { message, err } => {
+                write!(f, "Allocation error: {}: {}", message, err)
+            }
+            Self::Syscall { message, err } => {
+                write!(f, "Syscall error: {}: {}", message, err)
             }
             Self::Backend(err) => write!(f, "Backend error: {}", err),
         }


### PR DESCRIPTION
The JIT module has several places where it `expect`s or `panic`s on syscall or allocator errors. For example, `mmap` and `mprotect` can fail if Linux `vm.max_map_count` is not high enough, and some users may wish to handle this error rather than immediately crashing.

This commit plumbs these errors upward as new `ModuleError` types, so that callers of jit module functions like `finalize_definitions` and `define_function` can handle them (or just `unwrap()`, as desired).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
