### PR TITLE
Fix ABI of jitted function in cranelift-jit example.

### DIFF
--- a/cranelift/jit/examples/jit-minimal.rs
+++ b/cranelift/jit/examples/jit-minimal.rs
@@ -84,7 +84,7 @@ fn main() {
     let code_b = module.get_finalized_function(func_b);
 
     // Cast it to a rust function pointer type.
-    let ptr_b = unsafe { mem::transmute::<_, fn() -> u32>(code_b) };
+    let ptr_b = unsafe { mem::transmute::<_, extern "C" fn() -> u32>(code_b) };
 
     // Call it!
     let res = ptr_b();


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

Sorry if this is trivial! This issue was discussed on [Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/.E2.9C.94.20What.20is.20the.20ABI.20of.20functions.20created.20with.20cranelift_jit.3F).

The `jit-minimal` example calls the jitted function using Rust's (not stable) ABI. The correct ABI should be `extern "C"`.

I'm not sure who should review this, and I don't see a suggested list