### PR TITLE
riscv64: Avoid reusing a register during constant loading

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -235,7 +235,7 @@ impl Inst {
         alloc_tmp: &mut F,
     ) -> SmallInstVec<Inst> {
         let insts = Inst::load_const_imm(rd, value, alloc_tmp);
-        insts.unwrap_or(LoadConstant::U32(value as u32).load_constant(rd))
+        insts.unwrap_or(LoadConstant::U32(value as u32).load_constant(rd, alloc_tmp))
     }
 
     pub fn load_constant_u64<F: FnMut(Type) -> Writable<Reg>>(
@@ -244,7 +244,7 @@ impl Inst {
         alloc_tmp: &mut F,
     ) -> SmallInstVec<Inst> {
         let insts = Inst::load_const_imm(rd, value, alloc_tmp);
-        insts.unwrap_or(LoadConstant::U64(value).load_constant(rd))
+        insts.unwrap_or(LoadConstant::U64(value).load_constant(rd, alloc_tmp))
     }
 
     pub(crate) fn construct_auipc_and_jalr(

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -50,8 +50,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffff0000
 ;   ret
@@ -63,8 +63,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffff00000000
 ;   ret
@@ -76,8 +76,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffff000000000000
 ;   ret
@@ -109,8 +109,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffffffff0000ffff
 ;   ret
@@ -122,8 +122,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffff0000ffffffff
 ;   ret
@@ -135,8 +135,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xffffffffffff
 ;   ret
@@ -148,8 +148,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xf34bf0a31212003a
 ;   ret
@@ -161,8 +161,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0x12e900001ef40000
 ;   ret
@@ -174,8 +174,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0x12e9ffff1ef4ffff
 ;   ret
@@ -197,8 +197,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xfffffff7
 ;   ret
@@ -210,8 +210,8 @@ block0:
 }
 
 ; block0:
-;   auipc a0,0
-;   ld a0,12(a0)
+;   auipc t1,0
+;   ld a0,12(t1)
 ;   j 12
 ;   .8byte 0xfffffff7
 ;   ret
@@ -233,11 +233,11 @@ block0:
 }
 
 ; block0:
-;   auipc t1,0
-;   ld t1,12(t1)
+;   auipc t2,0
+;   ld t2,12(t2)
 ;   j 12
 ;   .8byte 0x3ff0000000000000
-;   fmv.d.x fa0,t1
+;   fmv.d.x fa0,t2
 ;   ret
 
 function %f() -> f32 {
@@ -258,11 +258,11 @@ block0:
 }
 
 ; block0:
-;   auipc t1,0
-;   ld t1,12(t1)
+;   auipc t2,0
+;   ld t2,12(t2)
 ;   j 12
 ;   .8byte 0x4049000000000000
-;   fmv.d.x fa0,t1
+;   fmv.d.x fa0,t2
 ;   ret
 
 function %f() -> f32 {
@@ -305,11 +305,11 @@ block0:
 }
 
 ; block0:
-;   auipc t1,0
-;   ld t1,12(t1)
+;   auipc t2,0
+;   ld t2,12(t2)
 ;   j 12
 ;   .8byte 0xc030000000000000
-;   fmv.d.x fa0,t1
+;   fmv.d.x fa0,t2
 ;   ret
 
 function %f() -> f32 {
@@ -319,10 +319,10 @@ block0:
 }
 
 ; block0:
-;   auipc t1,0
-;   lwu t1,12(t1)
+;   auipc t2,0
+;   lwu t2,12(t2)
 ;   j 8
 ;   .4byte 0xc1800000
-;   fmv.w.x fa0,t1
+;   fmv.w.x fa0,t2
 ;   ret
 


### PR DESCRIPTION
Avoid reusing a register when loading a constant, allocating a temporary instead.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
