### PR TITLE
Expose c-api as a library

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [lib]
 name = "wasmtime"
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "lib"]
 doc = false
 test = false
 doctest = false


### PR DESCRIPTION
That would allow projects to pull Wasmtime C API as a dependency through git and use it - e.g. by only exposing parts of the API and wrapping other parts in custom code.

Ideally, I would love to see the C API crate published to crates.io, but this small step is enough to boost developer experience significantly.

A concrete use case I have in mind is https://github.com/libsql/libsql/pull/45 - using C API as a dependency is a great fit for integrating Wasmtime into the project's build chain.