### PR TITLE
wasmtime: Add libc as a dependency on FreeBSD in the `jit-icache-coherence` crate

### DIFF
--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -19,5 +19,5 @@ features = [
     "Win32_System_Diagnostics_Debug",
 ]
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.libc]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))'.dependencies.libc]
 version = "0.2.42"


### PR DESCRIPTION
👋 Hey,

This gets this package to build for `x86_64`, but does not include any cache clearing for `aarch64-freebsd`. Which will probably build, but not work.

As far as I can tell membarriers are still in the process of being added.
See: https://reviews.freebsd.org/D32360

Since FreeBSD is mirroring the Linux membarrier syscall we may be able to reuse the same implementation for both Linux and FreeBSD for AArch64.

I wasn't able to test FreeBSD directly but cg_clif builds and passes its tests with this commit applied to the v3.0.0 tag. ([CI](https://cirrus-ci.com/task/4553534729879552))

Fixes: #5308
cc: @bjorn3 
