### PR TITLE
Update the documentation for `Caller::get_export`.

### DIFF
--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1726,24 +1726,23 @@ impl<T> Caller<'_, T> {
 
     /// Looks up an export from the caller's module by the `name` given.
     ///
-    /// Note that when accessing and calling exported functions, one should
-    /// adhere to the guidelines of the interface types proposal.  This method
-    /// is a temporary mechanism for accessing the caller's information until
-    /// interface types has been fully standardized and implemented. The
-    /// interface types proposal will obsolete this type and this will be
-    /// removed in the future at some point after interface types is
-    /// implemented. If you're relying on this method type it's recommended to
-    /// become familiar with interface types to ensure that your use case is
-    /// covered by the proposal.
+    /// This is a low-level function that's typically used to implement passing
+    /// of pointers or indices between core Wasm instances, where the callee
+    /// needs to consult the caller's exports to perform memory management and
+    /// resolve the references.
+    ///
+    /// For comparison, in components, the component model handles translating
+    /// arguments from one component instance to another and managing memory, so
+    /// that callees don't need to be aware of their callers, which promotes
+    /// virtualizability of APIs.
     ///
     /// # Return
     ///
-    /// If a memory or function export with the `name` provided was found, then it is
-    /// returned as a `Memory`. There are a number of situations, however, where
-    /// the memory or function may not be available:
+    /// If an export with the `name` provided was found, then it is returned as an
+    /// `Extern`. There are a number of situations, however, where the export may not
+    /// be available:
     ///
     /// * The caller instance may not have an export named `name`
-    /// * The export named `name` may not be an exported memory
     /// * There may not be a caller available, for example if `Func` was called
     ///   directly from host code.
     ///


### PR DESCRIPTION
Update the documentation for `Caller::get_export` to clarify that it's not expected to be removed in the future. Components do offer an alternative to `Caller::get_export`, so add a brief note mentioning that.

Also, as of #4431 `get_export` now works for all exports, not just memories and functions.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
