### PR TITLE
Assert that we only use virtual registers with moves

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -141,7 +141,6 @@
       (amount i64))
 
     ;; A MOV instruction. These are encoded as OrR's (AluRRR form) but we
-    ;; luRRR form) but we
     ;; keep them separate at the `Inst` level for better pretty-printing
     ;; and faster `is_move()` logic.
     (Mov
@@ -149,7 +148,9 @@
       (rm Reg)
       (ty Type))
 
-    ;; A MOV instruction, but where the source register is a PReg.
+    ;; A MOV instruction, but where the source register is a non-allocatable
+    ;; PReg. It's important that the register be non-allocatable, as regalloc2
+    ;; will not see it as used.
     (MovFromPReg
       (rd WritableReg)
       (rm PReg))
@@ -2157,5 +2158,8 @@
         (_ Unit (emit (MInst.MovFromPReg rd rm))))
     rd))
 
-(decl px_reg (u8) PReg)
-(extern constructor px_reg px_reg)
+(decl fp_reg () PReg)
+(extern constructor fp_reg fp_reg)
+
+(decl sp_reg () PReg)
+(extern constructor sp_reg sp_reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -141,12 +141,18 @@
       (amount i64))
 
     ;; A MOV instruction. These are encoded as OrR's (AluRRR form) but we
+    ;; luRRR form) but we
     ;; keep them separate at the `Inst` level for better pretty-printing
     ;; and faster `is_move()` logic.
     (Mov
       (rd WritableReg)
       (rm Reg)
       (ty Type))
+
+    ;; A MOV instruction, but where the source register is a PReg.
+    (MovFromPReg
+      (rd WritableReg)
+      (rm PReg))
 
     (Fence
       (pred FenceReq)
@@ -1958,9 +1964,6 @@
   (lower_branch (br_table index _ _) targets)
   (lower_br_table index targets))
 
-(decl x_reg (u8) Reg)
-(extern constructor x_reg x_reg)
-
 (decl load_ra () Reg)
 (extern constructor load_ra load_ra)
 
@@ -2142,3 +2145,17 @@
   (lower_bmask $I128 $I128 val)
   (let ((res ValueRegs (lower_bmask $I64 $I128 val)))
     (value_regs (value_regs_get res 0) (value_regs_get res 0))))
+
+
+;;;; Helpers for physical registers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl gen_mov_from_preg (PReg) Reg)
+
+(rule
+  (gen_mov_from_preg rm)
+  (let ((rd WritableReg (temp_writable_reg $I64))
+        (_ Unit (emit (MInst.MovFromPReg rd rm))))
+    rd))
+
+(decl px_reg (u8) PReg)
+(extern constructor px_reg px_reg)

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1125,6 +1125,7 @@ impl MachInstEmit for Inst {
             }
 
             &Inst::MovFromPReg { rd, rm } => {
+                debug_assert!([px_reg(2), px_reg(8)].contains(&rm));
                 let rd = allocs.next_writable(rd);
                 let x = Inst::AluRRImm12 {
                     alu_op: AluOPRRI::Ori,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1123,6 +1123,18 @@ impl MachInstEmit for Inst {
                     }
                 }
             }
+
+            &Inst::MovFromPReg { rd, rm } => {
+                let rd = allocs.next_writable(rd);
+                let x = Inst::AluRRImm12 {
+                    alu_op: AluOPRRI::Ori,
+                    rd,
+                    rs: Reg::from(rm),
+                    imm12: Imm12::zero(),
+                };
+                x.emit(&[], sink, emit_info, state);
+            }
+
             &Inst::BrTable {
                 index,
                 tmp1,

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -431,6 +431,9 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(rm);
             collector.reg_def(rd);
         }
+        &Inst::MovFromPReg { rd, .. } => {
+            collector.reg_def(rd);
+        }
         &Inst::Fence { .. } => {}
         &Inst::FenceI => {}
         &Inst::ECall => {}
@@ -1529,6 +1532,11 @@ impl Inst {
                     "mv"
                 };
                 format!("{} {},{}", v, rd, rm)
