### PR TITLE
cranelift: Add a conditional branch instruction with two targets

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/formats.rs
+++ b/cranelift/codegen/meta/src/cdsl/formats.rs
@@ -122,7 +122,6 @@ impl InstructionFormatBuilder {
             kind: operand_kind.clone(),
             member: operand_kind.rust_field_name,
         };
-
         self.0.imm_fields.push(field);
         self
     }

--- a/cranelift/codegen/meta/src/cdsl/formats.rs
+++ b/cranelift/codegen/meta/src/cdsl/formats.rs
@@ -38,6 +38,8 @@ pub(crate) struct InstructionFormat {
 
     pub imm_fields: Vec<FormatField>,
 
+    pub num_block_operands: usize,
+
     /// Index of the value input operand that is used to infer the controlling type variable. By
     /// default, this is `0`, the first `value` operand. The index is relative to the values only,
     /// ignoring immediate operands.
@@ -49,6 +51,7 @@ pub(crate) struct InstructionFormat {
 pub(crate) struct FormatStructure {
     pub num_value_operands: usize,
     pub has_value_list: bool,
+    pub num_block_operands: usize,
     /// Tuples of (Rust field name / Rust type) for each immediate field.
     pub imm_field_names: Vec<(&'static str, &'static str)>,
 }
@@ -62,8 +65,8 @@ impl fmt::Display for InstructionFormat {
             .collect::<Vec<_>>()
             .join(", ");
         fmt.write_fmt(format_args!(
-            "{}(imms=({}), vals={})",
-            self.name, imm_args, self.num_value_operands
+            "{}(imms=({}), vals={}, blocks={})",
+            self.name, imm_args, self.num_value_operands, self.num_block_operands,
         ))?;
         Ok(())
     }
@@ -75,6 +78,7 @@ impl InstructionFormat {
         FormatStructure {
             num_value_operands: self.num_value_operands,
             has_value_list: self.has_value_list,
+            num_block_operands: self.num_block_operands,
             imm_field_names: self
                 .imm_fields
                 .iter()
@@ -92,6 +96,7 @@ impl InstructionFormatBuilder {
             name,
             num_value_operands: 0,
             has_value_list: false,
+            num_block_operands: 0,
             imm_fields: Vec::new(),
             typevar_operand: None,
         })
@@ -107,11 +112,17 @@ impl InstructionFormatBuilder {
         self
     }
 
+    pub fn block(mut self) -> Self {
+        self.0.num_block_operands += 1;
+        self
+    }
+
     pub fn imm(mut self, operand_kind: &OperandKind) -> Self {
         let field = FormatField {
             kind: operand_kind.clone(),
             member: operand_kind.rust_field_name,
         };
+
         self.0.imm_fields.push(field);
         self
     }

--- a/cranelift/codegen/meta/src/shared/entities.rs
+++ b/cranelift/codegen/meta/src/shared/entities.rs
@@ -19,11 +19,11 @@ pub(crate) struct EntityRefs {
     /// This is primarily used in control flow instructions.
     pub(crate) label: OperandKind,
 
-    /// A reference to a basic block in the same function.
+    /// A reference to a basic block in the same function, with its arguments provided.
     /// This is primarily used in control flow instructions.
     pub(crate) block_then: OperandKind,
 
-    /// A reference to a basic block in the same function.
+    /// A reference to a basic block in the same function, with its arguments provided.
     /// This is primarily used in control flow instructions.
     pub(crate) block_else: OperandKind,
 

--- a/cranelift/codegen/meta/src/shared/entities.rs
+++ b/cranelift/codegen/meta/src/shared/entities.rs
@@ -19,6 +19,14 @@ pub(crate) struct EntityRefs {
     /// This is primarily used in control flow instructions.
     pub(crate) label: OperandKind,
 
+    /// A reference to a basic block in the same function.
+    /// This is primarily used in control flow instructions.
+    pub(crate) block_then: OperandKind,
+
+    /// A reference to a basic block in the same function.
+    /// This is primarily used in control flow instructions.
+    pub(crate) block_else: OperandKind,
+
     /// A reference to a stack slot declared in the function preamble.
     pub(crate) stack_slot: OperandKind,
 
@@ -59,6 +67,18 @@ impl EntityRefs {
                 "destination",
                 "ir::Block",
                 "a basic block in the same function.",
+            ),
+
+            block_then: new(
+                "block_then",
+                "ir::BlockCall",
+                "a basic block in the same function, with its arguments provided.",
+            ),
+
+            block_else: new(
+                "block_else",
+                "ir::BlockCall",
+                "a basic block in the same function, with its arguments provided.",
             ),
 
             stack_slot: new("stack_slot", "ir::StackSlot", "A stack slot"),

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -114,9 +114,9 @@ impl Formats {
 
             jump: Builder::new("Jump").block().build(),
 
-            brif: Builder::new("Brif").value().block().block().build(),
-
             branch: Builder::new("Branch").value().block().build(),
+
+            brif: Builder::new("Brif").value().block().block().build(),
 
             branch_table: Builder::new("BranchTable")
                 .value()

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -8,6 +8,7 @@ pub(crate) struct Formats {
     pub(crate) binary: Rc<InstructionFormat>,
     pub(crate) binary_imm8: Rc<InstructionFormat>,
     pub(crate) binary_imm64: Rc<InstructionFormat>,
+    pub(crate) brif: Rc<InstructionFormat>,
     pub(crate) branch: Rc<InstructionFormat>,
     pub(crate) branch_table: Rc<InstructionFormat>,
     pub(crate) call: Rc<InstructionFormat>,
@@ -112,6 +113,12 @@ impl Formats {
                 .build(),
 
             jump: Builder::new("Jump").imm(&entities.block_call).build(),
+
+            brif: Builder::new("Brif")
+                .value()
+                .imm(&entities.block_then)
+                .imm(&entities.block_else)
+                .build(),
 
             branch: Builder::new("Branch")
                 .value()

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -112,18 +112,11 @@ impl Formats {
                 .value()
                 .build(),
 
-            jump: Builder::new("Jump").imm(&entities.block_call).build(),
+            jump: Builder::new("Jump").block().build(),
 
-            brif: Builder::new("Brif")
-                .value()
-                .imm(&entities.block_then)
-                .imm(&entities.block_else)
-                .build(),
+            brif: Builder::new("Brif").value().block().block().build(),
 
-            branch: Builder::new("Branch")
-                .value()
-                .imm(&entities.block_call)
-                .build(),
+            branch: Builder::new("Branch").value().block().build(),
 
             branch_table: Builder::new("BranchTable")
                 .value()

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -46,6 +46,27 @@ fn define_control_flow(
 
     {
         let c = &Operand::new("c", ScalarTruthy).with_doc("Controlling value to test");
+        let block_then = &Operand::new("block_then", &entities.block_then).with_doc("Then block");
+        let block_else = &Operand::new("block_else", &entities.block_else).with_doc("Else block");
+
+        ig.push(
+            Inst::new(
+                "brif",
+                r#"
+        Conditional branch when cond is non-zero.
+
+        Take the ``then`` branch when ``c != 0``, and the ``else`` branch otherwise.
+        "#,
+                &formats.brif,
+            )
+            .operands_in(vec![c, block_then, block_else])
+            .is_terminator(true)
+            .is_branch(true),
+        );
+    }
+
+    {
+        let c = &Operand::new("c", ScalarTruthy).with_doc("Controlling value to test");
 
         ig.push(
             Inst::new(

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -356,6 +356,10 @@ impl DominatorTree {
                 BranchInfo::SingleDest(succ) => {
                     self.push_if_unseen(succ.block(&func.dfg.value_lists))
                 }
+                BranchInfo::Conditional(block_then, block_else) => {
+                    self.push_if_unseen(block_then.block(&func.dfg.value_lists));
+                    self.push_if_unseen(block_else.block(&func.dfg.value_lists));
+                }
                 BranchInfo::Table(jt, dest) => {
                     for succ in func.jump_tables[jt].iter() {
                         self.push_if_unseen(*succ);

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -125,6 +125,10 @@ impl ControlFlowGraph {
                 BranchInfo::SingleDest(dest) => {
                     self.add_edge(block, inst, dest.block(&func.dfg.value_lists));
                 }
+                BranchInfo::Conditional(block_then, block_else) => {
+                    self.add_edge(block, inst, block_then.block(&func.dfg.value_lists));
+                    self.add_edge(block, inst, block_else.block(&func.dfg.value_lists));
+                }
                 BranchInfo::Table(jt, dest) => {
                     self.add_edge(block, inst, dest);
 

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -169,6 +169,10 @@ fn visit_branch_targets<F: FnMut(Inst, Block, bool)>(f: &Function, inst: Inst, v
         BranchInfo::SingleDest(dest) => {
             visit(inst, dest.block(&f.dfg.value_lists), false);
         }
+        BranchInfo::Conditional(block_then, block_else) => {
+            visit(inst, block_then.block(&f.dfg.value_lists), false);
+            visit(inst, block_else.block(&f.dfg.value_lists), false);
+        }
         BranchInfo::Table(table, dest) => {
             // The default block is reached via a direct conditional branch,
             // so it is not part of the table.

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -691,9 +691,10 @@ impl DataFlowGraph {
             self.inst_args_mut(inst)[i] = body(self, arg);
         }
 
-        for mut block in self.insts[inst].branch_destination().into_iter() {
+        for block_ix in 0..self.insts[inst].branch_destination().len() {
             // We aren't changing the size of the args list, so we won't need to write the branch
             // back to the instruction.
+            let mut block = self.insts[inst].branch_destination()[block_ix];
             for i in 0..block.args_slice(&self.value_lists).len() {
                 let arg = block.args_slice(&self.value_lists)[i];
                 block.args_slice_mut(&mut self.value_lists)[i] = body(self, arg);
@@ -712,7 +713,8 @@ impl DataFlowGraph {
             *arg = values.next().unwrap();
         }
 
-        for mut block in self.insts[inst].branch_destination().into_iter() {
+        for block_ix in 0..self.insts[inst].branch_destination().len() {
+            let mut block = self.insts[inst].branch_destination()[block_ix];
             for arg in block.args_slice_mut(&mut self.value_lists) {
                 *arg = values.next().unwrap();
             }

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -277,17 +277,6 @@ impl FunctionStencil {
         self.dfg.collect_debug_info();
     }
 
-    /// Changes the destination of a jump or branch instruction.
-    /// Does nothing if called with a non-jump or non-branch instruction.
-    ///
-    /// Note that this method ignores multi-destination branches like `br_table`.
-    pub fn change_branch_destination(&mut self, inst: Inst, new_dest: Block) {
-        match self.dfg.insts[inst].branch_destination_mut() {
-            None => (),
-            Some(inst_dest) => inst_dest.set_block(new_dest, &mut self.dfg.value_lists),
-        }
-    }
-
     /// Rewrite the branch destination to `new_dest` if the destination matches `old_dest`.
     /// Does nothing if called with a non-jump or non-branch instruction.
     ///
@@ -297,13 +286,19 @@ impl FunctionStencil {
         match self.dfg.analyze_branch(inst) {
             BranchInfo::SingleDest(dest) => {
                 if dest.block(&self.dfg.value_lists) == old_dest {
-                    self.change_branch_destination(inst, new_dest);
+                    for block in self.dfg.insts[inst].branch_destination_mut() {
+                        block.set_block(new_dest, &mut self.dfg.value_lists)
+                    }
                 }
             }
 
             BranchInfo::Conditional(block_then, block_else) => {
                 if block_then.block(&self.dfg.value_lists) == old_dest {
-                    if let InstructionData::Brif { block_then, .. } = &mut self.dfg.insts[inst] {
+                    if let InstructionData::Brif {
+                        blocks: [block_then, _],
+                        ..
+                    } = &mut self.dfg.insts[inst]
+                    {
                         block_then.set_block(new_dest, &mut self.dfg.value_lists);
                     } else {
                         unreachable!();
@@ -311,7 +306,11 @@ impl FunctionStencil {
                 }
 
                 if block_else.block(&self.dfg.value_lists) == old_dest {
-                    if let InstructionData::Brif { block_else, .. } = &mut self.dfg.insts[inst] {
+                    if let InstructionData::Brif {
+                        blocks: [_, block_else],
+                        ..
+                    } = &mut self.dfg.insts[inst]
+                    {
                         block_else.set_block(new_dest, &mut self.dfg.value_lists);
                     } else {
                         unreachable!();

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -279,9 +279,6 @@ impl FunctionStencil {
 
     /// Rewrite the branch destination to `new_dest` if the destination matches `old_dest`.
     /// Does nothing if called with a non-jump or non-branch instruction.
-    ///
-    /// Unlike [change_branch_destination](FunctionStencil::change_branch_destination), this method
-    /// rewrite the destinations of multi-destination branches like `br_table`.
     pub fn rewrite_branch_destination(&mut self, inst: Inst, old_dest: Block, new_dest: Block) {
         match self.dfg.analyze_branch(inst) {
             BranchInfo::SingleDest(dest) => {

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -301,6 +301,24 @@ impl FunctionStencil {
                 }
             }
 
+            BranchInfo::Conditional(block_then, block_else) => {
+                if block_then.block(&self.dfg.value_lists) == old_dest {
+                    if let InstructionData::Brif { block_then, .. } = &mut self.dfg.insts[inst] {
+                        block_then.set_block(new_dest, &mut self.dfg.value_lists);
+                    } else {
+                        unreachable!();
+                    }
+                }
+
+                if block_else.block(&self.dfg.value_lists) == old_dest {
+                    if let InstructionData::Brif { block_else, .. } = &mut self.dfg.insts[inst] {
+                        block_else.set_block(new_dest, &mut self.dfg.value_lists);
+                    } else {
+                        unreachable!();
+                    }
+                }
+            }
+
             BranchInfo::Table(table, default_dest) => {
                 self.jump_tables[table].iter_mut().for_each(|entry| {
                     if *entry == old_dest {

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -285,10 +285,9 @@ impl InstructionData {
         }
     }
 
-    /// Get the single destination of this branch instruction, if it is a single destination
-    /// branch or jump.
+    /// Get the destinations of this instruction, if it's a branch.
     ///
-    /// Multi-destination branches like `br_table` return `None`.
+    /// `br_table` returns the empty slice.
     pub fn branch_destination(&self) -> &[BlockCall] {
         match self {
             Self::Jump {
@@ -306,10 +305,9 @@ impl InstructionData {
         }
     }
 
-    /// Get a mutable reference to the single destination of this branch instruction, if it is a
-    /// single destination branch or jump.
+    /// Get a mutable slice of the destinations of this instruction, if it's a branch.
     ///
-    /// Multi-destination branches like `br_table` return `None`.
+    /// `br_table` returns the empty slice.
     pub fn branch_destination_mut(&mut self) -> &mut [BlockCall] {
         match self {
             Self::Jump {

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -271,6 +271,11 @@ impl InstructionData {
         match *self {
             Self::Jump { destination, .. } => BranchInfo::SingleDest(destination),
             Self::Branch { destination, .. } => BranchInfo::SingleDest(destination),
+            Self::Brif {
+                block_then,
+                block_else,
+                ..
+            } => BranchInfo::Conditional(block_then, block_else),
             Self::BranchTable {
                 table, destination, ..
             } => BranchInfo::Table(table, destination),
@@ -455,6 +460,9 @@ pub enum BranchInfo {
 
     /// This is a branch or jump to a single destination block, possibly taking value arguments.
     SingleDest(BlockCall),
+
+    /// This is a conditional branch
+    Conditional(BlockCall, BlockCall),
 
     /// This is a jump table branch which can have many destination blocks and one default block.
     Table(JumpTable, Block),

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2461,6 +2461,52 @@
 (rule (lower (fvpromote_low val))
       (vec_rr_long (VecRRLongOp.Fcvtl32) val $false))
 
+;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; `brif` following `icmp`
+(rule (lower_branch (brif (icmp cc x @ (value_type ty) y) _ _) targets)
+      (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y ty))
+            (cond Cond (cond_code (flags_and_cc_cc comparison)))
+            (taken BranchTarget (branch_target targets 0))
+            (not_taken BranchTarget (branch_target targets 1)))
+        (emit_side_effect
+         (with_flags_side_effect (flags_and_cc_flags comparison)
+                                 (cond_br taken
+                                          not_taken
+                                          (cond_br_cond cond))))))
+
+;; `brif` following `fcmp`
+(rule (lower_branch (brif (fcmp cc x @ (value_type (ty_scalar_float ty)) y) _ _) targets)
+      (let ((cond Cond (fp_cond_code cc))
+            (taken BranchTarget (branch_target targets 0))
+            (not_taken BranchTarget (branch_target targets 1)))
+       (emit_side_effect
+        (with_flags_side_effect (fpu_cmp (scalar_size ty) x y)
+                                (cond_br taken not_taken
+                                 (cond_br_cond cond))))))
+
+;; standard `brif`
+(rule -1 (lower_branch (brif c @ (value_type $I128) _ _) targets)
+      (let ((flags ProducesFlags (flags_to_producesflags c))
+            (c ValueRegs (put_in_regs c))
+            (c_lo Reg (value_regs_get c 0))
+            (c_hi Reg (value_regs_get c 1))
+            (rt Reg (orr $I64 c_lo c_hi))
+            (taken BranchTarget (branch_target targets 0))
+            (not_taken BranchTarget (branch_target targets 1)))
+       (emit_side_effect
+        (with_flags_side_effect flags
+         (cond_br taken not_taken (cond_br_not_zero rt))))))
+(rule -2 (lower_branch (brif c @ (value_type ty) _ _) targets)
+      (if (ty_int_ref_scalar_64 ty))
+      (let ((flags ProducesFlags (flags_to_producesflags c))
+            (rt Reg (put_in_reg_zext64 c))
+            (taken BranchTarget (branch_target targets 0))
+            (not_taken BranchTarget (branch_target targets 1)))
+       (emit_side_effect
+        (with_flags_side_effect flags
+         (cond_br taken not_taken (cond_br_not_zero rt))))))
+
 ;;; Rules for `brz`/`brnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `brz` following `icmp`

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2464,7 +2464,7 @@
 ;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `brif` following `icmp`
-(rule (lower_branch (brif (icmp cc x @ (value_type ty) y) _ _) targets)
+(rule (lower_branch (brif (maybe_uextend (icmp cc x @ (value_type ty) y)) _ _) targets)
       (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y ty))
             (cond Cond (cond_code (flags_and_cc_cc comparison)))
             (taken BranchTarget (branch_target targets 0))
@@ -2476,7 +2476,7 @@
                                           (cond_br_cond cond))))))
 
 ;; `brif` following `fcmp`
-(rule (lower_branch (brif (fcmp cc x @ (value_type (ty_scalar_float ty)) y) _ _) targets)
+(rule (lower_branch (brif (maybe_uextend (fcmp cc x @ (value_type (ty_scalar_float ty)) y)) _ _) targets)
       (let ((cond Cond (fp_cond_code cc))
             (taken BranchTarget (branch_target targets 0))
             (not_taken BranchTarget (branch_target targets 1)))

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -24,8 +24,8 @@ use crate::machinst::{isle::*, InputSourceInst};
 use crate::{
     binemit::CodeOffset,
     ir::{
-        immediates::*, types::*, AtomicRmwOp, ExternalName, Inst, InstructionData, MemFlags,
-        TrapCode, Value, ValueList,
+        immediates::*, types::*, AtomicRmwOp, BlockCall, ExternalName, Inst, InstructionData,
+        MemFlags, TrapCode, Value, ValueList,
     },
     isa::aarch64::abi::AArch64Caller,
     isa::aarch64::inst::args::{ShiftOp, ShiftOpShiftImm},

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1898,7 +1898,7 @@
             (hi Reg (value_regs_get regs 1)))
         (alu_rrr (AluOPRRR.Or) lo hi)))
 
-;;;;
+;; Default behavior for branching based on an input value.
 (rule
   (lower_branch (brif v @ (value_type ty) _ _) targets)
   (lower_brz_or_nz (IntCC.NotEqual) (normalize_cmp_value ty v) targets ty))
@@ -1910,10 +1910,12 @@
         (cmp Reg (gen_icmp (IntCC.NotEqual) v zero $I128)))
     (lower_brz_or_nz (IntCC.NotEqual) cmp targets $I64)))
 
+;; Branching on the result of an icmp
 (rule 1
   (lower_branch (brif (icmp cc a @ (value_type ty) b) _ _) targets)
   (lower_br_icmp cc a b targets ty))
 
+;; Branching on the result of an fcmp
 (rule 1
   (lower_branch (brif (fcmp cc a @ (value_type ty) b) _ _) targets)
   (let ((then BranchTarget (label_to_br_target (vec_label_get targets 0)))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1898,6 +1898,28 @@
             (hi Reg (value_regs_get regs 1)))
         (alu_rrr (AluOPRRR.Or) lo hi)))
 
+;;;;
+(rule
+  (lower_branch (brif v @ (value_type ty) _ _) targets)
+  (lower_brz_or_nz (IntCC.NotEqual) (normalize_cmp_value ty v) targets ty))
+
+;; Special case for SI128 to reify the comparison value and branch on it.
+(rule 2
+  (lower_branch (brif v @ (value_type $I128) _ _) targets)
+  (let ((zero ValueRegs (value_regs (zero_reg) (zero_reg)))
+        (cmp Reg (gen_icmp (IntCC.NotEqual) v zero $I128)))
+    (lower_brz_or_nz (IntCC.NotEqual) cmp targets $I64)))
+
+(rule 1
+  (lower_branch (brif (icmp cc a @ (value_type ty) b) _ _) targets)
+  (lower_br_icmp cc a b targets ty))
+
+(rule 1
+  (lower_branch (brif (fcmp cc a @ (value_type ty) b) _ _) targets)
+  (let ((then BranchTarget (label_to_br_target (vec_label_get targets 0)))
+        (else BranchTarget (label_to_br_target (vec_label_get targets 1))))
+    (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else))))
+
 ;;;;;
 (rule
   (lower_branch (brz v @ (value_type ty) _) targets)

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -14,8 +14,8 @@ use crate::machinst::{isle::*, MachInst, SmallInstVec};
 use crate::machinst::{VCodeConstant, VCodeConstantData};
 use crate::{
     ir::{
-        immediates::*, types::*, AtomicRmwOp, ExternalName, Inst, InstructionData, MemFlags,
-        StackSlot, TrapCode, Value, ValueList,
+        immediates::*, types::*, AtomicRmwOp, BlockCall, ExternalName, Inst, InstructionData,
+        MemFlags, StackSlot, TrapCode, Value, ValueList,
     },
     isa::riscv64::inst::*,
     machinst::{ArgPair, InstOutput, Lower},

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3750,6 +3750,17 @@
         (emit_side_effect (jt_sequence (lshl_imm $I64 idx 2) targets))))
 
 
+;;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Two-way conditional branch on nonzero.  `targets` contains:
+;; - element 0: target if the condition is true (i.e. value is nonzero)
+;; - element 1: target if the condition is false (i.e. value is zero)
+(rule (lower_branch (brif val_cond _ _) targets)
+      (emit_side_effect (cond_br_bool (value_nonzero val_cond)
+                                      (vec_element targets 0)
+                                      (vec_element targets 1))))
+
+
 ;;;; Rules for `brz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Two-way conditional branch on zero.  `targets` contains:

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -16,8 +16,8 @@ use crate::machinst::isle::*;
 use crate::machinst::{MachLabel, Reg};
 use crate::{
     ir::{
-        condcodes::*, immediates::*, types::*, ArgumentPurpose, AtomicRmwOp, Endianness, Inst,
-        InstructionData, KnownSymbol, LibCall, MemFlags, Opcode, TrapCode, Value, ValueList,
+        condcodes::*, immediates::*, types::*, ArgumentPurpose, AtomicRmwOp, BlockCall, Endianness,
+        Inst, InstructionData, KnownSymbol, LibCall, MemFlags, Opcode, TrapCode, Value, ValueList,
     },
     isa::unwind::UnwindInst,
     isa::CallConv,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2885,6 +2885,33 @@
 (rule (lower_branch (jump _) (single_target target))
       (emit_side_effect (jmp_known target)))
 
+;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 2 (lower_branch (brif (icmp cc a b) _ _) (two_targets then else))
+        (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) then else)))
+
+(rule 2 (lower_branch (brif (fcmp cc a b) _ _) (two_targets then else))
+        (emit_side_effect (jmp_cond_fcmp (emit_fcmp cc a b) then else)))
+
+(rule 2 (lower_branch (brif (uextend (icmp cc a b)) _ _)
+                      (two_targets then else))
+        (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) then else)))
+
+(rule 2 (lower_branch (brif (uextend (fcmp cc a b)) _ _)
+                      (two_targets then else))
+        (emit_side_effect (jmp_cond_fcmp (emit_fcmp cc a b) then else)))
+
+(rule 1 (lower_branch (brif val @ (value_type $I128) _ _)
+                      (two_targets then else))
+      (emit_side_effect (jmp_cond_icmp (cmp_zero_i128 (CC.Z) val) then else)))
+
+(rule (lower_branch (brif val @ (value_type (ty_int_bool_or_ref)) _ _)
+                    (two_targets then else))
+      (emit_side_effect (with_flags_side_effect
+                          (cmp_zero_int_bool_ref val)
+                          (jmp_cond (CC.NZ) then else))))
+
+
 ;; Rules for `brz` and `brnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule 2 (lower_branch (brz (maybe_uextend (icmp cc a b)) _) (two_targets taken not_taken))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2887,18 +2887,10 @@
 
 ;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 2 (lower_branch (brif (icmp cc a b) _ _) (two_targets then else))
+(rule 2 (lower_branch (brif (maybe_uextend (icmp cc a b)) _ _) (two_targets then else))
         (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) then else)))
 
-(rule 2 (lower_branch (brif (fcmp cc a b) _ _) (two_targets then else))
-        (emit_side_effect (jmp_cond_fcmp (emit_fcmp cc a b) then else)))
-
-(rule 2 (lower_branch (brif (uextend (icmp cc a b)) _ _)
-                      (two_targets then else))
-        (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) then else)))
-
-(rule 2 (lower_branch (brif (uextend (fcmp cc a b)) _ _)
-                      (two_targets then else))
+(rule 2 (lower_branch (brif (maybe_uextend (fcmp cc a b)) _ _) (two_targets then else))
         (emit_side_effect (jmp_cond_fcmp (emit_fcmp cc a b) then else)))
 
 (rule 1 (lower_branch (brif val @ (value_type $I128) _ _)

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -20,7 +20,7 @@ use crate::{
         condcodes::{CondCode, FloatCC, IntCC},
         immediates::*,
         types::*,
-        Inst, InstructionData, MemFlags, Opcode, TrapCode, Value, ValueList,
+        BlockCall, Inst, InstructionData, MemFlags, Opcode, TrapCode, Value, ValueList,
     },
     isa::{
         unwind::UnwindInst,

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -637,5 +637,16 @@ macro_rules! isle_common_prelude_methods {
         fn pack_value_array_3(&mut self, a: Value, b: Value, c: Value) -> ValueArray3 {
             [a, b, c]
         }
+
+        #[inline]
+        fn unpack_block_array_2(&mut self, arr: &BlockArray2) -> (BlockCall, BlockCall) {
+            let [a, b] = *arr;
+            (a, b)
+        }
+
+        #[inline]
+        fn pack_block_array_2(&mut self, a: BlockCall, b: BlockCall) -> BlockArray2 {
+            [a, b]
+        }
     };
 }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1,4 +1,4 @@
-use crate::ir::{Value, ValueList};
+use crate::ir::{BlockCall, Value, ValueList};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use smallvec::SmallVec;
@@ -22,6 +22,7 @@ pub type Unit = ();
 pub type ValueSlice = (ValueList, usize);
 pub type ValueArray2 = [Value; 2];
 pub type ValueArray3 = [Value; 3];
+pub type BlockArray2 = [BlockCall; 2];
 pub type WritableReg = Writable<Reg>;
 pub type VecRetPair = Vec<RetPair>;
 pub type VecMask = Vec<u8>;

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -941,21 +941,19 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
         for succ_idx in 0..self.vcode.block_order().succ_indices(block).len() {
             // Avoid immutable borrow by explicitly indexing.
             let (inst, succ) = self.vcode.block_order().succ_indices(block)[succ_idx];
+
             // Get branch args and convert to Regs.
-
-            // TODO:
-            // let branch_args = self.f.dfg.insts[inst]
-            //     .branch_destination()
-            //     .into_iter()
-            //     .flat_map(|block| block.args_slice(&self.f.dfg.value_lists));
-
             let branch_args = match self.f.dfg.analyze_branch(inst) {
                 instructions::BranchInfo::NotABranch => unreachable!(),
                 instructions::BranchInfo::SingleDest(block) => {
                     block.args_slice(&self.f.dfg.value_lists)
                 }
                 instructions::BranchInfo::Conditional(then_block, else_block) => {
-                    // TODO: does succ_idx actually index the block of the instruction?
+                    // NOTE: `succ_idx == 0` implying that we're traversing the `then_block` is
+                    // enforced by the traversal order defined in `visit_block_succs`. Eventually
+                    // we should traverse the `branch_destination` slice instead of the result of
+                    // analyze_branch there, which would simplify computing the branch args
+                    // significantly.
                     if succ_idx == 0 {
                         then_block.args_slice(&self.f.dfg.value_lists)
                     } else {

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -9,9 +9,9 @@ use crate::entity::SecondaryMap;
 use crate::fx::{FxHashMap, FxHashSet};
 use crate::inst_predicates::{has_lowering_side_effect, is_constant_64bit};
 use crate::ir::{
-    ArgumentPurpose, Block, Constant, ConstantData, DataFlowGraph, ExternalName, Function,
-    GlobalValue, GlobalValueData, Immediate, Inst, InstructionData, MemFlags, Opcode, RelSourceLoc,
-    Type, Value, ValueDef, ValueLabelAssignments, ValueLabelStart,
+    instructions, ArgumentPurpose, Block, Constant, ConstantData, DataFlowGraph, ExternalName,
+    Function, GlobalValue, GlobalValueData, Immediate, Inst, InstructionData, MemFlags, Opcode,
+    RelSourceLoc, Type, Value, ValueDef, ValueLabelAssignments, ValueLabelStart,
 };
 use crate::machinst::{
     writable_value_regs, BlockIndex, BlockLoweringOrder, Callee, LoweredBlock, MachLabel, Reg,
@@ -942,11 +942,29 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             // Avoid immutable borrow by explicitly indexing.
             let (inst, succ) = self.vcode.block_order().succ_indices(block)[succ_idx];
             // Get branch args and convert to Regs.
-            let branch_args = self.f.dfg.insts[inst]
-                .branch_destination()
-                .into_iter()
-                .flat_map(|block| block.args_slice(&self.f.dfg.value_lists));
 
+            // TODO:
+            // let branch_args = self.f.dfg.insts[inst]
+            //     .branch_destination()
+            //     .into_iter()
+            //     .flat_map(|block| block.args_slice(&self.f.dfg.value_lists));
+
+            let branch_args = match self.f.dfg.analyze_branch(inst) {
+                instructions::BranchInfo::NotABranch => unreachable!(),
+                instructions::BranchInfo::SingleDest(block) => {
+                    block.args_slice(&self.f.dfg.value_lists)
+                }
+                instructions::BranchInfo::Conditional(then_block, else_block) => {
+                    // TODO: does succ_idx actually index the block of the instruction?
+                    if succ_idx == 0 {
+                        then_block.args_slice(&self.f.dfg.value_lists)
+                    } else {
+                        assert!(succ_idx == 1);
+                        else_block.args_slice(&self.f.dfg.value_lists)
+                    }
+                }
+                instructions::BranchInfo::Table(_, _) => &[],
+            };
             let mut branch_arg_vregs: SmallVec<[Reg; 16]> = smallvec![];
             for &arg in branch_args {
                 let arg = self.f.dfg.resolve_aliases(arg);
@@ -976,7 +994,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             if last_inst != Some(inst) {
                 branches.push(inst);
             } else {
-                debug_assert!(self.f.dfg.insts[inst].opcode() == Opcode::BrTable);
+                debug_assert!(
+                    self.f.dfg.insts[inst].opcode() == Opcode::BrTable
+                        || self.f.dfg.insts[inst].opcode() == Opcode::Brif
+                );
                 debug_assert!(branches.len() == 1);
             }
             last_inst = Some(inst);

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -34,6 +34,7 @@
 (type Type (primitive Type))
 (type Value (primitive Value))
 (type ValueList (primitive ValueList))
+(type BlockCall (primitive BlockCall))
 
 ;; ISLE representation of `&[Value]`.
 (type ValueSlice (primitive ValueSlice))

--- a/cranelift/codegen/src/remove_constant_phis.rs
+++ b/cranelift/codegen/src/remove_constant_phis.rs
@@ -113,7 +113,7 @@ struct OutEdge<'a> {
     inst: Inst,
     /// The index into branch_destinations for this instruction that corresponds
     /// to this edge.
-    branch_index: u8,
+    branch_index: u32,
     /// The block that control is transferred to.
     block: Block,
     /// The arguments to that block.
@@ -144,7 +144,7 @@ impl<'a> OutEdge<'a> {
 
         Some(OutEdge {
             inst,
-            branch_index: branch_index as u8,
+            branch_index: branch_index as u32,
             block: block.block(&dfg.value_lists),
             args: bump.alloc_slice_fill_iter(
                 inst_var_args

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -589,8 +589,7 @@ impl<'a> Verifier<'a> {
             }
             Brif {
                 arg,
-                block_then,
-                block_else,
+                blocks: [block_then, block_else],
                 ..
             } => {
                 self.verify_value(inst, arg, errors)?;

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -587,6 +587,16 @@ impl<'a> Verifier<'a> {
             Jump { destination, .. } | Branch { destination, .. } => {
                 self.verify_block(inst, destination.block(&self.func.dfg.value_lists), errors)?;
             }
+            Brif {
+                arg,
+                block_then,
+                block_else,
+                ..
+            } => {
+                self.verify_value(inst, arg, errors)?;
+                self.verify_block(inst, block_then.block(&self.func.dfg.value_lists), errors)?;
+                self.verify_block(inst, block_else.block(&self.func.dfg.value_lists), errors)?;
+            }
             BranchTable {
                 table, destination, ..
             } => {
@@ -1302,6 +1312,25 @@ impl<'a> Verifier<'a> {
                     .map(|&v| self.func.dfg.value_type(v));
                 let args = block.args_slice(&self.func.dfg.value_lists);
                 self.typecheck_variable_args_iterator(inst, iter, args, errors)?;
+            }
+            BranchInfo::Conditional(block_then, block_else) => {
+                let iter = self
+                    .func
+                    .dfg
+                    .block_params(block_then.block(&self.func.dfg.value_lists))
+                    .iter()
+                    .map(|&v| self.func.dfg.value_type(v));
+                let args_then = block_then.args_slice(&self.func.dfg.value_lists);
+                self.typecheck_variable_args_iterator(inst, iter, args_then, errors)?;
+
+                let iter = self
+                    .func
+                    .dfg
+                    .block_params(block_else.block(&self.func.dfg.value_lists))
+                    .iter()
+                    .map(|&v| self.func.dfg.value_type(v));
+                let args_else = block_else.args_slice(&self.func.dfg.value_lists);
+                self.typecheck_variable_args_iterator(inst, iter, args_else, errors)?;
             }
             BranchInfo::Table(table, block) => {
                 let arg_count = self.func.dfg.num_block_params(block);

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -418,6 +418,17 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             write!(w, " {}", destination.block(pool))?;
             write_block_args(w, destination.args_slice(pool))
         }
+        Brif {
+            arg,
+            block_then,
+            block_else,
+            ..
+        } => {
+            write!(w, " {}, {}", arg, block_then.block(pool))?;
+            write_block_args(w, block_then.args_slice(pool))?;
+            write!(w, ", {}", block_else.block(pool))?;
+            write_block_args(w, block_else.args_slice(pool))
+        }
         Branch {
             arg, destination, ..
         } => {

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -420,8 +420,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         }
         Brif {
             arg,
-            block_then,
-            block_else,
+            blocks: [block_then, block_else],
             ..
         } => {
             write!(w, " {}, {}", arg, block_then.block(pool))?;

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -394,3 +394,65 @@ block2:
 ;   popq    %rbp
 ;   ret
 
+function %brif_i8_icmp(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = icmp eq v0, v1
+  v3 = uextend.i32 v2
+  brif v3, block1, block2
+
+block1:
+  v4 = iconst.i32 1
+  return v4
+
+block2:
+  v5 = iconst.i32 2
+  return v5
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   cmpl    %esi, %edi
+;   jz      label1; j label2
+; block1:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $2, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+
+function %brif_i8_fcmp(f32, f32) -> i32 {
+block0(v0: f32, v1: f32):
+  v2 = fcmp eq v0, v1
+  v3 = uextend.i32 v2
+  brif v3, block1, block2
+
+block1:
+  v4 = iconst.i32 1
+  return v4
+
+block2:
+  v5 = iconst.i32 2
+  return v5
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   ucomiss %xmm1, %xmm0
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $2, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret

--- a/cranelift/filetests/filetests/parser/branch.clif
+++ b/cranelift/filetests/filetests/parser/branch.clif
@@ -114,3 +114,24 @@ block50:
 ; nextln: block50:
 ; nextln:     trap user1
 ; nextln: }
+
+function %twoargs(i32, f32) {
+block0(v90: i32, v91: f32):
+    brif v90, block1(v90, v91), block2(v91, v90)
+
+block1(v92: i32, v93: f32):
+    brif v90, block1(v90, v91), block2(v91, v90)
+
+block2(v94: f32, v95: i32):
+    brif v90, block1(v90, v91), block2(v91, v90)
+}
+; sameln: function %twoargs(i32, f32) fast {
+; nextln: block0(v90: i32, v91: f32):
+; nextln:     brif v90, block1(v90, v91), block2(v91, v90)
+; nextln: 
+; nextln: block1(v92: i32, v93: f32):
+; nextln:     brif.i32 v90, block1(v90, v91), block2(v91, v90)
+; nextln: 
+; nextln: block2(v94: f32, v95: i32):
+; nextln:     brif.i32 v90, block1(v90, v91), block2(v91, v90)
+; nextln: }

--- a/cranelift/filetests/filetests/runtests/brif.clif
+++ b/cranelift/filetests/filetests/runtests/brif.clif
@@ -1,0 +1,152 @@
+test interpret
+test run
+target aarch64
+target s390x
+target x86_64
+target riscv64
+
+function %brif_value(i8) -> i64 {
+block0(v0: i8):
+    brif v0, block1, block2
+block1:
+    v1 = uextend.i64 v0
+    return v1
+block2:
+    v2 = iconst.i64 42
+    return v2
+}
+
+; run: %brif_value(0) == 42
+; run: %brif_value(42) == 42
+; run: %brif_value(97) == 97
+
+function %brif_ne_zero(i8) -> i64 {
+block0(v0: i8):
+    v1 = iconst.i8 0
+    v2 = icmp ne v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = uextend.i64 v0
+    return v3
+block2:
+    v4 = iconst.i64 42
+    return v4
+}
+
+; run: %brif_ne_zero(0) == 42
+; run: %brif_ne_zero(42) == 42
+; run: %brif_ne_zero(97) == 97
+
+function %brif_ne_one(i8) -> i64 {
+block0(v0: i8):
+    v1 = iconst.i8 1
+    v2 = icmp ne v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = uextend.i64 v0
+    return v3
+block2:
+    v4 = iconst.i64 42
+    return v4
+}
+
+; run: %brif_ne_one(1) == 42
+; run: %brif_ne_one(0) == 0
+; run: %brif_ne_one(42) == 42
+; run: %brif_ne_one(97) == 97
+
+function %brif_uextend_ne_one(i8) -> i64 {
+block0(v0: i8):
+    v1 = iconst.i8 1
+    v2 = icmp ne v0, v1
+    v3 = uextend.i64 v2
+    brif v3, block1, block2
+block1:
+    v4 = uextend.i64 v0
+    return v4
+block2:
+    v5 = iconst.i64 42
+    return v5
+}
+
+; run: %brif_uextend_ne_one(1) == 42
+; run: %brif_uextend_ne_one(0) == 0
+; run: %brif_uextend_ne_one(42) == 42
+; run: %brif_uextend_ne_one(97) == 97
+
+
+function %brif_i64(i64) -> i8 {
+block0(v0: i64):
+    brif v0, block1, block2
+
+block1:
+    v1 = iconst.i8 1
+    return v1
+
+block2:
+    v2 = iconst.i8 0
+    return v2
+}
+; run: %brif_i64(0) == 0
+; run: %brif_i64(1) == 1
+; run: %brif_i64(-1) == 1
+
+function %brif_i32(i32) -> i8 {
+block0(v0: i32):
+    brif v0, block1, block2
+
+block1:
+    v1 = iconst.i8 1
+    return v1
+
+block2:
+    v2 = iconst.i8 0
+    return v2
+}
+; run: %brif_i32(0) == 0
+; run: %brif_i32(1) == 1
+; run: %brif_i32(-1) == 1
+
+function %brif_i16(i16) -> i8 {
+block0(v0: i16):
+    brif v0, block1, block2
+
+block1:
+    v1 = iconst.i8 1
+    return v1
+
+block2:
+    v2 = iconst.i8 0
+    return v2
+}
+; run: %brif_i16(0) == 0
+; run: %brif_i16(1) == 1
+; run: %brif_i16(-1) == 1
+
+function %brif_i8(i8) -> i8 {
+block0(v0: i8):
+    brif v0, block1, block2
+
+block1:
+    v1 = iconst.i8 1
+    return v1
+
+block2:
+    v2 = iconst.i8 0
+    return v2
+}
+; run: %brif_i8(0) == 0
+; run: %brif_i8(1) == 1
+; run: %brif_i8(-1) == 1
+; run: %brif_i8(97) == 1
+
+function %a() -> i8 system_v {
+block0:
+    v1 = iconst.i8 35
+    brif v1, block1(v1), block1(v1)  ; v1 = 35
+
+block1(v0: i8):
+    return v0
+}
+
+; run: %a() == 35

--- a/cranelift/filetests/filetests/runtests/brif.clif
+++ b/cranelift/filetests/filetests/runtests/brif.clif
@@ -140,6 +140,23 @@ block2:
 ; run: %brif_i8(-1) == 1
 ; run: %brif_i8(97) == 1
 
+function %brif_different_args(i8) -> i8 {
+block0(v0: i8):
+    brif v0, block1(v0, v0), block2(v0)
+
+block1(v1: i8, v2: i8):
+    v3 = iadd v1, v2
+    return v3
+
+block2(v4: i8):
+    return v4
+}
+
+; run: %brif_different_args(0) == 0
+; run: %brif_different_args(1) == 2
+; run: %brif_different_args(8) == 16
+; run: %brif_different_args(128) == 0
+
 function %fuzzgen_1() -> i8 system_v {
 block0:
     v1 = iconst.i8 35

--- a/cranelift/filetests/filetests/runtests/brif.clif
+++ b/cranelift/filetests/filetests/runtests/brif.clif
@@ -140,7 +140,7 @@ block2:
 ; run: %brif_i8(-1) == 1
 ; run: %brif_i8(97) == 1
 
-function %a() -> i8 system_v {
+function %fuzzgen_1() -> i8 system_v {
 block0:
     v1 = iconst.i8 35
     brif v1, block1(v1), block1(v1)  ; v1 = 35
@@ -149,4 +149,30 @@ block1(v0: i8):
     return v0
 }
 
-; run: %a() == 35
+; run: %fuzzgen_1() == 35
+
+function %fuzzgen_2(i16) -> i16, i16 system_v {
+block0(v0: i16):
+    brnz v0, block1(v0, v0)
+    jump block2(v0, v0)
+
+block1(v1: i16, v2: i16):
+    brif v1, block2(v2, v2), block2(v2, v2)
+
+block2(v3: i16, v4: i16):
+    return v3, v4
+}
+
+; run: %fuzzgen_2(0) == [0, 0]
+
+function %fuzzgen_3(i8 sext) -> i8 system_v {
+block0(v0: i8):
+    v1 = iconst.i8 -9
+    brif v0, block1(v1), block1(v0)
+
+block1(v2: i8):
+    return v2
+}
+
+; run: %fuzzgen_3(-65) == -9
+; run: %fuzzgen_3(0) == 0

--- a/cranelift/filetests/filetests/verifier/type_check.clif
+++ b/cranelift/filetests/filetests/verifier/type_check.clif
@@ -98,6 +98,22 @@ function %jump_args2() {
         return
 }
 
+function %brif_args() {
+block0:
+    v0 = iconst.i16 10
+    v1 = iconst.i16 10
+    brif v0, block1(v1), block2(v1)
+    ; error: arg 0 (v1) has type i16, expected i64
+    ; error: mismatched argument count
+    ; error: arg 0 (v1) has type i16, expected f32
+
+block1(v2: i64):
+    return
+
+block2(v3: f32, v4: i8):
+    return
+}
+
 function %bad_extend() {
 block0:
     v0 = iconst.i32 10

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -592,6 +592,26 @@ impl SSABuilder {
                     .append_argument(val, &mut dfg.value_lists);
                 None
             }
+            BranchInfo::Conditional(block_then, block_else) => {
+                let dfg = &mut func.dfg;
+                if dest_block == block_then.block(&dfg.value_lists) {
+                    if let InstructionData::Brif { block_then, .. } = &mut dfg.insts[branch] {
+                        block_then.append_argument(val, &mut dfg.value_lists);
+                    } else {
+                        unreachable!();
+                    }
+                }
+
+                if dest_block == block_else.block(&dfg.value_lists) {
+                    if let InstructionData::Brif { block_else, .. } = &mut dfg.insts[branch] {
+                        block_else.append_argument(val, &mut dfg.value_lists);
+                    } else {
+                        unreachable!();
+                    }
+                }
+
+                None
+            }
             BranchInfo::Table(mut jt, _default_block) => {
                 // In the case of a jump table, the situation is tricky because br_table doesn't
                 // support arguments. We have to split the critical edge.

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -591,32 +591,13 @@ impl SSABuilder {
                 }
                 None
             }
-            BranchInfo::Conditional(block_then, block_else) => {
+            BranchInfo::Conditional(_, _) => {
                 let dfg = &mut func.dfg;
-                if dest_block == block_then.block(&dfg.value_lists) {
-                    if let InstructionData::Brif {
-                        blocks: [block_then, _],
-                        ..
-                    } = &mut dfg.insts[branch]
-                    {
-                        block_then.append_argument(val, &mut dfg.value_lists);
-                    } else {
-                        unreachable!();
+                for block in dfg.insts[branch].branch_destination_mut() {
+                    if block.block(&dfg.value_lists) == dest_block {
+                        block.append_argument(val, &mut dfg.value_lists);
                     }
                 }
-
-                if dest_block == block_else.block(&dfg.value_lists) {
-                    if let InstructionData::Brif {
-                        blocks: [_, block_else],
-                        ..
-                    } = &mut dfg.insts[branch]
-                    {
-                        block_else.append_argument(val, &mut dfg.value_lists);
-                    } else {
-                        unreachable!();
-                    }
-                }
-
                 None
             }
             BranchInfo::Table(mut jt, _default_block) => {

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -586,16 +586,19 @@ impl SSABuilder {
             // is sufficient.
             BranchInfo::SingleDest(_) => {
                 let dfg = &mut func.dfg;
-                dfg.insts[branch]
-                    .branch_destination_mut()
-                    .unwrap()
-                    .append_argument(val, &mut dfg.value_lists);
+                for dest in dfg.insts[branch].branch_destination_mut() {
+                    dest.append_argument(val, &mut dfg.value_lists);
+                }
                 None
             }
             BranchInfo::Conditional(block_then, block_else) => {
                 let dfg = &mut func.dfg;
                 if dest_block == block_then.block(&dfg.value_lists) {
-                    if let InstructionData::Brif { block_then, .. } = &mut dfg.insts[branch] {
+                    if let InstructionData::Brif {
+                        blocks: [block_then, _],
+                        ..
+                    } = &mut dfg.insts[branch]
+                    {
                         block_then.append_argument(val, &mut dfg.value_lists);
                     } else {
                         unreachable!();
@@ -603,7 +606,11 @@ impl SSABuilder {
                 }
 
                 if dest_block == block_else.block(&dfg.value_lists) {
-                    if let InstructionData::Brif { block_else, .. } = &mut dfg.insts[branch] {
+                    if let InstructionData::Brif {
+                        blocks: [_, block_else],
+                        ..
+                    } = &mut dfg.insts[branch]
+                    {
                         block_else.append_argument(val, &mut dfg.value_lists);
                     } else {
                         unreachable!();

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1599,12 +1599,25 @@ where
                 let _type = *self.u.choose(&condbr_types[..])?;
                 let val = builder.use_var(self.get_variable_of_type(_type)?);
 
-                if bool::arbitrary(self.u)? {
-                    builder.ins().brz(val, left, &left_args[..]);
-                } else {
-                    builder.ins().brnz(val, left, &left_args[..]);
+                match self.u.int_in_range(0..=2)? {
+                    0 => {
+                        builder.ins().brnz(val, left, &left_args[..]);
+                        builder.ins().jump(right, &right_args[..]);
+                    }
+
+                    1 => {
+                        builder.ins().brz(val, left, &left_args[..]);
+                        builder.ins().jump(right, &right_args[..]);
+                    }
+
+                    2 => {
+                        builder
+                            .ins()
+                            .brif(val, left, &left_args[..], right, &right_args[..]);
+                    }
+
+                    _ => unreachable!(),
                 }
-                builder.ins().jump(right, &right_args[..]);
             }
             BlockTerminator::BrTable(default, targets) => {
                 // Create jump tables on demand

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -279,14 +279,13 @@ where
     // Interpret a Cranelift instruction.
     Ok(match inst.opcode() {
         Opcode::Jump => {
-            let block = inst.branch_destination().unwrap();
+            let block = inst.branch_destination()[0];
             continue_at(block)?
         }
         Opcode::Brif => {
             if let InstructionData::Brif {
                 arg,
-                block_then,
-                block_else,
+                blocks: [block_then, block_else],
                 ..
             } = inst
             {
@@ -305,7 +304,7 @@ where
             }
         }
         Opcode::Brz => {
-            let block = inst.branch_destination().unwrap();
+            let block = inst.branch_destination()[0];
             branch_when(
                 !arg(0)?
                     .convert(ValueConversionKind::ToBoolean)?
@@ -314,7 +313,7 @@ where
             )?
         }
         Opcode::Brnz => {
-            let block = inst.branch_destination().unwrap();
+            let block = inst.branch_destination()[0];
             branch_when(
                 arg(0)?
                     .convert(ValueConversionKind::ToBoolean)?

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -289,11 +289,10 @@ where
                 ..
             } = inst
             {
-                let condition = state
-                    .get_value(arg)
-                    .ok_or(StepError::UnknownValue(arg))?
-                    .into_bool()?;
-                let pool = &state.get_current_function().dfg.value_lists;
+                let arg = state.get_value(arg).ok_or(StepError::UnknownValue(arg))?;
+
+                let condition = arg.convert(ValueConversionKind::ToBoolean)?.into_bool()?;
+
                 if condition {
                     continue_at(block_then)?
                 } else {

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -7,8 +7,8 @@ use crate::value::{Value, ValueConversionKind, ValueError, ValueResult};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::{
-    types, AbiParam, Block, ExternalName, FuncRef, Function, InstructionData, Opcode, TrapCode,
-    Type, Value as ValueRef,
+    types, AbiParam, Block, BlockCall, ExternalName, FuncRef, Function, InstructionData, Opcode,
+    TrapCode, Type, Value as ValueRef,
 };
 use log::trace;
 use smallvec::{smallvec, SmallVec};
@@ -236,8 +236,7 @@ where
 
     // Retrieve an instruction's branch destination; expects the instruction to be a branch.
 
-    let continue_at = || {
-        let block = inst.branch_destination().unwrap();
+    let continue_at = |block: BlockCall| {
         let branch_args = state
             .collect_values(block.args_slice(&state.get_current_function().dfg.value_lists))
             .map_err(|v| StepError::UnknownValue(v))?;
@@ -248,9 +247,9 @@ where
     };
 
     // Based on `condition`, indicate where to continue the control flow.
-    let branch_when = |condition: bool| -> Result<ControlFlow<V>, StepError> {
+    let branch_when = |condition: bool, block| -> Result<ControlFlow<V>, StepError> {
         if condition {
-            continue_at()
+            continue_at(block)
         } else {
             Ok(ControlFlow::Continue)
         }
@@ -279,17 +278,50 @@ where
 
     // Interpret a Cranelift instruction.
     Ok(match inst.opcode() {
-        Opcode::Jump => continue_at()?,
-        Opcode::Brz => branch_when(
-            !arg(0)?
-                .convert(ValueConversionKind::ToBoolean)?
-                .into_bool()?,
-        )?,
-        Opcode::Brnz => branch_when(
-            arg(0)?
-                .convert(ValueConversionKind::ToBoolean)?
-                .into_bool()?,
-        )?,
+        Opcode::Jump => {
+            let block = inst.branch_destination().unwrap();
+            continue_at(block)?
+        }
+        Opcode::Brif => {
+            if let InstructionData::Brif {
+                arg,
+                block_then,
+                block_else,
+                ..
+            } = inst
+            {
+                let condition = state
+                    .get_value(arg)
+                    .ok_or(StepError::UnknownValue(arg))?
+                    .into_bool()?;
+                let pool = &state.get_current_function().dfg.value_lists;
+                if condition {
+                    continue_at(block_then)?
+                } else {
+                    continue_at(block_else)?
+                }
+            } else {
+                unreachable!()
+            }
+        }
+        Opcode::Brz => {
+            let block = inst.branch_destination().unwrap();
+            branch_when(
+                !arg(0)?
+                    .convert(ValueConversionKind::ToBoolean)?
+                    .into_bool()?,
+                block,
+            )?
+        }
+        Opcode::Brnz => {
+            let block = inst.branch_destination().unwrap();
+            branch_when(
+                arg(0)?
+                    .convert(ValueConversionKind::ToBoolean)?
+                    .into_bool()?,
+                block,
+            )?
+        }
         Opcode::BrTable => {
             if let InstructionData::BranchTable {
                 table, destination, ..

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2605,8 +2605,7 @@ impl<'a> Parser<'a> {
                 InstructionData::Brif {
                     opcode,
                     arg,
-                    block_then,
-                    block_else,
+                    blocks: [block_then, block_else],
                 }
             }
             InstructionFormat::Branch => {

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2588,6 +2588,27 @@ impl<'a> Parser<'a> {
                     destination,
                 }
             }
+            InstructionFormat::Brif => {
+                let arg = self.match_value("expected SSA value control operand")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let block_then = {
+                    let block_num = self.match_block("expected branch then block")?;
+                    let args = self.parse_opt_value_list()?;
+                    ctx.function.dfg.block_call(block_num, &args)
+                };
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let block_else = {
+                    let block_num = self.match_block("expected branch else block")?;
+                    let args = self.parse_opt_value_list()?;
+                    ctx.function.dfg.block_call(block_num, &args)
+                };
+                InstructionData::Brif {
+                    opcode,
+                    arg,
+                    block_then,
+                    block_else,
+                }
+            }
             InstructionFormat::Branch => {
                 let arg = self.match_value("expected SSA value control operand")?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;


### PR DESCRIPTION
Add a conditional branch instruction with two targets: `brif`. This instruction will eventually replace `brz` and `brnz`, as it encompasses the behavior of both.

This PR also changes the `InstructionData` layout for instruction formats that hold `BlockCall` values, taking the same approach we use for `Value`  arguments. This allows `branch_destination` to return a slice to the `BlockCall` values held in the instruction, rather than requiring that we pattern match on `InstructionData` to fetch the then/else blocks.

Function generation for fuzzing has been updated to generate uses of `brif`, and I've run the `cranelift-fuzzgen` target locally for hours without triggering any new failures.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
