### PR TITLE
Bump regalloc2 to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+checksum = "abdf64625ea14dd2a89d8076aaa4059a8380163dce34b978ddda25c403afe241"
 dependencies = [
  "fxhash",
  "log",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
-regalloc2 = { version = "0.5.1", features = ["checker"] }
+regalloc2 = { version = "0.6.0", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -27,7 +27,7 @@ use crate::trace;
 use crate::CodegenError;
 use crate::ValueLocRange;
 use regalloc2::{
-    Edit, Function as RegallocFunction, InstOrEdit, InstRange, Operand, OperandKind, PReg, PRegSet,
+    Edit, Function as RegallocFunction, InstOrEdit, InstRange, Operand, OperandKind, PRegSet,
     RegClass, VReg,
 };
 
@@ -1314,10 +1314,6 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
             self.assert_not_vreg_alias(*vreg);
         }
         &self.debug_value_labels[..]
-    }
-
-    fn is_pinned_vreg(&self, vreg: VReg) -> Option<PReg> {
-        pinned_vreg_to_preg(vreg)
     }
 
     fn spillslot_size(&self, regclass: RegClass) -> usize {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -563,6 +563,12 @@ criteria = "safe-to-deploy"
 delta = "0.5.0 -> 0.5.1"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[audits.regalloc2]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.1 -> 0.6.0"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 # In the next iteration we'll factor out the common bits so that they can be consumed
 # by Cranelift and Winch.
 cranelift-codegen = { workspace = true }
-regalloc2 = "0.5.1"
+regalloc2 = "0.6.0"
 
 [features]
 x64 = ["cranelift-codegen/x86"]


### PR DESCRIPTION
Bump our regalloc2 dependency to version 0.6.0, which removes support for both mod operands and pinned VRegs :tada: 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
