### PR TITLE
c-api: add wasm_config_parallel_compilation_set

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -201,6 +201,14 @@ WASMTIME_CONFIG_PROP(void, wasm_memory64, bool)
 WASMTIME_CONFIG_PROP(void, strategy, wasmtime_strategy_t)
 
 /**
+ * \brief Configure wether wasmtime should compile a module using multiple threads.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.parallel_compilation.
+ */
+WASMTIME_CONFIG_PROP(void, parallel_compilation, bool)
+
+/**
  * \brief Configures whether Cranelift's debug verifier is enabled.
  *
  * This setting in `false` by default.

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -113,6 +113,12 @@ pub extern "C" fn wasmtime_config_strategy_set(
 }
 
 #[no_mangle]
+#[cfg(feature = "parallel-compilation")]
+pub extern "C" fn wasmtime_config_parallel_compilation_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.parallel_compilation(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_cranelift_debug_verifier_set(
     c: &mut wasm_config_t,
     enable: bool,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1275,9 +1275,11 @@ impl Config {
         Ok(self)
     }
 
-    /// Configure wether wasmtime should compile a module using multiple threads.
+    /// Configure wether wasmtime should compile a module using multiple
+    /// threads.
     ///
-    /// Disabling this will result in a single thread being used to compile the wasm bytecode.
+    /// Disabling this will result in a single thread being used to compile
+    /// the wasm bytecode.
     ///
     /// By default parallel compilation is enabled.
     #[cfg(feature = "parallel-compilation")]


### PR DESCRIPTION
This has not been discussed in issues and I do not believe there are tests cases for the config C API. Nevertheless, could we add this flag in the C API with this small changeset?