### PR TITLE
Add `clif-util compile` option to output object file

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -28,6 +28,7 @@ use inst::create_reg_env;
 use self::inst::EmitInfo;
 
 /// An AArch64 backend.
+#[derive(Clone)]
 pub struct AArch64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -194,6 +195,10 @@ impl TargetIsa for AArch64Backend {
         // We use 32-byte alignment for performance reasons, but for correctness we would only need
         // 4-byte alignment.
         32
+    }
+
+    fn cloned(&self) -> Box<dyn TargetIsa> {
+        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -28,7 +28,6 @@ use inst::create_reg_env;
 use self::inst::EmitInfo;
 
 /// An AArch64 backend.
-#[derive(Clone)]
 pub struct AArch64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -195,10 +194,6 @@ impl TargetIsa for AArch64Backend {
         // We use 32-byte alignment for performance reasons, but for correctness we would only need
         // 4-byte alignment.
         32
-    }
-
-    fn cloned(&self) -> Box<dyn TargetIsa> {
-        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -216,7 +216,7 @@ pub fn isa_builder(triple: Triple) -> IsaBuilder {
         constructor: |triple, shared_flags, builder| {
             let isa_flags = aarch64_settings::Flags::new(&shared_flags, builder);
             let backend = AArch64Backend::new_with_flags(triple, shared_flags, isa_flags);
-            Ok(Box::new(backend))
+            Ok(backend.wrapped())
         },
     }
 }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -297,6 +297,9 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
     /// The function alignment required by this ISA.
     fn function_alignment(&self) -> u32;
+
+    /// Produce an owned copy of this ISA object.
+    fn cloned(&self) -> Box<dyn TargetIsa>;
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -297,9 +297,6 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
     /// The function alignment required by this ISA.
     fn function_alignment(&self) -> u32;
-
-    /// Produce an owned copy of this ISA object.
-    fn cloned(&self) -> Box<dyn TargetIsa>;
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -53,7 +53,7 @@ use crate::machinst::{CompiledCode, CompiledCodeStencil, TextSectionBuilder, Unw
 use crate::settings;
 use crate::settings::SetResult;
 use crate::CodegenResult;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::fmt;
 use core::fmt::{Debug, Formatter};
 use target_lexicon::{triple, Architecture, PointerWidth, Triple};
@@ -142,14 +142,16 @@ impl fmt::Display for LookupError {
     }
 }
 
+/// The type of a polymorphic TargetISA object which is 'static.
+pub type OwnedTargetIsa = Arc<dyn TargetIsa>;
+
 /// Builder for a `TargetIsa`.
 /// Modify the ISA-specific settings before creating the `TargetIsa` trait object with `finish`.
 #[derive(Clone)]
 pub struct Builder {
     triple: Triple,
     setup: settings::Builder,
-    constructor:
-        fn(Triple, settings::Flags, settings::Builder) -> CodegenResult<Box<dyn TargetIsa>>,
+    constructor: fn(Triple, settings::Flags, settings::Builder) -> CodegenResult<OwnedTargetIsa>,
 }
 
 impl Builder {
@@ -169,7 +171,7 @@ impl Builder {
     /// flags are inconsistent or incompatible: for example, some
     /// platform-independent features, like general SIMD support, may
     /// need certain ISA extensions to be enabled.
-    pub fn finish(self, shared_flags: settings::Flags) -> CodegenResult<Box<dyn TargetIsa>> {
+    pub fn finish(self, shared_flags: settings::Flags) -> CodegenResult<OwnedTargetIsa> {
         (self.constructor)(self.triple, shared_flags, self.setup)
     }
 }
@@ -297,6 +299,14 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
     /// The function alignment required by this ISA.
     fn function_alignment(&self) -> u32;
+
+    /// Create a polymorphic TargetIsa from this specific implementation.
+    fn wrapped(self) -> OwnedTargetIsa
+    where
+        Self: Sized + 'static,
+    {
+        Arc::new(self)
+    }
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -28,7 +28,6 @@ use inst::crate_reg_eviroment;
 use self::inst::EmitInfo;
 
 /// An riscv64 backend.
-#[derive(Clone)]
 pub struct Riscv64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -169,10 +168,6 @@ impl TargetIsa for Riscv64Backend {
 
     fn function_alignment(&self) -> u32 {
         4
-    }
-
-    fn cloned(&self) -> Box<dyn TargetIsa> {
-        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -193,7 +193,7 @@ pub fn isa_builder(triple: Triple) -> IsaBuilder {
         constructor: |triple, shared_flags, builder| {
             let isa_flags = riscv_settings::Flags::new(&shared_flags, builder);
             let backend = Riscv64Backend::new_with_flags(triple, shared_flags, isa_flags);
-            Ok(Box::new(backend))
+            Ok(backend.wrapped())
         },
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -28,6 +28,7 @@ use inst::crate_reg_eviroment;
 use self::inst::EmitInfo;
 
 /// An riscv64 backend.
+#[derive(Clone)]
 pub struct Riscv64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -168,6 +169,10 @@ impl TargetIsa for Riscv64Backend {
 
     fn function_alignment(&self) -> u32 {
         4
+    }
+
+    fn cloned(&self) -> Box<dyn TargetIsa> {
+        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -28,7 +28,6 @@ use inst::create_machine_env;
 use self::inst::EmitInfo;
 
 /// A IBM Z backend.
-#[derive(Clone)]
 pub struct S390xBackend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -170,10 +169,6 @@ impl TargetIsa for S390xBackend {
 
     fn function_alignment(&self) -> u32 {
         4
-    }
-
-    fn cloned(&self) -> Box<dyn TargetIsa> {
-        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -28,6 +28,7 @@ use inst::create_machine_env;
 use self::inst::EmitInfo;
 
 /// A IBM Z backend.
+#[derive(Clone)]
 pub struct S390xBackend {
     triple: Triple,
     flags: shared_settings::Flags,
@@ -169,6 +170,10 @@ impl TargetIsa for S390xBackend {
 
     fn function_alignment(&self) -> u32 {
         4
+    }
+
+    fn cloned(&self) -> Box<dyn TargetIsa> {
+        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -191,7 +191,7 @@ pub fn isa_builder(triple: Triple) -> IsaBuilder {
         constructor: |triple, shared_flags, builder| {
             let isa_flags = s390x_settings::Flags::new(&shared_flags, builder);
             let backend = S390xBackend::new_with_flags(triple, shared_flags, isa_flags);
-            Ok(Box::new(backend))
+            Ok(backend.wrapped())
         },
     }
 }

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -2,7 +2,7 @@
 
 pub use self::inst::{args, EmitInfo, EmitState, Inst};
 
-use super::TargetIsa;
+use super::{OwnedTargetIsa, TargetIsa};
 use crate::ir::{condcodes::IntCC, Function, Type};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv;
@@ -196,7 +196,7 @@ fn isa_constructor(
     triple: Triple,
     shared_flags: Flags,
     builder: shared_settings::Builder,
-) -> CodegenResult<Box<dyn TargetIsa>> {
+) -> CodegenResult<OwnedTargetIsa> {
     let isa_flags = x64_settings::Flags::new(&shared_flags, builder);
 
     // Check for compatibility between flags and ISA level
@@ -214,7 +214,7 @@ fn isa_constructor(
     }
 
     let backend = X64Backend::new_with_flags(triple, shared_flags, isa_flags);
-    Ok(Box::new(backend))
+    Ok(backend.wrapped())
 }
 
 #[cfg(test)]

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -26,7 +26,6 @@ mod lower;
 mod settings;
 
 /// An X64 backend.
-#[derive(Clone)]
 pub(crate) struct X64Backend {
     triple: Triple,
     flags: Flags,
@@ -171,10 +170,6 @@ impl TargetIsa for X64Backend {
     /// always from aligned memory.
     fn function_alignment(&self) -> u32 {
         16
-    }
-
-    fn cloned(&self) -> Box<dyn TargetIsa> {
-        Box::new(self.clone())
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -26,6 +26,7 @@ mod lower;
 mod settings;
 
 /// An X64 backend.
+#[derive(Clone)]
 pub(crate) struct X64Backend {
     triple: Triple,
     flags: Flags,
@@ -170,6 +171,10 @@ impl TargetIsa for X64Backend {
     /// always from aligned memory.
     fn function_alignment(&self) -> u32 {
         16
+    }
+
+    fn cloned(&self) -> Box<dyn TargetIsa> {
+        Box::new(self.clone())
     }
 }
 

--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -5,7 +5,7 @@ use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{
     ExternalName, Function, InstBuilder, Signature, UserExternalName, UserFuncName,
 };
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::{ir, settings, CodegenError, Context};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_jit::{JITBuilder, JITModule};
@@ -86,7 +86,7 @@ impl TestFileCompiler {
     /// Build a [TestFileCompiler] from a [TargetIsa]. For functions to be runnable on the
     /// host machine, this [TargetIsa] must match the host machine's ISA (see
     /// [TestFileCompiler::with_host_isa]).
-    pub fn new(isa: Box<dyn TargetIsa>) -> Self {
+    pub fn new(isa: OwnedTargetIsa) -> Self {
         let builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
         let module = JITModule::new(builder);
         let ctx = module.make_context();

--- a/cranelift/filetests/src/test_run.rs
+++ b/cranelift/filetests/src/test_run.rs
@@ -8,7 +8,7 @@ use crate::subtest::{Context, SubTest};
 use anyhow::Context as _;
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::Type;
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::{Configurable, Flags};
 use cranelift_codegen::{ir, settings};
 use cranelift_reader::TestCommand;
@@ -34,7 +34,7 @@ fn build_host_isa(
     infer_native_flags: bool,
     flags: settings::Flags,
     isa_flags: Vec<settings::Value>,
-) -> Box<dyn TargetIsa> {
+) -> OwnedTargetIsa {
     let mut builder = cranelift_native::builder_with_options(infer_native_flags)
         .expect("Unable to build a TargetIsa for the current host");
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -49,7 +49,7 @@ fn write_non_default_flags(f: &mut fmt::Formatter<'_>, flags: &settings::Flags) 
 /// A generated function with an ISA that targets one of cranelift's backends.
 pub struct FunctionWithIsa {
     /// TargetIsa to use when compiling this test case
-    pub isa: Box<dyn isa::TargetIsa>,
+    pub isa: isa::OwnedTargetIsa,
 
     /// Function under test
     pub func: Function,
@@ -96,7 +96,7 @@ impl<'a> Arbitrary<'a> for FunctionWithIsa {
 
 pub struct TestCase {
     /// TargetIsa to use when compiling this test case
-    pub isa: Box<dyn isa::TargetIsa>,
+    pub isa: isa::OwnedTargetIsa,
     /// Function under test
     pub func: Function,
     /// Generate multiple test inputs for each test case.

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -1,7 +1,7 @@
 //! Defines `JITModule`.
 
 use crate::{compiled_blob::CompiledBlob, memory::BranchProtection, memory::Memory};
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::Configurable;
 use cranelift_codegen::{self, ir, settings, MachReloc};
 use cranelift_codegen::{binemit::Reloc, CodegenError};
@@ -26,7 +26,7 @@ const READONLY_DATA_ALIGNMENT: u64 = 0x1;
 
 /// A builder for `JITModule`.
 pub struct JITBuilder {
-    isa: Box<dyn TargetIsa>,
+    isa: OwnedTargetIsa,
     symbols: HashMap<String, *const u8>,
     lookup_symbols: Vec<Box<dyn Fn(&str) -> Option<*const u8>>>,
     libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
@@ -67,7 +67,7 @@ impl JITBuilder {
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use `cranelift_module::default_libcall_names()`.
     pub fn with_isa(
-        isa: Box<dyn TargetIsa>,
+        isa: OwnedTargetIsa,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
     ) -> Self {
         let symbols = HashMap::new();
@@ -153,7 +153,7 @@ struct GotUpdate {
 ///
 /// See the `JITBuilder` for a convenient way to construct `JITModule` instances.
 pub struct JITModule {
-    isa: Box<dyn TargetIsa>,
+    isa: OwnedTargetIsa,
     hotswap_enabled: bool,
     symbols: RefCell<HashMap<String, *const u8>>,
     lookup_symbols: Vec<Box<dyn Fn(&str) -> Option<*const u8>>>,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -25,8 +25,8 @@ use std::mem;
 use target_lexicon::PointerWidth;
 
 /// A builder for `ObjectModule`.
-pub struct ObjectBuilder {
-    isa: Box<dyn TargetIsa>,
+pub struct ObjectBuilder<'a> {
+    isa: &'a dyn TargetIsa,
     binary_format: object::BinaryFormat,
     architecture: object::Architecture,
     flags: object::FileFlags,
@@ -36,7 +36,7 @@ pub struct ObjectBuilder {
     per_function_section: bool,
 }
 
-impl ObjectBuilder {
+impl<'a> ObjectBuilder<'a> {
     /// Create a new `ObjectBuilder` using the given Cranelift target, that
     /// can be passed to [`ObjectModule::new`].
     ///
@@ -45,7 +45,7 @@ impl ObjectBuilder {
     /// floating point instructions, and for stack probes. If you don't know what to use for this
     /// argument, use [cranelift_module::default_libcall_names]().
     pub fn new<V: Into<Vec<u8>>>(
-        isa: Box<dyn TargetIsa>,
+        isa: &'a dyn TargetIsa,
         name: V,
         libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
     ) -> ModuleResult<Self> {
@@ -123,8 +123,8 @@ impl ObjectBuilder {
 /// An `ObjectModule` implements `Module` and emits ".o" files using the `object` library.
 ///
 /// See the `ObjectBuilder` for a convenient way to construct `ObjectModule` instances.
-pub struct ObjectModule {
-    isa: Box<dyn TargetIsa>,
+pub struct ObjectModule<'a> {
+    isa: &'a dyn TargetIsa,
     object: Object<'static>,
     declarations: ModuleDeclarations,
     functions: SecondaryMap<FuncId, Option<(SymbolId, bool)>>,
@@ -138,9 +138,9 @@ pub struct ObjectModule {
     anon_data_number: u64,
 }
 
-impl ObjectModule {
+impl<'a> ObjectModule<'a> {
     /// Create a new `ObjectModule` using the given Cranelift target.
-    pub fn new(builder: ObjectBuilder) -> Self {
+    pub fn new(builder: ObjectBuilder<'a>) -> Self {
         let mut object = Object::new(builder.binary_format, builder.architecture, builder.endian);
         object.flags = builder.flags;
         object.add_file_symbol(builder.name);
@@ -173,7 +173,7 @@ fn validate_symbol(name: &str) -> ModuleResult<()> {
     Ok(())
 }
 
-impl Module for ObjectModule {
+impl<'a> Module for ObjectModule<'a> {
     fn isa(&self) -> &dyn TargetIsa {
         &*self.isa
     }
@@ -485,7 +485,7 @@ impl Module for ObjectModule {
     }
 }
 
-impl ObjectModule {
+impl<'a> ObjectModule<'a> {
     /// Finalize all relocations and output an object.
     pub fn finish(mut self) -> ObjectProduct {
         let symbol_relocs = mem::take(&mut self.relocs);

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -15,7 +15,7 @@ fn error_on_incompatible_sig_in_declare_function() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
     let mut sig = Signature {
         params: vec![AbiParam::new(types::I64)],
         returns: vec![],
@@ -66,7 +66,7 @@ fn panic_on_define_after_finalize() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
 
     define_simple_function(&mut module);
     define_simple_function(&mut module);
@@ -152,7 +152,7 @@ fn libcall_function() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
 
     let sig = Signature {
         params: vec![],
@@ -206,7 +206,7 @@ fn reject_nul_byte_symbol_for_func() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
 
     let sig = Signature {
         params: vec![],
@@ -228,7 +228,7 @@ fn reject_nul_byte_symbol_for_data() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
 
     let _ = module
         .declare_data(

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -15,7 +15,7 @@ fn error_on_incompatible_sig_in_declare_function() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
     let mut sig = Signature {
         params: vec![AbiParam::new(types::I64)],
         returns: vec![],
@@ -66,7 +66,7 @@ fn panic_on_define_after_finalize() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
 
     define_simple_function(&mut module);
     define_simple_function(&mut module);
@@ -152,7 +152,7 @@ fn libcall_function() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
 
     let sig = Signature {
         params: vec![],
@@ -206,7 +206,7 @@ fn reject_nul_byte_symbol_for_func() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
 
     let sig = Signature {
         params: vec![],
@@ -228,7 +228,7 @@ fn reject_nul_byte_symbol_for_data() {
         .finish(settings::Flags::new(flag_builder))
         .unwrap();
     let mut module =
-        ObjectModule::new(ObjectBuilder::new(&*isa, "foo", default_libcall_names()).unwrap());
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
 
     let _ = module
         .declare_data(

--- a/cranelift/reader/src/isaspec.rs
+++ b/cranelift/reader/src/isaspec.rs
@@ -8,7 +8,7 @@
 
 use crate::error::{Location, ParseError};
 use crate::testcommand::TestOption;
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::{Configurable, Flags, SetError};
 
 /// The ISA specifications in a `.clif` file.
@@ -19,7 +19,7 @@ pub enum IsaSpec {
 
     /// The parsed file does contain `isa` commands.
     /// Each `isa` command is used to configure a `TargetIsa` trait object.
-    Some(Vec<Box<dyn TargetIsa>>),
+    Some(Vec<OwnedTargetIsa>),
 }
 
 impl IsaSpec {

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -43,7 +43,7 @@ mod testcommand;
 mod testfile;
 
 use anyhow::{Error, Result};
-use cranelift_codegen::isa::{self, TargetIsa};
+use cranelift_codegen::isa::{self, OwnedTargetIsa};
 use cranelift_codegen::settings::{self, FlagsOrIsa};
 use std::str::FromStr;
 use target_lexicon::Triple;
@@ -52,7 +52,7 @@ use target_lexicon::Triple;
 #[allow(missing_docs)]
 pub enum OwnedFlagsOrIsa {
     Flags(settings::Flags),
-    Isa(Box<dyn TargetIsa>),
+    Isa(OwnedTargetIsa),
 }
 
 impl OwnedFlagsOrIsa {

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -37,18 +37,50 @@ pub struct Options {
 
     /// Specify an input file to be used. Use '-' for stdin.
     files: Vec<PathBuf>,
+
+    /// Output object file
+    #[clap(short = 'o', long = "output")]
+    output: Option<PathBuf>,
 }
 
 pub fn run(options: &Options) -> Result<()> {
     let parsed = parse_sets_and_triple(&options.settings, &options.target)?;
+
+    let mut module = match (&options.output, parsed.as_fisa().isa) {
+        (Some(output), Some(isa)) => {
+            let builder = cranelift_object::ObjectBuilder::new(
+                isa.cloned(),
+                output
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("a.out"),
+                cranelift_module::default_libcall_names(),
+            )?;
+            Some(cranelift_object::ObjectModule::new(builder))
+        }
+        _ => None,
+    };
+
     for path in &options.files {
         let name = String::from(path.as_os_str().to_string_lossy());
-        handle_module(options, path, &name, parsed.as_fisa())?;
+        handle_module(options, path, &name, parsed.as_fisa(), module.as_mut())?;
     }
+
+    if let (Some(module), Some(output)) = (module, &options.output) {
+        let bytes = module.finish().emit()?;
+        std::fs::write(output, bytes)?;
+    }
+
     Ok(())
 }
 
-fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -> Result<()> {
+fn handle_module(
+    options: &Options,
+    path: &Path,
+    name: &str,
+    fisa: FlagsOrIsa,
+    module: Option<&mut impl cranelift_module::Module>,
+) -> Result<()> {
     let buffer = read_to_string(&path)?;
     let test_file = parse_test(&buffer, ParseOptions::default())
         .with_context(|| format!("failed to parse {}", name))?;
@@ -57,39 +89,48 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
     // file contains a unique isa, use that.
     let isa = fisa.isa.or(test_file.isa_spec.unique_isa());
 
-    if isa.is_none() {
-        anyhow::bail!("compilation requires a target isa");
+    let isa = match isa {
+        None => anyhow::bail!("compilation requires a target isa"),
+        Some(isa) => isa,
     };
 
     for (func, _) in test_file.functions {
-        if let Some(isa) = isa {
-            let mut context = Context::new();
-            context.func = func;
-            let mut mem = vec![];
+        let mut context = Context::new();
+        context.func = func;
+        let mut mem = vec![];
 
-            // Compile and encode the result to machine code.
-            let compiled_code = context
-                .compile_and_emit(isa, &mut mem)
-                .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
-            let code_info = compiled_code.code_info();
+        // Compile and encode the result to machine code.
+        let compiled_code = context
+            .compile_and_emit(isa, &mut mem)
+            .map_err(|err| anyhow::anyhow!("{}", pretty_error(&err.func, err.inner)))?;
+        let code_info = compiled_code.code_info();
 
-            if options.print {
-                println!("{}", context.func.display());
-            }
+        if let Some(&mut ref mut module) = module {
+            let name = context.func.name.to_string();
+            let fid = module.declare_function(
+                &name,
+                cranelift_module::Linkage::Export,
+                &context.func.signature,
+            )?;
+            module.define_function(fid, &mut context)?;
+        }
 
-            if options.disasm {
-                let result = context.compiled_code().unwrap();
-                print_all(
-                    isa,
-                    &context.func.params,
-                    &mem,
-                    code_info.total_size,
-                    options.print,
-                    result.buffer.relocs(),
-                    result.buffer.traps(),
-                    result.buffer.stack_maps(),
-                )?;
-            }
+        if options.print {
+            println!("{}", context.func.display());
+        }
+
+        if options.disasm {
+            let result = context.compiled_code().unwrap();
+            print_all(
+                isa,
+                &context.func.params,
+                &mem,
+                code_info.total_size,
+                options.print,
+                result.buffer.relocs(),
+                result.buffer.traps(),
+                result.buffer.stack_maps(),
+            )?;
         }
     }
 

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -49,7 +49,7 @@ pub fn run(options: &Options) -> Result<()> {
     let mut module = match (&options.output, parsed.as_fisa().isa) {
         (Some(output), Some(isa)) => {
             let builder = cranelift_object::ObjectBuilder::new(
-                isa.cloned(),
+                isa,
                 output
                     .file_name()
                     .and_then(|s| s.to_str())

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -8,6 +8,7 @@ use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::settings::FlagsOrIsa;
 use cranelift_codegen::timing;
 use cranelift_codegen::Context;
+use cranelift_reader::OwnedFlagsOrIsa;
 use cranelift_reader::{parse_sets_and_triple, parse_test, ParseOptions};
 use std::path::Path;
 use std::path::PathBuf;
@@ -46,10 +47,10 @@ pub struct Options {
 pub fn run(options: &Options) -> Result<()> {
     let parsed = parse_sets_and_triple(&options.settings, &options.target)?;
 
-    let mut module = match (&options.output, parsed.as_fisa().isa) {
-        (Some(output), Some(isa)) => {
+    let mut module = match (&options.output, &parsed) {
+        (Some(output), OwnedFlagsOrIsa::Isa(isa)) => {
             let builder = cranelift_object::ObjectBuilder::new(
-                isa,
+                isa.clone(),
                 output
                     .file_name()
                     .and_then(|s| s.to_str())

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -3,7 +3,7 @@
 use crate::utils::{iterate_files, read_to_string};
 use anyhow::Result;
 use clap::Parser;
-use cranelift_codegen::isa::{CallConv, TargetIsa};
+use cranelift_codegen::isa::{CallConv, OwnedTargetIsa};
 use cranelift_filetests::TestFileCompiler;
 use cranelift_native::builder as host_isa_builder;
 use cranelift_reader::{parse_run_command, parse_test, Details, IsaSpec, ParseOptions};
@@ -105,7 +105,7 @@ fn run_file_contents(file_contents: String) -> Result<()> {
 }
 
 /// Build an ISA based on the current machine running this code (the host)
-fn create_target_isa(isa_spec: &IsaSpec) -> Result<Box<dyn TargetIsa>> {
+fn create_target_isa(isa_spec: &IsaSpec) -> Result<OwnedTargetIsa> {
     if let IsaSpec::None(flags) = isa_spec {
         // build an ISA for the current machine
         let builder = host_isa_builder().map_err(|s| anyhow::anyhow!("{}", s))?;

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -10,7 +10,7 @@ use anyhow::{Context as _, Result};
 use cranelift_codegen::ir::{
     self, ExternalName, Function, InstBuilder, MemFlags, UserExternalName, UserFuncName, Value,
 };
-use cranelift_codegen::isa::TargetIsa;
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::Context;
 use cranelift_codegen::{settings, MachReloc, MachTrap};
@@ -68,7 +68,7 @@ impl Default for CompilerContext {
 /// the Wasm to Compiler IR, optimizing it and then translating to assembly.
 pub(crate) struct Compiler {
     contexts: Mutex<Vec<CompilerContext>>,
-    isa: Box<dyn TargetIsa>,
+    isa: OwnedTargetIsa,
     linkopts: LinkOptions,
     cache_store: Option<Arc<dyn CacheStore>>,
 }
@@ -103,7 +103,7 @@ impl Drop for Compiler {
 
 impl Compiler {
     pub(crate) fn new(
-        isa: Box<dyn TargetIsa>,
+        isa: OwnedTargetIsa,
         cache_store: Option<Arc<dyn CacheStore>>,
         linkopts: LinkOptions,
     ) -> Compiler {


### PR DESCRIPTION
This PR adds a very dumb `-o whatever.o` option to `clif-util compile` using cranelift-object, so that external disassemblers, linkers, etc can be used when experimenting with cranelift. This was a stand-alone change I made while doing weirder stuff, and I thought would be nice to upstream. Not sure who should review or if it is actually desired.

The only really iffy part of the implementation IMO is the addition of the `cloned`  method to TargetISA, but it seemed like the best way to go from a `&dyn TargetIsa` to the boxed trait object needed by ObjectBuilder.
