### PR TITLE
Cranelift: Consider shifts as "simple" arithmetic in egraph cost model

### DIFF
--- a/cranelift/codegen/src/egraph/cost.rs
+++ b/cranelift/codegen/src/egraph/cost.rs
@@ -90,7 +90,10 @@ pub(crate) fn pure_op_cost(op: Opcode) -> Cost {
         | Opcode::BorNot
         | Opcode::Bxor
         | Opcode::BxorNot
-        | Opcode::Bnot => Cost(2),
+        | Opcode::Bnot
+        | Opcode::Ishl
+        | Opcode::Ushr
+        | Opcode::Sshr => Cost(2),
         // Everything else (pure.)
         _ => Cost(3),
     }


### PR DESCRIPTION
No tests yet because [the changes that build on top of this (strength reduction of multiplies by powers of two)](https://github.com/bytecodealliance/wasmtime/pull/5647) is hitting ISLE codegen bugs. This should be safe enough to merge I think tho.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
