### PR TITLE
Some refactorings to the ISLE parser

### DIFF
--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -232,7 +232,7 @@ impl<'a> Lexer<'a> {
                 debug_assert!(!s.is_empty());
                 Ok(Some((start_pos, Token::Symbol(s.to_string()))))
             }
-            c if (c >= b'0' && c <= b'9') || c == b'-' => {
+            c @ b'0'..=b'9' | c @ b'-' => {
                 let start_pos = self.pos();
                 let neg = if c == b'-' {
                     self.advance_pos();

--- a/cranelift/isle/isle/src/lexer.rs
+++ b/cranelift/isle/isle/src/lexer.rs
@@ -258,16 +258,8 @@ impl<'a> Lexer<'a> {
                 // string-to-integer conversion.
                 let mut s = vec![];
                 while self.pos.offset < self.buf.len()
-                    && ((radix == 10
-                        && self.buf[self.pos.offset] >= b'0'
-                        && self.buf[self.pos.offset] <= b'9')
-                        || (radix == 16
-                            && ((self.buf[self.pos.offset] >= b'0'
-                                && self.buf[self.pos.offset] <= b'9')
-                                || (self.buf[self.pos.offset] >= b'a'
-                                    && self.buf[self.pos.offset] <= b'f')
-                                || (self.buf[self.pos.offset] >= b'A'
-                                    && self.buf[self.pos.offset] <= b'F')))
+                    && ((radix == 10 && self.buf[self.pos.offset].is_ascii_digit())
+                        || (radix == 16 && self.buf[self.pos.offset].is_ascii_hexdigit())
                         || self.buf[self.pos.offset] == b'_')
                 {
                     if self.buf[self.pos.offset] != b'_' {

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -80,10 +80,10 @@ impl<'a> Parser<'a> {
         self.is(|tok| *tok == Token::At)
     }
     fn is_sym(&self) -> bool {
-        self.is(|tok| tok.is_sym())
+        self.is(Token::is_sym)
     }
     fn is_int(&self) -> bool {
-        self.is(|tok| tok.is_int())
+        self.is(Token::is_int)
     }
     fn is_sym_str(&self, s: &str) -> bool {
         self.is(|tok| match tok {
@@ -110,14 +110,14 @@ impl<'a> Parser<'a> {
     }
 
     fn symbol(&mut self) -> Result<String> {
-        match self.take(|tok| tok.is_sym())? {
+        match self.take(Token::is_sym)? {
             Token::Symbol(s) => Ok(s),
             _ => unreachable!(),
         }
     }
 
     fn int(&mut self) -> Result<i128> {
-        match self.take(|tok| tok.is_int())? {
+        match self.take(Token::is_int)? {
             Token::Int(i) => Ok(i),
             _ => unreachable!(),
         }

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -440,8 +440,7 @@ impl<'a> Parser<'a> {
             self.symbol()?;
             Ok(Pattern::Wildcard { pos })
         } else if self.is_sym() {
-            let s = self.symbol()?;
-            let var = self.str_to_ident(pos, &s)?;
+            let var = self.parse_ident()?;
             if self.is_at() {
                 self.at()?;
                 let subpat = Box::new(self.parse_pattern()?);


### PR DESCRIPTION
This uses a couple of functions in the ISLE lexer than significantly simply the code.

In addition it introduces a token eating api which tries to eat a specific token but returns `None` rather than an error if this fails and it renames take to expect. This brings it a bit more in line with the names used in rustc's parser and IMHO it is a bit nicer.