### PR TITLE
wasmtime: Add FreeBSD x86 check CI Job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,6 +172,11 @@ jobs:
       env:
         CARGO_PROFILE_DEV_DEBUG_ASSERTIONS: false
 
+    # Check whether `wasmtime` cross-compiles to x86_64-unknown-freebsd
+    # TODO: We aren't building with default features since the `ittapi` crate fails to compile on freebsd.
+    - run: rustup target add x86_64-unknown-freebsd
+    - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache --target x86_64-unknown-freebsd
+
   # Check whether `wasmtime` cross-compiles to aarch64-pc-windows-msvc
   # We don't build nor test it because it lacks trap handling.
   # Tracking issue: https://github.com/bytecodealliance/wasmtime/issues/4992


### PR DESCRIPTION
👋 Hey,

We accidentally broke the build for FreeBSD when introducing the jit-icache-coherence crate. To avoid this happening again, add a check job just to ensure that it can build.

See #5323 and #5331 for context.