### PR TITLE
offer function-level control over tracing

### DIFF
--- a/crates/wiggle/generate/src/codegen_settings.rs
+++ b/crates/wiggle/generate/src/codegen_settings.rs
@@ -1,4 +1,4 @@
-use crate::config::{AsyncConf, ErrorConf};
+use crate::config::{AsyncConf, ErrorConf, TracingConf};
 use anyhow::{anyhow, Error};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -15,7 +15,7 @@ pub struct CodegenSettings {
     // Disabling this feature makes it possible to remove all of the tracing
     // code emitted in the Wiggle-generated code; this can be helpful while
     // inspecting the code (e.g., with `cargo expand`).
-    pub tracing: bool,
+    pub tracing: TracingConf,
 }
 impl CodegenSettings {
     pub fn new(
@@ -23,14 +23,14 @@ impl CodegenSettings {
         async_: &AsyncConf,
         doc: &Document,
         wasmtime: bool,
-        tracing: bool,
+        tracing: &TracingConf,
     ) -> Result<Self, Error> {
         let errors = ErrorTransform::new(error_conf, doc)?;
         Ok(Self {
             errors,
             async_: async_.clone(),
             wasmtime,
-            tracing,
+            tracing: tracing.clone(),
         })
     }
     pub fn get_async(&self, module: &Module, func: &InterfaceFunc) -> Asyncness {

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -409,7 +409,7 @@ impl Parse for AsyncFunctions {
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::token::Brace) {
             let _ = braced!(content in input);
-            let items: Punctuated<AsyncConfField, Token![,]> =
+            let items: Punctuated<FunctionField, Token![,]> =
                 content.parse_terminated(Parse::parse)?;
             let mut functions: HashMap<String, Vec<String>> = HashMap::new();
             use std::collections::hash_map::Entry;
@@ -437,13 +437,13 @@ impl Parse for AsyncFunctions {
 }
 
 #[derive(Clone)]
-pub struct AsyncConfField {
+pub struct FunctionField {
     pub module_name: Ident,
     pub function_names: Vec<Ident>,
     pub err_loc: Span,
 }
 
-impl Parse for AsyncConfField {
+impl Parse for FunctionField {
     fn parse(input: ParseStream) -> Result<Self> {
         let err_loc = input.span();
         let module_name = input.parse::<Ident>()?;
@@ -454,14 +454,14 @@ impl Parse for AsyncConfField {
             let _ = braced!(content in input);
             let function_names: Punctuated<Ident, Token![,]> =
                 content.parse_terminated(Parse::parse)?;
-            Ok(AsyncConfField {
+            Ok(FunctionField {
                 module_name,
                 function_names: function_names.iter().cloned().collect(),
                 err_loc,
             })
         } else if lookahead.peek(Ident) {
             let name = input.parse()?;
-            Ok(AsyncConfField {
+            Ok(FunctionField {
                 module_name,
                 function_names: vec![name],
                 err_loc,
@@ -569,7 +569,6 @@ impl Parse for WasmtimeConfigField {
 #[derive(Clone, Default, Debug)]
 pub struct TracingConf {
     pub enabled: bool,
-    pub excluded_functions: HashMap<String, HashSet<String>>,
 }
 
 impl Parse for TracingConf {

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -15,7 +15,7 @@ pub struct Config {
     pub errors: ErrorConf,
     pub async_: AsyncConf,
     pub wasmtime: bool,
-    pub tracing: bool,
+    pub tracing: TracingConf,
 }
 
 mod kw {
@@ -34,7 +34,7 @@ pub enum ConfigField {
     Error(ErrorConf),
     Async(AsyncConf),
     Wasmtime(bool),
-    Tracing(bool),
+    Tracing(TracingConf),
 }
 
 impl Parse for ConfigField {
@@ -73,7 +73,7 @@ impl Parse for ConfigField {
         } else if lookahead.peek(kw::tracing) {
             input.parse::<kw::tracing>()?;
             input.parse::<Token![:]>()?;
-            Ok(ConfigField::Tracing(input.parse::<syn::LitBool>()?.value))
+            Ok(ConfigField::Tracing(input.parse()?))
         } else {
             Err(lookahead.error())
         }
@@ -128,7 +128,7 @@ impl Config {
             errors: errors.take().unwrap_or_default(),
             async_: async_.take().unwrap_or_default(),
             wasmtime: wasmtime.unwrap_or(true),
-            tracing: tracing.unwrap_or(true),
+            tracing: tracing.unwrap_or_default(),
         })
     }
 
@@ -563,5 +563,18 @@ impl Parse for WasmtimeConfigField {
         } else {
             Err(lookahead.error())
         }
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct TracingConf {
+    pub enabled: bool,
+    pub excluded_functions: HashMap<String, HashSet<String>>,
+}
+
+impl Parse for TracingConf {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let enabled = input.parse::<syn::LitBool>()?.value;
+        Ok(TracingConf { enabled })
     }
 }

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -84,7 +84,7 @@ fn _define_func(
         );
     );
     if settings.get_async(&module, &func).is_sync() {
-        let traced_body = if settings.tracing {
+        let traced_body = if settings.tracing.enabled {
             quote!(
                 #mk_span
                 _span.in_scope(|| {
@@ -109,7 +109,7 @@ fn _define_func(
             bounds,
         )
     } else {
-        let traced_body = if settings.tracing {
+        let traced_body = if settings.tracing.enabled {
             quote!(
                 use #rt::tracing::Instrument as _;
                 #mk_span
@@ -261,7 +261,7 @@ impl witx::Bindgen for Rust<'_> {
                         args.push(quote!(#name));
                     }
                 }
-                if self.settings.tracing && func.params.len() > 0 {
+                if self.settings.tracing.enabled && func.params.len() > 0 {
                     let args = func
                         .params
                         .iter()
@@ -290,7 +290,7 @@ impl witx::Bindgen for Rust<'_> {
                         let ret = #trait_name::#ident(ctx, #(#args),*).await;
                     })
                 };
-                if self.settings.tracing {
+                if self.settings.tracing.enabled {
                     self.src.extend(quote! {
                         #rt::tracing::event!(
                             #rt::tracing::Level::TRACE,

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -118,7 +118,11 @@ fn _define_func(
                 }.instrument(_span)
             )
         } else {
-            quote!(#body)
+            quote!(
+                async move {
+                    #body
+                }
+            )
         };
         (
             quote!(

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -84,7 +84,7 @@ fn _define_func(
         );
     );
     if settings.get_async(&module, &func).is_sync() {
-        let traced_body = if settings.tracing.enabled {
+        let traced_body = if settings.tracing.enabled_for(&mod_name, &func_name) {
             quote!(
                 #mk_span
                 _span.in_scope(|| {
@@ -109,7 +109,7 @@ fn _define_func(
             bounds,
         )
     } else {
-        let traced_body = if settings.tracing.enabled {
+        let traced_body = if settings.tracing.enabled_for(&mod_name, &func_name) {
             quote!(
                 use #rt::tracing::Instrument as _;
                 #mk_span
@@ -261,7 +261,12 @@ impl witx::Bindgen for Rust<'_> {
                         args.push(quote!(#name));
                     }
                 }
-                if self.settings.tracing.enabled && func.params.len() > 0 {
+                if self
+                    .settings
+                    .tracing
+                    .enabled_for(self.module.name.as_str(), self.funcname)
+                    && func.params.len() > 0
+                {
                     let args = func
                         .params
                         .iter()
@@ -290,7 +295,11 @@ impl witx::Bindgen for Rust<'_> {
                         let ret = #trait_name::#ident(ctx, #(#args),*).await;
                     })
                 };
-                if self.settings.tracing.enabled {
+                if self
+                    .settings
+                    .tracing
+                    .enabled_for(self.module.name.as_str(), self.funcname)
+                {
                     self.src.extend(quote! {
                         #rt::tracing::event!(
                             #rt::tracing::Level::TRACE,

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -153,7 +153,7 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         &config.async_,
         &doc,
         config.wasmtime,
-        config.tracing,
+        &config.tracing,
     )
     .expect("validating codegen settings");
 
@@ -195,7 +195,7 @@ pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
         &config.c.async_,
         &doc,
         true,
-        config.c.tracing,
+        &config.c.tracing,
     )
     .expect("validating codegen settings");
 

--- a/crates/wiggle/test-helpers/examples/tracing.rs
+++ b/crates/wiggle/test-helpers/examples/tracing.rs
@@ -15,6 +15,9 @@ pub enum RichError {
 // Define an errno with variants corresponding to RichError. Use it in a
 // trivial function.
 wiggle::from_witx!({
+    tracing: true disable_for {
+        one_error_conversion::foo,
+    },
 witx_literal: "
 (typename $errno (enum (@witx tag u8) $ok $invalid_arg $picket_line))
 (typename $s (record (field $f1 (@witx usize)) (field $f2 (@witx pointer u8))))

--- a/crates/wiggle/tests/tracing.rs
+++ b/crates/wiggle/tests/tracing.rs
@@ -1,0 +1,16 @@
+// This just tests that things compile when `tracing: false` is set,
+// which isn't the default.
+
+wiggle::from_witx!({
+    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    async: {
+        atoms::double_int_return_float,
+    },
+    tracing: false,
+});
+
+impl wiggle::GuestErrorType for types::Errno {
+    fn success() -> Self {
+        types::Errno::Ok
+    }
+}


### PR DESCRIPTION
This adds to the `tracing` boolean from the `from_witx!` macro a `disabled_for` list of identifiers that allow for suppression of tracing on a per-function basis.

Example:

```
wiggle::from_witx!({
    tracing: true disable_for {
        module1::func,
        module2::another_func,
    },
    witx: ["..."],
});
```

Fixes #5193

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
