### PR TITLE
Fix a flaky wait/notify test

### DIFF
--- a/tests/all/wait_notify.rs
+++ b/tests/all/wait_notify.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::time::Instant;
 use wasmtime::*;
 
 #[test]
@@ -23,17 +22,11 @@ fn atomic_wait_timeout_length() -> Result<()> {
     let mut store = Store::new(&engine, ());
     let shared_memory = SharedMemory::new(&engine, MemoryType::shared(1, 1))?;
     let instance = Instance::new(&mut store, &module, &[shared_memory.clone().into()])?;
-    let now = Instant::now();
     let func_ret = instance
         .get_typed_func::<(), i32>(&mut store, "func1")
         .unwrap()
         .call(&mut store, ())
         .unwrap();
-    let duration = now.elapsed();
-    assert!(
-        duration.as_nanos() >= sleep_nanoseconds,
-        "duration: {duration:?} < {sleep_nanoseconds:?}"
-    );
     assert_eq!(func_ret, 2);
     Ok(())
 }


### PR DESCRIPTION
This commit removes an assertion about the amount of time to sleep as part of the `memory.atomic.wait*` instructions. We've already seen one flaky test failure due to this and I think in general the timing around it isn't super precise so it seems best to leave this specific aspect perhaps untested for now but also pretty unlikely to regress. Otherwise though testing specific sleeping timeout behavior isn't something we're well structured to test at this time.

Closes #5312

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
