### PR TITLE
Cranelift: include return values in instruction pretty print output.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2657,7 +2657,16 @@ impl Inst {
                 }
                 s
             }
-            &Inst::Ret { .. } => "ret".to_string(),
+            &Inst::Ret { ref rets } => {
+                let mut s = "ret".to_string();
+                for ret in rets {
+                    use std::fmt::Write;
+                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
+                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                }
+                s
+            }
             &Inst::AuthenticatedRet { key, is_hint, .. } => {
                 let key = match key {
                     APIKey::A => "a",

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1406,8 +1406,16 @@ impl Inst {
                 }
                 s
             }
-            &Inst::Ret { .. } => {
-                format!("ret")
+            &Inst::Ret { ref rets } => {
+                let mut s = "ret".to_string();
+                let mut empty_allocs = AllocationConsumer::default();
+                for ret in rets {
+                    use std::fmt::Write;
+                    let preg = format_reg(ret.preg, &mut empty_allocs);
+                    let vreg = format_reg(ret.vreg, allocs);
+                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                }
+                s
             }
 
             &MInst::Extend {

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -3145,9 +3145,16 @@ impl Inst {
                 }
                 s
             }
-            &Inst::Ret { link, .. } => {
+            &Inst::Ret { link, ref rets } => {
                 debug_assert_eq!(link, gpr(14));
-                format!("br {}", show_reg(link))
+                let mut s = format!("br {}", show_reg(link));
+                for ret in rets {
+                    use std::fmt::Write;
+                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
+                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                }
+                s
             }
             &Inst::Jump { dest } => {
                 let dest = dest.to_string();

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1537,7 +1537,16 @@ impl PrettyPrint for Inst {
                 s
             }
 
-            Inst::Ret { .. } => "ret".to_string(),
+            Inst::Ret { rets } => {
+                let mut s = "ret".to_string();
+                for ret in rets {
+                    use std::fmt::Write;
+                    let preg = regs::show_reg(ret.preg);
+                    let vreg = pretty_print_reg(ret.vreg, 8, allocs);
+                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                }
+                s
+            }
 
             Inst::JmpKnown { dst } => {
                 format!("{} {}", ljustify("jmp".to_string()), dst.to_string())


### PR DESCRIPTION
While experimenting I noticed that the VCode debug output did not include the operands of return instructions. This can be annoying to follow the data flow and see the full register allocation constraints. 

For example:

```
[2022-12-24T16:28:14Z TRACE cranelift_codegen::machinst::lower] built vcode: VCode {
      Entry block: 0
      v130 := v132
    Block 0:
        (original IR block: block0)
        (successor: Block 1)
        (instruction range: 0 .. 3)
      Inst 0: args %v128=%rcx %v129=%rdx
      Inst 1: addq    %v128, %v129, %v132
      Inst 2: jmp     label1
    Block 1:
        (original IR block: block1)
        (instruction range: 3 .. 4)
      Inst 3: ret
    }
```

This PR fixes that for all ISAs, the new output looks like this:

```
      Inst 3: ret %v131=%rax
```

I didn't create an issue for this since it seemed like an easy and non-controversial fix. When formatting registers I always followed what the code around it was doing, which is a bit different for each of them.

I'm not sure who should review this.