### PR TITLE
Allocate temporary intermediates when loading constants on aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -64,7 +64,7 @@ pub fn mem_finalize(
             } else {
                 let tmp = writable_spilltmp_reg();
                 (
-                    Inst::load_constant(tmp, off as u64),
+                    Inst::load_constant(tmp, off as u64, &mut |_| tmp),
                     AMode::RegExtended {
                         rn: basereg,
                         rm: tmp.to_reg(),
@@ -3333,7 +3333,7 @@ impl MachInstEmit for Inst {
                     debug_assert!(rd.to_reg() != tmp2_reg());
                     debug_assert!(reg != tmp2_reg());
                     let tmp = writable_tmp2_reg();
-                    for insn in Inst::load_constant(tmp, abs_offset).into_iter() {
+                    for insn in Inst::load_constant(tmp, abs_offset, &mut |_| tmp).into_iter() {
                         insn.emit(&[], sink, emit_info, state);
                     }
                     let add = Inst::AluRRR {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -228,6 +228,8 @@ impl Inst {
                 prev_result = Some(rd.to_reg());
             }
 
+            assert!(prev_result.is_some());
+
             insts
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -130,7 +130,11 @@ fn inst_size_test() {
 impl Inst {
     /// Create an instruction that loads a constant, using one of serveral options (MOVZ, MOVN,
     /// logical immediate, or constant pool).
-    pub fn load_constant(rd: Writable<Reg>, value: u64) -> SmallVec<[Inst; 4]> {
+    pub fn load_constant<F: FnMut(Type) -> Writable<Reg>>(
+        rd: Writable<Reg>,
+        value: u64,
+        alloc_tmp: &mut F,
+    ) -> SmallVec<[Inst; 4]> {
         // NB: this is duplicated in `lower/isle.rs` and `inst.isle` right now,
         // if modifications are made here before this is deleted after moving to
         // ISLE then those locations should be updated as well.
@@ -169,60 +173,71 @@ impl Inst {
             } else {
                 (4, OperandSize::Size64, !value)
             };
+
             // If the number of 0xffff half words is greater than the number of 0x0000 half words
             // it is more efficient to use `movn` for the first instruction.
             let first_is_inverted = count_zero_half_words(negated, num_half_words)
                 > count_zero_half_words(value, num_half_words);
+
             // Either 0xffff or 0x0000 half words can be skipped, depending on the first
             // instruction used.
             let ignored_halfword = if first_is_inverted { 0xffff } else { 0 };
-            let mut first_mov_emitted = false;
 
-            for i in 0..num_half_words {
-                let imm16 = (value >> (16 * i)) & 0xffff;
-                if imm16 != ignored_halfword {
-                    if !first_mov_emitted {
-                        first_mov_emitted = true;
-                        if first_is_inverted {
-                            let imm =
-                                MoveWideConst::maybe_with_shift(((!imm16) & 0xffff) as u16, i * 16)
-                                    .unwrap();
-                            insts.push(Inst::MovWide {
-                                op: MoveWideOp::MovN,
-                                rd,
-                                imm,
-                                size,
-                            });
-                        } else {
-                            let imm =
-                                MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                            insts.push(Inst::MovWide {
-                                op: MoveWideOp::MovZ,
-                                rd,
-                                imm,
-                                size,
-                            });
-                        }
+            let halfwords: SmallVec<[_; 4]> = (0..num_half_words)
+                .filter_map(|i| {
+                    let imm16 = (value >> (16 * i)) & 0xffff;
+                    if imm16 == ignored_halfword {
+                        None
                     } else {
-                        let imm = MoveWideConst::maybe_with_shift(imm16 as u16, i * 16).unwrap();
-                        insts.push(Inst::MovK {
+                        Some((i, imm16))
+                    }
+                })
+                .collect();
+
+            let mut prev_result = None;
+            let last_index = halfwords.last().unwrap().0;
+            for (i, imm16) in halfwords {
+                let shift = i * 16;
+                let rd = if i == last_index { rd } else { alloc_tmp(I16) };
+
+                if let Some(rn) = prev_result {
+                    let imm = MoveWideConst::maybe_with_shift(imm16 as u16, shift).unwrap();
+                    insts.push(Inst::MovK { rd, rn, imm, size });
+                } else {
+                    if first_is_inverted {
+                        let imm =
+                            MoveWideConst::maybe_with_shift(((!imm16) & 0xffff) as u16, shift)
+                                .unwrap();
+                        insts.push(Inst::MovWide {
+                            op: MoveWideOp::MovN,
                             rd,
-                            rn: rd.to_reg(), // Redef the same virtual register.
+                            imm,
+                            size,
+                        });
+                    } else {
+                        let imm = MoveWideConst::maybe_with_shift(imm16 as u16, shift).unwrap();
+                        insts.push(Inst::MovWide {
+                            op: MoveWideOp::MovZ,
+                            rd,
                             imm,
                             size,
                         });
                     }
                 }
-            }
 
-            assert!(first_mov_emitted);
+                prev_result = Some(rd.to_reg());
+            }
 
             insts
         }
     }
 
     /// Create instructions that load a 128-bit constant.
-    pub fn load_constant128(to_regs: ValueRegs<Writable<Reg>>, value: u128) -> SmallVec<[Inst; 4]> {
+    pub fn load_constant128<F: FnMut(Type) -> Writable<Reg>>(
+        to_regs: ValueRegs<Writable<Reg>>,
+        value: u128,
+        mut alloc_tmp: F,
+    ) -> SmallVec<[Inst; 4]> {
         assert_eq!(to_regs.len(), 2, "Expected to load i128 into two registers");
 
         let lower = value as u64;
@@ -231,8 +246,8 @@ impl Inst {
         let lower_reg = to_regs.regs()[0];
         let upper_reg = to_regs.regs()[1];
 
-        let mut load_ins = Inst::load_constant(lower_reg, lower);
-        let load_upper = Inst::load_constant(upper_reg, upper);
+        let mut load_ins = Inst::load_constant(lower_reg, lower, &mut alloc_tmp);
+        let load_upper = Inst::load_constant(upper_reg, upper, &mut alloc_tmp);
 
         load_ins.extend(load_upper.into_iter());
         load_ins
@@ -264,7 +279,7 @@ impl Inst {
             }]
         } else {
             let tmp = alloc_tmp(I32);
-            let mut insts = Inst::load_constant(tmp, const_data as u64);
+            let mut insts = Inst::load_constant(tmp, const_data as u64, &mut alloc_tmp);
 
             insts.push(Inst::MovToFpu {
                 rd,
@@ -304,7 +319,7 @@ impl Inst {
             Inst::load_fp_constant32(rd, const_data, alloc_tmp)
         } else if const_data & (u32::MAX as u64) == 0 {
             let tmp = alloc_tmp(I64);
-            let mut insts = Inst::load_constant(tmp, const_data);
+            let mut insts = Inst::load_constant(tmp, const_data, &mut alloc_tmp);
 
             insts.push(Inst::MovToFpu {
                 rd,
@@ -426,7 +441,7 @@ impl Inst {
             smallvec![Inst::VecDupFPImm { rd, imm, size }]
         } else {
             let tmp = alloc_tmp(I64);
-            let mut insts = SmallVec::from(&Inst::load_constant(tmp, pattern)[..]);
+            let mut insts = SmallVec::from(&Inst::load_constant(tmp, pattern, &mut alloc_tmp)[..]);
 
             insts.push(Inst::VecDup {
                 rd,
@@ -1212,14 +1227,16 @@ impl MachInst for Inst {
         to_regs: ValueRegs<Writable<Reg>>,
         value: u128,
         ty: Type,
-        alloc_tmp: F,
+        mut alloc_tmp: F,
     ) -> SmallVec<[Inst; 4]> {
         let to_reg = to_regs.only_reg();
         match ty {
             F64 => Inst::load_fp_constant64(to_reg.unwrap(), value as u64, alloc_tmp),
             F32 => Inst::load_fp_constant32(to_reg.unwrap(), value as u32, alloc_tmp),
-            I8 | I16 | I32 | I64 | R32 | R64 => Inst::load_constant(to_reg.unwrap(), value as u64),
-            I128 => Inst::load_constant128(to_regs, value),
+            I8 | I16 | I32 | I64 | R32 | R64 => {
+                Inst::load_constant(to_reg.unwrap(), value as u64, &mut alloc_tmp)
+            }
+            I128 => Inst::load_constant128(to_regs, value, alloc_tmp),
             _ => panic!("Cannot generate constant for type: {}", ty),
         }
     }
@@ -2837,7 +2854,7 @@ impl Inst {
                     );
                 } else {
                     let tmp = writable_spilltmp_reg();
-                    for inst in Inst::load_constant(tmp, abs_offset).into_iter() {
+                    for inst in Inst::load_constant(tmp, abs_offset, &mut |_| tmp).into_iter() {
                         ret.push_str(
                             &inst.print_with_state(&mut EmitState::default(), &mut empty_allocs),
                         );

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -575,7 +575,7 @@ fn lower_add_immediate(ctx: &mut Lower<Inst>, dst: Writable<Reg>, src: Reg, imm:
 }
 
 pub(crate) fn lower_constant_u64(ctx: &mut Lower<Inst>, rd: Writable<Reg>, value: u64) {
-    for inst in Inst::load_constant(rd, value) {
+    for inst in Inst::load_constant(rd, value, &mut |ty| ctx.alloc_tmp(ty).only_reg().unwrap()) {
         ctx.emit(inst);
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -525,18 +525,18 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         insts
     }
 
-    fn gen_memcpy(
+    fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         call_conv: isa::CallConv,
         dst: Reg,
         src: Reg,
-        tmp: Writable<Reg>,
-        _tmp2: Writable<Reg>,
         size: usize,
+        mut alloc_tmp: F,
     ) -> SmallVec<[Self::I; 8]> {
         let mut insts = SmallVec::new();
         let arg0 = Writable::from_reg(x_reg(10));
         let arg1 = Writable::from_reg(x_reg(11));
         let arg2 = Writable::from_reg(x_reg(12));
+        let tmp = alloc_tmp(Self::word_type());
         insts.extend(Inst::load_constant_u64(tmp, size as u64).into_iter());
         insts.push(Inst::Call {
             info: Box::new(CallInfo {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -752,13 +752,12 @@ impl ABIMachineSpec for S390xMachineDeps {
         unreachable!();
     }
 
-    fn gen_memcpy(
+    fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         _call_conv: isa::CallConv,
         _dst: Reg,
         _src: Reg,
-        _tmp1: Writable<Reg>,
-        _tmp2: Writable<Reg>,
         _size: usize,
+        _alloc: F,
     ) -> SmallVec<[Self::I; 8]> {
         unimplemented!("StructArgs not implemented for S390X yet");
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -624,18 +624,19 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         insts
     }
 
-    fn gen_memcpy(
+    fn gen_memcpy<F: FnMut(Type) -> Writable<Reg>>(
         call_conv: isa::CallConv,
         dst: Reg,
         src: Reg,
-        temp: Writable<Reg>,
-        temp2: Writable<Reg>,
         size: usize,
+        mut alloc_tmp: F,
     ) -> SmallVec<[Self::I; 8]> {
         let mut insts = SmallVec::new();
         let arg0 = get_intreg_for_arg(&call_conv, 0, 0).unwrap();
         let arg1 = get_intreg_for_arg(&call_conv, 1, 1).unwrap();
         let arg2 = get_intreg_for_arg(&call_conv, 2, 2).unwrap();
+        let temp = alloc_tmp(Self::word_type());
+        let temp2 = alloc_tmp(Self::word_type());
         insts.extend(
             Inst::gen_constant(ValueRegs::one(temp), size as u128, I64, |_| {
                 panic!("tmp should not be needed")

--- a/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
@@ -37,9 +37,9 @@ block0(v0: i32):
 }
 
 ; block0:
-;   movz w2, #4369
-;   movk w2, w2, #17, LSL #16
-;   subs wzr, w0, w2
+;   movz w3, #4369
+;   movk w3, w3, #17, LSL #16
+;   subs wzr, w0, w3
 ;   cset x0, hs
 ;   ret
 
@@ -51,9 +51,9 @@ block0(v0: i32):
 }
 
 ; block0:
-;   movz w2, #4368
-;   movk w2, w2, #17, LSL #16
-;   subs wzr, w0, w2
+;   movz w3, #4368
+;   movk w3, w3, #17, LSL #16
+;   subs wzr, w0, w3
 ;   cset x0, hs
 ;   ret
 
@@ -89,9 +89,9 @@ block0(v0: i32):
 }
 
 ; block0:
-;   movz w2, #4369
-;   movk w2, w2, #17, LSL #16
-;   subs wzr, w0, w2
+;   movz w3, #4369
+;   movk w3, w3, #17, LSL #16
+;   subs wzr, w0, w3
 ;   cset x0, ge
 ;   ret
 
@@ -103,9 +103,9 @@ block0(v0: i32):
 }
 
 ; block0:
-;   movz w2, #4368
-;   movk w2, w2, #17, LSL #16
-;   subs wzr, w0, w2
+;   movz w3, #4368
+;   movk w3, w3, #17, LSL #16
+;   subs wzr, w0, w3
 ;   cset x0, ge
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
@@ -14,11 +14,11 @@ block0(v0: i8x16):
 ;   movk x5, x5, #8208, LSL #32
 ;   movk x5, x5, #32832, LSL #48
 ;   dup v16.2d, x5
-;   and v19.16b, v2.16b, v16.16b
-;   ext v21.16b, v19.16b, v19.16b, #8
-;   zip1 v23.16b, v19.16b, v21.16b
-;   addv h25, v23.8h
-;   umov w0, v25.h[0]
+;   and v22.16b, v2.16b, v16.16b
+;   ext v24.16b, v22.16b, v22.16b, #8
+;   zip1 v26.16b, v22.16b, v24.16b
+;   addv h28, v26.8h
+;   umov w0, v28.h[0]
 ;   ret
 
 function %f2(i8x16) -> i16 {
@@ -34,11 +34,11 @@ block0(v0: i8x16):
 ;   movk x5, x5, #8208, LSL #32
 ;   movk x5, x5, #32832, LSL #48
 ;   dup v16.2d, x5
-;   and v19.16b, v2.16b, v16.16b
-;   ext v21.16b, v19.16b, v19.16b, #8
-;   zip1 v23.16b, v19.16b, v21.16b
-;   addv h25, v23.8h
-;   umov w0, v25.h[0]
+;   and v22.16b, v2.16b, v16.16b
+;   ext v24.16b, v22.16b, v22.16b, #8
+;   zip1 v26.16b, v22.16b, v24.16b
+;   addv h28, v26.8h
+;   umov w0, v28.h[0]
 ;   ret
 
 function %f3(i16x8) -> i8 {


### PR DESCRIPTION
As loading constants on aarch64 can take up to 4 instructions, we need to plumb through some additional registers. Rather than pass a fixed list of registers in, pass an allocation function.

This forced a change to `ABIMachineSpec::gen_memcpy`, as it now needed to take an allocator to pass to uses of `gen_constant`. As a result, I removed the fixed temporary arguments and passed an allocator instead.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
