### PR TITLE
Add Store::set_fuel and Store::fuel_remaining

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -130,7 +130,7 @@ pub fn instantiate(wasm: &[u8], known_valid: bool, config: &generators::Config, 
 
     let mut timeout_state = SignalOnDrop::default();
     match timeout {
-        Timeout::Fuel(fuel) => set_fuel(&mut store, fuel),
+        Timeout::Fuel(fuel) => store.set_fuel(fuel).unwrap(),
 
         // If a timeout is requested then we spawn a helper thread to wait for
         // the requested time and then send us a signal to get interrupted. We
@@ -530,7 +530,7 @@ pub fn table_ops(
     {
         fuzz_config.wasmtime.consume_fuel = true;
         let mut store = fuzz_config.to_store();
-        set_fuel(&mut store, 1_000);
+        store.set_fuel(1_000).unwrap();
 
         let wasm = ops.to_wasm_binary();
         log_wasm(&wasm);
@@ -779,20 +779,6 @@ impl Drop for SignalOnDrop {
             thread.join().unwrap();
         }
     }
-}
-
-/// Set the amount of fuel in a store to a given value
-pub fn set_fuel<T>(store: &mut Store<T>, fuel: u64) {
-    // Determine the amount of fuel already within the store, if any, and
-    // add/consume as appropriate to set the remaining amount to` fuel`.
-    let remaining = store.consume_fuel(0).unwrap();
-    if fuel > remaining {
-        store.add_fuel(fuel - remaining).unwrap();
-    } else {
-        store.consume_fuel(remaining - fuel).unwrap();
-    }
-    // double-check that the store has the expected amount of fuel remaining
-    assert_eq!(store.consume_fuel(0).unwrap(), fuel);
 }
 
 /// Generate and execute a `crate::generators::component_types::TestCase` using the specified `input` to create

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1789,11 +1789,25 @@ impl<T> Caller<'_, T> {
         self.store.fuel_consumed()
     }
 
+    /// Returns the amount of fuel remaining in the store.
+    ///
+    /// For more information see [`Store::fuel_remaining`](crate::Store::fuel_remaining)
+    pub fn fuel_remaining(&self) -> Option<u64> {
+        self.store.fuel_remaining()
+    }
+
     /// Inject more fuel into this store to be consumed when executing wasm code.
     ///
     /// For more information see [`Store::add_fuel`](crate::Store::add_fuel)
     pub fn add_fuel(&mut self, fuel: u64) -> Result<()> {
         self.store.add_fuel(fuel)
+    }
+
+    /// Sets the amount of fuel that's present in the store.
+    ///
+    /// For more information see [`Store::set_fuel`](crate::Store::set_fuel)
+    pub fn set_fuel(&mut self, fuel: u64) -> Result<()> {
+        self.store.set_fuel(fuel)
     }
 
     /// Synthetically consumes fuel from the store.

--- a/examples/fuel.rs
+++ b/examples/fuel.rs
@@ -10,14 +10,14 @@ fn main() -> Result<()> {
     config.consume_fuel(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
-    store.add_fuel(10_000)?;
+    store.set_fuel(10_000)?;
     let module = Module::from_file(store.engine(), "examples/fuel.wat")?;
     let instance = Instance::new(&mut store, &module, &[])?;
 
     // Invoke `fibonacci` export with higher and higher numbers until we exhaust our fuel.
     let fibonacci = instance.get_typed_func::<i32, i32, _>(&mut store, "fibonacci")?;
     for n in 1.. {
-        let fuel_before = store.fuel_consumed().unwrap();
+        store.set_fuel(10_000)?;
         let output = match fibonacci.call(&mut store, n) {
             Ok(v) => v,
             Err(_) => {
@@ -25,9 +25,8 @@ fn main() -> Result<()> {
                 break;
             }
         };
-        let fuel_consumed = store.fuel_consumed().unwrap() - fuel_before;
+        let fuel_consumed = store.fuel_consumed().unwrap();
         println!("fib({}) = {} [consumed {} fuel]", n, output, fuel_consumed);
-        store.add_fuel(fuel_consumed)?;
     }
     Ok(())
 }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -142,6 +142,14 @@ fn manual_fuel() {
     assert_eq!(store.consume_fuel(1).unwrap(), 1);
     assert_eq!(store.consume_fuel(1).unwrap(), 0);
     assert_eq!(store.consume_fuel(0).unwrap(), 0);
+    store.add_fuel(5_000).unwrap();
+    assert_eq!(store.fuel_consumed(), Some(10_000));
+    assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
+    assert_eq!(store.fuel_consumed(), Some(12_500));
+    store.set_fuel(5_000).unwrap();
+    assert_eq!(store.fuel_consumed(), Some(0));
+    assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
+    assert_eq!(store.fuel_consumed(), Some(2_500));
 }
 
 #[test]
@@ -166,7 +174,9 @@ fn host_function_consumes_all() {
     store.add_fuel(FUEL).unwrap();
     let func = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| {
         let consumed = caller.fuel_consumed().unwrap();
-        assert_eq!(caller.consume_fuel((FUEL - consumed) - 1).unwrap(), 1);
+        let remaining = caller.fuel_remaining().unwrap();
+        assert_eq!(remaining, FUEL - consumed);
+        assert_eq!(caller.consume_fuel(remaining - 1).unwrap(), 1);
     });
 
     let instance = Instance::new(&mut store, &module, &[func.into()]).unwrap();


### PR DESCRIPTION
Resolves #5109. As discussed there, adds `Store::set_fuel` and `Store::fuel_remaining`, which sets the absolute amount of fuel in the store and returns the amount of fuel remaining in the store respectively. In updating the examples and tests, I was already able to change some stuff to be nicer/express intent more clearly. (`set_fuel` provides more of a use for `fuel_consumed`! e.g. see examples/fuel.rs).

This feature doesn't have a maintainer assigned.