### PR TITLE
Remove analyze_branch and BranchInfo

### DIFF
--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -2,8 +2,7 @@
 
 use crate::entity::SecondaryMap;
 use crate::flowgraph::{BlockPredecessor, ControlFlowGraph};
-use crate::ir::instructions::BranchInfo;
-use crate::ir::{Block, ExpandedProgramPoint, Function, Inst, Layout, ProgramOrder, Value};
+use crate::ir::{self, Block, ExpandedProgramPoint, Function, Inst, Layout, ProgramOrder, Value};
 use crate::packed_option::PackedOption;
 use crate::timing;
 use alloc::vec::Vec;
@@ -352,21 +351,28 @@ impl DominatorTree {
     /// post-order except for the insertion of the new block header at the split point.
     fn push_successors(&mut self, func: &Function, block: Block) {
         if let Some(inst) = func.layout.last_inst(block) {
-            match func.dfg.analyze_branch(inst) {
-                BranchInfo::SingleDest(succ) => {
-                    self.push_if_unseen(succ.block(&func.dfg.value_lists))
-                }
-                BranchInfo::Conditional(block_then, block_else) => {
+            match func.dfg.insts[inst] {
+                ir::InstructionData::Jump {
+                    destination: succ, ..
+                } => self.push_if_unseen(succ.block(&func.dfg.value_lists)),
+                ir::InstructionData::Brif {
+                    blocks: [block_then, block_else],
+                    ..
+                } => {
                     self.push_if_unseen(block_then.block(&func.dfg.value_lists));
                     self.push_if_unseen(block_else.block(&func.dfg.value_lists));
                 }
-                BranchInfo::Table(jt, dest) => {
+                ir::InstructionData::BranchTable {
+                    table: jt,
+                    destination: dest,
+                    ..
+                } => {
                     for succ in func.jump_tables[jt].iter() {
                         self.push_if_unseen(*succ);
                     }
                     self.push_if_unseen(dest);
                 }
-                BranchInfo::NotABranch => {}
+                _ => {}
             }
         }
     }

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -4,7 +4,7 @@ use crate::entity::{self, PrimaryMap, SecondaryMap};
 use crate::ir;
 use crate::ir::builder::ReplaceBuilder;
 use crate::ir::dynamic_type::{DynamicTypeData, DynamicTypes};
-use crate::ir::instructions::{BranchInfo, CallInfo, InstructionData};
+use crate::ir::instructions::{CallInfo, InstructionData};
 use crate::ir::{types, ConstantData, ConstantPool, Immediate};
 use crate::ir::{
     Block, BlockCall, DynamicType, FuncRef, Inst, SigRef, Signature, Type, Value,
@@ -1033,11 +1033,6 @@ impl DataFlowGraph {
         }
 
         impl ExactSizeIterator for InstResultTypes<'_> {}
-    }
-
-    /// Check if `inst` is a branch.
-    pub fn analyze_branch(&self, inst: Inst) -> BranchInfo {
-        self.insts[inst].analyze_branch()
     }
 
     /// Compute the type of an instruction result from opcode constraints and call signatures.

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -92,11 +92,6 @@ impl Value {
 /// the `Value` of such instructions, use [`inst_results`](super::DataFlowGraph::inst_results) or
 /// its analogue in `cranelift_frontend::FuncBuilder`.
 ///
-/// If you look around the API, you can find many inventive uses for `Inst`,
-/// such as [annotating specific instructions with a comment][inst_comment]
-/// or [performing reflection at compile time](super::DataFlowGraph::analyze_branch)
-/// on the type of instruction.
-///
 /// [inst_comment]: https://github.com/bjorn3/rustc_codegen_cranelift/blob/0f8814fd6da3d436a90549d4bb19b94034f2b19c/src/pretty_clif.rs
 ///
 /// While the order is stable, it is arbitrary and does not necessarily resemble the layout order.

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -20,7 +20,7 @@ use crate::ir::{
     self,
     condcodes::{FloatCC, IntCC},
     trapcode::TrapCode,
-    types, Block, FuncRef, JumpTable, MemFlags, SigRef, StackSlot, Type, Value,
+    types, Block, FuncRef, MemFlags, SigRef, StackSlot, Type, Value,
 };
 
 /// Some instructions use an external list of argument values because there is not enough space in
@@ -292,27 +292,6 @@ impl Default for VariableArgs {
 /// Avoid large matches on instruction formats by using the methods defined here to examine
 /// instructions.
 impl InstructionData {
-    /// Return information about the destination of a branch or jump instruction.
-    ///
-    /// Any instruction that can transfer control to another block reveals its possible destinations
-    /// here.
-    pub fn analyze_branch(&self) -> BranchInfo {
-        match *self {
-            Self::Jump { destination, .. } => BranchInfo::SingleDest(destination),
-            Self::Brif {
-                blocks: [block_then, block_else],
-                ..
-            } => BranchInfo::Conditional(block_then, block_else),
-            Self::BranchTable {
-                table, destination, ..
-            } => BranchInfo::Table(table, destination),
-            _ => {
-                debug_assert!(!self.opcode().is_branch());
-                BranchInfo::NotABranch
-            }
-        }
-    }
-
     /// Get the destinations of this instruction, if it's a branch.
     ///
     /// `br_table` returns the empty slice.
@@ -474,23 +453,6 @@ impl InstructionData {
             _ => {}
         }
     }
-}
-
-/// Information about branch and jump instructions.
-pub enum BranchInfo {
-    /// This is not a branch or jump instruction.
-    /// This instruction will not transfer control to another block in the function, but it may still
-    /// affect control flow by returning or trapping.
-    NotABranch,
-
-    /// This is a branch or jump to a single destination block, possibly taking value arguments.
-    SingleDest(BlockCall),
-
-    /// This is a conditional branch
-    Conditional(BlockCall, BlockCall),
-
-    /// This is a jump table branch which can have many destination blocks and one default block.
-    Table(JumpTable, Block),
 }
 
 /// Information about call instructions.

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -9,9 +9,9 @@ use crate::entity::SecondaryMap;
 use crate::fx::{FxHashMap, FxHashSet};
 use crate::inst_predicates::{has_lowering_side_effect, is_constant_64bit};
 use crate::ir::{
-    instructions, ArgumentPurpose, Block, Constant, ConstantData, DataFlowGraph, ExternalName,
-    Function, GlobalValue, GlobalValueData, Immediate, Inst, InstructionData, MemFlags, Opcode,
-    RelSourceLoc, Type, Value, ValueDef, ValueLabelAssignments, ValueLabelStart,
+    ArgumentPurpose, Block, Constant, ConstantData, DataFlowGraph, ExternalName, Function,
+    GlobalValue, GlobalValueData, Immediate, Inst, InstructionData, MemFlags, Opcode, RelSourceLoc,
+    Type, Value, ValueDef, ValueLabelAssignments, ValueLabelStart,
 };
 use crate::machinst::{
     writable_value_regs, BlockIndex, BlockLoweringOrder, Callee, LoweredBlock, MachLabel, Reg,
@@ -943,17 +943,18 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             let (inst, succ) = self.vcode.block_order().succ_indices(block)[succ_idx];
 
             // Get branch args and convert to Regs.
-            let branch_args = match self.f.dfg.analyze_branch(inst) {
-                instructions::BranchInfo::NotABranch => unreachable!(),
-                instructions::BranchInfo::SingleDest(block) => {
-                    block.args_slice(&self.f.dfg.value_lists)
-                }
-                instructions::BranchInfo::Conditional(then_block, else_block) => {
+            let branch_args = match self.f.dfg.insts[inst] {
+                InstructionData::Jump {
+                    destination: block, ..
+                } => block.args_slice(&self.f.dfg.value_lists),
+                InstructionData::Brif {
+                    blocks: [then_block, else_block],
+                    ..
+                } => {
                     // NOTE: `succ_idx == 0` implying that we're traversing the `then_block` is
                     // enforced by the traversal order defined in `visit_block_succs`. Eventually
-                    // we should traverse the `branch_destination` slice instead of the result of
-                    // analyze_branch there, which would simplify computing the branch args
-                    // significantly.
+                    // we should traverse the `branch_destination` slice there, which would
+                    // simplify computing the branch args significantly.
                     if succ_idx == 0 {
                         then_block.args_slice(&self.f.dfg.value_lists)
                     } else {
@@ -961,7 +962,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                         else_block.args_slice(&self.f.dfg.value_lists)
                     }
                 }
-                instructions::BranchInfo::Table(_, _) => &[],
+                InstructionData::BranchTable { .. } => &[],
+                _ => unreachable!(),
             };
             let mut branch_arg_vregs: SmallVec<[Reg; 16]> = smallvec![];
             for &arg in branch_args {

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -618,7 +618,7 @@ impl SSABuilder {
                     jt = func.create_jump_table(copied);
                 }
 
-                // Redo the match from, but this time capture mutable references
+                // Redo the match from above, but this time capture mutable references
                 match &mut func.dfg.insts[branch] {
                     InstructionData::BranchTable {
                         destination, table, ..

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -14,7 +14,6 @@ use core::mem;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
 use cranelift_codegen::entity::{EntityList, EntitySet, ListPool, SecondaryMap};
 use cranelift_codegen::ir::immediates::{Ieee32, Ieee64};
-use cranelift_codegen::ir::instructions::BranchInfo;
 use cranelift_codegen::ir::types::{F32, F64, I128, I64};
 use cranelift_codegen::ir::{
     Block, Function, Inst, InstBuilder, InstructionData, JumpTableData, Type, Value,
@@ -578,20 +577,17 @@ impl SSABuilder {
         dest_block: Block,
         val: Value,
     ) -> Option<(Block, Inst)> {
-        match func.dfg.analyze_branch(branch) {
-            BranchInfo::NotABranch => {
-                panic!("you have declared a non-branch instruction as a predecessor to a block");
-            }
+        match func.dfg.insts[branch] {
             // For a single destination appending a jump argument to the instruction
             // is sufficient.
-            BranchInfo::SingleDest(_) => {
+            InstructionData::Jump { .. } => {
                 let dfg = &mut func.dfg;
                 for dest in dfg.insts[branch].branch_destination_mut() {
                     dest.append_argument(val, &mut dfg.value_lists);
                 }
                 None
             }
-            BranchInfo::Conditional(_, _) => {
+            InstructionData::Brif { .. } => {
                 let dfg = &mut func.dfg;
                 for block in dfg.insts[branch].branch_destination_mut() {
                     if block.block(&dfg.value_lists) == dest_block {
@@ -600,7 +596,7 @@ impl SSABuilder {
                 }
                 None
             }
-            BranchInfo::Table(mut jt, _default_block) => {
+            InstructionData::BranchTable { table: mut jt, .. } => {
                 // In the case of a jump table, the situation is tricky because br_table doesn't
                 // support arguments. We have to split the critical edge.
                 let middle_block = func.dfg.make_block();
@@ -622,7 +618,7 @@ impl SSABuilder {
                     jt = func.create_jump_table(copied);
                 }
 
-                // Redo the match from `analyze_branch` but this time capture mutable references
+                // Redo the match from, but this time capture mutable references
                 match &mut func.dfg.insts[branch] {
                     InstructionData::BranchTable {
                         destination, table, ..
@@ -638,6 +634,9 @@ impl SSABuilder {
                 let mut cur = FuncCursor::new(func).at_bottom(middle_block);
                 let middle_jump_inst = cur.ins().jump(dest_block, &[val]);
                 Some((middle_block, middle_jump_inst))
+            }
+            _ => {
+                panic!("you have declared a non-branch instruction as a predecessor to a block");
             }
         }
     }
@@ -689,7 +688,7 @@ mod tests {
     use crate::Variable;
     use cranelift_codegen::cursor::{Cursor, FuncCursor};
     use cranelift_codegen::entity::EntityRef;
-    use cranelift_codegen::ir::instructions::BranchInfo;
+    use cranelift_codegen::ir;
     use cranelift_codegen::ir::types::*;
     use cranelift_codegen::ir::{Function, Inst, InstBuilder, JumpTableData, Opcode};
     use cranelift_codegen::settings;
@@ -838,8 +837,11 @@ mod tests {
 
         assert_eq!(x_ssa, x_use3);
         assert_eq!(y_ssa, y_use3);
-        match func.dfg.analyze_branch(brif_block0_block2_block1) {
-            BranchInfo::Conditional(block_then, block_else) => {
+        match func.dfg.insts[brif_block0_block2_block1] {
+            ir::InstructionData::Brif {
+                blocks: [block_then, block_else],
+                ..
+            } => {
                 assert_eq!(block_then.block(&func.dfg.value_lists), block2);
                 assert_eq!(block_then.args_slice(&func.dfg.value_lists).len(), 0);
                 assert_eq!(block_else.block(&func.dfg.value_lists), block1);
@@ -847,8 +849,11 @@ mod tests {
             }
             _ => assert!(false),
         };
-        match func.dfg.analyze_branch(brif_block0_block2_block1) {
-            BranchInfo::Conditional(block_then, block_else) => {
+        match func.dfg.insts[brif_block0_block2_block1] {
+            ir::InstructionData::Brif {
+                blocks: [block_then, block_else],
+                ..
+            } => {
                 assert_eq!(block_then.block(&func.dfg.value_lists), block2);
                 assert_eq!(block_then.args_slice(&func.dfg.value_lists).len(), 0);
                 assert_eq!(block_else.block(&func.dfg.value_lists), block1);
@@ -856,8 +861,10 @@ mod tests {
             }
             _ => assert!(false),
         };
-        match func.dfg.analyze_branch(jump_block1_block2) {
-            BranchInfo::SingleDest(dest) => {
+        match func.dfg.insts[jump_block1_block2] {
+            ir::InstructionData::Jump {
+                destination: dest, ..
+            } => {
                 assert_eq!(dest.block(&func.dfg.value_lists), block2);
                 assert_eq!(dest.args_slice(&func.dfg.value_lists).len(), 0);
             }


### PR DESCRIPTION
We don't have overlap in behavior for branch instructions anymore, so we can remove `analyze_branch` and instead match on the `InstructionData` directly.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
