### PR TITLE
Fix warnings in `cranelift-codegen` docs builds

### DIFF
--- a/cranelift/codegen/src/bitset.rs
+++ b/cranelift/codegen/src/bitset.rs
@@ -4,7 +4,7 @@
 //! T is intended to be a primitive unsigned type. Currently it can be any type between u8 and u32
 //!
 //! If you would like to add support for larger bitsets in the future, you need to change the trait
-//! bound Into<u32> and the u32 in the implementation of `max_bits()`.
+//! bound `Into<u32>` and the `u32` in the implementation of `max_bits()`.
 
 use core::convert::{From, Into};
 use core::mem::size_of;

--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -321,8 +321,8 @@ pub struct ExtFuncData {
     /// flag is best used when the target is known to be in the same unit of code generation, such
     /// as a Wasm module.
     ///
-    /// See the documentation for [`RelocDistance`](crate::machinst::RelocDistance) for more details. A
-    /// `colocated` flag value of `true` implies `RelocDistance::Near`.
+    /// See the documentation for `RelocDistance` for more details. A `colocated` flag value of
+    /// `true` implies `RelocDistance::Near`.
     pub colocated: bool,
 }
 

--- a/cranelift/codegen/src/ir/globalvalue.rs
+++ b/cranelift/codegen/src/ir/globalvalue.rs
@@ -70,7 +70,7 @@ pub enum GlobalValueData {
         ///
         /// If `true`, some backends may use relocation forms that have limited range: for example,
         /// a +/- 2^27-byte range on AArch64. See the documentation for
-        /// [`RelocDistance`](crate::machinst::RelocDistance) for more details.
+        /// `RelocDistance` for more details.
         colocated: bool,
 
         /// Does this symbol refer to a thread local storage value?


### PR DESCRIPTION
* Remove links to private types.
* Avoid ambiguity with HTML tags by wrapping code snippets in backticks.