### PR TITLE
Fix libcall relocations for precompiled modules

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -273,13 +273,6 @@ impl CodeMemory {
             return Ok(());
         }
 
-        // Mmaps currently all start as readonly so before updating relocations
-        // the mapping needs to be made writable first. Note that this isn't
-        // reset back to readonly since the `make_executable` call, which
-        // happens after this, will implicitly remove the writable bit and leave
-        // it as just read/execute.
-        self.mmap.make_writable(self.text.clone())?;
-
         for (offset, libcall) in self.relocations.iter() {
             let offset = self.text.start + offset;
             let libcall = match libcall {

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -151,7 +151,7 @@ impl Mmap {
                     file: Some(Arc::new(file)),
                 };
 
-                // Protect the entire file as PAGE_READONLY to start (i.e.
+                // Protect the entire file as PAGE_WRITECOPY to start (i.e.
                 // remove the execute bit)
                 let mut old = 0;
                 if VirtualProtect(ret.ptr as *mut _, ret.len, PAGE_WRITECOPY, &mut old) == 0 {

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -67,7 +67,7 @@ impl Mmap {
                 rustix::mm::mmap(
                     ptr::null_mut(),
                     len,
-                    rustix::mm::ProtFlags::READ,
+                    rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
                     rustix::mm::MapFlags::PRIVATE,
                     &file,
                     0,
@@ -109,12 +109,16 @@ impl Mmap {
                     .len();
                 let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
 
-                // Create a file mapping that allows PAGE_EXECUTE_READ which
-                // we'll be using for mapped text sections in ELF images later.
+                // Create a file mapping that allows PAGE_EXECUTE_WRITECOPY.
+                // This enables up-to these permissions but we won't leave all
+                // of these permissions active at all times. Execution is
+                // necessary for the generated code from Cranelift and the
+                // WRITECOPY part is needed for possibly resolving relocations,
+                // but otherwise writes don't happen.
                 let mapping = CreateFileMappingW(
                     file.as_raw_handle() as isize,
                     ptr::null_mut(),
-                    PAGE_EXECUTE_READ,
+                    PAGE_EXECUTE_WRITECOPY,
                     0,
                     0,
                     ptr::null(),
@@ -124,9 +128,16 @@ impl Mmap {
                         .context("failed to create file mapping");
                 }
 
-                // Create a view for the entire file using `FILE_MAP_EXECUTE`
-                // here so that we can later change the text section to execute.
-                let ptr = MapViewOfFile(mapping, FILE_MAP_READ | FILE_MAP_EXECUTE, 0, 0, len);
+                // Create a view for the entire file using all our requisite
+                // permissions so that we can change the virtual permissions
+                // later on.
+                let ptr = MapViewOfFile(
+                    mapping,
+                    FILE_MAP_READ | FILE_MAP_EXECUTE | FILE_MAP_COPY,
+                    0,
+                    0,
+                    len,
+                );
                 let err = io::Error::last_os_error();
                 CloseHandle(mapping);
                 if ptr.is_null() {
@@ -143,7 +154,7 @@ impl Mmap {
                 // Protect the entire file as PAGE_READONLY to start (i.e.
                 // remove the execute bit)
                 let mut old = 0;
-                if VirtualProtect(ret.ptr as *mut _, ret.len, PAGE_READONLY, &mut old) == 0 {
+                if VirtualProtect(ret.ptr as *mut _, ret.len, PAGE_WRITECOPY, &mut old) == 0 {
                     return Err(io::Error::last_os_error())
                         .context("failed change pages to `PAGE_READONLY`");
                 }
@@ -340,7 +351,6 @@ impl Mmap {
 
     /// Return the allocated memory as a mutable slice of u8.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        debug_assert!(!self.is_readonly());
         unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
     }
 
@@ -362,53 +372,6 @@ impl Mmap {
     /// Return whether any memory has been allocated.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    /// Returns whether the underlying mapping is readonly, meaning that
-    /// attempts to write will fault.
-    pub fn is_readonly(&self) -> bool {
-        self.file.is_some()
-    }
-
-    /// Makes the specified `range` within this `Mmap` to be read/write.
-    pub unsafe fn make_writable(&self, range: Range<usize>) -> Result<()> {
-        assert!(range.start <= self.len());
-        assert!(range.end <= self.len());
-        assert!(range.start <= range.end);
-        assert!(
-            range.start % crate::page_size() == 0,
-            "changing of protections isn't page-aligned",
-        );
-
-        let base = self.as_ptr().add(range.start) as *mut _;
-        let len = range.end - range.start;
-
-        // On Windows when we have a file mapping we need to specifically use
-        // `PAGE_WRITECOPY` to ensure that pages are COW'd into place because
-        // we don't want our modifications to go back to the original file.
-        #[cfg(windows)]
-        {
-            use std::io;
-            use windows_sys::Win32::System::Memory::*;
-
-            let mut old = 0;
-            let result = if self.file.is_some() {
-                VirtualProtect(base, len, PAGE_WRITECOPY, &mut old)
-            } else {
-                VirtualProtect(base, len, PAGE_READWRITE, &mut old)
-            };
-            if result == 0 {
-                return Err(io::Error::last_os_error().into());
-            }
-        }
-
-        #[cfg(not(windows))]
-        {
-            use rustix::mm::{mprotect, MprotectFlags};
-            mprotect(base, len, MprotectFlags::READ | MprotectFlags::WRITE)?;
-        }
-
-        Ok(())
     }
 
     /// Makes the specified `range` within this `Mmap` to be read/execute.

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -104,6 +104,14 @@ impl MmapVec {
         )
     }
 
+    /// Makes the specified `range` within this `mmap` to be read-only.
+    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        assert!(range.start <= range.end);
+        assert!(range.end <= self.range.len());
+        self.mmap
+            .make_readonly(range.start + self.range.start..range.end + self.range.start)
+    }
+
     /// Returns the underlying file that this mmap is mapping, if present.
     pub fn original_file(&self) -> Option<&Arc<File>> {
         self.mmap.original_file()

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -68,11 +68,6 @@ impl MmapVec {
         Ok(MmapVec::new(mmap, len))
     }
 
-    /// Returns whether the original mmap was created from a readonly mapping.
-    pub fn is_readonly(&self) -> bool {
-        self.mmap.is_readonly()
-    }
-
     /// Splits the collection into two at the given index.
     ///
     /// Returns a separate `MmapVec` which shares the underlying mapping, but
@@ -95,18 +90,14 @@ impl MmapVec {
         return ret;
     }
 
-    /// Makes the specified `range` within this `mmap` to be read/write.
-    pub unsafe fn make_writable(&self, range: Range<usize>) -> Result<()> {
-        self.mmap
-            .make_writable(range.start + self.range.start..range.end + self.range.start)
-    }
-
     /// Makes the specified `range` within this `mmap` to be read/execute.
     pub unsafe fn make_executable(
         &self,
         range: Range<usize>,
         enable_branch_protection: bool,
     ) -> Result<()> {
+        assert!(range.start <= range.end);
+        assert!(range.end <= self.range.len());
         self.mmap.make_executable(
             range.start + self.range.start..range.end + self.range.start,
             enable_branch_protection,
@@ -135,7 +126,6 @@ impl Deref for MmapVec {
 
 impl DerefMut for MmapVec {
     fn deref_mut(&mut self) -> &mut [u8] {
-        debug_assert!(!self.is_readonly());
         // SAFETY: The underlying mmap is protected behind an `Arc` which means
         // there there can be many references to it. We are guaranteed, though,
         // that each reference to the underlying `mmap` has a disjoint `range`


### PR DESCRIPTION
This commit fixes some asserts and support for relocation libcalls in precompiled modules loaded from disk. In doing so this reworks how mmaps are managed for files from disk. All non-file-backed `Mmap` entries are read/write but file-backed versions were readonly. This commit changes this such that all `Mmap` objects, even if they're file-backed, start as read/write. The file-based versions all use copy-on-write to preserve the private-ness of the mapping.

This is not functionally intended to change anything. Instead this should have some more memory writable after a module is loaded but the text section, for example, is still left as read/execute when loading is finished. Additionally this makes modules compiled in memory more consistent with modules loaded from disk.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
