### PR TITLE
cranelift-isle: Specialize for Term at rule root

### DIFF
--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -152,7 +152,6 @@ pub enum Pattern {
 impl Pattern {
     pub fn root_term(&self) -> Option<&Ident> {
         match self {
-            &Pattern::BindPattern { ref subpat, .. } => subpat.root_term(),
             &Pattern::Term { ref sym, .. } => Some(sym),
             _ => None,
         }

--- a/cranelift/isle/isle/src/trie.rs
+++ b/cranelift/isle/isle/src/trie.rs
@@ -290,7 +290,6 @@ impl TermFunctionsBuilder {
         log!("termenv: {:?}", termenv);
         for rule in termenv.rules.iter() {
             let (pattern, expr) = lower_rule(termenv, rule.id);
-            let root_term = rule.lhs.root_term().unwrap();
 
             log!(
                 "build:\n- rule {:?}\n- pattern {:?}\n- expr {:?}",
@@ -306,7 +305,7 @@ impl TermFunctionsBuilder {
                 .chain(std::iter::once(TrieSymbol::EndOfMatch));
 
             self.builders_by_term
-                .entry(root_term)
+                .entry(rule.root_term)
                 .or_insert(TrieNode::Empty)
                 .insert(rule.prio, symbols, expr);
         }

--- a/cranelift/isle/isle/src/trie_again.rs
+++ b/cranelift/isle/isle/src/trie_again.rs
@@ -174,7 +174,7 @@ pub fn build(
     let mut errors = Vec::new();
     let mut term = HashMap::new();
     for rule in termenv.rules.iter() {
-        term.entry(rule.lhs.root_term().unwrap())
+        term.entry(rule.root_term)
             .or_insert_with(RuleSetBuilder::default)
             .add_rule(rule, termenv, tyenv, &mut errors);
     }


### PR DESCRIPTION
In #5174 we decided it doesn't make sense for a rule to have a bind-pattern at the root of its left-hand side. There's no Rust value corresponding to the root value of such a term, because it actually represents a function declaration with one or more arguments.

This commit takes that to its logical conclusion.

`sema::Rule` previously had an `lhs` field whose value must always be a `Pattern::Term` variant, and anyone using that structure had to deal with the possibility of finding the wrong variant there.

Now the relevant fields from that variant are stored directly in `Rule` instead. Also, the (tiny!) portion of `translate_pattern` which applied when the pattern was the root term is now inlined in `collect_rules`.

Because `translate_pattern` no longer has to special-case the root term, we can delete its `rule_term` and `is_root` arguments. That brings it down to a more manageable four arguments, which means many calls fit on one line now.