### PR TITLE
winch: Force a rebuild when new files are added to the `filetests` directory

### DIFF
--- a/winch/filetests/build.rs
+++ b/winch/filetests/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Ensure that new files in the filetests directory cause a rebuild.
+    println!("cargo:rerun-if-changed=filetests");
+}


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

The previous setup wouldn't recognize new files without forcing a rebuild. This PR adds the `cargo:rerun-if-changed` build flag to make sure that if new files are added to the `filetests` directory the crate is rebuilt. New tests are then picked up automatically. 