### PR TITLE
[3.0.0] Backport some C-API trap-related changes

### DIFF
--- a/crates/c-api/include/wasmtime/error.h
+++ b/crates/c-api/include/wasmtime/error.h
@@ -48,6 +48,24 @@ WASM_API_EXTERN void wasmtime_error_message(
     wasm_name_t *message
 );
 
+/**
+ * \brief Attempts to extract a WASI-specific exit status from this error.
+ *
+ * Returns `true` if the error is a WASI "exit" trap and has a return status.
+ * If `true` is returned then the exit status is returned through the `status`
+ * pointer. If `false` is returned then this is not a wasi exit trap.
+ */
+WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int *status);
+
+/**
+ * \brief Attempts to extract a WebAssembly trace from this error.
+ *
+ * This is similar to #wasm_trap_trace except that it takes a #wasmtime_error_t
+ * as input. The `out` argument will be filled in with the wasm trace, if
+ * present.
+ */
+WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t*, wasm_frame_vec_t *out);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/trap.h
+++ b/crates/c-api/include/wasmtime/trap.h
@@ -70,15 +70,6 @@ WASM_API_EXTERN wasm_trap_t *wasmtime_trap_new(const char *msg, size_t msg_len);
 WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t *code);
 
 /**
- * \brief Attempts to extract a WASI-specific exit status from this trap.
- *
- * Returns `true` if the trap is a WASI "exit" trap and has a return status. If
- * `true` is returned then the exit status is returned through the `status`
- * pointer. If `false` is returned then this is not a wasi exit trap.
- */
-WASM_API_EXTERN bool wasmtime_trap_exit_status(const wasm_trap_t*, int *status);
-
-/**
  * \brief Returns a human-readable name for this frame's function.
  *
  * This function will attempt to load a human-readable name for function this

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -98,13 +98,14 @@ pub(crate) fn handle_instantiate(
             *instance_ptr = i;
             None
         }
-        Err(e) => match e.downcast::<Trap>() {
-            Ok(trap) => {
-                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(trap.into())));
+        Err(e) => {
+            if e.is::<Trap>() {
+                *trap_ptr = Box::into_raw(Box::new(wasm_trap_t::new(e)));
                 None
+            } else {
+                Some(Box::new(e.into()))
             }
-            Err(e) => Some(Box::new(e.into())),
-        },
+        }
     }
 }
 


### PR DESCRIPTION
This backports #5215 and https://github.com/bytecodealliance/wasmtime/pull/5223 to fix issues from https://github.com/bytecodealliance/wasmtime/pull/5149.