### PR TITLE
Rename `VMCallerCheckedAnyfunc` to `VMCallerCheckedFuncRef`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -95,7 +95,7 @@ impl ComponentCompiler for Compiler {
             None => builder.ins().iconst(pointer_type, 0),
         });
 
-        // realloc: *mut VMCallerCheckedAnyfunc
+        // realloc: *mut VMCallerCheckedFuncRef
         host_sig.params.push(ir::AbiParam::new(pointer_type));
         callee_args.push(match realloc {
             Some(idx) => builder.ins().load(

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -184,7 +184,7 @@ pub enum GlobalInitializer {
     /// A core wasm function was "generated" via `canon lower` of a function
     /// that was `canon lift`'d in the same component, meaning that the function
     /// always traps. This is recorded within the `VMComponentContext` as a new
-    /// `VMCallerCheckedAnyfunc` that's available for use.
+    /// `VMCallerCheckedFuncRef` that's available for use.
     AlwaysTrap(AlwaysTrap),
 
     /// A core wasm linear memory is going to be saved into the
@@ -213,7 +213,7 @@ pub enum GlobalInitializer {
     SaveModuleImport(RuntimeImportIndex),
 
     /// Similar to `ExtractMemory` and friends and indicates that a
-    /// `VMCallerCheckedAnyfunc` needs to be initialized for a transcoder
+    /// `VMCallerCheckedFuncRef` needs to be initialized for a transcoder
     /// function and this will later be used to instantiate an adapter module.
     Transcoder(Transcoder),
 }
@@ -469,7 +469,7 @@ pub enum StringEncoding {
 pub struct Transcoder {
     /// The index of the transcoder being defined and initialized.
     ///
-    /// This indicates which `VMCallerCheckedAnyfunc` slot is written to in a
+    /// This indicates which `VMCallerCheckedFuncRef` slot is written to in a
     /// `VMComponentContext`.
     pub index: RuntimeTranscoderIndex,
     /// The transcoding operation being performed.

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -181,7 +181,7 @@ indices! {
 
     /// Index into the list of transcoders identified during compilation.
     ///
-    /// This is used to index the `VMCallerCheckedAnyfunc` slots reserved for
+    /// This is used to index the `VMCallerCheckedFuncRef` slots reserved for
     /// string encoders which reference linear memories defined within a
     /// component.
     pub struct RuntimeTranscoderIndex(u32);

--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -6,13 +6,13 @@
 //      store: *mut dyn Store,
 //      limits: *const VMRuntimeLimits,
 //      flags: [VMGlobalDefinition; component.num_runtime_component_instances],
-//      lowering_anyfuncs: [VMCallerCheckedAnyfunc; component.num_lowerings],
-//      always_trap_anyfuncs: [VMCallerCheckedAnyfunc; component.num_always_trap],
-//      transcoder_anyfuncs: [VMCallerCheckedAnyfunc; component.num_transcoders],
+//      lowering_anyfuncs: [VMCallerCheckedFuncRef; component.num_lowerings],
+//      always_trap_anyfuncs: [VMCallerCheckedFuncRef; component.num_always_trap],
+//      transcoder_anyfuncs: [VMCallerCheckedFuncRef; component.num_transcoders],
 //      lowerings: [VMLowering; component.num_lowerings],
 //      memories: [*mut VMMemoryDefinition; component.num_memories],
-//      reallocs: [*mut VMCallerCheckedAnyfunc; component.num_reallocs],
-//      post_returns: [*mut VMCallerCheckedAnyfunc; component.num_post_returns],
+//      reallocs: [*mut VMCallerCheckedFuncRef; component.num_reallocs],
+//      post_returns: [*mut VMCallerCheckedFuncRef; component.num_post_returns],
 // }
 
 use crate::component::{
@@ -57,7 +57,7 @@ pub struct VMComponentOffsets<P> {
     /// least 1).
     pub num_runtime_component_instances: u32,
     /// Number of "always trap" functions which have their
-    /// `VMCallerCheckedAnyfunc` stored inline in the `VMComponentContext`.
+    /// `VMCallerCheckedFuncRef` stored inline in the `VMComponentContext`.
     pub num_always_trap: u32,
     /// Number of transcoders needed for string conversion.
     pub num_transcoders: u32,
@@ -148,9 +148,9 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             align(16),
             size(flags) = cmul(ret.num_runtime_component_instances, ret.ptr.size_of_vmglobal_definition()),
             align(u32::from(ret.ptr.size())),
-            size(lowering_anyfuncs) = cmul(ret.num_lowerings, ret.ptr.size_of_vmcaller_checked_anyfunc()),
-            size(always_trap_anyfuncs) = cmul(ret.num_always_trap, ret.ptr.size_of_vmcaller_checked_anyfunc()),
-            size(transcoder_anyfuncs) = cmul(ret.num_transcoders, ret.ptr.size_of_vmcaller_checked_anyfunc()),
+            size(lowering_anyfuncs) = cmul(ret.num_lowerings, ret.ptr.size_of_vmcaller_checked_func_ref()),
+            size(always_trap_anyfuncs) = cmul(ret.num_always_trap, ret.ptr.size_of_vmcaller_checked_func_ref()),
+            size(transcoder_anyfuncs) = cmul(ret.num_transcoders, ret.ptr.size_of_vmcaller_checked_func_ref()),
             size(lowerings) = cmul(ret.num_lowerings, ret.ptr.size() * 2),
             size(memories) = cmul(ret.num_runtime_memories, ret.ptr.size()),
             size(reallocs) = cmul(ret.num_runtime_reallocs, ret.ptr.size()),
@@ -210,12 +210,12 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.lowering_anyfuncs
     }
 
-    /// The offset of `VMCallerCheckedAnyfunc` for the `index` specified.
+    /// The offset of `VMCallerCheckedFuncRef` for the `index` specified.
     #[inline]
     pub fn lowering_anyfunc(&self, index: LoweredIndex) -> u32 {
         assert!(index.as_u32() < self.num_lowerings);
         self.lowering_anyfuncs()
-            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
+            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_func_ref())
     }
 
     /// The offset of the `always_trap_anyfuncs` field.
@@ -224,12 +224,12 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.always_trap_anyfuncs
     }
 
-    /// The offset of `VMCallerCheckedAnyfunc` for the `index` specified.
+    /// The offset of `VMCallerCheckedFuncRef` for the `index` specified.
     #[inline]
     pub fn always_trap_anyfunc(&self, index: RuntimeAlwaysTrapIndex) -> u32 {
         assert!(index.as_u32() < self.num_always_trap);
         self.always_trap_anyfuncs()
-            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
+            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_func_ref())
     }
 
     /// The offset of the `transcoder_anyfuncs` field.
@@ -238,12 +238,12 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.transcoder_anyfuncs
     }
 
-    /// The offset of `VMCallerCheckedAnyfunc` for the `index` specified.
+    /// The offset of `VMCallerCheckedFuncRef` for the `index` specified.
     #[inline]
     pub fn transcoder_anyfunc(&self, index: RuntimeTranscoderIndex) -> u32 {
         assert!(index.as_u32() < self.num_transcoders);
         self.transcoder_anyfuncs()
-            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_anyfunc())
+            + index.as_u32() * u32::from(self.ptr.size_of_vmcaller_checked_func_ref())
     }
 
     /// The offset of the `lowerings` field.
@@ -309,7 +309,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.reallocs
     }
 
-    /// The offset of the `*mut VMCallerCheckedAnyfunc` for the runtime index
+    /// The offset of the `*mut VMCallerCheckedFuncRef` for the runtime index
     /// provided.
     #[inline]
     pub fn runtime_realloc(&self, index: RuntimeReallocIndex) -> u32 {
@@ -323,7 +323,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
         self.post_returns
     }
 
-    /// The offset of the `*mut VMCallerCheckedAnyfunc` for the runtime index
+    /// The offset of the `*mut VMCallerCheckedFuncRef` for the runtime index
     /// provided.
     #[inline]
     pub fn runtime_post_return(&self, index: RuntimePostReturnIndex) -> u32 {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -809,7 +809,7 @@ pub struct Module {
     pub num_imported_globals: usize,
 
     /// Number of functions that "escape" from this module may need to have a
-    /// `VMCallerCheckedAnyfunc` constructed for them.
+    /// `VMCallerCheckedFuncRef` constructed for them.
     ///
     /// This is also the number of functions in the `functions` array below with
     /// an `anyfunc` index (and is the maximum anyfunc index).

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -7,7 +7,7 @@
 //! cranelift-compiled adapters, will use this `VMComponentContext` as well.
 
 use crate::{
-    Store, VMCallerCheckedAnyfunc, VMFunctionBody, VMGlobalDefinition, VMMemoryDefinition,
+    Store, VMCallerCheckedFuncRef, VMFunctionBody, VMGlobalDefinition, VMMemoryDefinition,
     VMOpaqueContext, VMSharedSignatureIndex, ValRaw,
 };
 use memoffset::offset_of;
@@ -79,7 +79,7 @@ pub type VMLoweringCallee = extern "C" fn(
     data: *mut u8,
     flags: InstanceFlags,
     opt_memory: *mut VMMemoryDefinition,
-    opt_realloc: *mut VMCallerCheckedAnyfunc,
+    opt_realloc: *mut VMCallerCheckedFuncRef,
     string_encoding: StringEncoding,
     args_and_results: *mut ValRaw,
     nargs_and_results: usize,
@@ -201,7 +201,7 @@ impl ComponentInstance {
     ///
     /// This can only be called after `idx` has been initialized at runtime
     /// during the instantiation process of a component.
-    pub fn runtime_realloc(&self, idx: RuntimeReallocIndex) -> NonNull<VMCallerCheckedAnyfunc> {
+    pub fn runtime_realloc(&self, idx: RuntimeReallocIndex) -> NonNull<VMCallerCheckedFuncRef> {
         unsafe {
             let ret = *self.vmctx_plus_offset::<NonNull<_>>(self.offsets.runtime_realloc(idx));
             debug_assert!(ret.as_ptr() as usize != INVALID_PTR);
@@ -216,7 +216,7 @@ impl ComponentInstance {
     pub fn runtime_post_return(
         &self,
         idx: RuntimePostReturnIndex,
-    ) -> NonNull<VMCallerCheckedAnyfunc> {
+    ) -> NonNull<VMCallerCheckedFuncRef> {
         unsafe {
             let ret = *self.vmctx_plus_offset::<NonNull<_>>(self.offsets.runtime_post_return(idx));
             debug_assert!(ret.as_ptr() as usize != INVALID_PTR);
@@ -246,7 +246,7 @@ impl ComponentInstance {
     ///
     /// This can only be called after `idx` has been initialized at runtime
     /// during the instantiation process of a component.
-    pub fn lowering_anyfunc(&self, idx: LoweredIndex) -> NonNull<VMCallerCheckedAnyfunc> {
+    pub fn lowering_anyfunc(&self, idx: LoweredIndex) -> NonNull<VMCallerCheckedFuncRef> {
         unsafe { self.anyfunc(self.offsets.lowering_anyfunc(idx)) }
     }
 
@@ -254,7 +254,7 @@ impl ComponentInstance {
     pub fn always_trap_anyfunc(
         &self,
         idx: RuntimeAlwaysTrapIndex,
-    ) -> NonNull<VMCallerCheckedAnyfunc> {
+    ) -> NonNull<VMCallerCheckedFuncRef> {
         unsafe { self.anyfunc(self.offsets.always_trap_anyfunc(idx)) }
     }
 
@@ -262,12 +262,12 @@ impl ComponentInstance {
     pub fn transcoder_anyfunc(
         &self,
         idx: RuntimeTranscoderIndex,
-    ) -> NonNull<VMCallerCheckedAnyfunc> {
+    ) -> NonNull<VMCallerCheckedFuncRef> {
         unsafe { self.anyfunc(self.offsets.transcoder_anyfunc(idx)) }
     }
 
-    unsafe fn anyfunc(&self, offset: u32) -> NonNull<VMCallerCheckedAnyfunc> {
-        let ret = self.vmctx_plus_offset::<VMCallerCheckedAnyfunc>(offset);
+    unsafe fn anyfunc(&self, offset: u32) -> NonNull<VMCallerCheckedFuncRef> {
+        let ret = self.vmctx_plus_offset::<VMCallerCheckedFuncRef>(offset);
         debug_assert!((*ret).func_ptr.as_ptr() as usize != INVALID_PTR);
         debug_assert!((*ret).vmctx as usize != INVALID_PTR);
         NonNull::new(ret).unwrap()
@@ -294,7 +294,7 @@ impl ComponentInstance {
     pub fn set_runtime_realloc(
         &mut self,
         idx: RuntimeReallocIndex,
-        ptr: NonNull<VMCallerCheckedAnyfunc>,
+        ptr: NonNull<VMCallerCheckedFuncRef>,
     ) {
         unsafe {
             let storage = self.vmctx_plus_offset(self.offsets.runtime_realloc(idx));
@@ -307,7 +307,7 @@ impl ComponentInstance {
     pub fn set_runtime_post_return(
         &mut self,
         idx: RuntimePostReturnIndex,
-        ptr: NonNull<VMCallerCheckedAnyfunc>,
+        ptr: NonNull<VMCallerCheckedFuncRef>,
     ) {
         unsafe {
             let storage = self.vmctx_plus_offset(self.offsets.runtime_post_return(idx));
@@ -378,7 +378,7 @@ impl ComponentInstance {
     ) {
         debug_assert!(*self.vmctx_plus_offset::<usize>(offset) == INVALID_PTR);
         let vmctx = self.vmctx();
-        *self.vmctx_plus_offset(offset) = VMCallerCheckedAnyfunc {
+        *self.vmctx_plus_offset(offset) = VMCallerCheckedFuncRef {
             func_ptr,
             type_index,
             vmctx: VMOpaqueContext::from_vmcomponent(vmctx),
@@ -510,7 +510,7 @@ impl OwnedComponentInstance {
     pub fn set_runtime_realloc(
         &mut self,
         idx: RuntimeReallocIndex,
-        ptr: NonNull<VMCallerCheckedAnyfunc>,
+        ptr: NonNull<VMCallerCheckedFuncRef>,
     ) {
         unsafe { self.instance_mut().set_runtime_realloc(idx, ptr) }
     }
@@ -519,7 +519,7 @@ impl OwnedComponentInstance {
     pub fn set_runtime_post_return(
         &mut self,
         idx: RuntimePostReturnIndex,
-        ptr: NonNull<VMCallerCheckedAnyfunc>,
+        ptr: NonNull<VMCallerCheckedFuncRef>,
     ) {
         unsafe { self.instance_mut().set_runtime_post_return(idx, ptr) }
     }

--- a/crates/runtime/src/export.rs
+++ b/crates/runtime/src/export.rs
@@ -1,5 +1,5 @@
 use crate::vmcontext::{
-    VMCallerCheckedAnyfunc, VMContext, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
+    VMCallerCheckedFuncRef, VMContext, VMGlobalDefinition, VMMemoryDefinition, VMTableDefinition,
 };
 use std::ptr::NonNull;
 use wasmtime_environ::{DefinedMemoryIndex, Global, MemoryPlan, TablePlan};
@@ -22,11 +22,11 @@ pub enum Export {
 /// A function export value.
 #[derive(Debug, Clone, Copy)]
 pub struct ExportFunction {
-    /// The `VMCallerCheckedAnyfunc` for this exported function.
+    /// The `VMCallerCheckedFuncRef` for this exported function.
     ///
     /// Note that exported functions cannot be a null funcref, so this is a
     /// non-null pointer.
-    pub anyfunc: NonNull<VMCallerCheckedAnyfunc>,
+    pub anyfunc: NonNull<VMCallerCheckedFuncRef>,
 }
 
 // It's part of the contract of using `ExportFunction` that synchronization

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub use crate::traphandlers::{
     Backtrace, SignalHandler, TlsRestore, Trap, TrapReason,
 };
 pub use crate::vmcontext::{
-    VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
+    VMCallerCheckedFuncRef, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,
     VMGlobalImport, VMHostFuncContext, VMInvokeArgument, VMMemoryDefinition, VMMemoryImport,
     VMOpaqueContext, VMRuntimeLimits, VMSharedSignatureIndex, VMTableDefinition, VMTableImport,
     VMTrampoline, ValRaw,

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -514,22 +514,22 @@ impl VMGlobalDefinition {
 
     /// Return a reference to the value as an anyfunc.
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn as_anyfunc(&self) -> *const VMCallerCheckedAnyfunc {
+    pub unsafe fn as_anyfunc(&self) -> *const VMCallerCheckedFuncRef {
         *(self
             .storage
             .as_ref()
             .as_ptr()
-            .cast::<*const VMCallerCheckedAnyfunc>())
+            .cast::<*const VMCallerCheckedFuncRef>())
     }
 
     /// Return a mutable reference to the value as an anyfunc.
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn as_anyfunc_mut(&mut self) -> &mut *const VMCallerCheckedAnyfunc {
+    pub unsafe fn as_anyfunc_mut(&mut self) -> &mut *const VMCallerCheckedFuncRef {
         &mut *(self
             .storage
             .as_mut()
             .as_mut_ptr()
-            .cast::<*const VMCallerCheckedAnyfunc>())
+            .cast::<*const VMCallerCheckedFuncRef>())
     }
 }
 
@@ -582,7 +582,7 @@ impl Default for VMSharedSignatureIndex {
 /// by the caller.
 #[derive(Debug, Clone)]
 #[repr(C)]
-pub struct VMCallerCheckedAnyfunc {
+pub struct VMCallerCheckedFuncRef {
     /// Function body.
     pub func_ptr: NonNull<VMFunctionBody>,
     /// Function signature id.
@@ -597,12 +597,12 @@ pub struct VMCallerCheckedAnyfunc {
     // If more elements are added here, remember to add offset_of tests below!
 }
 
-unsafe impl Send for VMCallerCheckedAnyfunc {}
-unsafe impl Sync for VMCallerCheckedAnyfunc {}
+unsafe impl Send for VMCallerCheckedFuncRef {}
+unsafe impl Sync for VMCallerCheckedFuncRef {}
 
 #[cfg(test)]
 mod test_vmcaller_checked_anyfunc {
-    use super::VMCallerCheckedAnyfunc;
+    use super::VMCallerCheckedFuncRef;
     use memoffset::offset_of;
     use std::mem::size_of;
     use wasmtime_environ::{Module, PtrSize, VMOffsets};
@@ -612,20 +612,20 @@ mod test_vmcaller_checked_anyfunc {
         let module = Module::new();
         let offsets = VMOffsets::new(size_of::<*mut u8>() as u8, &module);
         assert_eq!(
-            size_of::<VMCallerCheckedAnyfunc>(),
-            usize::from(offsets.ptr.size_of_vmcaller_checked_anyfunc())
+            size_of::<VMCallerCheckedFuncRef>(),
+            usize::from(offsets.ptr.size_of_vmcaller_checked_func_ref())
         );
         assert_eq!(
-            offset_of!(VMCallerCheckedAnyfunc, func_ptr),
-            usize::from(offsets.ptr.vmcaller_checked_anyfunc_func_ptr())
+            offset_of!(VMCallerCheckedFuncRef, func_ptr),
+            usize::from(offsets.ptr.vmcaller_checked_func_ref_func_ptr())
         );
         assert_eq!(
-            offset_of!(VMCallerCheckedAnyfunc, type_index),
-            usize::from(offsets.ptr.vmcaller_checked_anyfunc_type_index())
+            offset_of!(VMCallerCheckedFuncRef, type_index),
+            usize::from(offsets.ptr.vmcaller_checked_func_ref_type_index())
         );
         assert_eq!(
-            offset_of!(VMCallerCheckedAnyfunc, vmctx),
-            usize::from(offsets.ptr.vmcaller_checked_anyfunc_vmctx())
+            offset_of!(VMCallerCheckedFuncRef, vmctx),
+            usize::from(offsets.ptr.vmcaller_checked_func_ref_vmctx())
         );
     }
 }
@@ -1144,11 +1144,11 @@ pub type VMTrampoline =
 /// target context.
 ///
 /// This context is used to represent that contexts specified in
-/// `VMCallerCheckedAnyfunc` can have any type and don't have an implicit
+/// `VMCallerCheckedFuncRef` can have any type and don't have an implicit
 /// structure. Neither wasmtime nor cranelift-generated code can rely on the
 /// structure of an opaque context in general and only the code which configured
 /// the context is able to rely on a particular structure. This is because the
-/// context pointer configured for `VMCallerCheckedAnyfunc` is guaranteed to be
+/// context pointer configured for `VMCallerCheckedFuncRef` is guaranteed to be
 /// the first parameter passed.
 ///
 /// Note that Wasmtime currently has a layout where all contexts that are casted

--- a/crates/runtime/src/vmcontext/vm_host_func_context.rs
+++ b/crates/runtime/src/vmcontext/vm_host_func_context.rs
@@ -4,7 +4,7 @@
 
 use wasmtime_environ::VM_HOST_FUNC_MAGIC;
 
-use super::{VMCallerCheckedAnyfunc, VMFunctionBody, VMOpaqueContext, VMSharedSignatureIndex};
+use super::{VMCallerCheckedFuncRef, VMFunctionBody, VMOpaqueContext, VMSharedSignatureIndex};
 use std::{
     any::Any,
     ptr::{self, NonNull},
@@ -20,7 +20,7 @@ pub struct VMHostFuncContext {
     magic: u32,
     // _padding: u32, // (on 64-bit systems)
     pub(crate) host_func: NonNull<VMFunctionBody>,
-    wasm_to_host_trampoline: VMCallerCheckedAnyfunc,
+    wasm_to_host_trampoline: VMCallerCheckedFuncRef,
     host_state: Box<dyn Any + Send + Sync>,
 }
 
@@ -41,7 +41,7 @@ impl VMHostFuncContext {
         signature: VMSharedSignatureIndex,
         host_state: Box<dyn Any + Send + Sync>,
     ) -> Box<VMHostFuncContext> {
-        let wasm_to_host_trampoline = VMCallerCheckedAnyfunc {
+        let wasm_to_host_trampoline = VMCallerCheckedFuncRef {
             func_ptr: NonNull::new(crate::trampolines::wasm_to_host_trampoline as _).unwrap(),
             type_index: signature,
             vmctx: ptr::null_mut(),
@@ -58,7 +58,7 @@ impl VMHostFuncContext {
     }
 
     /// Get the Wasm-to-host trampoline for this host function context.
-    pub fn wasm_to_host_trampoline(&self) -> NonNull<VMCallerCheckedAnyfunc> {
+    pub fn wasm_to_host_trampoline(&self) -> NonNull<VMCallerCheckedFuncRef> {
         NonNull::from(&self.wasm_to_host_trampoline)
     }
 

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -50,7 +50,7 @@ struct CompiledComponentInfo {
     /// section of `code_memory`.
     ///
     /// These trampolines are the function pointer within the
-    /// `VMCallerCheckedAnyfunc` and will delegate indirectly to a host function
+    /// `VMCallerCheckedFuncRef` and will delegate indirectly to a host function
     /// pointer when called.
     lowerings: PrimaryMap<LoweredIndex, FunctionLoc>,
 

--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -15,7 +15,7 @@ use wasmtime_environ::component::{
 use wasmtime_runtime::component::{
     InstanceFlags, VMComponentContext, VMLowering, VMLoweringCallee,
 };
-use wasmtime_runtime::{VMCallerCheckedAnyfunc, VMMemoryDefinition, VMOpaqueContext};
+use wasmtime_runtime::{VMCallerCheckedFuncRef, VMMemoryDefinition, VMOpaqueContext};
 
 pub struct HostFunc {
     entrypoint: VMLoweringCallee,
@@ -43,7 +43,7 @@ impl HostFunc {
         data: *mut u8,
         flags: InstanceFlags,
         memory: *mut VMMemoryDefinition,
-        realloc: *mut VMCallerCheckedAnyfunc,
+        realloc: *mut VMCallerCheckedFuncRef,
         string_encoding: StringEncoding,
         storage: *mut ValRaw,
         storage_len: usize,
@@ -150,7 +150,7 @@ unsafe fn call_host<T, Params, Return, F>(
     cx: *mut VMOpaqueContext,
     mut flags: InstanceFlags,
     memory: *mut VMMemoryDefinition,
-    realloc: *mut VMCallerCheckedAnyfunc,
+    realloc: *mut VMCallerCheckedFuncRef,
     string_encoding: StringEncoding,
     storage: &mut [ValRaw],
     closure: F,
@@ -280,7 +280,7 @@ unsafe fn call_host_dynamic<T, F>(
     cx: *mut VMOpaqueContext,
     mut flags: InstanceFlags,
     memory: *mut VMMemoryDefinition,
-    realloc: *mut VMCallerCheckedAnyfunc,
+    realloc: *mut VMCallerCheckedFuncRef,
     string_encoding: StringEncoding,
     storage: &mut [ValRaw],
     closure: F,
@@ -398,7 +398,7 @@ extern "C" fn dynamic_entrypoint<T, F>(
     data: *mut u8,
     flags: InstanceFlags,
     memory: *mut VMMemoryDefinition,
-    realloc: *mut VMCallerCheckedAnyfunc,
+    realloc: *mut VMCallerCheckedFuncRef,
     string_encoding: StringEncoding,
     storage: *mut ValRaw,
     storage_len: usize,

--- a/crates/wasmtime/src/component/func/options.rs
+++ b/crates/wasmtime/src/component/func/options.rs
@@ -3,7 +3,7 @@ use crate::StoreContextMut;
 use anyhow::{bail, Result};
 use std::ptr::NonNull;
 use wasmtime_environ::component::StringEncoding;
-use wasmtime_runtime::{VMCallerCheckedAnyfunc, VMMemoryDefinition};
+use wasmtime_runtime::{VMCallerCheckedFuncRef, VMMemoryDefinition};
 
 /// Runtime representation of canonical ABI options in the component model.
 ///
@@ -30,7 +30,7 @@ pub struct Options {
     /// function.
     ///
     /// Safely using this pointer has the same restrictions as `memory` above.
-    realloc: Option<NonNull<VMCallerCheckedAnyfunc>>,
+    realloc: Option<NonNull<VMCallerCheckedFuncRef>>,
 
     /// The encoding used for strings, if found.
     ///
@@ -57,7 +57,7 @@ impl Options {
     pub unsafe fn new(
         store_id: StoreId,
         memory: Option<NonNull<VMMemoryDefinition>>,
-        realloc: Option<NonNull<VMCallerCheckedAnyfunc>>,
+        realloc: Option<NonNull<VMCallerCheckedFuncRef>>,
         string_encoding: StringEncoding,
     ) -> Options {
         Options {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -11,7 +11,7 @@ use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmtime_runtime::{
-    ExportFunction, InstanceHandle, VMCallerCheckedAnyfunc, VMContext, VMFunctionBody,
+    ExportFunction, InstanceHandle, VMCallerCheckedFuncRef, VMContext, VMFunctionBody,
     VMFunctionImport, VMHostFuncContext, VMOpaqueContext, VMSharedSignatureIndex, VMTrampoline,
 };
 
@@ -497,7 +497,7 @@ impl Func {
 
     pub(crate) unsafe fn from_caller_checked_anyfunc(
         store: &mut StoreOpaque,
-        raw: *mut VMCallerCheckedAnyfunc,
+        raw: *mut VMCallerCheckedFuncRef,
     ) -> Option<Func> {
         let anyfunc = NonNull::new(raw)?;
         debug_assert!(anyfunc.as_ref().type_index != VMSharedSignatureIndex::default());
@@ -891,7 +891,7 @@ impl Func {
 
     pub(crate) unsafe fn call_unchecked_raw<T>(
         store: &mut StoreContextMut<'_, T>,
-        anyfunc: NonNull<VMCallerCheckedAnyfunc>,
+        anyfunc: NonNull<VMCallerCheckedFuncRef>,
         trampoline: VMTrampoline,
         params_and_returns: *mut ValRaw,
     ) -> Result<()> {
@@ -1066,7 +1066,7 @@ impl Func {
     pub(crate) fn caller_checked_anyfunc(
         &self,
         store: &StoreOpaque,
-    ) -> NonNull<VMCallerCheckedAnyfunc> {
+    ) -> NonNull<VMCallerCheckedFuncRef> {
         store.store_data()[self.0].export().anyfunc
     }
 

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -6,7 +6,7 @@ use std::marker;
 use std::mem::{self, MaybeUninit};
 use std::ptr;
 use wasmtime_runtime::{
-    VMCallerCheckedAnyfunc, VMContext, VMFunctionBody, VMOpaqueContext, VMSharedSignatureIndex,
+    VMCallerCheckedFuncRef, VMContext, VMFunctionBody, VMOpaqueContext, VMSharedSignatureIndex,
 };
 
 /// A statically typed WebAssembly function.
@@ -130,7 +130,7 @@ where
 
     pub(crate) unsafe fn call_raw<T>(
         store: &mut StoreContextMut<'_, T>,
-        func: ptr::NonNull<VMCallerCheckedAnyfunc>,
+        func: ptr::NonNull<VMCallerCheckedFuncRef>,
         params: Params,
     ) -> Result<Results> {
         // double-check that params/results match for this function's type in
@@ -409,7 +409,7 @@ unsafe impl WasmTy for Option<ExternRef> {
 }
 
 unsafe impl WasmTy for Option<Func> {
-    type Abi = *mut wasmtime_runtime::VMCallerCheckedAnyfunc;
+    type Abi = *mut wasmtime_runtime::VMCallerCheckedFuncRef;
 
     #[inline]
     fn valtype() -> ValType {

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 use wasmtime_jit::CodeMemory;
-use wasmtime_runtime::{ModuleInfo, VMCallerCheckedAnyfunc, VMTrampoline};
+use wasmtime_runtime::{ModuleInfo, VMCallerCheckedFuncRef, VMTrampoline};
 
 /// Used for registering modules with a store.
 ///
@@ -125,7 +125,7 @@ impl ModuleRegistry {
     }
 
     /// Looks up a trampoline from an anyfunc.
-    pub fn lookup_trampoline(&self, anyfunc: &VMCallerCheckedAnyfunc) -> Option<VMTrampoline> {
+    pub fn lookup_trampoline(&self, anyfunc: &VMCallerCheckedFuncRef) -> Option<VMTrampoline> {
         let (code, _offset) = self.code(anyfunc.func_ptr.as_ptr() as usize)?;
         code.code.signatures().trampoline(anyfunc.type_index)
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -95,7 +95,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use wasmtime_runtime::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleInfo,
-    OnDemandInstanceAllocator, SignalHandler, StorePtr, VMCallerCheckedAnyfunc, VMContext,
+    OnDemandInstanceAllocator, SignalHandler, StorePtr, VMCallerCheckedFuncRef, VMContext,
     VMExternRef, VMExternRefActivationsTable, VMRuntimeLimits, VMSharedSignatureIndex,
     VMTrampoline,
 };
@@ -1263,7 +1263,7 @@ impl StoreOpaque {
     /// `self.host_trampolines` we lazily populate `self.host_trampolines` by
     /// iterating over `self.store_data().funcs`, inserting trampolines as we
     /// go. If we find the right trampoline then it's returned.
-    pub fn lookup_trampoline(&mut self, anyfunc: &VMCallerCheckedAnyfunc) -> VMTrampoline {
+    pub fn lookup_trampoline(&mut self, anyfunc: &VMCallerCheckedFuncRef) -> VMTrampoline {
         // First try to see if the `anyfunc` belongs to any module. Each module
         // has its own map of trampolines-per-type-index and the code pointer in
         // the `anyfunc` will enable us to quickly find a module.

--- a/docs/contributing-architecture.md
+++ b/docs/contributing-architecture.md
@@ -409,7 +409,7 @@ next.
 
 WebAssembly tables contain reference types, currently either `funcref` or
 `externref`. A `funcref` in Wasmtime is represented as `*mut
-VMCallerCheckedAnyfunc` and an `externref` is represented as `VMExternRef`
+VMCallerCheckedFuncRef` and an `externref` is represented as `VMExternRef`
 (which is internally `*mut VMExternData`). Tables are consequently represented
 as vectors of pointers.  Table storage memory management by default goes through
 Rust's `Vec` which uses `malloc` and friends for memory. With the pooling


### PR DESCRIPTION
At some point what is now `funcref` was called `anyfunc` and the spec changed, but we didn't update our internal names. This does that.

Co-Authored-By: Jamey Sharp <jsharp@fastly.com>

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
