### PR TITLE
cranelift: Fix implicit pointer argument register use

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1142,6 +1142,7 @@ impl MachInst for Inst {
         // See the note in [crate::isa::aarch64::abi::is_caller_save_reg] for
         // more information on this ABI-implementation hack.
         match self {
+            &Inst::Args { .. } => false,
             &Inst::Call { ref info } => info.caller_callconv != info.callee_callconv,
             &Inst::CallInd { ref info } => info.caller_callconv != info.callee_callconv,
             _ => true,

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -657,7 +657,10 @@ impl MachInst for Inst {
     }
 
     fn is_included_in_clobbers(&self) -> bool {
-        true
+        match self {
+            &Inst::Args { .. } => false,
+            _ => true,
+        }
     }
 
     fn is_args(&self) -> bool {

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1109,6 +1109,7 @@ impl MachInst for Inst {
         // half-caller-save, half-callee-save SysV ABI for some vector
         // registers.
         match self {
+            &Inst::Args { .. } => false,
             &Inst::Call { ref info, .. } => info.caller_callconv != info.callee_callconv,
             &Inst::CallInd { ref info, .. } => info.caller_callconv != info.callee_callconv,
             _ => true,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2236,6 +2236,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_included_in_clobbers(&self) -> bool {
+        match self {
+            &Inst::Args { .. } => false,
+            _ => true,
+        }
+    }
+
     fn is_args(&self) -> bool {
         match self {
             Self::Args { .. } => true,

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -573,7 +573,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                     .vcode
                     .vcode
                     .abi
-                    .gen_copy_arg_to_regs(&self.vcode.vcode.sigs, i, regs)
+                    .gen_copy_arg_to_regs(&self.vcode.vcode.sigs, i, regs, &mut self.vregs)
                     .into_iter()
                 {
                     self.emit(insn);
@@ -601,7 +601,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 .vcode
                 .vcode
                 .abi
-                .gen_retval_area_setup(&self.vcode.vcode.sigs)
+                .gen_retval_area_setup(&self.vcode.vcode.sigs, &mut self.vregs)
             {
                 self.emit(insn);
             }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -104,9 +104,7 @@ pub trait MachInst: Clone + Debug {
     fn is_args(&self) -> bool;
 
     /// Should this instruction be included in the clobber-set?
-    fn is_included_in_clobbers(&self) -> bool {
-        true
-    }
+    fn is_included_in_clobbers(&self) -> bool;
 
     /// Generate a move.
     fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self;

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -703,7 +703,7 @@ block0(v0: i128, v1: i128):
 
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
-;   lgr %r14, %r2
+;   lgr %r10, %r2
 ;   vl %v0, 0(%r3)
 ;   vl %v1, 0(%r4)
 ;   lgdr %r4, %f0
@@ -718,7 +718,7 @@ block0(v0: i128, v1: i128):
 ;   agrk %r4, %r2, %r8
 ;   agr %r5, %r4
 ;   vlvgp %v5, %r5, %r3
-;   lgr %r2, %r14
+;   lgr %r2, %r10
 ;   vst %v5, 0(%r2)
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -348,8 +348,8 @@ block0(v0: i128):
 
 ; block0:
 ;   vl %v0, 0(%r2)
-;   vgbm %v2, 0
-;   vceqgs %v4, %v0, %v2
+;   vgbm %v3, 0
+;   vceqgs %v5, %v0, %v3
 ;   lghi %r2, 0
 ;   locghine %r2, -1
 ;   br %r14
@@ -362,8 +362,8 @@ block0(v0: i128):
 
 ; block0:
 ;   vl %v0, 0(%r2)
-;   vgbm %v2, 0
-;   vceqgs %v4, %v0, %v2
+;   vgbm %v3, 0
+;   vceqgs %v5, %v0, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
@@ -376,8 +376,8 @@ block0(v0: i128):
 
 ; block0:
 ;   vl %v0, 0(%r2)
-;   vgbm %v2, 0
-;   vceqgs %v4, %v0, %v2
+;   vgbm %v3, 0
+;   vceqgs %v5, %v0, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
@@ -390,8 +390,8 @@ block0(v0: i128):
 
 ; block0:
 ;   vl %v0, 0(%r2)
-;   vgbm %v2, 0
-;   vceqgs %v4, %v0, %v2
+;   vgbm %v3, 0
+;   vceqgs %v5, %v0, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
@@ -10,7 +10,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vceqgs %v4, %v0, %v1
+;   vceqgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -24,7 +24,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vceqgs %v4, %v0, %v1
+;   vceqgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -38,7 +38,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vecg %v0, %v1 ; jne 10 ; vchlgs %v4, %v1, %v0
+;   vecg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -52,7 +52,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vecg %v1, %v0 ; jne 10 ; vchlgs %v4, %v0, %v1
+;   vecg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -66,7 +66,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vecg %v1, %v0 ; jne 10 ; vchlgs %v4, %v0, %v1
+;   vecg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -80,7 +80,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   vecg %v0, %v1 ; jne 10 ; vchlgs %v4, %v1, %v0
+;   vecg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -94,7 +94,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   veclg %v0, %v1 ; jne 10 ; vchlgs %v4, %v1, %v0
+;   veclg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -108,7 +108,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   veclg %v1, %v0 ; jne 10 ; vchlgs %v4, %v0, %v1
+;   veclg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -122,7 +122,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   veclg %v1, %v0 ; jne 10 ; vchlgs %v4, %v0, %v1
+;   veclg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -136,7 +136,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   vl %v0, 0(%r2)
 ;   vl %v1, 0(%r3)
-;   veclg %v0, %v1 ; jne 10 ; vchlgs %v4, %v1, %v0
+;   veclg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14


### PR DESCRIPTION
Constrain virtual registers when handling implicit pointer arguments, instead of using physical registers directly. Additionally, mark the `Args` instruction as not clobbering registers in the s390x and aarch64 backends, to avoid introducing unnecessary saves on function entry.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
