### PR TITLE
Fix the build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,13 @@
 name: Build
 on:
   push:
-    branches: [main]
-    tags-ignore: [dev]
+    branches:
+    - main
+    tags:
+    - 'v*'
   pull_request:
-    branches: ['main', 'release-*']
+    branches:
+    - 'release-*'
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,10 @@
 name: Build
 on:
   push:
-    branches:
-    - main
-    tags:
-    - 'v*'
+    branches: [main]
+    tags-ignore: [dev]
   pull_request:
-    branches:
-    - 'release-*'
+    branches: ['main', 'release-*']
 
 defaults:
   run:

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -49,6 +49,7 @@ if [ "$platform" = "x86_64-windows" ]; then
   "$WIX/bin/light" -out dist/$bin_pkgname.msi target/wasmtime.wixobj -ext WixUtilExtension
   rm dist/$bin_pkgname.wixpdb
 elif [ "$platform" = "x86_64-mingw" ]; then
+  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
   sudo chmod 0664 target/x86_64-pc-windows-gnu/release/libwasmtime.a
   cp target/x86_64-pc-windows-gnu/release/wasmtime.exe tmp/$bin_pkgname
   cp target/x86_64-pc-windows-gnu/release/{wasmtime.dll,libwasmtime.a,libwasmtime.dll.a} tmp/$api_pkgname/lib
@@ -58,19 +59,23 @@ elif [ "$platform" = "x86_64-macos" ]; then
   # directive than the default one that comes out of the linker when typically
   # doing `cargo build`. For more info see #984
   install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
+  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
   sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$platform" = "aarch64-macos" ]; then
   install_name_tool -id "@rpath/libwasmtime.dylib" target/aarch64-apple-darwin/release/libwasmtime.dylib
+  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
   sudo chmod 0664 target/aarch64-apple-darwin/release/libwasmtime.a
   cp target/aarch64-apple-darwin/release/wasmtime tmp/$bin_pkgname
   cp target/aarch64-apple-darwin/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$target" = "" ]; then
+  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
   sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib
 else
+  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
   sudo chmod 0664 target/$target/release/libwasmtime.a
   cp target/$target/release/wasmtime tmp/$bin_pkgname
   cp target/$target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -50,7 +50,7 @@ if [ "$platform" = "x86_64-windows" ]; then
   rm dist/$bin_pkgname.wixpdb
 elif [ "$platform" = "x86_64-mingw" ]; then
   # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  sudo chmod 0664 target/x86_64-pc-windows-gnu/release/libwasmtime.a
+  chmod 0664 target/x86_64-pc-windows-gnu/release/libwasmtime.a
   cp target/x86_64-pc-windows-gnu/release/wasmtime.exe tmp/$bin_pkgname
   cp target/x86_64-pc-windows-gnu/release/{wasmtime.dll,libwasmtime.a,libwasmtime.dll.a} tmp/$api_pkgname/lib
   fmt=zip

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -49,6 +49,7 @@ if [ "$platform" = "x86_64-windows" ]; then
   "$WIX/bin/light" -out dist/$bin_pkgname.msi target/wasmtime.wixobj -ext WixUtilExtension
   rm dist/$bin_pkgname.wixpdb
 elif [ "$platform" = "x86_64-mingw" ]; then
+  sudo chmod 0664 target/x86_64-pc-windows-gnu/release/libwasmtime.a
   cp target/x86_64-pc-windows-gnu/release/wasmtime.exe tmp/$bin_pkgname
   cp target/x86_64-pc-windows-gnu/release/{wasmtime.dll,libwasmtime.a,libwasmtime.dll.a} tmp/$api_pkgname/lib
   fmt=zip
@@ -57,16 +58,20 @@ elif [ "$platform" = "x86_64-macos" ]; then
   # directive than the default one that comes out of the linker when typically
   # doing `cargo build`. For more info see #984
   install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
+  sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$platform" = "aarch64-macos" ]; then
   install_name_tool -id "@rpath/libwasmtime.dylib" target/aarch64-apple-darwin/release/libwasmtime.dylib
+  sudo chmod 0664 target/aarch64-apple-darwin/release/libwasmtime.a
   cp target/aarch64-apple-darwin/release/wasmtime tmp/$bin_pkgname
   cp target/aarch64-apple-darwin/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$target" = "" ]; then
+  sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib
 else
+  sudo chmod 0664 target/$target/release/libwasmtime.a
   cp target/$target/release/wasmtime tmp/$bin_pkgname
   cp target/$target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib
 fi


### PR DESCRIPTION
Change the permissions on `libwasmtime.a` before copying it, to avoid errors stemming from new behavior in rustc-1.67. Mitigates the effects of https://github.com/rust-lang/rust/issues/107495. See #5665.

* [x] successful build of the `Build` workflow
* [x] remove the change that enabled the `Build` workflow for PRs
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
