### PR TITLE
Use `andn` for `band_not` when bmi1 is present

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -26,6 +26,15 @@
               (src1_dst SyntheticAmode)
               (src2 Gpr))
 
+       ;; Integer arithmetic binary op that relies on the VEX prefix.
+       ;; NOTE: we don't currently support emitting VEX instructions with memory
+       ;; arguments, so `src2` is artificially constrained to be a Gpr.
+       (AluRmRVex (size OperandSize)
+                  (op AluRmROpcode)
+                  (src1 Gpr)
+                  (src2 Gpr)
+                  (dst WritableGpr))
+
        ;; Instructions on general-purpose registers that only read src and
        ;; defines dst (dst is not modified). `bsr`, etc.
        (UnaryRmR (size OperandSize) ;; 2, 4, or 8
@@ -585,6 +594,9 @@
             Or
             Xor
             Mul))
+
+(type AluRmROpcode extern
+      (enum Andn))
 
 (type UnaryRmROpcode extern
       (enum Bsr
@@ -1836,6 +1848,18 @@
                  (AluRmiROpcode.Xor)
                  src1
                  src2))
+
+;; Helper for emitting `MInst.AluRmRVex` instructions.
+(decl alu_rm_r_vex (Type AluRmROpcode Gpr Gpr) Gpr)
+(rule (alu_rm_r_vex ty opcode src1 src2)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (size OperandSize (operand_size_of_type_32_64 ty))
+            (_ Unit (emit (MInst.AluRmRVex size opcode src1 src2 dst))))
+        dst))
+
+(decl x64_andn (Type Gpr Gpr) Gpr)
+(rule (x64_andn ty src1 src2)
+      (alu_rm_r_vex ty (AluRmROpcode.Andn) src1 src2))
 
 ;; Helper for emitting immediates with an `i64` value. Note that
 ;; integer constants in ISLE are always parsed as `i128`s; this enables

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -745,7 +745,7 @@ impl PrettyPrint for RegMem {
     }
 }
 
-/// Some basic ALU operations.  TODO: maybe add Adc, Sbb.
+/// Some basic ALU operations.
 #[derive(Copy, Clone, PartialEq)]
 pub enum AluRmiROpcode {
     /// Add operation.
@@ -783,6 +783,36 @@ impl fmt::Debug for AluRmiROpcode {
 }
 
 impl fmt::Display for AluRmiROpcode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
+}
+
+/// ALU operations that don't accept intermediates.
+#[derive(Copy, Clone, PartialEq)]
+pub enum AluRmROpcode {
+    /// And with negated second operand.
+    Andn,
+}
+
+impl AluRmROpcode {
+    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
+        match self {
+            AluRmROpcode::Andn => smallvec![InstructionSet::BMI1],
+        }
+    }
+}
+
+impl fmt::Debug for AluRmROpcode {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            AluRmROpcode::Andn => "andn",
+        };
+        write!(fmt, "{}", name)
+    }
+}
+
+impl fmt::Display for AluRmROpcode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
     }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -283,6 +283,40 @@ pub(crate) fn emit(
             );
         }
 
+        Inst::AluRmRVex {
+            size,
+            op,
+            dst,
+            src1,
+            src2,
+        } => {
+            use AluRmROpcode::*;
+            let dst = allocs.next(dst.to_reg().to_reg());
+            let src1 = allocs.next(src1.to_reg());
+            let src2 = allocs.next(src2.to_reg());
+
+            let w = match size {
+                OperandSize::Size32 => false,
+                OperandSize::Size64 => true,
+
+                // the other cases would be rejected by isle constructors
+                _ => unreachable!(),
+            };
+
+            let opcode = match op {
+                Andn => 0xf2,
+            };
+
+            VexInstruction::new()
+                .map(OpcodeMap::_0F38)
+                .w(w)
+                .reg(dst.to_real_reg().unwrap().hw_enc())
+                .vvvv(src1.to_real_reg().unwrap().hw_enc())
+                .rm(src2.to_real_reg().unwrap().hw_enc())
+                .opcode(opcode)
+                .encode(sink);
+        }
+
         Inst::UnaryRmR { size, op, src, dst } => {
             let dst = allocs.next(dst.to_reg().to_reg());
             let rex_flags = RexFlags::from(*size);

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1103,11 +1103,16 @@
       (sse_and_not ty y x))
 
 
-(rule 1 (lower (has_type ty (band_not x y)))
+(rule 1 (lower (has_type ty @ (use_bmi1 $false) (band_not x y)))
       (if (ty_int_ref_scalar_64 ty))
       (x64_and ty 
                x
                (x64_not ty y)))
+
+(rule 1 (lower (has_type ty @ (use_bmi1 $true) (band_not x y)))
+      (if (ty_int_ref_scalar_64 ty))
+      ;; the first argument is the one that gets inverted with andn
+      (x64_andn ty y x))
 
 
 ;;;; Rules for `bxor_not` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -1,0 +1,17 @@
+test compile precise-output
+target x86_64 has_bmi1
+
+function %f1(i8, i8) -> i8 {
+block0(v0: i8, v1: i8):
+    v2 = band_not v0, v1
+    return v2
+}
+
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   andn    %eax, %esi, %edi
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/bnot.clif
+++ b/cranelift/filetests/filetests/runtests/bnot.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target x86_64
+target x86_64 has_bmi1
 target aarch64
 target s390x
 


### PR DESCRIPTION
We can use the `andn` instruction for the lowering of `band_not` on x64 when `bmi1` is available.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
