### PR TITLE
Add component model wasmtime feature to Docs.rs

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "nightlydoc"]
+features = ["component-model"]
 
 [dependencies]
 wasmtime-runtime = { workspace = true }


### PR DESCRIPTION
This PR adds the `"component-model"` feature to the Docs.rs metadata section in `crates/wasmtime/Cargo.toml` so that the Wasmtime docs include the component model-specific apis and types. This was discussed on Zulip with @alexcrichton in [this thread](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/.22component-model.22.20Docs).