### PR TITLE
c-api: Fix `wasmtime_func_call_unchecked` to communicate all errors

### DIFF
--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -241,10 +241,11 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call(
  * faster than that function, but the tradeoff is that embeddings must uphold
  * more invariants rather than relying on Wasmtime to check them for you.
  */
-WASM_API_EXTERN wasm_trap_t *wasmtime_func_call_unchecked(
+WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call_unchecked(
     wasmtime_context_t *store,
     const wasmtime_func_t *func,
-    wasmtime_val_raw_t *args_and_results
+    wasmtime_val_raw_t *args_and_results,
+    wasm_trap_t **trap
 );
 
 /**


### PR DESCRIPTION
Change the return value of this function to a `wasmtime_error_t*` instead of the prior `wasm_trap_t*`. This is a leftover from #5149.

Closes #5257

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
