### PR TITLE
winch: Add missing conversions between x64 types

### DIFF
--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -66,7 +66,7 @@ impl Masm for MacroAssembler {
             return;
         }
 
-        self.asm.sub_ir(bytes, rsp(), OperandSize::S64);
+        self.asm.sub_ir(bytes as i32, rsp(), OperandSize::S64);
         self.increment_sp(bytes);
     }
 


### PR DESCRIPTION
This commit adds some missing conversions between Winch's x64 `Reg` type and Cranelift's `Gpr`, `WritableGpr` and `GprMemImm`. This results in less boilerplate. This is also a bit of groundwork in the assembler to support the rest of the integer binary instructions.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
