### PR TITLE
cranelift-isle: Minor error-handling cleanups

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -99,7 +99,7 @@ incremental-cache = [
 # Enable support for the Souper harvester.
 souper-harvest = ["souper-ir", "souper-ir/stringify"]
 
-# Provide fancy Miette-produced errors for ISLE.
+# Report any ISLE errors in pretty-printed style.
 isle-errors = ["cranelift-isle/fancy-errors"]
 
 # Put ISLE generated files in isle_generated_code/, for easier

--- a/cranelift/docs/isle-integration.md
+++ b/cranelift/docs/isle-integration.md
@@ -40,8 +40,7 @@ could cause significant confusion.
 If there are any errors during ISLE compilation (e.g., a type mismatch), you
 will see a basic error message with a file, line number, and one-line error. To
 see a more detailed output with context, `--features isle-errors` can be used.
-This will leverage the `miette` error-reporting library to give pretty-printed
-errors with source context.
+This will give pretty-printed errors with source context.
 
 Additionally, the `cranelift-codegen-meta` crate will automatically generate
 ISLE `extern` declarations and helpers for working with CLIF. The code that does

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -1176,7 +1176,7 @@ impl TermEnv {
                                 ()
                             })
                         })
-                        .collect::<std::result::Result<Vec<_>, _>>();
+                        .collect::<Result<Vec<_>, _>>();
                     let arg_tys = match arg_tys {
                         Ok(a) => a,
                         Err(_) => {


### PR DESCRIPTION
- Remove remaining references to Miette
- Borrow implementation of `line_starts` from codespan-reporting
- Clean up a use of `Result` that no longer conflicts with a local definition
- When printing plain errors, add a blank line between errors for readability

Extracted from #5322.