### PR TITLE
Don't reuse registers in make_i64x2_from_lanes

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1566,22 +1566,10 @@
 ;; Helper for creating an SSE register holding an `i64x2` from two `i64` values.
 (decl make_i64x2_from_lanes (GprMem GprMem) Xmm)
 (rule (make_i64x2_from_lanes lo hi)
-      (let ((dst_xmm WritableXmm (temp_writable_xmm))
-            (dst_reg WritableReg dst_xmm)
-            (_ Unit (emit (MInst.XmmUninitializedValue dst_xmm)))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pinsrd)
-                                           dst_reg
-                                           lo
-                                           dst_reg
-                                           0
-                                           (OperandSize.Size64))))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pinsrd)
-                                           dst_reg
-                                           hi
-                                           dst_reg
-                                           1
-                                           (OperandSize.Size64)))))
-        dst_xmm))
+      (let ((dst Xmm (xmm_uninit_value))
+            (dst Xmm (x64_pinsrd dst lo 0 (OperandSize.Size64)))
+            (dst Xmm (x64_pinsrd dst hi 1 (OperandSize.Size64))))
+        dst))
 
 ;; Move a `RegMemImm.Reg` operand to an XMM register, if necessary.
 (decl mov_rmi_to_xmm (RegMemImm) XmmMemImm)


### PR DESCRIPTION
Avoid reusing output registers in `make_i64x2_from_lanes` by threading the output name instead, and using smart constructors for `x64_pinsrd` instead of constructing the instructions directly.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
