### PR TITLE
Detect components in `wasmtime compile` more robustly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,6 +3491,7 @@ dependencies = [
  "tempfile",
  "test-programs",
  "tokio",
+ "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ listenfd = "1.0.0"
 wat = { workspace = true }
 serde = "1.0.94"
 serde_json = "1.0.26"
+wasmparser = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["mm", "param"] }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -90,7 +90,15 @@ impl CompileCommand {
         // bytes with the current component model proposal.
         #[cfg(feature = "component-model")]
         {
-            if input.starts_with(b"\0asm\x0a\0\x01\0") {
+            if let Ok(wasmparser::Chunk::Parsed {
+                payload:
+                    wasmparser::Payload::Version {
+                        encoding: wasmparser::Encoding::Component,
+                        ..
+                    },
+                ..
+            }) = wasmparser::Parser::new(0).parse(&input, true)
+            {
                 fs::write(output, engine.precompile_component(&input)?)?;
                 return Ok(());
             }


### PR DESCRIPTION
The binary version of component is going to change over time so use a more robust method than checking for a fixed 8 bytes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
