### PR TITLE
Fix multi-memory condition when spectest fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -116,8 +116,10 @@ impl Config {
         }
 
         // Make sure the runtime limits allow for the instantiation of all spec
-        // tests.
-        if config.max_memories < 1 || config.max_tables < 5 {
+        // tests. Note that the max memories must be precisely one since 0 won't
+        // instantiate spec tests and more than one is multi-memory which is
+        // disabled for spec tests.
+        if config.max_memories != 1 || config.max_tables < 5 {
             return false;
         }
 


### PR DESCRIPTION
The check needs to verify that the maximum number of memories is precisely one to ensure that multi-memory is disabled yet modules can still have up to one memory as configured in the pooling allocator.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
