### PR TITLE
Bump cargo-vet to 0.3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     name: Cargo vet
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.3.0
+      CARGO_VET_VERSION: 0.3.1
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This relaxes import parsing to ensure that adoption of the next major release by other projects doesn't break imports for this project. See https://github.com/mozilla/cargo-vet/issues/360#issuecomment-1384605968