### PR TITLE
Fix some minor issues with stdin-loaded modules

### DIFF
--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -62,6 +62,13 @@ impl Mmap {
                 .metadata()
                 .context("failed to get file metadata")?
                 .len();
+            if len == 0 {
+                return Ok(Self {
+                    ptr: 1,
+                    len: 0,
+                    file: None,
+                });
+            }
             let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
             let ptr = unsafe {
                 rustix::mm::mmap(

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -357,7 +357,7 @@ impl Module {
     #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
     pub unsafe fn from_trusted_file(engine: &Engine, file: impl AsRef<Path>) -> Result<Module> {
         let mmap = MmapVec::from_file(file.as_ref())?;
-        if &mmap[0..4] == b"\x7fELF" {
+        if mmap.starts_with(b"\x7fELF") {
             let code = engine.load_code(mmap, ObjectKind::Module)?;
             return Module::from_parts(engine, code, None);
         }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -431,7 +431,6 @@ fn run_cwasm() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 #[test]
 fn hello_wasi_snapshot0_from_stdin() -> Result<()> {
     // Run a simple WASI hello world, snapshot0 edition.
@@ -454,7 +453,6 @@ fn hello_wasi_snapshot0_from_stdin() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 #[test]
 fn run_cwasm_from_stdin() -> Result<()> {
     let td = TempDir::new()?;
@@ -468,8 +466,6 @@ fn run_cwasm_from_stdin() -> Result<()> {
     assert_eq!(stdout, "");
     let args: &[&str] = &["run", "--allow-precompiled", "-"];
     let output = run_wasmtime_for_output(args, Some(&cwasm))?;
-    if output.status.success() {
-        bail!("wasmtime should fail loading precompiled modules from piped files, but suceeded");
-    }
+    assert!(output.status.success());
     Ok(())
 }


### PR DESCRIPTION
This commit addresses a few items I saw after reading #5342 such as:

* `Module::from_trusted_file` no longer panics if the file length is less than 4
* `Module::from_trusted_file` with an empty file now returns a syntax error for `*.wat` instead of a "failed to map" error.
* Usage of `-` for stdin no works on Windows instead of just Unix.
* The filename for `-` reported to the executable is `<stdin>` rather than `stdin`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
