### PR TITLE
fix typo in hint about WASMTIME_BACKTRACE_DETAILS env var

### DIFF
--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -389,7 +389,7 @@ impl fmt::Display for WasmBacktrace {
             }
         }
         if self.hint_wasm_backtrace_details_env {
-            write!(f, "\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information")?;
+            write!(f, "\nnote: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information")?;
         }
         Ok(())
     }

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -790,7 +790,7 @@ fn hint_with_dwarf_info() -> Result<()> {
         "\
 error while executing at wasm backtrace:
     0:   0x1a - <unknown>!start
-note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable to may show more debugging information
+note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
 
 Caused by:
     wasm trap: wasm `unreachable` instruction executed\


### PR DESCRIPTION
This is a very small PR which removes an extra word from the message which I think was not meant to be there

There's no issue for this PR as the work is very minor