### PR TITLE
Avoid unconditional `getrandom` syscall creating a `WasiCtx`

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -47,7 +47,7 @@ pub use clocks::clocks_ctx;
 pub use sched::sched_ctx;
 
 use crate::net::Socket;
-use cap_rand::RngCore;
+use cap_rand::{Rng, RngCore, SeedableRng};
 use std::path::Path;
 use wasi_common::{file::FileCaps, table::Table, Error, WasiCtx, WasiFile};
 
@@ -141,5 +141,6 @@ impl WasiCtxBuilder {
 }
 
 pub fn random_ctx() -> Box<dyn RngCore + Send + Sync> {
-    Box::new(cap_rand::std_rng_from_entropy(cap_rand::ambient_authority()))
+    let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
+    Box::new(cap_rand::rngs::StdRng::from_seed(rng.gen()))
 }


### PR DESCRIPTION
This commit updates the default random context inserted into a `WasiCtxt` to be seeded from `thread_rng` rather than the system's entropy. This avoids an unconditional syscall on the creation of all `WasiCtx` structures shouldn't reduce the quality of the random numbers produced.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
