### PR TITLE
riscv64: Remove the TrapFf constructor

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -108,19 +108,11 @@
       (cc IntCC)
       (trap_code TrapCode))
 
-    (TrapFf
-      (cc FloatCC)
-      (x Reg)
-      (y Reg)
-      (ty Type)
-      (tmp WritableReg)
-      (trap_code TrapCode))
-
     (Jal
       ;; (rd WritableReg) don't use
       (dest BranchTarget))
 
-     (CondBr
+    (CondBr
       (taken BranchTarget)
       (not_taken BranchTarget)
       (kind IntegerCompare))
@@ -2068,15 +2060,6 @@
   (let ((extended Reg (ext_int_if_need $true val ty))
         (negated Reg (neg $I64 extended)))
     (max $I64 extended negated)))
-
-
-
-(decl gen_trapff (FloatCC Reg Reg Type TrapCode) InstOutput)
-(rule
-  (gen_trapff cc a b ty trap_code)
-  (let
-    ((tmp WritableReg (temp_writable_reg $I64)))
-    (side_effect (SideEffectNoResult.Inst (MInst.TrapFf cc a b ty tmp trap_code)))))
 
 (decl gen_trapif (Reg TrapCode) InstOutput)
 (rule

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -407,12 +407,6 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
         &Inst::TrapIf { test, .. } => {
             collector.reg_use(test);
         }
-        &Inst::TrapFf { x, y, tmp, .. } => {
-            collector.reg_use(x);
-            collector.reg_use(y);
-            collector.reg_early_def(tmp);
-        }
-
         &Inst::Jal { .. } => {}
         &Inst::CondBr { kind, .. } => {
             collector.reg_use(kind.rs1);
@@ -1431,22 +1425,6 @@ impl Inst {
                 let rs2 = format_reg(rs2, allocs);
                 format!("trap_ifc {}##({} {} {})", trap_code, rs1, cc, rs2)
             }
-            &MInst::TrapFf {
-                cc,
-                x,
-                y,
-                ty,
-                trap_code,
-                tmp,
-            } => format!(
-                "trap_ff_{} {} {},{}##tmp={} ty={}",
-                cc,
-                trap_code,
-                format_reg(x, allocs),
-                format_reg(y, allocs),
-                format_reg(tmp.to_reg(), allocs),
-                ty,
-            ),
             &MInst::Jal { dest, .. } => {
                 format!("{} {}", "j", dest)
             }


### PR DESCRIPTION
Remove the `MInst::TrapFf` instruction in the riscv64 backend. It was only used in two places in the emit case for `FloatRound`, and was easily replaced with a combination of `FpuRRR` and `TrapIf`.

This gets us a little bit closer to removing `lower_br_fcmp` completely.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
