### PR TITLE
Add deprecation notice to `cranelift_use_egraphs` option.

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -141,6 +141,7 @@ impl Config {
     }
 
     /// Converts this to a `wasmtime::Config` object
+    #[allow(deprecated)] // Allow use of `cranelift_use_egraphs` below.
     pub fn to_wasmtime(&self) -> wasmtime::Config {
         crate::init_fuzzing();
         log::debug!("creating wasmtime config with {:#?}", self.wasmtime);

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -841,6 +841,10 @@ impl Config {
     /// The default value for this is `true`.
     #[cfg(compiler)]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
+    #[deprecated(
+        since = "5.0.0",
+        note = "egraphs will be the default and this method will be removed in a future version."
+    )]
     pub fn cranelift_use_egraphs(&mut self, enable: bool) -> &mut Self {
         let val = if enable { "true" } else { "false" };
         self.compiler_config


### PR DESCRIPTION
After #5587, this is on by default. We are retaining the traditional (no-egraphs) path for now, selected by setting this option to `false`, but we eventually plan to delete it assuming that we don't find serious regressions or issues. This PR adds a deprecation notice to the option.

Updated as per [this comment](https://github.com/bytecodealliance/wasmtime/pull/5587#issuecomment-1398749623) (thanks!).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
