### PR TITLE
cranelift-isle: Reject unreachable rules

### DIFF
--- a/cranelift/isle/isle/src/lib.rs
+++ b/cranelift/isle/isle/src/lib.rs
@@ -197,6 +197,20 @@ impl<T: Copy + std::fmt::Debug + Eq + Hash> DisjointSets<T> {
     pub fn is_empty(&self) -> bool {
         self.parent.is_empty()
     }
+
+    /// Returns the total number of elements in all sets. This method takes constant time.
+    ///
+    /// ```
+    /// let mut sets = cranelift_isle::DisjointSets::default();
+    /// sets.merge(1, 2);
+    /// assert_eq!(sets.len(), 2);
+    /// sets.merge(3, 4);
+    /// sets.merge(3, 5);
+    /// assert_eq!(sets.len(), 5);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.parent.len()
+    }
 }
 
 pub mod ast;


### PR DESCRIPTION
Some of our ISLE rules can never fire because there's a higher-priority rule that will always fire instead.

Sometimes the worst that can happen is we generate sub-optimal output. That's not so bad but we'd still like to know about it so we can fix it. On x64, a current example is that lowering the combination of `imul` with `swiden_high` will always emit separate machine instructions for each, rather than a single instruction for the combination.

In other cases there might be instructions which can't be lowered in isolation. If a general rule for lowering one of the instructions is higher-priority than the rule for lowering the combined sequence, then lowering the combined sequence will always fail. I suspect there aren't any of these because somebody probably would have noticed already, but I don't know.

Either way, this is always a bug, so make it a fatal error if we can detect it.

I'm opening this as a draft because I've made this condition a fatal error without fixing any of the existing instances of that error. I'd like help from folks who are more familiar with the backends to figure out how to fix each case, and maybe write new filetests to exercise the relevant rules.

There are currently:
- 5 too-general rules in x64
- 5 too-general rules in s390x (cc: @uweigand)
- 24 too-general rules in aarch64

Details of all these cases are visible in the [failure output from CI](https://github.com/bytecodealliance/wasmtime/actions/runs/3537080635/jobs/5936732086) for this PR.