### PR TITLE
Pin release artifacts Rust toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,12 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      # Note that the usage of this nightly toolchain is temporary until it
+      # rides to stable. After this nightly version becomes stable (Rust 1.69.0)
+      # then this should switch back to using stable by deleting the `with` and
+      # `toolchain` options.
+      with:
+        toolchain: nightly-2023-01-31
     # On one builder produce the source tarball since there's no need to produce
     # it everywhere
     - run: ./ci/build-src-tarball.sh

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -49,8 +49,6 @@ if [ "$platform" = "x86_64-windows" ]; then
   "$WIX/bin/light" -out dist/$bin_pkgname.msi target/wasmtime.wixobj -ext WixUtilExtension
   rm dist/$bin_pkgname.wixpdb
 elif [ "$platform" = "x86_64-mingw" ]; then
-  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  chmod 0664 target/x86_64-pc-windows-gnu/release/libwasmtime.a
   cp target/x86_64-pc-windows-gnu/release/wasmtime.exe tmp/$bin_pkgname
   cp target/x86_64-pc-windows-gnu/release/{wasmtime.dll,libwasmtime.a,libwasmtime.dll.a} tmp/$api_pkgname/lib
   fmt=zip
@@ -59,24 +57,16 @@ elif [ "$platform" = "x86_64-macos" ]; then
   # directive than the default one that comes out of the linker when typically
   # doing `cargo build`. For more info see #984
   install_name_tool -id "@rpath/libwasmtime.dylib" target/release/libwasmtime.dylib
-  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$platform" = "aarch64-macos" ]; then
   install_name_tool -id "@rpath/libwasmtime.dylib" target/aarch64-apple-darwin/release/libwasmtime.dylib
-  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  sudo chmod 0664 target/aarch64-apple-darwin/release/libwasmtime.a
   cp target/aarch64-apple-darwin/release/wasmtime tmp/$bin_pkgname
   cp target/aarch64-apple-darwin/release/libwasmtime.{a,dylib} tmp/$api_pkgname/lib
 elif [ "$target" = "" ]; then
-  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  sudo chmod 0664 target/release/libwasmtime.a
   cp target/release/wasmtime tmp/$bin_pkgname
   cp target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib
 else
-  # FIXME: remove when https://github.com/rust-lang/rust/issues/107495 is fixed
-  sudo chmod 0664 target/$target/release/libwasmtime.a
   cp target/$target/release/wasmtime tmp/$bin_pkgname
   cp target/$target/release/libwasmtime.{a,so} tmp/$api_pkgname/lib
 fi


### PR DESCRIPTION
This fixes the build issue identified in #5664 at the toolchain level rather than working around it in our own build. The next step in fixing this will be to remove the nightly override in the future when the toolchain becomes stable.

Closes https://github.com/bytecodealliance/wasmtime/issues/5665
