### PR TITLE
Refactor matches that used to consume BranchInfo

### DIFF
--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -351,7 +351,7 @@ impl DominatorTree {
     /// post-order except for the insertion of the new block header at the split point.
     fn push_successors(&mut self, func: &Function, block: Block) {
         if let Some(inst) = func.layout.last_inst(block) {
-            match func.dfg.insts[inst] {
+            match &func.dfg.insts[inst] {
                 ir::InstructionData::Jump {
                     destination: succ, ..
                 } => self.push_if_unseen(succ.block(&func.dfg.value_lists)),
@@ -367,10 +367,10 @@ impl DominatorTree {
                     destination: dest,
                     ..
                 } => {
-                    for succ in func.jump_tables[jt].iter() {
+                    for succ in func.jump_tables[*jt].iter() {
                         self.push_if_unseen(*succ);
                     }
-                    self.push_if_unseen(dest);
+                    self.push_if_unseen(*dest);
                 }
                 _ => {}
             }

--- a/cranelift/codegen/src/flowgraph.rs
+++ b/cranelift/codegen/src/flowgraph.rs
@@ -117,7 +117,7 @@ impl ControlFlowGraph {
 
     fn compute_block(&mut self, func: &Function, block: Block) {
         if let Some(inst) = func.layout.last_inst(block) {
-            match func.dfg.insts[inst] {
+            match &func.dfg.insts[inst] {
                 ir::InstructionData::Jump {
                     destination: dest, ..
                 } => {
@@ -135,9 +135,9 @@ impl ControlFlowGraph {
                     destination: dest,
                     ..
                 } => {
-                    self.add_edge(block, inst, dest);
+                    self.add_edge(block, inst, *dest);
 
-                    for dest in func.jump_tables[jt].iter() {
+                    for dest in func.jump_tables[*jt].iter() {
                         self.add_edge(block, inst, *dest);
                     }
                 }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -175,7 +175,7 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
     mut visit: F,
 ) {
     if let Some(inst) = f.layout.last_inst(block) {
-        match f.dfg.insts[inst] {
+        match &f.dfg.insts[inst] {
             ir::InstructionData::Jump {
                 destination: dest, ..
             } => {
@@ -197,9 +197,9 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
             } => {
                 // The default block is reached via a direct conditional branch,
                 // so it is not part of the table.
-                visit(inst, dest, false);
+                visit(inst, *dest, false);
 
-                for &dest in f.jump_tables[table].as_slice() {
+                for &dest in f.jump_tables[*table].as_slice() {
                     visit(inst, dest, true);
                 }
             }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -943,7 +943,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             let (inst, succ) = self.vcode.block_order().succ_indices(block)[succ_idx];
 
             // Get branch args and convert to Regs.
-            let branch_args = match self.f.dfg.insts[inst] {
+            let branch_args = match &self.f.dfg.insts[inst] {
                 InstructionData::Jump {
                     destination: block, ..
                 } => block.args_slice(&self.f.dfg.value_lists),

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1293,7 +1293,7 @@ impl<'a> Verifier<'a> {
         inst: Inst,
         errors: &mut VerifierErrors,
     ) -> VerifierStepResult<()> {
-        match self.func.dfg.insts[inst] {
+        match &self.func.dfg.insts[inst] {
             ir::InstructionData::Jump {
                 destination: block, ..
             } => {
@@ -1333,7 +1333,7 @@ impl<'a> Verifier<'a> {
                 destination: block,
                 ..
             } => {
-                let arg_count = self.func.dfg.num_block_params(block);
+                let arg_count = self.func.dfg.num_block_params(*block);
                 if arg_count != 0 {
                     return errors.nonfatal((
                         inst,
@@ -1344,7 +1344,7 @@ impl<'a> Verifier<'a> {
                         ),
                     ));
                 }
-                for block in self.func.jump_tables[table].iter() {
+                for block in self.func.jump_tables[*table].iter() {
                     let arg_count = self.func.dfg.num_block_params(*block);
                     if arg_count != 0 {
                         return errors.nonfatal((

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -106,7 +106,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
             self.builder.func.set_srcloc(inst, self.builder.srcloc);
         }
 
-        match self.builder.func.dfg.insts[inst] {
+        match &self.builder.func.dfg.insts[inst] {
             ir::InstructionData::Jump {
                 destination: dest, ..
             } => {
@@ -140,7 +140,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                     .builder
                     .func
                     .jump_tables
-                    .get(table)
+                    .get(*table)
                     .expect("you are referencing an undeclared jump table")
                     .iter()
                     .filter(|&dest_block| unique.insert(*dest_block))
@@ -152,7 +152,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                         .ssa
                         .declare_block_predecessor(*dest_block, inst);
                 }
-                self.builder.declare_successor(destination, inst);
+                self.builder.declare_successor(*destination, inst);
             }
 
             _ => {}

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -577,7 +577,7 @@ impl SSABuilder {
         dest_block: Block,
         val: Value,
     ) -> Option<(Block, Inst)> {
-        match func.dfg.insts[branch] {
+        match &func.dfg.insts[branch] {
             // For a single destination appending a jump argument to the instruction
             // is sufficient.
             InstructionData::Jump { .. } => {


### PR DESCRIPTION
Explicitly borrow the instruction data, and use a mutable borrow to avoid rematch

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
