### PR TITLE
Add support for WASI sockets to C API

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -7,6 +7,7 @@
 #ifndef WASI_H
 #define WASI_H
 
+#include <stdint.h>
 #include "wasm.h"
 
 #ifndef WASI_API_EXTERN
@@ -155,6 +156,19 @@ WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t* config);
  * `guest_path` is the name by which it will be known in wasm.
  */
 WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* path, const char* guest_path);
+
+/**
+ * \brief Configures a "preopened socket" to be available to WASI APIs.
+ *
+ * By default WASI programs do not have access to open up network sockets on
+ * the host. This API can be used to grant WASI programs access to a network
+ * socket file descriptor on the host.
+ *
+ * The fd_num argument is the number of the file descriptor by which it will be
+ * known in WASM and the host_port is the IP address and port (e.g.
+ * "127.0.0.1:8080") requested to be open.
+ */
+WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t* config, uint32_t fd_num, const char* host_port);
 
 #undef own
 

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -158,7 +158,7 @@ WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t* config);
 WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* path, const char* guest_path);
 
 /**
- * \brief Configures a "preopened socket" to be available to WASI APIs.
+ * \brief Configures a "preopened" listen socket to be available to WASI APIs.
  *
  * By default WASI programs do not have access to open up network sockets on
  * the host. This API can be used to grant WASI programs access to a network
@@ -166,7 +166,7 @@ WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* 
  *
  * The fd_num argument is the number of the file descriptor by which it will be
  * known in WASM and the host_port is the IP address and port (e.g.
- * "127.0.0.1:8080") requested to be open.
+ * "127.0.0.1:8080") requested to listen on.
  */
 WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t* config, uint32_t fd_num, const char* host_port);
 

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -290,12 +290,12 @@ pub unsafe extern "C" fn wasi_config_preopen_socket(
         Some(s) => s,
         None => return false,
     };
-    let stdlistener = match std::net::TcpListener::bind(address) {
+    let listener = match std::net::TcpListener::bind(address) {
         Ok(listener) => listener,
         Err(_) => return false,
     };
 
-    if let Err(_) = stdlistener.set_nonblocking(true) {
+    if let Err(_) = listener.set_nonblocking(true) {
         return false;
     }
 
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn wasi_config_preopen_socket(
 
     (*config)
         .preopen_sockets
-        .insert(fd_num, TcpListener::from_std(stdlistener));
+        .insert(fd_num, TcpListener::from_std(listener));
 
     true
 }


### PR DESCRIPTION
This adds support for WASI sockets to the C API by adding a new API to handle preopening sockets for clients. This uses `HashMap` instead of `Vec` for preopened sockets to identify if the caller has called in more than once with the same FD number. If so, then we return false so caller is at least given a hint that they may be misusing the API e.g. attempting to overwrite an already existing socket FD.

I stuck with the same `bool` return value because it was already being done for the other APIs e.g. `wasi_config_preopen_dir`. I think it would be beneficial to have a more specific error type, if possible, but not something to address in this PR.

I don't think there are any tests for these APIs so none were added. Of course I was personally testing this with the `crun` container runtime that is using these APIs.

I don't know who could review this so any help identifying the right people would be greatly appreciated!

Fixes #5071

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
