### PR TITLE
Wasmtime: build release artifacts with `all-arch`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,9 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    # Build `wasmtime` and executables
-    - run: $CENTOS cargo build --release --bin wasmtime
+    # Build `wasmtime` and executables. Note that we include `all-arch` so our
+    # release artifacts can be used to compile `.cwasm`s for other targets.
+    - run: $CENTOS cargo build --release --bin wasmtime --features all-arch
 
     # Build `libwasmtime.so`
     - run: $CENTOS cargo build --release --manifest-path crates/c-api/Cargo.toml


### PR DESCRIPTION
This allows the `wasmtime` binary provided in our release artifacts to cross-compile: `wasmtime compile` can build a `.cwasm` for any platform that Wasmtime supports, not just the host platform. This may be useful in some deployment scenarios.

We don't turn on `all-arch` by default because it increases build time and binary size of Wasmtime itself, and other embedders of the `wasmtime` crate won't necessarily want this; hence, we set it only as part of the CI build configuration.

Fixes #5655.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
