### PR TITLE
winch: Fix retrieving function signature for compilation

### DIFF
--- a/winch/filetests/src/lib.rs
+++ b/winch/filetests/src/lib.rs
@@ -112,9 +112,9 @@ mod test {
 
         let binding = body_inputs
             .into_iter()
-            .flat_map(|func| compile(&*isa, module, types, func))
+            .map(|func| compile(&*isa, module, types, func).join("\n"))
             .collect::<Vec<String>>()
-            .join("\n");
+            .join("\n\n");
         let actual = binding.as_str();
 
         if std::env::var("WINCH_TEST_BLESS").unwrap_or_default() == "1" {
@@ -151,7 +151,7 @@ mod test {
     ) -> Vec<String> {
         let index = module.func_index(f.0);
         let sig = types
-            .func_type_at(index.as_u32())
+            .function_at(index.as_u32())
             .expect(&format!("function type at index {:?}", index.as_u32()));
         let FunctionBodyData { body, validator } = f.1;
         let validator = validator.into_validator(Default::default());

--- a/winch/src/compile.rs
+++ b/winch/src/compile.rs
@@ -56,7 +56,7 @@ fn compile(
 ) -> Result<()> {
     let index = module.func_index(f.0);
     let sig = types
-        .func_type_at(index.as_u32())
+        .function_at(index.as_u32())
         .expect(&format!("function type at index {:?}", index.as_u32()));
     let FunctionBodyData { body, validator } = f.1;
     let validator = validator.into_validator(Default::default());
@@ -64,6 +64,7 @@ fn compile(
         .compile_function(&sig, &body, validator)
         .expect("Couldn't compile function");
 
+    println!("Disassembly for function: {}", index.as_u32());
     disasm(buffer.data(), isa)?
         .iter()
         .for_each(|s| println!("{}", s));


### PR DESCRIPTION
This commit fixes an incorrect usage of `func_type_at` to retrieve a defined function signature and instead uses `function_at` to retrieve the signature. Without this change, compilation fails when trying to compile a module with multiple function definitions.

Additionally it enhances `winch-tools` `compile` and `test` commands to handle modules with multiple functions correctly.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
