### PR TITLE
wiggle: choose between `&mut self` and `&self`

### DIFF
--- a/crates/wiggle/generate/src/codegen_settings.rs
+++ b/crates/wiggle/generate/src/codegen_settings.rs
@@ -12,10 +12,13 @@ pub struct CodegenSettings {
     pub errors: ErrorTransform,
     pub async_: AsyncConf,
     pub wasmtime: bool,
-    // Disabling this feature makes it possible to remove all of the tracing
-    // code emitted in the Wiggle-generated code; this can be helpful while
-    // inspecting the code (e.g., with `cargo expand`).
+    /// Disabling this feature makes it possible to remove all of the tracing
+    /// code emitted in the Wiggle-generated code; this can be helpful while
+    /// inspecting the code (e.g., with `cargo expand`).
     pub tracing: TracingConf,
+    /// Determine whether the context structure will use `&mut self` (true) or
+    /// simply `&self`.
+    pub mutable: bool,
 }
 impl CodegenSettings {
     pub fn new(
@@ -24,6 +27,7 @@ impl CodegenSettings {
         doc: &Document,
         wasmtime: bool,
         tracing: &TracingConf,
+        mutable: bool,
     ) -> Result<Self, Error> {
         let errors = ErrorTransform::new(error_conf, doc)?;
         Ok(Self {
@@ -31,6 +35,7 @@ impl CodegenSettings {
             async_: async_.clone(),
             wasmtime,
             tracing: tracing.clone(),
+            mutable,
         })
     }
     pub fn get_async(&self, module: &Module, func: &InterfaceFunc) -> Asyncness {

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -619,7 +619,9 @@ impl Parse for WasmtimeConfigField {
         } else if lookahead.peek(kw::mutable) {
             input.parse::<kw::mutable>()?;
             input.parse::<Token![:]>()?;
-            Ok(WasmtimeConfigField::Core(ConfigField::Mutable(input.parse::<syn::LitBool>()?.value)))
+            Ok(WasmtimeConfigField::Core(ConfigField::Mutable(
+                input.parse::<syn::LitBool>()?.value,
+            )))
         } else {
             Err(lookahead.error())
         }

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -16,6 +16,7 @@ pub struct Config {
     pub async_: AsyncConf,
     pub wasmtime: bool,
     pub tracing: TracingConf,
+    pub mutable: bool,
 }
 
 mod kw {
@@ -25,6 +26,7 @@ mod kw {
     syn::custom_keyword!(errors);
     syn::custom_keyword!(target);
     syn::custom_keyword!(wasmtime);
+    syn::custom_keyword!(mutable);
     syn::custom_keyword!(tracing);
     syn::custom_keyword!(disable_for);
     syn::custom_keyword!(trappable);
@@ -37,6 +39,7 @@ pub enum ConfigField {
     Async(AsyncConf),
     Wasmtime(bool),
     Tracing(TracingConf),
+    Mutable(bool),
 }
 
 impl Parse for ConfigField {
@@ -76,6 +79,10 @@ impl Parse for ConfigField {
             input.parse::<kw::tracing>()?;
             input.parse::<Token![:]>()?;
             Ok(ConfigField::Tracing(input.parse()?))
+        } else if lookahead.peek(kw::mutable) {
+            input.parse::<kw::mutable>()?;
+            input.parse::<Token![:]>()?;
+            Ok(ConfigField::Mutable(input.parse::<syn::LitBool>()?.value))
         } else {
             Err(lookahead.error())
         }
@@ -89,6 +96,7 @@ impl Config {
         let mut async_ = None;
         let mut wasmtime = None;
         let mut tracing = None;
+        let mut mutable = None;
         for f in fields {
             match f {
                 ConfigField::Witx(c) => {
@@ -121,6 +129,12 @@ impl Config {
                     }
                     tracing = Some(c);
                 }
+                ConfigField::Mutable(c) => {
+                    if mutable.is_some() {
+                        return Err(Error::new(err_loc, "duplicate `mutable` field"));
+                    }
+                    mutable = Some(c);
+                }
             }
         }
         Ok(Config {
@@ -131,6 +145,7 @@ impl Config {
             async_: async_.take().unwrap_or_default(),
             wasmtime: wasmtime.unwrap_or(true),
             tracing: tracing.unwrap_or_default(),
+            mutable: mutable.unwrap_or(true),
         })
     }
 
@@ -601,6 +616,10 @@ impl Parse for WasmtimeConfigField {
                 blocking: true,
                 functions: input.parse()?,
             })))
+        } else if lookahead.peek(kw::mutable) {
+            input.parse::<kw::mutable>()?;
+            input.parse::<Token![:]>()?;
+            Ok(WasmtimeConfigField::Core(ConfigField::Mutable(input.parse::<syn::LitBool>()?.value)))
         } else {
             Err(lookahead.error())
         }

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -77,6 +77,7 @@ fn _define_func(
             function = #func_name
         );
     );
+    let ctx_type = if settings.mutable { quote!(&'a mut) } else { quote!(&'a) };
     if settings.get_async(&module, &func).is_sync() {
         let traced_body = if settings.tracing.enabled_for(&mod_name, &func_name) {
             quote!(
@@ -91,8 +92,8 @@ fn _define_func(
         (
             quote!(
                 #[allow(unreachable_code)] // deals with warnings in noreturn functions
-                pub fn #ident(
-                    ctx: &mut (impl #(#bounds)+*),
+                pub fn #ident<'a>(
+                    ctx: #ctx_type (impl #(#bounds)+*),
                     memory: &dyn wiggle::GuestMemory,
                     #(#abi_params),*
                 ) -> wiggle::anyhow::Result<#abi_ret> {
@@ -122,7 +123,7 @@ fn _define_func(
             quote!(
                 #[allow(unreachable_code)] // deals with warnings in noreturn functions
                 pub fn #ident<'a>(
-                    ctx: &'a mut (impl #(#bounds)+*),
+                    ctx: #ctx_type (impl #(#bounds)+*),
                     memory: &'a dyn wiggle::GuestMemory,
                     #(#abi_params),*
                 ) -> impl std::future::Future<Output = wiggle::anyhow::Result<#abi_ret>> + 'a {

--- a/crates/wiggle/generate/src/funcs.rs
+++ b/crates/wiggle/generate/src/funcs.rs
@@ -77,7 +77,11 @@ fn _define_func(
             function = #func_name
         );
     );
-    let ctx_type = if settings.mutable { quote!(&'a mut) } else { quote!(&'a) };
+    let ctx_type = if settings.mutable {
+        quote!(&'a mut)
+    } else {
+        quote!(&'a)
+    };
     if settings.get_async(&module, &func).is_sync() {
         let traced_body = if settings.tracing.enabled_for(&mod_name, &func_name) {
             quote!(

--- a/crates/wiggle/generate/src/module_trait.rs
+++ b/crates/wiggle/generate/src/module_trait.rs
@@ -81,10 +81,15 @@ pub fn define_module_trait(m: &Module, settings: &CodegenSettings) -> TokenStrea
             quote!(async)
         };
 
-        if is_anonymous {
-            quote!(#asyncness fn #funcname(&mut self, #(#args),*) -> #result; )
+        let self_ = if settings.mutable {
+            quote!(&mut self)
         } else {
-            quote!(#asyncness fn #funcname<#lifetime>(&mut self, #(#args),*) -> #result;)
+            quote!(&self)
+        };
+        if is_anonymous {
+            quote!(#asyncness fn #funcname(#self_, #(#args),*) -> #result; )
+        } else {
+            quote!(#asyncness fn #funcname<#lifetime>(#self_, #(#args),*) -> #result;)
         }
     });
 

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -46,11 +46,17 @@ pub fn link_module(
         format_ident!("add_{}_to_linker", module_ident)
     };
 
+    assert!(!settings.mutable);
+    let u = if settings.mutable {
+        quote!(&mut U)
+    } else {
+        quote!(&U)
+    };
     quote! {
         /// Adds all instance items to the specified `Linker`.
         pub fn #func_name<T, U>(
             linker: &mut wiggle::wasmtime_crate::Linker<T>,
-            get_cx: impl Fn(&mut T) -> &mut U + Send + Sync + Copy + 'static,
+            get_cx: impl Fn(&mut T) -> #u + Send + Sync + Copy + 'static,
         ) -> wiggle::anyhow::Result<()>
             where
                 U: #ctx_bound #send_bound

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -46,7 +46,6 @@ pub fn link_module(
         format_ident!("add_{}_to_linker", module_ident)
     };
 
-    assert!(!settings.mutable);
     let u = if settings.mutable {
         quote!(&mut U)
     } else {

--- a/crates/wiggle/macro/src/lib.rs
+++ b/crates/wiggle/macro/src/lib.rs
@@ -157,6 +157,7 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         &doc,
         config.wasmtime,
         &config.tracing,
+        config.mutable,
     )
     .expect("validating codegen settings");
 
@@ -198,6 +199,7 @@ pub fn wasmtime_integration(args: TokenStream) -> TokenStream {
         &doc,
         true,
         &config.c.tracing,
+        config.c.mutable,
     )
     .expect("validating codegen settings");
 


### PR DESCRIPTION
Previously, all Wiggle-generated traits were generated with `&mut self` signatures. With the addition of the `mutable` configuration option to `from_witx!` and `wasmtime_integration!`, one can disable this, emitting instead traits that use `&self` (i.e., `mutable: false`). This change is helpful for implementing wasi-threads: WASI implementations with interior mutability will now be able to communitcate this to their Wiggle-generated code.

The other side of this change is the `get_cx` closure passed to Wiggle's generated `add_to_linker` function. When `mutability` is set to `true` (default), the `get_cx` function takes a `&mut` data structure from the store and returns a corresponding `&mut` reference, usually to a field of the passed-in structure. When `mutability: false`, the `get_cx` closure will still take a `&mut` data structure but now will return a `&` reference.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
