### PR TITLE
Use vselect in NaN canonicalization pass.

### DIFF
--- a/cranelift/codegen/src/nan_canonicalization.rs
+++ b/cranelift/codegen/src/nan_canonicalization.rs
@@ -70,11 +70,9 @@ fn add_nan_canon_seq(pos: &mut FuncCursor, inst: Inst) {
             .select(is_nan, canon_nan, new_res);
     };
     let vector_select = |pos: &mut FuncCursor, canon_nan: Value| {
-        let cond = pos.ins().bitcast(types::I8X16, is_nan);
-        let canon_nan = pos.ins().bitcast(types::I8X16, canon_nan);
-        let result = pos.ins().bitcast(types::I8X16, new_res);
-        let bitmask = pos.ins().bitselect(cond, canon_nan, result);
-        pos.ins().with_result(val).bitcast(val_type, bitmask);
+        pos.ins()
+            .with_result(val)
+            .vselect(is_nan, canon_nan, new_res);
     };
 
     match val_type {
@@ -87,13 +85,13 @@ fn add_nan_canon_seq(pos: &mut FuncCursor, inst: Inst) {
             scalar_select(pos, canon_nan);
         }
         types::F32X4 => {
-            let canon_nan = pos.ins().iconst(types::I32, i64::from(CANON_32BIT_NAN));
-            let canon_nan = pos.ins().splat(types::I32X4, canon_nan);
+            let canon_nan = pos.ins().f32const(Ieee32::with_bits(CANON_32BIT_NAN));
+            let canon_nan = pos.ins().splat(types::F32X4, canon_nan);
             vector_select(pos, canon_nan);
         }
         types::F64X2 => {
-            let canon_nan = pos.ins().iconst(types::I64, CANON_64BIT_NAN as i64);
-            let canon_nan = pos.ins().splat(types::I64X2, canon_nan);
+            let canon_nan = pos.ins().f64const(Ieee64::with_bits(CANON_64BIT_NAN));
+            let canon_nan = pos.ins().splat(types::F64X2, canon_nan);
             vector_select(pos, canon_nan);
         }
         _ => {


### PR DESCRIPTION
Change add_nan_canon_seq to use vselect instead of bitselect. This is more straightforward and removes bitcast operations. Codegen should be unchanged.

CC @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
