### PR TITLE
Fix typo in examples/memory.rs

### DIFF
--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -4,7 +4,7 @@
 //! read and write memory through the `Memory` object, and how wasm functions
 //! can trap when dealing with out-of-bounds addresses.
 
-// You can execute this example with `cargo run --example example`
+// You can execute this example with `cargo run --example memory`
 
 use anyhow::Result;
 use wasmtime::*;


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Hi, just fixing this typo from the examples directory.