### PR TITLE
Fix some wit-bindgen-related issues with generated bindings

### DIFF
--- a/crates/component-macro/tests/codegen/function-new.wit
+++ b/crates/component-macro/tests/codegen/function-new.wit
@@ -1,0 +1,3 @@
+default world foo {
+  export new: func()
+}

--- a/crates/component-macro/tests/codegen/share-types.wit
+++ b/crates/component-macro/tests/codegen/share-types.wit
@@ -1,0 +1,19 @@
+interface http-types{
+  record request {
+    method: string
+  }
+  record response {
+    body: string
+  }
+}
+
+default world http-interface {
+  export http-handler: interface {
+    use self.http-types.{request,response}
+    handle-request: func(request: request) -> response
+  }
+  import http-fetch: interface {
+    use self.http-types.{request,response}
+    fetch-request: func(request: request) -> response
+  }
+}

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -101,7 +101,7 @@ impl Wasmtime {
 
     fn import(&mut self, resolve: &Resolve, name: &str, item: &WorldItem) {
         let snake = name.to_snake_case();
-        let mut gen = InterfaceGenerator::new(self, resolve, TypeMode::Owned);
+        let mut gen = InterfaceGenerator::new(self, resolve);
         let import = match item {
             WorldItem::Function(func) => {
                 gen.generate_function_trait_sig(TypeOwner::None, &func);
@@ -139,7 +139,7 @@ impl Wasmtime {
 
     fn export(&mut self, resolve: &Resolve, name: &str, item: &WorldItem) {
         let snake = name.to_snake_case();
-        let mut gen = InterfaceGenerator::new(self, resolve, TypeMode::AllBorrowed("'a"));
+        let mut gen = InterfaceGenerator::new(self, resolve);
         let (ty, getter) = match item {
             WorldItem::Function(func) => {
                 gen.define_rust_guest_export(None, func);
@@ -450,21 +450,15 @@ struct InterfaceGenerator<'a> {
     src: Source,
     gen: &'a mut Wasmtime,
     resolve: &'a Resolve,
-    default_param_mode: TypeMode,
     current_interface: Option<InterfaceId>,
 }
 
 impl<'a> InterfaceGenerator<'a> {
-    fn new(
-        gen: &'a mut Wasmtime,
-        resolve: &'a Resolve,
-        default_param_mode: TypeMode,
-    ) -> InterfaceGenerator<'a> {
+    fn new(gen: &'a mut Wasmtime, resolve: &'a Resolve) -> InterfaceGenerator<'a> {
         InterfaceGenerator {
             src: Source::default(),
             gen,
             resolve,
-            default_param_mode,
             current_interface: None,
         }
     }
@@ -1349,10 +1343,6 @@ impl<'a> RustGenerator<'a> for InterfaceGenerator<'a> {
 
     fn current_interface(&self) -> Option<InterfaceId> {
         self.current_interface
-    }
-
-    fn default_param_mode(&self) -> TypeMode {
-        self.default_param_mode
     }
 
     fn push_str(&mut self, s: &str) {

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1159,7 +1159,7 @@ impl<'a> InterfaceGenerator<'a> {
         self.rustdoc(&func.docs);
         uwrite!(
             self.src,
-            "pub {async_} fn {}<S: wasmtime::AsContextMut>(&self, mut store: S, ",
+            "pub {async_} fn call_{}<S: wasmtime::AsContextMut>(&self, mut store: S, ",
             func.name.to_snake_case(),
         );
         for (i, param) in func.params.iter().enumerate() {

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -46,8 +46,8 @@ mod no_imports {
         let linker = Linker::new(&engine);
         let mut store = Store::new(&engine, ());
         let (no_imports, _) = NoImports::instantiate(&mut store, &component, &linker)?;
-        no_imports.bar(&mut store)?;
-        no_imports.foo().foo(&mut store)?;
+        no_imports.call_bar(&mut store)?;
+        no_imports.foo().call_foo(&mut store)?;
         Ok(())
     }
 }
@@ -108,7 +108,7 @@ mod one_import {
         foo::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
         let mut store = Store::new(&engine, MyImports::default());
         let (one_import, _) = OneImport::instantiate(&mut store, &component, &linker)?;
-        one_import.bar(&mut store)?;
+        one_import.call_bar(&mut store)?;
         assert!(store.data().hit);
         Ok(())
     }

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -80,19 +80,22 @@ mod empty_error {
 
         assert_eq!(
             results
-                .empty_error(&mut store, 0.0)
+                .call_empty_error(&mut store, 0.0)
                 .expect("no trap")
                 .expect("no error returned"),
             0.0
         );
 
         results
-            .empty_error(&mut store, 1.0)
+            .call_empty_error(&mut store, 1.0)
             .expect("no trap")
             .err()
             .expect("() error returned");
 
-        let e = results.empty_error(&mut store, 2.0).err().expect("trap");
+        let e = results
+            .call_empty_error(&mut store, 2.0)
+            .err()
+            .expect("trap");
         assert_eq!(
             format!("{}", e.source().expect("trap message is stored in source")),
             "empty_error: trap"
@@ -188,20 +191,23 @@ mod string_error {
 
         assert_eq!(
             results
-                .string_error(&mut store, 0.0)
+                .call_string_error(&mut store, 0.0)
                 .expect("no trap")
                 .expect("no error returned"),
             0.0
         );
 
         let e = results
-            .string_error(&mut store, 1.0)
+            .call_string_error(&mut store, 1.0)
             .expect("no trap")
             .err()
             .expect("error returned");
         assert_eq!(e, "string_error: error");
 
-        let e = results.string_error(&mut store, 2.0).err().expect("trap");
+        let e = results
+            .call_string_error(&mut store, 2.0)
+            .err()
+            .expect("trap");
         assert_eq!(
             format!("{}", e.source().expect("trap message is stored in source")),
             "string_error: trap"
@@ -328,7 +334,7 @@ mod enum_error {
         assert_eq!(
             results
                 .foo()
-                .enum_error(&mut store, 0.0)
+                .call_enum_error(&mut store, 0.0)
                 .expect("no trap")
                 .expect("no error returned"),
             0.0
@@ -336,7 +342,7 @@ mod enum_error {
 
         let e = results
             .foo()
-            .enum_error(&mut store, 1.0)
+            .call_enum_error(&mut store, 1.0)
             .expect("no trap")
             .err()
             .expect("error returned");
@@ -344,7 +350,7 @@ mod enum_error {
 
         let e = results
             .foo()
-            .enum_error(&mut store, 2.0)
+            .call_enum_error(&mut store, 2.0)
             .err()
             .expect("trap");
         assert_eq!(
@@ -458,7 +464,7 @@ mod record_error {
         assert_eq!(
             results
                 .foo()
-                .record_error(&mut store, 0.0)
+                .call_record_error(&mut store, 0.0)
                 .expect("no trap")
                 .expect("no error returned"),
             0.0
@@ -466,7 +472,7 @@ mod record_error {
 
         let e = results
             .foo()
-            .record_error(&mut store, 1.0)
+            .call_record_error(&mut store, 1.0)
             .expect("no trap")
             .err()
             .expect("error returned");
@@ -480,7 +486,7 @@ mod record_error {
 
         let e = results
             .foo()
-            .record_error(&mut store, 2.0)
+            .call_record_error(&mut store, 2.0)
             .err()
             .expect("trap");
         assert_eq!(
@@ -594,7 +600,7 @@ mod variant_error {
         assert_eq!(
             results
                 .foo()
-                .variant_error(&mut store, 0.0)
+                .call_variant_error(&mut store, 0.0)
                 .expect("no trap")
                 .expect("no error returned"),
             0.0
@@ -602,7 +608,7 @@ mod variant_error {
 
         let e = results
             .foo()
-            .variant_error(&mut store, 1.0)
+            .call_variant_error(&mut store, 1.0)
             .expect("no trap")
             .err()
             .expect("error returned");
@@ -616,7 +622,7 @@ mod variant_error {
 
         let e = results
             .foo()
-            .variant_error(&mut store, 2.0)
+            .call_variant_error(&mut store, 2.0)
             .err()
             .expect("trap");
         assert_eq!(


### PR DESCRIPTION
More details in the commits, but some extra namespacing was added for methods and calculation of whether to generate owned or borrowed types was refactored and more specialized to Wasmtime now that it can.