### PR TITLE
Enable the ssa verifier in debug builds

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1171,6 +1171,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_trap(&self) -> bool {
+        match self {
+            Self::Udf { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_args(&self) -> bool {
         match self {
             Self::Args { .. } => true,

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -686,6 +686,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_trap(&self) -> bool {
+        match self {
+            Self::Udf { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_args(&self) -> bool {
         match self {
             Self::Args { .. } => true,

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1127,6 +1127,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_trap(&self) -> bool {
+        match self {
+            Self::Trap { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_args(&self) -> bool {
         match self {
             Self::Args { .. } => true,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2244,6 +2244,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_trap(&self) -> bool {
+        match self {
+            Self::Ud2 { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_args(&self) -> bool {
         match self {
             Self::Args { .. } => true,

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -57,6 +57,11 @@ pub fn compile<B: LowerBackend + TargetIsa>(
         let _tt = timing::regalloc();
         let mut options = RegallocOptions::default();
         options.verbose_log = b.flags().regalloc_verbose_logs();
+
+        if cfg!(debug_assertions) {
+            options.validate_ssa = true;
+        }
+
         regalloc2::run(&vcode, machine_env, &options)
             .map_err(|err| {
                 log::error!(

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -100,6 +100,9 @@ pub trait MachInst: Clone + Debug {
     /// (ret/uncond/cond) and target if applicable.
     fn is_term(&self) -> MachTerminator;
 
+    /// Is this an unconditional trap?
+    fn is_trap(&self) -> bool;
+
     /// Is this an "args" pseudoinst?
     fn is_args(&self) -> bool;
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1220,6 +1220,12 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
     }
 
     fn block_params(&self, block: BlockIndex) -> &[VReg] {
+        // As a special case we don't return block params for the entry block, as all the arguments
+        // will be defined by the `Inst::Args` instruction.
+        if block == self.entry {
+            return &[];
+        }
+
         let (start, end) = self.block_params_range[block.index()];
         let ret = &self.block_params[start as usize..end as usize];
         // Currently block params are never aliased to another vreg, but

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1245,10 +1245,8 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
 
     fn is_ret(&self, insn: InsnIndex) -> bool {
         match self.insts[insn.index()].is_term() {
-            // TODO: this is probably not the place for this, we likely need an `is_trap` in the
-            // regalloc2::Function trait that we can use when appropriate.
+            // We treat blocks terminated by an unconditional trap like a return for regalloc.
             MachTerminator::None => self.insts[insn.index()].is_trap(),
-
             MachTerminator::Ret => true,
             _ => false,
         }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1245,6 +1245,10 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
 
     fn is_ret(&self, insn: InsnIndex) -> bool {
         match self.insts[insn.index()].is_term() {
+            // TODO: this is probably not the place for this, we likely need an `is_trap` in the
+            // regalloc2::Function trait that we can use when appropriate.
+            MachTerminator::None => self.insts[insn.index()].is_trap(),
+
             MachTerminator::Ret => true,
             _ => false,
         }

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -8,9 +8,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vaq %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vaq %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -339,9 +339,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vsq %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vsq %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -569,12 +569,12 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
-;   vsq %v6, %v4, %v0
-;   vrepg %v16, %v0, 0
+;   vsq %v6, %v4, %v1
+;   vrepg %v16, %v1, 0
 ;   vchg %v18, %v4, %v16
-;   vsel %v20, %v6, %v0, %v18
+;   vsel %v20, %v6, %v1, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
 
@@ -638,9 +638,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
-;   vsq %v6, %v4, %v0
+;   vsq %v6, %v4, %v1
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -704,12 +704,12 @@ block0(v0: i128, v1: i128):
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
 ;   lgr %r10, %r2
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   lgdr %r4, %f0
-;   vlgvg %r5, %v0, 1
-;   lgdr %r7, %f1
-;   vlgvg %r9, %v1, 1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   lgdr %r4, %f1
+;   vlgvg %r5, %v1, 1
+;   lgdr %r7, %f3
+;   vlgvg %r9, %v3, 1
 ;   lgr %r3, %r5
 ;   mlgr %r2, %r9
 ;   lgr %r8, %r2

--- a/cranelift/filetests/filetests/isa/s390x/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitcast.clif
@@ -46,8 +46,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vst %v0, 0(%r2)
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
 ;   br %r14
 
 function %bitcast_r64_i64(r64) -> i64 {

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -8,11 +8,11 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 170
 ;   vrepib %v6, 1
-;   vsl %v16, %v0, %v6
-;   vsrl %v18, %v0, %v6
+;   vsl %v16, %v1, %v6
+;   vsrl %v18, %v1, %v6
 ;   vsel %v20, %v16, %v18, %v4
 ;   vrepib %v22, 204
 ;   vrepib %v24, 2
@@ -168,8 +168,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vclzg %v4, %v0
+;   vl %v1, 0(%r3)
+;   vclzg %v4, %v1
 ;   vgbm %v6, 0
 ;   vpdi %v16, %v6, %v4, 0
 ;   vpdi %v18, %v6, %v4, 1
@@ -233,11 +233,11 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 255
-;   vsrab %v6, %v0, %v4
+;   vsrab %v6, %v1, %v4
 ;   vsra %v16, %v6, %v4
-;   vx %v18, %v0, %v16
+;   vx %v18, %v1, %v16
 ;   vclzg %v20, %v18
 ;   vgbm %v22, 0
 ;   vpdi %v24, %v22, %v20, 0
@@ -312,8 +312,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vctzg %v4, %v0
+;   vl %v1, 0(%r3)
+;   vctzg %v4, %v1
 ;   vgbm %v6, 0
 ;   vpdi %v16, %v6, %v4, 0
 ;   vpdi %v18, %v6, %v4, 1
@@ -395,8 +395,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vpopctg %v4, %v0
+;   vl %v1, 0(%r3)
+;   vpopctg %v4, %v1
 ;   vgbm %v6, 0
 ;   vpdi %v16, %v6, %v4, 0
 ;   vpdi %v18, %v6, %v4, 1

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -11,9 +11,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vn %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vn %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -121,9 +121,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vo %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vo %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -231,9 +231,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vx %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vx %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -341,9 +341,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vnc %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vnc %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -402,9 +402,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   voc %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   voc %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -463,9 +463,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vnx %v6, %v0, %v1
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vnx %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
 
@@ -521,8 +521,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vno %v4, %v0, %v0
+;   vl %v1, 0(%r3)
+;   vno %v4, %v1, %v1
 ;   vst %v4, 0(%r2)
 ;   br %r14
 
@@ -574,10 +574,10 @@ block0(v0: i128, v1: i128, v2: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vl %v2, 0(%r5)
-;   vsel %v16, %v1, %v2, %v0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   vsel %v16, %v3, %v5, %v1
 ;   vst %v16, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -150,25 +150,25 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
 
 ;   stmg %r6, %r15, 48(%r15)
 ; block0:
-;   lg %r11, 160(%r15)
-;   lg %r12, 168(%r15)
-;   llgc %r13, 183(%r15)
-;   lg %r14, 184(%r15)
-;   lg %r8, 192(%r15)
+;   lg %r12, 160(%r15)
+;   lg %r14, 168(%r15)
+;   llgc %r7, 183(%r15)
+;   lg %r9, 184(%r15)
+;   lg %r11, 192(%r15)
 ;   llgfr %r3, %r3
 ;   llgfr %r4, %r4
-;   llgfr %r7, %r5
+;   llgfr %r13, %r5
 ;   llghr %r6, %r6
-;   llghr %r5, %r11
-;   llghr %r12, %r12
-;   llgcr %r13, %r13
-;   llgcr %r14, %r14
-;   llgcr %r8, %r8
+;   llghr %r5, %r12
+;   llghr %r12, %r14
+;   llgcr %r14, %r7
+;   llgcr %r7, %r9
+;   llgcr %r8, %r11
 ;   agrk %r3, %r2, %r3
-;   agr %r4, %r7
+;   agr %r4, %r13
 ;   agrk %r5, %r6, %r5
-;   agrk %r2, %r12, %r13
-;   agrk %r12, %r14, %r8
+;   agrk %r2, %r12, %r14
+;   agrk %r12, %r7, %r8
 ;   agr %r3, %r4
 ;   agrk %r4, %r5, %r2
 ;   agrk %r3, %r12, %r3
@@ -189,22 +189,22 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vl %v2, 0(%r5)
-;   vl %v3, 0(%r6)
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   vl %v7, 0(%r6)
 ;   lg %r3, 160(%r15)
-;   vl %v4, 0(%r3)
+;   vl %v18, 0(%r3)
 ;   lg %r3, 168(%r15)
-;   vl %v5, 0(%r3)
+;   vl %v21, 0(%r3)
 ;   lg %r5, 176(%r15)
-;   vl %v6, 0(%r5)
+;   vl %v24, 0(%r5)
 ;   lg %r4, 184(%r15)
-;   vl %v7, 0(%r4)
-;   vaq %v16, %v0, %v1
-;   vaq %v17, %v2, %v3
-;   vaq %v18, %v4, %v5
-;   vaq %v19, %v6, %v7
+;   vl %v27, 0(%r4)
+;   vaq %v16, %v1, %v3
+;   vaq %v17, %v5, %v7
+;   vaq %v18, %v18, %v21
+;   vaq %v19, %v24, %v27
 ;   vaq %v16, %v16, %v17
 ;   vaq %v17, %v18, %v19
 ;   vaq %v16, %v16, %v17

--- a/cranelift/filetests/filetests/isa/s390x/concat-split.clif
+++ b/cranelift/filetests/filetests/isa/s390x/concat-split.clif
@@ -19,8 +19,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   lgdr %r3, %f0
-;   vlgvg %r2, %v0, 1
+;   vl %v1, 0(%r2)
+;   lgdr %r3, %f1
+;   vlgvg %r2, %v1, 1
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -227,8 +227,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vlgvg %r2, %v0, 1
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
 ;   br %r14
 
 function %ireduce_i128_i32(i128) -> i32 {
@@ -238,8 +238,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vlgvg %r2, %v0, 1
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
 ;   br %r14
 
 function %ireduce_i128_i16(i128) -> i16 {
@@ -249,8 +249,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vlgvg %r2, %v0, 1
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
 ;   br %r14
 
 function %ireduce_i128_i8(i128) -> i8 {
@@ -260,8 +260,8 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vlgvg %r2, %v0, 1
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
 ;   br %r14
 
 function %ireduce_i64_i32(i64, i64) -> i32 {
@@ -331,9 +331,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
-;   vceqgs %v6, %v0, %v4
+;   vceqgs %v6, %v1, %v4
 ;   lghi %r3, 0
 ;   locghine %r3, -1
 ;   vlvgp %v20, %r3, %r3
@@ -347,9 +347,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
+;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
-;   vceqgs %v5, %v0, %v3
+;   vceqgs %v5, %v1, %v3
 ;   lghi %r2, 0
 ;   locghine %r2, -1
 ;   br %r14
@@ -361,9 +361,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
+;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
-;   vceqgs %v5, %v0, %v3
+;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
@@ -375,9 +375,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
+;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
-;   vceqgs %v5, %v0, %v3
+;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
@@ -389,9 +389,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
+;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
-;   vceqgs %v5, %v0, %v3
+;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
@@ -8,9 +8,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vceqgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
@@ -22,9 +22,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vceqgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
@@ -36,9 +36,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vecg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -50,9 +50,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vecg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -64,9 +64,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vecg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -78,9 +78,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   vecg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -92,9 +92,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   veclg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -106,9 +106,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   veclg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -120,9 +120,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   veclg %v1, %v0 ; jne 10 ; vchlgs %v5, %v0, %v1
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -134,9 +134,9 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vl %v1, 0(%r3)
-;   veclg %v0, %v1 ; jne 10 ; vchlgs %v5, %v1, %v0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -8,13 +8,13 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vrepb %v6, %v1, 15
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 15
 ;   vlcb %v16, %v6
-;   vslb %v18, %v0, %v16
+;   vslb %v18, %v1, %v16
 ;   vsl %v20, %v18, %v16
-;   vsrlb %v22, %v0, %v6
+;   vsrlb %v22, %v1, %v6
 ;   vsrl %v24, %v22, %v6
 ;   vo %v26, %v20, %v24
 ;   vst %v26, 0(%r2)
@@ -27,13 +27,13 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
 ;   vlcb %v17, %v7
-;   vslb %v19, %v0, %v17
+;   vslb %v19, %v1, %v17
 ;   vsl %v21, %v19, %v17
-;   vsrlb %v23, %v0, %v7
+;   vsrlb %v23, %v1, %v7
 ;   vsrl %v25, %v23, %v7
 ;   vo %v27, %v21, %v25
 ;   vst %v27, 0(%r2)
@@ -47,12 +47,12 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
 ;   vlcb %v6, %v4
-;   vslb %v16, %v0, %v6
+;   vslb %v16, %v1, %v6
 ;   vsl %v18, %v16, %v6
-;   vsrlb %v20, %v0, %v4
+;   vsrlb %v20, %v1, %v4
 ;   vsrl %v22, %v20, %v4
 ;   vo %v24, %v18, %v22
 ;   vst %v24, 0(%r2)
@@ -65,8 +65,8 @@ block0(v0: i64, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   rllg %r2, %r2, 0(%r4)
 ;   br %r14
@@ -100,8 +100,8 @@ block0(v0: i32, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   rll %r2, %r2, 0(%r4)
 ;   br %r14
@@ -135,9 +135,9 @@ block0(v0: i16, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
-;   vlgvg %r3, %v1, 1
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   nill %r3, 15
 ;   nill %r4, 15
@@ -183,9 +183,9 @@ block0(v0: i8, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
-;   vlgvg %r3, %v1, 1
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   nill %r3, 7
 ;   nill %r4, 7
@@ -231,13 +231,13 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vrepb %v6, %v1, 15
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 15
 ;   vlcb %v16, %v6
-;   vslb %v18, %v0, %v6
+;   vslb %v18, %v1, %v6
 ;   vsl %v20, %v18, %v6
-;   vsrlb %v22, %v0, %v16
+;   vsrlb %v22, %v1, %v16
 ;   vsrl %v24, %v22, %v16
 ;   vo %v26, %v20, %v24
 ;   vst %v26, 0(%r2)
@@ -250,13 +250,13 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
 ;   vlcb %v17, %v7
-;   vslb %v19, %v0, %v7
+;   vslb %v19, %v1, %v7
 ;   vsl %v21, %v19, %v7
-;   vsrlb %v23, %v0, %v17
+;   vsrlb %v23, %v1, %v17
 ;   vsrl %v25, %v23, %v17
 ;   vo %v27, %v21, %v25
 ;   vst %v27, 0(%r2)
@@ -270,12 +270,12 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
 ;   vlcb %v6, %v4
-;   vslb %v16, %v0, %v4
+;   vslb %v16, %v1, %v4
 ;   vsl %v18, %v16, %v4
-;   vsrlb %v20, %v0, %v6
+;   vsrlb %v20, %v1, %v6
 ;   vsrl %v22, %v20, %v6
 ;   vo %v24, %v18, %v22
 ;   vst %v24, 0(%r2)
@@ -288,8 +288,8 @@ block0(v0: i64, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   rllg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -321,8 +321,8 @@ block0(v0: i32, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   rll %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -354,9 +354,9 @@ block0(v0: i16, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
-;   vlgvg %r3, %v1, 1
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   nill %r3, 15
 ;   nill %r4, 15
@@ -402,9 +402,9 @@ block0(v0: i8, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
-;   vlgvg %r3, %v1, 1
+;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
 ;   nill %r3, 7
 ;   nill %r4, 7
@@ -450,10 +450,10 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vrepb %v6, %v1, 15
-;   vsrlb %v16, %v0, %v6
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 15
+;   vsrlb %v16, %v1, %v6
 ;   vsrl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
@@ -465,10 +465,10 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
-;   vsrlb %v17, %v0, %v7
+;   vsrlb %v17, %v1, %v7
 ;   vsrl %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
@@ -481,9 +481,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
-;   vsrlb %v6, %v0, %v4
+;   vsrlb %v6, %v1, %v4
 ;   vsrl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
@@ -495,8 +495,8 @@ block0(v0: i64, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   srlg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -528,8 +528,8 @@ block0(v0: i32, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
 ;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
@@ -564,9 +564,9 @@ block0(v0: i16, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
-;   vlgvg %r5, %v1, 1
+;   vlgvg %r5, %v2, 1
 ;   nill %r5, 15
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
@@ -602,9 +602,9 @@ block0(v0: i8, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
-;   vlgvg %r5, %v1, 1
+;   vlgvg %r5, %v2, 1
 ;   nill %r5, 7
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
@@ -640,10 +640,10 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vrepb %v6, %v1, 15
-;   vslb %v16, %v0, %v6
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 15
+;   vslb %v16, %v1, %v6
 ;   vsl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
@@ -655,10 +655,10 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
-;   vslb %v17, %v0, %v7
+;   vslb %v17, %v1, %v7
 ;   vsl %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
@@ -671,9 +671,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
-;   vslb %v6, %v0, %v4
+;   vslb %v6, %v1, %v4
 ;   vsl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
@@ -685,8 +685,8 @@ block0(v0: i64, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   sllg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -718,8 +718,8 @@ block0(v0: i32, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
@@ -754,8 +754,8 @@ block0(v0: i16, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   nill %r3, 15
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
@@ -790,8 +790,8 @@ block0(v0: i8, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   nill %r3, 7
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
@@ -826,10 +826,10 @@ block0(v0: i128, v1: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
-;   vl %v1, 0(%r4)
-;   vrepb %v6, %v1, 15
-;   vsrab %v16, %v0, %v6
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 15
+;   vsrab %v16, %v1, %v6
 ;   vsra %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
@@ -841,10 +841,10 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
-;   vsrab %v17, %v0, %v7
+;   vsrab %v17, %v1, %v7
 ;   vsra %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
@@ -857,9 +857,9 @@ block0(v0: i128):
 }
 
 ; block0:
-;   vl %v0, 0(%r3)
+;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
-;   vsrab %v6, %v0, %v4
+;   vsrab %v6, %v1, %v4
 ;   vsra %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
@@ -871,8 +871,8 @@ block0(v0: i64, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   srag %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -904,8 +904,8 @@ block0(v0: i32, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
-;   vlgvg %r3, %v1, 1
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
 ;   srak %r2, %r2, 0(%r3)
 ;   br %r14
@@ -940,9 +940,9 @@ block0(v0: i16, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   lhr %r2, %r2
-;   vlgvg %r5, %v1, 1
+;   vlgvg %r5, %v2, 1
 ;   nill %r5, 15
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
@@ -978,9 +978,9 @@ block0(v0: i8, v1: i128):
 }
 
 ; block0:
-;   vl %v1, 0(%r3)
+;   vl %v2, 0(%r3)
 ;   lbr %r2, %r2
-;   vlgvg %r5, %v1, 1
+;   vlgvg %r5, %v2, 1
 ;   nill %r5, 7
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
@@ -185,8 +185,8 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vst %v0, 0(%r3)
+;   vl %v1, 0(%r2)
+;   vst %v1, 0(%r3)
 ;   br %r14
 
 function %store_f32x4_big(f32x4, i64) {
@@ -397,8 +397,8 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vstbrq %v0, 0(%r3)
+;   vl %v1, 0(%r2)
+;   vstbrq %v1, 0(%r3)
 ;   br %r14
 
 function %store_f32x4_little(f32x4, i64) {

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -185,8 +185,8 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vst %v0, 0(%r3)
+;   vl %v1, 0(%r2)
+;   vst %v1, 0(%r3)
 ;   br %r14
 
 function %store_f32x4_big(f32x4, i64) {
@@ -462,9 +462,9 @@ block0(v0: i128, v1: i64):
 }
 
 ; block0:
-;   vl %v0, 0(%r2)
-;   vlgvg %r2, %v0, 1
-;   lgdr %r4, %f0
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   lgdr %r4, %f1
 ;   strvg %r2, 0(%r3)
 ;   strvg %r4, 8(%r3)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -130,8 +130,8 @@ block0(
 ;   movq    %rsi, %rdx
 ;   movq    %rdi, %rsi
 ;   movq    %rax, %rdi
-;   movq    16(%rbp), %r11
-;   movq    24(%rbp), %r10
+;   movq    16(%rbp), %r10
+;   movq    24(%rbp), %r11
 ;   movss   32(%rbp), %xmm9
 ;   movsd   40(%rbp), %xmm8
 ;   subq    %rsp, $144, %rsp
@@ -146,8 +146,8 @@ block0(
 ;   movsd   %xmm5, 88(%rsp)
 ;   movsd   %xmm6, 96(%rsp)
 ;   movsd   %xmm7, 104(%rsp)
-;   movq    %r11, 112(%rsp)
-;   movl    %r10d, 120(%rsp)
+;   movq    %r10, 112(%rsp)
+;   movl    %r11d, 120(%rsp)
 ;   movss   %xmm9, 128(%rsp)
 ;   movsd   %xmm8, 136(%rsp)
 ;   movq    %rdi, %r9

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -113,7 +113,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;   movq    %rsp, %rbp
 ;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ; block0:
-;   movq    48(%rbp), %r10
+;   movq    48(%rbp), %r8
 ;   movq    56(%rbp), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -129,7 +129,7 @@ block0(v0: i128, v1: i64, v2: i128, v3: i128):
 ;   movq    %rsp, %rbp
 ;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ; block0:
-;   movq    48(%rbp), %r10
+;   movq    48(%rbp), %r8
 ;   movq    56(%rbp), %rax
 ;   movq    64(%rbp), %rdx
 ;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -716,33 +716,39 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $32, %rsp
-;   movq    %r13, 0(%rsp)
-;   movq    %r14, 8(%rsp)
-;   movq    %r15, 16(%rsp)
+;   movq    %rbx, 0(%rsp)
+;   movq    %r12, 8(%rsp)
+;   movq    %r14, 16(%rsp)
+;   movq    %r15, 24(%rsp)
 ; block0:
-;   movq    %rcx, %r15
+;   movq    %r8, %r14
+;   movq    %rcx, %rbx
 ;   movq    %rdx, %rcx
-;   movq    16(%rbp), %r14
+;   movq    16(%rbp), %r15
 ;   movq    24(%rbp), %rax
 ;   movq    32(%rbp), %rdx
 ;   movq    40(%rbp), %r11
 ;   movq    48(%rbp), %r10
-;   addq    %rdi, %rcx, %rdi
+;   movq    %rdi, %r8
+;   addq    %r8, %rcx, %r8
+;   movq    %rbx, %rdi
 ;   movq    %rsi, %rcx
-;   adcq    %rcx, %r15, %rcx
-;   xorq    %r13, %r13, %r13
+;   adcq    %rcx, %rdi, %rcx
+;   xorq    %rdi, %rdi, %rdi
+;   movq    %r14, %r12
 ;   movq    %r9, %rsi
-;   addq    %rsi, %r8, %rsi
-;   adcq    %r14, %r13, %r14
+;   addq    %rsi, %r12, %rsi
+;   adcq    %r15, %rdi, %r15
 ;   addq    %rax, %r11, %rax
 ;   adcq    %rdx, %r10, %rdx
-;   addq    %rdi, %rsi, %rdi
-;   adcq    %rcx, %r14, %rcx
-;   addq    %rax, %rdi, %rax
+;   addq    %r8, %rsi, %r8
+;   adcq    %rcx, %r15, %rcx
+;   addq    %rax, %r8, %rax
 ;   adcq    %rdx, %rcx, %rdx
-;   movq    0(%rsp), %r13
-;   movq    8(%rsp), %r14
-;   movq    16(%rsp), %r15
+;   movq    0(%rsp), %rbx
+;   movq    8(%rsp), %r12
+;   movq    16(%rsp), %r14
+;   movq    24(%rsp), %r15
 ;   addq    %rsp, $32, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -27,9 +27,9 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     16(%rbp), %rsi
+;   lea     16(%rbp), %rcx
 ;   movzbq  0(%rdi), %rax
-;   movzbq  0(%rsi), %r9
+;   movzbq  0(%rcx), %r9
 ;   addl    %eax, %r9d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -102,9 +102,9 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   lea     16(%rbp), %rsi
-;   lea     144(%rbp), %rdi
+;   lea     144(%rbp), %rcx
 ;   movzbq  0(%rsi), %rax
-;   movzbq  0(%rdi), %r9
+;   movzbq  0(%rcx), %r9
 ;   addl    %eax, %r9d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
Enable regalloc2's SSA verifier in debug builds to check for any outstanding reuse of virtual registers in def constraints. As fuzzing enables `debug_assertions`, this will enable the SSA verifier when fuzzing as well.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
