### PR TITLE
Update how exits are modeled in the C API

### DIFF
--- a/crates/c-api/include/wasmtime/error.h
+++ b/crates/c-api/include/wasmtime/error.h
@@ -48,6 +48,24 @@ WASM_API_EXTERN void wasmtime_error_message(
     wasm_name_t *message
 );
 
+/**
+ * \brief Attempts to extract a WASI-specific exit status from this error.
+ *
+ * Returns `true` if the error is a WASI "exit" trap and has a return status.
+ * If `true` is returned then the exit status is returned through the `status`
+ * pointer. If `false` is returned then this is not a wasi exit trap.
+ */
+WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int *status);
+
+/**
+ * \brief Attempts to extract a WebAssembly trace from this error.
+ *
+ * This is similar to #wasm_trap_trace except that it takes a #wasmtime_error_t
+ * as input. The `out` argument will be filled in with the wasm trace, if
+ * present.
+ */
+WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t*, wasm_frame_vec_t *out);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/trap.h
+++ b/crates/c-api/include/wasmtime/trap.h
@@ -70,15 +70,6 @@ WASM_API_EXTERN wasm_trap_t *wasmtime_trap_new(const char *msg, size_t msg_len);
 WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t *code);
 
 /**
- * \brief Attempts to extract a WASI-specific exit status from this trap.
- *
- * Returns `true` if the trap is a WASI "exit" trap and has a return status. If
- * `true` is returned then the exit status is returned through the `status`
- * pointer. If `false` is returned then this is not a wasi exit trap.
- */
-WASM_API_EXTERN bool wasmtime_trap_exit_status(const wasm_trap_t*, int *status);
-
-/**
  * \brief Returns a human-readable name for this frame's function.
  *
  * This function will attempt to load a human-readable name for function this


### PR DESCRIPTION
Previously extracting an exit code was only possibly on a `wasm_trap_t` which will never successfully have an exit code on it, so the exit code extractor is moved over to `wasmtime_error_t`. Additionally extracting a wasm trace from a `wasmtime_error_t` is added since traces happen on both traps and errors now.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
