### PR TITLE
Update wasi-tests to wasi 0.11.

### DIFF
--- a/crates/test-programs/wasi-tests/Cargo.lock
+++ b/crates/test-programs/wasi-tests/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-tests"

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 libc = "0.2.65"
-wasi = "0.10.2"
+wasi = "0.11.0"
 once_cell = "1.12"
 
 # This crate is built with the wasm32-wasi target, so it's separate

--- a/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
+++ b/crates/test-programs/wasi-tests/src/bin/close_preopen.rs
@@ -8,17 +8,14 @@ unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
 
     // Try to close a preopened directory handle.
     assert_errno!(
-        wasi::fd_close(pre_fd)
-            .expect_err("closing a preopened file descriptor")
-            .raw_error(),
+        wasi::fd_close(pre_fd).expect_err("closing a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 
     // Try to renumber over a preopened directory handle.
     assert_errno!(
         wasi::fd_renumber(dir_fd, pre_fd)
-            .expect_err("renumbering over a preopened file descriptor")
-            .raw_error(),
+            .expect_err("renumbering over a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 
@@ -33,8 +30,7 @@ unsafe fn test_close_preopen(dir_fd: wasi::Fd) {
     // Try to renumber a preopened directory handle.
     assert_errno!(
         wasi::fd_renumber(pre_fd, dir_fd)
-            .expect_err("renumbering over a preopened file descriptor")
-            .raw_error(),
+            .expect_err("renumbering over a preopened file descriptor"),
         wasi::ERRNO_NOTSUP
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/dangling_symlink.rs
+++ b/crates/test-programs/wasi-tests/src/bin/dangling_symlink.rs
@@ -9,8 +9,7 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
         // Try to open it as a directory with O_NOFOLLOW.
         assert_errno!(
             wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                .expect_err("opening a dangling symlink as a directory")
-                .raw_error(),
+                .expect_err("opening a dangling symlink as a directory"),
             wasi::ERRNO_NOTDIR,
             wasi::ERRNO_LOOP
         );
@@ -18,8 +17,7 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
         // Try to open it as a file with O_NOFOLLOW.
         assert_errno!(
             wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
-                .expect_err("opening a dangling symlink as a file")
-                .raw_error(),
+                .expect_err("opening a dangling symlink as a file"),
             wasi::ERRNO_LOOP
         );
 

--- a/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
+++ b/crates/test-programs/wasi-tests/src/bin/directory_seek.rs
@@ -23,9 +23,7 @@ unsafe fn test_directory_seek(dir_fd: wasi::Fd) {
 
     // Attempt to seek.
     assert_errno!(
-        wasi::fd_seek(fd, 0, wasi::WHENCE_CUR)
-            .expect_err("seek on a directory")
-            .raw_error(),
+        wasi::fd_seek(fd, 0, wasi::WHENCE_CUR).expect_err("seek on a directory"),
         wasi::ERRNO_BADF
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/fd_filestat_get.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_filestat_get.rs
@@ -1,5 +1,4 @@
 unsafe fn test_fd_filestat_get() {
-
     let stat = wasi::fd_filestat_get(libc::STDIN_FILENO as u32).expect("failed filestat 0");
     assert_eq!(stat.size, 0, "stdio size should be 0");
     assert_eq!(stat.atim, 0, "stdio atim should be 0");

--- a/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
+++ b/crates/test-programs/wasi-tests/src/bin/file_seek_tell.rs
@@ -57,8 +57,7 @@ unsafe fn test_file_seek_tell(dir_fd: wasi::Fd) {
     // Seek before byte 0 is an error though
     assert_errno!(
         wasi::fd_seek(file_fd, -2000, wasi::WHENCE_CUR)
-            .expect_err("seeking before byte 0 should be an error")
-            .raw_error(),
+            .expect_err("seeking before byte 0 should be an error"),
         wasi::ERRNO_INVAL
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
+++ b/crates/test-programs/wasi-tests/src/bin/interesting_paths.rs
@@ -14,8 +14,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open it with an absolute path.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "/dir/nested/file", 0, 0, 0, 0)
-            .expect_err("opening a file with an absolute path")
-            .raw_error(),
+            .expect_err("opening a file with an absolute path"),
         wasi::ERRNO_PERM
     );
 
@@ -39,8 +38,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open it with a trailing NUL.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "dir/nested/file\0", 0, 0, 0, 0)
-            .expect_err("opening a file with a trailing NUL")
-            .raw_error(),
+            .expect_err("opening a file with a trailing NUL"),
         wasi::ERRNO_INVAL,
         wasi::ERRNO_ILSEQ
     );
@@ -48,8 +46,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open it with a trailing slash.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "dir/nested/file/", 0, 0, 0, 0)
-            .expect_err("opening a file with a trailing slash should fail")
-            .raw_error(),
+            .expect_err("opening a file with a trailing slash should fail"),
         wasi::ERRNO_NOTDIR,
         wasi::ERRNO_NOENT
     );
@@ -57,8 +54,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     // Now open it with trailing slashes.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "dir/nested/file///", 0, 0, 0, 0)
-            .expect_err("opening a file with trailing slashes should fail")
-            .raw_error(),
+            .expect_err("opening a file with trailing slashes should fail"),
         wasi::ERRNO_NOTDIR,
         wasi::ERRNO_NOENT
     );
@@ -85,8 +81,7 @@ unsafe fn test_interesting_paths(dir_fd: wasi::Fd, arg: &str) {
     let bad_path = format!("dir/nested/../../../{}/dir/nested/file", arg);
     assert_errno!(
         wasi::path_open(dir_fd, 0, &bad_path, 0, 0, 0, 0)
-            .expect_err("opening a file with too many \"..\"s in the path should fail")
-            .raw_error(),
+            .expect_err("opening a file with too many \"..\"s in the path should fail"),
         wasi::ERRNO_PERM
     );
     wasi::path_unlink_file(dir_fd, "dir/nested/file")

--- a/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
+++ b/crates/test-programs/wasi-tests/src/bin/nofollow_errors.rs
@@ -11,8 +11,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
     // Try to open it as a directory with O_NOFOLLOW again.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-            .expect_err("opening a directory symlink as a directory should fail")
-            .raw_error(),
+            .expect_err("opening a directory symlink as a directory should fail"),
         wasi::ERRNO_LOOP,
         wasi::ERRNO_NOTDIR
     );
@@ -20,8 +19,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
     // Try to open it with just O_NOFOLLOW.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
-            .expect_err("opening a symlink with O_NOFOLLOW should fail")
-            .raw_error(),
+            .expect_err("opening a symlink with O_NOFOLLOW should fail"),
         wasi::ERRNO_LOOP,
         wasi::ERRNO_ACCES
     );
@@ -56,8 +54,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
     // Try to open it as a directory with O_NOFOLLOW again.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-            .expect_err("opening a directory symlink as a directory should fail")
-            .raw_error(),
+            .expect_err("opening a directory symlink as a directory should fail"),
         wasi::ERRNO_LOOP,
         wasi::ERRNO_NOTDIR
     );
@@ -65,8 +62,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
     // Try to open it with just O_NOFOLLOW.
     assert_errno!(
         wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
-            .expect_err("opening a symlink with NOFOLLOW should fail")
-            .raw_error(),
+            .expect_err("opening a symlink with NOFOLLOW should fail"),
         wasi::ERRNO_LOOP
     );
 
@@ -81,8 +77,7 @@ unsafe fn test_nofollow_errors(dir_fd: wasi::Fd) {
             0,
             0,
         )
-        .expect_err("opening a symlink to a file as a directory")
-        .raw_error(),
+        .expect_err("opening a symlink to a file as a directory"),
         wasi::ERRNO_NOTDIR
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_filestat.rs
@@ -67,8 +67,7 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
                 0,
                 wasi::FDFLAGS_SYNC,
             )
-            .expect_err("FDFLAGS_SYNC not supported by platform")
-            .raw_error(),
+            .expect_err("FDFLAGS_SYNC not supported by platform"),
             wasi::ERRNO_NOTSUP
         );
     }
