### PR TITLE
Simplify "unimplemented" operation error message

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower.rs
@@ -55,8 +55,9 @@ impl LowerBackend for Riscv64Backend {
             assert!(temp_regs.len() == 0);
             return Ok(());
         }
+
         unreachable!(
-            "implemented in ISLE: branch = `{}`",
+            "not implemented in ISLE: branch = `{}`",
             ctx.dfg().display_inst(branches[0]),
         );
     }

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -20,221 +20,17 @@ impl LowerBackend for S390xBackend {
             return Ok(temp_regs);
         }
 
-        let op = ctx.data(ir_inst).opcode();
         let ty = if ctx.num_outputs(ir_inst) > 0 {
             Some(ctx.output_ty(ir_inst, 0))
         } else {
             None
         };
 
-        match op {
-            Opcode::Nop
-            | Opcode::Iconst
-            | Opcode::F32const
-            | Opcode::F64const
-            | Opcode::Vconst
-            | Opcode::Null
-            | Opcode::Isplit
-            | Opcode::Iconcat
-            | Opcode::Iadd
-            | Opcode::Isub
-            | Opcode::UaddSat
-            | Opcode::SaddSat
-            | Opcode::UsubSat
-            | Opcode::SsubSat
-            | Opcode::IaddPairwise
-            | Opcode::Smin
-            | Opcode::Umin
-            | Opcode::Smax
-            | Opcode::Umax
-            | Opcode::AvgRound
-            | Opcode::Iabs
-            | Opcode::Ineg
-            | Opcode::Imul
-            | Opcode::Umulhi
-            | Opcode::Smulhi
-            | Opcode::WideningPairwiseDotProductS
-            | Opcode::SqmulRoundSat
-            | Opcode::Udiv
-            | Opcode::Urem
-            | Opcode::Sdiv
-            | Opcode::Srem
-            | Opcode::Ishl
-            | Opcode::Ushr
-            | Opcode::Sshr
-            | Opcode::Rotr
-            | Opcode::Rotl
-            | Opcode::Ireduce
-            | Opcode::Uextend
-            | Opcode::Sextend
-            | Opcode::Snarrow
-            | Opcode::Unarrow
-            | Opcode::Uunarrow
-            | Opcode::SwidenLow
-            | Opcode::SwidenHigh
-            | Opcode::UwidenLow
-            | Opcode::UwidenHigh
-            | Opcode::Bnot
-            | Opcode::Band
-            | Opcode::Bor
-            | Opcode::Bxor
-            | Opcode::BandNot
-            | Opcode::BorNot
-            | Opcode::BxorNot
-            | Opcode::Bitselect
-            | Opcode::Vselect
-            | Opcode::Bmask
-            | Opcode::Bitrev
-            | Opcode::Bswap
-            | Opcode::Clz
-            | Opcode::Cls
-            | Opcode::Ctz
-            | Opcode::Popcnt
-            | Opcode::Fadd
-            | Opcode::Fsub
-            | Opcode::Fmul
-            | Opcode::Fdiv
-            | Opcode::Fmin
-            | Opcode::Fmax
-            | Opcode::FminPseudo
-            | Opcode::FmaxPseudo
-            | Opcode::Sqrt
-            | Opcode::Fneg
-            | Opcode::Fabs
-            | Opcode::Fpromote
-            | Opcode::Fdemote
-            | Opcode::FvpromoteLow
-            | Opcode::Fvdemote
-            | Opcode::Ceil
-            | Opcode::Floor
-            | Opcode::Trunc
-            | Opcode::Nearest
-            | Opcode::Fma
-            | Opcode::Fcopysign
-            | Opcode::FcvtFromUint
-            | Opcode::FcvtFromSint
-            | Opcode::FcvtLowFromSint
-            | Opcode::FcvtToUint
-            | Opcode::FcvtToSint
-            | Opcode::FcvtToUintSat
-            | Opcode::FcvtToSintSat
-            | Opcode::Splat
-            | Opcode::Swizzle
-            | Opcode::Shuffle
-            | Opcode::Insertlane
-            | Opcode::Extractlane
-            | Opcode::ScalarToVector
-            | Opcode::VhighBits
-            | Opcode::Bitcast
-            | Opcode::Load
-            | Opcode::Uload8
-            | Opcode::Sload8
-            | Opcode::Uload16
-            | Opcode::Sload16
-            | Opcode::Uload32
-            | Opcode::Sload32
-            | Opcode::Uload8x8
-            | Opcode::Sload8x8
-            | Opcode::Uload16x4
-            | Opcode::Sload16x4
-            | Opcode::Uload32x2
-            | Opcode::Sload32x2
-            | Opcode::Store
-            | Opcode::Istore8
-            | Opcode::Istore16
-            | Opcode::Istore32
-            | Opcode::AtomicRmw
-            | Opcode::AtomicCas
-            | Opcode::AtomicLoad
-            | Opcode::AtomicStore
-            | Opcode::Fence
-            | Opcode::Icmp
-            | Opcode::Fcmp
-            | Opcode::VanyTrue
-            | Opcode::VallTrue
-            | Opcode::IsNull
-            | Opcode::IsInvalid
-            | Opcode::Select
-            | Opcode::SelectSpectreGuard
-            | Opcode::Trap
-            | Opcode::ResumableTrap
-            | Opcode::Trapz
-            | Opcode::Trapnz
-            | Opcode::ResumableTrapnz
-            | Opcode::Debugtrap
-            | Opcode::UaddOverflowTrap
-            | Opcode::Call
-            | Opcode::CallIndirect
-            | Opcode::Return
-            | Opcode::StackAddr
-            | Opcode::FuncAddr
-            | Opcode::SymbolValue
-            | Opcode::TlsValue
-            | Opcode::GetFramePointer
-            | Opcode::GetStackPointer
-            | Opcode::GetReturnAddress => {
-                unreachable!(
-                    "implemented in ISLE: inst = `{}`, type = `{:?}`",
-                    ctx.dfg().display_inst(ir_inst),
-                    ty
-                )
-            }
-
-            Opcode::GetPinnedReg
-            | Opcode::SetPinnedReg
-            | Opcode::Vsplit
-            | Opcode::Vconcat
-            | Opcode::DynamicStackLoad
-            | Opcode::DynamicStackStore
-            | Opcode::DynamicStackAddr
-            | Opcode::ExtractVector => {
-                unreachable!(
-                    "TODO: not yet implemented in ISLE: inst = `{}`, type = `{:?}`",
-                    ctx.dfg().display_inst(ir_inst),
-                    ty
-                )
-            }
-
-            Opcode::StackLoad | Opcode::StackStore => {
-                panic!("Direct stack memory access not supported; should not be used by Wasm");
-            }
-            Opcode::HeapLoad | Opcode::HeapStore | Opcode::HeapAddr => {
-                panic!("heap access instructions should have been removed by legalization!");
-            }
-            Opcode::TableAddr => {
-                panic!("table_addr should have been removed by legalization!");
-            }
-            Opcode::GlobalValue => {
-                panic!("global_value should have been removed by legalization!");
-            }
-            Opcode::Jump | Opcode::Brz | Opcode::Brnz | Opcode::BrTable => {
-                panic!("Branch opcode reached non-branch lowering logic!");
-            }
-            Opcode::IaddImm
-            | Opcode::ImulImm
-            | Opcode::UdivImm
-            | Opcode::SdivImm
-            | Opcode::UremImm
-            | Opcode::SremImm
-            | Opcode::IrsubImm
-            | Opcode::IaddCin
-            | Opcode::IaddCout
-            | Opcode::IaddCarry
-            | Opcode::IsubBin
-            | Opcode::IsubBout
-            | Opcode::IsubBorrow
-            | Opcode::BandImm
-            | Opcode::BorImm
-            | Opcode::BxorImm
-            | Opcode::RotlImm
-            | Opcode::RotrImm
-            | Opcode::IshlImm
-            | Opcode::UshrImm
-            | Opcode::SshrImm
-            | Opcode::IcmpImm => {
-                panic!("ALU+imm and ALU+carry ops should not appear here!");
-            }
-        }
+        unreachable!(
+            "not implemented in ISLE: inst = `{}`, type = `{:?}`",
+            ctx.dfg().display_inst(ir_inst),
+            ty
+        );
     }
 
     fn lower_branch_group(
@@ -261,8 +57,9 @@ impl LowerBackend for S390xBackend {
             assert!(temp_regs.len() == 0);
             return Ok(());
         }
+
         unreachable!(
-            "implemented in ISLE: branch = `{}`",
+            "not implemented in ISLE: branch = `{}`",
             ctx.dfg().display_inst(branches[0]),
         );
     }

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -304,235 +304,17 @@ impl LowerBackend for X64Backend {
             return Ok(temp_regs);
         }
 
