### PR TITLE
cranelift: Rework pinned register lowering

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -167,9 +167,15 @@
 
        ;; Like `Move` but with a particular `PReg` source (for implementing CLIF
        ;; instructions like `get_stack_pointer`).
-       (MovPReg
+       (MovFromPReg
         (rd WritableReg)
         (rm PReg))
+
+       ;; Like `Move` but with a particular `PReg` destination (for
+       ;; implementing CLIF instructions like `get_stack_pointer`).
+       (MovToPReg
+        (rd PReg)
+        (rm Reg))
 
        ;; A MOV[Z,N] with a 16-bit immediate.
        (MovWide
@@ -3061,11 +3067,15 @@
         dst))
 
 ;; Helper for emitting `MInst.MovPReg` instructions.
-(decl mov_preg (PReg) Reg)
-(rule (mov_preg src)
+(decl mov_from_preg (PReg) Reg)
+(rule (mov_from_preg src)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.MovPReg dst src))))
+            (_ Unit (emit (MInst.MovFromPReg dst src))))
         dst))
+
+(decl mov_to_preg (PReg Reg) SideEffectNoResult)
+(rule (mov_to_preg dst src)
+      (SideEffectNoResult.Inst (MInst.MovToPReg dst src)))
 
 (decl preg_sp () PReg)
 (extern constructor preg_sp preg_sp)
@@ -3076,13 +3086,16 @@
 (decl preg_link () PReg)
 (extern constructor preg_link preg_link)
 
+(decl preg_pinned () PReg)
+(extern constructor preg_pinned preg_pinned)
+
 (decl aarch64_sp () Reg)
 (rule (aarch64_sp)
-      (mov_preg (preg_sp)))
+      (mov_from_preg (preg_sp)))
 
 (decl aarch64_fp () Reg)
 (rule (aarch64_fp)
-      (mov_preg (preg_fp)))
+      (mov_from_preg (preg_fp)))
 
 (decl aarch64_link () Reg)
 (rule 1 (aarch64_link)
@@ -3111,7 +3124,7 @@
             (lr WritableReg (writable_link_reg))
             (_ Unit (emit (MInst.ULoad64 lr addr (mem_flags_trusted))))
             (_ Unit (emit (MInst.Xpaclri))))
-           (mov_preg (preg_link))))
+           (mov_from_preg (preg_link))))
 
 ;; Helper for getting the maximum shift amount for a type.
 
@@ -3270,16 +3283,9 @@
 
 ;; Helpers for pinned register manipulation.
 
-(decl writable_pinned_reg () WritableReg)
-(extern constructor writable_pinned_reg writable_pinned_reg)
-
-(decl pinned_reg () Reg)
-(rule (pinned_reg) (writable_pinned_reg))
-
 (decl write_pinned_reg (Reg) SideEffectNoResult)
 (rule (write_pinned_reg val)
-      (let ((dst WritableReg (writable_pinned_reg)))
-        (SideEffectNoResult.Inst (gen_move $I64 dst val))))
+      (mov_to_preg (preg_pinned) val))
 
 ;; Helpers for stackslot effective address generation.
 

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -172,7 +172,7 @@
         (rm PReg))
 
        ;; Like `Move` but with a particular `PReg` destination (for
-       ;; implementing CLIF instructions like `get_stack_pointer`).
+       ;; implementing CLIF instructions like `set_pinned_reg`).
        (MovToPReg
         (rd PReg)
         (rm Reg))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1367,12 +1367,33 @@ impl MachInstEmit for Inst {
                     }
                 }
             }
