### PR TITLE
cranelift: Support derived instruction builder functions

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -57,6 +57,10 @@ pub(crate) struct InstructionContent {
     /// Indices in operands_out of output operands that are values.
     pub value_results: Vec<usize>,
 
+    /// True when this instruction's generated builder should have a trailing '_' in the name to
+    /// indicate that it's a lower-level interface.
+    pub is_raw: bool,
+
     /// True for instructions that terminate the block.
     pub is_terminator: bool,
     /// True for all branch or jump instructions.
@@ -133,6 +137,7 @@ pub(crate) struct InstructionBuilder {
     can_store: bool,
     can_trap: bool,
     other_side_effects: bool,
+    is_raw: bool,
 }
 
 impl InstructionBuilder {
@@ -152,6 +157,7 @@ impl InstructionBuilder {
             can_store: false,
             can_trap: false,
             other_side_effects: false,
+            is_raw: false,
         }
     }
 
@@ -211,6 +217,14 @@ impl InstructionBuilder {
         self
     }
 
+    /// Mark this instruction as not needing a generated builder function. This is useful for the
+    /// cases where we want to define a different builder interface manually than would have been
+    /// generated.
+    pub fn is_raw(mut self, val: bool) -> Self {
+        self.is_raw = val;
+        self
+    }
+
     fn build(self) -> Instruction {
         let operands_in = self.operands_in.unwrap_or_else(Vec::new);
         let operands_out = self.operands_out.unwrap_or_else(Vec::new);
@@ -250,6 +264,7 @@ impl InstructionBuilder {
             polymorphic_info,
             value_opnums,
             value_results,
+            is_raw: self.is_raw,
             imm_opnums,
             is_terminator: self.is_terminator,
             is_branch: self.is_branch,

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -944,9 +944,12 @@ fn gen_inst_builder(inst: &Instruction, format: &InstructionFormat, fmt: &mut Fo
         "".into()
     };
 
+    let raw_suffix = if inst.is_raw { "_" } else { "" };
+
     let proto = format!(
-        "{}{}({}) -> {}",
+        "{}{}{}({}) -> {}",
         inst.snake_name(),
+        raw_suffix,
         tmpl,
         args.join(", "),
         rtype

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -33,6 +33,7 @@ fn define_control_flow(
             &formats.jump,
         )
         .operands_in(vec![block, args])
+        .is_raw(true)
         .is_terminator(true)
         .is_branch(true),
     );

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -627,7 +627,7 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::flowgraph::ControlFlowGraph;
     use crate::ir::types::*;
-    use crate::ir::{Function, InstBuilder, TrapCode};
+    use crate::ir::{Function, InstBuilder, InstBuilderDerived, TrapCode};
 
     #[test]
     fn empty() {

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -213,7 +213,7 @@ pub type SuccIter<'a> = bforest::SetIter<'a, Block>;
 mod tests {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
-    use crate::ir::{types, Function, InstBuilder};
+    use crate::ir::{types, Function, InstBuilder, InstBuilderDerived};
     use alloc::vec::Vec;
 
     #[test]

--- a/cranelift/codegen/src/ir/builder.rs
+++ b/cranelift/codegen/src/ir/builder.rs
@@ -41,6 +41,25 @@ include!(concat!(env!("OUT_DIR"), "/inst_builder.rs"));
 /// Any type implementing `InstBuilderBase` gets all the `InstBuilder` methods for free.
 impl<'f, T: InstBuilderBase<'f>> InstBuilder<'f> for T {}
 
+/// Additional helper functions derived on top of `InstBuilder`.
+pub trait InstBuilderDerived<'f>: InstBuilder<'f> {
+    /// Jump.
+    ///
+    /// Unconditionally jump to a basic block, passing the specified
+    /// block arguments. The number and types of arguments must match the
+    /// destination block.
+    ///
+    /// Inputs:
+    ///
+    /// - block: Destination basic block
+    /// - args: block arguments
+    fn jump(self, block: ir::Block, args: &[Value]) -> Inst {
+        self.jump_(block, args)
+    }
+}
+
+impl<'f, T: InstBuilder<'f>> InstBuilderDerived<'f> for T {}
+
 /// Base trait for instruction inserters.
 ///
 /// This is an alternative base trait for an instruction builder to implement.

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -30,7 +30,8 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::ir::atomic_rmw_op::AtomicRmwOp;
 pub use crate::ir::builder::{
-    InsertBuilder, InstBuilder, InstBuilderBase, InstInserterBase, ReplaceBuilder,
+    InsertBuilder, InstBuilder, InstBuilderBase, InstBuilderDerived, InstInserterBase,
+    ReplaceBuilder,
 };
 pub use crate::ir::constant::{ConstantData, ConstantPool};
 pub use crate::ir::dfg::{DataFlowGraph, ValueDef};

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -70,7 +70,8 @@ impl crate::isa::unwind::systemv::RegisterMapper<Reg> for RegisterMapper {
 mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::{
-        types, AbiParam, Function, InstBuilder, Signature, StackSlotData, StackSlotKind,
+        types, AbiParam, Function, InstBuilder, InstBuilderDerived, Signature, StackSlotData,
+        StackSlotKind,
     };
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -226,7 +226,9 @@ mod test {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::types::*;
-    use crate::ir::{AbiParam, Function, InstBuilder, JumpTableData, Signature, UserFuncName};
+    use crate::ir::{
+        AbiParam, Function, InstBuilder, InstBuilderDerived, JumpTableData, Signature, UserFuncName,
+    };
     use crate::isa::CallConv;
     use crate::settings;
     use crate::settings::Configurable;

--- a/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
@@ -67,8 +67,8 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
 
     use crate::ir::{
-        types, AbiParam, Function, InstBuilder, Signature, StackSlotData, StackSlotKind,
-        UserFuncName,
+        types, AbiParam, Function, InstBuilder, InstBuilderDerived, Signature, StackSlotData,
+        StackSlotKind, UserFuncName,
     };
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -101,7 +101,8 @@ impl crate::isa::unwind::systemv::RegisterMapper<Reg> for RegisterMapper {
 mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::{
-        types, AbiParam, Function, InstBuilder, Signature, StackSlotData, StackSlotKind,
+        types, AbiParam, Function, InstBuilder, InstBuilderDerived, Signature, StackSlotData,
+        StackSlotKind,
     };
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -202,7 +202,7 @@ mod test {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::types::*;
     use crate::ir::UserFuncName;
-    use crate::ir::{AbiParam, Function, InstBuilder, Signature};
+    use crate::ir::{AbiParam, Function, InstBuilder, InstBuilderDerived, Signature};
     use crate::isa::CallConv;
     use crate::settings;
     use crate::settings::Configurable;

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -97,7 +97,8 @@ impl crate::isa::unwind::systemv::RegisterMapper<Reg> for RegisterMapper {
 mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::{
-        types, AbiParam, Function, InstBuilder, Signature, StackSlotData, StackSlotKind,
+        types, AbiParam, Function, InstBuilder, InstBuilderDerived, Signature, StackSlotData,
+        StackSlotKind,
     };
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -221,8 +221,10 @@ fn isa_constructor(
 mod test {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
-    use crate::ir::{types::*, RelSourceLoc, SourceLoc, UserFuncName, ValueLabel, ValueLabelStart};
-    use crate::ir::{AbiParam, Function, InstBuilder, JumpTableData, Signature};
+    use crate::ir::{
+        types::*, AbiParam, Function, InstBuilder, InstBuilderDerived, JumpTableData, RelSourceLoc,
+        Signature, SourceLoc, UserFuncName, ValueLabel, ValueLabelStart,
+    };
     use crate::isa::CallConv;
     use crate::settings;
     use crate::settings::Configurable;

--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -17,7 +17,7 @@ use crate::cursor::{Cursor, FuncCursor};
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::immediates::Imm64;
 use crate::ir::types::{I128, I64};
-use crate::ir::{self, InstBuilder, InstructionData, MemFlags, Value};
+use crate::ir::{self, InstBuilder, InstBuilderDerived, InstructionData, MemFlags, Value};
 use crate::isa::TargetIsa;
 use crate::trace;
 

--- a/cranelift/codegen/src/licm.rs
+++ b/cranelift/codegen/src/licm.rs
@@ -6,7 +6,8 @@ use crate::entity::{EntityList, ListPool};
 use crate::flowgraph::{BlockPredecessor, ControlFlowGraph};
 use crate::fx::FxHashSet;
 use crate::ir::{
-    Block, DataFlowGraph, Function, Inst, InstBuilder, InstructionData, Layout, Opcode, Type, Value,
+    Block, DataFlowGraph, Function, Inst, InstBuilderDerived, InstructionData, Layout, Opcode,
+    Type, Value,
 };
 use crate::loop_analysis::{Loop, LoopAnalysis};
 use crate::timing;

--- a/cranelift/codegen/src/loop_analysis.rs
+++ b/cranelift/codegen/src/loop_analysis.rs
@@ -319,7 +319,7 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::dominator_tree::DominatorTree;
     use crate::flowgraph::ControlFlowGraph;
-    use crate::ir::{types, Function, InstBuilder};
+    use crate::ir::{types, Function, InstBuilder, InstBuilderDerived};
     use crate::loop_analysis::{Loop, LoopAnalysis};
     use alloc::vec::Vec;
 

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -526,7 +526,7 @@ mod test {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::types::*;
     use crate::ir::UserFuncName;
-    use crate::ir::{AbiParam, Function, InstBuilder, Signature};
+    use crate::ir::{AbiParam, Function, InstBuilder, InstBuilderDerived, Signature};
     use crate::isa::CallConv;
 
     fn build_test_func(n_blocks: usize, edges: &[(usize, usize)]) -> Function {

--- a/cranelift/codegen/src/simple_preopt.rs
+++ b/cranelift/codegen/src/simple_preopt.rs
@@ -12,7 +12,8 @@ use crate::ir::{
     condcodes::{CondCode, IntCC},
     instructions::Opcode,
     types::{I128, I32, I64},
-    Block, DataFlowGraph, Function, Inst, InstBuilder, InstructionData, Type, Value,
+    Block, DataFlowGraph, Function, Inst, InstBuilder, InstBuilderDerived, InstructionData, Type,
+    Value,
 };
 use crate::isa::TargetIsa;
 use crate::timing;

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1098,8 +1098,11 @@ mod tests {
     use alloc::string::ToString;
     use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::condcodes::IntCC;
-    use cranelift_codegen::ir::{types::*, UserFuncName};
-    use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, Value};
+    use cranelift_codegen::ir::types::*;
+    use cranelift_codegen::ir::{
+        AbiParam, Function, InstBuilder, InstBuilderDerived, MemFlags, Signature, UserFuncName,
+        Value,
+    };
     use cranelift_codegen::isa::{CallConv, TargetFrontendConfig, TargetIsa};
     use cranelift_codegen::settings;
     use cranelift_codegen::verifier::verify_function;

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -17,7 +17,8 @@ use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
 use cranelift_codegen::ir::instructions::BranchInfo;
 use cranelift_codegen::ir::types::{F32, F64, I128, I64};
 use cranelift_codegen::ir::{
-    Block, Function, Inst, InstBuilder, InstructionData, JumpTableData, Type, Value,
+    Block, Function, Inst, InstBuilder, InstBuilderDerived, InstructionData, JumpTableData, Type,
+    Value,
 };
 use cranelift_codegen::packed_option::PackedOption;
 
@@ -679,7 +680,9 @@ mod tests {
     use cranelift_codegen::entity::EntityRef;
     use cranelift_codegen::ir::instructions::BranchInfo;
     use cranelift_codegen::ir::types::*;
-    use cranelift_codegen::ir::{Function, Inst, InstBuilder, JumpTableData, Opcode};
+    use cranelift_codegen::ir::{
+        Function, Inst, InstBuilder, InstBuilderDerived, JumpTableData, Opcode,
+    };
     use cranelift_codegen::settings;
     use cranelift_codegen::verify_function;
 

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -12,8 +12,8 @@ use cranelift::codegen::ir::{
 use cranelift::codegen::isa::CallConv;
 use cranelift::frontend::{FunctionBuilder, FunctionBuilderContext, Switch, Variable};
 use cranelift::prelude::{
-    EntityRef, ExtFuncData, FloatCC, InstBuilder, IntCC, JumpTableData, MemFlags, StackSlotData,
-    StackSlotKind,
+    EntityRef, ExtFuncData, FloatCC, InstBuilder, InstBuilderDerived, IntCC, JumpTableData,
+    MemFlags, StackSlotData, StackSlotKind,
 };
 use std::collections::HashMap;
 use std::ops::RangeInclusive;

--- a/cranelift/preopt/src/constant_folding.rs
+++ b/cranelift/preopt/src/constant_folding.rs
@@ -3,7 +3,7 @@
 
 use cranelift_codegen::{
     cursor::{Cursor, FuncCursor},
-    ir::{self, dfg::ValueDef, InstBuilder},
+    ir::{self, dfg::ValueDef, InstBuilder, InstBuilderDerived},
 };
 // use rustc_apfloat::{
 //     ieee::{Double, Single},

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -36,8 +36,9 @@ pub mod prelude {
     pub use crate::codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Uimm64};
     pub use crate::codegen::ir::types;
     pub use crate::codegen::ir::{
-        AbiParam, Block, ExtFuncData, ExternalName, GlobalValueData, InstBuilder, JumpTableData,
-        MemFlags, Signature, StackSlotData, StackSlotKind, TrapCode, Type, Value,
+        AbiParam, Block, ExtFuncData, ExternalName, GlobalValueData, InstBuilder,
+        InstBuilderDerived, JumpTableData, MemFlags, Signature, StackSlotData, StackSlotKind,
+        TrapCode, Type, Value,
     };
     pub use crate::codegen::isa;
     pub use crate::codegen::settings::{self, Configurable};

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -87,7 +87,8 @@ use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{
-    self, AtomicRmwOp, ConstantData, InstBuilder, JumpTableData, MemFlags, Value, ValueLabel,
+    self, AtomicRmwOp, ConstantData, InstBuilder, InstBuilderDerived, JumpTableData, MemFlags,
+    Value, ValueLabel,
 };
 use cranelift_codegen::packed_option::ReservedValue;
 use cranelift_frontend::{FunctionBuilder, Variable};

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3,7 +3,9 @@ use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::*;
 use cranelift_codegen::ir::immediates::{Imm64, Offset32, Uimm64};
 use cranelift_codegen::ir::types::*;
-use cranelift_codegen::ir::{AbiParam, ArgumentPurpose, Function, InstBuilder, Signature};
+use cranelift_codegen::ir::{
+    AbiParam, ArgumentPurpose, Function, InstBuilder, InstBuilderDerived, Signature,
+};
 use cranelift_codegen::isa::{self, TargetFrontendConfig, TargetIsa};
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_frontend::FunctionBuilder;


### PR DESCRIPTION
Add the `InsnBuilderDerived` trait as a place to add new derived builder functions. Also add support in the instruction specificaton dsl for marking instructions as `raw`, which indicates that their generated builder function is not meant to be the primary interface for generating that instruction.

As an example, port over the `jump` builder function with an implementation that dispatches directly to the raw `jump_` builder function. This functionality will greatly simplify landing #5464, where the largest portion of the diff is due to the arguments of the `jump` builder function changing.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
