### PR TITLE
`generated-code.rs` is not itself generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,3 @@
 
 # ISLE should use lisp syntax highlighting.
 *.isle linguist-language=lisp
-
-# Tell GitHub this is generated code, and doesn't need to be shown in diffs by
-# default.
-cranelift/codegen/src/isa/*/lower/isle/generated_code.rs linguist-generated


### PR DESCRIPTION
cranelift/codegen/src/isa/*/lower/isle/generated_code.rs are hand-written modules that `include!` the actual generated code.

Tagging these hand-written files as `linguist-generated` in .gitattributes tells GitHub not to show them in diffs by default. But they're actually important to review, so they should be included in diffs.