### PR TITLE
wasi: support opening with FdFlags::SYNC family

### DIFF
--- a/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/cap_std_sync.rs
@@ -54,9 +54,6 @@ fn run(
             builder = builder.env(var, val)?;
         }
 
-        // cap-std-sync does not yet support the sync family of fdflags
-        builder = builder.env("NO_FDFLAGS_SYNC_SUPPORT", "1")?;
-
         let mut store = Store::new(&engine, builder.build());
         let instance = linker.instantiate(&mut store, &module)?;
         let start = instance.get_typed_func::<(), ()>(&mut store, "_start")?;

--- a/crates/test-programs/tests/wasm_tests/runtime/tokio.rs
+++ b/crates/test-programs/tests/wasm_tests/runtime/tokio.rs
@@ -60,10 +60,6 @@ fn run(
                 builder = builder.env(var, val)?;
             }
 
-            // tokio does not yet support the sync family of fdflags, because cap-std-sync
-            // does not.
-            builder = builder.env("NO_FDFLAGS_SYNC_SUPPORT", "1")?;
-
             let mut store = Store::new(&engine, builder.build());
 
             let instance = linker.instantiate_async(&mut store, &module).await?;

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -16,7 +16,7 @@ wasi-common = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 cap-std = { workspace = true }
-cap-fs-ext = "1.0.0"
+cap-fs-ext = "1.0.5"
 cap-time-ext = "1.0.0"
 cap-rand = { workspace = true }
 fs-set-times = "0.18.0"


### PR DESCRIPTION
@sunfishcode just added OpenOptionsSyncExt to cap-fs-ext: https://docs.rs/cap-fs-ext/latest/cap_fs_ext/struct.OpenOptions.html#impl-OpenOptionsSyncExt-for-OpenOptions

This PR hooks up that trait to the relevant wasi-cap-std-sync path open method, and disables the workaround to ignore this misbehavior in our tests. 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
