### PR TITLE
Fix issues in `FunctionBuilder` API

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -596,10 +596,11 @@ impl<'a> FunctionBuilder<'a> {
         }
     }
 
-    /// Declare that translation of the current function is complete. This
-    /// resets the state of the `FunctionBuilder` in preparation to be used
-    /// for another function.
-    pub fn finalize(&mut self) {
+    /// Declare that translation of the current function is complete.
+    ///
+    /// This resets the state of the `FunctionBuilderContext` in preparation to
+    /// be used for another function.
+    pub fn finalize(self) {
         // Check that all the `Block`s are filled and sealed.
         #[cfg(debug_assertions)]
         {
@@ -637,10 +638,6 @@ impl<'a> FunctionBuilder<'a> {
         // Clear the state (but preserve the allocated buffers) in preparation
         // for translation another function.
         self.func_ctx.clear();
-
-        // Reset srcloc and position to initial states.
-        self.srcloc = Default::default();
-        self.position = Default::default();
     }
 }
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -766,7 +766,7 @@ impl Compiler {
             .ins()
             .call_indirect(new_sig, callee_value, &callee_args);
 
-        self.wasm_to_host_load_results(ty, &mut builder, values_vec_ptr_val);
+        self.wasm_to_host_load_results(ty, builder, values_vec_ptr_val);
 
         let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
         self.save_context(CompilerContext {
@@ -840,7 +840,7 @@ impl Compiler {
     fn wasm_to_host_load_results(
         &self,
         ty: &WasmFuncType,
-        builder: &mut FunctionBuilder,
+        mut builder: FunctionBuilder,
         values_vec_ptr_val: Value,
     ) {
         let isa = &*self.isa;


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
- [x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [x] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.
-->
[Here on this zulip stream](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/.E2.9C.94.20Questions.20about.20Cranelift), I have asked about some inconsistencies in the `FunctionBuilderContext` and `FunctionBuilder` APIs, and it was suggested that I could probably fix these issues. This PR addresses two of them.

`FunctionBuilder` is supposed to be used to only build a single `Function`, but `FunctionBuilder::finalize()` indicates that it can be used for multiples `Function`s. The first commit fixed that by making `finalize()` consume `self`. Nowhere in the codebase `FunctionBuilder` was reused, so the change was very straight forward.

The other one was that `FunctionBuilder::func` was public, which could allow the `Function` to be messed up mid-translation. I tried replacing it by an immutable `func()` getter, but in the codebase `func` is in fact messed with mid-translation. So, I also added a `func_mut()` getter. I am not sure if this change brings meaningful benefits, so I could remove it if you prefer.