### PR TITLE
cranelift: Disable select rule for i128 types on riscv64

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -612,7 +612,7 @@
   (gen_select ty (truthy_to_reg cty (normalize_cmp_value cty c)) x y))
 
 (rule 1
-  (lower (has_type ty (select (icmp cc a b @ (value_type in_ty)) x y)))
+  (lower (has_type (fits_in_64 ty) (select (icmp cc a b @ (value_type in_ty)) x y)))
   (let ((a Reg (normalize_cmp_value in_ty a))
         (b Reg (normalize_cmp_value in_ty b)))
     (gen_select_reg cc a b x y)))

--- a/cranelift/filetests/filetests/isa/riscv64/issue-5583.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-5583.clif
@@ -1,0 +1,16 @@
+test compile
+target riscv64
+
+function u1:0() system_v {
+block0:
+    v3 = iconst.i16 0
+    v5 = iconst.i64 0
+    v6 = uextend.i128 v5  ; v5 = 0
+    v13 = icmp slt v3, v3  ; v3 = 0, v3 = 0
+    v15 = select v13, v6, v6
+    v20 = select v15, v5, v5  ; v5 = 0, v5 = 0
+    v22 = ishl v13, v20
+    v58 = iconst.i8 0
+    v25 = udiv v22, v58  ; v58 = 0
+    return
+}

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -602,13 +602,10 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 // TODO
                 (Opcode::SelectSpectreGuard, &[I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5526
-                (Opcode::SelectSpectreGuard, &[I64, I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5526
-                (Opcode::SelectSpectreGuard, &[I32, I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5526
-                (Opcode::SelectSpectreGuard, &[I16, I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5526
-                (Opcode::SelectSpectreGuard, &[I8, I128, I128]),
+                (Opcode::SelectSpectreGuard, &[_, I128, I128]),
+                // https://github.com/bytecodealliance/wasmtime/issues/5524
+                (Opcode::Select, &[I128]),
+                (Opcode::Select, &[_, I128, I128]),
                 // TODO
                 (Opcode::BandNot, &[F32, F32]),
                 (Opcode::BandNot, &[F64, F64]),


### PR DESCRIPTION
👋 Hey

This PR disables one of the `select` rules for i128 values. This rule was enabled for all types, but only supports single register values. `gen_select_reg` only supports `Reg` values and not `ValueRegs`.

It also disables i128 select from being generated. While in this case it did catch an actual issue, it is broken for fuzzgen (#5524) and it somehow got lost when updating #5502.

Fixes #5583