### PR TITLE
cranelift: Implement TLS on aarch64 Mach-O (Apple Silicon)

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -56,20 +56,20 @@ pub enum Reloc {
     /// Mach-O x86_64 32 bit signed PC relative offset to a `__thread_vars` entry.
     MachOX86_64Tlv,
 
-    /// Mach-O AAarch64 TLS
+    /// Mach-O Aarch64 TLS
     /// PC-relative distance to the page of the TLVP slot.
     MachOAarch64TlsAdrPage21,
 
-    /// Mach-O AAarch64 TLS
+    /// Mach-O Aarch64 TLS
     /// Offset within page of TLVP slot.
     MachOAarch64TlsAdrPageOff12,
 
-    /// AArch64 TLS GD
+    /// Aarch64 TLS GD
     /// Set an ADRP immediate field to the top 21 bits of the final address. Checks for overflow.
     /// This is equivalent to `R_AARCH64_TLSGD_ADR_PAGE21` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
     Aarch64TlsGdAdrPage21,
 
-    /// AArch64 TLS GD
+    /// Aarch64 TLS GD
     /// Set the add immediate field to the low 12 bits of the final address. Does not check for overflow.
     /// This is equivalent to `R_AARCH64_TLSGD_ADD_LO12_NC` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
     Aarch64TlsGdAddLo12Nc,

--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -56,6 +56,14 @@ pub enum Reloc {
     /// Mach-O x86_64 32 bit signed PC relative offset to a `__thread_vars` entry.
     MachOX86_64Tlv,
 
+    /// Mach-O AAarch64 TLS
+    /// PC-relative distance to the page of the TLVP slot.
+    MachOAarch64TlsAdrPage21,
+
+    /// Mach-O AAarch64 TLS
+    /// Offset within page of TLVP slot.
+    MachOAarch64TlsAdrPageOff12,
+
     /// AArch64 TLS GD
     /// Set an ADRP immediate field to the top 21 bits of the final address. Checks for overflow.
     /// This is equivalent to `R_AARCH64_TLSGD_ADR_PAGE21` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
@@ -109,6 +117,8 @@ impl fmt::Display for Reloc {
 
             Self::ElfX86_64TlsGd => write!(f, "ElfX86_64TlsGd"),
             Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
+            Self::MachOAarch64TlsAdrPage21 => write!(f, "MachOAarch64TlsAdrPage21"),
+            Self::MachOAarch64TlsAdrPageOff12 => write!(f, "MachOAarch64TlsAdrPageOff12"),
             Self::Aarch64TlsGdAdrPage21 => write!(f, "Aarch64TlsGdAdrPage21"),
             Self::Aarch64TlsGdAddLo12Nc => write!(f, "Aarch64TlsGdAddLo12Nc"),
             Self::Aarch64AdrGotPage21 => write!(f, "Aarch64AdrGotPage21"),

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -929,8 +929,7 @@
 
        (MachOTlsGetAddr
         (symbol ExternalName)
-        (rd WritableReg)
-        (rtmp WritableReg))
+        (rd WritableReg))
 
        ;; An unwind pseudo-instruction.
        (Unwind
@@ -3599,8 +3598,7 @@
 (decl macho_tls_get_addr (ExternalName) Reg)
 (rule (macho_tls_get_addr name)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (tmp WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.MachOTlsGetAddr name dst tmp))))
+            (_ Unit (emit (MInst.MachOTlsGetAddr name dst))))
         dst))
 
 ;; A tuple of `ProducesFlags` and `IntCC`.

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -927,6 +927,11 @@
         (symbol ExternalName)
         (rd WritableReg))
 
+       (MachOTlsGetAddr
+        (symbol ExternalName)
+        (rd WritableReg)
+        (rtmp WritableReg))
+
        ;; An unwind pseudo-instruction.
        (Unwind
         (inst UnwindInst))
@@ -3589,6 +3594,13 @@
 (rule (elf_tls_get_addr name)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.ElfTlsGetAddr name dst))))