@@ -95,8 +94,7 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
             new_mtim,
             wasi::FSTFLAGS_MTIM | wasi::FSTFLAGS_MTIM_NOW,
         )
-        .expect_err("MTIM and MTIM_NOW can't both be set")
-        .raw_error(),
+        .expect_err("MTIM and MTIM_NOW can't both be set"),
         wasi::ERRNO_INVAL
     );
 
@@ -118,8 +116,7 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
             0,
             wasi::FSTFLAGS_ATIM | wasi::FSTFLAGS_ATIM_NOW,
         )
-        .expect_err("ATIM & ATIM_NOW can't both be set")
-        .raw_error(),
+        .expect_err("ATIM & ATIM_NOW can't both be set"),
         wasi::ERRNO_INVAL
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/path_link.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_link.rs
@@ -101,8 +101,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_link(dir_fd, 0, "file", dir_fd, "link")
-            .expect_err("creating a link to existing path should fail")
-            .raw_error(),
+            .expect_err("creating a link to existing path should fail"),
         wasi::ERRNO_EXIST
     );
     wasi::path_unlink_file(dir_fd, "link").expect("removing a file");
@@ -110,8 +109,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
     // Create a link to itself
     assert_errno!(
         wasi::path_link(dir_fd, 0, "file", dir_fd, "file")
-            .expect_err("creating a link to itself should fail")
-            .raw_error(),
+            .expect_err("creating a link to itself should fail"),
         wasi::ERRNO_EXIST
     );
 
