### PR TITLE
[4.0.0] CI: pin to Ubuntu 20.04. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
   doc:
     name: Doc build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: remove pin when fixed (#5408)
     env:
       CARGO_MDBOOK_VERSION: 0.4.21
       RUSTDOCFLAGS: -Dbroken_intra_doc_links --cfg nightlydoc
@@ -335,7 +335,7 @@ jobs:
   # Build and test the wasi-nn module.
   test_wasi_nn:
     name: Test wasi-nn module
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: remove pin when fixed (#5408)
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is a backport of #5407 to the 4.0.0 release branch to fix CI there as well.