### PR TITLE
Fix built with latest `wit-parser` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893834cffb239f88413eead7cf91862a6f24c2233afae15d7808256d8c58f91e"
+checksum = "703eb1d2f89ff2c52d50f7ff002735e423cea75f0a5dc5c8a4626c4c47cd9ca6"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -5,7 +5,7 @@ use syn::punctuated::Punctuated;
 use syn::token;
 use syn::Token;
 use wasmtime_wit_bindgen::Opts;
-use wit_parser::World;
+use wit_parser::{Document, World};
 
 #[derive(Default)]
 pub struct Config {
@@ -119,8 +119,10 @@ impl Parse for Opt {
             let span = input.parse::<kw::inline>()?.span;
             input.parse::<Token![:]>()?;
             let s = input.parse::<syn::LitStr>()?;
-            let world =
-                World::parse("<macro-input>", &s.value()).map_err(|e| Error::new(s.span(), e))?;
+            let world = Document::parse("<macro-input>".as_ref(), &s.value())
+                .map_err(|e| Error::new(s.span(), e))?
+                .into_world()
+                .map_err(|e| Error::new(s.span(), e))?;
             Ok(Opt::Inline(span, world))
         } else if l.peek(kw::tracing) {
             input.parse::<kw::tracing>()?;

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -998,3 +998,9 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = "The Bytecode Alliance is the author of this crate."
+


### PR DESCRIPTION
A mistake was made in the publication of `wit-parser` where a breaking change was made without bumping its major version, causing build issues on `main` if `wit-parser` is updated. This commit updates `wit-parser` to the latest and we'll handle breaking changes better next time.

Closes #5390

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