+            }
+            &MInst::MovFromPReg { rd, rm } => {
+                let rd = format_reg(rd.to_reg(), allocs);
+                let rm = reg_name(Reg::from(rm));
+                format!("fmv.d {},{}", rd, rm)
             }
             &MInst::Fence { pred, succ } => {
                 format!(

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -431,7 +431,8 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(rm);
             collector.reg_def(rd);
         }
-        &Inst::MovFromPReg { rd, .. } => {
+        &Inst::MovFromPReg { rd, rm } => {
+            debug_assert!([px_reg(2), px_reg(8)].contains(&rm));
             collector.reg_def(rd);
         }
         &Inst::Fence { .. } => {}
@@ -1535,8 +1536,9 @@ impl Inst {
             }
             &MInst::MovFromPReg { rd, rm } => {
                 let rd = format_reg(rd.to_reg(), allocs);
+                debug_assert!([px_reg(2), px_reg(8)].contains(&rm));
                 let rm = reg_name(Reg::from(rm));
-                format!("fmv.d {},{}", rd, rm)
+                format!("mv {},{}", rd, rm)
             }
             &MInst::Fence { pred, succ } => {
                 format!(

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -858,10 +858,10 @@
 ;;; Rules for `get_{frame,stack}_pointer` and `get_return_address` ;;;;;;;;;;;;;
 
 (rule (lower (get_frame_pointer))
-  (gen_move2 (x_reg 8) $I64 $I64))
+  (gen_mov_from_preg (px_reg 8)))
 
 (rule (lower (get_stack_pointer))
-  (gen_move2 (x_reg 2) $I64 $I64))
+  (gen_mov_from_preg (px_reg 2)))
 
 (rule (lower (get_return_address))
   (load_ra))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -858,10 +858,10 @@
 ;;; Rules for `get_{frame,stack}_pointer` and `get_return_address` ;;;;;;;;;;;;;
 
 (rule (lower (get_frame_pointer))
-  (gen_mov_from_preg (px_reg 8)))
+  (gen_mov_from_preg (fp_reg)))
 
 (rule (lower (get_stack_pointer))
-  (gen_mov_from_preg (px_reg 2)))
+  (gen_mov_from_preg (sp_reg)))
 
 (rule (lower (get_return_address))
   (load_ra))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -407,9 +407,15 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Riscv64Backend> {
             targets,
         });
     }
-    fn px_reg(&mut self, x: u8) -> PReg {
-        px_reg(x as usize)
+
+    fn fp_reg(&mut self) -> PReg {
+        px_reg(8)
     }
+
+    fn sp_reg(&mut self) -> PReg {
+        px_reg(2)
+    }
+
     fn shift_int_to_most_significant(&mut self, v: Reg, ty: Type) -> Reg {
         assert!(ty.is_int() && ty.bits() <= 64);
         if ty == I64 {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -407,8 +407,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, Riscv64Backend> {
             targets,
         });
     }
-    fn x_reg(&mut self, x: u8) -> Reg {
-        x_reg(x as usize)
+    fn px_reg(&mut self, x: u8) -> PReg {
+        px_reg(x as usize)
     }
     fn shift_int_to_most_significant(&mut self, v: Reg, ty: Type) -> Reg {
         assert!(ty.is_int() && ty.bits() <= 64);

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -568,11 +568,25 @@ impl<I: VCodeInst> VCodeBuilder<I> {
             }
 
             if let Some((dst, src)) = insn.is_move() {
+                // We should never see non-virtual registers present in move
+                // instructions.
+                assert!(
+                    src.is_virtual(),
+                    "the real register {:?} was used as the source of a move instruction",
+                    src
+                );
+                assert!(
+                    dst.to_reg().is_virtual(),
+                    "the real register {:?} was used as the destination of a move instruction",
+                    dst.to_reg()
+                );
+
                 let src = Operand::reg_use(Self::resolve_vreg_alias_impl(vreg_aliases, src.into()));
                 let dst = Operand::reg_def(Self::resolve_vreg_alias_impl(
                     vreg_aliases,
                     dst.to_reg().into(),
                 ));
+
                 // Note that regalloc2 requires these in (src, dst) order.
                 self.vcode.is_move.insert(InsnIndex::new(i), (src, dst));
             }


### PR DESCRIPTION
Assert that we never see real registers as arguments to move instructions in `VCodeBuilder::collect_operands`.

Also fix a bug in the riscv64 backend that was discovered by these assertions: the lowerings of `get_stack_pointer` and `get_frame_pointer` were using physical registers 8 and 2 directly. The solution was similar to other backends: add a move instruction specifically for moving out of physical registers, whose source operand is opaque to regalloc2.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
