### PR TITLE
wiggle: adapt Wiggle guest slices for `unsafe` shared use

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -468,14 +468,16 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
             .get_file_mut(u32::from(fd))?
             .get_cap_mut(FileCaps::READ)?;
 
-        let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> = iovs
-            .iter()
-            .map(|iov_ptr| {
-                let iov_ptr = iov_ptr?;
-                let iov: types::Iovec = iov_ptr.read()?;
-                Ok(iov.buf.as_array(iov.buf_len).as_slice_mut()?)
-            })
-            .collect::<Result<_, Error>>()?;
+        let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> =
+            iovs.iter()
+                .map(|iov_ptr| {
+                    let iov_ptr = iov_ptr?;
+                    let iov: types::Iovec = iov_ptr.read()?;
+                    Ok(iov.buf.as_array(iov.buf_len).as_slice_mut()?.expect(
+                        "cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)",
+                    ))
+                })
+                .collect::<Result<_, Error>>()?;
 
         let mut ioslices: Vec<IoSliceMut> = guest_slices
             .iter_mut()
@@ -497,14 +499,16 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
             .get_file_mut(u32::from(fd))?
             .get_cap_mut(FileCaps::READ | FileCaps::SEEK)?;
 
-        let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> = iovs
-            .iter()
-            .map(|iov_ptr| {
-                let iov_ptr = iov_ptr?;
-                let iov: types::Iovec = iov_ptr.read()?;
-                Ok(iov.buf.as_array(iov.buf_len).as_slice_mut()?)
-            })
-            .collect::<Result<_, Error>>()?;
+        let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> =
+            iovs.iter()
+                .map(|iov_ptr| {
+                    let iov_ptr = iov_ptr?;
+                    let iov: types::Iovec = iov_ptr.read()?;
+                    Ok(iov.buf.as_array(iov.buf_len).as_slice_mut()?.expect(
+                        "cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)",
+                    ))
+                })
+                .collect::<Result<_, Error>>()?;
 
         let mut ioslices: Vec<IoSliceMut> = guest_slices
             .iter_mut()
@@ -530,7 +534,11 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
             .map(|iov_ptr| {
                 let iov_ptr = iov_ptr?;
                 let iov: types::Ciovec = iov_ptr.read()?;
-                Ok(iov.buf.as_array(iov.buf_len).as_slice()?)
+                Ok(iov
+                    .buf
+                    .as_array(iov.buf_len)
+                    .as_slice()?
+                    .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)"))
             })
             .collect::<Result<_, Error>>()?;
 
@@ -559,7 +567,11 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
             .map(|iov_ptr| {
                 let iov_ptr = iov_ptr?;
                 let iov: types::Ciovec = iov_ptr.read()?;
-                Ok(iov.buf.as_array(iov.buf_len).as_slice()?)
+                Ok(iov
+                    .buf
+                    .as_array(iov.buf_len)
+                    .as_slice()?
+                    .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)"))
             })
             .collect::<Result<_, Error>>()?;
 

--- a/crates/wasi-crypto/src/wiggle_interfaces/asymmetric_common.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/asymmetric_common.rs
@@ -39,7 +39,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         kp_id_ptr: &wiggle::GuestPtr<'_, u8>,
         kp_id_max_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let key_id_buf = &mut *kp_id_ptr.as_array(kp_id_max_len).as_slice_mut()?;
