### PR TITLE
test: check that the `--vtune` flag works

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -473,3 +473,19 @@ fn run_cwasm_from_stdin() -> Result<()> {
     }
     Ok(())
 }
+
+#[cfg(feature = "vtune")]
+#[test]
+fn run_in_vtune() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/simple.wat")?;
+    run_wasmtime(&[
+        "run",
+        wasm.path().to_str().unwrap(),
+        "--vtune",
+        "--invoke",
+        "simple",
+        "--disable-cache",
+        "4",
+    ])?;
+    Ok(())
+}


### PR DESCRIPTION
In #5628, it appeared that Wasmtime had regressed and the `--vtune` flag now resulted in errors. This test checks that using the flag does not result in an error (the expected behavior). It does not yet fix #5628.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