@@ -120,8 +118,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_link(dir_fd, 0, "file", dir_fd, "link")
-            .expect_err("creating a link where target is a directory should fail")
-            .raw_error(),
+            .expect_err("creating a link where target is a directory should fail"),
         wasi::ERRNO_EXIST
     );
     wasi::path_remove_directory(dir_fd, "link").expect("removing a dir");
@@ -132,8 +129,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_link(dir_fd, 0, "subdir", dir_fd, "link")
-            .expect_err("creating a link to a directory should fail")
-            .raw_error(),
+            .expect_err("creating a link to a directory should fail"),
         wasi::ERRNO_PERM,
         wasi::ERRNO_ACCES
     );
@@ -143,8 +139,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
     // Create a link to a file with trailing slash
     assert_errno!(
         wasi::path_link(dir_fd, 0, "file", dir_fd, "link/")
-            .expect_err("creating a link to a file with trailing slash should fail")
-            .raw_error(),
+            .expect_err("creating a link to a file with trailing slash should fail"),
         wasi::ERRNO_NOENT
     );
 
@@ -171,8 +166,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
 
         assert_errno!(
             wasi::path_link(dir_fd, 0, "file", dir_fd, "symlink")
-                .expect_err("creating a link where target is a dangling symlink")
-                .raw_error(),
+                .expect_err("creating a link where target is a dangling symlink"),
             wasi::ERRNO_EXIST
         );
         wasi::path_unlink_file(dir_fd, "symlink").expect("removing a symlink");
@@ -189,8 +183,7 @@ unsafe fn test_path_link(dir_fd: wasi::Fd) {
                 dir_fd,
                 "link",
             )
-            .expect_err("calling path_link with LOOKUPFLAGS_SYMLINK_FOLLOW should fail")
-            .raw_error(),
+            .expect_err("calling path_link with LOOKUPFLAGS_SYMLINK_FOLLOW should fail"),
             wasi::ERRNO_INVAL
         );
 

--- a/crates/test-programs/wasi-tests/src/bin/path_open_create_existing.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_create_existing.rs
@@ -13,8 +13,7 @@ unsafe fn test_path_open_create_existing(dir_fd: wasi::Fd) {
             0,
             0,
         )
-        .expect_err("trying to create a file that already exists")
-        .raw_error(),
+        .expect_err("trying to create a file that already exists"),
         wasi::ERRNO_EXIST
     );
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");

--- a/crates/test-programs/wasi-tests/src/bin/path_open_dirfd_not_dir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_dirfd_not_dir.rs
@@ -8,8 +8,7 @@ unsafe fn test_dirfd_not_dir(dir_fd: wasi::Fd) {
     // Now try to open a file underneath it as if it were a directory.
     assert_errno!(
         wasi::path_open(file_fd, 0, "foo", wasi::OFLAGS_CREAT, 0, 0, 0)
-            .expect_err("non-directory base fd should get ERRNO_NOTDIR")
-            .raw_error(),
+            .expect_err("non-directory base fd should get ERRNO_NOTDIR"),
         wasi::ERRNO_NOTDIR
     );
     wasi::fd_close(file_fd).expect("closing a file");

--- a/crates/test-programs/wasi-tests/src/bin/path_open_missing.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_missing.rs
@@ -7,8 +7,7 @@ unsafe fn test_path_open_missing(dir_fd: wasi::Fd) {
             dir_fd, 0, "file", 0, // not passing O_CREAT here
             0, 0, 0,
         )
-        .expect_err("trying to open a file that doesn't exist")
-        .raw_error(),
+        .expect_err("trying to open a file that doesn't exist"),
         wasi::ERRNO_NOENT
     );
 }

