### PR TITLE
Document wasmtime-rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ the implementation:
 * **[Python]** - the [`wasmtime` PyPI package]
 * **[.NET]** - the [`Wasmtime` NuGet package]
 * **[Go]** - the [`wasmtime-go` repository]
+* **[Ruby]** - the [`wasmtime` gem]
 
 [Rust]: https://bytecodealliance.github.io/wasmtime/lang-rust.html
 [C]: https://bytecodealliance.github.io/wasmtime/examples-c-embed.html
@@ -130,6 +131,8 @@ the implementation:
 [wasmtime-cpp]: https://github.com/bytecodealliance/wasmtime-cpp
 [`wasmtime` Conan package]: https://conan.io/center/wasmtime
 [`wasmtime-cpp` Conan package]: https://conan.io/center/wasmtime-cpp
+[Ruby]: https://bytecodealliance.github.io/wasmtime/lang-ruby.html
+[`wasmtime` gem]: https://rubygems.org/gems/wasmtime
 
 ## Documentation
 

--- a/docs/lang-ruby.md
+++ b/docs/lang-ruby.md
@@ -1,0 +1,63 @@
+# Using WebAssembly from Ruby
+
+Wasmtime [is available on RubyGems](https://rubygems.org/gems/wasmtime) and can
+be used programmatically to interact with Wasm modules. This guide will go over
+installing the Wasmtime gem and running a simple Wasm module from Ruby.
+
+Make sure you've got Ruby 3.0 or newer installed locally, and we can get
+started!
+
+## Getting started and simple example
+
+First, copy this example WebAssembly text module into your project. It exports
+a function for calculating the greatest common denominator of two numbers.
+
+```wat
+{{#include ../examples/gcd.wat}}
+```
+
+Next, install the Wasmtime Ruby gems by either adding it your project's
+`Gemfile`:
+
+```bash
+bundle add wasmtime
+```
+
+Or by using the `gem` command directly:
+
+```bash
+gem install wasmtime
+```
+
+The gem has a Rust-based native extension, but thanks to precompiled gems, you
+should not have to compile anything. It'll just work!
+
+Now that you have the Wasmtime gem installed, let's create a Ruby script to
+execute the `gcd` module from before.
+
+```ruby
+require "wasmtime"
+
+engine = Wasmtime::Engine.new
+mod = Wasmtime::Module.from_file(engine, "gcd.wat")
+store = Wasmtime::Store.new(engine)
+instance = Wasmtime::Instance.new(store, mod)
+
+puts "gcd(27, 6) = #{instance.invoke("gcd", 27, 6)}"
+```
+
+This script should output
+
+```bash
+gcd(27, 6) = 3
+```
+
+If this is the output you see, congrats! You've successfully ran your first
+WebAssembly code in Ruby!
+
+## More examples and contributing
+
+To learn more, check out the [more adavanced examples](https://github.com/bytecodealliance/wasmtime-rb/tree/main/examples)
+and the [API documentation](https://bytecodealliance.github.io/wasmtime-rb/latest/).
+If you have any questions or found an issue, make sure to open an issue on the
+[GitHub repository](https://github.com/bytecodealliance/wasmtime-rb).

--- a/docs/lang-ruby.md
+++ b/docs/lang-ruby.md
@@ -57,7 +57,7 @@ WebAssembly code in Ruby!
 
 ## More examples and contributing
 
-To learn more, check out the [more adavanced examples](https://github.com/bytecodealliance/wasmtime-rb/tree/main/examples)
+To learn more, check out the [more advanced examples](https://github.com/bytecodealliance/wasmtime-rb/tree/main/examples)
 and the [API documentation](https://bytecodealliance.github.io/wasmtime-rb/latest/).
-If you have any questions or found an issue, make sure to open an issue on the
+If you have any questions, do not hesitate to open an issue on the
 [GitHub repository](https://github.com/bytecodealliance/wasmtime-rb).

--- a/docs/stability-release.md
+++ b/docs/stability-release.md
@@ -56,6 +56,7 @@ release is made, such as:
 * [`wasmtime-py`](https://github.com/bytecodealliance/wasmtime-py)
 * [`wasmtime-go`](https://github.com/bytecodealliance/wasmtime-go)
 * [`wasmtime-cpp`](https://github.com/bytecodealliance/wasmtime-cpp)
+* [`wasmtime-rb`](https://github.com/bytecodealliance/wasmtime-rb)
 
 Note, though, that bugs and security issues in these projects do not at this
 time warrant patch releases for Wasmtime.


### PR DESCRIPTION
Add doc page for the Ruby embedding of Wasmtime. I've essentially searched for `wasmtime-go` and `wasmtime-py` and made sure `wasmtime-rb` was also mentioned where it made sense.

I've just released v0.4.0 of the Ruby embedding, and planning on releasing v4.0.0 in the new year, matching Wasmtime's version number. While the current released version is still in 0.x, it's starting to look pretty good; the current API should be relatively stable. We can start suggesting people try it out, hence this PR.