### PR TITLE
CI: pin to Ubuntu 20.04.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
   doc:
     name: Doc build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: remove pin when fixed (#5408)
     env:
       CARGO_MDBOOK_VERSION: 0.4.21
       RUSTDOCFLAGS: -Dbroken_intra_doc_links --cfg nightlydoc
@@ -335,7 +335,7 @@ jobs:
   # Build and test the wasi-nn module.
   test_wasi_nn:
     name: Test wasi-nn module
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: remove pin when fixed (#5408)
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
CI is currently broken because `ubuntu-latest` moved to 22.04, which is missing at least one package (`libclang1-9` used in our CI jobs) and may be causing other issues as well.

This PR pins us back to 20.04; separately we should look into upgrading when issues are resolved.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
