### PR TITLE
Fix some warnings on nightly Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version 
 wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=6.0.0" }
 
 cranelift-wasm = { path = "cranelift/wasm", version = "0.93.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.93.0", default-features = false }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.93.0" }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.93.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.93.0" }
 cranelift-native = { path = "cranelift/native", version = "0.93.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version 
 wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=6.0.0" }
 
 cranelift-wasm = { path = "cranelift/wasm", version = "0.93.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.93.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.93.0", default-features = false }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.93.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.93.0" }
 cranelift-native = { path = "cranelift/native", version = "0.93.0" }

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition.workspace = true
 
 [dependencies]
-cranelift-codegen = { workspace = true, default-features = false }
+cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 log = { workspace = true }
 hashbrown = { workspace = true, optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 [dependencies]
 cranelift-module = { workspace = true }
 cranelift-native = { workspace = true }
-cranelift-codegen = { workspace = true, default-features = false, features = ["std"] }
+cranelift-codegen = { workspace = true, features = ["std"] }
 cranelift-entity = { workspace = true }
 anyhow = { workspace = true }
 region = "2.2.0"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition.workspace = true
 
 [dependencies]
-cranelift-codegen = { workspace = true, default-features = false }
+cranelift-codegen = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 anyhow = { workspace = true }
 

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition.workspace = true
 
 [dependencies]
-cranelift-codegen = { workspace = true, default-features = false }
+cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 
 [target.'cfg(any(target_arch = "s390x", target_arch = "riscv64"))'.dependencies]
@@ -24,4 +24,4 @@ core = ["cranelift-codegen/core"]
 
 [badges]
 maintenance = { status = "experimental" }
- 
+

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 
 [dependencies]
 cranelift-module = { workspace = true }
-cranelift-codegen = { workspace = true, default-features = false, features = ["std"] }
+cranelift-codegen = { workspace = true, features = ["std"] }
 object = { workspace = true, features = ["write"] }
 target-lexicon = { workspace = true }
 anyhow = { workspace = true }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -13,9 +13,9 @@ edition.workspace = true
 
 [dependencies]
 wasmparser = { workspace = true }
-cranelift-codegen = { workspace = true, default-features = false }
+cranelift-codegen = { workspace = true }
 cranelift-entity = { workspace = true }
-cranelift-frontend = { workspace = true, default-features = false }
+cranelift-frontend = { workspace = true }
 wasmtime-types = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 itertools = "0.10.0"


### PR DESCRIPTION
Cargo is warning about the usage of workspace dependencies where the workspace declaration does not mention `default-features` but the dependency mentions `default-features`, so this explicitly turns off default features for `cranelift-codegen` at the workspace level and removes the explicit `default-features = false` at the manifest levels.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
