### PR TITLE
Remove brz and brnz from cranelift-wasm

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -680,14 +680,14 @@ impl<'a> FunctionBuilder<'a> {
     ///
     /// **Note:** You are responsible for maintaining the coherence with the arguments of
     /// other jump instructions.
-    pub fn change_jump_destination(&mut self, inst: Inst, new_dest: Block) {
+    pub fn change_jump_destination(&mut self, inst: Inst, old_block: Block, new_block: Block) {
         let dfg = &mut self.func.dfg;
-        for old_dest in dfg.insts[inst].branch_destination_mut() {
-            self.func_ctx
-                .ssa
-                .remove_block_predecessor(old_dest.block(&dfg.value_lists), inst);
-            old_dest.set_block(new_dest, &mut dfg.value_lists);
-            self.func_ctx.ssa.declare_block_predecessor(new_dest, inst);
+        for block in dfg.insts[inst].branch_destination_mut() {
+            if block.block(&dfg.value_lists) == old_block {
+                self.func_ctx.ssa.remove_block_predecessor(old_block, inst);
+                block.set_block(new_block, &mut dfg.value_lists);
+                self.func_ctx.ssa.declare_block_predecessor(new_block, inst);
+            }
         }
     }
 

--- a/cranelift/wasm/src/state.rs
+++ b/cranelift/wasm/src/state.rs
@@ -22,6 +22,9 @@ pub enum ElseData {
         /// instruction that needs to be fixed up to point to the new `else`
         /// block rather than the destination block after the `if...end`.
         branch_inst: Inst,
+
+        /// The placeholder block we're replacing.
+        placeholder: Block,
     },
 
     /// We have already allocated an `else` block.
@@ -43,9 +46,8 @@ pub enum ElseData {
 /// - `num_return_values`: number of values returned by the control block;
 /// - `original_stack_size`: size of the value stack at the beginning of the control block.
 ///
-/// Moreover, the `if` frame has the `branch_inst` field that points to the `brz` instruction
-/// separating the `true` and `false` branch. The `loop` frame has a `header` field that references
-/// the `Block` that contains the beginning of the body of the loop.
+/// The `loop` frame has a `header` field that references the `Block` that contains the beginning
+/// of the body of the loop.
 #[derive(Debug)]
 pub enum ControlStackFrame {
     If {


### PR DESCRIPTION
Incrementally working towards removing `brz` and `brnz` completely.

The meat of this change is that when we translate an `if` with no `else` branch, we're now fixing up a specific block of a `brif` instruction, rather than the only destination of a `brnz` instruction. Making this change also exposed that `change_jump_destination` in cranelift-frontend was replacing all branch destinations. The fix there was to include the specific block that we're interested in rewriting, which also necessitated tracking that block value in cranelift-wasm.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
