### PR TITLE
Use deterministic randomness fuzzing the pooling allocator

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -21,7 +21,7 @@ memoffset = "0.6.0"
 indexmap = "1.0.2"
 thiserror = "1.0.4"
 cfg-if = "1.0"
-rand = "0.8.3"
+rand = { version = "0.8.3", features = ['small_rng'] }
 anyhow = { workspace = true }
 memfd = { version = "0.6.1", optional = true }
 paste = "1.0.3"


### PR DESCRIPTION
This commit updates the index allocation performed in the pooling allocator with a few refactorings:

* With `cfg(fuzzing)` a deterministic rng is now used to improve reproducibility of fuzz test cases.
* The `Mutex` was pushed inside of `IndexAllocator`, renamed from `PoolingAllocationState`.
* Randomness is now always done through a `SmallRng` stored in the `IndexAllocator` instead of using `thread_rng`.
* The `is_empty` method has been removed in favor of an `Option`-based return on `alloc`.

This refactoring is additionally intended to encapsulate more implementation details of `IndexAllocator` to more easily allow for alternate implementations in the future such as lock-free approaches (possibly).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
