### PR TITLE
Add Elixir into 'Language Support'

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Hello, world!
 ## Language Support
 
 You can use Wasmtime from a variety of different languages through embeddings of
-the implementation:
+the implementation.
+
+Languages supported by the Bytecode Alliance:
 
 * **[Rust]** - the [`wasmtime` crate]
 * **[C]** - the [`wasm.h`, `wasi.h`, and `wasmtime.h` headers][c-headers], [CMake](crates/c-api/CMakeLists.txt) or [`wasmtime` Conan package]
@@ -117,6 +119,10 @@ the implementation:
 * **[.NET]** - the [`Wasmtime` NuGet package]
 * **[Go]** - the [`wasmtime-go` repository]
 * **[Ruby]** - the [`wasmtime` gem]
+
+Languages supported by the community:
+
+* **[Elixir]** - the [`wasmex` hex package]
 
 [Rust]: https://bytecodealliance.github.io/wasmtime/lang-rust.html
 [C]: https://bytecodealliance.github.io/wasmtime/examples-c-embed.html
@@ -133,6 +139,8 @@ the implementation:
 [`wasmtime-cpp` Conan package]: https://conan.io/center/wasmtime-cpp
 [Ruby]: https://bytecodealliance.github.io/wasmtime/lang-ruby.html
 [`wasmtime` gem]: https://rubygems.org/gems/wasmtime
+[Elixir]: https://docs.wasmtime.dev/lang-elixir.html
+[`wasmex` hex package]: https://hex.pm/packages/wasmex
 
 ## Documentation
 

--- a/docs/lang-elixir.md
+++ b/docs/lang-elixir.md
@@ -1,0 +1,43 @@
+# Using WebAssembly from Elixir
+
+Wasmtime [is available on Hex](https://hex.pm/packages/wasmex) and can
+be used programmatically to interact with Wasm modules. This guide will go over
+installing the wasmex package and running a simple Wasm module from Elixir.
+
+## Getting started and simple example
+
+First, copy this example WebAssembly text module into the current directory. It exports
+a function for calculating the greatest common denominator of two numbers.
+
+```wat
+{{#include ../examples/gcd.wat}}
+```
+
+The library has a Rust-based native extension, but thanks to `rustler_precompiled`, you
+should not have to compile anything. It'll just work!
+
+This WAT file can be executed in `iex`:
+
+```elixir
+Mix.install([:wasmex])
+bytes = File.read!("gcd.wat")
+{:ok, pid} = Wasmex.start_link(%{bytes: bytes}) # starts a GenServer running a WASM instance
+Wasmex.call_function(pid, "gcd", [27, 6])
+```
+
+The last command should output:
+
+```elixir
+iex(5)> Wasmex.call_function(pid, "gcd", [27, 6])
+{:ok, [3]}
+```
+
+If this is the output you see, congrats! You've successfully ran your first
+WebAssembly code in Elixir!
+
+## More examples and contributing
+
+To learn more, check out an [another example](https://github.com/tessi/wasmex#example)
+and the [API documentation](https://hexdocs.pm/wasmex/Wasmex.html).
+If you have any questions, do not hesitate to open an issue on the
+[GitHub repository](https://github.com/tessi/wasmex).

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -11,3 +11,4 @@ through a C API for a number of other languages too:
 * [Go](lang-go.md)
 * [Bash](lang-bash.md)
 * [Ruby](lang-ruby.md)
+* [Elixir](lang-elixir.md)


### PR DESCRIPTION
`wasmex` is using `wasmtime` from the version [v0.8.0](https://github.com/tessi/wasmex/blob/main/CHANGELOG.md#080---2023-01-03).

Is a library should be somehow verified/approved to get into the list?

