### PR TITLE
aarch64: Support GOT Relative relocations in PIC mode

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -66,6 +66,17 @@ pub enum Reloc {
     /// This is equivalent to `R_AARCH64_TLSGD_ADD_LO12_NC` in the [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#relocations-for-thread-local-storage)
     Aarch64TlsGdAddLo12Nc,
 
+    /// AArch64 GOT Page
+    /// Set the immediate value of an ADRP to bits 32:12 of X; check that –232 <= X < 232
+    /// This is equivalent to `R_AARCH64_ADR_GOT_PAGE` (311) in the  [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#static-aarch64-relocations)
+    Aarch64AdrGotPage21,
+
+    /// AArch64 GOT Low bits
+
+    /// Set the LD/ST immediate field to bits 11:3 of X. No overflow check; check that X&7 = 0
+    /// This is equivalent to `R_AARCH64_LD64_GOT_LO12_NC` (312) in the  [aaelf64](https://github.com/ARM-software/abi-aa/blob/2bcab1e3b22d55170c563c3c7940134089176746/aaelf64/aaelf64.rst#static-aarch64-relocations)
+    Aarch64Ld64GotLo12Nc,
+
     /// procedure call.
     /// call symbol
     /// expands to the following assembly and relocation:
@@ -100,6 +111,8 @@ impl fmt::Display for Reloc {
             Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
             Self::Aarch64TlsGdAdrPage21 => write!(f, "Aarch64TlsGdAdrPage21"),
             Self::Aarch64TlsGdAddLo12Nc => write!(f, "Aarch64TlsGdAddLo12Nc"),
+            Self::Aarch64AdrGotPage21 => write!(f, "Aarch64AdrGotPage21"),
+            Self::Aarch64Ld64GotLo12Nc => write!(f, "Aarch64AdrGotLo12Nc"),
             Self::S390xTlsGd64 => write!(f, "TlsGd64"),
             Self::S390xTlsGdCall => write!(f, "TlsGdCall"),
         }

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -852,6 +852,11 @@
         (rd WritableReg)
         ;; Offset in range -2^20 .. 2^20.
         (off i32))