+        let key_id_buf = &mut *kp_id_ptr
+            .as_array(kp_id_max_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).keypair_store_managed(
             secrets_manager_handle.into(),
             kp_handle.into(),
@@ -69,7 +72,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         kp_id_len: guest_types::Size,
         kp_version: guest_types::Version,
     ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
-        let kp_id = &*kp_id_ptr.as_array(kp_id_len).as_slice()?;
+        let kp_id = &*kp_id_ptr
+            .as_array(kp_id_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .keypair_from_id(secrets_manager_handle.into(), kp_id, Version(kp_version))?
             .into())
@@ -102,7 +108,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         encoding: guest_types::KeypairEncoding,
     ) -> Result<guest_types::Keypair, guest_types::CryptoErrno> {
         let alg_str = &*alg_str.as_str()?;
-        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        let encoded = &*encoded_ptr
+            .as_array(encoded_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .keypair_import(alg_type.into(), alg_str, encoded, encoding.into())?
             .into())
@@ -114,7 +123,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         kp_id_ptr: &wiggle::GuestPtr<'_, u8>,
         kp_id_max_len: guest_types::Size,
     ) -> Result<(guest_types::Size, guest_types::Version), guest_types::CryptoErrno> {
-        let kp_id_buf = &mut *kp_id_ptr.as_array(kp_id_max_len as _).as_slice_mut()?;
+        let kp_id_buf = &mut *kp_id_ptr
+            .as_array(kp_id_max_len as _)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         let (kp_id, version) = (&*self).keypair_id(kp_handle.into())?;
         ensure!(kp_id.len() <= kp_id_buf.len(), CryptoError::Overflow.into());
         kp_id_buf.copy_from_slice(&kp_id);
@@ -156,7 +168,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         encoding: guest_types::PublickeyEncoding,
     ) -> Result<guest_types::Publickey, guest_types::CryptoErrno> {
         let alg_str = &*alg_str.as_str()?;
-        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        let encoded = &*encoded_ptr
+            .as_array(encoded_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .publickey_import(alg_type.into(), alg_str, encoded, encoding.into())?
             .into())
@@ -204,7 +219,10 @@ impl super::wasi_ephemeral_crypto_asymmetric_common::WasiEphemeralCryptoAsymmetr
         encoding: guest_types::SecretkeyEncoding,
     ) -> Result<guest_types::Secretkey, guest_types::CryptoErrno> {
         let alg_str = &*alg_str.as_str()?;
-        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        let encoded = &*encoded_ptr
+            .as_array(encoded_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .secretkey_import(alg_type.into(), alg_str, encoded, encoding.into())?
             .into())

--- a/crates/wasi-crypto/src/wiggle_interfaces/common.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/common.rs
@@ -28,7 +28,12 @@ impl super::wasi_ephemeral_crypto_common::WasiEphemeralCryptoCommon for WasiCryp
         value_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
         let name_str: &str = &*name_str.as_str()?;
-        let value: &[u8] = { &*value_ptr.as_array(value_len).as_slice()? };
+        let value: &[u8] = {
+            &*value_ptr
+                .as_array(value_len)
+                .as_slice()?
+                .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)")
+        };
         Ok((&*self).options_set(options_handle.into(), name_str, value)?)
     }
 
@@ -40,8 +45,14 @@ impl super::wasi_ephemeral_crypto_common::WasiEphemeralCryptoCommon for WasiCryp
         buffer_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
         let name_str: &str = &*name_str.as_str()?;
-        let buffer: &'static mut [u8] =
-            unsafe { std::mem::transmute(&mut *buffer_ptr.as_array(buffer_len).as_slice_mut()?) };
+        let buffer: &'static mut [u8] = unsafe {
+            std::mem::transmute(
+                &mut *buffer_ptr
+                    .as_array(buffer_len)
+                    .as_slice_mut()?
+                    .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)"),
+            )
+        };
         Ok((&*self).options_set_guest_buffer(options_handle.into(), name_str, buffer)?)
     }
 
@@ -72,7 +83,12 @@ impl super::wasi_ephemeral_crypto_common::WasiEphemeralCryptoCommon for WasiCryp
         buf_ptr: &wiggle::GuestPtr<'_, u8>,
         buf_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
-        let buf: &mut [u8] = { &mut *buf_ptr.as_array(buf_len).as_slice_mut()? };
+        let buf: &mut [u8] = {
+            &mut *buf_ptr
+                .as_array(buf_len)
+                .as_slice_mut()?
+                .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)")
+        };
         Ok((&*self)
             .array_output_pull(array_output_handle.into(), buf)?
             .try_into()?)
@@ -107,7 +123,12 @@ impl super::wasi_ephemeral_crypto_common::WasiEphemeralCryptoCommon for WasiCryp
         key_id_len: guest_types::Size,
         key_version: guest_types::Version,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let key_id: &[u8] = { &*key_id_ptr.as_array(key_id_len).as_slice()? };
