### PR TITLE
cranelift: Small documentation fixes

### DIFF
--- a/cranelift/codegen/src/ir/sourceloc.rs
+++ b/cranelift/codegen/src/ir/sourceloc.rs
@@ -63,10 +63,6 @@ impl RelSourceLoc {
     }
 
     /// Creates a new `RelSourceLoc` based on the given base and offset.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the offset is smaller than the base.
     pub fn from_base_offset(base: SourceLoc, offset: SourceLoc) -> Self {
         if base.is_default() || offset.is_default() {
             Self::default()

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -100,8 +100,7 @@ use wasmparser::{FuncValidator, MemArg, Operator, WasmModuleResources};
     feature = "cargo-clippy",
     allow(clippy::unneeded_field_pattern, clippy::cognitive_complexity)
 )]
-/// Translates wasm operators into Cranelift IR instructions. Returns `true` if it inserted
-/// a return.
+/// Translates wasm operators into Cranelift IR instructions.
 pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
     validator: &mut FuncValidator<impl WasmModuleResources>,
     op: &Operator,


### PR DESCRIPTION
* `translate_operator` doesn't return a boolean.
* `from_base_offset` doesn't panic if offset is smaller than base.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
