### PR TITLE
component bindgen: accept strs as well as identifiers for wit identifiers

### DIFF
--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -373,7 +373,9 @@ mod record_error {
                 record-error: func(a: float64) -> result<float64, e2>
             }
         }",
-        trappable_error_type: { imports::e2: TrappableE2 }
+        // Literal strings can be used for the interface and typename fields instead of
+        // identifiers, because wit identifiers arent always Rust identifiers.
+        trappable_error_type: { "imports"::"e2": TrappableE2 }
     });
 
     #[test]


### PR DESCRIPTION

This is required because not all wit identifiers are Rust identifiers, so we can smuggle the invalid ones inside quotes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
