### PR TITLE
wiggle: new error configuration for generating a "trappable error"

### DIFF
--- a/crates/wiggle/generate/src/lib.rs
+++ b/crates/wiggle/generate/src/lib.rs
@@ -3,7 +3,7 @@ pub mod config;
 mod funcs;
 mod lifetimes;
 mod module_trait;
-mod names;
+pub mod names;
 mod types;
 pub mod wasmtime;
 
@@ -12,19 +12,16 @@ use lifetimes::anon_lifetime;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 
-pub use codegen_settings::{CodegenSettings, UserErrorType};
+pub use codegen_settings::{CodegenSettings, ErrorType, UserErrorType};
 pub use config::{Config, WasmtimeConfig};
 pub use funcs::define_func;
 pub use module_trait::define_module_trait;
-pub use names::Names;
 pub use types::define_datatype;
 
-pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings) -> TokenStream {
-    // TODO at some point config should grow more ability to configure name
-    // overrides.
-    let rt = names.runtime_mod();
-
-    let types = doc.typenames().map(|t| define_datatype(&names, &t));
+pub fn generate(doc: &witx::Document, settings: &CodegenSettings) -> TokenStream {
+    let types = doc
+        .typenames()
+        .map(|t| define_datatype(&t, settings.errors.for_name(&t)));
 
     let constants = doc.constants().map(|c| {
         let name = quote::format_ident!(
@@ -32,39 +29,50 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
             c.ty.as_str().to_shouty_snake_case(),
             c.name.as_str().to_shouty_snake_case()
         );
-        let ty = names.type_(&c.ty);
+        let ty = names::type_(&c.ty);
         let value = Literal::u64_unsuffixed(c.value);
         quote! {
             pub const #name: #ty = #value;
         }
     });
 
-    let user_error_methods = settings.errors.iter().map(|errtype| {
-        let abi_typename = names.type_ref(&errtype.abi_type(), anon_lifetime());
-        let user_typename = errtype.typename();
-        let methodname = names.user_error_conversion_method(&errtype);
-        quote!(fn #methodname(&mut self, e: super::#user_typename) -> #rt::anyhow::Result<#abi_typename>;)
-    });
-    let user_error_conversion = quote! {
-        pub trait UserErrorConversion {
-            #(#user_error_methods)*
+    let user_error_methods = settings
+        .errors
+        .iter()
+        .filter_map(|errtype| match errtype {
+            ErrorType::User(errtype) => {
+                let abi_typename = names::type_ref(&errtype.abi_type(), anon_lifetime());
+                let user_typename = errtype.typename();
+                let methodname = names::user_error_conversion_method(&errtype);
+                Some(quote! {
+                    fn #methodname(&mut self, e: super::#user_typename)
+                        -> wiggle::anyhow::Result<#abi_typename>;
+                })
+            }
+            ErrorType::Generated(_) => None,
+        })
+        .collect::<Vec<TokenStream>>();
+    let user_error_conversion = if !user_error_methods.is_empty() {
+        quote! {
+            pub trait UserErrorConversion {
+                #(#user_error_methods)*
+            }
         }
+    } else {
+        Default::default()
     };
     let modules = doc.modules().map(|module| {
-        let modname = names.module(&module.name);
-        let fs = module
-            .funcs()
-            .map(|f| define_func(&names, &module, &f, &settings));
-        let modtrait = define_module_trait(&names, &module, &settings);
+        let modname = names::module(&module.name);
+        let fs = module.funcs().map(|f| define_func(&module, &f, &settings));
+        let modtrait = define_module_trait(&module, &settings);
         let wasmtime = if settings.wasmtime {
-            crate::wasmtime::link_module(&module, &names, None, &settings)
+            crate::wasmtime::link_module(&module, None, &settings)
         } else {
             quote! {}
         };
         quote!(
             pub mod #modname {
                 use super::types::*;
-                pub use super::types::UserErrorConversion;
                 #(#fs)*
 
                 #modtrait
@@ -86,14 +94,13 @@ pub fn generate(doc: &witx::Document, names: &Names, settings: &CodegenSettings)
     )
 }
 
-pub fn generate_metadata(doc: &witx::Document, names: &Names) -> TokenStream {
-    let rt = names.runtime_mod();
+pub fn generate_metadata(doc: &witx::Document) -> TokenStream {
     let doc_text = &format!("{}", doc);
     quote! {
         pub mod metadata {
             pub const DOC_TEXT: &str = #doc_text;
-            pub fn document() -> #rt::witx::Document {
-                #rt::witx::parse(DOC_TEXT).unwrap()
+            pub fn document() -> wiggle::witx::Document {
+                wiggle::witx::parse(DOC_TEXT).unwrap()
             }
         }
     }

--- a/crates/wiggle/generate/src/module_trait.rs
+++ b/crates/wiggle/generate/src/module_trait.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::codegen_settings::CodegenSettings;
+use crate::codegen_settings::{CodegenSettings, ErrorType};
 use crate::lifetimes::{anon_lifetime, LifetimeExt};
-use crate::names::Names;
+use crate::names;
 use witx::Module;
 
 pub fn passed_by_reference(ty: &witx::Type) -> bool {
@@ -15,9 +15,8 @@ pub fn passed_by_reference(ty: &witx::Type) -> bool {
     }
 }
 
-pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings) -> TokenStream {
-    let traitname = names.trait_name(&m.name);
-    let rt = names.runtime_mod();
+pub fn define_module_trait(m: &Module, settings: &CodegenSettings) -> TokenStream {
+    let traitname = names::trait_name(&m.name);
     let traitmethods = m.funcs().map(|f| {
         // Check if we're returning an entity anotated with a lifetime,
         // in which case, we'll need to annotate the function itself, and
@@ -32,10 +31,10 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
         } else {
             (anon_lifetime(), true)
         };
-        let funcname = names.func(&f.name);
+        let funcname = names::func(&f.name);
         let args = f.params.iter().map(|arg| {
-            let arg_name = names.func_param(&arg.name);
-            let arg_typename = names.type_ref(&arg.tref, lifetime.clone());
+            let arg_name = names::func_param(&arg.name);
+            let arg_typename = names::type_ref(&arg.tref, lifetime.clone());
             let arg_type = if passed_by_reference(&*arg.tref.type_()) {
                 quote!(&#arg_typename)
             } else {
@@ -45,7 +44,7 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
         });
 
         let result = match f.results.len() {
-            0 if f.noreturn => quote!(#rt::anyhow::Error),
+            0 if f.noreturn => quote!(wiggle::anyhow::Error),
             0 => quote!(()),
             1 => {
                 let (ok, err) = match &**f.results[0].tref.type_() {
@@ -57,16 +56,17 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
                 };
 
                 let ok = match ok {
-                    Some(ty) => names.type_ref(ty, lifetime.clone()),
+                    Some(ty) => names::type_ref(ty, lifetime.clone()),
                     None => quote!(()),
                 };
                 let err = match err {
                     Some(ty) => match settings.errors.for_abi_error(ty) {
-                        Some(custom) => {
+                        Some(ErrorType::User(custom)) => {
                             let tn = custom.typename();
                             quote!(super::#tn)
                         }
-                        None => names.type_ref(ty, lifetime.clone()),
+                        Some(ErrorType::Generated(g)) => g.typename(),
+                        None => names::type_ref(ty, lifetime.clone()),
                     },
                     None => quote!(()),
                 };
@@ -89,7 +89,7 @@ pub fn define_module_trait(names: &Names, m: &Module, settings: &CodegenSettings
     });
 
     quote! {
-        #[#rt::async_trait]
+        #[wiggle::async_trait]
         pub trait #traitname {
             #(#traitmethods)*
         }

--- a/crates/wiggle/generate/src/types/error.rs
+++ b/crates/wiggle/generate/src/types/error.rs
@@ -1,0 +1,53 @@
+use crate::codegen_settings::TrappableErrorType;
+use crate::names;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(super) fn define_error(
+    name: &witx::Id,
+    _v: &witx::Variant,
+    e: &TrappableErrorType,
+) -> TokenStream {
+    let abi_error = names::type_(name);
+    let rich_error = e.typename();
+
+    quote! {
+        #[derive(Debug)]
+        pub struct #rich_error {
+            inner: anyhow::Error,
+        }
+
+        impl std::fmt::Display for #rich_error {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.inner)
+            }
+        }
+        impl std::error::Error for #rich_error {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.inner.source()
+            }
+        }
+
+        impl #rich_error {
+            pub fn trap(inner: anyhow::Error) -> #rich_error {
+                Self { inner }
+            }
+            pub fn downcast(self) -> Result<#abi_error, anyhow::Error> {
+                self.inner.downcast()
+            }
+            pub fn downcast_ref(&self) -> Option<&#abi_error> {
+                self.inner.downcast_ref()
+            }
+            pub fn context(self, s: impl Into<String>) -> Self {
+                Self { inner: self.inner.context(s.into()) }
+            }
+        }
+
+        impl From<#abi_error> for #rich_error {
+            fn from(abi: #abi_error) -> #rich_error {
+                #rich_error { inner: anyhow::Error::from(abi) }
+            }
+        }
+    }
+}

--- a/crates/wiggle/generate/src/types/flags.rs
+++ b/crates/wiggle/generate/src/types/flags.rs
@@ -1,30 +1,28 @@
-use crate::names::Names;
+use crate::names;
 
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 
 pub(super) fn define_flags(
-    names: &Names,
     name: &witx::Id,
     repr: witx::IntRepr,
     record: &witx::RecordDatatype,
 ) -> TokenStream {
-    let rt = names.runtime_mod();
-    let ident = names.type_(&name);
-    let abi_repr = names.wasm_type(repr.into());
+    let ident = names::type_(&name);
+    let abi_repr = names::wasm_type(repr.into());
     let repr = super::int_repr_tokens(repr);
 
     let mut names_ = vec![];
     let mut values_ = vec![];
     for (i, member) in record.members.iter().enumerate() {
-        let name = names.flag_member(&member.name);
+        let name = names::flag_member(&member.name);
         let value_token = Literal::usize_unsuffixed(1 << i);
         names_.push(name);
         values_.push(value_token);
     }
 
     quote! {
-        #rt::bitflags::bitflags! {
+        wiggle::bitflags::bitflags! {
             pub struct #ident: #repr {
                 #(const #names_ = #values_;)*
             }
@@ -43,10 +41,10 @@ pub(super) fn define_flags(
         }
 
         impl TryFrom<#repr> for #ident {
-            type Error = #rt::GuestError;
-            fn try_from(value: #repr) -> Result<Self, #rt::GuestError> {
+            type Error = wiggle::GuestError;
+            fn try_from(value: #repr) -> Result<Self, wiggle::GuestError> {
                 if #repr::from(!#ident::all()) & value != 0 {
-                    Err(#rt::GuestError::InvalidFlagValue(stringify!(#ident)))
+                    Err(wiggle::GuestError::InvalidFlagValue(stringify!(#ident)))
                 } else {
                     Ok(#ident { bits: value })
                 }
@@ -54,8 +52,8 @@ pub(super) fn define_flags(
         }
 
         impl TryFrom<#abi_repr> for #ident {
-            type Error = #rt::GuestError;
-            fn try_from(value: #abi_repr) -> Result<Self, #rt::GuestError> {
+            type Error = wiggle::GuestError;
+            fn try_from(value: #abi_repr) -> Result<Self, wiggle::GuestError> {
                 #ident::try_from(#repr::try_from(value)?)
             }
         }
@@ -66,7 +64,7 @@ pub(super) fn define_flags(
             }
         }
 
-        impl<'a> #rt::GuestType<'a> for #ident {
+        impl<'a> wiggle::GuestType<'a> for #ident {
             fn guest_size() -> u32 {
                 #repr::guest_size()
             }
@@ -75,14 +73,14 @@ pub(super) fn define_flags(
                 #repr::guest_align()
             }
 
-            fn read(location: &#rt::GuestPtr<#ident>) -> Result<#ident, #rt::GuestError> {
+            fn read(location: &wiggle::GuestPtr<#ident>) -> Result<#ident, wiggle::GuestError> {
                 use std::convert::TryFrom;
                 let reprval = #repr::read(&location.cast())?;
                 let value = #ident::try_from(reprval)?;
                 Ok(value)
             }
 
-            fn write(location: &#rt::GuestPtr<'_, #ident>, val: Self) -> Result<(), #rt::GuestError> {
+            fn write(location: &wiggle::GuestPtr<'_, #ident>, val: Self) -> Result<(), wiggle::GuestError> {
                 let val: #repr = #repr::from(val);
                 #repr::write(&location.cast(), val)
             }

--- a/crates/wiggle/generate/src/types/handle.rs
+++ b/crates/wiggle/generate/src/types/handle.rs
@@ -1,16 +1,11 @@
-use crate::names::Names;
+use crate::names;
 
 use proc_macro2::TokenStream;
 use quote::quote;
 use witx::Layout;
 
-pub(super) fn define_handle(
-    names: &Names,
-    name: &witx::Id,
-    h: &witx::HandleDatatype,
-) -> TokenStream {
-    let rt = names.runtime_mod();
-    let ident = names.type_(name);
+pub(super) fn define_handle(name: &witx::Id, h: &witx::HandleDatatype) -> TokenStream {
+    let ident = names::type_(name);
     let size = h.mem_size_align().size as u32;
     let align = h.mem_size_align().align as usize;
     quote! {
@@ -53,7 +48,7 @@ pub(super) fn define_handle(
             }
         }
 
-        impl<'a> #rt::GuestType<'a> for #ident {
+        impl<'a> wiggle::GuestType<'a> for #ident {
             fn guest_size() -> u32 {
                 #size
             }
@@ -62,11 +57,11 @@ pub(super) fn define_handle(
                 #align
             }
 
-            fn read(location: &#rt::GuestPtr<'a, #ident>) -> Result<#ident, #rt::GuestError> {
+            fn read(location: &wiggle::GuestPtr<'a, #ident>) -> Result<#ident, wiggle::GuestError> {
                 Ok(#ident(u32::read(&location.cast())?))
             }
 
-            fn write(location: &#rt::GuestPtr<'_, Self>, val: Self) -> Result<(), #rt::GuestError> {
+            fn write(location: &wiggle::GuestPtr<'_, Self>, val: Self) -> Result<(), wiggle::GuestError> {
                 u32::write(&location.cast(), val.0)
             }
         }

--- a/crates/wiggle/generate/src/types/mod.rs
+++ b/crates/wiggle/generate/src/types/mod.rs
@@ -1,42 +1,49 @@
 // mod r#enum;
+mod error;
 mod flags;
 mod handle;
 mod record;
 mod variant;
 
+use crate::codegen_settings::ErrorType;
 use crate::lifetimes::LifetimeExt;
-use crate::names::Names;
+use crate::names;
 
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub fn define_datatype(names: &Names, namedtype: &witx::NamedType) -> TokenStream {
+pub fn define_datatype(namedtype: &witx::NamedType, error: Option<&ErrorType>) -> TokenStream {
     match &namedtype.tref {
-        witx::TypeRef::Name(alias_to) => define_alias(names, &namedtype.name, &alias_to),
+        witx::TypeRef::Name(alias_to) => define_alias(&namedtype.name, &alias_to),
         witx::TypeRef::Value(v) => match &**v {
             witx::Type::Record(r) => match r.bitflags_repr() {
-                Some(repr) => flags::define_flags(names, &namedtype.name, repr, &r),
-                None => record::define_struct(names, &namedtype.name, &r),
+                Some(repr) => flags::define_flags(&namedtype.name, repr, &r),
+                None => record::define_struct(&namedtype.name, &r),
             },
-            witx::Type::Variant(v) => variant::define_variant(names, &namedtype.name, &v),
-            witx::Type::Handle(h) => handle::define_handle(names, &namedtype.name, &h),
-            witx::Type::Builtin(b) => define_builtin(names, &namedtype.name, *b),
+            witx::Type::Variant(v) => match error {
+                Some(ErrorType::Generated(error)) => {
+                    let d = variant::define_variant(&namedtype.name, &v, true);
+                    let e = error::define_error(&namedtype.name, &v, error);
+                    quote!( #d #e )
+                }
+                _ => variant::define_variant(&namedtype.name, &v, false),
+            },
+            witx::Type::Handle(h) => handle::define_handle(&namedtype.name, &h),
+            witx::Type::Builtin(b) => define_builtin(&namedtype.name, *b),
             witx::Type::Pointer(p) => {
-                let rt = names.runtime_mod();
-                define_witx_pointer(names, &namedtype.name, quote!(#rt::GuestPtr), p)
+                define_witx_pointer(&namedtype.name, quote!(wiggle::GuestPtr), p)
             }
             witx::Type::ConstPointer(p) => {
-                let rt = names.runtime_mod();
-                define_witx_pointer(names, &namedtype.name, quote!(#rt::GuestPtr), p)
+                define_witx_pointer(&namedtype.name, quote!(wiggle::GuestPtr), p)
             }
-            witx::Type::List(arr) => define_witx_list(names, &namedtype.name, &arr),
+            witx::Type::List(arr) => define_witx_list(&namedtype.name, &arr),
         },
     }
 }
 
-fn define_alias(names: &Names, name: &witx::Id, to: &witx::NamedType) -> TokenStream {
-    let ident = names.type_(name);
-    let rhs = names.type_(&to.name);
+fn define_alias(name: &witx::Id, to: &witx::NamedType) -> TokenStream {
+    let ident = names::type_(name);
+    let rhs = names::type_(&to.name);
     if to.tref.needs_lifetime() {
         quote!(pub type #ident<'a> = #rhs<'a>;)
     } else {
@@ -44,29 +51,27 @@ fn define_alias(names: &Names, name: &witx::Id, to: &witx::NamedType) -> TokenSt
     }
 }
 
-fn define_builtin(names: &Names, name: &witx::Id, builtin: witx::BuiltinType) -> TokenStream {
-    let ident = names.type_(name);
-    let built = names.builtin_type(builtin);
+fn define_builtin(name: &witx::Id, builtin: witx::BuiltinType) -> TokenStream {
+    let ident = names::type_(name);
+    let built = names::builtin_type(builtin);
     quote!(pub type #ident = #built;)
 }
 
 fn define_witx_pointer(
-    names: &Names,
     name: &witx::Id,
     pointer_type: TokenStream,
     pointee: &witx::TypeRef,
 ) -> TokenStream {
-    let ident = names.type_(name);
-    let pointee_type = names.type_ref(pointee, quote!('a));
+    let ident = names::type_(name);
+    let pointee_type = names::type_ref(pointee, quote!('a));
 
     quote!(pub type #ident<'a> = #pointer_type<'a, #pointee_type>;)
 }
 
-fn define_witx_list(names: &Names, name: &witx::Id, arr_raw: &witx::TypeRef) -> TokenStream {
-    let ident = names.type_(name);
-    let rt = names.runtime_mod();
-    let pointee_type = names.type_ref(arr_raw, quote!('a));
-    quote!(pub type #ident<'a> = #rt::GuestPtr<'a, [#pointee_type]>;)
+fn define_witx_list(name: &witx::Id, arr_raw: &witx::TypeRef) -> TokenStream {
+    let ident = names::type_(name);
+    let pointee_type = names::type_ref(arr_raw, quote!('a));
+    quote!(pub type #ident<'a> = wiggle::GuestPtr<'a, [#pointee_type]>;)
 }
 
 pub fn int_repr_tokens(int_repr: witx::IntRepr) -> TokenStream {

--- a/crates/wiggle/generate/src/types/record.rs
+++ b/crates/wiggle/generate/src/types/record.rs
@@ -1,26 +1,21 @@
 use crate::lifetimes::{anon_lifetime, LifetimeExt};
-use crate::names::Names;
+use crate::names;
 
 use proc_macro2::TokenStream;
 use quote::quote;
 use witx::Layout;
 
-pub(super) fn define_struct(
-    names: &Names,
-    name: &witx::Id,
-    s: &witx::RecordDatatype,
-) -> TokenStream {
-    let rt = names.runtime_mod();
-    let ident = names.type_(name);
+pub(super) fn define_struct(name: &witx::Id, s: &witx::RecordDatatype) -> TokenStream {
+    let ident = names::type_(name);
     let size = s.mem_size_align().size as u32;
     let align = s.mem_size_align().align as usize;
 
-    let member_names = s.members.iter().map(|m| names.struct_member(&m.name));
+    let member_names = s.members.iter().map(|m| names::struct_member(&m.name));
     let member_decls = s.members.iter().map(|m| {
-        let name = names.struct_member(&m.name);
+        let name = names::struct_member(&m.name);
         let type_ = match &m.tref {
             witx::TypeRef::Name(nt) => {
-                let tt = names.type_(&nt.name);
+                let tt = names::type_(&nt.name);
                 if m.tref.needs_lifetime() {
                     quote!(#tt<'a>)
                 } else {
@@ -28,10 +23,10 @@ pub(super) fn define_struct(
                 }
             }
             witx::TypeRef::Value(ty) => match &**ty {
-                witx::Type::Builtin(builtin) => names.builtin_type(*builtin),
+                witx::Type::Builtin(builtin) => names::builtin_type(*builtin),
                 witx::Type::Pointer(pointee) | witx::Type::ConstPointer(pointee) => {
-                    let pointee_type = names.type_ref(&pointee, quote!('a));
-                    quote!(#rt::GuestPtr<'a, #pointee_type>)
+                    let pointee_type = names::type_ref(&pointee, quote!('a));
+                    quote!(wiggle::GuestPtr<'a, #pointee_type>)
                 }
                 _ => unimplemented!("other anonymous struct members: {:?}", m.tref),
             },
@@ -40,27 +35,27 @@ pub(super) fn define_struct(
     });
 
     let member_reads = s.member_layout().into_iter().map(|ml| {
-        let name = names.struct_member(&ml.member.name);
+        let name = names::struct_member(&ml.member.name);
         let offset = ml.offset as u32;
         let location = quote!(location.cast::<u8>().add(#offset)?.cast());
         match &ml.member.tref {
             witx::TypeRef::Name(nt) => {
-                let type_ = names.type_(&nt.name);
+                let type_ = names::type_(&nt.name);
                 quote! {
-                    let #name = <#type_ as #rt::GuestType>::read(&#location)?;
+                    let #name = <#type_ as wiggle::GuestType>::read(&#location)?;
                 }
             }
             witx::TypeRef::Value(ty) => match &**ty {
                 witx::Type::Builtin(builtin) => {
-                    let type_ = names.builtin_type(*builtin);
+                    let type_ = names::builtin_type(*builtin);
                     quote! {
-                        let #name = <#type_ as #rt::GuestType>::read(&#location)?;
+                        let #name = <#type_ as wiggle::GuestType>::read(&#location)?;
                     }
                 }
                 witx::Type::Pointer(pointee) | witx::Type::ConstPointer(pointee) => {
-                    let pointee_type = names.type_ref(&pointee, anon_lifetime());
+                    let pointee_type = names::type_ref(&pointee, anon_lifetime());
                     quote! {
-                        let #name = <#rt::GuestPtr::<#pointee_type> as #rt::GuestType>::read(&#location)?;
+                        let #name = <wiggle::GuestPtr::<#pointee_type> as wiggle::GuestType>::read(&#location)?;
                     }
                 }
                 _ => unimplemented!("other anonymous struct members: {:?}", ty),
@@ -69,10 +64,10 @@ pub(super) fn define_struct(
     });
 
     let member_writes = s.member_layout().into_iter().map(|ml| {
-        let name = names.struct_member(&ml.member.name);
+        let name = names::struct_member(&ml.member.name);
         let offset = ml.offset as u32;
         quote! {
-            #rt::GuestType::write(
+            wiggle::GuestType::write(
                 &location.cast::<u8>().add(#offset)?.cast(),
                 val.#name,
             )?;
@@ -91,7 +86,7 @@ pub(super) fn define_struct(
             #(#member_decls),*
         }
 
-        impl<'a> #rt::GuestType<'a> for #ident #struct_lifetime {
+        impl<'a> wiggle::GuestType<'a> for #ident #struct_lifetime {
             fn guest_size() -> u32 {
                 #size
             }
@@ -100,12 +95,12 @@ pub(super) fn define_struct(
                 #align
             }
 
-            fn read(location: &#rt::GuestPtr<'a, Self>) -> Result<Self, #rt::GuestError> {
+            fn read(location: &wiggle::GuestPtr<'a, Self>) -> Result<Self, wiggle::GuestError> {
                 #(#member_reads)*
                 Ok(#ident { #(#member_names),* })
             }
 
-            fn write(location: &#rt::GuestPtr<'_, Self>, val: Self) -> Result<(), #rt::GuestError> {
+            fn write(location: &wiggle::GuestPtr<'_, Self>, val: Self) -> Result<(), wiggle::GuestError> {
                 #(#member_writes)*
                 Ok(())
             }

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -1,17 +1,17 @@
 use crate::config::Asyncness;
 use crate::funcs::func_bounds;
-use crate::{CodegenSettings, Names};
+use crate::names;
+use crate::CodegenSettings;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
 use std::collections::HashSet;
 
 pub fn link_module(
     module: &witx::Module,
-    names: &Names,
     target_path: Option<&syn::Path>,
     settings: &CodegenSettings,
 ) -> TokenStream {
-    let module_ident = names.module(&module.name);
+    let module_ident = names::module(&module.name);
 
     let send_bound = if settings.async_.contains_async(module) {
         quote! { + Send, T: Send }
@@ -23,8 +23,8 @@ pub fn link_module(
     let mut bounds = HashSet::new();
     for f in module.funcs() {
         let asyncness = settings.async_.get(module.name.as_str(), f.name.as_str());
-        bodies.push(generate_func(&module, &f, names, target_path, asyncness));
-        let bound = func_bounds(names, module, &f, settings);
+        bodies.push(generate_func(&module, &f, target_path, asyncness));
+        let bound = func_bounds(module, &f, settings);
         for b in bound {
             bounds.insert(b);
         }
@@ -46,14 +46,12 @@ pub fn link_module(
         format_ident!("add_{}_to_linker", module_ident)
     };
 
-    let rt = names.runtime_mod();
-
     quote! {
         /// Adds all instance items to the specified `Linker`.
         pub fn #func_name<T, U>(
-            linker: &mut #rt::wasmtime_crate::Linker<T>,
+            linker: &mut wiggle::wasmtime_crate::Linker<T>,
             get_cx: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
-        ) -> #rt::anyhow::Result<()>
+        ) -> wiggle::anyhow::Result<()>
             where
                 U: #ctx_bound #send_bound
         {
@@ -66,17 +64,14 @@ pub fn link_module(
 fn generate_func(
     module: &witx::Module,
     func: &witx::InterfaceFunc,
-    names: &Names,
     target_path: Option<&syn::Path>,
     asyncness: Asyncness,
 ) -> TokenStream {
-    let rt = names.runtime_mod();
-
     let module_str = module.name.as_str();
-    let module_ident = names.module(&module.name);
+    let module_ident = names::module(&module.name);
 
     let field_str = func.name.as_str();
-    let field_ident = names.func(&func.name);
+    let field_ident = names::func(&func.name);
 
     let (params, results) = func.wasm_signature();
 
@@ -88,14 +83,14 @@ fn generate_func(
         .enumerate()
         .map(|(i, ty)| {
             let name = &arg_names[i];
-            let wasm = names.wasm_type(*ty);
+            let wasm = names::wasm_type(*ty);
             quote! { #name: #wasm }
         })
         .collect::<Vec<_>>();
 
     let ret_ty = match results.len() {
         0 => quote!(()),
-        1 => names.wasm_type(results[0]),
+        1 => names::wasm_type(results[0]),
         _ => unimplemented!(),
     };
 
@@ -114,16 +109,16 @@ fn generate_func(
     let body = quote! {
         let export = caller.get_export("memory");
         let (mem, ctx) = match &export {
-            Some(#rt::wasmtime_crate::Extern::Memory(m)) => {
+            Some(wiggle::wasmtime_crate::Extern::Memory(m)) => {
                 let (mem, ctx) = m.data_and_store_mut(&mut caller);
                 let ctx = get_cx(ctx);
-                (#rt::wasmtime::WasmtimeGuestMemory::new(mem), ctx)
+                (wiggle::wasmtime::WasmtimeGuestMemory::new(mem), ctx)
             }
-            Some(#rt::wasmtime_crate::Extern::SharedMemory(m)) => {
+            Some(wiggle::wasmtime_crate::Extern::SharedMemory(m)) => {
                 let ctx = get_cx(caller.data_mut());
-                (#rt::wasmtime::WasmtimeGuestMemory::shared(m.data()), ctx)
+                (wiggle::wasmtime::WasmtimeGuestMemory::shared(m.data()), ctx)
             }
-            _ => #rt::anyhow::bail!("missing required memory export"),
+            _ => wiggle::anyhow::bail!("missing required memory export"),
         };
         Ok(<#ret_ty>::from(#abi_func(ctx, &mem #(, #arg_names)*) #await_ ?))
     };
@@ -135,7 +130,7 @@ fn generate_func(
                 linker.#wrapper(
                     #module_str,
                     #field_str,
-                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| {
+                    move |mut caller: wiggle::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| {
                         Box::new(async move { #body })
                     },
                 )?;
@@ -147,9 +142,9 @@ fn generate_func(
                 linker.func_wrap(
                     #module_str,
                     #field_str,
-                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> #rt::anyhow::Result<#ret_ty> {
+                    move |mut caller: wiggle::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> wiggle::anyhow::Result<#ret_ty> {
                         let result = async { #body };
-                        #rt::run_in_dummy_executor(result)?
+                        wiggle::run_in_dummy_executor(result)?
                     },
                 )?;
             }
@@ -160,7 +155,7 @@ fn generate_func(
                 linker.func_wrap(
                     #module_str,
                     #field_str,
-                    move |mut caller: #rt::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> #rt::anyhow::Result<#ret_ty> {
+                    move |mut caller: wiggle::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> wiggle::anyhow::Result<#ret_ty> {
                         #body
                     },
                 )?;


### PR DESCRIPTION
Largely due to pains in wasi-common and experimentation in wit-bindgen, I have added a slightly different error handling strategy to `wiggle`.

When the user specifies `errno => trappable Error` in the macro's optional `errors: {...}`argument, wiggle will now generate a type named `Error` to be used in all positions where a function returned a witx `errno` in the error position.

The generated error type is an opaque struct. Internally, it contains either the errno (which wiggle generates as an `enum Errno`), or an `anyhow::Error` for trapping execution. These are constructed using either the generated `impl From<Errno> for Error` impl, or the `Error::trap(t: anyhow::Error) -> Self` constructor.

The error can be destructured using `Error::downcast(self) -> Result<Errno, anyhow::Error>`, inspected using `Error::downcast_ref(&self) -> Option<&Errno>`, and it can have context added via `Error::context(self, s: Into<String>) -> Self`. The context is only observable via the Debug and Display impls.

This design came about because the user defined error type wasn't really serving our needs in `wasi-common`. There, we had essentially 2 choices:
1. the user maintains a `thiserror` style error enum that contains all of the `errno` values, plus a `Trap(anyhow::Error)` variation for trapping execution. They then write `From` impls for all of the foreign error types that need to be converted into their error enum, e.g. `impl From<std::io::Error> for MyErrno`. They then implement the (very mechanical) translation to the wiggle generated `Errno` cases in `UserErrorConversion`.
2. They use `anyhow::Error`. To implement the translation to `Errno` or trap, the user downcasts all of the foreign error types they suspect may be thrown in their implementations.

I used both of these designs in wasi-common, in that chronological order. I found that both had real drawbacks:
1. This error enum is repetitive to define and maintain. Additionally, it doesn't provide any way to keep additional context around on an error, which makes debugging harder.
2. Suffers from safety problems. Since introducing this design in the 2019 wasi-common rewrite, I (unknowingly) introduced a bug where a `cap_rand::Error` was thrown in the random methods, but I never tried to downcast to it in `UserErrorConversion`. The end result is that any error in the cap_rand crate would end up trapping execution of the wasm module, rather than returning it an appropriate errno. I don't think I ever would have discovered this bug if I hadn't attempted a refactor back towards design 1.

So, my design here basically uses code generation to generate an acceptable implementation of design 1, while providing the `.context("help figuring out what went wrong")` method available in design 2. I was reluctant to give up the ergonomics of approach 2, but the design of wasi is evolving to give us lots of different concrete errnos in the preview 2 interfaces, so I wanted to give us as much type safety as possible when managing the complexity of the coming evolution in this crate.