### PR TITLE
Update base64 dependency to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = "0.13.0"
+base64 = "0.21.0"
 bincode = "1.1.4"
 directories-next = "2.0"
 file-per-thread-logger = "0.1.1"

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -86,7 +87,7 @@ impl<'config> ModuleCacheEntry<'config> {
         state.hash(&mut hasher);
         let hash: [u8; 32] = hasher.0.finalize().into();
         // standard encoding uses '/' which can't be used for filename
-        let hash = base64::encode_config(&hash, base64::URL_SAFE_NO_PAD);
+        let hash = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&hash);
 
         if let Some(cached_val) = inner.get_data(&hash) {
             if let Some(val) = deserialize(state, cached_val) {


### PR DESCRIPTION
- [X] This is related to #5678 there's a dependency mis-match that between some libraries I need for HTTP and the (old) base64 crate in wasmtime.
- [X] Revs the base64 dependency to 0.21.0, small API change.
- [X] This PR contains test cases, if meaningful. Not necessary, covered by existing tests.
