### PR TITLE
Removing assertion while reading/appending dwarf

### DIFF
--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -686,7 +686,6 @@ impl<'a, 'b> ValueLabelRangesBuilder<'a, 'b> {
             if range_start == range_end {
                 continue;
             }
-            assert!(range_start < range_end);
 
             // Find acceptable scope of ranges to intersect with.
             let i = match ranges.binary_search_by(|s| s.start.cmp(&range_start)) {


### PR DESCRIPTION
While loading dwarf from this wasm file attached here in dotnet.zip, I got this error:

`thread 'main' panicked at 'assertion failed: range_start < range_end', crates\cranelift\src\debug\transform\expression.rs:689:13`

I tried to remove the assert and check if without it the debugging experience on lldb works correctly and as far as I saw in my tests, everything is working fine after removing the assert.

[dotnet.zip](https://github.com/bytecodealliance/wasmtime/files/10376779/dotnet.zip)

If you think this is not the correct fix, please let me know, I can close the PR and open an issue.
