### PR TITLE
Fix an assertion failure with an empty Switch

### DIFF
--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -379,12 +379,12 @@ mod tests {
 
     #[test]
     fn switch_empty() {
-        let func = setup!(0, []);
+        let func = setup!(42, []);
         assert_eq_output!(
             func,
             "block0:
     v0 = iconst.i8 0
-    jump block0"
+    jump block42"
         );
     }
 

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -366,15 +366,14 @@ mod tests {
 
     macro_rules! assert_eq_output {
         ($actual:ident, $expected:literal) => {
-            if $actual != $expected {
-                assert!(
-                    false,
-                    "\n{}",
-                    similar::TextDiff::from_lines($expected, &$actual)
-                        .unified_diff()
-                        .header("expected", "actual")
-                );
-            }
+            assert_eq!(
+                $actual,
+                $expected,
+                "\n{}",
+                similar::TextDiff::from_lines($expected, &$actual)
+                    .unified_diff()
+                    .header("expected", "actual")
+            )
         };
     }
 
@@ -385,7 +384,7 @@ mod tests {
             func,
             "block0:
     v0 = iconst.i8 0
-    jump block1"
+    jump block0"
         );
     }
 


### PR DESCRIPTION
Fix an error introduced in #5644, where an unsigned subtraction from zero was possible with an empty Switch structure. Additionally, missing the empty case caused us to not emit a branch to the default block. This PR fixes the issue by detecting the empty Switch case early, and emitting a jump.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
