### PR TITLE
fuzzgen: Add `bitcast`

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -272,9 +272,7 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::IaddCout, &[I8, I8], &[I8, I8], insert_opcode),
     #[cfg(not(target_arch = "x86_64"))]
     (Opcode::IaddCout, &[I16, I16], &[I16, I8], insert_opcode),
-    #[cfg(not(target_arch = "x86_64"))]
     (Opcode::IaddCout, &[I32, I32], &[I32, I8], insert_opcode),
-    #[cfg(not(target_arch = "x86_64"))]
     (Opcode::IaddCout, &[I64, I64], &[I64, I8], insert_opcode),
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     (Opcode::IaddCout, &[I128, I128], &[I128, I8], insert_opcode),

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -188,6 +188,26 @@ fn insert_const(
     Ok(())
 }
 
+fn insert_bitcast(
+    fgen: &mut FunctionGenerator,
+    builder: &mut FunctionBuilder,
+    _opcode: Opcode,
+    args: &'static [Type],
+    rets: &'static [Type],
+) -> Result<()> {
+    let from_var = fgen.get_variable_of_type(args[0])?;
+    let from_val = builder.use_var(from_var);
+
+    let to_var = fgen.get_variable_of_type(rets[0])?;
+
+    // TODO: We can generate little/big endian flags here.
+    let memflags = MemFlags::new();
+
+    let res = builder.ins().bitcast(rets[0], memflags, from_val);
+    builder.def_var(to_var, res);
+    Ok(())
+}
+
 fn insert_load_store(
     fgen: &mut FunctionGenerator,
     builder: &mut FunctionBuilder,
@@ -1017,6 +1037,11 @@ const OPCODE_SIGNATURES: &'static [(
     (Opcode::Istore16, &[I32], &[], insert_load_store),
     (Opcode::Istore16, &[I64], &[], insert_load_store),
     (Opcode::Istore32, &[I64], &[], insert_load_store),
+    // Bitcast
+    (Opcode::Bitcast, &[F32], &[I32], insert_bitcast),
+    (Opcode::Bitcast, &[I32], &[F32], insert_bitcast),
+    (Opcode::Bitcast, &[F64], &[I64], insert_bitcast),
+    (Opcode::Bitcast, &[I64], &[F64], insert_bitcast),
     // Integer Consts
     (Opcode::Iconst, &[], &[I8], insert_const),
     (Opcode::Iconst, &[], &[I16], insert_const),


### PR DESCRIPTION
👋 Hey,

This adds `bitcast` and also enables the `iadd_cout` instruction for x86 that was added in #5285.