### PR TITLE
Add more links to Ruby bindings

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
   - [.NET](./lang-dotnet.md)
   - [Go](./lang-go.md)
   - [Bash](./lang-bash.md)
+  - [Ruby](./lang-ruby.md)
 - [Using the `wasmtime` CLI](./cli.md)
   - [Installation](./cli-install.md)
   - [CLI Options](./cli-options.md)

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -10,3 +10,4 @@ through a C API for a number of other languages too:
 * [.NET](lang-dotnet.md)
 * [Go](lang-go.md)
 * [Bash](lang-bash.md)
+* [Ruby](lang-ruby.md)


### PR DESCRIPTION
PR #5485 added doc pages for the Ruby bindings, but didn't link to it from the sidebar nor lang page. This commit fixes that.

Sorry about that!