### PR TITLE
cranelift-object: Make sections read only by default

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -457,7 +457,7 @@ impl Module for ObjectModule {
                 } else if relocs.is_empty() {
                     SectionKind::ReadOnlyData
                 } else {
-                    SectionKind::Data
+                    SectionKind::ReadOnlyDataWithRel
                 },
             )
         };


### PR DESCRIPTION
This changes the default section type to be `ReadOnlyDataWithRel` instead of `Data`. 

On COFF the CRT initializers do not run unless their section is read only. (See:  https://github.com/bjorn3/rustc_codegen_cranelift/issues/1249#issuecomment-1382431789)

The new `SectionKind` makes these sections read only for COFF and MachO, but leaves it as Writable as required by ELF.

cc: @bjorn3 
