### PR TITLE
Cranelift: Fix `select` condition harvesting

### DIFF
--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -387,7 +387,8 @@ fn harvest_candidate_lhs(
                         let a = arg(allocs, 0);
 
                         // While Cranelift allows any width condition for
-                        // `select`, Souper requires an `i1`.
+                        // `select` and checks it against `0`, Souper requires
+                        // an `i1`. So insert a `ne %x, 0` as needed.
                         let a = match a {
                             ast::Operand::Value(id) => match lhs.get_value(id).r#type {
                                 Some(ast::Type { width: 1 }) => a,
@@ -395,7 +396,14 @@ fn harvest_candidate_lhs(
                                     .assignment(
                                         None,
                                         Some(ast::Type { width: 1 }),
-                                        ast::Instruction::Trunc { a },
+                                        ast::Instruction::Ne {
+                                            a,
+                                            b: ast::Constant {
+                                                value: 0,
+                                                r#type: None,
+                                            }
+                                            .into(),
+                                        },
                                         vec![],
                                     )
                                     .into(),


### PR DESCRIPTION
Souper requires an `i1` condition value, we don't and will implicitly check against 0. We were truncating conditions in the harvester but should actually be inserting the comparison against `0`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
