### PR TITLE
wasi-threads: fix import name

### DIFF
--- a/crates/wasi-threads/src/lib.rs
+++ b/crates/wasi-threads/src/lib.rs
@@ -112,7 +112,7 @@ pub fn add_to_linker<T: Clone + Send + 'static>(
 ) -> anyhow::Result<SharedMemory> {
     linker.func_wrap(
         "wasi",
-        "thread_spawn",
+        "thread-spawn",
         move |mut caller: Caller<'_, T>, start_arg: i32| -> i32 {
             log::trace!("new thread requested via `wasi::thread_spawn` call");
             let host = caller.data().clone();

--- a/tests/all/cli_tests/threads.wat
+++ b/tests/all/cli_tests/threads.wat
@@ -6,7 +6,7 @@
     (func $__wasi_fd_write (param i32 i32 i32 i32) (result i32)))
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $__wasi_proc_exit (param i32)))
-  (import "wasi" "thread_spawn"
+  (import "wasi" "thread-spawn"
     (func $__wasi_thread_spawn (param i32) (result i32)))
 
   (func (export "_start")


### PR DESCRIPTION
As @TerrorJack pointed out in #5484, that PR implements an older name--`thread_spawn`. This change uses the now-official name from the specification--`thread-spawn`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
