### PR TITLE
Change spectest fuzzing to throw out some fuzz inputs

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -501,9 +501,11 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
 /// Executes the wast `test` spectest with the `config` specified.
 ///
 /// Ensures that spec tests pass regardless of the `Config`.
-pub fn spectest(mut fuzz_config: generators::Config, test: generators::SpecTest) {
+pub fn spectest(fuzz_config: generators::Config, test: generators::SpecTest) {
     crate::init_fuzzing();
-    fuzz_config.set_spectest_compliant();
+    if !fuzz_config.is_spectest_compliant() {
+        return;
+    }
     log::debug!("running {:?}", test.file);
     let mut wast_context = WastContext::new(fuzz_config.to_store());
     wast_context.register_spectest(false).unwrap();


### PR DESCRIPTION
A fuzz bug came in last night from #5567 where spectest fuzzing will first generate a config, possibly with SSE features for SIMD disabled, only to have SIMD later enabled by `set_spectest_compliant`. This commit fixes the issue by changing to `is_spectest_compliant` as a query and throwing out the fuzz case if it isn't. This means that the spectest fuzzer will throw out more inputs but means we can continue to generate interesting configs and such for other inputs.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
