### PR TITLE
cranelift: Remove predicate not macro branch

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/mod.rs
+++ b/cranelift/codegen/meta/src/cdsl/mod.rs
@@ -17,15 +17,6 @@ macro_rules! predicate {
     ($a:ident && $($b:tt)*) => {
         PredicateNode::And(Box::new($a.into()), Box::new(predicate!($($b)*)))
     };
-    (!$a:ident && $($b:tt)*) => {
-        PredicateNode::And(
-            Box::new(PredicateNode::Not(Box::new($a.into()))),
-            Box::new(predicate!($($b)*))
-        )
-    };
-    (!$a:ident) => {
-        PredicateNode::Not(Box::new($a.into()))
-    };
     ($a:ident) => {
         $a.into()
     };


### PR DESCRIPTION
As a follow up to https://github.com/bytecodealliance/wasmtime/pull/5548#pullrequestreview-1240953027