### PR TITLE
Cranelift: consider heap's guard pages when legalizing `heap_addr`

### DIFF
--- a/cranelift/codegen/src/legalizer/heap.rs
+++ b/cranelift/codegen/src/legalizer/heap.rs
@@ -197,10 +197,10 @@ fn static_addr(
     // (Note that `bound + guard_size` cannot overflow for correctly-configured
     // heaps, as otherwise the heap wouldn't fit in a 64-bit memory space.)
     //
-    // If we know the right-hand side is greater than or equal to 4GiB then with
-    // a 32-bit index we're guaranteed:
+    // If we know the right-hand side is greater than or equal to 4GiB - 1, aka
+    // 0xffff_ffff, then with a 32-bit index we're guaranteed:
     //
-    //     index < 4GiB <= bound + guard_size - offset - access_size
+    //     index <= 0xffff_ffff <= bound + guard_size - offset - access_size
     //
     // meaning that `index` is always either in bounds or within the guard page
     // region, neither of which require emitting an explicit bounds check.

--- a/cranelift/filetests/filetests/legalizer/static-heap-with-guard-pages.clif
+++ b/cranelift/filetests/filetests/legalizer/static-heap-with-guard-pages.clif
@@ -1,0 +1,21 @@
+test legalizer
+set enable_heap_access_spectre_mitigation=true
+target x86_64
+
+;; The offset guard is large enough that we don't need explicit bounds checks.
+
+function %test(i64 vmctx, i32) -> i64 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0+0
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i32
+
+block0(v0: i64, v1: i32):
+    v2 = heap_addr.i64 heap0, v1, 0, 4
+    return v2
+}
+
+; check:  block0(v0: i64, v1: i32):
+; nextln:     v3 = uextend.i64 v1
+; nextln:     v4 = load.i64 notrap aligned v0
+; nextln:     v2 = iadd v4, v3
+; nextln:     return v2

--- a/cranelift/filetests/filetests/legalizer/static-heap-without-guard-pages.clif
+++ b/cranelift/filetests/filetests/legalizer/static-heap-without-guard-pages.clif
@@ -1,0 +1,34 @@
+test legalizer
+set enable_heap_access_spectre_mitigation=true
+target x86_64
+
+;; The offset guard is not large enough to avoid explicit bounds checks.
+
+function %test(i64 vmctx, i32) -> i64 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0+0
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_0000, index_type i32
+
+block0(v0: i64, v1: i32):
+    v2 = heap_addr.i64 heap0, v1, 0, 4
+    return v2
+}
+
+; check:  block0(v0: i64, v1: i32):
+; nextln:     v3 = uextend.i64 v1
+; nextln:     v10 = iconst.i64 4092
+; nextln:     v4 = icmp ugt v3, v10  ; v10 = 4092
+; nextln:     brz v4, block2
+; nextln:     jump block1
+; nextln: 
+; nextln: block1:
+; nextln:     trap heap_oob
+; nextln: 
+; nextln: block2:
+; nextln:     v5 = iconst.i64 4092
+; nextln:     v6 = load.i64 notrap aligned v0
+; nextln:     v7 = iadd v6, v3
+; nextln:     v8 = iconst.i64 0
+; nextln:     v9 = icmp.i64 ugt v3, v5  ; v5 = 4092
+; nextln:     v2 = select_spectre_guard v9, v8, v7  ; v8 = 0
+; nextln:     return v2


### PR DESCRIPTION
Fixes #5328

FYI, I opted not to mess with or dedupe the similar logic in `cranelift-wasm` since that stuff is going to go away soon-ish when we remove `heap_addr` and collect all this logic into `heap_{load,store}`. Excited to get to a point where this logic isn't spread across crates and straddling interfaces.