### PR TITLE
Add assertions for matches that used to use analyze_branch

### DIFF
--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -372,7 +372,7 @@ impl DominatorTree {
                     }
                     self.push_if_unseen(dest);
                 }
-                inst => assert!(!inst.opcode().is_branch()),
+                inst => debug_assert!(!inst.opcode().is_branch()),
             }
         }
     }

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -372,7 +372,7 @@ impl DominatorTree {
                     }
                     self.push_if_unseen(dest);
                 }
-                _ => {}
+                inst => assert!(!inst.opcode().is_branch()),
             }
         }
     }

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -141,7 +141,7 @@ impl ControlFlowGraph {
                         self.add_edge(block, inst, *dest);
                     }
                 }
-                inst => assert!(!inst.opcode().is_branch()),
+                inst => debug_assert!(!inst.opcode().is_branch()),
             }
         }
     }

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -141,7 +141,7 @@ impl ControlFlowGraph {
                         self.add_edge(block, inst, *dest);
                     }
                 }
-                _ => {}
+                inst => assert!(!inst.opcode().is_branch()),
             }
         }
     }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -204,7 +204,7 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
                 }
             }
 
-            inst => assert!(!inst.opcode().is_branch()),
+            inst => debug_assert!(!inst.opcode().is_branch()),
         }
     }
 }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -204,7 +204,7 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
                 }
             }
 
-            _ => {}
+            inst => assert!(!inst.opcode().is_branch()),
         }
     }
 }

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -341,7 +341,7 @@ impl FunctionStencil {
                 }
             }
 
-            _ => {}
+            inst => assert!(!inst.opcode().is_branch()),
         }
     }
 

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -341,7 +341,7 @@ impl FunctionStencil {
                 }
             }
 
-            inst => assert!(!inst.opcode().is_branch()),
+            inst => debug_assert!(!inst.opcode().is_branch()),
         }
     }
 

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1358,7 +1358,7 @@ impl<'a> Verifier<'a> {
                     }
                 }
             }
-            inst => assert!(!inst.opcode().is_branch()),
+            inst => debug_assert!(!inst.opcode().is_branch()),
         }
 
         match self.func.dfg.insts[inst].analyze_call(&self.func.dfg.value_lists) {

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1358,7 +1358,7 @@ impl<'a> Verifier<'a> {
                     }
                 }
             }
-            _ => {}
+            inst => assert!(!inst.opcode().is_branch()),
         }
 
         match self.func.dfg.insts[inst].analyze_call(&self.func.dfg.value_lists) {

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -155,7 +155,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                 self.builder.declare_successor(destination, inst);
             }
 
-            _ => {}
+            inst => assert!(!inst.opcode().is_branch()),
         }
 
         if data.opcode().is_terminator() {

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -155,7 +155,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                 self.builder.declare_successor(destination, inst);
             }
 
-            inst => assert!(!inst.opcode().is_branch()),
+            inst => debug_assert!(!inst.opcode().is_branch()),
         }
 
         if data.opcode().is_terminator() {


### PR DESCRIPTION
Following up from #5730, add assertions to ensure that new branch instructions don't slip through matches that used to use `analyze_branch`.

cc @bjorn3 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
