### PR TITLE
Treat `wasmtime::component::Val::Float{32,64}` zero and negative zero as inequal

### DIFF
--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -1007,16 +1007,20 @@ impl Val {
 impl PartialEq for Val {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            // This breaks conformance with IEEE-754 equality to simplify testing logic.
+            // IEEE 754 equality considers NaN inequal to NaN and negative zero
+            // equal to positive zero, however we do the opposite here, because
+            // this logic is used by testing and fuzzing, which want to know
+            // whether two values are semantically the same, rather than
+            // numerically equal.
             (Self::Float32(l), Self::Float32(r)) => {
-                (l != 0.0 && l == r)
-                    || (l == 0 && l.to_bits() == r.to_bits())
+                (*l != 0.0 && l == r)
+                    || (*l == 0.0 && l.to_bits() == r.to_bits())
                     || (l.is_nan() && r.is_nan())
             }
             (Self::Float32(_), _) => false,
             (Self::Float64(l), Self::Float64(r)) => {
-                (l != 0.0 && l == r)
-                    || (l == 0 && l.to_bits() == r.to_bits())
+                (*l != 0.0 && l == r)
+                    || (*l == 0.0 && l.to_bits() == r.to_bits())
                     || (l.is_nan() && r.is_nan())
             }
             (Self::Float64(_), _) => false,

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -1008,9 +1008,17 @@ impl PartialEq for Val {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             // This breaks conformance with IEEE-754 equality to simplify testing logic.
-            (Self::Float32(l), Self::Float32(r)) => l == r || (l.is_nan() && r.is_nan()),
+            (Self::Float32(l), Self::Float32(r)) => {
+                (l != 0.0 && l == r)
+                    || (l == 0 && l.to_bits() == r.to_bits())
+                    || (l.is_nan() && r.is_nan())
+            }
             (Self::Float32(_), _) => false,
-            (Self::Float64(l), Self::Float64(r)) => l == r || (l.is_nan() && r.is_nan()),
+            (Self::Float64(l), Self::Float64(r)) => {
+                (l != 0.0 && l == r)
+                    || (l == 0 && l.to_bits() == r.to_bits())
+                    || (l.is_nan() && r.is_nan())
+            }
             (Self::Float64(_), _) => false,
 
             (Self::Bool(l), Self::Bool(r)) => l == r,


### PR DESCRIPTION
Following up on #5535, treat positive and negative zero as inequal in wasmtime::component::Val::Float{32,64}'s `PartialEq` logic. IEEE 754 equality considers these values equal, but they are semantically distinct values, and testing and fuzzing should be aware of the difference.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
