### PR TITLE
Allow at least 1 page of memory when disallowing traps

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -311,6 +311,20 @@ impl<'a> Arbitrary<'a> for Config {
                 cfg.max_memory_pages = pooling.instance_memory_pages;
             }
 
+            // If traps are disallowed then memories must have at least one page
+            // of memory so if we still are only allowing 0 pages of memory then
+            // increase that to one here.
+            if cfg.disallow_traps {
+                if pooling.instance_memory_pages == 0 {
+                    pooling.instance_memory_pages = 1;
+                    cfg.max_memory_pages = 1;
+                }
+                // .. additionally update tables
+                if pooling.instance_table_elements == 0 {
+                    pooling.instance_table_elements = 1;
+                }
+            }
+
             // Forcibly don't use the `CustomUnaligned` memory configuration
             // with the pooling allocator active.
             if let MemoryConfig::CustomUnaligned = config.wasmtime.memory_config {


### PR DESCRIPTION
This commit fixes configuration of the pooling instance allocator when traps are disallowed while fuzzing to ensure that there's at least one page of memory. The support in `wasm-smith` currently forcibly creates a 1-page memory which was previously invalid in the pooling instance allocator under the generated configuration, so this commit updates the configuration generated to ensure that it can fit the generated module.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
