### PR TITLE
Move the endianness notes introduced with #4035 to `wasmtime_val_raw`

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -119,38 +119,24 @@ typedef uint8_t wasmtime_v128[16];
  */
 typedef union wasmtime_valunion {
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
-  ///
-  /// Note that this field is always stored in a little-endian format.
   int32_t i32;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
-  ///
-  /// Note that this field is always stored in a little-endian format.
   int64_t i64;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
-  ///
-  /// Note that this field is always stored in a little-endian format.
   float32_t f32;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
-  ///
-  /// Note that this field is always stored in a little-endian format.
   float64_t f64;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
   ///
   /// If this value represents a `ref.null func` value then the `store_id` field
   /// is set to zero.
-  ///
-  /// Note that this field is always stored in a little-endian format.
   wasmtime_func_t funcref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
   ///
   /// If this value represents a `ref.null extern` value then this pointer will
   /// be `NULL`.
-  ///
-  /// Note that this field is always stored in a little-endian format.
   wasmtime_externref_t *externref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
-  ///
-  /// Note that this field is always stored in a little-endian format.
   wasmtime_v128 v128;
 } wasmtime_valunion_t;
 
@@ -169,25 +155,39 @@ typedef union wasmtime_valunion {
  */
 typedef union wasmtime_val_raw {
   /// Field for when this val is a WebAssembly `i32` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   int32_t i32;
   /// Field for when this val is a WebAssembly `i64` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   int64_t i64;
   /// Field for when this val is a WebAssembly `f32` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   float32_t f32;
   /// Field for when this val is a WebAssembly `f64` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   float64_t f64;
   /// Field for when this val is a WebAssembly `v128` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   wasmtime_v128 v128;
   /// Field for when this val is a WebAssembly `funcref` value.
   ///
   /// If this is set to 0 then it's a null funcref, otherwise this must be
   /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   size_t funcref;
   /// Field for when this val is a WebAssembly `externref` value.
   ///
   /// If this is set to 0 then it's a null externref, otherwise this must be
   /// passed to `wasmtime_externref_from_raw` to determine the
   /// `wasmtime_externref_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
   size_t externref;
 } wasmtime_val_raw_t;
 


### PR DESCRIPTION
Hi, it seems  #4035 mistakenly added the notes about the little-endian storage in the C API to `wasmtime_valunion`, whereas it's actually the `ValRaw` Rust type (represented by `wasmtime_val_raw`) that is affected by the change.

Thanks!

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
