### PR TITLE
Change the return type of `SharedMemory::data`

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -169,12 +169,11 @@ impl DiffInstance for WasmtimeInstance {
 
     fn get_memory(&mut self, name: &str, shared: bool) -> Option<Vec<u8>> {
         Some(if shared {
-            let data = self
+            let memory = self
                 .instance
                 .get_shared_memory(&mut self.store, name)
-                .unwrap()
-                .data();
-            unsafe { (*data).to_vec() }
+                .unwrap();
+            memory.data().iter().map(|i| unsafe { *i.get() }).collect()
         } else {
             self.instance
                 .get_memory(&mut self.store, name)


### PR DESCRIPTION
This commit is an attempt at improving the safety of using the return value of the `SharedMemory::data` method. Previously this returned `*mut [u8]` which, while correct, is unwieldy and unsafe to work with. The new return value of `&[UnsafeCell<u8>]` has a few advantages:

* The lifetime of the returned data is now connected to the `SharedMemory` itself, removing the possibility for a class of errors of accidentally using the prior `*mut [u8]` beyond its original lifetime.

* It's not possibly to safely access `.len()` as opposed to requiring an `unsafe` dereference before.

* The data internally within the slice is now what retains the `unsafe` bits, namely indicating that accessing any memory inside of the contents returned is `unsafe` but addressing it is safe.

I was inspired by the `wiggle`-based discussion on #5229 and felt it appropriate to apply a similar change here.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
