### PR TITLE
Bump regalloc2 to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2eab54204ea0117fe9a060537e0b07a4e72f7c7d182361ecc346cab2240e5"
+checksum = "10b072c75d1b10368447a55cf1d589f2527d956e92c281c81c3e788cda81b983"
 dependencies = [
  "fxhash",
  "log",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
-regalloc2 = { version = "0.4.2", features = ["checker"] }
+regalloc2 = { version = "0.5.0", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -25,7 +25,7 @@ use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::fmt::Debug;
 
-use super::{preg_set_from_machine_env, VCodeBuildDirection, VRegAllocator};
+use super::{VCodeBuildDirection, VRegAllocator};
 
 /// An "instruction color" partitions CLIF instructions by side-effecting ops.
 /// All instructions with the same "color" are guaranteed not to be separated by
@@ -417,7 +417,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         Ok(Lower {
             f,
             flags,
-            allocatable: preg_set_from_machine_env(machine_env),
+            allocatable: PRegSet::from(machine_env),
             vcode,
             vregs,
             value_regs,

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -4,7 +4,7 @@
 
 use alloc::{string::String, vec::Vec};
 use core::{fmt::Debug, hash::Hash};
-use regalloc2::{Allocation, MachineEnv, Operand, OperandConstraint, PReg, PRegSet, VReg};
+use regalloc2::{Allocation, Operand, OperandConstraint, PReg, PRegSet, VReg};
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -36,26 +36,6 @@ pub fn first_user_vreg_index() -> usize {
     // specific name in order to ensure other parts of the code don't
     // open-code and depend on the index-space scheme.
     PINNED_VREGS
-}
-
-/// Collect the registers from a regalloc2 MachineEnv into a PRegSet.
-/// TODO: remove this once it's upstreamed in regalloc2
-pub fn preg_set_from_machine_env(machine_env: &MachineEnv) -> PRegSet {
-    let mut regs = PRegSet::default();
-
-    for class in machine_env.preferred_regs_by_class.iter() {
-        for reg in class.iter() {
-            regs.add(*reg);
-        }
-    }
-
-    for class in machine_env.non_preferred_regs_by_class.iter() {
-        for reg in class.iter() {
-            regs.add(*reg);
-        }
-    }
-
-    regs
 }
 
 /// A register named in an instruction. This register can be either a

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -416,6 +416,12 @@ criteria = "safe-to-deploy"
 delta = "0.4.1 -> 0.4.2"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[audits.regalloc2]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.5.0"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 # In the next iteration we'll factor out the common bits so that they can be consumed
 # by Cranelift and Winch.
 cranelift-codegen = { workspace = true }
-regalloc2 = "0.4.2"
+regalloc2 = "0.5.0"
 
 [features]
 x64 = ["cranelift-codegen/x86"]


### PR DESCRIPTION
- Bump the regalloc2 dependency to 0.5.0
- Replace preg_set_from_machine_env with PRegSet::from

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