+        dst))
+
+(decl macho_tls_get_addr (ExternalName) Reg)
+(rule (macho_tls_get_addr name)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (tmp WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.MachOTlsGetAddr name dst tmp))))
         dst))
 
 ;; A tuple of `ProducesFlags` and `IntCC`.

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3499,15 +3499,9 @@ impl MachInstEmit for Inst {
                 Inst::CallInd {
                     info: crate::isa::Box::new(CallIndInfo {
                         rn: rtmp.to_reg(),
-                        uses: smallvec![CallArgPair {
-                            vreg: rd.to_reg(),
-                            preg: rd.to_reg(),
-                        }],
-                        defs: smallvec![CallRetPair {
-                            vreg: rd,
-                            preg: rd.to_reg(),
-                        }],
-                        clobbers: PRegSet::empty().with(xreg_preg(16)).with(xreg_preg(17)),
+                        uses: smallvec![],
+                        defs: smallvec![],
+                        clobbers: PRegSet::empty(),
                         opcode: Opcode::CallIndirect,
                         caller_callconv: CallConv::AppleAarch64,
                         callee_callconv: CallConv::AppleAarch64,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3458,11 +3458,7 @@ impl MachInstEmit for Inst {
                 sink.put4(0xd503201f);
             }
 
-            &Inst::MachOTlsGetAddr {
-                ref symbol,
-                rd,
-                rtmp,
-            } => {
+            &Inst::MachOTlsGetAddr { ref symbol, rd } => {
                 // Each thread local variable gets a descriptor, where the first xword of the descriptor is a pointer
                 // to a function that takes the descriptor address in x0, and after the function returns x0
                 // contains the address for the thread local variable
@@ -3477,7 +3473,7 @@ impl MachInstEmit for Inst {
 
                 let rd = allocs.next_writable(rd);
                 assert_eq!(xreg(0), rd.to_reg());
-                let rtmp = allocs.next_writable(rtmp);
+                let rtmp = writable_xreg(1);
 
                 // adrp x0, <label>@TLVPPAGE
                 sink.add_reloc(Reloc::MachOAarch64TlsAdrPage21, symbol, 0);

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -907,6 +907,14 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             clobbers.remove(regs::xreg_preg(0));
             collector.reg_clobbers(clobbers);
         }
+        &Inst::MachOTlsGetAddr { rd, rtmp, .. } => {
+            collector.reg_fixed_def(rd, regs::xreg(0));
+            collector.reg_def(rtmp);
+            let mut clobbers =
+                AArch64MachineDeps::get_regs_clobbered_by_call(CallConv::AppleAarch64);
+            clobbers.remove(regs::xreg_preg(0));
+            collector.reg_clobbers(clobbers);
+        }
         &Inst::Unwind { .. } => {}
         &Inst::EmitIsland { .. } => {}
         &Inst::DummyUse { reg } => {
@@ -2700,6 +2708,20 @@ impl Inst {
             &Inst::ElfTlsGetAddr { ref symbol, rd } => {
                 let rd = pretty_print_reg(rd.to_reg(), allocs);
                 format!("elf_tls_get_addr {}, {}", rd, symbol.display(None))
+            }
+            &Inst::MachOTlsGetAddr {
+                ref symbol,
+                rd,
+                rtmp,
+            } => {
+                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                let rtmp = pretty_print_reg(rtmp.to_reg(), allocs);
+                format!(
+                    "macho_tls_get_addr {}, {}, {}",
+                    rd,
+                    rtmp,
+                    symbol.display(None)
+                )
             }
             &Inst::Unwind { ref inst } => {
                 format!("unwind {:?}", inst)

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -907,9 +907,8 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             clobbers.remove(regs::xreg_preg(0));
             collector.reg_clobbers(clobbers);
         }
-        &Inst::MachOTlsGetAddr { rd, rtmp, .. } => {
+        &Inst::MachOTlsGetAddr { rd, .. } => {
             collector.reg_fixed_def(rd, regs::xreg(0));
-            collector.reg_def(rtmp);
             let mut clobbers =
                 AArch64MachineDeps::get_regs_clobbered_by_call(CallConv::AppleAarch64);
             clobbers.remove(regs::xreg_preg(0));
@@ -2709,19 +2708,9 @@ impl Inst {
                 let rd = pretty_print_reg(rd.to_reg(), allocs);
                 format!("elf_tls_get_addr {}, {}", rd, symbol.display(None))
             }
-            &Inst::MachOTlsGetAddr {
-                ref symbol,
-                rd,
-                rtmp,
-            } => {
+            &Inst::MachOTlsGetAddr { ref symbol, rd } => {
                 let rd = pretty_print_reg(rd.to_reg(), allocs);
-                let rtmp = pretty_print_reg(rtmp.to_reg(), allocs);
-                format!(
-                    "macho_tls_get_addr {}, {}, {}",
-                    rd,
-                    rtmp,
-                    symbol.display(None)
-                )
+                format!("macho_tls_get_addr {}, {}", rd, symbol.display(None))
             }
             &Inst::Unwind { ref inst } => {
                 format!("unwind {:?}", inst)

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2575,11 +2575,9 @@
 ;;; Rules for `tls_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type (tls_model (TlsModel.ElfGd)) (tls_value (symbol_value_data name _ _))))
-      (if (tls_model_is_elf_gd))
       (elf_tls_get_addr name))
 
 (rule (lower (has_type (tls_model (TlsModel.Macho)) (tls_value (symbol_value_data name _ _))))
-      (if (tls_model_is_macho))
       (macho_tls_get_addr name))
 
 ;;; Rules for `fcvt_low_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2574,9 +2574,13 @@
 
 ;;; Rules for `tls_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (tls_value (symbol_value_data name _ _)))
+(rule (lower (has_type (tls_model (TlsModel.ElfGd)) (tls_value (symbol_value_data name _ _))))
       (if (tls_model_is_elf_gd))
       (elf_tls_get_addr name))
+
+(rule (lower (has_type (tls_model (TlsModel.Macho)) (tls_value (symbol_value_data name _ _))))
+      (if (tls_model_is_macho))
+      (macho_tls_get_addr name))
 
 ;;; Rules for `fcvt_low_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
@@ -1,0 +1,31 @@
+test compile precise-output
+set tls_model=macho
+target aarch64
+
+function u0:0(i32) -> i32, i64 {
+gv0 = symbol colocated tls u1:0
+
+block0(v0: i32):
+    v1 = global_value.i64 gv0
+    return v0, v1
+}
+
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x23, x25, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+; block0:
+;   mov x25, x0
+;   macho_tls_get_addr x0, x23, userextname0
+;   mov x1, x0
+;   mov x0, x25
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x23, x25, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
@@ -10,6 +10,7 @@ block0(v0: i32):
     return v0, v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x24, [sp, #-16]!
@@ -29,3 +30,29 @@ block0(v0: i32):
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x24, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+; block1: ; offset 0x1c
+;   mov x24, x0
+;   adrp x0, #0 ; reloc_external MachOAarch64TlsAdrPage21 u1:0 0
+;   ldr x0, [x0] ; reloc_external MachOAarch64TlsAdrPageOff12 u1:0 0
+;   ldr x1, [x0]
+;   blr x1
+;   mov x1, x0
+;   mov x0, x24
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldr x24, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
@@ -12,20 +12,20 @@ block0(v0: i32):
 
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   stp x23, x25, [sp, #-16]!
+;   str x24, [sp, #-16]!
 ;   stp d14, d15, [sp, #-16]!
 ;   stp d12, d13, [sp, #-16]!
 ;   stp d10, d11, [sp, #-16]!
 ;   stp d8, d9, [sp, #-16]!
 ; block0:
-;   mov x25, x0
-;   macho_tls_get_addr x0, x23, userextname0
+;   mov x24, x0
+;   macho_tls_get_addr x0, userextname0
 ;   mov x1, x0
-;   mov x0, x25
+;   mov x0, x24
 ;   ldp d8, d9, [sp], #16
 ;   ldp d10, d11, [sp], #16
 ;   ldp d12, d13, [sp], #16
 ;   ldp d14, d15, [sp], #16
-;   ldp x23, x25, [sp], #16
+;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -654,6 +654,36 @@ impl ObjectModule {
                     32,
                 )
             }
+            Reloc::MachOAarch64TlsAdrPage21 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::MachO,
+                    "MachOAarch64TlsAdrPage21 is not supported for this file format"
+                );
+                (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_TLVP_LOAD_PAGE21,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    21,
+                )
+            }
+            Reloc::MachOAarch64TlsAdrPageOff12 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::MachO,
+                    "MachOAarch64TlsAdrPageOff12 is not supported for this file format"
+                );
+                (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_TLVP_LOAD_PAGEOFF12,
+                        relative: false,
+                    },
+                    RelocationEncoding::Generic,
+                    12,
+                )
+            }
             Reloc::Aarch64TlsGdAdrPage21 => {
                 assert_eq!(
                     self.object.format(),


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
Fixes #5433.

This PR implements support for TLS on aarch64 Mach-O (i.e. Apple silicon). This also includes an update to `object` as this PR depends on a fix released in `object 0.30`.

For testing, I've added a filetest similar to the existing test for aarch64 ELF. I wasn't sure if I should add an emit test as well, since there doesn't seem to be one for TLS on aarch64 ELF. I've also tested these changes on a local branch of cg_clif, and it passes the TLS tests there.