### PR TITLE
Fix mprotect failures by enabling cranelift-jit selinux-fix

### DIFF
--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-interpreter = { workspace = true }
 cranelift-native = { workspace = true }
 cranelift-reader = { workspace = true }
 cranelift-preopt = { workspace = true }
-cranelift-jit = { workspace = true }
+cranelift-jit = { workspace = true, features = ["selinux-fix"] }
 cranelift-module = { workspace = true }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"


### PR DESCRIPTION
The sample program in cranelift/filetests/src/function_runner.rs would abort with an mprotect failure under certain circumstances, see https://github.com/bytecodealliance/wasmtime/pull/4453#issuecomment-1303803222

Root cause was that enabling PROT_EXEC on the main process heap may be prohibited, depending on Linux distro and version.

This only shows up in the doc test sample program because the main clif-util is multi-threaded and therefore allocations will happen on glibc's per-thread heap, which is allocated via mmap, and not the main process heap.

Work around the problem by enabling the "selinux-fix" feature of the cranelift-jit crate dependency in the filetests.  Note that this didn't compile out of the box, so a separate fix is also required and provided as part of this PR.

Going forward, it would be preferable to always use mmap to allocate the backing memory for JITted code.

CC @cfallin @afonso360 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
