### PR TITLE
wasmtime: default to blocking sockets

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -250,9 +250,6 @@ impl RunCommand {
         for address in &self.run.common.wasi.tcplisten {
             let stdlistener = std::net::TcpListener::bind(address)
                 .with_context(|| format!("failed to bind to address '{}'", address))?;
-
-            let _ = stdlistener.set_nonblocking(true)?;
-
             listeners.push(TcpListener::from_std(stdlistener))
         }
         Ok(listeners)
@@ -874,7 +871,6 @@ fn ctx_set_listenfd(mut num_fd: usize, builder: &mut WasiCtxBuilder) -> Result<u
 
     for i in 0..listenfd.len() {
         if let Some(stdlistener) = listenfd.take_tcp_listener(i)? {
-            let _ = stdlistener.set_nonblocking(true)?;
             let listener = TcpListener::from_std(stdlistener);
             builder.preopened_socket((3 + i) as _, listener)?;
             num_fd = 3 + i;


### PR DESCRIPTION
This commit is a follow-up on f81a663da7846ebf8a41282ef60b1eaf3c834e89, (https://github.com/bytecodealliance/wasmtime/pull/3729)
in which pre-opened socket support was added, but sockets opened by
wasmtime were made to default to non-blocking mode and pre-opened
sockets passed to wasmtime via `listenfd` were explicitly set to
non-blocking mode.

Avoid explicitly setting the mode and use OS default mode in the
former case or whichever mode was pre-configured in the latter.

Note, that Windows, POSIX and Berkeley sockets are blocking by default.