### PR TITLE
Cranelift: implement general select_spectre_guard fallbacks.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1746,6 +1746,12 @@
             (_ InstOutput (side_effect (csdb))))
        dst))
 
+(rule -1 (lower (has_type ty (select_spectre_guard rcond rn rm)))
+      (let ((rcond Reg (put_in_reg_zext64 rcond)))
+       (lower_select
+        (cmp (OperandSize.Size64) rcond (zero_reg))
+        (Cond.Ne) ty rn rm)))
+
 ;;;; Rules for `vconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (ty_vec128 _) (vconst (u128_from_constant x))))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -831,6 +831,9 @@
       (_ Unit (emit (MInst.SelectIf $true (vec_writable_clone dst) r a b))))
     (vec_writable_to_regs dst)))
 
+(rule -1
+  (lower (has_type ty (select_spectre_guard c @ (value_type cty) x y)))
+  (gen_select ty (normalize_cmp_value cty c) x y))
 
 ;;;;;  Rules for `bmask`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2948,6 +2948,11 @@
 (rule (lower (select_spectre_guard (icmp cc a b) x y))
       (select_icmp (emit_cmp cc a b) x y))
 
+(rule -1 (lower (has_type ty (select_spectre_guard c @ (value_type (fits_in_64 a_ty)) x y)))
+      (let ((size OperandSize (raw_operand_size_of_type a_ty))
+            (gpr_c Gpr (put_in_gpr c)))
+           (with_flags (x64_test size gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
+
 ;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 2 (lower (has_type $F32 (fcvt_from_sint a @ (value_type $I8))))

--- a/cranelift/filetests/filetests/egraph/issue-5417.clif
+++ b/cranelift/filetests/filetests/egraph/issue-5417.clif
@@ -1,0 +1,15 @@
+test compile
+set opt_level=speed
+set use_egraphs=true
+target x86_64
+target aarch64
+target s390x
+target riscv64
+
+function %my_fn(i16) system_v {
+block0(v0: i16):
+    v1 = icmp eq v0, v0
+    v2 = select_spectre_guard v1, v1, v1
+    return
+}
+; run: %my_fn(6330)


### PR DESCRIPTION
When adding some optimization rules for `icmp` in the egraph infrastructure, we ended up creating a path to legal CLIF but with patterns unsupported by three of our four backends: specifically, `select_spectre_guard` with a general truthy input, rather than an `icmp`.

In #5206 we discussed replacing `select_spectre_guard` with something more specific, and that could still be a long-term solution here, but doing so now would interfere with ongoing refactoring of heap access lowering, so I've opted not to do so. (In that issue I was concerned about complexity and didn't see the need but with this fuzzbug I'm starting to feel a bit differently; maybe we should remove this non-orthogonal op in the long run.)

Fixes #5417.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