--- a/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_read_without_rights.rs
@@ -27,9 +27,7 @@ unsafe fn try_read_file(dir_fd: wasi::Fd) {
     // Since we no longer have the right to fd_read, trying to read a file
     // should be an error.
     assert_errno!(
-        wasi::fd_read(fd, &[iovec])
-            .expect_err("reading bytes from file should fail")
-            .raw_error(),
+        wasi::fd_read(fd, &[iovec]).expect_err("reading bytes from file should fail"),
         wasi::ERRNO_BADF
     );
 }

--- a/crates/test-programs/wasi-tests/src/bin/path_rename.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_rename.rs
@@ -12,8 +12,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     // Check that source directory doesn't exist anymore
     assert_errno!(
         wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-            .expect_err("opening a nonexistent path as a directory should fail")
-            .raw_error(),
+            .expect_err("opening a nonexistent path as a directory should fail"),
         wasi::ERRNO_NOENT
     );
 
@@ -41,8 +40,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
         // Check that source directory doesn't exist anymore
         assert_errno!(
             wasi::path_open(dir_fd, 0, "source", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
-                .expect_err("opening a nonexistent path as a directory")
-                .raw_error(),
+                .expect_err("opening a nonexistent path as a directory"),
             wasi::ERRNO_NOENT
         );
 
@@ -72,8 +70,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target")
-            .expect_err("renaming directory to a nonempty directory")
-            .raw_error(),
+            .expect_err("renaming directory to a nonempty directory"),
         windows => wasi::ERRNO_ACCES,
         unix => wasi::ERRNO_NOTEMPTY
     );
@@ -85,8 +82,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
         // Try renaming dir to a file
         assert_errno!(
             wasi::path_rename(dir_fd, "source", dir_fd, "target/file")
-                .expect_err("renaming a directory to a file")
-                .raw_error(),
+                .expect_err("renaming a directory to a file"),
             wasi::ERRNO_NOTDIR
         );
         wasi::path_unlink_file(dir_fd, "target/file").expect("removing a file");
@@ -107,8 +103,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
     // Check that source file doesn't exist anymore
     assert_errno!(
         wasi::path_open(dir_fd, 0, "source", 0, 0, 0, 0)
-            .expect_err("opening a nonexistent path should fail")
-            .raw_error(),
+            .expect_err("opening a nonexistent path should fail"),
         wasi::ERRNO_NOENT
     );
 
@@ -131,9 +126,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 
     // Check that source file doesn't exist anymore
     assert_errno!(
-        wasi::path_open(dir_fd, 0, "source", 0, 0, 0, 0)
-            .expect_err("opening a nonexistent path")
-            .raw_error(),
+        wasi::path_open(dir_fd, 0, "source", 0, 0, 0, 0).expect_err("opening a nonexistent path"),
         wasi::ERRNO_NOENT
     );
 
@@ -153,8 +146,7 @@ unsafe fn test_path_rename(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_rename(dir_fd, "source", dir_fd, "target")
-            .expect_err("renaming a file to existing directory should fail")
-            .raw_error(),
+            .expect_err("renaming a file to existing directory should fail"),
         windows => wasi::ERRNO_ACCES,
         unix => wasi::ERRNO_ISDIR
     );

--- a/crates/test-programs/wasi-tests/src/bin/path_rename_file_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_rename_file_trailing_slashes.rs
@@ -11,20 +11,19 @@ unsafe fn test_path_rename_trailing_slashes(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_rename(dir_fd, "source/", dir_fd, "target")
-            .expect_err("renaming a file with a trailing slash in the source name should fail")
-            .raw_error(),
+            .expect_err("renaming a file with a trailing slash in the source name should fail"),
         wasi::ERRNO_NOTDIR
     );
     assert_errno!(
-        wasi::path_rename(dir_fd, "source", dir_fd, "target/")
-            .expect_err("renaming a file with a trailing slash in the destination name should fail")
-            .raw_error(),
+        wasi::path_rename(dir_fd, "source", dir_fd, "target/").expect_err(
+            "renaming a file with a trailing slash in the destination name should fail"
+        ),
         wasi::ERRNO_NOTDIR
     );
     assert_errno!(
-        wasi::path_rename(dir_fd, "source/", dir_fd, "target/")
-            .expect_err("renaming a file with a trailing slash in the source and destination names should fail")
-            .raw_error(),
+        wasi::path_rename(dir_fd, "source/", dir_fd, "target/").expect_err(
+            "renaming a file with a trailing slash in the source and destination names should fail"
+        ),
         wasi::ERRNO_NOTDIR
     );
     wasi::path_unlink_file(dir_fd, "source").expect("removing a file");