-            &Inst::MovPReg { rd, rm } => {
+            &Inst::MovFromPReg { rd, rm } => {
                 let rd = allocs.next_writable(rd);
                 let rm: Reg = rm.into();
-                debug_assert!([regs::fp_reg(), regs::stack_reg(), regs::link_reg()].contains(&rm));
+                debug_assert!([
+                    regs::fp_reg(),
+                    regs::stack_reg(),
+                    regs::link_reg(),
+                    regs::pinned_reg()
+                ]
+                .contains(&rm));
                 assert!(rm.class() == RegClass::Int);
                 assert!(rd.to_reg().class() == rm.class());
+                let size = OperandSize::Size64;
+                Inst::Mov { size, rd, rm }.emit(&[], sink, emit_info, state);
+            }
+            &Inst::MovToPReg { rd, rm } => {
+                let rd: Writable<Reg> = Writable::from_reg(rd.into());
+                let rm = allocs.next(rm);
+                debug_assert!([
+                    regs::fp_reg(),
+                    regs::stack_reg(),
+                    regs::link_reg(),
+                    regs::pinned_reg()
+                ]
+                .contains(&rd.to_reg()));
+                assert!(rd.to_reg().class() == RegClass::Int);
+                assert!(rm.class() == rd.to_reg().class());
                 let size = OperandSize::Size64;
                 Inst::Mov { size, rd, rm }.emit(&[], sink, emit_info, state);
             }

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -93,6 +93,11 @@ pub fn link_reg() -> Reg {
     xreg(30)
 }
 
+/// Get a reference to the pinned register (x21).
+pub fn pinned_reg() -> Reg {
+    xreg(PINNED_REG)
+}
+
 /// Get a writable reference to the link register.
 pub fn writable_link_reg() -> Writable<Reg> {
     Writable::from_reg(link_reg())

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2189,7 +2189,7 @@
 ;;; Rules for `{get,set}_pinned_reg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (get_pinned_reg))
-      (pinned_reg))
+      (mov_from_preg (preg_pinned)))
 
 (rule (lower (set_pinned_reg val))
       (side_effect (write_pinned_reg val)))

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -794,6 +794,6 @@ impl LowerBackend for AArch64Backend {
     }
 
     fn maybe_pinned_reg(&self) -> Option<Reg> {
-        Some(xreg(PINNED_REG))
+        Some(regs::pinned_reg())
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -559,6 +559,10 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
         super::regs::link_reg().to_real_reg().unwrap().into()
     }
 
+    fn preg_pinned(&mut self) -> PReg {
+        super::regs::pinned_reg().to_real_reg().unwrap().into()
+    }
+
     fn branch_target(&mut self, elements: &VecMachLabel, idx: u8) -> BranchTarget {
         BranchTarget::Label(elements[idx as usize])
     }
@@ -717,9 +721,5 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
                 shift
             );
         }
-    }
-
-    fn writable_pinned_reg(&mut self) -> WritableReg {
-        super::regs::writable_xreg(super::regs::PINNED_REG)
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -95,8 +95,13 @@
 
        ;; Like `MovRR` but with a physical register source (for implementing
        ;; CLIF instructions like `get_stack_pointer`).
-       (MovPReg (src PReg)
-                (dst WritableGpr))
+       (MovFromPReg (src PReg)
+                    (dst WritableGpr))
+
+       ;; Like `MovRR` but with a physical register destination (for
+       ;; implementing CLIF instructions like `get_pinned_reg`).
+       (MovToPReg (src Gpr)
+                  (dst PReg))
 
        ;; Zero-extended loads, except for 64 bits: movz (bl bq wl wq lq) addr
        ;; reg.
@@ -1199,10 +1204,6 @@
 ;; Allocate a new temporary XMM register.
 (decl temp_writable_xmm () WritableXmm)
 (extern constructor temp_writable_xmm temp_writable_xmm)
-
-;; Fetch the special pinned register.
-(decl pinned_writable_gpr () WritableGpr)
-(extern constructor pinned_writable_gpr pinned_writable_gpr)
 
 ;; Construct a new `XmmMem` from the given `RegMem`.
 ;;
@@ -3701,12 +3702,11 @@
 
 (decl read_pinned_gpr () Gpr)
 (rule (read_pinned_gpr)
-      (pinned_writable_gpr))
+      (mov_from_preg (preg_pinned)))
 
 (decl write_pinned_gpr (Gpr) SideEffectNoResult)
 (rule (write_pinned_gpr val)
-      (let ((dst WritableGpr (pinned_writable_gpr)))
-        (SideEffectNoResult.Inst (gen_move $I64 dst val))))
+      (mov_to_preg (preg_pinned) val))
 
 ;;;; Shuffle ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3882,12 +3882,16 @@
 (decl const_to_synthetic_amode (VCodeConstant) SyntheticAmode)
 (extern constructor const_to_synthetic_amode const_to_synthetic_amode)
 
-;; Helper for creating `MovPReg` instructions.
-(decl mov_preg (PReg) Reg)
-(rule (mov_preg preg)
+;; Helper for creating `MovFromPReg` instructions.
+(decl mov_from_preg (PReg) Reg)
+(rule (mov_from_preg preg)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.MovPReg preg dst))))
+            (_ Unit (emit (MInst.MovFromPReg preg dst))))
         dst))
+
+(decl mov_to_preg (PReg Gpr) SideEffectNoResult)
+(rule (mov_to_preg dst src)
+      (SideEffectNoResult.Inst (MInst.MovToPReg src dst)))
 
 (decl preg_rbp () PReg)
 (extern constructor preg_rbp preg_rbp)
@@ -3895,13 +3899,16 @@
 (decl preg_rsp () PReg)
 (extern constructor preg_rsp preg_rsp)
 
+(decl preg_pinned () PReg)
+(extern constructor preg_pinned preg_pinned)
+
 (decl x64_rbp () Reg)
 (rule (x64_rbp)
-      (mov_preg (preg_rbp)))
+      (mov_from_preg (preg_rbp)))
 
 (decl x64_rsp () Reg)
 (rule (x64_rsp)
-      (mov_preg (preg_rsp)))
+      (mov_from_preg (preg_rsp)))
 
 ;;;; Helpers for Emitting LibCalls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -99,7 +99,7 @@
                     (dst WritableGpr))
 
        ;; Like `MovRR` but with a physical register destination (for
-       ;; implementing CLIF instructions like `get_pinned_reg`).
+       ;; implementing CLIF instructions like `set_pinned_reg`).
        (MovToPReg (src Gpr)
                   (dst PReg))
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -698,13 +698,23 @@ pub(crate) fn emit(
             );
         }
 
-        Inst::MovPReg { src, dst } => {
+        Inst::MovFromPReg { src, dst } => {
             let src: Reg = (*src).into();
-            debug_assert!([regs::rsp(), regs::rbp()].contains(&src));
+            debug_assert!([regs::rsp(), regs::rbp(), regs::pinned_reg()].contains(&src));
             let src = Gpr::new(src).unwrap();
             let size = OperandSize::Size64;
             let dst = allocs.next(dst.to_reg().to_reg());
             let dst = WritableGpr::from_writable_reg(Writable::from_reg(dst)).unwrap();
+            Inst::MovRR { size, src, dst }.emit(&[], sink, info, state);
+        }
+
+        Inst::MovToPReg { src, dst } => {
+            let src = allocs.next(src.to_reg());
+            let src = Gpr::new(src).unwrap();
+            let dst: Reg = (*dst).into();
+            debug_assert!([regs::rsp(), regs::rbp(), regs::pinned_reg()].contains(&dst));
+            let dst = WritableGpr::from_writable_reg(Writable::from_reg(dst)).unwrap();
+            let size = OperandSize::Size64;
             Inst::MovRR { size, src, dst }.emit(&[], sink, info, state);
         }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -640,6 +640,11 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
         regs::rsp().to_real_reg().unwrap().into()
     }
 
+    #[inline]
+    fn preg_pinned(&mut self) -> PReg {
+        regs::pinned_reg().to_real_reg().unwrap().into()
+    }
+
     fn libcall_1(&mut self, libcall: &LibCall, a: Reg) -> Reg {
         let call_conv = self.lower_ctx.abi().call_conv(self.lower_ctx.sigs());
         let ret_ty = libcall.signature(call_conv).returns[0].value_type;
@@ -767,11 +772,6 @@ impl Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> {
         ];
         self.lower_ctx
             .use_constant(VCodeConstantData::WellKnown(&UMAX_MASK))
-    }
-
-    #[inline]
-    fn pinned_writable_gpr(&mut self) -> WritableGpr {
-        Writable::from_reg(Gpr::new(regs::pinned_reg()).unwrap())
     }
 
     #[inline]

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1276,24 +1276,11 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             }
         }
 
-        let mut regs = self.value_regs[val];
+        let regs = self.value_regs[val];
         trace!(" -> regs {:?}", regs);
         assert!(regs.is_valid());
 
         self.value_lowered_uses[val] += 1;
-
-        // Pinned-reg hack: if backend specifies a fixed pinned register, use it
-        // directly when we encounter a GetPinnedReg op, rather than lowering
-        // the actual op, and do not return the source inst to the caller; the
-        // value comes "out of the ether" and we will not force generation of
-        // the superfluous move.
-        if let ValueDef::Result(i, 0) = self.f.dfg.value_def(val) {
-            if self.f.dfg[i].opcode() == Opcode::GetPinnedReg {
-                if let Some(pr) = self.pinned_reg {
-                    regs = ValueRegs::one(pr);
-                }
-            }
-        }
 
         regs
     }

--- a/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
@@ -11,6 +11,8 @@ block0:
 }
 
 ; block0:
-;   add x21, x21, #1
+;   mov x1, x21
+;   add x1, x1, #1
+;   mov x21, x1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -13,7 +13,9 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   addq    %r15, $1, %r15
+;   movq    %r15, %rsi
+;   addq    %rsi, $1, %rsi
+;   movq    %rsi, %r15
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -28,8 +30,14 @@ block0:
 
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rsi, 0(%rsp)
 ; block0:
-;   addq    %r15, $1, %r15
+;   movq    %r15, %rsi
+;   addq    %rsi, $1, %rsi
+;   movq    %rsi, %r15
+;   movq    0(%rsp), %rsi
+;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
Rework pinned register lowering to avoid the use of pinned virtual registers, instead using the `MovFromPReg` and `MovToPReg` pseudo instructions.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
