### PR TITLE
fuzzgen: Re-enable `srem.i8` on x86

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -288,8 +288,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Sdiv, &[I128, I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5474
                 (Opcode::Urem, &[I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5470
-                (Opcode::Srem, &[I8, I8]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5474
                 (Opcode::Srem, &[I128, I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5466


### PR DESCRIPTION
👋 Hey,

With #5470 fixed (Thanks!) we can now re-enable fuzzing for this instruction.

I ran the fuzzer for a while and it didn't point anything else out.