### PR TITLE
Fix calculation of param/result types in wit-bindgen

### DIFF
--- a/crates/component-macro/tests/codegen/simple-wasi.wit
+++ b/crates/component-macro/tests/codegen/simple-wasi.wit
@@ -1,0 +1,15 @@
+interface wasi-filesystem {
+  record descriptor-stat {
+  }
+
+  enum errno { e }
+
+
+  create-directory-at: func() -> result<_, errno>
+
+  stat: func() -> result<descriptor-stat, errno>
+}
+
+default world wasi {
+  import wasi-filesystem: self.wasi-filesystem
+}


### PR DESCRIPTION
This commit fixes a bug in the `bindgen!` macro for components where previously the `param` and `result` properties weren't properly calculated depending on the structure of the type and which types were visited in which order. This is simplified to use a `LiveTypes` structure from the `wit-parser` crate and relies on that to do necessary recursion.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
