### PR TITLE
wiggle: add initial support for shared memory

### DIFF
--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -118,7 +118,7 @@ fn generate_func(
         };
         let (mem , ctx) = mem.data_and_store_mut(&mut caller);
         let ctx = get_cx(ctx);
-        let mem = #rt::wasmtime::WasmtimeGuestMemory::new(mem);
+        let mem = #rt::wasmtime::WasmtimeGuestMemory::new(mem, false);
         Ok(<#ret_ty>::from(#abi_func(ctx, &mem #(, #arg_names)*) #await_ ?))
     };
 

--- a/crates/wiggle/src/guest_type.rs
+++ b/crates/wiggle/src/guest_type.rs
@@ -97,7 +97,7 @@ macro_rules! integer_primitives {
                 // difference between an additional branch and a relaxed memory
                 // access and thus always do the relaxed access here.
                 let atomic_value_ref: &$ty_atomic =
-                    unsafe { &*(host_ptr as *mut $ty as *const $ty_atomic) };
+                    unsafe { &*(host_ptr.cast::<$ty_atomic>()) };
                 Ok($ty::from_le(atomic_value_ref.load(Ordering::Relaxed)))
             }
 
@@ -123,7 +123,7 @@ macro_rules! integer_primitives {
                 // difference between an additional branch and a relaxed memory
                 // access and thus always do the relaxed access here.
                 let atomic_value_ref: &$ty_atomic =
-                    unsafe { &*(host_ptr as *mut $ty as *const $ty_atomic) };
+                    unsafe { &*(host_ptr.cast::<$ty_atomic>()) };
                 atomic_value_ref.store(val.to_le(), Ordering::Relaxed);
                 Ok(())
             }
@@ -174,7 +174,7 @@ macro_rules! float_primitives {
                 // difference between an additional branch and a relaxed memory
                 // access and thus always do the relaxed access here.
                 let atomic_value_ref: &$ty_atomic =
-                    unsafe { &*(host_ptr as *mut $ty as *const $ty_atomic) };
+                    unsafe { &*(host_ptr.cast::<$ty_atomic>()) };
                 let value = $ty_unsigned::from_le(atomic_value_ref.load(Ordering::Relaxed));
                 Ok($ty::from_bits(value))
             }
@@ -201,7 +201,7 @@ macro_rules! float_primitives {
                 // difference between an additional branch and a relaxed memory
                 // access and thus always do the relaxed access here.
                 let atomic_value_ref: &$ty_atomic =
-                    unsafe { &*(host_ptr as *mut $ty as *const $ty_atomic) };
+                    unsafe { &*(host_ptr.cast::<$ty_atomic>()) };
                 let le_value = $ty_unsigned::to_le(val.to_bits());
                 atomic_value_ref.store(le_value, Ordering::Relaxed);
                 Ok(())

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -192,6 +192,12 @@ pub unsafe trait GuestMemory: Send + Sync {
     /// `GuestStr` are implemented correctly, a shared `BorrowHandle` should only be
     /// unborrowed once.
     fn shared_unborrow(&self, h: BorrowHandle);
+
+    /// Check if the underlying memory is shared across multiple threads; e.g.,
+    /// with a WebAssembly shared memory.
+    fn is_shared_memory(&self) -> bool {
+        false
+    }
 }
 
 /// A handle to a borrow on linear memory. It is produced by `{mut, shared}_borrow` and

--- a/crates/wiggle/src/wasmtime.rs
+++ b/crates/wiggle/src/wasmtime.rs
@@ -6,10 +6,11 @@ use crate::{BorrowHandle, GuestError, GuestMemory, Region};
 pub struct WasmtimeGuestMemory<'a> {
     mem: &'a mut [u8],
     bc: BorrowChecker,
+    shared: bool,
 }
 
 impl<'a> WasmtimeGuestMemory<'a> {
-    pub fn new(mem: &'a mut [u8]) -> Self {
+    pub fn new(mem: &'a mut [u8], shared: bool) -> Self {
         Self {
             mem,
             // Wiggle does not expose any methods for functions to re-enter
@@ -22,6 +23,7 @@ impl<'a> WasmtimeGuestMemory<'a> {
             // integrated fully with wasmtime:
             // https://github.com/bytecodealliance/wasmtime/issues/1917
             bc: BorrowChecker::new(),
+            shared,
         }
     }
 }
@@ -50,5 +52,8 @@ unsafe impl GuestMemory for WasmtimeGuestMemory<'_> {
     }
     fn mut_unborrow(&self, h: BorrowHandle) {
         self.bc.mut_unborrow(h)
+    }
+    fn is_shared_memory(&self) -> bool {
+        self.shared
     }
 }


### PR DESCRIPTION
This change is the first in a series of changes to support shared memory in Wiggle. Since Wiggle was written under the assumption of single-threaded guest-side access, this change introduces a `shared` field to guest memories in order to flag when this assumption will not be the case. This change always sets `shared` to `false`; once a few more pieces are in place, `shared` will be set dynamically when a shared memory is detected, e.g., in a change like #5054.

Using the `shared` field, we can now decide to load Wiggle values differently under the new assumptions. This change  makes the guest `T::read` and `T::write` calls into `Relaxed` atomic loads and stores in order to maintain WebAssembly's expected memory consistency guarantees. We choose Rust's `Relaxed` here to match the `Unordered` memory consistency described in the [memory model] section of the ECMA spec.

[memory model]: https://tc39.es/ecma262/multipage/memory-model.html#sec-memory-model

Since 128-bit scalar types do not have `Atomic*` equivalents, we remove their `T::read` and `T::write` implementations here. They are unused by any WASI implementations in the project.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
