### PR TITLE
feat:  remove mutability from the WasiCtx Table

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -94,15 +94,15 @@ impl WasiCtxBuilder {
         }
         Ok(self)
     }
-    pub fn stdin(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stdin(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stdin(f);
         self
     }
-    pub fn stdout(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stdout(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stdout(f);
         self
     }
-    pub fn stderr(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stderr(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stderr(f);
         self
     }
@@ -118,12 +118,12 @@ impl WasiCtxBuilder {
     pub fn inherit_stdio(self) -> Self {
         self.inherit_stdin().inherit_stdout().inherit_stderr()
     }
-    pub fn preopened_dir(mut self, dir: Dir, guest_path: impl AsRef<Path>) -> Result<Self, Error> {
+    pub fn preopened_dir(self, dir: Dir, guest_path: impl AsRef<Path>) -> Result<Self, Error> {
         let dir = Box::new(crate::dir::Dir::from_cap_std(dir));
         self.0.push_preopened_dir(dir, guest_path)?;
         Ok(self)
     }
-    pub fn preopened_socket(mut self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
+    pub fn preopened_socket(self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
         let socket: Socket = socket.into();
         let file: Box<dyn WasiFile> = socket.into();
 

--- a/crates/wasi-common/cap-std-sync/src/net.rs
+++ b/crates/wasi-common/cap-std-sync/src/net.rs
@@ -8,6 +8,7 @@ use io_lifetimes::{AsSocket, BorrowedSocket};
 use std::any::Any;
 use std::convert::TryInto;
 use std::io;
+use std::sync::Arc;
 #[cfg(unix)]
 use system_interface::fs::GetSetFdFlags;
 use system_interface::io::IoExt;
@@ -17,6 +18,11 @@ use wasi_common::{
     file::{FdFlags, FileType, RiFlags, RoFlags, SdFlags, SiFlags, WasiFile},
     Error, ErrorExt,
 };
+
+#[cfg(unix)]
+use wasi_common::file::BorrowedAsFd;
+#[cfg(windows)]
+use wasi_common::file::BorrowedAsRawHandleOrSocket;
 
 pub enum Socket {
     TcpListener(cap_std::net::TcpListener),
@@ -83,29 +89,28 @@ macro_rules! wasi_listen_write_impl {
                 self
             }
             #[cfg(unix)]
-            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
-                Some(self.0.as_fd())
+            fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
+                Some(Arc::new(BorrowedAsFd::new(&self.0)))
             }
-
             #[cfg(windows)]
-            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
-                Some(self.0.as_raw_handle_or_socket())
+            fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
+                Some(Arc::new(BorrowedAsRawHandleOrSocket::new(&self.0)))
             }
-            async fn sock_accept(&mut self, fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
+            async fn sock_accept(&self, fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
                 let (stream, _) = self.0.accept()?;
-                let mut stream = <$stream>::from_cap_std(stream);
+                let stream = <$stream>::from_cap_std(stream);
                 stream.set_fdflags(fdflags).await?;
                 Ok(Box::new(stream))
             }
-            async fn get_filetype(&mut self) -> Result<FileType, Error> {
+            async fn get_filetype(&self) -> Result<FileType, Error> {
                 Ok(FileType::SocketStream)
             }
             #[cfg(unix)]
-            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
                 let fdflags = get_fd_flags(&self.0)?;
                 Ok(fdflags)
             }
-            async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
+            async fn set_fdflags(&self, fdflags: FdFlags) -> Result<(), Error> {
                 if fdflags == wasi_common::file::FdFlags::NONBLOCK {
                     self.0.set_nonblocking(true)?;
                 } else if fdflags.is_empty() {
@@ -117,7 +122,7 @@ macro_rules! wasi_listen_write_impl {
                 }
                 Ok(())
             }
-            async fn num_ready_bytes(&self) -> Result<u64, Error> {
+            fn num_ready_bytes(&self) -> Result<u64, Error> {
                 Ok(1)
             }
         }
@@ -177,23 +182,22 @@ macro_rules! wasi_stream_write_impl {
                 self
             }
             #[cfg(unix)]
-            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
-                Some(self.0.as_fd())
+            fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
+                Some(Arc::new(BorrowedAsFd::new(&self.0)))
             }
-
             #[cfg(windows)]
-            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
-                Some(self.0.as_raw_handle_or_socket())
+            fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
+                Some(Arc::new(BorrowedAsRawHandleOrSocket::new(&self.0)))
             }
-            async fn get_filetype(&mut self) -> Result<FileType, Error> {
+            async fn get_filetype(&self) -> Result<FileType, Error> {
                 Ok(FileType::SocketStream)
             }
             #[cfg(unix)]
-            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
                 let fdflags = get_fd_flags(&self.0)?;
                 Ok(fdflags)
             }
-            async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
+            async fn set_fdflags(&self, fdflags: FdFlags) -> Result<(), Error> {
                 if fdflags == wasi_common::file::FdFlags::NONBLOCK {
                     self.0.set_nonblocking(true)?;
                 } else if fdflags.is_empty() {
@@ -206,23 +210,23 @@ macro_rules! wasi_stream_write_impl {
                 Ok(())
             }
             async fn read_vectored<'a>(
-                &mut self,
+                &self,
                 bufs: &mut [io::IoSliceMut<'a>],
             ) -> Result<u64, Error> {
                 use std::io::Read;
                 let n = Read::read_vectored(&mut &*self.as_socketlike_view::<$std_ty>(), bufs)?;
                 Ok(n.try_into()?)
             }
-            async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+            async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 use std::io::Write;
                 let n = Write::write_vectored(&mut &*self.as_socketlike_view::<$std_ty>(), bufs)?;
                 Ok(n.try_into()?)
             }
-            async fn peek(&mut self, buf: &mut [u8]) -> Result<u64, Error> {
+            async fn peek(&self, buf: &mut [u8]) -> Result<u64, Error> {
                 let n = self.0.peek(buf)?;
                 Ok(n.try_into()?)
             }
-            async fn num_ready_bytes(&self) -> Result<u64, Error> {
+            fn num_ready_bytes(&self) -> Result<u64, Error> {
                 let val = self.as_socketlike_view::<$std_ty>().num_ready_bytes()?;
                 Ok(val)
             }
@@ -244,7 +248,7 @@ macro_rules! wasi_stream_write_impl {
             }
 
             async fn sock_recv<'a>(
-                &mut self,
+                &self,
                 ri_data: &mut [std::io::IoSliceMut<'a>],
                 ri_flags: RiFlags,
             ) -> Result<(u64, RoFlags), Error> {
@@ -272,7 +276,7 @@ macro_rules! wasi_stream_write_impl {
             }
 
             async fn sock_send<'a>(
-                &mut self,
+                &self,
                 si_data: &[std::io::IoSlice<'a>],
                 si_flags: SiFlags,
             ) -> Result<u64, Error> {
@@ -284,7 +288,7 @@ macro_rules! wasi_stream_write_impl {
                 Ok(n as u64)
             }
 
-            async fn sock_shutdown(&mut self, how: SdFlags) -> Result<(), Error> {
+            async fn sock_shutdown(&self, how: SdFlags) -> Result<(), Error> {
                 let how = if how == SdFlags::RD | SdFlags::WR {
                     cap_std::net::Shutdown::Both
                 } else if how == SdFlags::RD {

--- a/crates/wasi-common/cap-std-sync/src/sched/windows.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/windows.rs
@@ -96,7 +96,7 @@ pub async fn poll_oneoff_<'a>(
         }
     }
     for r in immediate_reads {
-        match r.file.num_ready_bytes().await {
+        match r.file.num_ready_bytes() {
             Ok(ready_bytes) => {
                 r.complete(ready_bytes, RwEventFlags::empty());
                 ready = true;

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -7,7 +7,13 @@ use std::convert::TryInto;
 use std::fs::File;
 use std::io;
 use std::io::{Read, Write};
+use std::sync::Arc;
 use system_interface::io::ReadReady;
+
+#[cfg(unix)]
+use wasi_common::file::BorrowedAsFd;
+#[cfg(windows)]
+use wasi_common::file::BorrowedAsRawHandleOrSocket;
 
 #[cfg(windows)]
 use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
@@ -31,41 +37,43 @@ impl WasiFile for Stdin {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
     #[cfg(unix)]
-    fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
-        Some(self.0.as_fd())
+    fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
+        Some(Arc::new(BorrowedAsFd::new(&self.0)))
     }
 
     #[cfg(windows)]
-    fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
-        Some(self.0.as_raw_handle_or_socket())
+    fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
+        Some(Arc::new(BorrowedAsRawHandleOrSocket::new(&self.0)))
     }
-    async fn get_filetype(&mut self) -> Result<FileType, Error> {
+
+    async fn get_filetype(&self) -> Result<FileType, Error> {
         if self.isatty() {
             Ok(FileType::CharacterDevice)
         } else {
             Ok(FileType::Unknown)
         }
     }
-    async fn read_vectored<'a>(&mut self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
+    async fn read_vectored<'a>(&self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
         let n = (&*self.0.as_filelike_view::<File>()).read_vectored(bufs)?;
         Ok(n.try_into().map_err(|_| Error::range())?)
     }
     async fn read_vectored_at<'a>(
-        &mut self,
+        &self,
         _bufs: &mut [io::IoSliceMut<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
         Err(Error::seek_pipe())
     }
-    async fn seek(&mut self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
+    async fn seek(&self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
         Err(Error::seek_pipe())
     }
-    async fn peek(&mut self, _buf: &mut [u8]) -> Result<u64, Error> {
+    async fn peek(&self, _buf: &mut [u8]) -> Result<u64, Error> {
         Err(Error::seek_pipe())
     }
     async fn set_times(
-        &mut self,
+        &self,
         atime: Option<wasi_common::SystemTimeSpec>,
         mtime: Option<wasi_common::SystemTimeSpec>,
     ) -> Result<(), Error> {
@@ -73,10 +81,10 @@ impl WasiFile for Stdin {
             .set_times(convert_systimespec(atime), convert_systimespec(mtime))?;
         Ok(())
     }
-    async fn num_ready_bytes(&self) -> Result<u64, Error> {
+    fn num_ready_bytes(&self) -> Result<u64, Error> {
         Ok(self.0.num_ready_bytes()?)
     }
-    fn isatty(&mut self) -> bool {
+    fn isatty(&self) -> bool {
         self.0.is_terminal()
     }
 }
@@ -108,42 +116,41 @@ macro_rules! wasi_file_write_impl {
                 self
             }
             #[cfg(unix)]
-            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
-                Some(self.0.as_fd())
+            fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
+                Some(Arc::new(BorrowedAsFd::new(&self.0)))
             }
-
             #[cfg(windows)]
-            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
-                Some(self.0.as_raw_handle_or_socket())
+            fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
+                Some(Arc::new(BorrowedAsRawHandleOrSocket::new(&self.0)))
             }
-            async fn get_filetype(&mut self) -> Result<FileType, Error> {
+            async fn get_filetype(&self) -> Result<FileType, Error> {
                 if self.isatty() {
                     Ok(FileType::CharacterDevice)
                 } else {
                     Ok(FileType::Unknown)
                 }
             }
-            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
                 Ok(FdFlags::APPEND)
             }
-            async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+            async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 let n = (&*self.0.as_filelike_view::<File>()).write_vectored(bufs)?;
                 Ok(n.try_into().map_err(|_| {
                     Error::range().context("converting write_vectored total length")
                 })?)
             }
             async fn write_vectored_at<'a>(
-                &mut self,
+                &self,
                 _bufs: &[io::IoSlice<'a>],
                 _offset: u64,
             ) -> Result<u64, Error> {
                 Err(Error::seek_pipe())
             }
-            async fn seek(&mut self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
+            async fn seek(&self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
                 Err(Error::seek_pipe())
             }
             async fn set_times(
-                &mut self,
+                &self,
                 atime: Option<wasi_common::SystemTimeSpec>,
                 mtime: Option<wasi_common::SystemTimeSpec>,
             ) -> Result<(), Error> {
@@ -151,7 +158,7 @@ macro_rules! wasi_file_write_impl {
                     .set_times(convert_systimespec(atime), convert_systimespec(mtime))?;
                 Ok(())
             }
-            fn isatty(&mut self) -> bool {
+            fn isatty(&self) -> bool {
                 self.0.is_terminal()
             }
         }

--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -7,6 +7,7 @@ use crate::table::Table;
 use crate::Error;
 use cap_rand::RngCore;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 pub struct WasiCtx {
     pub args: StringArray,
@@ -24,7 +25,7 @@ impl WasiCtx {
         sched: Box<dyn WasiSched>,
         table: Table,
     ) -> Self {
-        let mut s = WasiCtx {
+        let s = WasiCtx {
             args: StringArray::new(),
             env: StringArray::new(),
             random,
@@ -38,17 +39,17 @@ impl WasiCtx {
         s
     }
 
-    pub fn insert_file(&mut self, fd: u32, file: Box<dyn WasiFile>, caps: FileCaps) {
+    pub fn insert_file(&self, fd: u32, file: Box<dyn WasiFile>, caps: FileCaps) {
         self.table()
-            .insert_at(fd, Box::new(FileEntry::new(caps, file)));
+            .insert_at(fd, Arc::new(FileEntry::new(caps, file)));
     }
 
-    pub fn push_file(&mut self, file: Box<dyn WasiFile>, caps: FileCaps) -> Result<u32, Error> {
-        self.table().push(Box::new(FileEntry::new(caps, file)))
+    pub fn push_file(&self, file: Box<dyn WasiFile>, caps: FileCaps) -> Result<u32, Error> {
+        self.table().push(Arc::new(FileEntry::new(caps, file)))
     }
 
     pub fn insert_dir(
-        &mut self,
+        &self,
         fd: u32,
         dir: Box<dyn WasiDir>,
         caps: DirCaps,
@@ -57,23 +58,23 @@ impl WasiCtx {
     ) {
         self.table().insert_at(
             fd,
-            Box::new(DirEntry::new(caps, file_caps, Some(path), dir)),
+            Arc::new(DirEntry::new(caps, file_caps, Some(path), dir)),
         );
     }
 
     pub fn push_dir(
-        &mut self,
+        &self,
         dir: Box<dyn WasiDir>,
         caps: DirCaps,
         file_caps: FileCaps,
         path: PathBuf,
     ) -> Result<u32, Error> {
         self.table()
-            .push(Box::new(DirEntry::new(caps, file_caps, Some(path), dir)))
+            .push(Arc::new(DirEntry::new(caps, file_caps, Some(path), dir)))
     }
 
-    pub fn table(&mut self) -> &mut Table {
-        &mut self.table
+    pub fn table(&self) -> &Table {
+        &self.table
     }
 
     pub fn push_arg(&mut self, arg: &str) -> Result<(), StringArrayError> {
@@ -85,17 +86,17 @@ impl WasiCtx {
         Ok(())
     }
 
-    pub fn set_stdin(&mut self, mut f: Box<dyn WasiFile>) {
+    pub fn set_stdin(&self, mut f: Box<dyn WasiFile>) {
         let rights = Self::stdio_rights(&mut *f);
         self.insert_file(0, f, rights);
     }
 
-    pub fn set_stdout(&mut self, mut f: Box<dyn WasiFile>) {
+    pub fn set_stdout(&self, mut f: Box<dyn WasiFile>) {
         let rights = Self::stdio_rights(&mut *f);
         self.insert_file(1, f, rights);
     }
 
-    pub fn set_stderr(&mut self, mut f: Box<dyn WasiFile>) {
+    pub fn set_stderr(&self, mut f: Box<dyn WasiFile>) {
         let rights = Self::stdio_rights(&mut *f);
         self.insert_file(2, f, rights);
     }
@@ -114,13 +115,13 @@ impl WasiCtx {
     }
 
     pub fn push_preopened_dir(
-        &mut self,
+        &self,
         dir: Box<dyn WasiDir>,
         path: impl AsRef<Path>,
     ) -> Result<(), Error> {
         let caps = DirCaps::all();
         let file_caps = FileCaps::all();
-        self.table().push(Box::new(DirEntry::new(
+        self.table().push(Arc::new(DirEntry::new(
             caps,
             file_caps,
             Some(path.as_ref().to_owned()),

--- a/crates/wasi-common/src/dir.rs
+++ b/crates/wasi-common/src/dir.rs
@@ -3,6 +3,7 @@ use crate::{Error, ErrorExt, SystemTimeSpec};
 use bitflags::bitflags;
 use std::any::Any;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 #[wiggle::async_trait]
 pub trait WasiDir: Send + Sync {
@@ -98,67 +99,50 @@ pub trait WasiDir: Send + Sync {
 }
 
 pub(crate) struct DirEntry {
-    caps: DirCaps,
-    file_caps: FileCaps,
+    caps: RwLock<DirFdStat>,
     preopen_path: Option<PathBuf>, // precondition: PathBuf is valid unicode
     dir: Box<dyn WasiDir>,
 }
 
 impl DirEntry {
     pub fn new(
-        caps: DirCaps,
+        dir_caps: DirCaps,
         file_caps: FileCaps,
         preopen_path: Option<PathBuf>,
         dir: Box<dyn WasiDir>,
     ) -> Self {
         DirEntry {
-            caps,
-            file_caps,
+            caps: RwLock::new(DirFdStat {
+                dir_caps,
+                file_caps,
+            }),
             preopen_path,
             dir,
         }
     }
     pub fn capable_of_dir(&self, caps: DirCaps) -> Result<(), Error> {
-        if self.caps.contains(caps) {
-            Ok(())
-        } else {
-            let missing = caps & !self.caps;
-            let err = if missing.intersects(DirCaps::READDIR) {
-                Error::not_dir()
-            } else {
-                Error::perm()
-            };
-            Err(err.context(format!("desired rights {:?}, has {:?}", caps, self.caps)))
-        }
+        let fdstat = self.caps.read().unwrap();
+        fdstat.capable_of_dir(caps)
     }
-    pub fn capable_of_file(&self, caps: FileCaps) -> Result<(), Error> {
-        if self.file_caps.contains(caps) {
-            Ok(())
-        } else {
-            Err(Error::perm().context(format!(
-                "desired rights {:?}, has {:?}",
-                caps, self.file_caps
-            )))
-        }
-    }
-    pub fn drop_caps_to(&mut self, caps: DirCaps, file_caps: FileCaps) -> Result<(), Error> {
-        self.capable_of_dir(caps)?;
-        self.capable_of_file(file_caps)?;
-        self.caps = caps;
-        self.file_caps = file_caps;
+
+    pub fn drop_caps_to(&self, dir_caps: DirCaps, file_caps: FileCaps) -> Result<(), Error> {
+        let mut fdstat = self.caps.write().unwrap();
+        fdstat.capable_of_dir(dir_caps)?;
+        fdstat.capable_of_file(file_caps)?;
+        *fdstat = DirFdStat {
+            dir_caps,
+            file_caps,
+        };
         Ok(())
     }
     pub fn child_dir_caps(&self, desired_caps: DirCaps) -> DirCaps {
-        self.caps & desired_caps
+        self.caps.read().unwrap().dir_caps & desired_caps
     }
     pub fn child_file_caps(&self, desired_caps: FileCaps) -> FileCaps {
-        self.file_caps & desired_caps
+        self.caps.read().unwrap().file_caps & desired_caps
     }
     pub fn get_dir_fdstat(&self) -> DirFdStat {
-        DirFdStat {
-            dir_caps: self.caps,
-            file_caps: self.file_caps,
-        }
+        self.caps.read().unwrap().clone()
     }
     pub fn preopen_path(&self) -> &Option<PathBuf> {
         &self.preopen_path
@@ -203,18 +187,47 @@ pub struct DirFdStat {
     pub dir_caps: DirCaps,
 }
 
+impl DirFdStat {
+    pub fn capable_of_dir(&self, caps: DirCaps) -> Result<(), Error> {
+        if self.dir_caps.contains(caps) {
+            Ok(())
+        } else {
+            let missing = caps & !self.dir_caps;
+            let err = if missing.intersects(DirCaps::READDIR) {
+                Error::not_dir()
+            } else {
+                Error::perm()
+            };
+            Err(err.context(format!(
+                "desired rights {:?}, has {:?}",
+                caps, self.dir_caps
+            )))
+        }
+    }
+    pub fn capable_of_file(&self, caps: FileCaps) -> Result<(), Error> {
+        if self.file_caps.contains(caps) {
+            Ok(())
+        } else {
+            Err(Error::perm().context(format!(
+                "desired rights {:?}, has {:?}",
+                caps, self.file_caps
+            )))
+        }
+    }
+}
+
 pub(crate) trait TableDirExt {
-    fn get_dir(&self, fd: u32) -> Result<&DirEntry, Error>;
+    fn get_dir(&self, fd: u32) -> Result<Arc<DirEntry>, Error>;
     fn is_preopen(&self, fd: u32) -> bool;
 }
 
 impl TableDirExt for crate::table::Table {
-    fn get_dir(&self, fd: u32) -> Result<&DirEntry, Error> {
+    fn get_dir(&self, fd: u32) -> Result<Arc<DirEntry>, Error> {
         self.get(fd)
     }
     fn is_preopen(&self, fd: u32) -> bool {
         if self.is::<DirEntry>(fd) {
-            let dir_entry: &DirEntry = self.get(fd).unwrap();
+            let dir_entry: Arc<DirEntry> = self.get(fd).unwrap();
             dir_entry.preopen_path.is_some()
         } else {
             false

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -1,32 +1,39 @@
 use crate::{Error, ErrorExt, SystemTimeSpec};
 use bitflags::bitflags;
 use std::any::Any;
+use std::sync::{Arc, RwLock};
+
+#[cfg(unix)]
+use cap_std::io_lifetimes::{AsFd, BorrowedFd};
+
+#[cfg(windows)]
+use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
 
 #[wiggle::async_trait]
 pub trait WasiFile: Send + Sync {
     fn as_any(&self) -> &dyn Any;
-    async fn get_filetype(&mut self) -> Result<FileType, Error>;
+    async fn get_filetype(&self) -> Result<FileType, Error>;
 
     #[cfg(unix)]
-    fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
+    fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
         None
     }
 
     #[cfg(windows)]
-    fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
+    fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
         None
     }
 
-    fn isatty(&mut self) -> bool {
+    fn isatty(&self) -> bool {
         false
     }
 
-    async fn sock_accept(&mut self, _fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
+    async fn sock_accept(&self, _fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
         Err(Error::badf())
     }
 
     async fn sock_recv<'a>(
-        &mut self,
+        &self,
         _ri_data: &mut [std::io::IoSliceMut<'a>],
         _ri_flags: RiFlags,
     ) -> Result<(u64, RoFlags), Error> {
@@ -34,34 +41,34 @@ pub trait WasiFile: Send + Sync {
     }
 
     async fn sock_send<'a>(
-        &mut self,
+        &self,
         _si_data: &[std::io::IoSlice<'a>],
         _si_flags: SiFlags,
     ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn sock_shutdown(&mut self, _how: SdFlags) -> Result<(), Error> {
+    async fn sock_shutdown(&self, _how: SdFlags) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn datasync(&mut self) -> Result<(), Error> {
+    async fn datasync(&self) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(&self) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+    async fn get_fdflags(&self) -> Result<FdFlags, Error> {
         Ok(FdFlags::empty())
     }
 
-    async fn set_fdflags(&mut self, _flags: FdFlags) -> Result<(), Error> {
+    async fn set_fdflags(&self, _flags: FdFlags) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn get_filestat(&mut self) -> Result<Filestat, Error> {
+    async fn get_filestat(&self) -> Result<Filestat, Error> {
         Ok(Filestat {
             device_id: 0,
             inode: 0,
@@ -74,62 +81,59 @@ pub trait WasiFile: Send + Sync {
         })
     }
 
-    async fn set_filestat_size(&mut self, _size: u64) -> Result<(), Error> {
+    async fn set_filestat_size(&self, _size: u64) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn advise(&mut self, _offset: u64, _len: u64, _advice: Advice) -> Result<(), Error> {
+    async fn advise(&self, _offset: u64, _len: u64, _advice: Advice) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn allocate(&mut self, _offset: u64, _len: u64) -> Result<(), Error> {
+    async fn allocate(&self, _offset: u64, _len: u64) -> Result<(), Error> {
         Err(Error::badf())
     }
 
     async fn set_times(
-        &mut self,
+        &self,
         _atime: Option<SystemTimeSpec>,
         _mtime: Option<SystemTimeSpec>,
     ) -> Result<(), Error> {
         Err(Error::badf())
     }
 
-    async fn read_vectored<'a>(
-        &mut self,
-        _bufs: &mut [std::io::IoSliceMut<'a>],
-    ) -> Result<u64, Error> {
+    async fn read_vectored<'a>(&self, _bufs: &mut [std::io::IoSliceMut<'a>]) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
     async fn read_vectored_at<'a>(
-        &mut self,
+        &self,
         _bufs: &mut [std::io::IoSliceMut<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn write_vectored<'a>(&mut self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
+    async fn write_vectored<'a>(&self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
     async fn write_vectored_at<'a>(
-        &mut self,
+        &self,
         _bufs: &[std::io::IoSlice<'a>],
         _offset: u64,
     ) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn seek(&mut self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
+    async fn seek(&self, _pos: std::io::SeekFrom) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn peek(&mut self, _buf: &mut [u8]) -> Result<u64, Error> {
+    async fn peek(&self, _buf: &mut [u8]) -> Result<u64, Error> {
         Err(Error::badf())
     }
 
-    async fn num_ready_bytes(&self) -> Result<u64, Error> {
+    fn num_ready_bytes(&self) -> Result<u64, Error> {
         Ok(0)
     }
 
@@ -212,33 +216,32 @@ pub struct Filestat {
 }
 
 pub(crate) trait TableFileExt {
-    fn get_file(&self, fd: u32) -> Result<&FileEntry, Error>;
-    fn get_file_mut(&mut self, fd: u32) -> Result<&mut FileEntry, Error>;
+    fn get_file(&self, fd: u32) -> Result<Arc<FileEntry>, Error>;
 }
 impl TableFileExt for crate::table::Table {
-    fn get_file(&self, fd: u32) -> Result<&FileEntry, Error> {
+    fn get_file(&self, fd: u32) -> Result<Arc<FileEntry>, Error> {
         self.get(fd)
-    }
-    fn get_file_mut(&mut self, fd: u32) -> Result<&mut FileEntry, Error> {
-        self.get_mut(fd)
     }
 }
 
 pub(crate) struct FileEntry {
-    caps: FileCaps,
+    caps: RwLock<FileCaps>,
     file: Box<dyn WasiFile>,
 }
 
 impl FileEntry {
     pub fn new(caps: FileCaps, file: Box<dyn WasiFile>) -> Self {
-        FileEntry { caps, file }
+        FileEntry {
+            caps: RwLock::new(caps),
+            file,
+        }
     }
 
     pub fn capable_of(&self, caps: FileCaps) -> Result<(), Error> {
-        if self.caps.contains(caps) {
+        if self.caps.read().unwrap().contains(caps) {
             Ok(())
         } else {
-            let missing = caps & !self.caps;
+            let missing = caps & !(*self.caps.read().unwrap());
             let err = if missing.intersects(FileCaps::READ | FileCaps::WRITE) {
                 // `EBADF` is a little surprising here because it's also used
                 // for unknown-file-descriptor errors, but it's what POSIX uses
@@ -251,16 +254,17 @@ impl FileEntry {
         }
     }
 
-    pub fn drop_caps_to(&mut self, caps: FileCaps) -> Result<(), Error> {
+    pub fn drop_caps_to(&self, caps: FileCaps) -> Result<(), Error> {
         self.capable_of(caps)?;
-        self.caps = caps;
+        *self.caps.write().unwrap() = caps;
         Ok(())
     }
 
-    pub async fn get_fdstat(&mut self) -> Result<FdStat, Error> {
+    pub async fn get_fdstat(&self) -> Result<FdStat, Error> {
+        let caps = self.caps.read().unwrap().clone();
         Ok(FdStat {
             filetype: self.file.get_filetype().await?,
-            caps: self.caps,
+            caps,
             flags: self.file.get_fdflags().await?,
         })
     }
@@ -268,18 +272,12 @@ impl FileEntry {
 
 pub trait FileEntryExt {
     fn get_cap(&self, caps: FileCaps) -> Result<&dyn WasiFile, Error>;
-    fn get_cap_mut(&mut self, caps: FileCaps) -> Result<&mut dyn WasiFile, Error>;
 }
 
 impl FileEntryExt for FileEntry {
     fn get_cap(&self, caps: FileCaps) -> Result<&dyn WasiFile, Error> {
         self.capable_of(caps)?;
         Ok(&*self.file)
-    }
-
-    fn get_cap_mut(&mut self, caps: FileCaps) -> Result<&mut dyn WasiFile, Error> {
-        self.capable_of(caps)?;
-        Ok(&mut *self.file)
     }
 }
 
@@ -316,4 +314,40 @@ pub enum Advice {
     WillNeed,
     DontNeed,
     NoReuse,
+}
+
+#[cfg(unix)]
+pub struct BorrowedAsFd<'a, T: AsFd>(&'a T);
+
+#[cfg(unix)]
+impl<'a, T: AsFd> BorrowedAsFd<'a, T> {
+    pub fn new(t: &'a T) -> Self {
+        BorrowedAsFd(t)
+    }
+}
+
+#[cfg(unix)]
+impl<T: AsFd> AsFd for BorrowedAsFd<'_, T> {
+    #[inline]
+    fn as_fd(&self) -> BorrowedFd {
+        self.0.as_fd()
+    }
+}
+
+#[cfg(windows)]
+pub struct BorrowedAsRawHandleOrSocket<'a, T: AsRawHandleOrSocket>(&'a T);
+
+#[cfg(windows)]
+impl<'a, T: AsRawHandleOrSocket> BorrowedAsRawHandleOrSocket<'a, T> {
+    pub fn new(t: &'a T) -> Self {
+        BorrowedAsRawHandleOrSocket(t)
+    }
+}
+
+#[cfg(windows)]
+impl<T: AsRawHandleOrSocket> AsRawHandleOrSocket for BorrowedAsRawHandleOrSocket<'_, T> {
+    #[inline]
+    fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
+        self.0.as_raw_handle_or_socket()
+    }
 }

--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -105,10 +105,10 @@ impl<R: Read + Any + Send + Sync> WasiFile for ReadPipe<R> {
     fn as_any(&self) -> &dyn Any {
         self
     }
-    async fn get_filetype(&mut self) -> Result<FileType, Error> {
+    async fn get_filetype(&self) -> Result<FileType, Error> {
         Ok(FileType::Pipe)
     }
-    async fn read_vectored<'a>(&mut self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
+    async fn read_vectored<'a>(&self, bufs: &mut [io::IoSliceMut<'a>]) -> Result<u64, Error> {
         let n = self.borrow().read_vectored(bufs)?;
         Ok(n.try_into()?)
     }
@@ -189,13 +189,13 @@ impl<W: Write + Any + Send + Sync> WasiFile for WritePipe<W> {
     fn as_any(&self) -> &dyn Any {
         self
     }
-    async fn get_filetype(&mut self) -> Result<FileType, Error> {
+    async fn get_filetype(&self) -> Result<FileType, Error> {
         Ok(FileType::Pipe)
     }
-    async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+    async fn get_fdflags(&self) -> Result<FdFlags, Error> {
         Ok(FdFlags::APPEND)
     }
-    async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+    async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
         let n = self.borrow().write_vectored(bufs)?;
         Ok(n.try_into()?)
     }

--- a/crates/wasi-common/src/snapshots/preview_0.rs
+++ b/crates/wasi-common/src/snapshots/preview_0.rs
@@ -527,10 +527,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         fd: types::Fd,
         iovs: &types::IovecArray<'a>,
     ) -> Result<types::Size, Error> {
-        let f = self
-            .table()
-            .get_file_mut(u32::from(fd))?
-            .get_cap_mut(FileCaps::READ)?;
+        let f = self.table().get_file(u32::from(fd))?;
+        let f = f.get_cap(FileCaps::READ)?;
 
         let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> =
             iovs.iter()
@@ -558,10 +556,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         iovs: &types::IovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, Error> {
-        let f = self
-            .table()
-            .get_file_mut(u32::from(fd))?
-            .get_cap_mut(FileCaps::READ | FileCaps::SEEK)?;
+        let f = self.table().get_file(u32::from(fd))?;
+        let f = f.get_cap(FileCaps::READ | FileCaps::SEEK)?;
 
         let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> =
             iovs.iter()
@@ -588,10 +584,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         fd: types::Fd,
         ciovs: &types::CiovecArray<'a>,
     ) -> Result<types::Size, Error> {
-        let f = self
-            .table()
-            .get_file_mut(u32::from(fd))?
-            .get_cap_mut(FileCaps::WRITE)?;
+        let f = self.table().get_file(u32::from(fd))?;
+        let f = f.get_cap(FileCaps::WRITE)?;
 
         let guest_slices: Vec<wiggle::GuestSlice<u8>> = ciovs
             .iter()
@@ -621,10 +615,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
         ciovs: &types::CiovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, Error> {
-        let f = self
-            .table()
-            .get_file_mut(u32::from(fd))?
-            .get_cap_mut(FileCaps::WRITE | FileCaps::SEEK)?;
+        let f = self.table().get_file(u32::from(fd))?;
+        let f = f.get_cap(FileCaps::WRITE | FileCaps::SEEK)?;
 
         let guest_slices: Vec<wiggle::GuestSlice<u8>> = ciovs
             .iter()
@@ -874,7 +866,7 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
             }
         }
 
-        let table = &mut self.table;
+        let table = &self.table;
         let mut sub_fds: HashSet<types::Fd> = HashSet::new();
         // We need these refmuts to outlive Poll, which will hold the &mut dyn WasiFile inside
         let mut reads: Vec<(u32, Userdata)> = Vec::new();
@@ -924,8 +916,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
                         sub_fds.insert(fd);
                     }
                     table
-                        .get_file_mut(u32::from(fd))?
-                        .get_cap_mut(FileCaps::POLL_READWRITE)?;
+                        .get_file(u32::from(fd))?
+                        .get_cap(FileCaps::POLL_READWRITE)?;
                     reads.push((u32::from(fd), sub.userdata.into()));
                 }
                 types::SubscriptionU::FdWrite(writesub) => {
@@ -937,8 +929,8 @@ impl wasi_unstable::WasiUnstable for WasiCtx {
                         sub_fds.insert(fd);
                     }
                     table
-                        .get_file_mut(u32::from(fd))?
-                        .get_cap_mut(FileCaps::POLL_READWRITE)?;
+                        .get_file(u32::from(fd))?
+                        .get_cap(FileCaps::POLL_READWRITE)?;
                     writes.push((u32::from(fd), sub.userdata.into()));
                 }
             }

--- a/crates/wasi-common/src/table.rs
+++ b/crates/wasi-common/src/table.rs
@@ -1,6 +1,7 @@
 use crate::{Error, ErrorExt};
 use std::any::Any;
 use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 /// The `Table` type is designed to map u32 handles to resources. The table is now part of the
 /// public interface to a `WasiCtx` - it is reference counted so that it can be shared beyond a
@@ -9,76 +10,67 @@ use std::collections::HashMap;
 ///
 /// The `Table` type is intended to model how the Interface Types concept of Resources is shaping
 /// up. Right now it is just an approximation.
-pub struct Table {
-    map: HashMap<u32, Box<dyn Any + Send + Sync>>,
+pub struct Table(RwLock<Inner>);
+
+struct Inner {
+    map: HashMap<u32, Arc<dyn Any + Send + Sync>>,
     next_key: u32,
 }
 
 impl Table {
     /// Create an empty table. New insertions will begin at 3, above stdio.
     pub fn new() -> Self {
-        Table {
+        Table(RwLock::new(Inner {
             map: HashMap::new(),
             next_key: 3, // 0, 1 and 2 are reserved for stdio
-        }
+        }))
     }
 
     /// Insert a resource at a certain index.
-    pub fn insert_at(&mut self, key: u32, a: Box<dyn Any + Send + Sync>) {
-        self.map.insert(key, a);
+    pub fn insert_at<T: Any + Send + Sync>(&self, key: u32, a: Arc<T>) {
+        self.0.write().unwrap().map.insert(key, a);
     }
 
     /// Insert a resource at the next available index.
-    pub fn push(&mut self, a: Box<dyn Any + Send + Sync>) -> Result<u32, Error> {
+    pub fn push<T: Any + Send + Sync>(&self, a: Arc<T>) -> Result<u32, Error> {
+        let mut inner = self.0.write().unwrap();
         // NOTE: The performance of this new key calculation could be very bad once keys wrap
         // around.
-        if self.map.len() == u32::MAX as usize {
+        if inner.map.len() == u32::MAX as usize {
             return Err(Error::trap(anyhow::Error::msg("table has no free keys")));
         }
         loop {
-            let key = self.next_key;
-            self.next_key = self.next_key.wrapping_add(1);
-            if self.map.contains_key(&key) {
+            let key = inner.next_key;
+            inner.next_key += 1;
+            if inner.map.contains_key(&key) {
                 continue;
             }
-            self.map.insert(key, a);
+            inner.map.insert(key, a);
             return Ok(key);
         }
     }
 
     /// Check if the table has a resource at the given index.
     pub fn contains_key(&self, key: u32) -> bool {
-        self.map.contains_key(&key)
+        self.0.read().unwrap().map.contains_key(&key)
     }
 
     /// Check if the resource at a given index can be downcast to a given type.
     /// Note: this will always fail if the resource is already borrowed.
     pub fn is<T: Any + Sized>(&self, key: u32) -> bool {
-        if let Some(r) = self.map.get(&key) {
+        if let Some(r) = self.0.read().unwrap().map.get(&key) {
             r.is::<T>()
         } else {
             false
         }
     }
 
-    /// Get an immutable reference to a resource of a given type at a given index. Multiple
-    /// immutable references can be borrowed at any given time. Borrow failure
-    /// results in a trapping error.
-    pub fn get<T: Any + Sized>(&self, key: u32) -> Result<&T, Error> {
-        if let Some(r) = self.map.get(&key) {
-            r.downcast_ref::<T>()
-                .ok_or_else(|| Error::badf().context("element is a different type"))
-        } else {
-            Err(Error::badf().context("key not in table"))
-        }
-    }
-
-    /// Get a mutable reference to a resource of a given type at a given index. Only one mutable
-    /// reference can be borrowed at any given time. Borrow failure results in a trapping error.
-    pub fn get_mut<T: Any + Sized>(&mut self, key: u32) -> Result<&mut T, Error> {
-        if let Some(r) = self.map.get_mut(&key) {
-            r.downcast_mut::<T>()
-                .ok_or_else(|| Error::badf().context("element is a different type"))
+    /// Get an Arc reference to a resource of a given type at a given index. Multiple
+    /// immutable references can be borrowed at any given time.
+    pub fn get<T: Any + Send + Sync + Sized>(&self, key: u32) -> Result<Arc<T>, Error> {
+        if let Some(r) = self.0.read().unwrap().map.get(&key).cloned() {
+            r.downcast::<T>()
+                .map_err(|_| Error::badf().context("element is a different type"))
         } else {
             Err(Error::badf().context("key not in table"))
         }
@@ -86,7 +78,21 @@ impl Table {
 
     /// Remove a resource at a given index from the table. Returns the resource
     /// if it was present.
-    pub fn delete(&mut self, key: u32) -> Option<Box<dyn Any + Send + Sync>> {
-        self.map.remove(&key)
+    pub fn delete<T: Any + Send + Sync>(&self, key: u32) -> Option<Arc<T>> {
+        self.0
+            .write()
+            .unwrap()
+            .map
+            .remove(&key)
+            .map(|r| r.downcast::<T>().unwrap())
+    }
+
+    /// Remove a resource at a given index from the table. Returns the resource
+    /// if it was present.
+    pub fn renumber(&self, from: u32, to: u32) -> Result<(), Error> {
+        let map = &mut self.0.write().unwrap().map;
+        let from_entry = map.remove(&from).ok_or(Error::badf())?;
+        map.insert(to, from_entry);
+        Ok(())
     }
 }

--- a/crates/wasi-common/tokio/src/file.rs
+++ b/crates/wasi-common/tokio/src/file.rs
@@ -4,7 +4,9 @@ use io_extras::os::windows::{AsRawHandleOrSocket, RawHandleOrSocket};
 #[cfg(not(windows))]
 use io_lifetimes::AsFd;
 use std::any::Any;
+use std::borrow::Borrow;
 use std::io;
+use std::sync::Arc;
 use wasi_common::{
     file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error,
@@ -95,81 +97,80 @@ macro_rules! wasi_file_impl {
                 self
             }
             #[cfg(unix)]
-            fn pollable(&self) -> Option<rustix::fd::BorrowedFd> {
-                Some(self.0.as_fd())
+            fn pollable(&self) -> Option<Arc<dyn AsFd + '_>> {
+                self.0.pollable()
             }
-
             #[cfg(windows)]
-            fn pollable(&self) -> Option<io_extras::os::windows::RawHandleOrSocket> {
-                Some(self.0.as_raw_handle_or_socket())
+            fn pollable(&self) -> Option<Arc<dyn AsRawHandleOrSocket + '_>> {
+                self.0.pollable()
             }
-            async fn datasync(&mut self) -> Result<(), Error> {
+            async fn datasync(&self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.datasync())
             }
-            async fn sync(&mut self) -> Result<(), Error> {
+            async fn sync(&self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.sync())
             }
-            async fn get_filetype(&mut self) -> Result<FileType, Error> {
+            async fn get_filetype(&self) -> Result<FileType, Error> {
                 block_on_dummy_executor(|| self.0.get_filetype())
             }
-            async fn get_fdflags(&mut self) -> Result<FdFlags, Error> {
+            async fn get_fdflags(&self) -> Result<FdFlags, Error> {
                 block_on_dummy_executor(|| self.0.get_fdflags())
             }
-            async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
+            async fn set_fdflags(&self, fdflags: FdFlags) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.set_fdflags(fdflags))
             }
-            async fn get_filestat(&mut self) -> Result<Filestat, Error> {
+            async fn get_filestat(&self) -> Result<Filestat, Error> {
                 block_on_dummy_executor(|| self.0.get_filestat())
             }
-            async fn set_filestat_size(&mut self, size: u64) -> Result<(), Error> {
+            async fn set_filestat_size(&self, size: u64) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.set_filestat_size(size))
             }
-            async fn advise(&mut self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
+            async fn advise(&self, offset: u64, len: u64, advice: Advice) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.advise(offset, len, advice))
             }
-            async fn allocate(&mut self, offset: u64, len: u64) -> Result<(), Error> {
+            async fn allocate(&self, offset: u64, len: u64) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.allocate(offset, len))
             }
             async fn read_vectored<'a>(
-                &mut self,
+                &self,
                 bufs: &mut [io::IoSliceMut<'a>],
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.read_vectored(bufs))
             }
             async fn read_vectored_at<'a>(
-                &mut self,
+                &self,
                 bufs: &mut [io::IoSliceMut<'a>],
                 offset: u64,
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.read_vectored_at(bufs, offset))
             }
-            async fn write_vectored<'a>(&mut self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
+            async fn write_vectored<'a>(&self, bufs: &[io::IoSlice<'a>]) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.write_vectored(bufs))
             }
             async fn write_vectored_at<'a>(
-                &mut self,
+                &self,
                 bufs: &[io::IoSlice<'a>],
                 offset: u64,
             ) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.write_vectored_at(bufs, offset))
             }
-            async fn seek(&mut self, pos: std::io::SeekFrom) -> Result<u64, Error> {
+            async fn seek(&self, pos: std::io::SeekFrom) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.seek(pos))
             }
-            async fn peek(&mut self, buf: &mut [u8]) -> Result<u64, Error> {
+            async fn peek(&self, buf: &mut [u8]) -> Result<u64, Error> {
                 block_on_dummy_executor(move || self.0.peek(buf))
             }
             async fn set_times(
-                &mut self,
+                &self,
                 atime: Option<wasi_common::SystemTimeSpec>,
                 mtime: Option<wasi_common::SystemTimeSpec>,
             ) -> Result<(), Error> {
                 block_on_dummy_executor(move || self.0.set_times(atime, mtime))
             }
-            async fn num_ready_bytes(&self) -> Result<u64, Error> {
-                block_on_dummy_executor(|| self.0.num_ready_bytes())
+            fn num_ready_bytes(&self) -> Result<u64, Error> {
+                self.0.num_ready_bytes()
             }
-            fn isatty(&mut self) -> bool {
+            fn isatty(&self) -> bool {
                 self.0.isatty()
             }
 
@@ -182,7 +183,7 @@ macro_rules! wasi_file_impl {
                 // lifetime of the AsyncFd.
                 use std::os::unix::io::AsRawFd;
                 use tokio::io::{unix::AsyncFd, Interest};
-                let rawfd = self.0.as_fd().as_raw_fd();
+                let rawfd = self.0.borrow().as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::READABLE) {
                     Ok(asyncfd) => {
                         let _ = asyncfd.readable().await?;
@@ -206,7 +207,7 @@ macro_rules! wasi_file_impl {
                 // lifetime of the AsyncFd.
                 use std::os::unix::io::AsRawFd;
                 use tokio::io::{unix::AsyncFd, Interest};
-                let rawfd = self.0.as_fd().as_raw_fd();
+                let rawfd = self.0.borrow().as_fd().as_raw_fd();
                 match AsyncFd::with_interest(rawfd, Interest::WRITABLE) {
                     Ok(asyncfd) => {
                         let _ = asyncfd.writable().await?;
@@ -221,7 +222,7 @@ macro_rules! wasi_file_impl {
                 }
             }
 
-            async fn sock_accept(&mut self, fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
+            async fn sock_accept(&self, fdflags: FdFlags) -> Result<Box<dyn WasiFile>, Error> {
                 block_on_dummy_executor(|| self.0.sock_accept(fdflags))
             }
         }
@@ -229,7 +230,7 @@ macro_rules! wasi_file_impl {
         impl AsRawHandleOrSocket for $ty {
             #[inline]
             fn as_raw_handle_or_socket(&self) -> RawHandleOrSocket {
-                self.0.as_raw_handle_or_socket()
+                self.0.borrow().as_raw_handle_or_socket()
             }
         }
     };

--- a/crates/wasi-common/tokio/src/lib.rs
+++ b/crates/wasi-common/tokio/src/lib.rs
@@ -62,15 +62,15 @@ impl WasiCtxBuilder {
         }
         Ok(self)
     }
-    pub fn stdin(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stdin(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stdin(f);
         self
     }
-    pub fn stdout(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stdout(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stdout(f);
         self
     }
-    pub fn stderr(mut self, f: Box<dyn WasiFile>) -> Self {
+    pub fn stderr(self, f: Box<dyn WasiFile>) -> Self {
         self.0.set_stderr(f);
         self
     }
@@ -87,7 +87,7 @@ impl WasiCtxBuilder {
         self.inherit_stdin().inherit_stdout().inherit_stderr()
     }
     pub fn preopened_dir(
-        mut self,
+        self,
         dir: cap_std::fs::Dir,
         guest_path: impl AsRef<Path>,
     ) -> Result<Self, Error> {
@@ -95,7 +95,7 @@ impl WasiCtxBuilder {
         self.0.push_preopened_dir(dir, guest_path)?;
         Ok(self)
     }
-    pub fn preopened_socket(mut self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
+    pub fn preopened_socket(self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
         let socket: Socket = socket.into();
         let file: Box<dyn WasiFile> = socket.into();
 

--- a/crates/wasi-common/tokio/src/sched/unix.rs
+++ b/crates/wasi-common/tokio/src/sched/unix.rs
@@ -63,7 +63,6 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                     f.complete(
                         f.file
                             .num_ready_bytes()
-                            .await
                             .map_err(|e| e.context("read num_ready_bytes"))?,
                         RwEventFlags::empty(),
                     );

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -20,7 +20,7 @@ async fn empty_file_readable() -> Result<(), Error> {
     let d = workspace.open_dir("d").context("open dir")?;
     let d = Dir::from_cap_std(d);
 
-    let mut f = d
+    let f = d
         .open_file(false, "f", OFlags::CREATE, false, true, FdFlags::empty())
         .await
         .context("create writable file f")?;


### PR DESCRIPTION
This patch adds interior mutability to the WasiCtx Table and the Table elements.

Major pain points:
* `File` only needs `RwLock<cap_std::fs::File>` to implement `File::set_fdflags()` on Windows, because of https://github.com/bytecodealliance/system-interface/blob/da238e324e752033f315f09c082ad9ce35d42696/src/fs/fd_flags.rs#L210-L217
* Because `File` needs a `RwLock` and `RwLock*Guard` cannot be hold across an `.await`, The `async` from `async fn num_ready_bytes(&self)` had to be removed
* Because `File` needs a `RwLock` and `RwLock*Guard` cannot be dereferenced in `pollable`, the signature of `fn pollable(&self) -> Option<rustix::fd::BorrowedFd>` changed to `fn pollable(&self) -> Option<Arc<dyn AsFd + '_>>`

Related: https://github.com/bytecodealliance/wasmtime/issues/5235