### PR TITLE
Fix `OutOfFuel` trap code not represented in the C API.

### DIFF
--- a/crates/c-api/include/wasmtime/trap.h
+++ b/crates/c-api/include/wasmtime/trap.h
@@ -46,6 +46,8 @@ enum wasmtime_trap_code_enum {
   WASMTIME_TRAP_CODE_UNREACHABLE_CODE_REACHED,
   /// Execution has potentially run too long and may be interrupted.
   WASMTIME_TRAP_CODE_INTERRUPT,
+  /// Execution has run out of the configured fuel amount.
+  WASMTIME_TRAP_CODE_OUT_OF_FUEL,
 };
 
 /**

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -133,6 +133,8 @@ pub extern "C" fn wasmtime_trap_code(raw: &wasm_trap_t, code: &mut u8) -> bool {
         Trap::BadConversionToInteger => 8,
         Trap::UnreachableCodeReached => 9,
         Trap::Interrupt => 10,
+        Trap::OutOfFuel => 11,
+        Trap::AlwaysTrapAdapter => unreachable!("component model not supported"),
         _ => unreachable!(),
     };
     true

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -100,6 +100,11 @@ int main() {
     wasmtime_val_t results[1];
     error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
     if (error != NULL || trap != NULL) {
+      if (trap != NULL) {
+        wasmtime_trap_code_t code;
+        assert(wasmtime_trap_code(trap, &code));
+        assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
+      }
       printf("Exhausted fuel computing fib(%d)\n", n);
       break;
     }

--- a/examples/fuel.rs
+++ b/examples/fuel.rs
@@ -20,7 +20,8 @@ fn main() -> Result<()> {
         let fuel_before = store.fuel_consumed().unwrap();
         let output = match fibonacci.call(&mut store, n) {
             Ok(v) => v,
-            Err(_) => {
+            Err(e) => {
+                assert_eq!(e.downcast::<Trap>()?, Trap::OutOfFuel);
                 println!("Exhausted fuel computing fib({})", n);
                 break;
             }


### PR DESCRIPTION
This PR adds the missing "out of fuel" trap code to the C API.

Without this, calls to `wasmtime_trap_code` will trigger an unreachable panic on traps from running out of fuel.

