### PR TITLE
Fix a fuzz failure due to changing errors

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -315,7 +315,7 @@ pub fn instantiate_with_dummy(store: &mut Store<StoreLimits>, module: &Module) -
     }
 
     // Also allow failures to instantiate as a result of hitting instance limits
-    if string.contains("concurrent instances has been reached") {
+    if string.contains("maximum concurrent instance limit") {
         log::debug!("failed to instantiate: {}", string);
         return None;
     }


### PR DESCRIPTION
Fix the `instantiate-many` fuzzer from a recent regression introduced in #5347 where an error message changed slightly. Ideally a concrete error type would be tested for here but that's deferred to a future PR.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
