### PR TITLE
cranelift-isle: if-let patterns aren't root terms

### DIFF
--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -2402,7 +2402,7 @@ impl TermEnv {
             &iflet.pattern,
             Some(ty),
             bindings,
-            /* is_root = */ true,
+            /* is_root = */ false,
         )?;
 
         Some(IfLet { lhs, rhs })


### PR DESCRIPTION
The `is_root` flag to `translate_pattern` just determines whether the `rule_term` argument is used, which begs a larger cleanup. But that cleanup is less clear if `is_root` is set anywhere aside from the call in `collect_rules`. So I wanted to get confirmation that this particular use of that flag is incorrect first.

These two arguments (`is_root` and `rule_term`) are used to prevent expansion of a term as an internal extractor ("macro") if:
- that term is also an internal constructor
- and it's the root term on the left-hand side of the current rule
- and the pattern we're currently translating has no parents.

I'm not sure what it should mean to use the term you're currently defining as the root pattern on the left-hand side of an if-let in the same rule, but I don't think it should have this particular special treatment.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