+        let key_id: &[u8] = {
+            &*key_id_ptr
+                .as_array(key_id_len)
+                .as_slice()?
+                .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)")
+        };
         Ok((&*self).secrets_manager_invalidate(
             secrets_manager_handle.into(),
             key_id,

--- a/crates/wasi-crypto/src/wiggle_interfaces/key_exchange.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/key_exchange.rs
@@ -31,7 +31,8 @@ impl super::wasi_ephemeral_crypto_kx::WasiEphemeralCryptoKx for WasiCryptoCtx {
     ) -> Result<guest_types::ArrayOutput, guest_types::CryptoErrno> {
         let encapsulated_secret = &*encapsulated_secret_ptr
             .as_array(encapsulated_secret_len)
-            .as_slice()?;
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .kx_decapsulate(sk_handle.into(), encapsulated_secret)?
             .into())

--- a/crates/wasi-crypto/src/wiggle_interfaces/signatures.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/signatures.rs
@@ -23,7 +23,10 @@ impl super::wasi_ephemeral_crypto_signatures::WasiEphemeralCryptoSignatures for 
         encoding: guest_types::SignatureEncoding,
     ) -> Result<guest_types::Signature, guest_types::CryptoErrno> {
         let alg_str = &*alg_str.as_str()?;
-        let encoded = &*encoded_ptr.as_array(encoded_len).as_slice()?;
+        let encoded = &*encoded_ptr
+            .as_array(encoded_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .signature_import(alg_str, encoded, encoding.into())?
             .into())
@@ -42,7 +45,10 @@ impl super::wasi_ephemeral_crypto_signatures::WasiEphemeralCryptoSignatures for 
         input_ptr: &wiggle::GuestPtr<'_, u8>,
         input_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let input = &*input_ptr.as_array(input_len).as_slice()?;
+        let input = &*input_ptr
+            .as_array(input_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).signature_state_update(state_handle.into(), input)?)
     }
 
@@ -77,7 +83,10 @@ impl super::wasi_ephemeral_crypto_signatures::WasiEphemeralCryptoSignatures for 
         input_ptr: &wiggle::GuestPtr<'_, u8>,
         input_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let input: &[u8] = &*input_ptr.as_array(input_len).as_slice()?;
+        let input: &[u8] = &*input_ptr
+            .as_array(input_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok(
             (&*self)
                 .signature_verification_state_update(verification_state_handle.into(), input)?,

--- a/crates/wasi-crypto/src/wiggle_interfaces/symmetric.rs
+++ b/crates/wasi-crypto/src/wiggle_interfaces/symmetric.rs
@@ -35,7 +35,8 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
     ) -> Result<(), guest_types::CryptoErrno> {
         let key_id_buf = &mut *symmetric_key_id_ptr
             .as_array(symmetric_key_id_max_len)
-            .as_slice_mut()?;
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).symmetric_key_store_managed(
             secrets_manager_handle.into(),
             symmetric_key_handle.into(),
@@ -67,7 +68,8 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
     ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
         let symmetric_key_id = &*symmetric_key_id_ptr
             .as_array(symmetric_key_id_len)
-            .as_slice()?;
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_key_from_id(
                 secrets_manager_handle.into(),
@@ -101,7 +103,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         raw_len: guest_types::Size,
     ) -> Result<guest_types::SymmetricKey, guest_types::CryptoErrno> {
         let alg_str = &*alg_str.as_str()?;
-        let raw = &*raw_ptr.as_array(raw_len).as_slice()?;
+        let raw = &*raw_ptr
+            .as_array(raw_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).symmetric_key_import(alg_str, raw)?.into())
     }
 
@@ -122,7 +127,8 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
     ) -> Result<(guest_types::Size, guest_types::Version), guest_types::CryptoErrno> {
         let key_id_buf = &mut *symmetric_key_id_ptr
             .as_array(symmetric_key_id_max_len)
-            .as_slice_mut()?;
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         let (key_id, version) = (&*self).symmetric_key_id(symmetric_key_handle.into())?;
         ensure!(
             key_id.len() <= key_id_buf.len(),
@@ -173,7 +179,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         value_max_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
         let name_str: &str = &*name_str.as_str()?;
-        let value = &mut *value_ptr.as_array(value_max_len).as_slice_mut()?;
+        let value = &mut *value_ptr
+            .as_array(value_max_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .options_get(symmetric_state_handle.into(), name_str, value)?
             .try_into()?)
@@ -201,7 +210,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         data_ptr: &wiggle::GuestPtr<'_, u8>,
         data_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        let data = &*data_ptr
+            .as_array(data_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).symmetric_state_absorb(symmetric_state_handle.into(), data)?)
     }
 
