### PR TITLE
`--json` option for `wasmtime settings` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,11 +2194,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
- "unicode-ident",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2527,9 +2527,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2557,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2723,13 +2723,13 @@ checksum = "7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71"
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-ident",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2989,12 +2989,6 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,11 +2194,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2527,9 +2527,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2557,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -2723,13 +2723,13 @@ checksum = "7c68d531d83ec6c531150584c42a4290911964d5f0d79132b193b67252a23b71"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2989,6 +2989,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -3475,6 +3481,8 @@ dependencies = [
  "once_cell",
  "rayon",
  "rustix",
+ "serde",
+ "serde_json",
  "target-lexicon",
  "tempfile",
  "test-programs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ humantime = "2.0.0"
 once_cell = { workspace = true }
 listenfd = "1.0.0"
 wat = { workspace = true }
-serde = "1.0.143"
-serde_json = "1.0.83"
+serde = "1.0.94"
+serde_json = "1.0.26"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["mm", "param"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ humantime = "2.0.0"
 once_cell = { workspace = true }
 listenfd = "1.0.0"
 wat = { workspace = true }
+serde = "1.0.143"
+serde_json = "1.0.83"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["mm", "param"] }

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -34,6 +34,7 @@ impl Serialize for SettingData {
     }
 }
 
+// Gather together all of the setting data to displays
 #[derive(Serialize)]
 struct Settings {
     triple: String,
@@ -101,7 +102,6 @@ impl Settings {
 impl SettingsCommand {
     /// Executes the command.
     pub fn execute(self) -> Result<()> {
-
         // Gather settings from the cranelift compiler builder
         let mut builder = wasmtime_cranelift::builder();
         if let Some(target) = &self.target {
@@ -123,8 +123,7 @@ impl SettingsCommand {
         }
     }
 
-    fn print_json(self, settings: Settings) -> Result<()>
-    {
+    fn print_json(self, settings: Settings) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&settings)?);
         Ok(())
     }

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -2,10 +2,10 @@
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use serde::{ser::SerializeMap, Serialize};
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use wasmtime_environ::{FlagValue, Setting, SettingKind, CompilerBuilder};
-use serde::{Serialize, ser::SerializeMap};
+use wasmtime_environ::{CompilerBuilder, FlagValue, Setting, SettingKind};
 
 /// Displays available Cranelift settings for a target.
 #[derive(Parser)]
@@ -24,7 +24,8 @@ struct SettingData(Setting);
 
 impl Serialize for SettingData {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer
+    where
+        S: serde::Serializer,
     {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("name", self.0.name)?;
@@ -44,7 +45,7 @@ struct Settings {
     bools: Vec<SettingData>,
     presets: Vec<SettingData>,
 
-    inferred: Option<Vec<String>>
+    inferred: Option<Vec<String>>,
 }
 
 impl Settings {
@@ -87,7 +88,8 @@ impl Settings {
     }
 
     fn add_settings<I>(&mut self, iterable: I)
-        where I: IntoIterator<Item=Setting>
+    where
+        I: IntoIterator<Item = Setting>,
     {
         for item in iterable.into_iter() {
             self.add_setting(item);
@@ -95,7 +97,10 @@ impl Settings {
     }
 
     fn is_empty(&self) -> bool {
-        self.enums.is_empty() && self.nums.is_empty() && self.bools.is_empty() && self.presets.is_empty()
+        self.enums.is_empty()
+            && self.nums.is_empty()
+            && self.bools.is_empty()
+            && self.presets.is_empty()
     }
 }
 
@@ -154,7 +159,6 @@ impl SettingsCommand {
     }
 
     fn print_settings_human_readable(header: &str, settings: &[SettingData]) {
-
         if settings.is_empty() {
             return;
         }
@@ -162,17 +166,15 @@ impl SettingsCommand {
         println!();
         println!("{}", header);
 
-        let width = settings.iter()
-            .map(|s| s.0.name.len())
-            .max()
-            .unwrap_or(0);
+        let width = settings.iter().map(|s| s.0.name.len()).max().unwrap_or(0);
 
         for setting in settings {
             println!(
                 "  {:width$} {}{}",
                 setting.0.name,
                 setting.0.description,
-                setting.0
+                setting
+                    .0
                     .values
                     .map(|v| format!(" Supported values: {}.", v.join(", ")))
                     .unwrap_or("".to_string()),


### PR DESCRIPTION
Added a `--json` flag to the `wasmtime settings` command, as discussed in #5404. Settings data is gathered into the `Settings` struct, which is then printed either in human readable form (exactly the same format as before) or JSON (using serde).

I'm not very familiar with Rust, so please tell me if I've done any weird non-idiomatic things and I'll try to fix them!