--- a/crates/test-programs/wasi-tests/src/bin/path_symlink_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_symlink_trailing_slashes.rs
@@ -6,8 +6,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
         // Dangling symlink: Link destination shouldn't end with a slash.
         assert_errno!(
             wasi::path_symlink("source", dir_fd, "target/")
-                .expect_err("link destination ending with a slash should fail")
-                .raw_error(),
+                .expect_err("link destination ending with a slash should fail"),
             wasi::ERRNO_NOENT
         );
 
@@ -21,8 +20,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
     wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
     assert_errno!(
         wasi::path_symlink("source", dir_fd, "target/")
-            .expect_err("link destination already exists")
-            .raw_error(),
+            .expect_err("link destination already exists"),
         unix => wasi::ERRNO_EXIST,
         windows => wasi::ERRNO_NOENT
     );
@@ -32,8 +30,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
     wasi::path_create_directory(dir_fd, "target").expect("creating a directory");
     assert_errno!(
         wasi::path_symlink("source", dir_fd, "target")
-            .expect_err("link destination already exists")
-            .raw_error(),
+            .expect_err("link destination already exists"),
         unix => wasi::ERRNO_EXIST,
         windows => wasi::ERRNO_NOENT
     );
@@ -44,8 +41,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_symlink("source", dir_fd, "target/")
-            .expect_err("link destination already exists")
-            .raw_error(),
+            .expect_err("link destination already exists"),
         unix => wasi::ERRNO_NOTDIR,
         windows => wasi::ERRNO_NOENT
     );
