### PR TITLE
Split CMake tests into a separate step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -303,6 +303,44 @@ jobs:
         touch ${{ runner.tool_cache }}/qemu/built
       if: matrix.gcc != ''
 
+    # Build and test all features
+    - run: ./ci/run-tests.sh --locked
+      env:
+        RUST_BACKTRACE: 1
+
+    # Test debug (DWARF) related functionality.
+    - run: |
+        sudo apt-get update && sudo apt-get install -y gdb lldb llvm
+        cargo test test_debug_dwarf -- --ignored --test-threads 1
+      if: matrix.os == 'ubuntu-latest' && matrix.target == ''
+      env:
+        RUST_BACKTRACE: 1
+
+  # Build and test the C interface
+  test_cmake:
+    name: Test C Interface
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+
+    # Install targets in order to build various tests throughout the repo
+    - run: rustup target add wasm32-wasi wasm32-unknown-unknown ${{ matrix.target }}
+    - run: echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+      if: matrix.target != ''
+
+    - run: cargo fetch --locked
+    - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
+
     # Prepare tests in CMake
     - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
       if: matrix.target == ''
@@ -318,19 +356,6 @@ jobs:
       env:
         RUST_BACKTRACE: 1
       if: matrix.target == '' && matrix.os != 'windows-latest'
-
-    # Build and test all features
-    - run: ./ci/run-tests.sh --locked
-      env:
-        RUST_BACKTRACE: 1
-
-    # Test debug (DWARF) related functionality.
-    - run: |
-        sudo apt-get update && sudo apt-get install -y gdb lldb llvm
-        cargo test test_debug_dwarf -- --ignored --test-threads 1
-      if: matrix.os == 'ubuntu-latest' && matrix.target == ''
-      env:
-        RUST_BACKTRACE: 1
 
   # Build and test the wasi-nn module.
   test_wasi_nn:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -333,29 +333,22 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
 
-    # Install targets in order to build various tests throughout the repo
-    - run: rustup target add wasm32-wasi wasm32-unknown-unknown ${{ matrix.target }}
-    - run: echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-      if: matrix.target != ''
-
     - run: cargo fetch --locked
     - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
 
     # Prepare tests in CMake
     - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
-      if: matrix.target == ''
     # Build tests
     - run: cmake --build examples/build --config Debug
-      if: matrix.target == ''
     # Run tests
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
       env:
         RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest'
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
       env:
         RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-latest'
 
   # Build and test the wasi-nn module.
   test_wasi_nn:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,36 +319,21 @@ jobs:
   # Build and test the C interface
   test_cmake:
     name: Test C Interface
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: windows-latest
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
 
-    - run: cargo fetch --locked
-    - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
-
     # Prepare tests in CMake
     - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
     # Build tests
     - run: cmake --build examples/build --config Debug
     # Run tests
-    - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
-      env:
-        RUST_BACKTRACE: 1
-      if: matrix.os == 'windows-latest'
     - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
       env:
         RUST_BACKTRACE: 1
-      if: matrix.os != 'windows-latest'
 
   # Build and test the wasi-nn module.
   test_wasi_nn:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -326,6 +326,9 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
 
+    - run: cargo fetch --locked
+    - run: cargo fetch --locked --manifest-path crates/test-programs/wasi-tests/Cargo.toml
+
     # Prepare tests in CMake
     - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
     # Build tests


### PR DESCRIPTION
Split the CMake tests for exercising the c-api out into a separate step. There
doesn't appear to be any reuse between build artifacts from the CMake-based
tests and the cargo test step later on in the `Test` job, so this should speed
up the average build time.

Additionally, this PR only runs the CMake tests on ubuntu and windows. I'd be
happy to expand the matrix out to the same set as the `Test` job if we think
it's worth it.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
