### PR TITLE
Tidy up some internals of instance allocation

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -31,11 +31,6 @@ use cranelift_entity::packed_option::ReservedValue;
 use std::convert::TryFrom;
 use wasmtime_types::OwnedMemoryIndex;
 
-/// Sentinel value indicating that wasm has been interrupted.
-// Note that this has a bit of an odd definition. See the `insert_stack_check`
-// function in `cranelift/codegen/src/isa/x86/abi.rs` for more information
-pub const INTERRUPTED: usize = usize::max_value() - 32 * 1024;
-
 #[cfg(target_pointer_width = "32")]
 fn cast_to_u32(sz: usize) -> u32 {
     u32::try_from(sz).unwrap()

--- a/crates/jit/src/profiling/jitdump_linux.rs
+++ b/crates/jit/src/profiling/jitdump_linux.rs
@@ -83,7 +83,8 @@ impl State {
         let tid = pid; // ThreadId does appear to track underlying thread. Using PID.
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((*func).as_ptr().cast::<u8>(), (*func).len()) };
+            let addr = func.as_ptr();
+            let len = func.len();
             if let Some(img) = &dbg_image {
                 if let Err(err) = self.dump_from_debug_image(img, "wasm", addr, len, pid, tid) {
                     println!(

--- a/crates/jit/src/profiling/vtune.rs
+++ b/crates/jit/src/profiling/vtune.rs
@@ -93,7 +93,8 @@ impl State {
             .unwrap_or_else(|| format!("wasm_module_{}", global_module_id));
 
         for (idx, func) in module.finished_functions() {
-            let (addr, len) = unsafe { ((*func).as_ptr().cast::<u8>(), (*func).len()) };
+            let addr = func.as_ptr();
+            let len = func.len();
             let method_name = super::debug_name(module, idx);
             log::trace!(
                 "new function {:?}::{:?} @ {:?}\n",

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -503,9 +503,7 @@ impl Instance {
 
         let (func_ptr, vmctx) = if let Some(def_index) = self.module().defined_func_index(index) {
             (
-                (self.runtime_info.image_base()
-                    + self.runtime_info.function_loc(def_index).start as usize)
-                    as *mut _,
+                self.runtime_info.function(def_index),
                 VMOpaqueContext::from_vmcontext(self.vmctx_ptr()),
             )
         } else {

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -13,7 +13,7 @@ use crate::vmcontext::{
 };
 use crate::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, Imports, ModuleRuntimeInfo, Store,
-    VMFunctionBody,
+    VMFunctionBody, VMSharedSignatureIndex,
 };
 use anyhow::Error;
 use memoffset::offset_of;
@@ -499,7 +499,11 @@ impl Instance {
         sig: SignatureIndex,
         into: *mut VMCallerCheckedAnyfunc,
     ) {
-        let type_index = self.runtime_info.signature(sig);
+        let type_index = unsafe {
+            let base: *const VMSharedSignatureIndex =
+                *self.vmctx_plus_offset(self.offsets.vmctx_signature_ids_array());
+            *base.add(sig.index())
+        };
 
         let (func_ptr, vmctx) = if let Some(def_index) = self.module().defined_func_index(index) {
             (

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -92,8 +92,8 @@ impl StorePtr {
 /// This trait is unsafe as it requires knowledge of Wasmtime's runtime internals to implement correctly.
 pub unsafe trait InstanceAllocator: Send + Sync {
     /// Validates that a module is supported by the allocator.
-    fn validate(&self, module: &Module) -> Result<()> {
-        drop(module);
+    fn validate(&self, module: &Module, offsets: &VMOffsets<HostPtr>) -> Result<()> {
+        drop((module, offsets));
         Ok(())
     }
 
@@ -464,11 +464,9 @@ pub unsafe fn allocate_single_memory_instance(
     let mut memories = PrimaryMap::default();
     memories.push(memory);
     let tables = PrimaryMap::default();
-    let module = req.runtime_info.module();
-    let offsets = VMOffsets::new(HostPtr, module);
-    let layout = Instance::alloc_layout(&offsets);
+    let layout = Instance::alloc_layout(req.runtime_info.offsets());
     let instance = alloc::alloc(layout) as *mut Instance;
-    Instance::new_at(instance, layout.size(), offsets, req, memories, tables);
+    Instance::new_at(instance, layout.size(), req, memories, tables);
     Ok(InstanceHandle { instance })
 }
 
@@ -476,7 +474,7 @@ pub unsafe fn allocate_single_memory_instance(
 ///
 /// See [`InstanceAllocator::deallocate()`] for more details.
 pub unsafe fn deallocate(handle: &InstanceHandle) {
-    let layout = Instance::alloc_layout(&handle.instance().offsets);
+    let layout = Instance::alloc_layout(handle.instance().offsets());
     ptr::drop_in_place(handle.instance);
     alloc::dealloc(handle.instance.cast(), layout);
 }
@@ -485,12 +483,10 @@ unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
     unsafe fn allocate(&self, mut req: InstanceAllocationRequest) -> Result<InstanceHandle> {
         let memories = self.create_memories(&mut req.store, &req.runtime_info)?;
         let tables = Self::create_tables(&mut req.store, &req.runtime_info)?;
-        let module = req.runtime_info.module();
-        let offsets = VMOffsets::new(HostPtr, module);
-        let layout = Instance::alloc_layout(&offsets);
+        let layout = Instance::alloc_layout(req.runtime_info.offsets());
         let instance_ptr = alloc::alloc(layout) as *mut Instance;
 
-        Instance::new_at(instance_ptr, layout.size(), offsets, req, memories, tables);
+        Instance::new_at(instance_ptr, layout.size(), req, memories, tables);
 
         Ok(InstanceHandle {
             instance: instance_ptr,

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -97,13 +97,6 @@ pub unsafe trait InstanceAllocator: Send + Sync {
         Ok(())
     }
 
-    /// Adjusts the tunables prior to creation of any JIT compiler.
-    ///
-    /// This method allows the instance allocator control over tunables passed to a `wasmtime_jit::Compiler`.
-    fn adjust_tunables(&self, tunables: &mut wasmtime_environ::Tunables) {
-        drop(tunables);
-    }
-
     /// Allocates an instance for the given allocation request.
     ///
     /// # Safety

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -23,8 +23,7 @@
 use anyhow::Error;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use wasmtime_environ::DefinedFuncIndex;
-use wasmtime_environ::DefinedMemoryIndex;
+use wasmtime_environ::{DefinedFuncIndex, DefinedMemoryIndex, HostPtr, VMOffsets};
 
 #[macro_use]
 mod trampolines;
@@ -189,6 +188,9 @@ pub trait ModuleRuntimeInfo: Send + Sync + 'static {
     /// Returns an array, indexed by `SignatureIndex` of all
     /// `VMSharedSignatureIndex` entries corresponding to the `SignatureIndex`.
     fn signature_ids(&self) -> &[VMSharedSignatureIndex];
+
+    /// Offset information for the current host.
+    fn offsets(&self) -> &VMOffsets<HostPtr>;
 }
 
 /// Returns the host OS page size, in bytes.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,7 +25,6 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use wasmtime_environ::DefinedFuncIndex;
 use wasmtime_environ::DefinedMemoryIndex;
-use wasmtime_environ::SignatureIndex;
 
 #[macro_use]
 mod trampolines;
@@ -170,9 +169,6 @@ pub unsafe trait Store {
 pub trait ModuleRuntimeInfo: Send + Sync + 'static {
     /// The underlying Module.
     fn module(&self) -> &Arc<wasmtime_environ::Module>;
-
-    /// The signatures.
-    fn signature(&self, index: SignatureIndex) -> VMSharedSignatureIndex;
 
     /// Returns the address, in memory, that the function `index` resides at.
     fn function(&self, index: DefinedFuncIndex) -> *mut VMFunctionBody;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -25,7 +25,6 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use wasmtime_environ::DefinedFuncIndex;
 use wasmtime_environ::DefinedMemoryIndex;
-use wasmtime_environ::FunctionLoc;
 use wasmtime_environ::SignatureIndex;
 
 #[macro_use]
@@ -175,12 +174,8 @@ pub trait ModuleRuntimeInfo: Send + Sync + 'static {
     /// The signatures.
     fn signature(&self, index: SignatureIndex) -> VMSharedSignatureIndex;
 
-    /// The base address of where JIT functions are located.
-    fn image_base(&self) -> usize;
-
-    /// Descriptors about each compiled function, such as the offset from
-    /// `image_base`.
-    fn function_loc(&self, func_index: DefinedFuncIndex) -> &FunctionLoc;
+    /// Returns the address, in memory, that the function `index` resides at.
+    fn function(&self, index: DefinedFuncIndex) -> *mut VMFunctionBody;
 
     /// Returns the `MemoryImage` structure used for copy-on-write
     /// initialization of the memory, if it's applicable.

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -88,7 +88,6 @@ impl Engine {
         let compiler = config.build_compiler()?;
 
         let allocator = config.build_allocator()?;
-        allocator.adjust_tunables(&mut config.tunables);
         let profiler = config.build_profiler()?;
 
         Ok(Engine {

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -86,6 +86,7 @@ impl Engine {
 
         #[cfg(compiler)]
         let compiler = config.build_compiler()?;
+        drop(&mut config); // silence warnings without `cfg(compiler)`
 
         let allocator = config.build_allocator()?;
         let profiler = config.build_profiler()?;

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -161,7 +161,7 @@ impl LoadedCode {
             // functions.
             None => return,
         };
-        let start = unsafe { (*func).as_ptr() as usize };
+        let start = func.as_ptr() as usize;
 
         match self.modules.entry(start) {
             // This module is already present, and it should be the same as

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -279,9 +279,9 @@ fn test_frame_info() -> Result<(), anyhow::Error> {
     Instance::new(&mut store, &module, &[])?;
 
     for (i, alloc) in module.compiled_module().finished_functions() {
-        let (start, end) = unsafe {
-            let ptr = (*alloc).as_ptr();
-            let len = (*alloc).len();
+        let (start, end) = {
+            let ptr = alloc.as_ptr();
+            let len = alloc.len();
             (ptr as usize, ptr as usize + len)
         };
         for pc in start..end {

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -17,7 +17,7 @@ use crate::{GlobalType, MemoryType, TableType, Val};
 use anyhow::Result;
 use std::any::Any;
 use std::sync::Arc;
-use wasmtime_environ::{GlobalIndex, MemoryIndex, Module, SignatureIndex, TableIndex};
+use wasmtime_environ::{GlobalIndex, MemoryIndex, Module, TableIndex};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator, SharedMemory,
     StorePtr, VMFunctionImport, VMSharedSignatureIndex,
@@ -28,7 +28,7 @@ fn create_handle(
     store: &mut StoreOpaque,
     host_state: Box<dyn Any + Send + Sync>,
     func_imports: &[VMFunctionImport],
-    one_signature: Option<(SignatureIndex, VMSharedSignatureIndex)>,
+    one_signature: Option<VMSharedSignatureIndex>,
 ) -> Result<InstanceId> {
     let mut imports = Imports::default();
     imports.functions = func_imports;

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -39,8 +39,8 @@ pub fn create_global(store: &mut StoreOpaque, gt: &GlobalType, val: Val) -> Resu
                 // our global with a `ref.func` to grab that imported function.
                 let f = f.caller_checked_anyfunc(store);
                 let f = unsafe { f.as_ref() };
-                let sig_id = SignatureIndex::from_u32(u32::max_value() - 1);
-                one_signature = Some((sig_id, f.type_index));
+                let sig_id = SignatureIndex::from_u32(0);
+                one_signature = Some(f.type_index);
                 module.types.push(ModuleType::Function(sig_id));
                 let func_index = module.push_escaped_function(sig_id, AnyfuncIndex::from_u32(0));
                 module.num_imported_funcs = 1;

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -646,10 +646,11 @@ fn instance_too_large() -> Result<()> {
 
     let engine = Engine::new(&config)?;
     let expected = "\
-instance allocation for this module requires 336 bytes which exceeds the \
+instance allocation for this module requires 224 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 76.19% - 256 bytes - instance state management
+ * 64.29% - 144 bytes - instance state management
+ * 7.14% - 16 bytes - jit store state
 ";
     match Module::new(&engine, "(module)") {
         Ok(_) => panic!("should have failed to compile"),
@@ -663,11 +664,11 @@ configured maximum of 16 bytes; breakdown of allocation requirement:
     lots_of_globals.push_str(")");
 
     let expected = "\
-instance allocation for this module requires 1936 bytes which exceeds the \
+instance allocation for this module requires 1824 bytes which exceeds the \
 configured maximum of 16 bytes; breakdown of allocation requirement:
 
- * 13.22% - 256 bytes - instance state management
- * 82.64% - 1600 bytes - defined globals
+ * 7.89% - 144 bytes - instance state management
+ * 87.72% - 1600 bytes - defined globals
 ";
     match Module::new(&engine, &lots_of_globals) {
         Ok(_) => panic!("should have failed to compile"),


### PR DESCRIPTION
This is a series of commits in preparation for eventually more closely integrating components with the pooling instance allocator. None of these are directly related to the end goal but were cleanups I noticed while reading through existing code and figure out how best to structure things. The main benefits of this commit are:

* Simplification of `ModuleRuntimeInfo` by coalescing some methods and removing extraneous ones.
* Some dead code elimination
* Removal of the computation of `VMOffsets` on each instantiation, now performed only once during module construction.