### PR TITLE
Decouple `MachBufferFinalized<Stencil>` from `ir::FunctionParameters`

### DIFF
--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -323,7 +323,7 @@ impl CompiledCodeStencil {
     /// Apply function parameters to finalize a stencil into its final form.
     pub fn apply_params(self, params: &FunctionParameters) -> CompiledCode {
         CompiledCode {
-            buffer: self.buffer.apply_params(params),
+            buffer: self.buffer.apply_base_srcloc(params.base_srcloc()),
             frame_size: self.frame_size,
             disasm: self.disasm,
             value_labels_ranges: self.value_labels_ranges,


### PR DESCRIPTION
This commit allows retrieving a `MachBufferFinalized<Final>` from a `MachBufferFinalized<Stencil>` without relying on
`ir::FunctionParameters`. Instead it uses the function's base source location, which is the only piece used by the previous `apply_params` definition.

This change allows other uses cases (e.g. Winch) to use an opaque, common concept, exposed outside of `cranelift-codegen` to get the finalized state of the machine buffer. This change implies that Winch will transitively know about the `Stencil` compilation phase, but the `Stencil` phase is not exposed to Winch.

Other alternatives considered:

Parametrizing `MachBufferFinzalized` in a way such that it allows specifying which compilation phase the caller is targetting. Such approach would require also parametrizing the `MachSrcLoc` definition. One of the main drawbacks of this approach is that it also requires changing how the `MachBuffer`'s `start_srcloc` works: for caller requesting a `Final` `MachBufferFinalized`, the `MachBuffer` will need to work in terms of `SourceLoc` rather than in `RelSourceLoc` terms. This approach doesn't necessarily present more advantages than the approach presented in this change, in which there's no need to make any fundamental changes and in which all the `cranelift-codegen` primitives are already exposed.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
