### PR TITLE
x64: reduce work in non-stack using leaf functions

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -468,9 +468,9 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
         if flags.unwind_info() && setup_frame {
             // Emit unwind info: start the frame. The frame (from unwind
-            // consumers' point of view) starts at clobbbers, just below
-            // the FP and return address. Spill slots and stack slots are
-            // part of our actual frame but do not concern the unwinder.
+            // consumers' point of view) starts at clobbers, just below the FP
+            // and return address. Spill slots and stack slots are part of our
+            // actual frame but do not concern the unwinder.
             insts.push(Inst::Unwind {
                 inst: UnwindInst::DefineNewFrame {
                     offset_downward_to_clobbers: clobbered_size,
@@ -732,12 +732,17 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     fn is_frame_setup_needed(
-        _is_leaf: bool,
-        _stack_args_size: u32,
-        _num_clobbered_callee_saves: usize,
-        _frame_storage_size: u32,
+        is_leaf: bool,
+        stack_args_size: u32,
+        num_clobbered_callee_saves: usize,
+        frame_storage_size: u32,
     ) -> bool {
-        true
+        !is_leaf
+            // The function arguments that are passed on the stack are addressed
+            // relative to the Frame Pointer.
+            || stack_args_size > 0
+            || num_clobbered_callee_saves > 0
+            || frame_storage_size > 0
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -737,12 +737,14 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         num_clobbered_callee_saves: usize,
         frame_storage_size: u32,
     ) -> bool {
-        !is_leaf
+        (!is_leaf
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
             || stack_args_size > 0
             || num_clobbered_callee_saves > 0
-            || frame_storage_size > 0
+            || frame_storage_size > 0)
+            // TODO
+            && !cfg!(target_os = "macos")
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -130,7 +130,12 @@ mod tests {
             _ => panic!("expected unwind information"),
         };
 
-        assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(1234), length: 17, lsda: None, instructions: [(1, CfaOffset(16)), (1, Offset(Register(6), -16)), (4, CfaRegister(Register(6)))] }");
+        if cfg!(target_os = "macos") {
+            // TODO
+            assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(1234), length: 9, lsda: None, instructions: [] }");
+        } else {
+            assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(1234), length: 17, lsda: None, instructions: [(1, CfaOffset(16)), (1, Offset(Register(6), -16)), (4, CfaRegister(Register(6)))] }");
+        }
     }
 
     fn create_function(call_conv: CallConv, stack_slot: Option<StackSlotData>) -> Function {

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -169,7 +169,7 @@ mod tests {
             _ => panic!("expected unwind information"),
         };
 
-        assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(4321), length: 22, lsda: None, instructions: [(1, CfaOffset(16)), (1, Offset(Register(6), -16)), (4, CfaRegister(Register(6)))] }");
+        assert_eq!(format!("{:?}", fde), "FrameDescriptionEntry { address: Constant(4321), length: 10, lsda: None, instructions: [] }");
     }
 
     fn create_multi_return_function(call_conv: CallConv) -> Function {

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -343,32 +343,28 @@ mod test {
         // command on it:
         // > objdump -b binary -D <file> -m i386:x86-64 -M intel
         //
-        //  0:   55                      push   rbp
-        //  1:   48 89 e5                mov    rbp,rsp
-        //  4:   48 89 fe                mov    rsi,rdi
-        //  7:   81 c6 34 12 00 00       add    esi,0x1234
-        //  d:   85 f6                   test   esi,esi
-        //  f:   0f 84 1c 00 00 00       je     0x31
-        // 15:   49 89 f0                mov    r8,rsi
-        // 18:   48 89 f0                mov    rax,rsi
-        // 1b:   81 e8 34 12 00 00       sub    eax,0x1234
-        // 21:   44 01 c0                add    eax,r8d
-        // 24:   85 f6                   test   esi,esi
-        // 26:   0f 85 05 00 00 00       jne    0x31
-        // 2c:   48 89 ec                mov    rsp,rbp
-        // 2f:   5d                      pop    rbp
-        // 30:   c3                      ret
-        // 31:   49 89 f0                mov    r8,rsi
-        // 34:   41 81 c0 34 12 00 00    add    r8d,0x1234
-        // 3b:   45 85 c0                test   r8d,r8d
-        // 3e:   0f 85 ed ff ff ff       jne    0x31
-        // 44:   e9 cf ff ff ff          jmp    0x18
+        //     0:   48 89 fe                mov    rsi,rdi
+        //     3:   81 c6 34 12 00 00       add    esi,0x1234
+        //     9:   85 f6                   test   esi,esi
+        //     b:   0f 84 18 00 00 00       je     0x29
+        //    11:   49 89 f0                mov    r8,rsi
+        //    14:   48 89 f0                mov    rax,rsi
+        //    17:   81 e8 34 12 00 00       sub    eax,0x1234
+        //    1d:   44 01 c0                add    eax,r8d
+        //    20:   85 f6                   test   esi,esi
+        //    22:   0f 85 01 00 00 00       jne    0x29
+        //    28:   c3                      ret
+        //    29:   49 89 f0                mov    r8,rsi
+        //    2c:   41 81 c0 34 12 00 00    add    r8d,0x1234
+        //    33:   45 85 c0                test   r8d,r8d
+        //    36:   0f 85 ed ff ff ff       jne    0x29
+        //    3c:   e9 d3 ff ff ff          jmp    0x14
 
         let golden = vec![
-            85, 72, 137, 229, 72, 137, 254, 129, 198, 52, 18, 0, 0, 133, 246, 15, 132, 28, 0, 0, 0,
-            73, 137, 240, 72, 137, 240, 129, 232, 52, 18, 0, 0, 68, 1, 192, 133, 246, 15, 133, 5,
-            0, 0, 0, 72, 137, 236, 93, 195, 73, 137, 240, 65, 129, 192, 52, 18, 0, 0, 69, 133, 192,
-            15, 133, 237, 255, 255, 255, 233, 207, 255, 255, 255,
+            72, 137, 254, 129, 198, 52, 18, 0, 0, 133, 246, 15, 132, 24, 0, 0, 0, 73, 137, 240, 72,
+            137, 240, 129, 232, 52, 18, 0, 0, 68, 1, 192, 133, 246, 15, 133, 1, 0, 0, 0, 195, 73,
+            137, 240, 65, 129, 192, 52, 18, 0, 0, 69, 133, 192, 15, 133, 237, 255, 255, 255, 233,
+            211, 255, 255, 255,
         ];
 
         assert_eq!(code, &golden[..]);
@@ -448,39 +444,30 @@ mod test {
         // command on it:
         // > objdump -b binary -D <file> -m i386:x86-64 -M intel
         //
-        //  0:   55                      push   rbp
-        //  1:   48 89 e5                mov    rbp,rsp
-        //  4:   83 ff 02                cmp    edi,0x2
-        //  7:   0f 83 27 00 00 00       jae    0x34
-        //  d:   44 8b d7                mov    r10d,edi
-        // 10:   41 b9 00 00 00 00       mov    r9d,0x0
-        // 16:   4d 0f 43 d1             cmovae r10,r9
-        // 1a:   4c 8d 0d 0b 00 00 00    lea    r9,[rip+0xb]        # 0x2c
-        // 21:   4f 63 54 91 00          movsxd r10,DWORD PTR [r9+r10*4+0x0]
-        // 26:   4d 01 d1                add    r9,r10
-        // 29:   41 ff e1                jmp    r9
-        // 2c:   12 00                   adc    al,BYTE PTR [rax]
-        // 2e:   00 00                   add    BYTE PTR [rax],al
-        // 30:   1c 00                   sbb    al,0x0
-        // 32:   00 00                   add    BYTE PTR [rax],al
-        // 34:   b8 03 00 00 00          mov    eax,0x3
-        // 39:   48 89 ec                mov    rsp,rbp
-        // 3c:   5d                      pop    rbp
-        // 3d:   c3                      ret
-        // 3e:   b8 01 00 00 00          mov    eax,0x1
-        // 43:   48 89 ec                mov    rsp,rbp
-        // 46:   5d                      pop    rbp
-        // 47:   c3                      ret
-        // 48:   b8 02 00 00 00          mov    eax,0x2
-        // 4d:   48 89 ec                mov    rsp,rbp
-        // 50:   5d                      pop    rbp
-        // 51:   c3                      ret
+        //    0:   83 ff 02                cmp    edi,0x2
+        //    3:   0f 83 27 00 00 00       jae    0x30
+        //    9:   44 8b d7                mov    r10d,edi
+        //    c:   41 b9 00 00 00 00       mov    r9d,0x0
+        //   12:   4d 0f 43 d1             cmovae r10,r9
+        //   16:   4c 8d 0d 0b 00 00 00    lea    r9,[rip+0xb]        # 0x28
+        //   1d:   4f 63 54 91 00          movsxd r10,DWORD PTR [r9+r10*4+0x0]
+        //   22:   4d 01 d1                add    r9,r10
+        //   25:   41 ff e1                jmp    r9
+        //   28:   0e                      (bad)
+        //   29:   00 00                   add    BYTE PTR [rax],al
+        //   2b:   00 14 00                add    BYTE PTR [rax+rax*1],dl
+        //   2e:   00 00                   add    BYTE PTR [rax],al
+        //   30:   b8 03 00 00 00          mov    eax,0x3
+        //   35:   c3                      ret
+        //   36:   b8 01 00 00 00          mov    eax,0x1
+        //   3b:   c3                      ret
+        //   3c:   b8 02 00 00 00          mov    eax,0x2
+        //   41:   c3                      ret
 
         let golden = vec![
-            85, 72, 137, 229, 131, 255, 2, 15, 131, 39, 0, 0, 0, 68, 139, 215, 65, 185, 0, 0, 0, 0,
-            77, 15, 67, 209, 76, 141, 13, 11, 0, 0, 0, 79, 99, 84, 145, 0, 77, 1, 209, 65, 255,
-            225, 18, 0, 0, 0, 28, 0, 0, 0, 184, 3, 0, 0, 0, 72, 137, 236, 93, 195, 184, 1, 0, 0, 0,
-            72, 137, 236, 93, 195, 184, 2, 0, 0, 0, 72, 137, 236, 93, 195,
+            131, 255, 2, 15, 131, 39, 0, 0, 0, 68, 139, 215, 65, 185, 0, 0, 0, 0, 77, 15, 67, 209,
+            76, 141, 13, 11, 0, 0, 0, 79, 99, 84, 145, 0, 77, 1, 209, 65, 255, 225, 14, 0, 0, 0,
+            20, 0, 0, 0, 184, 3, 0, 0, 0, 195, 184, 1, 0, 0, 0, 195, 184, 2, 0, 0, 0, 195,
         ];
 
         assert_eq!(code, &golden[..]);

--- a/cranelift/filetests/filetests/egraph/not_a_load.clif
+++ b/cranelift/filetests/filetests/egraph/not_a_load.clif
@@ -12,12 +12,8 @@ function u0:1302(i64) -> i64 system_v {
     return v0
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   atomically { 64_bits_at_[%r9]) Add= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -8,12 +8,8 @@ block0(v0: i64, v1: i64):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rdi,%rsi,1), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_add_imm(i64) -> i64 {
@@ -24,12 +20,8 @@ block0(v0: i64):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    42(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_add_imm_order(i64) -> i64 {
@@ -40,12 +32,8 @@ block0(v0: i64):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    42(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_add_uext_imm(i64) -> i64 {
@@ -57,12 +45,8 @@ block0(v0: i64):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    42(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_reg_reg_imm(i64, i64) -> i64 {
@@ -74,12 +58,8 @@ block0(v0: i64, v1: i64):
     return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    320(%rdi,%rsi,1), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_reg_reg_imm_negative(i64, i64) -> i64 {
@@ -91,12 +71,8 @@ block0(v0: i64, v1: i64):
     return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    -1(%rdi,%rsi,1), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_reg_reg_imm_scaled(i64, i64) -> i64 {
@@ -109,14 +85,9 @@ block0(v0: i64, v1: i64):
     return v6
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    -1(%rdi,%rsi,8), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
-
 
 function %amode_reg_reg_imm_uext_scaled(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):
@@ -129,13 +100,9 @@ block0(v0: i64, v1: i32):
     return v7
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %ecx
 ;   movq    -1(%rdi,%rcx,8), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %amode_reg_reg_imm_uext_scaled_add(i64, i32, i32) -> i64 {
@@ -150,13 +117,9 @@ block0(v0: i64, v1: i32, v2: i32):
     return v9
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %r8
 ;   addl    %r8d, %edx, %r8d
 ;   movq    -1(%rdi,%r8,4), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -7,12 +7,8 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addl    %eax, %esi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -7,12 +7,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movd    %xmm0, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32) -> f32 {
@@ -21,12 +17,8 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movd    %edi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(f64) -> i64 {
@@ -35,12 +27,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %xmm0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64) -> f64 {
@@ -49,11 +37,7 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -9,15 +9,11 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
 ;   sbbq    %rax, %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i64_i32(i64) -> i32 {
@@ -26,15 +22,11 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i64_i16(i64) -> i16 {
@@ -43,15 +35,11 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i64_i8(i64) -> i8 {
@@ -60,15 +48,11 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i32_i64(i32) -> i64 {
@@ -77,15 +61,11 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
 ;   sbbq    %rax, %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i32_i32(i32) -> i32 {
@@ -94,15 +74,11 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i32_i16(i32) -> i16 {
@@ -111,15 +87,11 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i32_i8(i32) -> i8 {
@@ -128,15 +100,11 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i16_i64(i16) -> i64 {
@@ -145,15 +113,11 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
 ;   sbbq    %rax, %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i16_i32(i16) -> i32 {
@@ -162,15 +126,11 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i16_i16(i16) -> i16 {
@@ -179,15 +139,11 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i16_i8(i16) -> i8 {
@@ -196,15 +152,11 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i8_i64(i8) -> i64 {
@@ -213,15 +165,11 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
 ;   sbbq    %rax, %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i8_i32(i8) -> i32 {
@@ -230,15 +178,11 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i8_i16(i8) -> i16 {
@@ -247,15 +191,11 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i8_i8(i8) -> i8 {
@@ -264,15 +204,11 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rax
 ;   sbbl    %eax, %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i128_i128(i128) -> i128 {
@@ -281,8 +217,6 @@ block0(v0: i128):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rdx
 ;   orq     %rdx, %rsi, %rdx
@@ -290,8 +224,6 @@ block0(v0: i128):
 ;   negq    %r8, %r8
 ;   sbbq    %rdx, %rdx, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i128_i64(i128) -> i64 {
@@ -300,16 +232,12 @@ block0(v0: i128):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   orq     %rax, %rsi, %rax
 ;   movq    %rax, %r8
 ;   negq    %r8, %r8
 ;   sbbq    %rax, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i128_i32(i128) -> i32 {
@@ -318,16 +246,12 @@ block0(v0: i128):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   orq     %rax, %rsi, %rax
 ;   movq    %rax, %r8
 ;   negq    %r8, %r8
 ;   sbbl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i128_i16(i128) -> i16 {
@@ -336,16 +260,12 @@ block0(v0: i128):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   orq     %rax, %rsi, %rax
 ;   movq    %rax, %r8
 ;   negq    %r8, %r8
 ;   sbbl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i128_i8(i128) -> i8 {
@@ -354,16 +274,12 @@ block0(v0: i128):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   orq     %rax, %rsi, %rax
 ;   movq    %rax, %r8
 ;   negq    %r8, %r8
 ;   sbbl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i64_i128(i64) -> i128 {
@@ -372,16 +288,12 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negq    %rax, %rax
 ;   movq    %rdi, %rdx
 ;   sbbq    %rdx, %rdi, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i32_i128(i32) -> i128 {
@@ -390,16 +302,12 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negl    %eax, %eax
 ;   movq    %rdi, %rdx
 ;   sbbq    %rdx, %rdi, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i16_i128(i16) -> i128 {
@@ -408,16 +316,12 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negw    %ax, %ax
 ;   movq    %rdi, %rdx
 ;   sbbq    %rdx, %rdi, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bmask_i8_i128(i8) -> i128 {
@@ -426,15 +330,11 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   negb    %al, %al
 ;   movq    %rdi, %rdx
 ;   sbbq    %rdx, %rdi, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -16,20 +16,14 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i32, i32) -> i32 {
@@ -47,20 +41,14 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
 ;   jnz     label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32, i32) -> i32 {
@@ -78,20 +66,14 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(f32, f32) -> i32 {
@@ -109,21 +91,15 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
 ;   jp      label2
 ;   jnz     label2; j label1
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32, f32) -> i8 {
@@ -139,21 +115,15 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
 ;   jp      label1
 ;   jnz     label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   xorl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32, f32) -> i8 {
@@ -169,23 +139,16 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
 ;   jp      label2
 ;   jnz     label2; j label1
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   xorl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
-
 
 function %f5(i32) -> i8 {
   jt0 = jump_table [block1, block2]
@@ -202,8 +165,6 @@ block2:
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    $2, %edi
 ;   br_table %rdi, %r8, %r9
@@ -213,13 +174,9 @@ block2:
 ;   jmp     label3
 ; block3:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block4:
 ;   xorl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(i64) -> i8 {
@@ -236,20 +193,14 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
 ;   jl      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   xorl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f7(i32) -> i8 {
@@ -266,20 +217,14 @@ block2:
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    $0, %edi
 ;   jl      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   xorl    %eax, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fflags(f32) {
@@ -304,8 +249,6 @@ block202:
     trap heap_oob
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $1112539136, %r8d
 ;   movd    %r8d, %xmm5
@@ -324,7 +267,5 @@ block202:
 ; block4:
 ;   jmp     label5
 ; block5:
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/x64/bswap.clif
@@ -7,13 +7,9 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   bswapq  %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i32) -> i32 {
@@ -22,13 +18,9 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   bswapl  %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16) -> i16 {
@@ -37,12 +29,8 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   rolw    $8, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -7,13 +7,9 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %CeilF32+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -22,12 +18,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %CeilF64+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -7,12 +7,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundss $2, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -21,12 +17,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundsd $2, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32x4) -> f32x4 {
@@ -35,12 +27,8 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundps $2, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -49,11 +37,7 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundpd $2, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -7,12 +7,8 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   lzcntq  %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %clz(i32) -> i32 {
@@ -21,11 +17,7 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   lzcntl  %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -10,8 +10,6 @@ block0(v0: i64, v1: i64):
     return v4, v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rsi), %r9
 ;   cmpq    %r9, %rdi
@@ -20,8 +18,6 @@ block0(v0: i64, v1: i64):
 ;   cmpq    %r9, %rdi
 ;   movq    %rsi, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(f64, i64) -> i64, f64 {
@@ -33,8 +29,6 @@ block0(v0: f64, v1: i64):
     return v4, v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsd   0(%rdi), %xmm9
 ;   ucomisd %xmm9, %xmm0
@@ -46,7 +40,5 @@ block0(v0: f64, v1: i64):
 ;   movdqa  %xmm0, %xmm2
 ;   mov z, sd; j%xmm2 $next; mov%xmm0 %xmm0, %xmm0; $next: 
 ;   mov np, sd; j%xmm2 $next; mov%xmm0 %xmm0, %xmm0; $next: 
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -7,14 +7,10 @@ block0(v0: i8, v1: i32, v2: i32):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   testb   %dil, %dil
 ;   movq    %rdx, %rax
 ;   cmovnzl %esi, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i8) -> i32 {
@@ -29,20 +25,14 @@ block2:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   testb   %dil, %dil
 ;   jnz     label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i8) -> i32 {
@@ -57,20 +47,14 @@ block2:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   testb   %dil, %dil
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64) -> i32 {
@@ -88,21 +72,15 @@ block2:
   return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    0(%rdi), %edx
 ;   cmpl    $1, %edx
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64) -> i32 {
@@ -120,21 +98,15 @@ block2:
   return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    0(%rdi), %edx
 ;   cmpl    $1, %edx
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_x_slt_0_i64(i64) -> i8 {
@@ -144,13 +116,9 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrq    $63, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_x_slt_0_i32f4(i32) -> i8 {
@@ -160,13 +128,9 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrl    $31, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_0_sgt_x_i64(i64) -> i8 {
@@ -176,13 +140,9 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrq    $63, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_0_sgt_x_i32f4(i32) -> i8 {
@@ -192,13 +152,9 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrl    $31, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_0_sle_x_i64(i64) -> i8 {
@@ -208,14 +164,10 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   notq    %rax, %rax
 ;   shrq    $63, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_0_sle_x_i32f4(i32) -> i8 {
@@ -225,14 +177,10 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   notq    %rax, %rax
 ;   shrl    $31, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_x_sge_x_i64(i64) -> i8 {
@@ -242,14 +190,10 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   notq    %rax, %rax
 ;   shrq    $63, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %test_x_sge_x_i32f4(i32) -> i8 {
@@ -259,13 +203,9 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   notq    %rax, %rax
 ;   shrl    $31, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -7,12 +7,8 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   tzcntq  %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ctz(i32) -> i32 {
@@ -21,11 +17,7 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   tzcntl  %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -14,15 +14,11 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %al, %dl, %sil, %al, %dl, tmp=(none)
 ;   shrq    $8, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %i16(i16, i16) -> i16 {
@@ -32,15 +28,11 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %ax, %dx, %si, %ax, %dx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %i32(i32, i32) -> i32 {
@@ -50,15 +42,11 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %eax, %edx, %esi, %eax, %edx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %i64(i64, i64) -> i64 {
@@ -68,14 +56,10 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %rax, %rdx, %rsi, %rax, %rdx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -7,12 +7,8 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pextrb  $1, %xmm0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16x8) -> i16 {
@@ -21,12 +17,8 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pextrw  $1, %xmm0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32x4) -> i32 {
@@ -35,12 +27,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pextrd  $1, %xmm0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64x2) -> i64 {
@@ -49,12 +37,8 @@ block0(v0: i64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pextrd.w $1, %xmm0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(f32x4) -> f32 {
@@ -63,12 +47,8 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $1, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(f64x2) -> f64 {
@@ -77,11 +57,7 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $238, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/fabs.clif
@@ -7,14 +7,10 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $2147483647, %eax
 ;   movd    %eax, %xmm4
 ;   andps   %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -23,14 +19,10 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $9223372036854775807, %rax
 ;   movq    %rax, %xmm4
 ;   andpd   %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(f32x4) -> f32x4 {
@@ -39,14 +31,10 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm3, %xmm3, %xmm3
 ;   psrld   %xmm3, $1, %xmm3
 ;   andps   %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -55,13 +43,9 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm3, %xmm3, %xmm3
 ;   psrlq   %xmm3, $1, %xmm3
 ;   andpd   %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -7,8 +7,6 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $-2147483648, %ecx
 ;   movd    %ecx, %xmm7
@@ -17,8 +15,6 @@ block0(v0: f32, v1: f32):
 ;   andnps  %xmm0, %xmm10, %xmm0
 ;   andps   %xmm7, %xmm1, %xmm7
 ;   orps    %xmm0, %xmm7, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(f64, f64) -> f64 {
@@ -27,8 +23,6 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $-9223372036854775808, %rcx
 ;   movq    %rcx, %xmm7
@@ -37,7 +31,5 @@ block0(v0: f64, v1: f64):
 ;   andnpd  %xmm0, %xmm10, %xmm0
 ;   andpd   %xmm7, %xmm1, %xmm7
 ;   orpd    %xmm0, %xmm7, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -8,11 +8,7 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   vcvtudq2ps %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -7,13 +7,9 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsbl  %dil, %eax
 ;   cvtsi2ss %eax, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16) -> f32 {
@@ -22,13 +18,9 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movswl  %di, %eax
 ;   cvtsi2ss %eax, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32) -> f32 {
@@ -37,12 +29,8 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvtsi2ss %edi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64) -> f32 {
@@ -51,12 +39,8 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvtsi2ss %rdi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i8) -> f64 {
@@ -65,13 +49,9 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsbl  %dil, %eax
 ;   cvtsi2sd %eax, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(i16) -> f64 {
@@ -80,13 +60,9 @@ block0(v0: i16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movswl  %di, %eax
 ;   cvtsi2sd %eax, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f7(i32) -> f64 {
@@ -95,12 +71,8 @@ block0(v0: i32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvtsi2sd %edi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f8(i64) -> f64 {
@@ -109,12 +81,8 @@ block0(v0: i64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvtsi2sd %rdi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f9(i32x4) -> f64x2 {
@@ -123,12 +91,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvtdq2pd %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f10(i8, i16, i32, i64) -> f32 {
@@ -143,8 +107,6 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
   return v10
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %r9
 ;   cvtsi2ss %r9, %xmm0
@@ -156,8 +118,6 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   addss   %xmm0, %xmm1, %xmm0
 ;   addss   %xmm0, %xmm2, %xmm0
 ;   addss   %xmm0, %xmm14, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f11(i32x4) -> f64x2 {
@@ -167,15 +127,11 @@ block0(v0: i32x4):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm2
 ;   unpcklps %xmm0, %xmm2, %xmm0
 ;   movdqu  const(1), %xmm6
 ;   subpd   %xmm0, %xmm6, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f12(i32x4) -> f32x4 {
@@ -184,8 +140,6 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
 ;   pslld   %xmm3, $16, %xmm3
@@ -197,8 +151,6 @@ block0(v0: i32x4):
 ;   cvtdq2ps %xmm9, %xmm0
 ;   addps   %xmm0, %xmm0, %xmm0
 ;   addps   %xmm0, %xmm8, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f13(f32) -> i32 {
@@ -207,12 +159,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_uint32_seq %xmm0, %eax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f14(f32) -> i64 {
@@ -221,12 +169,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_uint64_seq %xmm0, %rax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f15(f64) -> i32 {
@@ -235,12 +179,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_uint32_seq %xmm0, %eax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f16(f64) -> i64 {
@@ -249,12 +189,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_uint64_seq %xmm0, %rax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f17(f32) -> i32 {
@@ -263,12 +199,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_uint32_sat_seq %xmm0, %eax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f18(f32) -> i64 {
@@ -277,12 +209,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_uint64_sat_seq %xmm0, %rax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f19(f64) -> i32 {
@@ -291,12 +219,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_uint32_sat_seq %xmm0, %eax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f20(f64) -> i64 {
@@ -305,12 +229,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_uint64_sat_seq %xmm0, %rax, %r8, %xmm3, %xmm4
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f21(f32) -> i32 {
@@ -319,12 +239,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_sint32_seq %xmm0, %eax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f22(f32) -> i64 {
@@ -333,12 +249,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_sint64_seq %xmm0, %rax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f23(f64) -> i32 {
@@ -347,12 +259,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_sint32_seq %xmm0, %eax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f24(f64) -> i64 {
@@ -361,12 +269,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_sint64_seq %xmm0, %rax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f25(f32) -> i32 {
@@ -375,12 +279,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_sint32_sat_seq %xmm0, %eax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f26(f32) -> i64 {
@@ -389,12 +289,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float32_to_sint64_sat_seq %xmm0, %rax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f27(f64) -> i32 {
@@ -403,12 +299,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_sint32_sat_seq %xmm0, %eax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f28(f64) -> i64 {
@@ -417,12 +309,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cvt_float64_to_sint64_sat_seq %xmm0, %rax, %rdx, %xmm3
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f29(f32x4) -> i32x4 {
@@ -431,8 +319,6 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pxor    %xmm2, %xmm2, %xmm2
 ;   movdqa  %xmm0, %xmm9
@@ -448,8 +334,6 @@ block0(v0: f32x4):
 ;   pxor    %xmm6, %xmm6, %xmm6
 ;   pmaxsd  %xmm0, %xmm6, %xmm0
 ;   paddd   %xmm0, %xmm12, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f30(f32x4) -> i32x4 {
@@ -458,8 +342,6 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   cmpps   $0, %xmm4, %xmm0, %xmm4
@@ -471,7 +353,5 @@ block0(v0: f32x4):
 ;   pand    %xmm0, %xmm4, %xmm0
 ;   psrad   %xmm0, $31, %xmm0
 ;   pxor    %xmm0, %xmm8, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -7,14 +7,10 @@ block0(v0: f64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $9223372036854775807, %rax
 ;   movq    %rax, %xmm4
 ;   andpd   %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f(i64) -> f64 {
@@ -24,14 +20,10 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsd   0(%rdi), %xmm0
 ;   movabsq $9223372036854775807, %rcx
 ;   movq    %rcx, %xmm5
 ;   andpd   %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -7,13 +7,9 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %FloorF32+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -22,12 +18,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %FloorF64+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/floor.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor.clif
@@ -7,12 +7,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundss $1, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -21,12 +17,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundsd $1, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32x4) -> f32x4 {
@@ -35,12 +27,8 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundps $1, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -49,11 +37,7 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundpd $1, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -7,13 +7,9 @@ block0(v0: f32, v1: f32, v2: f32):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %FmaF32+0, %r8
 ;   call    *%r8
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fma_f64(f64, f64, f64) -> f64 {
@@ -22,12 +18,8 @@ block0(v0: f64, v1: f64, v2: f64):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %FmaF64+0, %r8
 ;   call    *%r8
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fma-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-inst.clif
@@ -7,12 +7,8 @@ block0(v0: f32, v1: f32, v2: f32):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   vfmadd213ss %xmm0, %xmm1, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fma_f64(f64, f64, f64) -> f64 {
@@ -21,11 +17,7 @@ block0(v0: f64, v1: f64, v2: f64):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   vfmadd213sd %xmm0, %xmm1, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fneg.clif
+++ b/cranelift/filetests/filetests/isa/x64/fneg.clif
@@ -7,14 +7,10 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $-2147483648, %eax
 ;   movd    %eax, %xmm4
 ;   xorps   %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -23,14 +19,10 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $-9223372036854775808, %rax
 ;   movq    %rax, %xmm4
 ;   xorpd   %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(f32x4) -> f32x4 {
@@ -39,14 +31,10 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm3, %xmm3, %xmm3
 ;   pslld   %xmm3, $31, %xmm3
 ;   xorps   %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -55,13 +43,9 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm3, %xmm3, %xmm3
 ;   psllq   %xmm3, $63, %xmm3
 ;   xorpd   %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap-no-spectre.clif
@@ -16,8 +16,6 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %edi, %eax
 ;   movq    %rax, %r10
@@ -29,8 +27,6 @@ block0(v0: i32, v1: i64):
 ; block1:
 ;   addq    %rax, 0(%rsi), %rax
 ;   addq    %rax, $32768, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   ud2 heap_oob
@@ -48,16 +44,12 @@ block0(v0: i64, v1: i32):
     return v10
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %eax
 ;   cmpq    $4096, %rax
 ;   jbe     label1; j label2
 ; block1:
 ;   addq    %rax, 0(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   ud2 heap_oob
@@ -75,12 +67,8 @@ block0(v0: i64, v1: i32):
     return v10
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %eax
 ;   addq    %rax, 0(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/heap.clif
+++ b/cranelift/filetests/filetests/isa/x64/heap.clif
@@ -29,8 +29,6 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %edi, %eax
 ;   movq    %rax, %rdi
@@ -42,8 +40,6 @@ block0(v0: i32, v1: i64):
 ;   xorq    %rsi, %rsi, %rsi
 ;   cmpq    %rcx, %rdi
 ;   cmovnbeq %rsi, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 ;; The heap address calculation for this statically-allocated memory checks that
@@ -60,8 +56,6 @@ block0(v0: i64, v1: i32):
     return v10
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %r9d
 ;   movq    %r9, %rax
@@ -69,8 +63,6 @@ block0(v0: i64, v1: i32):
 ;   xorq    %r8, %r8, %r8
 ;   cmpq    $4096, %r9
 ;   cmovnbeq %r8, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 ;; When a static memory is the "right" size (4GB memory, 2GB guard regions), the
@@ -86,13 +78,9 @@ block0(v0: i64, v1: i32):
     return v10
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %eax
 ;   addq    %rax, 0(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %dynamic_heap_check_with_offset(i64 vmctx, i32) -> i64 {
@@ -105,8 +93,6 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %esi
 ;   movq    %rsi, %r11
@@ -118,8 +104,6 @@ block0(v0: i64, v1: i32):
 ;   xorq    %rsi, %rsi, %rsi
 ;   cmpq    0(%rdi), %r11
 ;   cmovnbeq %rsi, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %static_heap_check_with_offset(i64 vmctx, i32) -> i64 {
@@ -131,8 +115,6 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    %esi, %r10d
 ;   movq    %rdi, %rax
@@ -141,7 +123,5 @@ block0(v0: i64, v1: i32):
 ;   xorq    %r9, %r9, %r9
 ;   cmpq    $65512, %r10
 ;   cmovnbeq %r9, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -8,15 +8,11 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addq    %rax, %rdx, %rax
 ;   movq    %rsi, %rdx
 ;   adcq    %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i128, i128) -> i128 {
@@ -25,15 +21,11 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   subq    %rax, %rdx, %rax
 ;   movq    %rsi, %rdx
 ;   sbbq    %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i128, i128) -> i128 {
@@ -42,15 +34,11 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   andq    %rax, %rdx, %rax
 ;   movq    %rsi, %rdx
 ;   andq    %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i128, i128) -> i128 {
@@ -59,15 +47,11 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   orq     %rax, %rdx, %rax
 ;   movq    %rsi, %rdx
 ;   orq     %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i128, i128) -> i128 {
@@ -76,15 +60,11 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorq    %rax, %rdx, %rax
 ;   movq    %rsi, %rdx
 ;   xorq    %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i128) -> i128 {
@@ -93,15 +73,11 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   notq    %rax, %rax
 ;   movq    %rsi, %rdx
 ;   notq    %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(i128, i128) -> i128 {
@@ -110,8 +86,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rax
 ;   movq    %rdi, %rdx
@@ -126,8 +100,6 @@ block0(v0: i128, v1: i128):
 ;   movq    %rdx, %rcx
 ;   movq    %r9, %rdx
 ;   addq    %rdx, %rcx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f7(i64, i64) -> i128 {
@@ -136,13 +108,9 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rdx
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f8(i128) -> i64, i64 {
@@ -151,13 +119,9 @@ block0(v0: i128):
     return v1, v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rdx
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f9(i128, i128) -> i8 {
@@ -314,8 +278,6 @@ block2:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
 ;   setz    %r9b
@@ -325,13 +287,9 @@ block2:
 ;   jnz     label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f11(i128) -> i32 {
@@ -348,8 +306,6 @@ block2:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
 ;   setz    %r9b
@@ -359,13 +315,9 @@ block2:
 ;   jz      label1; j label2
 ; block1:
 ;   movl    $1, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movl    $2, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f12(i64) -> i128 {
@@ -374,13 +326,9 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f13(i64) -> i128 {
@@ -389,14 +337,10 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rdx
 ;   sarq    $63, %rdx, %rdx
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f14(i8) -> i128 {
@@ -405,14 +349,10 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsbq  %dil, %rax
 ;   movq    %rax, %rdx
 ;   sarq    $63, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f15(i8) -> i128 {
@@ -421,13 +361,9 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f16(i128) -> i64 {
@@ -436,12 +372,8 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f17(i128) -> i8 {
@@ -450,12 +382,8 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f18(i8) -> i128 {
@@ -464,13 +392,9 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dil, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f19(i128) -> i128 {
@@ -479,8 +403,6 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrq    $1, %rax, %rax
@@ -524,8 +446,6 @@ block0(v0: i128):
 ;   shrq    $56, %rsi, %rsi
 ;   addq    %rax, %rsi, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f20(i128) -> i128 {
@@ -534,8 +454,6 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movabsq $6148914691236517205, %rcx
 ;   movq    %rsi, %rdx
@@ -621,8 +539,6 @@ block0(v0: i128):
 ;   shrq    $32, %r8, %r8
 ;   shlq    $32, %rdx, %rdx
 ;   orq     %rdx, %r8, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f21(i128, i64) {
@@ -631,13 +547,9 @@ block0(v0: i128, v1: i64):
     return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, 0(%rdx)
 ;   movq    %rsi, 8(%rdx)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f22(i64) -> i128 {
@@ -646,13 +558,9 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rdi), %rax
 ;   movq    8(%rdi), %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f23(i128, i8) -> i128 {
@@ -675,8 +583,6 @@ block2(v8: i128):
     return v11
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorq    %rax, %rax, %rax
 ;   xorq    %r9, %r9, %r9
@@ -688,8 +594,6 @@ block2(v8: i128):
 ;   addq    %rax, %r8, %rax
 ;   movq    %r9, %rdx
 ;   adcq    %rdx, %r10, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   movq    %r9, %rdx
@@ -697,8 +601,6 @@ block2(v8: i128):
 ;   xorq    %r11, %r11, %r11
 ;   addq    %rax, %r9, %rax
 ;   adcq    %rdx, %r11, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f24(i128, i128, i64, i128, i128, i128) -> i128 {
@@ -754,8 +656,6 @@ block0(v0: i128):
     return v0, v0, v0, v1, v0, v0
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, 0(%rdx)
 ;   movq    %rsi, 8(%rdx)
@@ -768,8 +668,6 @@ block0(v0: i128):
 ;   movq    %rdi, %rax
 ;   movq    %rsi, 64(%rdx)
 ;   movq    %rsi, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f26(i128, i128) -> i128, i128 {
@@ -809,8 +707,6 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %r8
 ;   movabsq $-1, %rcx
@@ -827,8 +723,6 @@ block0(v0: i128):
 ;   cmpq    $64, %rdi
 ;   cmovnzq %rdi, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f28(i128) -> i128 {
@@ -837,8 +731,6 @@ block0(v0: i128):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $64, %ecx
 ;   bsfq    %rdi, %rax
@@ -850,8 +742,6 @@ block0(v0: i128):
 ;   cmpq    $64, %rax
 ;   cmovzq  %rdx, %rax, %rax
 ;   xorq    %rdx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f29(i8, i128) -> i8 {
@@ -860,15 +750,11 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f30(i128, i128) -> i128 {
@@ -877,8 +763,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -898,8 +782,6 @@ block0(v0: i128, v1: i128):
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f31(i128, i128) -> i128 {
@@ -908,8 +790,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r8
@@ -930,8 +810,6 @@ block0(v0: i128, v1: i128):
 ;   movq    %r10, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f32(i128, i128) -> i128 {
@@ -940,8 +818,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r8
@@ -963,8 +839,6 @@ block0(v0: i128, v1: i128):
 ;   movq    %r10, %rax
 ;   cmovzq  %r8, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f33(i128, i128) -> i128 {
@@ -973,8 +847,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -1017,8 +889,6 @@ block0(v0: i128, v1: i128):
 ;   cmovzq  %r9, %r8, %r8
 ;   orq     %rax, %r11, %rax
 ;   orq     %rdx, %r8, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f34(i128, i128) -> i128 {
@@ -1027,8 +897,6 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r8
@@ -1071,7 +939,5 @@ block0(v0: i128, v1: i128):
 ;   cmovzq  %r11, %r9, %r9
 ;   orq     %rax, %rdi, %rax
 ;   orq     %rdx, %r9, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -15,8 +15,6 @@ block0(v0: i64, v1: i64):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %r9
 ;   addq    %r9, const(0), %r9
@@ -29,7 +27,5 @@ block0(v0: i64, v1: i64):
 ;   movq    %r11, 0(%rsi)
 ;   orq     %rdi, const(0), %rdi
 ;   movq    %rdi, 0(%rsi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -14,8 +14,6 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dl, %rcx
 ;   movq    %rdi, %rdx
@@ -35,8 +33,6 @@ block0(v0: i128, v1: i8):
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i128_i64(i128, i64) -> i128 {
@@ -45,8 +41,6 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -66,8 +60,6 @@ block0(v0: i128, v1: i64):
 ;   testq   $64, %rsi
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i128_i32(i128, i32) -> i128 {
@@ -76,8 +68,6 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -97,8 +87,6 @@ block0(v0: i128, v1: i32):
 ;   testq   $64, %rsi
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i128_i16(i128, i16) -> i128 {
@@ -107,8 +95,6 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -128,8 +114,6 @@ block0(v0: i128, v1: i16):
 ;   testq   $64, %rsi
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i128_i8(i128, i8) -> i128 {
@@ -138,8 +122,6 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -159,8 +141,6 @@ block0(v0: i128, v1: i8):
 ;   testq   $64, %rsi
 ;   cmovzq  %rdx, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_i128(i64, i128) -> i64 {
@@ -169,14 +149,10 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shlq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_i128(i32, i128) -> i32 {
@@ -185,14 +161,10 @@ block0(v0: i32, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shll    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_i128(i16, i128) -> i16 {
@@ -201,15 +173,11 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shlw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_i128(i8, i128) -> i8 {
@@ -218,15 +186,11 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_i64(i64, i64) -> i64 {
@@ -235,14 +199,10 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shlq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_i32(i64, i32) -> i64 {
@@ -251,14 +211,10 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shlq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_i16(i64, i16) -> i64 {
@@ -267,14 +223,10 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shlq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_i8(i64, i8) -> i64 {
@@ -283,14 +235,10 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shlq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_i64(i32, i64) -> i32 {
@@ -299,14 +247,10 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shll    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_i32(i32, i32) -> i32 {
@@ -315,14 +259,10 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shll    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_i16(i32, i16) -> i32 {
@@ -331,14 +271,10 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shll    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_i8(i32, i8) -> i32 {
@@ -347,14 +283,10 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shll    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_i64(i16, i64) -> i16 {
@@ -363,15 +295,11 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shlw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_i32(i16, i32) -> i16 {
@@ -380,15 +308,11 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shlw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_i16(i16, i16) -> i16 {
@@ -397,15 +321,11 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shlw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_i8(i16, i8) -> i16 {
@@ -414,15 +334,11 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shlw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_i64(i8, i64) -> i8 {
@@ -431,15 +347,11 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_i32(i8, i32) -> i8 {
@@ -448,15 +360,11 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_i16(i8, i16) -> i8 {
@@ -465,15 +373,11 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_i8(i8, i8) -> i8 {
@@ -482,15 +386,11 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shlb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i64_const(i64) -> i64 {
@@ -499,13 +399,9 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shlq    $1, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i32_const(i32) -> i32 {
@@ -514,13 +410,9 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shll    $1, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i16_const(i16) -> i16 {
@@ -529,13 +421,9 @@ block0(v0: i16):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shlw    $1, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8_const(i8) -> i8 {
@@ -544,12 +432,8 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shlb    $1, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf.clif
@@ -10,11 +10,7 @@ block0(v0: i64):
     return v0
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/load-op-store.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op-store.clif
@@ -9,12 +9,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   addl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i64, i32) {
@@ -25,12 +21,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   addl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i64, i32) {
@@ -41,12 +33,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   subl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64, i32) {
@@ -57,12 +45,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   andl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i32) {
@@ -73,12 +57,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   andl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i64, i32) {
@@ -89,12 +69,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   orl     %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(i64, i32) {
@@ -105,12 +81,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   orl     %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f7(i64, i32) {
@@ -121,12 +93,8 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f8(i64, i32) {
@@ -137,11 +105,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorl    %esi, 32(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -8,13 +8,9 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
 ;   addl    %eax, 0(%rdi), %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %add_from_mem_u32_2(i64, i32) -> i32 {
@@ -24,13 +20,9 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
 ;   addl    %eax, 0(%rdi), %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %add_from_mem_u64_1(i64, i64) -> i64 {
@@ -40,13 +32,9 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
 ;   addq    %rax, 0(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %add_from_mem_u64_2(i64, i64) -> i64 {
@@ -56,13 +44,9 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rax
 ;   addq    %rax, 0(%rdi), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %add_from_mem_not_narrow(i64, i8) -> i8 {
@@ -72,13 +56,9 @@ block0(v0: i64, v1: i8):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  0(%rdi), %rax
 ;   addl    %eax, %esi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %no_merge_if_lookback_use(i64, i64) -> i64 {
@@ -90,16 +70,12 @@ block0(v0: i64, v1: i64):
   return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rdi), %r8
 ;   movq    %r8, %r9
 ;   addq    %r9, %rdi, %r9
 ;   movq    %r9, 0(%rsi)
 ;   movq    0(%r8,%rdi,1), %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %merge_scalar_to_vector(i64) -> i32x4 {
@@ -112,14 +88,10 @@ block1:
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movss   0(%rdi), %xmm0
 ;   jmp     label1
 ; block1:
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %cmp_mem(i64) -> i64 {
@@ -130,13 +102,9 @@ block0(v0: i64):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    0(%rdi), %rdi
 ;   setz    %dl
 ;   movzbq  %dl, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -13,10 +13,6 @@ block0(v0: i32x4):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -7,12 +7,8 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   packsswb %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32x4, i32x4) -> i16x8 {
@@ -21,12 +17,8 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   packssdw %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(f64x2) -> i32x4 {
@@ -37,8 +29,6 @@ block0(v0: f64x2):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   cmppd   $0, %xmm4, %xmm0, %xmm4
@@ -47,8 +37,6 @@ block0(v0: f64x2):
 ;   movdqa  %xmm0, %xmm8
 ;   minpd   %xmm8, %xmm4, %xmm8
 ;   cvttpd2dq %xmm8, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i16x8, i16x8) -> i8x16 {
@@ -57,12 +45,8 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   packuswb %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i32x4, i32x4) -> i16x8 {
@@ -71,11 +55,7 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   packusdw %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -7,13 +7,9 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %NearestF32+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -22,12 +18,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %NearestF64+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -7,12 +7,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundss $0, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -21,12 +17,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundsd $0, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32x4) -> f32x4 {
@@ -35,12 +27,8 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundps $0, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -49,11 +37,7 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundpd $0, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -10,14 +10,10 @@ block0:
     return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %r15, %rsi
 ;   addq    %rsi, $1, %rsi
 ;   movq    %rsi, %r15
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1() windows_fastcall {

--- a/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
@@ -7,12 +7,8 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   popcntq %rdi, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %popcnt(i32) -> i32 {
@@ -21,11 +17,7 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   popcntl %edi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -7,8 +7,6 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rcx
 ;   shrq    $1, %rdi, %rdi
@@ -30,8 +28,6 @@ block0(v0: i64):
 ;   movabsq $72340172838076673, %rcx
 ;   imulq   %rax, %rcx, %rax
 ;   shrq    $56, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %popcnt64load(i64) -> i64 {
@@ -41,8 +37,6 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rdi), %rdx
 ;   movq    %rdx, %rcx
@@ -64,8 +58,6 @@ block0(v0: i64):
 ;   movabsq $72340172838076673, %rdx
 ;   imulq   %rax, %rdx, %rax
 ;   shrq    $56, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %popcnt32(i32) -> i32 {
@@ -74,8 +66,6 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrl    $1, %edi, %edi
@@ -95,8 +85,6 @@ block0(v0: i32):
 ;   andl    %eax, $252645135, %eax
 ;   imull   %eax, $16843009, %eax
 ;   shrl    $24, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %popcnt32load(i64) -> i32 {
@@ -106,8 +94,6 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    0(%rdi), %edx
 ;   movq    %rdx, %rcx
@@ -127,7 +113,5 @@ block0(v0: i64):
 ;   andl    %eax, $252645135, %eax
 ;   imull   %eax, $16843009, %eax
 ;   shrl    $24, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -7,14 +7,10 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   cbw %al, %al
 ;   idiv    %al, (none), %sil, %al, (none)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16, i16) -> i16 {
@@ -23,14 +19,10 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   cwd %ax, %dx
 ;   idiv    %ax, %dx, %si, %ax, %dx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32, i32) -> i32 {
@@ -39,14 +31,10 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   cdq %eax, %edx
 ;   idiv    %eax, %edx, %esi, %eax, %edx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -55,13 +43,9 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   cqo %rax, %rdx
 ;   idiv    %rax, %rdx, %rsi, %rax, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -10,8 +10,6 @@ block0(v0: i32, v1: i128, v2: i128):
     return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    $42, %edi
 ;   movq    %rcx, %rax
@@ -19,8 +17,6 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   movq    %rdx, %rdi
 ;   movq    %r8, %rdx
 ;   cmovzq  %rdi, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(f32, i128, i128) -> i128 {
@@ -30,8 +26,6 @@ block0(v0: f32, v1: i128, v2: i128):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm0, %xmm0
 ;   movq    %rdi, %rax
@@ -40,7 +34,5 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq    %rsi, %rdx
 ;   cmovnzq %rcx, %rdx, %rdx
 ;   cmovpq  %rcx, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/sextend.clif
+++ b/cranelift/filetests/filetests/isa/x64/sextend.clif
@@ -7,11 +7,7 @@ block0(v0: i8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movsbq  %dil, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -9,15 +9,11 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm5, %xmm6
 ;   vpermi2b %xmm1, %xmm6, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %shuffle_out_of_bounds(i8x16, i8x16) -> i8x16 {
@@ -29,8 +25,6 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm7
 ;   movdqu  const(1), %xmm0
@@ -38,8 +32,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   movdqa  %xmm7, %xmm9
 ;   vpermi2b %xmm1, %xmm9, %xmm6, %xmm6
 ;   andps   %xmm0, %xmm6, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i8x16, i8x16) -> i8x16 {
@@ -48,14 +40,10 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm5, %xmm6
 ;   vpermi2b %xmm1, %xmm6, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -9,8 +9,6 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   pcmpeqb %xmm4, %xmm1, %xmm4
@@ -19,8 +17,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   movdqa  %xmm1, %xmm4
 ;   pblendvb %xmm4, %xmm7, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %mask_from_fcmp(f32x4, f32x4, i32x4, i32x4) -> i32x4  {
@@ -30,15 +26,11 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
     return v5
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   cmpps   $0, %xmm0, %xmm1, %xmm0
 ;   movdqa  %xmm3, %xmm6
 ;   pblendvb %xmm6, %xmm2, %xmm6
 ;   movdqa  %xmm6, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %mask_casted(i8x16, i8x16, i32x4) -> i8x16 {
@@ -48,16 +40,12 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   pand    %xmm4, %xmm2, %xmm4
 ;   movdqa  %xmm2, %xmm0
 ;   pandn   %xmm0, %xmm1, %xmm0
 ;   por     %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %good_const_mask_i8x16(i8x16, i8x16) -> i8x16 {
@@ -67,8 +55,6 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
@@ -76,8 +62,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   movdqa  %xmm1, %xmm4
 ;   pblendvb %xmm4, %xmm6, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %good_const_mask_i16x8(i16x8, i16x8) -> i16x8 {
@@ -87,8 +71,6 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
@@ -96,8 +78,6 @@ block0(v0: i16x8, v1: i16x8):
 ;   movdqa  %xmm1, %xmm4
 ;   pblendvb %xmm4, %xmm6, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bad_const_mask(i8x16, i8x16) -> i8x16 {
@@ -107,8 +87,6 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm8
 ;   movdqu  const(0), %xmm0
@@ -116,7 +94,5 @@ block0(v0: i8x16, v1: i8x16):
 ;   pand    %xmm4, %xmm0, %xmm4
 ;   pandn   %xmm0, %xmm1, %xmm0
 ;   por     %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -8,12 +8,8 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   andps   %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %band_f64x2(f64x2, f64x2) -> f64x2 {
@@ -22,12 +18,8 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   andpd   %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %band_i32x4(i32x4, i32x4) -> i32x4 {
@@ -36,12 +28,8 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pand    %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bor_f32x4(f32x4, f32x4) -> f32x4 {
@@ -50,12 +38,8 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   orps    %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bor_f64x2(f64x2, f64x2) -> f64x2 {
@@ -64,12 +48,8 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   orpd    %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bor_i32x4(i32x4, i32x4) -> i32x4 {
@@ -78,12 +58,8 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   por     %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bxor_f32x4(f32x4, f32x4) -> f32x4 {
@@ -92,12 +68,8 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorps   %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bxor_f64x2(f64x2, f64x2) -> f64x2 {
@@ -106,12 +78,8 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorpd   %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %bxor_i32x4(i32x4, i32x4) -> i32x4 {
@@ -120,12 +88,8 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pxor    %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %vselect_i16x8(i16x8, i16x8, i16x8) -> i16x8 {
@@ -134,14 +98,10 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm2, %xmm4
 ;   pblendvb %xmm4, %xmm1, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %vselect_f32x4(i32x4, f32x4, f32x4) -> f32x4 {
@@ -150,14 +110,10 @@ block0(v0: i32x4, v1: f32x4, v2: f32x4):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm2, %xmm4
 ;   blendvps %xmm4, %xmm1, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %vselect_f64x2(i64x2, f64x2, f64x2) -> f64x2 {
@@ -166,14 +122,10 @@ block0(v0: i64x2, v1: f64x2, v2: f64x2):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm2, %xmm4
 ;   blendvpd %xmm4, %xmm1, %xmm4
 ;   movdqa  %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ishl_i8x16(i32) -> i8x16 {
@@ -183,8 +135,6 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(1), %xmm0
 ;   movq    %rdi, %r10
@@ -195,8 +145,6 @@ block0(v0: i32):
 ;   shlq    $4, %r10, %r10
 ;   movdqu  0(%rsi,%r10,1), %xmm13
 ;   pand    %xmm0, %xmm13, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8x16_imm() -> i8x16 {
@@ -207,8 +155,6 @@ block0:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(1), %xmm0
 ;   movl    $1, %r9d
@@ -219,8 +165,6 @@ block0:
 ;   shlq    $4, %r9, %r9
 ;   movdqu  0(%rsi,%r9,1), %xmm13
 ;   pand    %xmm0, %xmm13, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8x16(i32) -> i8x16 {
@@ -230,8 +174,6 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm8
 ;   movq    %rdi, %r9
@@ -244,8 +186,6 @@ block0(v0: i32):
 ;   psraw   %xmm0, %xmm11, %xmm0
 ;   psraw   %xmm8, %xmm11, %xmm8
 ;   packsswb %xmm0, %xmm8, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8x16_imm(i8x16, i32) -> i8x16 {
@@ -254,8 +194,6 @@ block0(v0: i8x16, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $3, %r10d
 ;   andq    %r10, $7, %r10
@@ -270,8 +208,6 @@ block0(v0: i8x16, v1: i32):
 ;   psraw   %xmm0, %xmm14, %xmm0
 ;   psraw   %xmm13, %xmm14, %xmm13
 ;   packsswb %xmm0, %xmm13, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64x2(i64x2, i32) -> i64x2 {
@@ -280,8 +216,6 @@ block0(v0: i64x2, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pextrd.w $0, %xmm0, %r8
 ;   pextrd.w $1, %xmm0, %r10
@@ -291,7 +225,5 @@ block0(v0: i64x2, v1: i32):
 ;   uninit  %xmm0
 ;   pinsrd.w $0, %xmm0, %r8, %xmm0
 ;   pinsrd.w $1, %xmm0, %r10, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -8,14 +8,10 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm5, %xmm5, %xmm5
 ;   pxor    %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %icmp_ugt_i32x4(i32x4, i32x4) -> i32x4 {
@@ -24,15 +20,11 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmaxud  %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm0, %xmm1, %xmm0
 ;   pcmpeqd %xmm7, %xmm7, %xmm7
 ;   pxor    %xmm0, %xmm7, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %icmp_sge_i16x8(i16x8, i16x8) -> i16x8 {
@@ -41,14 +33,10 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
 ;   pmaxsw  %xmm3, %xmm1, %xmm3
 ;   pcmpeqw %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %icmp_uge_i8x16(i8x16, i8x16) -> i8x16 {
@@ -57,13 +45,9 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
 ;   pmaxub  %xmm3, %xmm1, %xmm3
 ;   pcmpeqb %xmm0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -12,8 +12,6 @@ block0:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(3), %xmm0
 ;   movdqu  const(2), %xmm4
@@ -22,8 +20,6 @@ block0:
 ;   movdqu  const(1), %xmm6
 ;   pshufb  %xmm4, %xmm6, %xmm4
 ;   por     %xmm0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %shuffle_same_ssa_value() -> i8x16 {
@@ -33,14 +29,10 @@ block0:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(1), %xmm0
 ;   movdqu  const(0), %xmm1
 ;   pshufb  %xmm0, %xmm1, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %swizzle() -> i8x16 {
@@ -51,16 +43,12 @@ block0:
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(1), %xmm0
 ;   movdqu  const(1), %xmm2
 ;   movdqu  const(0), %xmm3
 ;   paddusb %xmm2, %xmm3, %xmm2
 ;   pshufb  %xmm0, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %splat_i8(i8) -> i8x16 {
@@ -69,15 +57,11 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   uninit  %xmm0
 ;   pinsrb  $0, %xmm0, %rdi, %xmm0
 ;   pxor    %xmm6, %xmm6, %xmm6
 ;   pshufb  %xmm0, %xmm6, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %splat_i16() -> i16x8 {
@@ -87,16 +71,12 @@ block0:
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    $-1, %esi
 ;   uninit  %xmm4
 ;   pinsrw  $0, %xmm4, %rsi, %xmm4
 ;   pinsrw  $1, %xmm4, %rsi, %xmm4
 ;   pshufd  $0, %xmm4, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %splat_i32(i32) -> i32x4 {
@@ -105,14 +85,10 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   uninit  %xmm3
 ;   pinsrd  $0, %xmm3, %rdi, %xmm3
 ;   pshufd  $0, %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %splat_f64(f64) -> f64x2 {
@@ -121,16 +97,12 @@ block0(v0: f64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   uninit  %xmm0
 ;   movdqa  %xmm5, %xmm6
 ;   movsd   %xmm0, %xmm6, %xmm0
 ;   movlhps %xmm0, %xmm6, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %load32_zero_coalesced(i64) -> i32x4 {
@@ -140,12 +112,8 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movss   0(%rdi), %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %load32_zero_int(i32) -> i32x4 {
@@ -154,12 +122,8 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movd    %edi, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %load32_zero_float(f32) -> f32x4 {
@@ -168,10 +132,6 @@ block0(v0: f32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -8,13 +8,9 @@ block0(v0: i32x4):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pcmpeqd %xmm2, %xmm2, %xmm2
 ;   pxor    %xmm0, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %vany_true_i32x4(i32x4) -> i8 {
@@ -23,13 +19,9 @@ block0(v0: i32x4):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ptest   %xmm0, %xmm0
 ;   setnz   %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %vall_true_i64x2(i64x2) -> i8 {
@@ -38,15 +30,11 @@ block0(v0: i64x2):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pxor    %xmm2, %xmm2, %xmm2
 ;   movdqa  %xmm0, %xmm4
 ;   pcmpeqq %xmm4, %xmm2, %xmm4
 ;   ptest   %xmm4, %xmm4
 ;   setz    %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -9,15 +9,11 @@ block0(v0: i8x16):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm4, %xmm5
 ;   pmaddubsw %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fn2(i16x8) -> i32x4 {
@@ -28,13 +24,9 @@ block0(v0: i16x8):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm2
 ;   pmaddwd %xmm0, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fn3(i8x16) -> i16x8 {
@@ -45,13 +37,9 @@ block0(v0: i8x16):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm2
 ;   pmaddubsw %xmm0, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %fn4(i16x8) -> i32x4 {
@@ -62,8 +50,6 @@ block0(v0: i16x8):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm2
 ;   pxor    %xmm0, %xmm2, %xmm0
@@ -71,7 +57,5 @@ block0(v0: i16x8):
 ;   pmaddwd %xmm0, %xmm6, %xmm0
 ;   movdqu  const(2), %xmm10
 ;   paddd   %xmm0, %xmm10, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -12,8 +12,6 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
 ;   palignr $8, %xmm3, %xmm0, %xmm3
@@ -22,8 +20,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   palignr $8, %xmm7, %xmm1, %xmm7
 ;   pmovsxbw %xmm7, %xmm9
 ;   pmullw  %xmm0, %xmm9, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_swiden_hi_i16x8(i16x8, i16x8) -> i32x4 {
@@ -34,8 +30,6 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
@@ -44,8 +38,6 @@ block0(v0: i16x8, v1: i16x8):
 ;   pmulhw  %xmm5, %xmm1, %xmm5
 ;   movdqa  %xmm6, %xmm0
 ;   punpckhwd %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_swiden_hi_i32x4(i32x4, i32x4) -> i64x2 {
@@ -56,14 +48,10 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $250, %xmm0, %xmm0
 ;   pshufd  $250, %xmm1, %xmm5
 ;   pmuldq  %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_swiden_low_i8x16(i8x16, i8x16) -> i16x8 {
@@ -74,14 +62,10 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovsxbw %xmm0, %xmm0
 ;   pmovsxbw %xmm1, %xmm5
 ;   pmullw  %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_swiden_low_i16x8(i16x8, i16x8) -> i32x4 {
@@ -92,8 +76,6 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
@@ -102,8 +84,6 @@ block0(v0: i16x8, v1: i16x8):
 ;   pmulhw  %xmm5, %xmm1, %xmm5
 ;   movdqa  %xmm6, %xmm0
 ;   punpcklwd %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_swiden_low_i32x4(i32x4, i32x4) -> i64x2 {
@@ -114,14 +94,10 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $80, %xmm0, %xmm0
 ;   pshufd  $80, %xmm1, %xmm5
 ;   pmuldq  %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_hi_i8x16(i8x16, i8x16) -> i16x8 {
@@ -132,8 +108,6 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm3
 ;   palignr $8, %xmm3, %xmm0, %xmm3
@@ -142,8 +116,6 @@ block0(v0: i8x16, v1: i8x16):
 ;   palignr $8, %xmm7, %xmm1, %xmm7
 ;   pmovzxbw %xmm7, %xmm9
 ;   pmullw  %xmm0, %xmm9, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_hi_i16x8(i16x8, i16x8) -> i32x4 {
@@ -154,8 +126,6 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
@@ -164,8 +134,6 @@ block0(v0: i16x8, v1: i16x8):
 ;   pmulhuw %xmm5, %xmm1, %xmm5
 ;   movdqa  %xmm6, %xmm0
 ;   punpckhwd %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_hi_i32x4(i32x4, i32x4) -> i64x2 {
@@ -176,14 +144,10 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $250, %xmm0, %xmm0
 ;   pshufd  $250, %xmm1, %xmm5
 ;   pmuludq %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_low_i8x16(i8x16, i8x16) -> i16x8 {
@@ -194,14 +158,10 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovzxbw %xmm0, %xmm0
 ;   pmovzxbw %xmm1, %xmm5
 ;   pmullw  %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_low_i16x8(i16x8, i16x8) -> i32x4 {
@@ -212,8 +172,6 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
@@ -222,8 +180,6 @@ block0(v0: i16x8, v1: i16x8):
 ;   pmulhuw %xmm5, %xmm1, %xmm5
 ;   movdqa  %xmm6, %xmm0
 ;   punpcklwd %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %imul_uwiden_low_i32x4(i32x4, i32x4) -> i64x2 {
@@ -234,13 +190,9 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $80, %xmm0, %xmm0
 ;   pshufd  $80, %xmm1, %xmm5
 ;   pmuludq %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/smulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/smulhi.clif
@@ -7,14 +7,10 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   imul    %ax, %si, %ax, %dx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32, i32) -> i32 {
@@ -23,14 +19,10 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   imul    %eax, %esi, %eax, %edx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64, i64) -> i64 {
@@ -39,13 +31,9 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   imul    %rax, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -7,14 +7,10 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm5
 ;   pmulhrsw %xmm0, %xmm1, %xmm0
 ;   pcmpeqw %xmm5, %xmm0, %xmm5
 ;   pxor    %xmm0, %xmm5, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -7,15 +7,11 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %al, %dl, %sil, %al, %dl, tmp=(none)
 ;   shrq    $8, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16, i16) -> i16 {
@@ -24,15 +20,11 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %ax, %dx, %si, %ax, %dx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32, i32) -> i32 {
@@ -41,15 +33,11 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %eax, %edx, %esi, %eax, %edx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -58,14 +46,10 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   xorl    %edx, %edx, %edx
 ;   srem_seq %rax, %rdx, %rsi, %rax, %rdx, tmp=(none)
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -13,8 +13,6 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dl, %rcx
 ;   movq    %rdi, %r8
@@ -37,8 +35,6 @@ block0(v0: i128, v1: i8):
 ;   movq    %r10, %rax
 ;   cmovzq  %r8, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i128_i64(i128, i64) -> i128 {
@@ -47,8 +43,6 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r11
@@ -70,8 +64,6 @@ block0(v0: i128, v1: i64):
 ;   movq    %r9, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i128_i32(i128, i32) -> i128 {
@@ -80,8 +72,6 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r11
@@ -103,8 +93,6 @@ block0(v0: i128, v1: i32):
 ;   movq    %r9, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i128_i16(i128, i16) -> i128 {
@@ -113,8 +101,6 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r11
@@ -136,8 +122,6 @@ block0(v0: i128, v1: i16):
 ;   movq    %r9, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
@@ -146,8 +130,6 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %r11
@@ -169,8 +151,6 @@ block0(v0: i128, v1: i8):
 ;   movq    %r9, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_i128(i64, i128) -> i64 {
@@ -179,14 +159,10 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_i128(i32, i128) -> i32 {
@@ -195,14 +171,10 @@ block0(v0: i32, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_i128(i16, i128) -> i16 {
@@ -211,15 +183,11 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   sarw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_i128(i8, i128) -> i8 {
@@ -228,15 +196,11 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   sarb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_i64(i64, i64) -> i64 {
@@ -245,14 +209,10 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_i32(i64, i32) -> i64 {
@@ -261,14 +221,10 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_i16(i64, i16) -> i64 {
@@ -277,14 +233,10 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_i8(i64, i8) -> i64 {
@@ -293,14 +245,10 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_i64(i32, i64) -> i32 {
@@ -309,14 +257,10 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_i32(i32, i32) -> i32 {
@@ -325,14 +269,10 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_i16(i32, i16) -> i32 {
@@ -341,14 +281,10 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_i8(i32, i8) -> i32 {
@@ -357,14 +293,10 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   sarl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_i64(i16, i64) -> i16 {
@@ -373,15 +305,11 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   sarw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_i32(i16, i32) -> i16 {
@@ -390,15 +318,11 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   sarw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_i16(i16, i16) -> i16 {
@@ -407,15 +331,11 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   sarw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_i8(i16, i8) -> i16 {
@@ -424,15 +344,11 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   sarw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_i64(i8, i64) -> i8 {
@@ -441,15 +357,11 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   sarb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_i32(i8, i32) -> i8 {
@@ -458,15 +370,11 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   sarb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_i16(i8, i16) -> i8 {
@@ -475,15 +383,11 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   sarb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_i8(i8, i8) -> i8 {
@@ -492,15 +396,11 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   sarb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i64_const(i64) -> i64 {
@@ -509,13 +409,9 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   sarq    $1, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i32_const(i32) -> i32 {
@@ -524,13 +420,9 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   sarl    $1, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i16_const(i16) -> i16 {
@@ -539,13 +431,9 @@ block0(v0: i16):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   sarw    $1, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %sshr_i8_const(i8) -> i8 {
@@ -554,12 +442,8 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   sarb    $1, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -8,16 +8,11 @@ block0(v0: i64):
     return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $42, %edx
 ;   movq    %rdx, 0(%rdi)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
-
 
 function %f1(i64, i64) -> i64 {
     fn0 = %f2(i64 sret) -> i64

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -25,11 +25,7 @@ block0:
     return v0
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %global0+0, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -16,8 +16,6 @@ block0(v0: i32, v1: r64, v2: i64):
     return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    8(%rdx), %r11d
 ;   cmpl    %r11d, %edi
@@ -30,8 +28,6 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   cmpl    %r11d, %edi
 ;   cmovnbq %rax, %rdx, %rdx
 ;   movq    %rsi, 0(%rdx)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 ; block2:
 ;   ud2 table_oob

--- a/cranelift/filetests/filetests/isa/x64/tls_coff.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_coff.clif
@@ -11,11 +11,7 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   %rax = coff_tls_get_addr User(userextname0)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -10,11 +10,7 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   %rax = elf_tls_get_addr User(userextname0)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -6,11 +6,8 @@ block0:
   trap user0
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   ud2 user0
-
 
 function %trap_iadd_ifcout(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -18,13 +15,9 @@ block0(v0: i64, v1: i64):
   return
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rcx
 ;   addq    %rcx, %rsi, %rcx
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -7,13 +7,9 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %TruncF32+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -22,12 +18,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %TruncF64+0, %rcx
 ;   call    *%rcx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/trunc.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc.clif
@@ -7,12 +7,8 @@ block0(v0: f32):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundss $3, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(f64) -> f64 {
@@ -21,12 +17,8 @@ block0(v0: f64):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundsd $3, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f32x4) -> f32x4 {
@@ -35,12 +27,8 @@ block0(v0: f32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundps $3, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(f64x2) -> f64x2 {
@@ -49,11 +37,7 @@ block0(v0: f64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   roundpd $3, %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
@@ -8,14 +8,10 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addl    %eax, $127, %eax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f1(i32) -> i32 {
@@ -25,14 +21,10 @@ block0(v0: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addl    %eax, $127, %eax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32, i32) -> i32 {
@@ -41,14 +33,10 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addl    %eax, %esi, %eax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -58,14 +46,10 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addq    %rax, $127, %rax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -75,14 +59,10 @@ block0(v0: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addq    %rax, $127, %rax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -91,13 +71,9 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addq    %rax, %rsi, %rax
 ;   jnb ; ud2 user0 ;
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -7,13 +7,9 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbl  %dil, %eax
 ;   div     %al, (none), %sil, %al, (none)
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16, i16) -> i16 {
@@ -22,14 +18,10 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %ax, %dx, %si, %ax, %dx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32, i32) -> i32 {
@@ -38,14 +30,10 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %eax, %edx, %esi, %eax, %edx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -54,13 +42,9 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %rax, %rdx, %rsi, %rax, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
@@ -8,12 +8,8 @@ block0(v0: i32, v1: i32):
     return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   addl    %eax, %esi, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -8,14 +8,10 @@ block0(v1: i32, v2: i64):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movl    0(%rsi), %edx
 ;   cmpl    %edi, %edx
 ;   movq    %rdi, %rax
 ;   cmovnbl %edx, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/umulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/umulhi.clif
@@ -7,14 +7,10 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   mul     %ax, %si, %ax, %dx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i32, i32) -> i32 {
@@ -23,14 +19,10 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   mul     %eax, %esi, %eax, %edx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i64, i64) -> i64 {
@@ -39,13 +31,9 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   mul     %rax, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/unused_jt_unreachable_block.clif
+++ b/cranelift/filetests/filetests/isa/x64/unused_jt_unreachable_block.clif
@@ -13,10 +13,6 @@ block1:
     trap unreachable
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -7,14 +7,10 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbl  %dil, %eax
 ;   div     %al, (none), %sil, %al, (none)
 ;   shrq    $8, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16, i16) -> i16 {
@@ -23,15 +19,11 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %ax, %dx, %si, %ax, %dx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32, i32) -> i32 {
@@ -40,15 +32,11 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %eax, %edx, %esi, %eax, %edx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -57,14 +45,10 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   movl    $0, %edx
 ;   div     %rax, %rdx, %rsi, %rax, %rdx
 ;   movq    %rdx, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -12,8 +12,6 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dl, %rcx
 ;   movq    %rdi, %r8
@@ -35,8 +33,6 @@ block0(v0: i128, v1: i8):
 ;   movq    %r10, %rax
 ;   cmovzq  %r11, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i128_i64(i128, i64) -> i128 {
@@ -45,8 +41,6 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -68,8 +62,6 @@ block0(v0: i128, v1: i64):
 ;   movq    %r9, %rax
 ;   cmovzq  %r10, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i128_i32(i128, i32) -> i128 {
@@ -78,8 +70,6 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -101,8 +91,6 @@ block0(v0: i128, v1: i32):
 ;   movq    %r9, %rax
 ;   cmovzq  %r10, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i128_i16(i128, i16) -> i128 {
@@ -111,8 +99,6 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -134,8 +120,6 @@ block0(v0: i128, v1: i16):
 ;   movq    %r9, %rax
 ;   cmovzq  %r10, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
@@ -144,8 +128,6 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdi, %rdx
@@ -167,8 +149,6 @@ block0(v0: i128, v1: i8):
 ;   movq    %r9, %rax
 ;   cmovzq  %r10, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_i128(i64, i128) -> i64 {
@@ -177,14 +157,10 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_i128(i32, i64, i64) -> i32 {
@@ -194,14 +170,10 @@ block0(v0: i32, v1: i64, v2: i64):
     return v4
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_i128(i16, i128) -> i16 {
@@ -210,15 +182,11 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shrw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_i128(i8, i128) -> i8 {
@@ -227,15 +195,11 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shrb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_i64(i64, i64) -> i64 {
@@ -244,14 +208,10 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_i32(i64, i32) -> i64 {
@@ -260,14 +220,10 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_i16(i64, i16) -> i64 {
@@ -276,14 +232,10 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_i8(i64, i8) -> i64 {
@@ -292,14 +244,10 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrq    %cl, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_i64(i32, i64) -> i32 {
@@ -308,14 +256,10 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_i32(i32, i32) -> i32 {
@@ -324,14 +268,10 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_i16(i32, i16) -> i32 {
@@ -340,14 +280,10 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_i8(i32, i8) -> i32 {
@@ -356,14 +292,10 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   movq    %rdi, %rax
 ;   shrl    %cl, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_i64(i16, i64) -> i16 {
@@ -372,15 +304,11 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shrw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_i32(i16, i32) -> i16 {
@@ -389,15 +317,11 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shrw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_i16(i16, i16) -> i16 {
@@ -406,15 +330,11 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shrw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_i8(i16, i8) -> i16 {
@@ -423,15 +343,11 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $15, %rcx
 ;   movq    %rdi, %rax
 ;   shrw    %cl, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_i64(i8, i64) -> i8 {
@@ -440,15 +356,11 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shrb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_i32(i8, i32) -> i8 {
@@ -457,15 +369,11 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shrb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_i16(i8, i16) -> i8 {
@@ -474,15 +382,11 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shrb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_i8(i8, i8) -> i8 {
@@ -491,15 +395,11 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rsi, %rcx
 ;   andq    %rcx, $7, %rcx
 ;   movq    %rdi, %rax
 ;   shrb    %cl, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i64_const(i64) -> i64 {
@@ -508,13 +408,9 @@ block0(v0: i64):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrq    $1, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i32_const(i32) -> i32 {
@@ -523,13 +419,9 @@ block0(v0: i32):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrl    $1, %eax, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i16_const(i16) -> i16 {
@@ -538,13 +430,9 @@ block0(v0: i16):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrw    $1, %ax, %ax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %ushr_i8_const(i8) -> i8 {
@@ -553,12 +441,8 @@ block0(v0: i8):
     return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
 ;   shrb    $1, %al, %al
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -9,8 +9,6 @@ block0(v0: f64x2):
   return v3
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   xorpd   %xmm2, %xmm2, %xmm2
 ;   movdqa  %xmm0, %xmm6
@@ -21,7 +19,5 @@ block0(v0: f64x2):
 ;   movupd  const(1), %xmm12
 ;   addpd   %xmm0, %xmm12, %xmm0
 ;   shufps  $136, %xmm0, %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
@@ -7,12 +7,8 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovmskb %xmm0, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i8x16) -> i16 {
@@ -21,12 +17,8 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovmskb %xmm0, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i16x8) -> i8 {
@@ -35,15 +27,11 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm2
 ;   packsswb %xmm2, %xmm0, %xmm2
 ;   pmovmskb %xmm2, %eax
 ;   shrq    $8, %rax, %rax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i32x4) -> i8 {
@@ -52,12 +40,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movmskps %xmm0, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i64x2) -> i8 {
@@ -66,11 +50,7 @@ block0(v0: i64x2):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movmskpd %xmm0, %eax
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -8,13 +8,9 @@ block0(v0: i64, v2: i8x16):
     return v6
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  80(%rdi), %xmm3
 ;   palignr $8, %xmm3, %xmm3, %xmm3
 ;   pmovzxbw %xmm3, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -7,12 +7,8 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovsxbw %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f2(i16x8) -> i32x4 {
@@ -21,12 +17,8 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovsxwd %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f3(i32x4) -> i64x2 {
@@ -35,12 +27,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovsxdq %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f4(i8x16) -> i16x8 {
@@ -49,14 +37,10 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm2
 ;   palignr $8, %xmm2, %xmm0, %xmm2
 ;   pmovsxbw %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f5(i16x8) -> i32x4 {
@@ -65,14 +49,10 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm2
 ;   palignr $8, %xmm2, %xmm0, %xmm2
 ;   pmovsxwd %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f6(i32x4) -> i64x2 {
@@ -81,13 +61,9 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $238, %xmm0, %xmm2
 ;   pmovsxdq %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f7(i8x16) -> i16x8 {
@@ -96,12 +72,8 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovzxbw %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f8(i16x8) -> i32x4 {
@@ -110,12 +82,8 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovzxwd %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f9(i32x4) -> i64x2 {
@@ -124,12 +92,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pmovzxdq %xmm0, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f10(i8x16) -> i16x8 {
@@ -138,14 +102,10 @@ block0(v0: i8x16):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm2
 ;   palignr $8, %xmm2, %xmm0, %xmm2
 ;   pmovzxbw %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f11(i16x8) -> i32x4 {
@@ -154,14 +114,10 @@ block0(v0: i16x8):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   movdqa  %xmm0, %xmm2
 ;   palignr $8, %xmm2, %xmm0, %xmm2
 ;   pmovzxwd %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 
 function %f12(i32x4) -> i64x2 {
@@ -170,12 +126,8 @@ block0(v0: i32x4):
   return v1
 }
 
-;   pushq   %rbp
-;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $238, %xmm0, %xmm2
 ;   pmovzxdq %xmm2, %xmm0
-;   movq    %rbp, %rsp
-;   popq    %rbp
 ;   ret
 


### PR DESCRIPTION
Cranelift has had the ability for some time to identify leaf functions;
by Cranelift's definition, a leaf function is one that knows of no other
call signatures. https://github.com/bytecodealliance/wasmtime/issues/1148 noted how it would be a good idea to avoid extra
frame setup work in leaf functions and https://github.com/bytecodealliance/wasmtime/pull/2960 implemented this for
aarch64 and s390x. This improvement was not made for x64 due to some
test failures. This change avoids any frame setup for non-stack-using
leaf functions in x64.

Because this updates the generated code, there are multiple sets of tests
to update -- each of these is separated here into its own commit. I will follow
up in the comments with benchmark results.