### PR TITLE
Fuel documentation fixes

### DIFF
--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -766,10 +766,10 @@ impl<T> Store<T> {
     /// Note that at this time when fuel is entirely consumed it will cause
     /// wasm to trap. More usages of fuel are planned for the future.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if the store's [`Config`](crate::Config) did
-    /// not have fuel consumption enabled.
+    /// This function will return an error if fuel consumption is not enabled via
+    /// [`Config::consume_fuel`](crate::Config::consume_fuel).
     pub fn add_fuel(&mut self, fuel: u64) -> Result<()> {
         self.inner.add_fuel(fuel)
     }
@@ -790,9 +790,9 @@ impl<T> Store<T> {
     ///
     /// # Errors
     ///
-    /// This function will return an either either if fuel consumption via
-    /// [`Config`](crate::Config) is disabled or if `fuel` exceeds the amount
-    /// of remaining fuel within this store.
+    /// This function will return an error either if fuel consumption is not
+    /// enabled via [`Config::consume_fuel`](crate::Config::consume_fuel) or if
+    /// `fuel` exceeds the amount of remaining fuel within this store.
     pub fn consume_fuel(&mut self, fuel: u64) -> Result<u64> {
         self.inner.consume_fuel(fuel)
     }


### PR DESCRIPTION
Minor changes to the Store's documentation for fuel:

- `Store::add_fuel` documentation said it'd panic when the engine is not configured to have fuel, but it in fact returns an error[1].

- There was a typo in `Store::add_fuel`'s documentation (either either). I "fixed" the typo by rewording the section using the same wording as `Store::fuel_consumed` (_if fuel consumption is not enabled via..._)

[1]: https://github.com/bytecodealliance/wasmtime/blob/ff5abfd9938c78cd75c6c5d6a41565097128c5d3/crates/wasmtime/src/store.rs#L1397-L1400

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
