### PR TITLE
Implement vsplit in cranelift interpreter

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-vsplit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vsplit.clif
@@ -1,0 +1,31 @@
+test interpret
+
+function %vsplit_i32x4_hi(i32x4) -> i32x2 {
+block0(v0: i32x4):
+    v1, v2 = vsplit.i32x4 v0
+    return v1
+}
+; run: %vsplit_i32x4_hi([1 2 3 4]) == [1 2]
+
+function %vsplit_i32x4_lo(i32x4) -> i32x2 {
+block0(v0: i32x4):
+    v1, v2 = vsplit.i32x4 v0
+    return v2
+}
+; run: %vsplit_i32x4_lo([1 2 3 4]) == [3 4]
+
+
+
+function %vsplit_scalar_i64x2_hi(i64x2) -> i64 {
+block0(v0: i64x2):
+    v1, v2 = vsplit.i64x2 v0
+    return v1
+}
+; run: %vsplit_scalar_i64x2_hi([1 2]) == 1
+
+function %vsplit_scalar_i64x2_lo(i64x2) -> i64 {
+block0(v0: i64x2):
+    v1, v2 = vsplit.i64x2 v0
+    return v2
+}
+; run: %vsplit_scalar_i64x2_lo([3 4]) == 4

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -985,7 +985,15 @@ where
             }
             assign(Value::int(result, ctrl_ty)?)
         }
-        Opcode::Vsplit => unimplemented!("Vsplit"),
+        Opcode::Vsplit => {
+            let new_type = ctrl_ty.half_vector().unwrap();
+            let vector = extractlanes(&arg(0)?, ctrl_ty)?;
+            let (high, low) = vector.split_at((ctrl_ty.lane_count() / 2) as usize);
+            assign_multiple(&[
+                vectorizelanes(high, new_type)?,
+                vectorizelanes(low, new_type)?,
+            ])
+        }
         Opcode::Vconcat => unimplemented!("Vconcat"),
         Opcode::Vselect => assign(vselect(&arg(0)?, &arg(1)?, &arg(2)?, ctrl_ty)?),
         Opcode::VanyTrue => {


### PR DESCRIPTION
<!--
Please ensure that the following steps are all taken care of before submitting
the PR.
- [x] This has been discussed in issue #..., or if not, please tell us why
  here.
- x ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [x] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
This change is for #5454 

Adds implementation for [vsplit](https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.vsplit) opcode to the cranelift IR interpreter. This felt surprisingly straightfoward to add! (I think) 
The `ir.md` document was very helpful and interesting to read through.

### Steps to test 

`cargo run -- test filetests\filetests\runtests\simd-vsplit.clif`
