### PR TITLE
egraph opt rules: do `(icmp cc x x) == {0,1}` only for integer types.

### DIFF
--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -211,32 +211,32 @@
 ;; `x == x` is always true for integers; `x != x` is false. Strict
 ;; inequalities are false, and loose inequalities are true.
 (rule (simplify
-       (icmp ty (IntCC.Equal) x x))
+       (icmp (ty_int ty) (IntCC.Equal) x x))
       (iconst ty (imm64 1)))
 (rule (simplify
-       (icmp ty (IntCC.NotEqual) x x))
+       (icmp (ty_int ty) (IntCC.NotEqual) x x))
       (iconst ty (imm64 0)))
 (rule (simplify
-       (icmp ty (IntCC.UnsignedGreaterThan) x x))
+       (icmp (ty_int ty) (IntCC.UnsignedGreaterThan) x x))
       (iconst ty (imm64 0)))
 (rule (simplify
-       (icmp ty (IntCC.UnsignedGreaterThanOrEqual) x x))
+       (icmp (ty_int ty) (IntCC.UnsignedGreaterThanOrEqual) x x))
       (iconst ty (imm64 1)))
 (rule (simplify
-       (icmp ty (IntCC.SignedGreaterThan) x x))
+       (icmp (ty_int ty) (IntCC.SignedGreaterThan) x x))
       (iconst ty (imm64 0)))
 (rule (simplify
-       (icmp ty (IntCC.SignedGreaterThanOrEqual) x x))
+       (icmp (ty_int ty) (IntCC.SignedGreaterThanOrEqual) x x))
       (iconst ty (imm64 1)))
 (rule (simplify
-       (icmp ty (IntCC.UnsignedLessThan) x x))
+       (icmp (ty_int ty) (IntCC.UnsignedLessThan) x x))
       (iconst ty (imm64 0)))
 (rule (simplify
-       (icmp ty (IntCC.UnsignedLessThanOrEqual) x x))
+       (icmp (ty_int ty) (IntCC.UnsignedLessThanOrEqual) x x))
       (iconst ty (imm64 1)))
 (rule (simplify
-       (icmp ty (IntCC.SignedLessThan) x x))
+       (icmp (ty_int ty) (IntCC.SignedLessThan) x x))
       (iconst ty (imm64 0)))
 (rule (simplify
-       (icmp ty (IntCC.SignedLessThanOrEqual) x x))
+       (icmp (ty_int ty) (IntCC.SignedLessThanOrEqual) x x))
       (iconst ty (imm64 1)))

--- a/cranelift/filetests/filetests/egraph/issue-5437.clif
+++ b/cranelift/filetests/filetests/egraph/issue-5437.clif
@@ -1,0 +1,41 @@
+test compile
+set use_egraphs=true
+target x86_64
+target aarch64
+target s390x
+
+function u0:0(i64 vmctx, i64) fast {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned readonly gv0+8
+    gv2 = load.i64 notrap aligned gv1
+    sig0 = (i64 vmctx, i64) fast
+    fn0 = colocated u0:2 sig0
+    jt0 = jump_table [block1]
+    stack_limit = gv2
+
+                                block0(v0: i64, v1: i64):
+@0019                               v2 = vconst.i8x16 [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
+@001b                               v3 = iconst.i32 0
+@001d                               brz v3, block2  ; v3 = 0
+@001d                               jump block3
+
+                                block3:
+@001f                               trap unreachable
+
+                                block2:
+@0025                               v4 = bitcast.i16x8 little v2  ; v2 = const0
+@0025                               v5 = bitcast.i16x8 little v2  ; v2 = const0
+@0025                               v6 = icmp ult v4, v5
+@0027                               v7 = bitcast.i32x4 little v6
+@0027                               v8 = vhigh_bits.i32 v7
+@002a                               v9 = iconst.i32 0
+@002c                               brnz v9, block1  ; v9 = 0
+@002c                               jump block4
+
+                                block4:
+@002e                               call fn0(v0, v0)
+@0030                               br_table v8, block1, jt0
+
+                                block1:
+@0036                               return
+}


### PR DESCRIPTION
We could do these for vectors too, in theory, but for now let's fix the bug by applying the equivalence only for integer types.

Fixes #5437.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
