### PR TITLE
Add `contains` and `intersects` to the component-macro bindings for flags

### DIFF
--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -1114,6 +1114,14 @@ pub fn expand_flags(flags: &Flags) -> Result<TokenStream> {
                 use std::ops::Not;
                 Self::default().not()
             }
+
+            pub fn contains(&self, other: Self) -> bool {
+                *self & other == other
+            }
+
+            pub fn intersects(&self, other: Self) -> bool {
+                *self & other != Self::empty()
+            }
         }
 
         impl std::cmp::PartialEq for #name {


### PR DESCRIPTION
In component-macro, when expanding the bindings for flags types, add `contains` and `intersects` methods, for convenience.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
