### PR TITLE
riscv64: Use a temporary when translating shift amount

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -294,10 +294,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
         };
         let len_sub_shamt = {
             let tmp = self.temp_writable_reg(I64);
-            self.emit(&MInst::load_imm12(
-                tmp,
-                Imm12::from_bits(ty.bits() as i16),
-            ));
+            self.emit(&MInst::load_imm12(tmp, Imm12::from_bits(ty.bits() as i16)));
             let len_sub_shamt = self.temp_writable_reg(I64);
             self.emit(&MInst::AluRRR {
                 alu_op: AluOPRRR::Sub,

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -293,15 +293,16 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Flags, IsaFlags, 6> 
             tmp.to_reg()
         };
         let len_sub_shamt = {
-            let len_sub_shamt = self.temp_writable_reg(I64);
+            let tmp = self.temp_writable_reg(I64);
             self.emit(&MInst::load_imm12(
-                len_sub_shamt,
+                tmp,
                 Imm12::from_bits(ty.bits() as i16),
             ));
+            let len_sub_shamt = self.temp_writable_reg(I64);
             self.emit(&MInst::AluRRR {
                 alu_op: AluOPRRR::Sub,
                 rd: len_sub_shamt,
-                rs1: len_sub_shamt.to_reg(),
+                rs1: tmp.to_reg(),
                 rs2: shamt,
             });
             len_sub_shamt.to_reg()

--- a/cranelift/filetests/filetests/isa/riscv64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops.clif
@@ -795,18 +795,19 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   mv a4,a1
+;   mv t2,a1
 ;   andi a1,a2,127
 ;   li a3,128
-;   sub a3,a3,a1
-;   sll a6,a0,a1
-;   srl t3,a0,a3
-;   select_reg t0,zero,t3##condition=(a1 eq zero)
-;   sll t2,a4,a1
-;   or a2,t0,t2
-;   li a3,64
-;   select_reg a0,zero,a6##condition=(a1 uge a3)
-;   select_reg a1,a6,a2##condition=(a1 uge a3)
+;   sub a5,a3,a1
+;   sll a7,a0,a1
+;   srl t4,a0,a5
+;   select_reg t1,zero,t4##condition=(a1 eq zero)
+;   mv a5,t2
+;   sll a0,a5,a1
+;   or a2,t1,a0
+;   li a4,64
+;   select_reg a0,zero,a7##condition=(a1 uge a4)
+;   select_reg a1,a7,a2##condition=(a1 uge a4)
 ;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
@@ -818,15 +819,15 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   andi a2,a2,127
 ;   li a4,128
-;   sub a4,a4,a2
-;   sll a7,a0,a2
-;   srl t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   sll a0,a1,a2
-;   or a3,t1,a0
-;   li a4,64
-;   select_reg a0,zero,a7##condition=(a2 uge a4)
-;   select_reg a1,a7,a3##condition=(a2 uge a4)
+;   sub a6,a4,a2
+;   sll t3,a0,a2
+;   srl t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   sll a1,a1,a2
+;   or a3,t2,a1
+;   li a5,64
+;   select_reg a0,zero,t3##condition=(a2 uge a5)
+;   select_reg a1,t3,a3##condition=(a2 uge a5)
 ;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
@@ -836,18 +837,18 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   mv t1,a1
+;   mv t2,a1
 ;   andi a1,a2,127
 ;   li a3,128
-;   sub a3,a3,a1
-;   mv a2,t1
-;   sll a6,a2,a3
-;   select_reg t3,zero,a6##condition=(a1 eq zero)
-;   srl t0,a0,a1
-;   or t2,t3,t0
+;   sub a5,a3,a1
+;   mv a2,t2
+;   sll a7,a2,a5
+;   select_reg t4,zero,a7##condition=(a1 eq zero)
+;   srl t1,a0,a1
+;   or a0,t4,t1
 ;   li a3,64
 ;   srl a4,a2,a1
-;   select_reg a0,a4,t2##condition=(a1 uge a3)
+;   select_reg a0,a4,a0##condition=(a1 uge a3)
 ;   select_reg a1,zero,a4##condition=(a1 uge a3)
 ;   ret
 
@@ -860,15 +861,15 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   andi a2,a2,127
 ;   li a4,128
-;   sub a4,a4,a2
-;   sll a7,a1,a4
-;   select_reg t4,zero,a7##condition=(a2 eq zero)
-;   srl t1,a0,a2
-;   or a0,t4,t1
+;   sub a6,a4,a2
+;   sll t3,a1,a6
+;   select_reg t0,zero,t3##condition=(a2 eq zero)
+;   srl t2,a0,a2
+;   or a4,t0,t2
 ;   li a3,64
-;   srl a4,a1,a2
-;   select_reg a0,a4,a0##condition=(a2 uge a3)
-;   select_reg a1,zero,a4##condition=(a2 uge a3)
+;   srl a5,a1,a2
+;   select_reg a0,a5,a4##condition=(a2 uge a3)
+;   select_reg a1,zero,a5##condition=(a2 uge a3)
 ;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
@@ -878,20 +879,20 @@ block0(v0: i128, v1: i8):
 }
 
 ; block0:
-;   mv a3,a1
+;   mv a4,a1
 ;   andi a1,a2,127
-;   li a4,128
-;   sub a4,a4,a1
-;   sll a6,a3,a4
-;   select_reg t3,zero,a6##condition=(a1 eq zero)
-;   srl t0,a0,a1
-;   or t2,t3,t0
+;   li a3,128
+;   sub a5,a3,a1
+;   sll a7,a4,a5
+;   select_reg t4,zero,a7##condition=(a1 eq zero)
+;   srl t1,a0,a1
+;   or a0,t4,t1
 ;   li a2,64
-;   sra a4,a3,a1
-;   li a5,-1
-;   select_reg a7,a5,zero##condition=(a3 slt zero)
-;   select_reg a0,a4,t2##condition=(a1 uge a2)
-;   select_reg a1,a7,a4##condition=(a1 uge a2)
+;   sra a5,a4,a1
+;   li a6,-1
+;   select_reg t3,a6,zero##condition=(a4 slt zero)
+;   select_reg a0,a5,a0##condition=(a1 uge a2)
+;   select_reg a1,t3,a5##condition=(a1 uge a2)
 ;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
@@ -903,16 +904,16 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   andi a2,a2,127
 ;   li a4,128
-;   sub a4,a4,a2
-;   sll a7,a1,a4
-;   select_reg t4,zero,a7##condition=(a2 eq zero)
-;   srl t1,a0,a2
-;   or a0,t4,t1
+;   sub a6,a4,a2
+;   sll t3,a1,a6
+;   select_reg t0,zero,t3##condition=(a2 eq zero)
+;   srl t2,a0,a2
+;   or a4,t0,t2
 ;   li a3,64
-;   sra a4,a1,a2
-;   li a6,-1
-;   select_reg t3,a6,zero##condition=(a1 slt zero)
-;   select_reg a0,a4,a0##condition=(a2 uge a3)
-;   select_reg a1,t3,a4##condition=(a2 uge a3)
+;   sra a5,a1,a2
+;   li a7,-1
+;   select_reg t4,a7,zero##condition=(a1 slt zero)
+;   select_reg a0,a5,a4##condition=(a2 uge a3)
+;   select_reg a1,t4,a5##condition=(a2 uge a3)
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
@@ -15,18 +15,18 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   andi a2,a2,127
 ;   li a4,128
-;   sub a4,a4,a2
-;   srl a7,a0,a2
-;   sll t4,a1,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a3,a7,t1
-;   srl a5,a1,a2
-;   sll a4,a0,a4
-;   select_reg a6,zero,a4##condition=(a2 eq zero)
-;   or t3,a5,a6
-;   li t0,64
-;   select_reg a0,t3,a3##condition=(a2 uge t0)
-;   select_reg a1,a3,t3##condition=(a2 uge t0)
+;   sub a6,a4,a2
+;   srl t3,a0,a2
+;   sll t0,a1,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a3,t3,t2
+;   srl a4,a1,a2
+;   sll a5,a0,a6
+;   select_reg a7,zero,a5##condition=(a2 eq zero)
+;   or t4,a4,a7
+;   li t1,64
+;   select_reg a0,t4,a3##condition=(a2 uge t1)
+;   select_reg a1,a3,t4##condition=(a2 uge t1)
 ;   ret
 
 function %f0(i64, i64) -> i64 {
@@ -36,15 +36,15 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   mv a6,a0
+;   mv a7,a0
 ;   andi a0,a1,63
 ;   li a2,64
-;   sub a2,a2,a0
-;   mv t4,a6
-;   srl a5,t4,a0
-;   sll a7,t4,a2
-;   select_reg t4,zero,a7##condition=(a0 eq zero)
-;   or a0,a5,t4
+;   sub a4,a2,a0
+;   mv t0,a7
+;   srl a6,t0,a0
+;   sll t3,t0,a4
+;   select_reg t0,zero,t3##condition=(a0 eq zero)
+;   or a0,a6,t0
 ;   ret
 
 function %f1(i32, i32) -> i32 {
@@ -57,11 +57,11 @@ block0(v0: i32, v1: i32):
 ;   uext.w a0,a0
 ;   andi a2,a1,31
 ;   li a4,32
-;   sub a4,a4,a2
-;   srl a7,a0,a2
-;   sll t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   srl t3,a0,a2
+;   sll t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %f2(i16, i16) -> i16 {
@@ -74,11 +74,11 @@ block0(v0: i16, v1: i16):
 ;   uext.h a0,a0
 ;   andi a2,a1,15
 ;   li a4,16
-;   sub a4,a4,a2
-;   srl a7,a0,a2
-;   sll t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   srl t3,a0,a2
+;   sll t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %f3(i8, i8) -> i8 {
@@ -91,11 +91,11 @@ block0(v0: i8, v1: i8):
 ;   uext.b a0,a0
 ;   andi a2,a1,7
 ;   li a4,8
-;   sub a4,a4,a2
-;   srl a7,a0,a2
-;   sll t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   srl t3,a0,a2
+;   sll t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %i128_rotl(i128, i128) -> i128 {
@@ -107,18 +107,18 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   andi a2,a2,127
 ;   li a4,128
-;   sub a4,a4,a2
-;   sll a7,a0,a2
-;   srl t4,a1,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a3,a7,t1
-;   sll a5,a1,a2
-;   srl a4,a0,a4
-;   select_reg a6,zero,a4##condition=(a2 eq zero)
-;   or t3,a5,a6
-;   li t0,64
-;   select_reg a0,t3,a3##condition=(a2 uge t0)
-;   select_reg a1,a3,t3##condition=(a2 uge t0)
+;   sub a6,a4,a2
+;   sll t3,a0,a2
+;   srl t0,a1,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a3,t3,t2
+;   sll a4,a1,a2
+;   srl a5,a0,a6
+;   select_reg a7,zero,a5##condition=(a2 eq zero)
+;   or t4,a4,a7
+;   li t1,64
+;   select_reg a0,t4,a3##condition=(a2 uge t1)
+;   select_reg a1,a3,t4##condition=(a2 uge t1)
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -128,15 +128,15 @@ block0(v0: i64, v1: i64):
 }
 
 ; block0:
-;   mv a6,a0
+;   mv a7,a0
 ;   andi a0,a1,63
 ;   li a2,64
-;   sub a2,a2,a0
-;   mv t4,a6
-;   sll a5,t4,a0
-;   srl a7,t4,a2
-;   select_reg t4,zero,a7##condition=(a0 eq zero)
-;   or a0,a5,t4
+;   sub a4,a2,a0
+;   mv t0,a7
+;   sll a6,t0,a0
+;   srl t3,t0,a4
+;   select_reg t0,zero,t3##condition=(a0 eq zero)
+;   or a0,a6,t0
 ;   ret
 
 function %f5(i32, i32) -> i32 {
@@ -149,11 +149,11 @@ block0(v0: i32, v1: i32):
 ;   uext.w a0,a0
 ;   andi a2,a1,31
 ;   li a4,32
-;   sub a4,a4,a2
-;   sll a7,a0,a2
-;   srl t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   sll t3,a0,a2
+;   srl t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %f6(i16, i16) -> i16 {
@@ -166,11 +166,11 @@ block0(v0: i16, v1: i16):
 ;   uext.h a0,a0
 ;   andi a2,a1,15
 ;   li a4,16
-;   sub a4,a4,a2
-;   sll a7,a0,a2
-;   srl t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   sll t3,a0,a2
+;   srl t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %f7(i8, i8) -> i8 {
@@ -183,11 +183,11 @@ block0(v0: i8, v1: i8):
 ;   uext.b a0,a0
 ;   andi a2,a1,7
 ;   li a4,8
-;   sub a4,a4,a2
-;   sll a7,a0,a2
-;   srl t4,a0,a4
-;   select_reg t1,zero,t4##condition=(a2 eq zero)
-;   or a0,a7,t1
+;   sub a6,a4,a2
+;   sll t3,a0,a2
+;   srl t0,a0,a6
+;   select_reg t2,zero,t0##condition=(a2 eq zero)
+;   or a0,t3,t2
 ;   ret
 
 function %f8(i64, i64) -> i64 {
@@ -331,11 +331,11 @@ block0(v0: i64):
 ;   li t2,17
 ;   andi a1,t2,63
 ;   li a3,64
-;   sub a3,a3,a1
-;   srl a6,a0,a1
-;   sll t3,a0,a3
-;   select_reg t0,zero,t3##condition=(a1 eq zero)
-;   or a0,a6,t0
+;   sub a5,a3,a1
+;   srl a7,a0,a1
+;   sll t4,a0,a5
+;   select_reg t1,zero,t4##condition=(a1 eq zero)
+;   or a0,a7,t1
 ;   ret
 
 function %f21(i64) -> i64 {
@@ -349,11 +349,11 @@ block0(v0: i64):
 ;   li t2,17
 ;   andi a1,t2,63
 ;   li a3,64
-;   sub a3,a3,a1
-;   sll a6,a0,a1
-;   srl t3,a0,a3
-;   select_reg t0,zero,t3##condition=(a1 eq zero)
-;   or a0,a6,t0
+;   sub a5,a3,a1
+;   sll a7,a0,a1
+;   srl t4,a0,a5
+;   select_reg t1,zero,t4##condition=(a1 eq zero)
+;   or a0,a7,t1
 ;   ret
 
 function %f22(i32) -> i32 {
@@ -368,11 +368,11 @@ block0(v0: i32):
 ;   uext.w a1,a0
 ;   andi a3,t2,31
 ;   li a5,32
-;   sub a5,a5,a3
-;   sll t3,a1,a3
-;   srl t0,a1,a5
-;   select_reg t2,zero,t0##condition=(a3 eq zero)
-;   or a0,t3,t2
+;   sub a7,a5,a3
+;   sll t4,a1,a3
+;   srl t1,a1,a7
+;   select_reg a0,zero,t1##condition=(a3 eq zero)
+;   or a0,t4,a0
 ;   ret
 
 function %f23(i16) -> i16 {
@@ -387,11 +387,11 @@ block0(v0: i16):
 ;   uext.h a1,a0
 ;   andi a3,t2,15
 ;   li a5,16
-;   sub a5,a5,a3
-;   sll t3,a1,a3
-;   srl t0,a1,a5
-;   select_reg t2,zero,t0##condition=(a3 eq zero)
-;   or a0,t3,t2
+;   sub a7,a5,a3
+;   sll t4,a1,a3
+;   srl t1,a1,a7
+;   select_reg a0,zero,t1##condition=(a3 eq zero)
+;   or a0,t4,a0
 ;   ret
 
 function %f24(i8) -> i8 {
@@ -406,11 +406,11 @@ block0(v0: i8):
 ;   uext.b a1,a0
 ;   andi a3,t2,7
 ;   li a5,8
-;   sub a5,a5,a3
-;   sll t3,a1,a3
-;   srl t0,a1,a5
-;   select_reg t2,zero,t0##condition=(a3 eq zero)
-;   or a0,t3,t2
+;   sub a7,a5,a3
+;   sll t4,a1,a3
+;   srl t1,a1,a7
+;   select_reg a0,zero,t1##condition=(a3 eq zero)
+;   or a0,t4,a0
 ;   ret
 
 function %f25(i64) -> i64 {


### PR DESCRIPTION
Use a temporary when translating the shift amount, instead of reusing the destination register.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
