### PR TITLE
Cranelift: fix `heap_{load,store}` test generator script

### DIFF
--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_no_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_no_guards_no_spectre.clif
@@ -9,30 +9,30 @@ test interpret
 
 set enable_heap_access_spectre_mitigation=false
 
-function %do_store(i64 vmctx, i64, i32) {
+function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i32
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
     return
 }
 
-function %test(i64 vmctx, i64, i32) -> i32 {
+function %test(i64 vmctx, i32, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
-    fn0 = %do_store(i64, i64, i32)
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i32
+    fn0 = %do_store(i64, i32, i32)
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     call fn0(v0, v1, v2)
     v3 = heap_load.i32 heap0 little v1+4
     return v3
 }
-; heap: static, size=0x1000, ptr=vmctx+0, bound=vmctx+8
+; heap: dynamic, size=0x1000, ptr=vmctx+0, bound=vmctx+8
 ; run: %test(0, 0) == 0
 ; run: %test(0, -1) == -1
 ; run: %test(16, 1) == 1

--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_no_guards_yes_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_no_guards_yes_spectre.clif
@@ -7,32 +7,32 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=false
+set enable_heap_access_spectre_mitigation=true
 
-function %do_store(i64 vmctx, i64, i32) {
+function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i32
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
     return
 }
 
-function %test(i64 vmctx, i64, i32) -> i32 {
+function %test(i64 vmctx, i32, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
-    fn0 = %do_store(i64, i64, i32)
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i32
+    fn0 = %do_store(i64, i32, i32)
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     call fn0(v0, v1, v2)
     v3 = heap_load.i32 heap0 little v1+4
     return v3
 }
-; heap: static, size=0x1000, ptr=vmctx+0, bound=vmctx+8
+; heap: dynamic, size=0x1000, ptr=vmctx+0, bound=vmctx+8
 ; run: %test(0, 0) == 0
 ; run: %test(0, -1) == -1
 ; run: %test(16, 1) == 1

--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_yes_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i32_yes_guards_no_spectre.clif
@@ -7,7 +7,7 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=true
+set enable_heap_access_spectre_mitigation=false
 
 function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_no_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_no_guards_no_spectre.clif
@@ -12,8 +12,8 @@ set enable_heap_access_spectre_mitigation=false
 function %do_store(i64 vmctx, i64, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i64
 
 block0(v0: i64, v1: i64, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
@@ -23,8 +23,8 @@ block0(v0: i64, v1: i64, v2: i32):
 function %test(i64 vmctx, i64, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i64
     fn0 = %do_store(i64, i64, i32)
 
 block0(v0: i64, v1: i64, v2: i32):
@@ -32,7 +32,7 @@ block0(v0: i64, v1: i64, v2: i32):
     v3 = heap_load.i32 heap0 little v1+4
     return v3
 }
-; heap: static, size=0x1000, ptr=vmctx+0, bound=vmctx+8
+; heap: dynamic, size=0x1000, ptr=vmctx+0, bound=vmctx+8
 ; run: %test(0, 0) == 0
 ; run: %test(0, -1) == -1
 ; run: %test(16, 1) == 1

--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_no_guards_yes_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_no_guards_yes_spectre.clif
@@ -7,13 +7,13 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=false
+set enable_heap_access_spectre_mitigation=true
 
 function %do_store(i64 vmctx, i64, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i64
 
 block0(v0: i64, v1: i64, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
@@ -23,8 +23,8 @@ block0(v0: i64, v1: i64, v2: i32):
 function %test(i64 vmctx, i64, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
-    
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    gv2 = load.i64 notrap aligned gv0+8
+    heap0 = dynamic gv1, min 0x1000, bound gv2, offset_guard 0, index_type i64
     fn0 = %do_store(i64, i64, i32)
 
 block0(v0: i64, v1: i64, v2: i32):
@@ -32,7 +32,7 @@ block0(v0: i64, v1: i64, v2: i32):
     v3 = heap_load.i32 heap0 little v1+4
     return v3
 }
-; heap: static, size=0x1000, ptr=vmctx+0, bound=vmctx+8
+; heap: dynamic, size=0x1000, ptr=vmctx+0, bound=vmctx+8
 ; run: %test(0, 0) == 0
 ; run: %test(0, -1) == -1
 ; run: %test(16, 1) == 1

--- a/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_yes_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_dynamic_i64_yes_guards_no_spectre.clif
@@ -7,7 +7,7 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=true
+set enable_heap_access_spectre_mitigation=false
 
 function %do_store(i64 vmctx, i64, i32) {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_no_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_no_guards_no_spectre.clif
@@ -9,25 +9,25 @@ test interpret
 
 set enable_heap_access_spectre_mitigation=false
 
-function %do_store(i64 vmctx, i64, i32) {
+function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i32
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
     return
 }
 
-function %test(i64 vmctx, i64, i32) -> i32 {
+function %test(i64 vmctx, i32, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
-    fn0 = %do_store(i64, i64, i32)
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i32
+    fn0 = %do_store(i64, i32, i32)
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     call fn0(v0, v1, v2)
     v3 = heap_load.i32 heap0 little v1+4
     return v3

--- a/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_no_guards_yes_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_no_guards_yes_spectre.clif
@@ -7,27 +7,27 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=false
+set enable_heap_access_spectre_mitigation=true
 
-function %do_store(i64 vmctx, i64, i32) {
+function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i32
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
     return
 }
 
-function %test(i64 vmctx, i64, i32) -> i32 {
+function %test(i64 vmctx, i32, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
-    fn0 = %do_store(i64, i64, i32)
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i32
+    fn0 = %do_store(i64, i32, i32)
 
-block0(v0: i64, v1: i64, v2: i32):
+block0(v0: i64, v1: i32, v2: i32):
     call fn0(v0, v1, v2)
     v3 = heap_load.i32 heap0 little v1+4
     return v3

--- a/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_yes_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_static_i32_yes_guards_no_spectre.clif
@@ -7,7 +7,7 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=true
+set enable_heap_access_spectre_mitigation=false
 
 function %do_store(i64 vmctx, i32, i32) {
     gv0 = vmctx

--- a/cranelift/filetests/filetests/runtests/heap_load_store_static_i64_no_guards_no_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_static_i64_no_guards_no_spectre.clif
@@ -13,7 +13,7 @@ function %do_store(i64 vmctx, i64, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i64
 
 block0(v0: i64, v1: i64, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
@@ -24,7 +24,7 @@ function %test(i64 vmctx, i64, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i64
     fn0 = %do_store(i64, i64, i32)
 
 block0(v0: i64, v1: i64, v2: i32):

--- a/cranelift/filetests/filetests/runtests/heap_load_store_static_i64_no_guards_yes_spectre.clif
+++ b/cranelift/filetests/filetests/runtests/heap_load_store_static_i64_no_guards_yes_spectre.clif
@@ -7,13 +7,13 @@ test interpret
 ;; target aarch64
 ;; target riscv64
 
-set enable_heap_access_spectre_mitigation=false
+set enable_heap_access_spectre_mitigation=true
 
 function %do_store(i64 vmctx, i64, i32) {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i64
 
 block0(v0: i64, v1: i64, v2: i32):
     heap_store.i32 heap0 little v1+4, v2
@@ -24,7 +24,7 @@ function %test(i64 vmctx, i64, i32) -> i32 {
     gv0 = vmctx
     gv1 = load.i64 notrap aligned gv0+0
     
-    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0xffff_ffff, index_type i64
+    heap0 = static gv1, min 0x1000, bound 0x1000, offset_guard 0, index_type i64
     fn0 = %do_store(i64, i64, i32)
 
 block0(v0: i64, v1: i64, v2: i32):

--- a/cranelift/filetests/filetests/runtests/make-heap-load-store-tests.sh
+++ b/cranelift/filetests/filetests/runtests/make-heap-load-store-tests.sh
@@ -16,12 +16,12 @@ function generate_one_test() {
     local spectre=$4
 
     local enable_spectre=true
-    if [[ spectre == "no" ]]; then
+    if [[ $spectre == "no" ]]; then
         enable_spectre=false
     fi
 
     local have_guards=yes
-    if [[ guard == "0" ]]; then
+    if [[ $guard == "0" ]]; then
         have_guards=no
     fi
 
@@ -79,10 +79,10 @@ block0(v0: i64, v1: ${index_type}, v2: i32):
 EOF
 }
 
-for spectre in yes no; do
-    for guard in 0 0xffff_ffff; do
-        for index_type in i32 i64; do
-            for kind in static dynamic; do
+for spectre in "yes" "no"; do
+    for guard in "0" "0xffff_ffff"; do
+        for index_type in "i32" "i64"; do
+            for kind in "static" "dynamic"; do
                 generate_one_test $kind $index_type $guard $spectre
             done
         done


### PR DESCRIPTION
Was missing some '$' characters and so was comparing string literals against string literals instead of variable values against string literals. Regenerated tests to fix them and add missing tests.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
