### PR TITLE
Slim down temporary trampoline objects

### DIFF
--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -120,7 +120,6 @@ where
         stub_fn::<F> as usize,
         &mut obj,
     )?;
-    engine.append_compiler_info(&mut obj);
     engine.append_bti(&mut obj);
     let obj = wasmtime_jit::ObjectBuilder::new(obj, &engine.config().tunables).finish()?;
 


### PR DESCRIPTION
I noticed this in the backtrace of something that timed out on oss-fuzz and there's no need to include this information in trampolines, so this removes the extra sections from being generated.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
