### PR TITLE
cranelift: Forbid argument extensions for floats and SIMD vectors

### DIFF
--- a/cranelift/filetests/filetests/verifier/argument-extension.clif
+++ b/cranelift/filetests/filetests/verifier/argument-extension.clif
@@ -1,0 +1,26 @@
+test verifier
+
+function %float_with_sext(f32 sext) -> f32 { ; error: Parameter at position 0 has invalid extension Sext
+block0(v0: f32):
+    return v0
+}
+
+function %float_with_uext(f32 uext) -> f32 { ; error: Parameter at position 0 has invalid extension Uext
+block0(v0: f32):
+    return v0
+}
+
+function %float_ret_with_sext(f32) -> f32 sext { ; error: Return value at position 0 has invalid extension Sext
+block0(v0: f32):
+    return v0
+}
+
+function %float_ret_with_uext(f32) -> f32 uext { ; error: Return value at position 0 has invalid extension Uext
+block0(v0: f32):
+    return v0
+}
+
+function %simd_ext(i32x4 sext) -> i32x4 { ; error: Parameter at position 0 has invalid extension Sext
+block0(v0: i32x4):
+    return v0
+}

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1177,10 +1177,14 @@ where
         let value_type = self.generate_type()?;
         // TODO: There are more argument purposes to be explored...
         let purpose = ArgumentPurpose::Normal;
-        let extension = match self.u.int_in_range(0..=2)? {
-            2 => ArgumentExtension::Sext,
-            1 => ArgumentExtension::Uext,
-            _ => ArgumentExtension::None,
+        let extension = if value_type.is_int() {
+            *self.u.choose(&[
+                ArgumentExtension::Sext,
+                ArgumentExtension::Uext,
+                ArgumentExtension::None,
+            ])?
+        } else {
+            ArgumentExtension::None
         };
 
         Ok(AbiParam {


### PR DESCRIPTION
👋 Hey,

This fixes #5531 by adding a verifier check and changing fuzzgen to not produce this type of code.

The check forbids argument extensions for anything that is not a scalar integer.