### PR TITLE
cranelift: Add support for `bswap.i128`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1528,6 +1528,11 @@
 (rule (lower (has_type $I64 (bswap x)))
       (a64_rev64 $I64 x))
 
+(rule (lower (has_type $I128 (bswap x)))
+      (value_regs
+       (a64_rev64 $I64 (value_regs_get x 1))
+       (a64_rev64 $I64 (value_regs_get x 0))))
+
 ;;;; Rules for `bmask` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Bmask tests the value against zero, and uses `csetm` to assert the result.

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -1190,15 +1190,8 @@
 
 ;;;; Rules for `bswap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $I16 (bswap x)))
-      (lshr_imm $I32 (bswap_reg $I32 x) 16))
-
-(rule (lower (has_type $I32 (bswap x)))
-      (bswap_reg $I32 x))
-
-(rule (lower (has_type $I64 (bswap x)))
-      (bswap_reg $I64 x))
-
+(rule (lower (has_type ty (bswap x)))
+      (bitrev_bytes ty x))
 
 ;;;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2060,6 +2060,11 @@
 (rule (lower (has_type $I64 (bswap src)))
       (x64_bswap $I64 src))
 
+(rule (lower (has_type $I128 (bswap src)))
+      (value_regs
+       (x64_bswap $I64 (value_regs_get_gpr src 1))
+       (x64_bswap $I64 (value_regs_get_gpr src 0))))
+
 ;; Rules for `is_null` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Null references are represented by the constant value `0`.

--- a/cranelift/filetests/filetests/runtests/i128-bswap.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bswap.clif
@@ -1,4 +1,9 @@
 test interpret
+test run
+set enable_llvm_abi_extensions
+target x86_64
+target aarch64
+target s390x
 
 function %bswap_i128(i128) -> i128 {
 block0(v0: i128):
@@ -9,4 +14,3 @@ block0(v0: i128):
 ; run: %bswap_i128(1) == 0x01000000_00000000_00000000_00000000
 ; run: %bswap_i128(0x12345678_9ABCDEF0_CAFEF00D_F00DCAFE) == 0xFECA0DF0_0DF0FECA_F0DEBC9A_78563412
 ; run: %bswap_i128(-2) == 0xFEFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF
-

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -672,12 +672,12 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::Bmask, &[I64], &[I128], insert_opcode),
     (Opcode::Bmask, &[I128], &[I128], insert_opcode),
     // Bswap
-    (Opcode::Bswap, &[I16, I16], &[I16], insert_opcode),
-    (Opcode::Bswap, &[I32, I32], &[I32], insert_opcode),
-    (Opcode::Bswap, &[I64, I64], &[I64], insert_opcode),
+    (Opcode::Bswap, &[I16], &[I16], insert_opcode),
+    (Opcode::Bswap, &[I32], &[I32], insert_opcode),
+    (Opcode::Bswap, &[I64], &[I64], insert_opcode),
     // I128 version not yet implemented.
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-    (Opcode::Bswap, &[I128, I128], &[I128], insert_opcode),
+    (Opcode::Bswap, &[I128], &[I128], insert_opcode),
     // Fadd
     (Opcode::Fadd, &[F32, F32], &[F32], insert_opcode),
     (Opcode::Fadd, &[F64, F64], &[F64], insert_opcode),

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -675,8 +675,6 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::Bswap, &[I16], &[I16], insert_opcode),
     (Opcode::Bswap, &[I32], &[I32], insert_opcode),
     (Opcode::Bswap, &[I64], &[I64], insert_opcode),
-    // I128 version not yet implemented.
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     (Opcode::Bswap, &[I128], &[I128], insert_opcode),
     // Fadd
     (Opcode::Fadd, &[F32, F32], &[F32], insert_opcode),


### PR DESCRIPTION
👋 Hey,

This adds support for `bswap.i128` on x86, AArch64 and S390X.

Also fixes an issue on the fuzzer definitions where we were accidentally requesting two variables for bswap, but bswap only has one input.

Fuzzed for about an hour on x86 and aarch64 without issues.