### PR TITLE
wiggle: fix compilation with async functions when tracing is off

### DIFF
--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -118,7 +118,11 @@ fn _define_func(
                 }.instrument(_span)
             )
         } else {
-            quote!(#body)
+            quote!(
+                async move {
+                    #body
+                }
+            )
         };
         (
             quote!(

--- a/crates/wiggle/tests/tracing.rs
+++ b/crates/wiggle/tests/tracing.rs
@@ -1,0 +1,16 @@
+// This just tests that things compile when `tracing: false` is set,
+// which isn't the default.
+
+wiggle::from_witx!({
+    witx: ["$CARGO_MANIFEST_DIR/tests/atoms.witx"],
+    async: {
+        atoms::double_int_return_float,
+    },
+    tracing: false,
+});
+
+impl wiggle::GuestErrorType for types::Errno {
+    fn success() -> Self {
+        types::Errno::Ok
+    }
+}


### PR DESCRIPTION
Fixes #5202

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
