### PR TITLE
riscv64: Fix `br_table` segfault with zero sized jump tables

### DIFF
--- a/cranelift/filetests/filetests/runtests/br_table.clif
+++ b/cranelift/filetests/filetests/runtests/br_table.clif
@@ -40,3 +40,23 @@ block5(v5: i32):
 ; run: %br_table_i32(5) == 9
 ; run: %br_table_i32(6) == 10
 ; run: %br_table_i32(-1) == 3
+
+
+
+; RISC-V had a bug where having a br_table on a cold block would cause a segfault
+; See #5496 for more details.
+function %br_table_cold_block(i32) -> i32 system_v {
+    jt0 = jump_table []
+
+block0(v0: i32):
+    jump block1
+
+block1 cold:
+    br_table v0, block2, jt0
+
+block2:
+    v1 = iconst.i32 0
+    return v1
+}
+; run: %br_table_cold_block(0) == 0
+; run: %br_table_cold_block(1) == 0


### PR DESCRIPTION
👋 Hey,

We had a off-by-one bounds check error when checking if we should jump to the default block in a `br_table`. Instead of always jumping to the default block when we have a jump table with 0 targets we would try to compute an offset past the end of the table.

This sometimes would not crash, but it would crash if the there was no block after the `br_table`, thus adding a cold block would cause a segfault.

The actual fix is quite simple, do not count the default block as a jump table entry when computing the limits.

This commit also does a bunch of cleanup and adding some comments to the `br_table` emission code.

Fixes #5496
