### PR TITLE
Cranelift: log number of CLIF insts/blocks to optimize/lower

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -148,8 +148,17 @@ impl Context {
     ///
     /// Public only for testing purposes.
     pub fn optimize(&mut self, isa: &dyn TargetIsa) -> CodegenResult<()> {
+        log::debug!(
+            "Number of CLIF instructions to optimize: {}",
+            self.func.dfg.num_insts()
+        );
+        log::debug!(
+            "Number of CLIF blocks to optimize: {}",
+            self.func.dfg.num_blocks()
+        );
+
         let opt_level = isa.flags().opt_level();
-        log::trace!(
+        crate::trace!(
             "Optimizing (opt level {:?}):\n{}",
             opt_level,
             self.func.display()

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -35,6 +35,12 @@ pub fn compile<B: LowerBackend + TargetIsa>(
 
     // Lower the IR.
     let vcode = {
+        log::debug!(
+            "Number of CLIF instructions to lower: {}",
+            f.dfg.num_insts()
+        );
+        log::debug!("Number of CLIF blocks to lower: {}", f.dfg.num_blocks());
+
         let _tt = timing::vcode_lower();
         lower.lower(b)?
     };


### PR DESCRIPTION
Similar to #5332 but for CLIF rather than vcode.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
