### PR TITLE
Add a `WasmBacktrace::new()` constructor

### DIFF
--- a/crates/runtime/src/traphandlers/backtrace.rs
+++ b/crates/runtime/src/traphandlers/backtrace.rs
@@ -74,6 +74,11 @@ impl Frame {
 }
 
 impl Backtrace {
+    /// Returns an empty backtrace
+    pub fn empty() -> Backtrace {
+        Backtrace(Vec::new())
+    }
+
     /// Capture the current Wasm stack in a backtrace.
     pub fn new() -> Backtrace {
         tls::with(|state| match state {

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -222,7 +222,7 @@ impl WasmBacktrace {
     ///
     /// let mut store = Store::new(&engine, ());
     /// let func = Func::wrap(&mut store, |cx: Caller<'_, ()>| {
-    ///     let trace = WasmBacktrace::new(&cx);
+    ///     let trace = WasmBacktrace::capture(&cx);
     ///     println!("{trace:?}");
     /// });
     /// let instance = Instance::new(&mut store, &module, &[func.into()])?;


### PR DESCRIPTION
This commit adds a method of manually capturing a backtrace of WebAssembly frames within a `Store`. The new constructor can be called with any `AsContext` values, primarily `&Store` and `&Caller`, during host functions to inspect the calling state.

For now this does not respect the `Config::wasm_backtrace` option and instead unconditionally captures the backtrace. It's hoped that this can continue to adapt to needs of embedders by making it more configurable int he future if necessary.

Closes #5339

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
