### PR TITLE
component-macro: add a `fn contains(&self, &Self) -> bool` method to flags

### DIFF
--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -1102,6 +1102,10 @@ pub fn expand_flags(flags: &Flags) -> Result<TokenStream> {
         impl #name {
             #constants
 
+            pub fn contains(&self, rhs: &Self) -> bool {
+                (self & rhs) == self
+            }
+
             pub fn as_array(&self) -> [u32; #count] {
                 #as_array
             }


### PR DESCRIPTION
This is a pretty common method to need, see https://github.com/bytecodealliance/preview2-prototyping/blob/main/host/src/filesystem.rs#L17-L20
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
