### PR TITLE
aarch64: Don't reuse destination registers when lowering splat

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -421,8 +421,9 @@ impl Inst {
                 size
             }]
         } else if let Some(imm) = widen_32_bit_pattern(pattern, lane_size) {
+            let tmp = alloc_tmp(types::I64X2);
             let mut insts = smallvec![Inst::VecDupImm {
-                rd,
+                rd: tmp,
                 imm,
                 invert: false,
                 size: VectorSize::Size64x2,
@@ -433,7 +434,7 @@ impl Inst {
             if !size.is_128bits() {
                 insts.push(Inst::FpuExtend {
                     rd,
-                    rn: rd.to_reg(),
+                    rn: tmp.to_reg(),
                     size: ScalarSize::Size64,
                 });
             }

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -101,8 +101,8 @@ block0:
 }
 
 ; block0:
-;   movi v0.2d, #18374687579166474495
-;   fmov d0, d0
+;   movi v1.2d, #18374687579166474495
+;   fmov d0, d1
 ;   ret
 
 function %f10() -> i32x4 {


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
