### PR TITLE
Notify wasmtime install is local not system wide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Installation
 
-The Wasmtime CLI can be installed on Linux and macOS with a small install
+The Wasmtime CLI can be installed on Linux and macOS (locally) with a small install
 script:
 
 ```sh


### PR DESCRIPTION
I don't think an issue is needed for this. Just a brief notice that the install script install `wasmtime` locally, not system wide.

**Why**

This won't work when executed as a standalone script outside of a local terminal

```
#!/usr/bin/env wasmtime ...
```

because 

```
$ sudo su
# wasmtime --help
wasmtime: command not found
```