### PR TITLE
Wasmtime: set the `cranelift_wasm::Heap`'s min size

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1471,7 +1471,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         });
         Ok(self.heaps.push(HeapData {
             base: heap_base,
-            min_size: 0,
+            min_size: self.module.memory_plans[index].memory.minimum * u64::from(WASM_PAGE_SIZE),
             offset_guard_size,
             style: heap_style,
             index_type: self.memory_index_type(index),


### PR DESCRIPTION
This unlocks certain bounds checking optimizations in some configurations. Wasn't able to measure any delta in sightglass, but still worth doing anyways.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
