### PR TITLE
cranelift: Generate the correct souper size for comparisons in LHSes

### DIFF
--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -528,9 +528,16 @@ fn souper_type_of(dfg: &ir::DataFlowGraph, val: ir::Value) -> Option<ast::Type> 
     let ty = dfg.value_type(val);
     assert!(ty.is_int());
     assert_eq!(ty.lane_count(), 1);
-    Some(ast::Type {
-        width: ty.bits().try_into().unwrap(),
-    })
+    let width = match dfg.value_def(val).inst() {
+        Some(inst)
+            if dfg.insts[inst].opcode() == ir::Opcode::IcmpImm
+                || dfg.insts[inst].opcode() == ir::Opcode::Icmp =>
+        {
+            1
+        }
+        _ => ty.bits().try_into().unwrap(),
+    };
+    Some(ast::Type { width })
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
