### PR TITLE
Implemented `b{and,or,xor}_not` bitops for ty_int_ref_scalar_64 type.

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1099,8 +1099,32 @@
 ;; while x86 does
 ;;
 ;;   pandn(x, y) = and(not(x), y)
-(rule (lower (has_type ty (band_not x y)))
+(rule 0 (lower (has_type ty (band_not x y)))
       (sse_and_not ty y x))
+
+
+(rule 1 (lower (has_type ty (band_not x y)))
+      (if (ty_int_ref_scalar_64 ty))
+      (x64_and ty 
+               x
+               (x64_not ty y)))
+
+
+;;;; Rules for `bxor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type ty (bxor_not x y)))
+      (if (ty_int_ref_scalar_64 ty))
+      (x64_xor ty 
+               x
+               (x64_not ty y)))
+
+;;;; Rules for `bor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type ty (bor_not x y)))
+      (if (ty_int_ref_scalar_64 ty))
+      (x64_or ty 
+               x
+               (x64_not ty y)))
 
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/runtests/bnot.clif
+++ b/cranelift/filetests/filetests/runtests/bnot.clif
@@ -35,3 +35,34 @@ block0(v0: i64):
 }
 ; run: %bnot_i64(0) == -1
 ; run: %bnot_i64(1) == -2
+
+
+function %band_not(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = band_not.i8 v0, v1
+    return v2
+}
+
+; run: %band_not(0xFF, 0) == -1
+; run: %band_not(0x55, 0xFF) == 0
+; run: %band_not(0, 0) == 0
+
+function %bor_not(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = bor_not.i8 v0, v1
+    return v2
+}
+
+; run: %bor_not(0xFF, 0) == -1
+; run: %bor_not(0x55, 0xFF) == 85
+; run: %bor_not(0, 0) == -1
+
+function %bxor_not(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = bxor_not.i8 v0, v1
+    return v2
+}
+
+; run: %bxor_not(0xFF, 0) == 0
+; run: %bxor_not(0x55, 0xFF) == 85
+; run: %bxor_not(0, 0) == -1


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Fix #5041

Todo
- [x] Implement Tests