### PR TITLE
x64: Cleanup the use of `maybe_extend` in branch lowerings

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2923,17 +2923,10 @@
                                 (jmp_cond (CC.Z) taken not_taken))))
 
 
-(rule 2 (lower_branch (brnz (icmp cc a b) _) (two_targets taken not_taken))
+(rule 2 (lower_branch (brnz (maybe_uextend (icmp cc a b)) _) (two_targets taken not_taken))
       (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) taken not_taken)))
 
-(rule 2 (lower_branch (brnz (fcmp cc a b) _) (two_targets taken not_taken))
-      (let ((cmp FcmpCondResult (emit_fcmp cc a b)))
-        (emit_side_effect (jmp_cond_fcmp cmp taken not_taken))))
-
-(rule 2 (lower_branch (brnz (uextend (icmp cc a b)) _) (two_targets taken not_taken))
-      (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) taken not_taken)))
-
-(rule 2 (lower_branch (brnz (uextend (fcmp cc a b)) _) (two_targets taken not_taken))
+(rule 2 (lower_branch (brnz (maybe_uextend (fcmp cc a b)) _) (two_targets taken not_taken))
       (let ((cmp FcmpCondResult (emit_fcmp cc a b)))
         (emit_side_effect (jmp_cond_fcmp cmp taken not_taken))))
 


### PR DESCRIPTION
Use `maybe_uextend` for the `brnz` lowerings on x64.

This change will be undone by #5630, but given how small the change is and how big that PR is, it seemed like it might be nice to have this functionality in the meantime :)
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
