### PR TITLE
Use workspace inheritance for some more dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ wast = { workspace = true }
 criterion = "0.3.4"
 num_cpus = "1.13.0"
 memchr = "2.4"
-async-trait = "0.1"
+async-trait = { workspace = true }
 wat = { workspace = true }
 rayon = "1.5.0"
 wasmtime-wast = { workspace = true, features = ['component-model'] }
@@ -171,8 +171,14 @@ gimli = { version = "0.26.0", default-features = false, features = ['read', 'std
 clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 hashbrown = "0.12"
 cap-std = "1.0.0"
+cap-rand = "1.0.0"
 once_cell = "1.12.0"
 smallvec = { version = "1.6.1", features = ["union"] }
+io-lifetimes = { version = "1.0.0", default-features = false }
+tracing = "0.1.26"
+bitflags = "1.2"
+thiserror = "1.0.15"
+async-trait = "0.1.42"
 
 [features]
 default = [

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -42,7 +42,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 pretty_env_logger = "0.4.0"
 rayon = { version = "1", optional = true }
 indicatif = "0.13.0"
-thiserror = "1.0.15"
+thiserror = { workspace = true }
 walkdir = "2.2"
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -24,6 +24,6 @@ gimli = { workspace = true }
 log = { workspace = true }
 num_cpus = "1.8.0"
 target-lexicon = { workspace = true }
-thiserror = "1.0.15"
+thiserror = { workspace = true }
 anyhow = { workspace = true }
 similar = "2.1.0"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-codegen = { workspace = true }
 cranelift-entity = { workspace = true }
 log = { workspace = true }
 smallvec = { workspace = true }
-thiserror = "1.0.15"
+thiserror = { workspace = true }
 
 [target.x86_64-pc-windows-gnu.dependencies]
 libm = "0.2.4"

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -23,7 +23,7 @@ wasmparser = { workspace = true }
 target-lexicon = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true, features = ['write'] }
-thiserror = "1.0.4"
+thiserror = { workspace = true }
 
 [features]
 all-arch = ["cranelift-codegen/all-arch"]

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-entity = { workspace = true }
 wasmtime-types = { workspace = true }
 wasmparser = { workspace = true }
 indexmap = { version = "1.0.2", features = ["serde-1"] }
-thiserror = "1.0.4"
+thiserror = { workspace = true }
 serde = { version = "1.0.94", features = ["derive"] }
 log = { workspace = true }
 gimli = { workspace = true }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 wasmtime-environ = { workspace = true }
 wasmtime-jit-debug = { workspace = true, features = ["perf_jitdump"], optional = true }
 wasmtime-runtime = { workspace = true }
-thiserror = "1.0.4"
+thiserror = { workspace = true }
 target-lexicon = { workspace = true }
 anyhow = { workspace = true }
 cfg-if = "1.0"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,7 +19,7 @@ libc = { version = "0.2.112", default-features = false }
 log = { workspace = true }
 memoffset = "0.6.0"
 indexmap = "1.0.2"
-thiserror = "1.0.4"
+thiserror = { workspace = true }
 cfg-if = "1.0"
 rand = { version = "0.8.3", features = ['small_rng'] }
 anyhow = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -11,5 +11,5 @@ edition.workspace = true
 [dependencies]
 cranelift-entity = { workspace = true, features = ['enable-serde'] }
 serde = { version = "1.0.94", features = ["derive"] }
-thiserror = "1.0.4"
+thiserror = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -19,13 +19,13 @@ links = "wasi-common-19"
 
 [dependencies]
 anyhow = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 wiggle = { workspace = true }
 wasmtime = { workspace = true }
-tracing = "0.1.19"
+tracing = { workspace = true }
 cap-std = { workspace = true }
-cap-rand = "1.0.0"
-bitflags = "1.2"
+cap-rand = { workspace = true }
+bitflags = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs"] }

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -13,16 +13,16 @@ include = ["src/**/*", "README.md", "LICENSE" ]
 
 [dependencies]
 wasi-common = { workspace = true }
-async-trait = "0.1"
+async-trait = { workspace = true }
 anyhow = { workspace = true }
 cap-std = { workspace = true }
 cap-fs-ext = "1.0.0"
 cap-time-ext = "1.0.0"
-cap-rand = "1.0.0"
+cap-rand = { workspace = true }
 fs-set-times = "0.18.0"
 system-interface = { version = "0.25.0", features = ["cap_std_impls"] }
-tracing = "0.1.19"
-io-lifetimes = { version = "1.0.0", default-features = false }
+tracing = { workspace = true }
+io-lifetimes = { workspace = true }
 is-terminal = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -17,7 +17,7 @@ wiggle = { workspace = true }
 tokio = { version = "1.8.0", features = [ "rt", "fs", "time", "io-util", "net", "io-std", "rt-multi-thread"] }
 cap-std = { workspace = true }
 anyhow = { workspace = true }
-io-lifetimes = { version = "1.0.0", default-features = false }
+io-lifetimes = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs"] }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -18,7 +18,7 @@ wiggle = { workspace = true }
 
 # These dependencies are necessary for the wasi-nn implementation:
 openvino = { version = "0.4.2", features = ["runtime-linking"] }
-thiserror = "1.0"
+thiserror = { workspace = true }
 
 [build-dependencies]
 walkdir = "2.3"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -36,7 +36,7 @@ psm = "0.1.11"
 once_cell = { workspace = true }
 rayon = { version = "1.0", optional = true }
 object = { workspace = true }
-async-trait = { version = "0.1.51", optional = true }
+async-trait = { workspace = true, optional = true }
 encoding_rs = { version = "0.8.31", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "README.md", "LICENSE"]
 
 [dependencies]
-thiserror = "1"
+thiserror = { workspace = true }
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }
 wiggle-macro = { workspace = true }
-tracing = "0.1.26"
-bitflags = "1.2"
-async-trait = "0.1.42"
+tracing = { workspace = true }
+bitflags = { workspace = true }
+async-trait = { workspace = true }
 wasmtime = { workspace = true }
 anyhow = { workspace = true }
 

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -17,8 +17,8 @@ wiggle = { path = "..", features = ["tracing_log"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-thiserror = "1.0"
-tracing = "0.1.26"
+thiserror = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt'] }
 env_logger = "0.9"
 


### PR DESCRIPTION
Deduplicate some dependency directives through `[workspace.dependencies]`

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
