### PR TITLE
Don't allow reuse_def constraints in the s390x Loop instruction

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1068,6 +1068,12 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
             for inst in body.iter() {
                 s390x_get_operands(inst, collector);
             }
+
+            // `reuse_def` constraints can't be permitted in a Loop instruction because the operand
+            // index will always be relative to the Loop instruction, not the individual
+            // instruction in the loop body. However, fixed-nonallocatable registers used with
+            // instructions that would have emitted `reuse_def` constraints are fine.
+            debug_assert!(collector.no_reuse_def());
         }
         &Inst::CondBreak { .. } => {}
         &Inst::VirtualSPOffsetAdj { .. } => {}

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -4,7 +4,7 @@
 
 use alloc::{string::String, vec::Vec};
 use core::{fmt::Debug, hash::Hash};
-use regalloc2::{Allocation, MachineEnv, Operand, PReg, PRegSet, VReg};
+use regalloc2::{Allocation, MachineEnv, Operand, OperandConstraint, PReg, PRegSet, VReg};
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -327,6 +327,16 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
             allocatable,
             renamer,
         }
+    }
+
+    /// Returns true if no reuse_def constraints have been added.
+    pub fn no_reuse_def(&self) -> bool {
+        !self.operands[self.operands_start..]
+            .iter()
+            .any(|operand| match operand.constraint() {
+                OperandConstraint::Reuse(_) => true,
+                _ => false,
+            })
     }
 
     fn is_allocatable_preg(&self, reg: PReg) -> bool {


### PR DESCRIPTION
Assert that instructions in the body of the s390x `Loop` pseudo-instruction do not add `reuse_def` constraints, as the indices they refer to would be relative to the `Loop` instruction, not their own constraints.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
