### PR TITLE
Add some cargo-vet updates.

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[[audits.ahash]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.7.6 -> 0.8.2"
+
 [[audits.anyhow]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -248,6 +253,12 @@ criteria = "safe-to-deploy"
 version = "0.18.0"
 notes = "I am the author of this crate."
 
+[[audits.hashbrown]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.12.3 -> 0.13.1"
+notes = "The diff looks plausible. Much of it is low-level memory-layout code and I can't be 100% certain without a deeper dive into the implementation logic, but nothing looks actively malicious."
+
 [[audits.heck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -378,6 +389,16 @@ notes = """
 This bump only changed from a function to an associated `const` and trivially
 contains no significant changes.
 """
+
+[[audits.object]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "0.29.0 -> 0.30.1"
+
+[[audits.once_cell]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+delta = "1.16.0 -> 1.17.0"
 
 [[audits.openvino]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -233,6 +233,11 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.12.0 -> 1.13.1"
 
+[[audits.mozilla.audits.once_cell]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.13.1 -> 1.16.0"
+
 [[audits.mozilla.audits.os_str_bytes]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This is a cargo-vet commit I had pushed to #5550, cherry-picked out as a separate PR. It includes vets of updates/diffs for `hashbrown` and deps, and `object` and deps.