### PR TITLE
cranelift: fix register for `srem.i8` on x86_64 

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -543,7 +543,7 @@ pub(crate) fn emit(
 
                 // Here, divisor == -1.
                 if !kind.is_div() {
-                    // x % -1 = 0; put the result into the destination, $rdx.
+                    // x % -1 = 0; put the result into the destination, $rax.
                     let done_label = sink.get_label();
 
                     let inst = Inst::imm(OperandSize::Size64, 0, Writable::from_reg(regs::rax()));

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -546,7 +546,7 @@ pub(crate) fn emit(
                     // x % -1 = 0; put the result into the destination, $rdx.
                     let done_label = sink.get_label();
 
-                    let inst = Inst::imm(OperandSize::Size64, 0, Writable::from_reg(regs::rdx()));
+                    let inst = Inst::imm(OperandSize::Size64, 0, Writable::from_reg(regs::rax()));
                     inst.emit(&[], sink, info, state);
 
                     let inst = Inst::jmp_known(done_label);

--- a/cranelift/filetests/filetests/runtests/srem.clif
+++ b/cranelift/filetests/filetests/runtests/srem.clif
@@ -150,3 +150,4 @@ block0(v0: i64, v1: i8):
     return v3
 }
 ; run: %srem_with_bmask(4352, -1) == 0
+; run: %srem_with_bmask(4352, 1) == 0

--- a/cranelift/filetests/filetests/runtests/srem.clif
+++ b/cranelift/filetests/filetests/runtests/srem.clif
@@ -142,3 +142,11 @@ block0(v0: i8):
 ; run: %srem_imm_i8(-19) == -1
 ; run: %srem_imm_i8(0xC0) == -1
 ; run: %srem_imm_i8(0x80) == -2
+
+function %srem_with_bmask(i64, i8) -> i8 {
+block0(v0: i64, v1: i8):
+    v2 = bmask.i8 v0
+    v3 = srem v2, v1
+    return v3
+}
+; run: %srem_with_bmask(4352, -1) == 0


### PR DESCRIPTION
 Change register written to in specific srem case in #5470. Add regression test as filetest case. Draft pending CI. 

Fixes #5470 