-        let op = ctx.data(ir_inst).opcode();
         let ty = if ctx.num_outputs(ir_inst) > 0 {
             Some(ctx.output_ty(ir_inst, 0))
         } else {
             None
         };
 
-        match op {
-            Opcode::Iconst
-            | Opcode::F32const
-            | Opcode::F64const
-            | Opcode::Null
-            | Opcode::Iadd
-            | Opcode::IaddCout
-            | Opcode::SaddSat
-            | Opcode::UaddSat
-            | Opcode::Isub
-            | Opcode::SsubSat
-            | Opcode::UsubSat
-            | Opcode::AvgRound
-            | Opcode::Band
-            | Opcode::Bor
-            | Opcode::Bxor
-            | Opcode::Imul
-            | Opcode::BandNot
-            | Opcode::Iabs
-            | Opcode::Smax
-            | Opcode::Umax
-            | Opcode::Smin
-            | Opcode::Umin
-            | Opcode::Bnot
-            | Opcode::Bitselect
-            | Opcode::Vselect
-            | Opcode::Ushr
-            | Opcode::Sshr
-            | Opcode::Ishl
-            | Opcode::Rotl
-            | Opcode::Rotr
-            | Opcode::Ineg
-            | Opcode::Trap
-            | Opcode::ResumableTrap
-            | Opcode::UaddOverflowTrap
-            | Opcode::Clz
-            | Opcode::Ctz
-            | Opcode::Popcnt
-            | Opcode::Bitrev
-            | Opcode::Bswap
-            | Opcode::IsNull
-            | Opcode::IsInvalid
-            | Opcode::Uextend
-            | Opcode::Sextend
-            | Opcode::Ireduce
-            | Opcode::Debugtrap
-            | Opcode::WideningPairwiseDotProductS
-            | Opcode::Fadd
-            | Opcode::Fsub
-            | Opcode::Fmul
-            | Opcode::Fdiv
-            | Opcode::Fmin
-            | Opcode::Fmax
-            | Opcode::FminPseudo
-            | Opcode::FmaxPseudo
-            | Opcode::Sqrt
-            | Opcode::Fpromote
-            | Opcode::FvpromoteLow
-            | Opcode::Fdemote
-            | Opcode::Fvdemote
-            | Opcode::Fma
-            | Opcode::Icmp
-            | Opcode::Fcmp
-            | Opcode::Load
-            | Opcode::Uload8
-            | Opcode::Sload8
-            | Opcode::Uload16
-            | Opcode::Sload16
-            | Opcode::Uload32
-            | Opcode::Sload32
-            | Opcode::Sload8x8
-            | Opcode::Uload8x8
-            | Opcode::Sload16x4
-            | Opcode::Uload16x4
-            | Opcode::Sload32x2
-            | Opcode::Uload32x2
-            | Opcode::Store
-            | Opcode::Istore8
-            | Opcode::Istore16
-            | Opcode::Istore32
-            | Opcode::AtomicRmw
-            | Opcode::AtomicCas
-            | Opcode::AtomicLoad
-            | Opcode::AtomicStore
-            | Opcode::Fence
-            | Opcode::FuncAddr
-            | Opcode::SymbolValue
-            | Opcode::Return
-            | Opcode::Call
-            | Opcode::CallIndirect
-            | Opcode::GetFramePointer
-            | Opcode::GetStackPointer
-            | Opcode::GetReturnAddress
-            | Opcode::Select
-            | Opcode::SelectSpectreGuard
-            | Opcode::FcvtFromSint
-            | Opcode::FcvtLowFromSint
-            | Opcode::FcvtFromUint
-            | Opcode::FcvtToUint
-            | Opcode::FcvtToSint
-            | Opcode::FcvtToUintSat
-            | Opcode::FcvtToSintSat
-            | Opcode::IaddPairwise
-            | Opcode::UwidenHigh
-            | Opcode::UwidenLow
-            | Opcode::SwidenHigh
-            | Opcode::SwidenLow
-            | Opcode::Snarrow
-            | Opcode::Unarrow
-            | Opcode::Bitcast
-            | Opcode::Fabs
-            | Opcode::Fneg
-            | Opcode::Fcopysign
-            | Opcode::Ceil
-            | Opcode::Floor
-            | Opcode::Nearest
-            | Opcode::Trunc
-            | Opcode::StackAddr
-            | Opcode::Udiv
-            | Opcode::Urem
-            | Opcode::Sdiv
-            | Opcode::Srem
-            | Opcode::Umulhi
-            | Opcode::Smulhi
-            | Opcode::GetPinnedReg
-            | Opcode::SetPinnedReg
-            | Opcode::Vconst
-            | Opcode::Insertlane
-            | Opcode::Shuffle
-            | Opcode::Swizzle
-            | Opcode::Extractlane
-            | Opcode::ScalarToVector
-            | Opcode::Splat
-            | Opcode::VanyTrue
-            | Opcode::VallTrue
-            | Opcode::VhighBits
-            | Opcode::Iconcat
-            | Opcode::Isplit
-            | Opcode::TlsValue
-            | Opcode::SqmulRoundSat
-            | Opcode::Uunarrow
-            | Opcode::Nop
-            | Opcode::Bmask => {
-                unreachable!(
-                    "implemented in ISLE: inst = `{}`, type = `{:?}`",
-                    ctx.dfg().display_inst(ir_inst),
-                    ty
-                )
-            }
-
-            Opcode::DynamicStackAddr => unimplemented!("DynamicStackAddr"),
-
-            // Unimplemented opcodes below. These are not currently used by Wasm
-            // lowering or other known embeddings, but should be either supported or
-            // removed eventually
-            Opcode::ExtractVector => {
-                unimplemented!("ExtractVector not supported");
-            }
-
-            Opcode::Cls => unimplemented!("Cls not supported"),
-
-            Opcode::BorNot | Opcode::BxorNot => {
-                unimplemented!("or-not / xor-not opcodes not implemented");
-            }
-
-            Opcode::Vsplit | Opcode::Vconcat => {
-                unimplemented!("Vector split/concat ops not implemented.");
-            }
-
-            Opcode::IaddImm
-            | Opcode::ImulImm
-            | Opcode::UdivImm
-            | Opcode::SdivImm
-            | Opcode::UremImm
-            | Opcode::SremImm
-            | Opcode::IrsubImm
-            | Opcode::IaddCin
-            | Opcode::IaddCarry
-            | Opcode::IsubBin
-            | Opcode::IsubBout
-            | Opcode::IsubBorrow
-            | Opcode::BandImm
-            | Opcode::BorImm
-            | Opcode::BxorImm
-            | Opcode::RotlImm
-            | Opcode::RotrImm
-            | Opcode::IshlImm
-            | Opcode::UshrImm
-            | Opcode::SshrImm
-            | Opcode::IcmpImm => {
-                panic!("ALU+imm and ALU+carry ops should not appear here!");
-            }
-
-            Opcode::StackLoad
-            | Opcode::StackStore
-            | Opcode::DynamicStackStore
-            | Opcode::DynamicStackLoad => {
-                panic!("Direct stack memory access not supported; should have been legalized");
-            }
-
-            Opcode::GlobalValue => {
-                panic!("global_value should have been removed by legalization!");
-            }
-
-            Opcode::HeapLoad | Opcode::HeapStore | Opcode::HeapAddr => {
-                panic!("heap access instructions should have been removed by legalization!");
-            }
-
-            Opcode::TableAddr => {
-                panic!("table_addr should have been removed by legalization!");
-            }
-
-            Opcode::Trapz | Opcode::Trapnz | Opcode::ResumableTrapnz => {
-                panic!(
-                    "trapz / trapnz / resumable_trapnz should have been removed by legalization!"
-                );
-            }
-
-            Opcode::Jump | Opcode::Brz | Opcode::Brnz | Opcode::BrTable => {
-                panic!("Branch opcode reached non-branch lowering logic!");
-            }
-        }
+        unreachable!(
+            "not implemented in ISLE: inst = `{}`, type = `{:?}`",
+            ctx.dfg().display_inst(ir_inst),
+            ty
+        );
     }
 
     fn lower_branch_group(
@@ -559,7 +341,7 @@ impl LowerBackend for X64Backend {
         }
 
         unreachable!(
-            "implemented in ISLE: branch = `{}`",
+            "not implemented in ISLE: branch = `{}`",
             ctx.dfg().display_inst(branches[0]),
         );
     }


### PR DESCRIPTION
Now that all operations are implemented in ISLE, simplify Rust code by providing a generic error message if any operation is not implemented in ISLE.  Done across all targets.

@cfallin - as requested here https://github.com/bytecodealliance/wasmtime/pull/5427#pullrequestreview-1216397097

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
