### PR TITLE
Refactor BranchInfo::Table to no longer have an optional default branch

### DIFF
--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -360,9 +360,7 @@ impl DominatorTree {
                     for succ in func.jump_tables[jt].iter() {
                         self.push_if_unseen(*succ);
                     }
-                    if let Some(dest) = dest {
-                        self.push_if_unseen(dest);
-                    }
+                    self.push_if_unseen(dest);
                 }
                 BranchInfo::NotABranch => {}
             }

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -126,9 +126,8 @@ impl ControlFlowGraph {
                     self.add_edge(block, inst, dest.block(&func.dfg.value_lists));
                 }
                 BranchInfo::Table(jt, dest) => {
-                    if let Some(dest) = dest {
-                        self.add_edge(block, inst, dest);
-                    }
+                    self.add_edge(block, inst, dest);
+
                     for dest in func.jump_tables[jt].iter() {
                         self.add_edge(block, inst, *dest);
                     }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -169,12 +169,11 @@ fn visit_branch_targets<F: FnMut(Inst, Block, bool)>(f: &Function, inst: Inst, v
         BranchInfo::SingleDest(dest) => {
             visit(inst, dest.block(&f.dfg.value_lists), false);
         }
-        BranchInfo::Table(table, maybe_dest) => {
-            if let Some(dest) = maybe_dest {
-                // The default block is reached via a direct conditional branch,
-                // so it is not part of the table.
-                visit(inst, dest, false);
-            }
+        BranchInfo::Table(table, dest) => {
+            // The default block is reached via a direct conditional branch,
+            // so it is not part of the table.
+            visit(inst, dest, false);
+
             for &dest in f.jump_tables[table].as_slice() {
                 visit(inst, dest, true);
             }

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -308,7 +308,7 @@ impl FunctionStencil {
                     }
                 });
 
-                if default_dest == Some(old_dest) {
+                if default_dest == old_dest {
                     match &mut self.dfg.insts[inst] {
                         InstructionData::BranchTable { destination, .. } => {
                             *destination = new_dest;

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -273,7 +273,7 @@ impl InstructionData {
             Self::Branch { destination, .. } => BranchInfo::SingleDest(destination),
             Self::BranchTable {
                 table, destination, ..
-            } => BranchInfo::Table(table, Some(destination)),
+            } => BranchInfo::Table(table, destination),
             _ => {
                 debug_assert!(!self.opcode().is_branch());
                 BranchInfo::NotABranch
@@ -456,8 +456,8 @@ pub enum BranchInfo {
     /// This is a branch or jump to a single destination block, possibly taking value arguments.
     SingleDest(BlockCall),
 
-    /// This is a jump table branch which can have many destination blocks and maybe one default block.
-    Table(JumpTable, Option<Block>),
+    /// This is a jump table branch which can have many destination blocks and one default block.
+    Table(JumpTable, Block),
 }
 
 /// Information about call instructions.

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1304,18 +1304,16 @@ impl<'a> Verifier<'a> {
                 self.typecheck_variable_args_iterator(inst, iter, args, errors)?;
             }
             BranchInfo::Table(table, block) => {
-                if let Some(block) = block {
-                    let arg_count = self.func.dfg.num_block_params(block);
-                    if arg_count != 0 {
-                        return errors.nonfatal((
-                            inst,
-                            self.context(inst),
-                            format!(
-                                "takes no arguments, but had target {} with {} arguments",
-                                block, arg_count,
-                            ),
-                        ));
-                    }
+                let arg_count = self.func.dfg.num_block_params(block);
+                if arg_count != 0 {
+                    return errors.nonfatal((
+                        inst,
+                        self.context(inst),
+                        format!(
+                            "takes no arguments, but had target {} with {} arguments",
+                            block, arg_count,
+                        ),
+                    ));
                 }
                 for block in self.func.jump_tables[table].iter() {
                     let arg_count = self.func.dfg.num_block_params(*block);


### PR DESCRIPTION
While working through the changes for #5446 I noticed that we never construct a `BranchInfo::Table` value with a `None` default destination. This PR changes the constructor to no longer allow that case.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
