### PR TITLE
wasmtime: enable stack probing for x86_64 targets.

### DIFF
--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -58,32 +58,32 @@ fn host_always_has_some_stack() -> Result<()> {
 
 #[test]
 fn big_stack_works_ok() -> Result<()> {
-    const N: usize = 5000;
+    const N: usize = 10000;
 
     // Build a module with a function that uses a very large amount of stack space,
-    // modeled here by calling a v128-returning-function many times followed by
-    // collecting that all into one v128.
+    // modeled here by calling an i64-returning-function many times followed by
+    // adding them all into one i64.
     //
     // This should exercise the ability to consume multi-page stacks and
     // only touch a few internals of it at a time.
     let mut s = String::new();
     s.push_str("(module\n");
-    s.push_str("(func (export \"\") (result i32)\n");
-    s.push_str("v128.const i64x2 0 0\n");
+    s.push_str("(func (export \"\") (result i64)\n");
+    s.push_str("i64.const 0\n");
     for _ in 0..N {
         s.push_str("call $get\n");
     }
     for _ in 0..N {
-        s.push_str("i64x2.add\n");
+        s.push_str("i64.add\n");
     }
-    s.push_str("i8x16.bitmask\n)\n");
-    s.push_str("(func $get (result v128) v128.const i64x2 0 0)\n");
+    s.push_str(")\n");
+    s.push_str("(func $get (result i64) i64.const 0)\n");
     s.push_str(")\n");
 
     let mut store = Store::<()>::default();
     let module = Module::new(store.engine(), &s)?;
     let instance = Instance::new(&mut store, &module, &[])?;
-    let func = instance.get_typed_func::<(), i32>(&mut store, "")?;
+    let func = instance.get_typed_func::<(), i64>(&mut store, "")?;
     assert_eq!(func.call(&mut store, ())?, 0);
     Ok(())
 }


### PR DESCRIPTION
This PR unconditionally enables stack probing for x86_64 targets.

On Windows, stack probing is always required because of the way Windows commits stack pages (via guard page access).

Fixes #5340.