### PR TITLE
c-api: Avoid losing error context with instance traps

### DIFF
--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -98,13 +98,14 @@ pub(crate) fn handle_instantiate(
             *instance_ptr = i;
             None
         }
-        Err(e) => match e.downcast::<Trap>() {
-            Ok(trap) => {
-                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(trap.into())));
+        Err(e) => {
+            if e.is::<Trap>() {
+                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(e)));
                 None
+            } else {
+                Some(Box::new(e.into()))
             }
-            Err(e) => Some(Box::new(e.into())),
-        },
+        }
     }
 }
 


### PR DESCRIPTION
This commit was a mistake from #5149

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
