### PR TITLE
test: Remove destructor in cancel_during_run.

### DIFF
--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -269,6 +269,9 @@ async fn cancel_during_run() {
             *caller.data_mut() = 1;
             let dtor = SetOnDrop(caller);
             Box::new(async move {
+                // SetOnDrop is not destroyed when dropping the reference of it
+                // here. Instead, it is moved into the future where it's forced
+                // to live in and will be destroyed at the end of the future.
                 drop(&dtor);
                 tokio::task::yield_now().await;
                 Ok(())


### PR DESCRIPTION
Signed-off-by: Tricster <mediosrity@gmail.com>

Since we want to test if all the Rust bits are deallocated when the future is cancelled, we should not call the destructor before yielding.
So I suggest removing the destructor or moving it after yielding.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
