### PR TITLE
riscv64: Terminate blocks with a single branch in riscv64

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1921,6 +1921,13 @@
   (lower_branch (brz v @ (value_type ty) _ _) targets)
   (lower_brz_or_nz (IntCC.Equal) (normalize_cmp_value ty v) targets ty))
 
+;; Special case for SI128 to reify the comparison value and branch on it.
+(rule 2
+  (lower_branch (brz v @ (value_type $I128) _ _) targets)
+  (let ((zero ValueRegs (value_regs (zero_reg) (zero_reg)))
+        (cmp Reg (gen_icmp (IntCC.Equal) v zero $I128)))
+    (lower_brz_or_nz (IntCC.NotEqual) cmp targets $I64)))
+
 (rule 1
   (lower_branch (brz (icmp cc a @ (value_type ty) b) _ _) targets)
   (lower_br_icmp (intcc_inverse cc) a b targets ty))
@@ -1933,6 +1940,13 @@
 (rule 
   (lower_branch (brnz v @ (value_type ty) _ _) targets)
   (lower_brz_or_nz (IntCC.NotEqual) (normalize_cmp_value ty v) targets ty))
+
+;; Special case for SI128 to reify the comparison value and branch on it.
+(rule 2
+  (lower_branch (brnz v @ (value_type $I128) _ _) targets)
+  (let ((zero ValueRegs (value_regs (zero_reg) (zero_reg)))
+        (cmp Reg (gen_icmp (IntCC.NotEqual) v zero $I128)))
+    (lower_brz_or_nz (IntCC.NotEqual) cmp targets $I64)))
 
 (rule 1
   (lower_branch (brnz (icmp cc a @ (value_type ty) b) _ _) targets)

--- a/cranelift/filetests/filetests/isa/riscv64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condbr.clif
@@ -170,8 +170,8 @@ block1:
 }
 
 ; block0:
-;   bne a1,zero,taken(label2),not_taken(0)
-;   beq a0,zero,taken(label1),not_taken(label2)
+;   eq a0,[a0,a1],[zerozero]##ty=i128
+;   bne a0,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3
 ; block2:
@@ -190,7 +190,7 @@ block1:
 }
 
 ; block0:
-;   bne a1,zero,taken(label1),not_taken(0)
+;   ne a0,[a0,a1],[zerozero]##ty=i128
 ;   bne a0,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3


### PR DESCRIPTION
Ensure that we're terminating blocks with a single branch instruction, when testing I128 values against zero.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