@@ -56,8 +52,7 @@ unsafe fn test_path_symlink_trailing_slashes(dir_fd: wasi::Fd) {
 
     assert_errno!(
         wasi::path_symlink("source", dir_fd, "target")
-            .expect_err("link destination already exists")
-            .raw_error(),
+            .expect_err("link destination already exists"),
         unix => wasi::ERRNO_EXIST,
         windows => wasi::ERRNO_NOENT
     );

--- a/crates/test-programs/wasi-tests/src/bin/readlink.rs
+++ b/crates/test-programs/wasi-tests/src/bin/readlink.rs
@@ -25,7 +25,7 @@ unsafe fn test_readlink(dir_fd: wasi::Fd) {
     let err = wasi::path_readlink(dir_fd, "symlink", buf.as_mut_ptr(), buf.len())
         .err()
         .expect("readlink with too-small buffer should fail");
-    assert_errno!(err.raw_error(), wasi::ERRNO_RANGE);
+    assert_errno!(err, wasi::ERRNO_RANGE);
 
     // Clean up.
     wasi::path_unlink_file(dir_fd, "target").expect("removing a file");

--- a/crates/test-programs/wasi-tests/src/bin/remove_directory_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/remove_directory_trailing_slashes.rs
@@ -21,16 +21,14 @@ unsafe fn test_remove_directory_trailing_slashes(dir_fd: wasi::Fd) {
     // Test that removing it with no trailing slash fails.
     assert_errno!(
         wasi::path_remove_directory(dir_fd, "file")
-            .expect_err("remove_directory without a trailing slash on a file should fail")
-            .raw_error(),
+            .expect_err("remove_directory without a trailing slash on a file should fail"),
         wasi::ERRNO_NOTDIR
     );
 
     // Test that removing it with a trailing slash fails.
     assert_errno!(
         wasi::path_remove_directory(dir_fd, "file/")
-            .expect_err("remove_directory with a trailing slash on a file should fail")
-            .raw_error(),
+            .expect_err("remove_directory with a trailing slash on a file should fail"),
         unix => wasi::ERRNO_NOTDIR,
         windows => wasi::ERRNO_NOENT
     );

--- a/crates/test-programs/wasi-tests/src/bin/remove_nonempty_directory.rs
+++ b/crates/test-programs/wasi-tests/src/bin/remove_nonempty_directory.rs
@@ -11,8 +11,7 @@ unsafe fn test_remove_nonempty_directory(dir_fd: wasi::Fd) {
     // Test that attempting to unlink the first directory returns the expected error code.
     assert_errno!(
         wasi::path_remove_directory(dir_fd, "dir")
-            .expect_err("remove_directory on a directory should return ENOTEMPTY")
-            .raw_error(),
+            .expect_err("remove_directory on a directory should return ENOTEMPTY"),
         wasi::ERRNO_NOTEMPTY
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/renumber.rs
+++ b/crates/test-programs/wasi-tests/src/bin/renumber.rs
@@ -47,9 +47,7 @@ unsafe fn test_renumber(dir_fd: wasi::Fd) {
 
     // Ensure that fd_from is closed
     assert_errno!(
-        wasi::fd_close(fd_from)
-            .expect_err("closing already closed file descriptor")
-            .raw_error(),
+        wasi::fd_close(fd_from).expect_err("closing already closed file descriptor"),
         wasi::ERRNO_BADF
     );
 

--- a/crates/test-programs/wasi-tests/src/bin/symlink_loop.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_loop.rs
@@ -9,8 +9,7 @@ unsafe fn test_symlink_loop(dir_fd: wasi::Fd) {
         // Try to open it.
         assert_errno!(
             wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
-                .expect_err("opening a self-referencing symlink")
-                .raw_error(),
+                .expect_err("opening a self-referencing symlink"),
             wasi::ERRNO_LOOP
         );
 

--- a/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
+++ b/crates/test-programs/wasi-tests/src/bin/truncation_rights.rs
@@ -66,8 +66,7 @@ unsafe fn test_truncation_rights(dir_fd: wasi::Fd) {
         // wasi_unstable::RIGHT_PATH_FILESTAT_SET_SIZE right.
         assert_errno!(
             wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_TRUNC, 0, 0, 0)
-                .expect_err("truncating a file without path_filestat_set_size right")
-                .raw_error(),
+                .expect_err("truncating a file without path_filestat_set_size right"),
             wasi::ERRNO_PERM
         );
     }

--- a/crates/test-programs/wasi-tests/src/bin/unlink_file_trailing_slashes.rs
+++ b/crates/test-programs/wasi-tests/src/bin/unlink_file_trailing_slashes.rs
@@ -8,8 +8,7 @@ unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
     // Test that unlinking it fails.
     assert_errno!(
         wasi::path_unlink_file(dir_fd, "dir")
-            .expect_err("unlink_file on a directory should fail")
-            .raw_error(),
+            .expect_err("unlink_file on a directory should fail"),
         macos => wasi::ERRNO_PERM,
         unix => wasi::ERRNO_ISDIR,
         windows => wasi::ERRNO_ACCES
@@ -18,8 +17,7 @@ unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
     // Test that unlinking it with a trailing flash fails.
     assert_errno!(
         wasi::path_unlink_file(dir_fd, "dir/")
-            .expect_err("unlink_file on a directory should fail")
-            .raw_error(),
+            .expect_err("unlink_file on a directory should fail"),
         macos => wasi::ERRNO_PERM,
         unix => wasi::ERRNO_ISDIR,
         windows => wasi::ERRNO_ACCES
@@ -34,8 +32,7 @@ unsafe fn test_unlink_file_trailing_slashes(dir_fd: wasi::Fd) {
     // Test that unlinking it with a trailing flash fails.
     assert_errno!(
         wasi::path_unlink_file(dir_fd, "file/")
-            .expect_err("unlink_file with a trailing slash should fail")
-            .raw_error(),
+            .expect_err("unlink_file with a trailing slash should fail"),
         unix => wasi::ERRNO_NOTDIR,
         windows => wasi::ERRNO_NOENT
     );

--- a/crates/test-programs/wasi-tests/src/lib.rs
+++ b/crates/test-programs/wasi-tests/src/lib.rs
@@ -18,7 +18,7 @@ pub fn open_scratch_directory(path: &str) -> Result<wasi::Fd, String> {
                 Ok(s) => s,
                 Err(_) => break,
             };
-            if stat.tag != wasi::PREOPENTYPE_DIR {
+            if stat.tag != wasi::PREOPENTYPE_DIR.raw() {
                 continue;
             }
             let mut dst = Vec::with_capacity(stat.u.dir.pr_name_len);
@@ -122,8 +122,8 @@ macro_rules! assert_errno {
             }
             assert!( $( e == $i || )+ false,
                 "expected errno {}; got {}",
-                Alt(&[ $( wasi::errno_name($i) ),+ ]),
-                wasi::errno_name(e),
+                Alt(&[ $( $i.name() ),+ ]),
+                e.name()
             )
         }
     };


### PR DESCRIPTION
This updates the tests to version 0.11 of the wasi bindings. There aren't any fundamental changes here; this just syncs up with the latest version so that it's consistent with other users of the wasi APIs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
