### PR TITLE
cranelift-codegen: [x64] Prepare cranelift codegen for usage from Winch

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2487,7 +2487,8 @@ pub struct EmitInfo {
 }
 
 impl EmitInfo {
-    pub(crate) fn new(flags: settings::Flags, isa_flags: x64_settings::Flags) -> Self {
+    /// Create a constant state for emission of instructions.
+    pub fn new(flags: settings::Flags, isa_flags: x64_settings::Flags) -> Self {
         Self { flags, isa_flags }
     }
 }

--- a/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle/generated_code.rs
@@ -4,6 +4,11 @@
 // mod generated_code;` trick either.
 #![allow(dead_code, unreachable_code, unreachable_patterns)]
 #![allow(unused_imports, unused_variables, non_snake_case, unused_mut)]
-#![allow(irrefutable_let_patterns, unused_assignments, non_camel_case_types)]
+#![allow(
+    irrefutable_let_patterns,
+    unused_assignments,
+    non_camel_case_types,
+    missing_docs
+)]
 
 include!(concat!(env!("ISLE_DIR"), "/isle_x64.rs"));

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -1,6 +1,6 @@
 //! X86_64-bit Instruction Set Architecture.
 
-use self::inst::EmitInfo;
+pub use self::inst::{args, EmitInfo, EmitState, Inst};
 
 use super::TargetIsa;
 use crate::ir::{condcodes::IntCC, Function, Type};

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -89,7 +89,10 @@ pub mod write;
 
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::{MachCallSite, MachReloc, MachSrcLoc, MachStackMap, MachTrap};
-pub use crate::machinst::{CompiledCode, TextSectionBuilder};
+pub use crate::machinst::{
+    CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit, Reg,
+    TextSectionBuilder, Writable,
+};
 
 mod alias_analysis;
 mod bitset;


### PR DESCRIPTION
This commit prepares the x64 pieces from `cranelift-codegen` to be consumed by Winch for binary emission. This change doesn't introduce or modifies functionality it makes the necessary pieces for binary emission public.

This change also improves documentation where applicable. I decided to introduce `#[allow(missing_docs)]` for the `Avx512Opcode`, `SseOpcode` and `AvxOpcode`, but happy to add documentation there too if we want to document those opcodes.

[I have a binary emission proof-of-concept branch](https://github.com/bytecodealliance/wasmtime/compare/main...saulecabrera:wasmtime:winch-dep-cranelift-codegen) that I'm using a base to extract individual PRs.


<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
