### PR TITLE
cranelift: Resize with `types::INVALID` isntead of `types::I8`

### DIFF
--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1408,7 +1408,7 @@ impl<I: VCodeInst> VRegAllocator<I> {
     /// Set the type of this virtual register.
     pub fn set_vreg_type(&mut self, vreg: VirtualReg, ty: Type) {
         if self.vreg_types.len() <= vreg.index() {
-            self.vreg_types.resize(vreg.index() + 1, ir::types::I8);
+            self.vreg_types.resize(vreg.index() + 1, ir::types::INVALID);
         }
         self.vreg_types[vreg.index()] = ty;
         if is_reftype(ty) {


### PR DESCRIPTION
Follow up from #5222 to resize the vreg_types vector with `types::INVALID`  instead of `types::I8`.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