@@ -211,7 +223,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         out_ptr: &wiggle::GuestPtr<'_, u8>,
         out_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
+        let out = &mut *out_ptr
+            .as_array(out_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).symmetric_state_squeeze(symmetric_state_handle.into(), out)?)
     }
 
@@ -252,8 +267,14 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         data_ptr: &wiggle::GuestPtr<'_, u8>,
         data_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
-        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
-        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        let out = &mut *out_ptr
+            .as_array(out_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let data = &*data_ptr
+            .as_array(data_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_state_encrypt(symmetric_state_handle.into(), out, data)?
             .try_into()?)
@@ -267,8 +288,14 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         data_ptr: &wiggle::GuestPtr<'_, u8>,
         data_len: guest_types::Size,
     ) -> Result<guest_types::SymmetricTag, guest_types::CryptoErrno> {
-        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
-        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        let out = &mut *out_ptr
+            .as_array(out_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let data = &*data_ptr
+            .as_array(data_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_state_encrypt_detached(symmetric_state_handle.into(), out, data)?
             .into())
@@ -282,8 +309,14 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         data_ptr: &wiggle::GuestPtr<'_, u8>,
         data_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
-        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
-        let data = &*data_ptr.as_array(data_len).as_slice()?;
+        let out = &mut *out_ptr
+            .as_array(out_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let data = &*data_ptr
+            .as_array(data_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_state_decrypt(symmetric_state_handle.into(), out, data)?
             .try_into()?)
@@ -299,9 +332,18 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         raw_tag_ptr: &wiggle::GuestPtr<'_, u8>,
         raw_tag_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
-        let out = &mut *out_ptr.as_array(out_len).as_slice_mut()?;
-        let data = &*data_ptr.as_array(data_len).as_slice()?;
-        let raw_tag: &[u8] = &*raw_tag_ptr.as_array(raw_tag_len).as_slice()?;
+        let out = &mut *out_ptr
+            .as_array(out_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let data = &*data_ptr
+            .as_array(data_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let raw_tag: &[u8] = &*raw_tag_ptr
+            .as_array(raw_tag_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_state_decrypt_detached(symmetric_state_handle.into(), out, data, raw_tag)?
             .try_into()?)
@@ -331,7 +373,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         buf_ptr: &wiggle::GuestPtr<'_, u8>,
         buf_len: guest_types::Size,
     ) -> Result<guest_types::Size, guest_types::CryptoErrno> {
-        let buf = &mut *buf_ptr.as_array(buf_len).as_slice_mut()?;
+        let buf = &mut *buf_ptr
+            .as_array(buf_len)
+            .as_slice_mut()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self)
             .symmetric_tag_pull(symmetric_tag_handle.into(), buf)?
             .try_into()?)
@@ -343,7 +388,10 @@ impl super::wasi_ephemeral_crypto_symmetric::WasiEphemeralCryptoSymmetric for Wa
         expected_raw_ptr: &wiggle::GuestPtr<'_, u8>,
         expected_raw_len: guest_types::Size,
     ) -> Result<(), guest_types::CryptoErrno> {
-        let expected_raw = &*expected_raw_ptr.as_array(expected_raw_len).as_slice()?;
+        let expected_raw = &*expected_raw_ptr
+            .as_array(expected_raw_len)
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         Ok((&*self).symmetric_tag_verify(symmetric_tag_handle.into(), expected_raw)?)
     }
 

--- a/crates/wasi-nn/src/impl.rs
+++ b/crates/wasi-nn/src/impl.rs
@@ -80,8 +80,11 @@ impl<'a> WasiEphemeralNn for WasiNnCtx {
         out_buffer: &GuestPtr<'_, u8>,
         out_buffer_max_size: u32,
     ) -> Result<u32> {
-        let mut destination = out_buffer.as_array(out_buffer_max_size).as_slice_mut()?;
         if let Some(exec_context) = self.executions.get_mut(exec_context_id) {
+            let mut destination = out_buffer
+                .as_array(out_buffer_max_size)
+                .as_slice_mut()?
+                .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
             Ok(exec_context.get_output(index, &mut destination)?)
         } else {
             Err(UsageError::InvalidGraphHandle.into())

--- a/crates/wasi-nn/src/openvino.rs
+++ b/crates/wasi-nn/src/openvino.rs
@@ -31,8 +31,15 @@ impl Backend for OpenvinoBackend {
 
         // Read the guest array.
         let builders = builders.as_ptr();
-        let xml = builders.read()?.as_slice()?;
-        let weights = builders.add(1)?.read()?.as_slice()?;
+        let xml = builders
+            .read()?
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let weights = builders
+            .add(1)?
+            .read()?
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
 
         // Construct OpenVINO graph structures: `cnn_network` contains the graph
         // structure, `exec_network` can perform inference.
@@ -78,6 +85,7 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
         let dimensions = tensor
             .dimensions
             .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)")
             .iter()
             .map(|d| *d as usize)
             .collect::<Vec<_>>();
@@ -86,7 +94,10 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
         // TODO There must be some good way to discover the layout here; this
         // should not have to default to NHWC.
         let desc = TensorDesc::new(Layout::NHWC, &dimensions, precision);
-        let data = tensor.data.as_slice()?;
+        let data = tensor
+            .data
+            .as_slice()?
+            .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
         let blob = openvino::Blob::new(&desc, &data)?;
 
         // Actually assign the blob to the request.

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -147,7 +147,10 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
             let len: u32 = iov.buf_len;
             let buf: GuestPtr<[u8]> = base.as_array(len);
             // GuestSlice will remain borrowed until dropped:
-            let slice = buf.as_slice().expect("borrow slice from iovec");
+            let slice = buf
+                .as_slice()
+                .expect("borrow slice from iovec")
+                .expect("expected non-shared memory");
             slices.push(slice);
         }
         println!("iovec slices: [");


### PR DESCRIPTION
When multiple threads can concurrently modify a WebAssembly shared memory, the underlying data for a Wiggle `GuestSlice` and `GuestSliceMut` could change due to access from other threads. This breaks Rust guarantees when `&[T]` and `&mut [T]` slices are handed out. This change modifies `GuestPtr` to make `as_slice` and `as_slice_mut` return an `Option` which is `None` when the underlying WebAssembly memory is shared.

But WASI implementations still need access to the underlying WebAssembly memory, both to read to it and write from it. This change adds new APIs:
- `GuestPtr::to_vec` copies the  bytes from WebAssembly memory (from which we can safely take a `&[T]`)
- `GuestPtr::as_unsafe_slice_mut` returns a wrapper `struct` from which we can  `unsafe`-ly return a mutable slice (users must accept the unsafety of concurrently modifying a `&mut [T]`)

This approach allows us to maintain Wiggle's borrow-checking infrastructure, which enforces the guarantee that Wiggle will not modify overlapping regions, e.g. This is important because the underlying system calls may expect this. Other threads may modify the same underlying region and this is impossible to prevent; at least Wiggle will not be able to do so.

Finally, the changes to Wiggle's API are propagated to all WASI implementations in Wasmtime. For now, code locations that attempt to get a guest slice will panic if the underlying memory is shared. Note that Wiggle is not enabled for shared memory (that will come later in something like #5054), but when it is, these panics will be clear indicators of locations that must be re-implemented in a thread-safe way.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
