### PR TITLE
fuzzgen: Allow inline stack probes on x86

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -37,6 +37,8 @@ pub struct Config {
     pub static_stack_slots_per_function: RangeInclusive<usize>,
     /// Size in bytes
     pub static_stack_slot_size: RangeInclusive<usize>,
+    /// Allowed stack probe sizes
+    pub stack_probe_size_log2: RangeInclusive<usize>,
 
     /// Determines how often we generate a backwards branch
     /// Backwards branches are prone to infinite loops, and thus cause timeouts.
@@ -80,6 +82,19 @@ impl Default for Config {
             funcrefs_per_function: 0..=8,
             static_stack_slots_per_function: 0..=8,
             static_stack_slot_size: 0..=128,
+            // We need the mix of sizes that allows us to:
+            //  * not generates any stack probes
+            //  * generate unrolled stack probes
+            //  * generate loop stack probes
+            //
+            // This depends on the total amount of stack space that we have for this function
+            // (controlled by `static_stack_slots_per_function` and `static_stack_slot_size`)
+            //
+            // 1<<6 = 64 and 1<<14 = 16384
+            //
+            // This range allows us to generate all 3 cases within the current allowed
+            // stack size range.
+            stack_probe_size_log2: 6..=14,
             // 0.1% allows us to explore this, while not causing enough timeouts to significantly
             // impact execs/s
             backwards_branch_ratio: (1, 1000),

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -238,7 +238,6 @@ where
         builder.set("opt_level", &format!("{}", opt)[..])?;
 
         // Boolean flags
-        // TODO: probestack is semantics preserving, but only works inline and on x64
         // TODO: enable_pinned_reg does not work with our current trampolines. See: #4376
         // TODO: is_pic has issues:
         //   x86: https://github.com/bytecodealliance/wasmtime/issues/5005
@@ -265,6 +264,19 @@ where
 
             let value = format!("{}", enabled);
             builder.set(flag_name, value.as_str())?;
+        }
+
+        // Optionally test inline stackprobes on x86
+        // TODO: inline stack probes are not available on AArch64
+        // TODO: Test outlined stack probes.
+        if cfg!(target_arch = "x86_64") && bool::arbitrary(self.u)? {
+            builder.enable("enable_probestack")?;
+            builder.set("probestack_strategy", "inline")?;
+
+            let size = self
+                .u
+                .int_in_range(self.config.stack_probe_size_log2.clone())?;
+            builder.set("probestack_size_log2", &format!("{}", size))?;
         }
 
         // Fixed settings


### PR DESCRIPTION
👋 Hey,

This PR adds the option for fuzzgen to enable inline stack probing on x86.

Fuzzing for the last hour does not seem to have raised any issues.