+      
+       ;; Compute the address (using a PC-relative offset) of a 4KB page.
+       (Adrp
+        (rd WritableReg)
+        (off i32))
 
        ;; Raw 32-bit word, used for inline constants and jump-table entries.
        (Word4

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6074,6 +6074,24 @@ fn test_aarch64_binemit() {
     ));
 
     insns.push((
+        Inst::Adrp {
+            rd: writable_xreg(8),
+            off: 0,
+        },
+        "08000090",
+        "adrp x8, pc+0",
+    ));
+
+    insns.push((
+        Inst::Adrp {
+            rd: writable_xreg(0),
+            off: 10,
+        },
+        "400000D0",
+        "adrp x0, pc+40960",
+    ));
+
+    insns.push((
         Inst::FpuMove64 {
             rd: writable_vreg(8),
             rn: vreg(4),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -6084,11 +6084,11 @@ fn test_aarch64_binemit() {
 
     insns.push((
         Inst::Adrp {
-            rd: writable_xreg(0),
-            off: 10,
+            rd: writable_xreg(3),
+            off: 16,
         },
-        "400000D0",
-        "adrp x0, pc+40960",
+        "83000090",
+        "adrp x3, pc+65536",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -2795,7 +2795,7 @@ impl Inst {
                 offset,
             } => {
                 let rd = pretty_print_reg(rd.to_reg(), allocs);
-                format!("ldr {}, 8 ; b 12 ; data {:?} + {}", rd, name, offset)
+                format!("load_ext_name {rd}, {name:?}+{offset}")
             }
             &Inst::LoadAddr { rd, ref mem } => {
                 // TODO: we really should find a better way to avoid duplication of

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1080,7 +1080,7 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             }
             CondBrKind::Cond(_) => {}
         },
-        &Inst::Adr { rd, .. } => {
+        &Inst::Adr { rd, .. } | &Inst::Adrp { rd, .. } => {
             collector.reg_def(rd);
         }
         &Inst::Word4 { .. } | &Inst::Word8 { .. } => {}
@@ -2744,6 +2744,12 @@ impl Inst {
             &Inst::Adr { rd, off } => {
                 let rd = pretty_print_reg(rd.to_reg(), allocs);
                 format!("adr {}, pc+{}", rd, off)
+            }
+            &Inst::Adrp { rd, off } => {
+                let rd = pretty_print_reg(rd.to_reg(), allocs);
+                // This instruction addresses 4KiB pages, so multiply it by the page size.
+                let byte_offset = off * 4096;
+                format!("adrp {}, pc+{}", rd, byte_offset)
             }
             &Inst::Word4 { data } => format!("data.i32 {}", data),
             &Inst::Word8 { data } => format!("data.i64 {}", data),

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -102,7 +102,7 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -30,7 +30,7 @@ block0(v0: i32):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -54,7 +54,7 @@ block0(v0: i32):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -91,7 +91,7 @@ block0(v0: i8):
 ;   movz w6, #42
 ;   movz w7, #42
 ;   strb w8, [sp]
-;   ldr x8, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x8, TestCase(%g)+0
 ;   blr x8
 ;   add sp, sp, #16
 ;   virtual_sp_offset_adjust -16
@@ -140,24 +140,24 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
+;   load_ext_name x9, TestCase(%g0)+0
 ;   blr x9
 ;   str q0, [sp, #32]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g1) + 0
+;   load_ext_name x9, TestCase(%g1)+0
 ;   blr x9
 ;   str q0, [sp, #16]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g1) + 0
+;   load_ext_name x9, TestCase(%g1)+0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g2) + 0
+;   load_ext_name x9, TestCase(%g2)+0
 ;   blr x9
-;   ldr x10, 8 ; b 12 ; data TestCase(%g3) + 0
+;   load_ext_name x10, TestCase(%g3)+0
 ;   ldr q0, [sp, #32]
 ;   blr x10
-;   ldr x11, 8 ; b 12 ; data TestCase(%g4) + 0
+;   load_ext_name x11, TestCase(%g4)+0
 ;   ldr q0, [sp, #16]
 ;   blr x11
-;   ldr x12, 8 ; b 12 ; data TestCase(%g4) + 0
+;   load_ext_name x12, TestCase(%g4)+0
 ;   ldr q0, [sp]
 ;   blr x12
 ;   add sp, sp, #48
@@ -184,24 +184,24 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
+;   load_ext_name x9, TestCase(%g0)+0
 ;   blr x9
 ;   str q0, [sp, #32]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
+;   load_ext_name x9, TestCase(%g0)+0
 ;   blr x9
 ;   str q0, [sp, #16]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
+;   load_ext_name x9, TestCase(%g0)+0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g1) + 0
+;   load_ext_name x9, TestCase(%g1)+0
 ;   blr x9
-;   ldr x10, 8 ; b 12 ; data TestCase(%g2) + 0
+;   load_ext_name x10, TestCase(%g2)+0
 ;   ldr q0, [sp, #32]
 ;   blr x10
-;   ldr x11, 8 ; b 12 ; data TestCase(%g2) + 0
+;   load_ext_name x11, TestCase(%g2)+0
 ;   ldr q0, [sp, #16]
 ;   blr x11
-;   ldr x12, 8 ; b 12 ; data TestCase(%g2) + 0
+;   load_ext_name x12, TestCase(%g2)+0
 ;   ldr q0, [sp]
 ;   blr x12
 ;   add sp, sp, #48
@@ -232,24 +232,24 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #48
 ; block0:
-;   ldr x9, 8 ; b 12 ; data TestCase(%g0) + 0
+;   load_ext_name x9, TestCase(%g0)+0
 ;   blr x9
 ;   str q0, [sp, #32]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g1) + 0
+;   load_ext_name x9, TestCase(%g1)+0
 ;   blr x9
 ;   str q0, [sp, #16]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g2) + 0
+;   load_ext_name x9, TestCase(%g2)+0
 ;   blr x9
 ;   str q0, [sp]
-;   ldr x9, 8 ; b 12 ; data TestCase(%g3) + 0
+;   load_ext_name x9, TestCase(%g3)+0
 ;   blr x9
-;   ldr x10, 8 ; b 12 ; data TestCase(%g4) + 0
+;   load_ext_name x10, TestCase(%g4)+0
 ;   ldr q0, [sp, #32]
 ;   blr x10
-;   ldr x11, 8 ; b 12 ; data TestCase(%g5) + 0
+;   load_ext_name x11, TestCase(%g5)+0
 ;   ldr q0, [sp, #16]
 ;   blr x11
-;   ldr x12, 8 ; b 12 ; data TestCase(%g6) + 0
+;   load_ext_name x12, TestCase(%g6)+0
 ;   ldr q0, [sp]
 ;   blr x12
 ;   add sp, sp, #48
@@ -282,7 +282,7 @@ block0(v0: i64):
 ;   mov x1, x0
 ;   movz x0, #42
 ;   movz x2, #42
-;   ldr x6, 8 ; b 12 ; data TestCase(%f11) + 0
+;   load_ext_name x6, TestCase(%f11)+0
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -313,7 +313,7 @@ block0(v0: i64):
 ;   mov x2, x0
 ;   movz x3, #42
 ;   movz x0, #42
-;   ldr x6, 8 ; b 12 ; data TestCase(%f12) + 0
+;   load_ext_name x6, TestCase(%f12)+0
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -344,7 +344,7 @@ block0(v0: i64):
 ;   mov x1, x0
 ;   movz x2, #42
 ;   movz x0, #42
-;   ldr x6, 8 ; b 12 ; data TestCase(%f13) + 0
+;   load_ext_name x6, TestCase(%f13)+0
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -380,7 +380,7 @@ block0(v0: i128, v1: i64):
 ;   mov x4, x0
 ;   str x1, [sp, #8]
 ;   mov x5, x1
-;   ldr x10, 8 ; b 12 ; data TestCase(%f14) + 0
+;   load_ext_name x10, TestCase(%f14)+0
 ;   mov x0, x4
 ;   mov x2, x4
 ;   mov x1, x5
@@ -422,7 +422,7 @@ block0(v0: i128, v1: i64):
 ;   mov x4, x0
 ;   str x1, [sp, #8]
 ;   mov x5, x1
-;   ldr x10, 8 ; b 12 ; data TestCase(%f15) + 0
+;   load_ext_name x10, TestCase(%f15)+0
 ;   mov x0, x4
 ;   mov x2, x4
 ;   mov x1, x5
@@ -472,7 +472,7 @@ block0(v0: i64):
 ;   mov fp, sp
 ; block0:
 ;   mov x8, x0
-;   ldr x3, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -490,7 +490,7 @@ block0(v0: i64):
 ;   str x24, [sp, #-16]!
 ; block0:
 ;   mov x24, x8
-;   ldr x4, 8 ; b 12 ; data TestCase(%g) + 0
+;   load_ext_name x4, TestCase(%g)+0
 ;   blr x4
 ;   mov x8, x24
 ;   ldr x24, [sp], #16

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -68,7 +68,7 @@ block3(v7: r64, v8: r64):
 ; block0:
 ;   str x0, [sp, #8]
 ;   str x1, [sp, #16]
-;   ldr x1, 8 ; b 12 ; data TestCase(%f) + 0
+;   load_ext_name x1, TestCase(%f)+0
 ;   blr x1
 ;   mov x15, sp
 ;   ldr x6, [sp, #8]

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -42,7 +42,7 @@ block0(v0: i64):
 ;   subs xzr, sp, x0, UXTX
 ;   b.hs 8 ; udf
 ; block0:
-;   ldr x2, 8 ; b 12 ; data TestCase(%foo) + 0
+;   load_ext_name x2, TestCase(%foo)+0
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -65,7 +65,7 @@ block0(v0: i64):
 ;   subs xzr, sp, x16, UXTX
 ;   b.hs 8 ; udf
 ; block0:
-;   ldr x2, 8 ; b 12 ; data TestCase(%foo) + 0
+;   load_ext_name x2, TestCase(%foo)+0
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
@@ -1,5 +1,6 @@
 test compile precise-output
 set unwind_info=false
+set is_pic
 target aarch64
 
 function %f() -> i64 {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -678,30 +678,38 @@ impl ObjectModule {
                     12,
                 )
             }
-            Reloc::Aarch64AdrGotPage21 => {
-                assert_eq!(
-                    self.object.format(),
-                    object::BinaryFormat::Elf,
-                    "Aarch64AdrGotPage21 is not supported for this file format"
-                );
-                (
+            Reloc::Aarch64AdrGotPage21 => match self.object.format() {
+                object::BinaryFormat::Elf => (
                     RelocationKind::Elf(object::elf::R_AARCH64_ADR_GOT_PAGE),
                     RelocationEncoding::Generic,
                     21,
-                )
-            }
-            Reloc::Aarch64Ld64GotLo12Nc => {
-                assert_eq!(
-                    self.object.format(),
-                    object::BinaryFormat::Elf,
-                    "Aarch64Ld64GotLo12Nc is not supported for this file format"
-                );
-                (
+                ),
+                object::BinaryFormat::MachO => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_GOT_LOAD_PAGE21,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    21,
+                ),
+                _ => unimplemented!("Aarch64AdrGotPage21 is not supported for this file format"),
+            },
+            Reloc::Aarch64Ld64GotLo12Nc => match self.object.format() {
+                object::BinaryFormat::Elf => (
                     RelocationKind::Elf(object::elf::R_AARCH64_LD64_GOT_LO12_NC),
                     RelocationEncoding::Generic,
                     12,
-                )
-            }
+                ),
+                object::BinaryFormat::MachO => (
+                    RelocationKind::MachO {
+                        value: object::macho::ARM64_RELOC_GOT_LOAD_PAGEOFF12,
+                        relative: true,
+                    },
+                    RelocationEncoding::Generic,
+                    12,
+                ),
+                _ => unimplemented!("Aarch64Ld64GotLo12Nc is not supported for this file format"),
+            },
             Reloc::S390xPCRel32Dbl => (RelocationKind::Relative, RelocationEncoding::S390xDbl, 32),
             Reloc::S390xPLTRel32Dbl => (
                 RelocationKind::PltRelative,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -678,6 +678,30 @@ impl ObjectModule {
                     12,
                 )
             }
+            Reloc::Aarch64AdrGotPage21 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "Aarch64AdrGotPage21 is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_AARCH64_ADR_GOT_PAGE),
+                    RelocationEncoding::Generic,
+                    21,
+                )
+            }
+            Reloc::Aarch64Ld64GotLo12Nc => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "Aarch64Ld64GotLo12Nc is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_AARCH64_LD64_GOT_LO12_NC),
+                    RelocationEncoding::Generic,
+                    12,
+                )
+            }
             Reloc::S390xPCRel32Dbl => (RelocationKind::Relative, RelocationEncoding::S390xDbl, 32),
             Reloc::S390xPLTRel32Dbl => (
                 RelocationKind::PltRelative,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -703,7 +703,7 @@ impl ObjectModule {
                 object::BinaryFormat::MachO => (
                     RelocationKind::MachO {
                         value: object::macho::ARM64_RELOC_GOT_LOAD_PAGEOFF12,
-                        relative: true,
+                        relative: false,
                     },
                     RelocationEncoding::Generic,
                     12,


### PR DESCRIPTION
👋 Hey,

This PR adds support for using the GOT in PIC mode on AArch64. It implements the relocations for both ELF and MachO.

In order to support the MachO relocations we need to update the object crate. Unfortunately that also brings a few other dependencies which also need to be vetted. 

[@cfallin has already validated the object crate update up to `0.30.0` in #5434](https://github.com/bytecodealliance/wasmtime/pull/5434#issuecomment-1350337637) so we just need to do `0.30.0 -> 0.30.1` and the rest of the new dependencies.

Tested this using [the awesome example](https://github.com/acw/cranelift-hmmm/) provided by @acw in [zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/Tricks.20with.20linkage.20internal.20.2F.20module.20external.20functions.3F).
On aarch64-linux I was able to fully test this, on aarch64-darwin the decompiled file seems correct but I don't have a M1/2 machine to link and run it. Maybe @acw can test and report back if anything is wrong?

Fixes #2907
Fixes #5544