### PR TITLE
winch: Prepare for an update to the `wasm-tools` crates

### DIFF
--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -34,7 +34,7 @@ impl TargetIsa for Aarch64 {
     fn compile_function(
         &self,
         _sig: &FuncType,
-        mut _body: FunctionBody,
+        _body: &FunctionBody,
         mut _validator: FuncValidator<ValidatorResources>,
     ) -> Result<Vec<String>> {
         todo!()

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -85,7 +85,7 @@ pub trait TargetIsa: Send + Sync {
     fn compile_function(
         &self,
         sig: &FuncType,
-        body: FunctionBody,
+        body: &FunctionBody,
         validator: FuncValidator<ValidatorResources>,
     ) -> Result<Vec<String>>;
 

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -47,9 +47,10 @@ impl TargetIsa for X64 {
     fn compile_function(
         &self,
         sig: &FuncType,
-        mut body: FunctionBody,
+        body: &FunctionBody,
         mut validator: FuncValidator<ValidatorResources>,
     ) -> Result<Vec<String>> {
+        let mut body = body.get_binary_reader();
         let masm = MacroAssembler::new();
         let stack = Stack::new();
         let abi = abi::X64ABI::default();
@@ -58,9 +59,8 @@ impl TargetIsa for X64 {
         // TODO Add in floating point bitmask
         let regalloc = RegAlloc::new(RegSet::new(ALL_GPR, 0), regs::scratch());
         let codegen_context = CodeGenContext::new(masm, stack, &frame);
-        let mut codegen =
-            CodeGen::new::<abi::X64ABI>(codegen_context, abi_sig, body, validator, regalloc);
+        let mut codegen = CodeGen::new::<abi::X64ABI>(codegen_context, abi_sig, regalloc);
 
-        codegen.emit()
+        codegen.emit(&mut body, validator)
     }
 }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -7,7 +7,6 @@
 use crate::codegen::CodeGen;
 use crate::masm::{MacroAssembler, OperandSize, RegImm};
 use crate::stack::Val;
-use anyhow::Result;
 use wasmparser::ValType;
 use wasmparser::VisitOperator;
 
@@ -15,23 +14,6 @@ impl<'a, M> CodeGen<'a, M>
 where
     M: MacroAssembler,
 {
-    fn emit_i32_add(&mut self) -> Result<()> {
-        let is_const = self
-            .context
-            .stack
-            .peek()
-            .expect("value at stack top")
-            .is_i32_const();
-
-        if is_const {
-            self.add_imm_i32();
-        } else {
-            self.add_i32();
-        }
-
-        Ok(())
-    }
-
     fn add_imm_i32(&mut self) {
         let val = self
             .context
@@ -64,41 +46,6 @@ where
 
         self.regalloc.free_gpr(src);
         self.context.stack.push(Val::reg(dst));
-    }
-
-    fn emit_i32_const(&mut self, val: i32) -> Result<()> {
-        self.context.stack.push(Val::i32(val));
-        Ok(())
-    }
-
-    fn emit_local_get(&mut self, index: u32) -> Result<()> {
-        let context = &mut self.context;
-        let slot = context
-            .frame
-            .get_local(index)
-            .expect(&format!("valid local at slot = {}", index));
-        match slot.ty {
-            ValType::I32 | ValType::I64 => context.stack.push(Val::local(index)),
-            _ => panic!("Unsupported type {:?} for local", slot.ty),
-        }
-
-        Ok(())
-    }
-
-    // TODO verify the case where the target local is on the stack.
-    fn emit_local_set(&mut self, index: u32) -> Result<()> {
-        let context = &mut self.context;
-        let frame = context.frame;
-        let slot = frame
-            .get_local(index)
-            .expect(&format!("vald local at slot = {}", index));
-        let size: OperandSize = slot.ty.into();
-        let src = self.regalloc.pop_to_reg(context, size);
-        let addr = context.masm.local_address(&slot);
-        context.masm.store(RegImm::reg(src), addr, size);
-        self.regalloc.free_gpr(src);
-
-        Ok(())
     }
 }
 
@@ -136,30 +83,53 @@ impl<'a, M> VisitOperator<'a> for CodeGen<'a, M>
 where
     M: MacroAssembler,
 {
-    type Output = Result<()>;
+    type Output = ();
 
-    fn visit_i32_const(&mut self, offset: usize, value: i32) -> Result<()> {
-        self.validator.visit_i32_const(offset, value)?;
-        self.emit_i32_const(value)
+    fn visit_i32_const(&mut self, _offset: usize, val: i32) {
+        self.context.stack.push(Val::i32(val));
     }
 
-    fn visit_i32_add(&mut self, offset: usize) -> Result<()> {
-        self.validator.visit_i32_add(offset)?;
-        self.emit_i32_add()
+    fn visit_i32_add(&mut self, _offset: usize) {
+        let is_const = self
+            .context
+            .stack
+            .peek()
+            .expect("value at stack top")
+            .is_i32_const();
+
+        if is_const {
+            self.add_imm_i32();
+        } else {
+            self.add_i32();
+        }
     }
 
-    fn visit_end(&mut self, offset: usize) -> Result<()> {
-        self.validator.visit_end(offset).map_err(|e| e.into())
+    fn visit_end(&mut self, _offset: usize) {}
+
+    fn visit_local_get(&mut self, _offset: usize, index: u32) {
+        let context = &mut self.context;
+        let slot = context
+            .frame
+            .get_local(index)
+            .expect(&format!("valid local at slot = {}", index));
+        match slot.ty {
+            ValType::I32 | ValType::I64 => context.stack.push(Val::local(index)),
+            _ => panic!("Unsupported type {:?} for local", slot.ty),
+        }
     }
 
-    fn visit_local_get(&mut self, offset: usize, local_index: u32) -> Result<()> {
-        self.validator.visit_local_get(offset, local_index)?;
-        self.emit_local_get(local_index)
-    }
-
-    fn visit_local_set(&mut self, offset: usize, local_index: u32) -> Result<()> {
-        self.validator.visit_local_set(offset, local_index)?;
-        self.emit_local_set(local_index)
+    // TODO verify the case where the target local is on the stack.
+    fn visit_local_set(&mut self, _offset: usize, index: u32) {
+        let context = &mut self.context;
+        let frame = context.frame;
+        let slot = frame
+            .get_local(index)
+            .expect(&format!("vald local at slot = {}", index));
+        let size: OperandSize = slot.ty.into();
+        let src = self.regalloc.pop_to_reg(context, size);
+        let addr = context.masm.local_address(&slot);
+        context.masm.store(RegImm::reg(src), addr, size);
+        self.regalloc.free_gpr(src);
     }
 
     wasmparser::for_each_operator!(def_unsupported);

--- a/winch/src/main.rs
+++ b/winch/src/main.rs
@@ -63,7 +63,7 @@ fn compile(
     let FunctionBodyData { body, validator } = f.1;
     let validator = validator.into_validator(Default::default());
     let buffer = isa
-        .compile_function(&sig, body, validator)
+        .compile_function(&sig, &body, validator)
         .expect("Couldn't compile function");
     for i in buffer {
         println!("{}", i);


### PR DESCRIPTION
This commit prepares the `winch` crate for updating `wasm-tools`, notably changing a bit about how the visitation of operators works. This moves the function body and wasm validator out of the `CodeGen` structure and into parameters threaded into the emission of the actual function.

Additionally the `VisitOperator` implementation was updated to remove the explicit calls to the validator, favoring instead a macro-generated solution to guarantee that all validation happens before any translation proceeds. This means that the `VisitOperator for CodeGen` impl is now infallible and the various methods have been inlined into the trait methods as well as removing the `Result<_>`.

Finally this commit updates translation to call `validator.finish(..)` which is required to perform the final validation steps of the function body.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
