### PR TITLE
cranelift-codegen: Expose `EmitState` and `EmitInfo` from aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -21,7 +21,7 @@ pub mod imms;
 pub use self::imms::*;
 pub mod args;
 pub use self::args::*;
-pub(crate) mod emit;
+pub mod emit;
 pub(crate) use self::emit::*;
 use crate::isa::aarch64::abi::AArch64MachineDeps;
 


### PR DESCRIPTION
This commit exposes `EmitState` and `EmitInfo` so that they can be consumed by Winch.

This is a follow up to https://github.com/bytecodealliance/wasmtime/pull/5570, in which this should've been included.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
