### PR TITLE
aarch64: Rework amode compilation to produce SSA code

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -479,19 +479,9 @@ pub(crate) fn lower_address(
             rm,
             extendop,
         },
-        AMode::RegOffset { off, ty, .. } => AMode::RegOffset {
-            rn: addr,
-            off,
-            ty,
-        },
-        AMode::RegReg { rn, .. } => AMode::RegReg {
-            rn: addr,
-            rm: rn,
-        },
-        AMode::UnsignedOffset { uimm12, .. } => AMode::UnsignedOffset {
-            rn: addr,
-            uimm12,
-        },
+        AMode::RegOffset { off, ty, .. } => AMode::RegOffset { rn: addr, off, ty },
+        AMode::RegReg { rn, .. } => AMode::RegReg { rn: addr, rm: rn },
+        AMode::UnsignedOffset { uimm12, .. } => AMode::UnsignedOffset { rn: addr, uimm12 },
         _ => unreachable!(),
     }
 }

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -52,10 +52,10 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   add x3, x0, #68
-;   add x3, x3, x0
-;   add x3, x3, x1, SXTW
-;   ldr w0, [x3, w1, SXTW]
+;   add x4, x0, #68
+;   add x6, x4, x0
+;   add x8, x6, x1, SXTW
+;   ldr w0, [x8, w1, SXTW]
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -69,10 +69,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   mov x5, x0
-;   add x5, x5, x2
-;   add x5, x5, x1
-;   ldr w0, [x5, #48]
+;   add x5, x0, x2
+;   add x7, x5, x1
+;   ldr w0, [x7, #48]
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -86,10 +85,10 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movz x4, #4100
-;   add x4, x4, x1
-;   add x4, x4, x2
-;   ldr w0, [x4, x0]
+;   movz x6, #4100
+;   add x6, x6, x1
+;   add x9, x6, x2
+;   ldr w0, [x9, x0]
 ;   ret
 
 function %f10() -> i32 {
@@ -113,8 +112,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   add x2, x0, #8388608
-;   ldr w0, [x2]
+;   add x3, x0, #8388608
+;   ldr w0, [x3]
 ;   ret
 
 function %f12(i64) -> i32 {
@@ -126,8 +125,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   sub x2, x0, #4
-;   ldr w0, [x2]
+;   sub x3, x0, #4
+;   ldr w0, [x3]
 ;   ret
 
 function %f13(i64) -> i32 {
@@ -139,10 +138,10 @@ block0(v0: i64):
 }
 
 ; block0:
-;   movz w2, #51712
-;   movk w2, w2, #15258, LSL #16
-;   add x2, x2, x0
-;   ldr w0, [x2]
+;   movz w4, #51712
+;   movk w4, w4, #15258, LSL #16
+;   add x5, x4, x0
+;   ldr w0, [x5]
 ;   ret
 
 function %f14(i32) -> i32 {
@@ -233,10 +232,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   mov x6, x0
-;   mov x4, x6
-;   ldp x0, x1, [x4]
-;   mov x5, x6
+;   mov x5, x0
+;   ldp x0, x1, [x5]
 ;   stp x0, x1, [x5]
 ;   ret
 
@@ -248,10 +245,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   mov x6, x0
-;   mov x4, x6
-;   ldp x0, x1, [x4, #16]
-;   mov x5, x6
+;   mov x5, x0
+;   ldp x0, x1, [x5, #16]
 ;   stp x0, x1, [x5, #16]
 ;   ret
 
@@ -263,10 +258,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   mov x6, x0
-;   mov x4, x6
-;   ldp x0, x1, [x4, #504]
-;   mov x5, x6
+;   mov x5, x0
+;   ldp x0, x1, [x5, #504]
 ;   stp x0, x1, [x5, #504]
 ;   ret
 
@@ -278,10 +271,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   mov x6, x0
-;   mov x4, x6
-;   ldp x0, x1, [x4, #-512]
-;   mov x5, x6
+;   mov x5, x0
+;   ldp x0, x1, [x5, #-512]
 ;   stp x0, x1, [x5, #-512]
 ;   ret
 
@@ -294,10 +285,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   mov x6, x0
-;   mov x4, x6
-;   ldp x0, x1, [x4, #32]
-;   mov x5, x6
+;   mov x5, x0
+;   ldp x0, x1, [x5, #32]
 ;   stp x0, x1, [x5, #32]
 ;   ret
 
@@ -310,11 +299,11 @@ block0(v0: i32):
 }
 
 ; block0:
-;   sxtw x4, w0
-;   mov x11, x0
-;   ldp x0, x1, [x4]
-;   sxtw x5, w11
-;   stp x0, x1, [x5]
+;   sxtw x3, w0
+;   mov x8, x0
+;   ldp x0, x1, [x3]
+;   sxtw x4, w8
+;   stp x0, x1, [x4]
 ;   ret
 
 function %i128_32bit_sextend(i64, i32) -> i128 {
@@ -328,13 +317,11 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   mov x9, x0
-;   mov x5, x9
-;   add x5, x5, x1, SXTW
-;   mov x11, x1
-;   ldp x0, x1, [x5, #24]
-;   mov x7, x9
-;   add x7, x7, x11, SXTW
-;   stp x0, x1, [x7, #24]
+;   add x4, x0, x1, SXTW
+;   mov x11, x0
+;   mov x9, x1
+;   ldp x0, x1, [x4, #24]
+;   add x5, x11, x9, SXTW
+;   stp x0, x1, [x5, #24]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -52,10 +52,10 @@ block0(v0: i64, v1: i32):
 }
 
 ; block0:
-;   add x4, x0, #68
-;   add x6, x4, x0
-;   add x8, x6, x1, SXTW
-;   ldr w0, [x8, w1, SXTW]
+;   add x3, x0, #68
+;   add x5, x3, x0
+;   add x7, x5, x1, SXTW
+;   ldr w0, [x7, w1, SXTW]
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -69,9 +69,9 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   add x5, x0, x2
-;   add x7, x5, x1
-;   ldr w0, [x7, #48]
+;   add x4, x0, x2
+;   add x6, x4, x1
+;   ldr w0, [x6, #48]
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -85,10 +85,10 @@ block0(v0: i64, v1: i64, v2: i64):
 }
 
 ; block0:
-;   movz x6, #4100
-;   add x6, x6, x1
-;   add x9, x6, x2
-;   ldr w0, [x9, x0]
+;   movz x5, #4100
+;   add x5, x5, x1
+;   add x8, x5, x2
+;   ldr w0, [x8, x0]
 ;   ret
 
 function %f10() -> i32 {
@@ -112,8 +112,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   add x3, x0, #8388608
-;   ldr w0, [x3]
+;   add x2, x0, #8388608
+;   ldr w0, [x2]
 ;   ret
 
 function %f12(i64) -> i32 {
@@ -125,8 +125,8 @@ block0(v0: i64):
 }
 
 ; block0:
-;   sub x3, x0, #4
-;   ldr w0, [x3]
+;   sub x2, x0, #4
+;   ldr w0, [x2]
 ;   ret
 
 function %f13(i64) -> i32 {
@@ -138,10 +138,10 @@ block0(v0: i64):
 }
 
 ; block0:
-;   movz w4, #51712
-;   movk w4, w4, #15258, LSL #16
-;   add x5, x4, x0
-;   ldr w0, [x5]
+;   movz w3, #51712
+;   movk w3, w3, #15258, LSL #16
+;   add x4, x3, x0
+;   ldr w0, [x4]
 ;   ret
 
 function %f14(i32) -> i32 {

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -442,8 +442,8 @@ block0(v0: i128):
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   mov x4, sp
-;   stp x0, x1, [x4]
+;   mov x3, sp
+;   stp x0, x1, [x3]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -461,8 +461,8 @@ block0(v0: i128):
 ;   mov fp, sp
 ;   sub sp, sp, #32
 ; block0:
-;   add x4, sp, #32
-;   stp x0, x1, [x4]
+;   add x3, sp, #32
+;   stp x0, x1, [x3]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -482,8 +482,8 @@ block0(v0: i128):
 ;   movk w16, w16, #1, LSL #16
 ;   sub sp, sp, x16, UXTX
 ; block0:
-;   mov x4, sp
-;   stp x0, x1, [x4]
+;   mov x3, sp
+;   stp x0, x1, [x3]
 ;   movz w16, #34480
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
@@ -502,8 +502,8 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   mov x3, sp
-;   ldp x0, x1, [x3]
+;   mov x2, sp
+;   ldp x0, x1, [x2]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -521,8 +521,8 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #32
 ; block0:
-;   add x3, sp, #32
-;   ldp x0, x1, [x3]
+;   add x2, sp, #32
+;   ldp x0, x1, [x2]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -542,8 +542,8 @@ block0:
 ;   movk w16, w16, #1, LSL #16
 ;   sub sp, sp, x16, UXTX
 ; block0:
-;   mov x3, sp
-;   ldp x0, x1, [x3]
+;   mov x2, sp
+;   ldp x0, x1, [x2]
 ;   movz w16, #34480
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX


### PR DESCRIPTION
Rework the compilation of amodes in the aarch64 backend to stop reusing registers and instead generate fresh virtual registers for intermediates. This resolves some SSA checker violations with the aarch64 backend, and as a nice side-effect removes some unnecessary `mov`s in the generated code.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
