### PR TITLE
Release Wasmtime 5.0.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 5.0.0
 
-Unreleased.
+Released 2023-01-20.
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,46 @@ Released 2023-01-20.
 
 ### Added
 
+* A `wasmtime::component::bingen!` macro has been added for generating bindings
+  from `*.wit` files. Note that WIT is still heavily in development so this is
+  more of a preview of what will be as opposed to a finished feature.
+  [#5317](https://github.com/bytecodealliance/wasmtime/pull/5317)
+  [#5397](https://github.com/bytecodealliance/wasmtime/pull/5397)
+
+* The `wasmtime settings` CLI command now has a `--json` option for
+  machine-readable output.
+  [#5411](https://github.com/bytecodealliance/wasmtime/pull/5411)
+
+* Wiggle-generated bindings can now generate the trait for either `&mut self` or
+  `&self`.
+  [#5428](https://github.com/bytecodealliance/wasmtime/pull/5428)
+
+* The `wiggle` crate has more convenience APIs for working with guest data
+  that resides in shared memory.
+  [#5471](https://github.com/bytecodealliance/wasmtime/pull/5471)
+  [#5475](https://github.com/bytecodealliance/wasmtime/pull/5475)
+
 ### Changed
+
+* Cranelift's egraph support has been rewritten and updated. This functionality
+  is still gated behind a flag and may become the default in the next release.
+  [#5382](https://github.com/bytecodealliance/wasmtime/pull/5382)
+
+* The implementation of codegen for WebAssembly linear memory has changed
+  significantly internally in Cranelift, moving more responsibility to the
+  Wasmtime embedding rather than Cranelift itself. This should have no
+  user-visible change, however.
+  [#5386](https://github.com/bytecodealliance/wasmtime/pull/5386)
+
+* The `Val::Float32` and `Val::Float64` variants for components now store `f32`
+  and `f64` instead of the bit representation.
+  [#5510](https://github.com/bytecodealliance/wasmtime/pull/5510)
+
+### Fixed
+
+* Handling of DWARF debugging information in components with multiple modules
+  has been fixed to ensure the right info is used for each module.
+  [#5358](https://github.com/bytecodealliance/wasmtime/pull/5358)
 
 --------------------------------------------------------------------------------
 

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "nightlydoc"]
+features = ["component-model"]
 
 [dependencies]
 wasmtime-runtime = { workspace = true }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -365,8 +365,6 @@ impl Config {
     /// This option is `true` by default.
     ///
     /// [`WasmBacktrace`]: crate::WasmBacktrace
-    #[deprecated = "Backtraces will always be enabled in future Wasmtime releases; if this \
-                    causes problems for you, please file an issue."]
     pub fn wasm_backtrace(&mut self, enable: bool) -> &mut Self {
         self.wasm_backtrace = enable;
         self

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -98,7 +98,9 @@ pub(crate) fn from_runtime_box(
             error,
             needs_backtrace,
         } => {
-            debug_assert!(needs_backtrace == backtrace.is_some());
+            debug_assert!(
+                needs_backtrace == backtrace.is_some() || !store.engine().config().wasm_backtrace
+            );
             (error, None)
         }
         wasmtime_runtime::TrapReason::Jit(pc) => {

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1160,3 +1160,28 @@ fn standalone_backtrace_disabled() -> Result<()> {
     f.call(&mut store, ())?;
     Ok(())
 }
+
+#[test]
+fn host_return_error_no_backtrace() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_backtrace(false);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "" "" (func $host))
+                (func $foo (export "f") call $bar)
+                (func $bar call $host)
+            )
+        "#,
+    )?;
+    let func = Func::wrap(&mut store, |_cx: Caller<'_, ()>| -> Result<()> {
+        bail!("test")
+    });
+    let instance = Instance::new(&mut store, &module, &[func.into()])?;
+    let f = instance.get_typed_func::<(), ()>(&mut store, "f")?;
+    assert!(f.call(&mut store, ()).is_err());
+    Ok(())
+}


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is
intended to notify maintainers that it's time to release Wasmtime
5.0.0. The [release branch][branch] was created roughly two weeks ago
and it's now time for it to be published and released.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-5.0.0
