### PR TITLE
Move default blocks into jump tables

### DIFF
--- a/cranelift/codegen/meta/src/shared/entities.rs
+++ b/cranelift/codegen/meta/src/shared/entities.rs
@@ -15,10 +15,6 @@ pub(crate) struct EntityRefs {
     /// This is primarily used in control flow instructions.
     pub(crate) block_call: OperandKind,
 
-    /// A reference to a basic block in the same function.
-    /// This is primarily used in control flow instructions.
-    pub(crate) label: OperandKind,
-
     /// A reference to a basic block in the same function, with its arguments provided.
     /// This is primarily used in control flow instructions.
     pub(crate) block_then: OperandKind,
@@ -61,12 +57,6 @@ impl EntityRefs {
                 "destination",
                 "ir::BlockCall",
                 "a basic block in the same function, with its arguments provided.",
-            ),
-
-            label: new(
-                "destination",
-                "ir::Block",
-                "a basic block in the same function.",
             ),
 
             block_then: new(

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -117,7 +117,6 @@ impl Formats {
 
             branch_table: Builder::new("BranchTable")
                 .value()
-                .imm(&entities.label)
                 .imm(&entities.jump_table)
                 .build(),
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -19,7 +19,6 @@ fn define_control_flow(
 ) {
     let block_call = &Operand::new("block_call", &entities.block_call)
         .with_doc("Destination basic block, with its arguments provided");
-    let label = &Operand::new("label", &entities.label).with_doc("Destination basic block");
 
     ig.push(
         Inst::new(
@@ -93,7 +92,7 @@ fn define_control_flow(
         "#,
                 &formats.branch_table,
             )
-            .operands_in(vec![x, label, JT])
+            .operands_in(vec![x, JT])
             .branches(),
         );
     }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -197,7 +197,7 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
                 // so it is not part of the table.
                 visit(inst, table.default_block(), false);
 
-                for &dest in table.table_slice() {
+                for &dest in table.as_slice() {
                     visit(inst, dest, true);
                 }
             }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -190,16 +190,14 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
                 visit(inst, block_else.block(&f.dfg.value_lists), false);
             }
 
-            ir::InstructionData::BranchTable {
-                table,
-                destination: dest,
-                ..
-            } => {
+            ir::InstructionData::BranchTable { table, .. } => {
+                let table = &f.stencil.dfg.jump_tables[*table];
+
                 // The default block is reached via a direct conditional branch,
                 // so it is not part of the table.
-                visit(inst, *dest, false);
+                visit(inst, table.default_block(), false);
 
-                for &dest in f.stencil.dfg.jump_tables[*table].as_slice() {
+                for &dest in table.table_slice() {
                     visit(inst, dest, true);
                 }
             }

--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -194,7 +194,9 @@ pub(crate) fn visit_block_succs<F: FnMut(Inst, Block, bool)>(
                 let table = &f.stencil.dfg.jump_tables[*table];
 
                 // The default block is reached via a direct conditional branch,
-                // so it is not part of the table.
+                // so it is not part of the table. We visit the default block first
+                // explicitly, as some callers of visit_block_succs depend on that
+                // ordering.
                 visit(inst, table.default_block(), false);
 
                 for &dest in table.as_slice() {

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -296,11 +296,11 @@ impl FunctionStencil {
             }
 
             InstructionData::BranchTable { table, .. } => {
-                self.dfg.jump_tables[*table].iter_mut().for_each(|entry| {
+                for entry in self.dfg.jump_tables[*table].all_branches_mut() {
                     if *entry == old_dest {
                         *entry = new_dest;
                     }
-                });
+                }
             }
 
             inst => debug_assert!(!inst.opcode().is_branch()),

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -295,20 +295,12 @@ impl FunctionStencil {
                 }
             }
 
-            InstructionData::BranchTable {
-                table,
-                destination: default_dest,
-                ..
-            } => {
+            InstructionData::BranchTable { table, .. } => {
                 self.dfg.jump_tables[*table].iter_mut().for_each(|entry| {
                     if *entry == old_dest {
                         *entry = new_dest;
                     }
                 });
-
-                if *default_dest == old_dest {
-                    *default_dest = new_dest;
-                }
             }
 
             inst => debug_assert!(!inst.opcode().is_branch()),

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// The default block for the jump table is stored as the last element of the underlying vector,
 /// and is not included in the length of the jump table. It can be accessed through the
-/// `default_block` function. The default block is iterated via the `iter` and `iter_mut` methods.
+/// `default_block` and `default_block_mut` functions. All blocks may be iterated using the
+/// `all_branches` and `all_branches_mut` functions, which will both iterate over the default block
+/// last.
 #[derive(Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct JumpTableData {

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -14,6 +14,10 @@ use serde::{Deserialize, Serialize};
 /// Contents of a jump table.
 ///
 /// All jump tables use 0-based indexing and are densely populated.
+///
+/// The default block for the jump table is stored as the last element of the underlying vector,
+/// and is not included in the length of the jump table. It can be accessed through the
+/// `default_block` function. The default block is iterated via the `iter` and `iter_mut` methods.
 #[derive(Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct JumpTableData {
@@ -23,42 +27,59 @@ pub struct JumpTableData {
 
 impl JumpTableData {
     /// Create a new empty jump table.
-    pub fn new() -> Self {
-        Self { table: Vec::new() }
+    pub fn new(def: Block) -> Self {
+        Self { table: vec![def] }
     }
 
-    /// Create a new empty jump table with the specified capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            table: Vec::with_capacity(capacity),
-        }
-    }
     /// Create a new jump table with the provided blocks
-    pub fn with_blocks(table: Vec<Block>) -> Self {
+    pub fn with_blocks(def: Block, mut table: Vec<Block>) -> Self {
+        table.push(def);
         Self { table }
+    }
+
+    /// Fetch the default block for this jump table.
+    pub fn default_block(&self) -> Block {
+        *self.table.last().unwrap()
     }
 
     /// Get the number of table entries.
     pub fn len(&self) -> usize {
-        self.table.len()
+        self.table.len() - 1
     }
 
     /// Append a table entry.
     pub fn push_entry(&mut self, dest: Block) {
-        self.table.push(dest)
+        let last = self.table.len();
+        self.table.push(dest);
+
+        // Ensure that the default block stays as the final element in the table.
+        self.table.swap(last - 1, last);
     }
 
-    /// Checks if any of the entries branch to `block`.
+    /// Checks if any of the entries branch to `block`. The default block will be considered when
+    /// checking for a possible branch.
     pub fn branches_to(&self, block: Block) -> bool {
         self.table.iter().any(|target_block| *target_block == block)
     }
 
-    /// Access the whole table as a slice.
+    /// Access the jump table as a slice, excluding the default block.
+    pub fn table_slice(&self) -> &[Block] {
+        let last = self.len();
+        &self.table.as_slice()[0..last]
+    }
+
+    /// Access the jump table as a slice, excluding the default block.
+    pub fn table_slice_mut(&mut self) -> &mut [Block] {
+        let last = self.len();
+        &mut self.table.as_mut_slice()[0..last]
+    }
+
+    /// Access the entire jump table as a slice.
     pub fn as_slice(&self) -> &[Block] {
         self.table.as_slice()
     }
 
-    /// Access the whole table as a mutable slice.
+    /// Access the whole table as a mutable slice, excluding the default block.
     pub fn as_mut_slice(&mut self) -> &mut [Block] {
         self.table.as_mut_slice()
     }
@@ -68,26 +89,25 @@ impl JumpTableData {
         self.table.iter()
     }
 
-    /// Returns an iterator that allows modifying each value.
+    /// Returns an iterator that allows modifying each value, including the default block.
     pub fn iter_mut(&mut self) -> IterMut<Block> {
         self.table.iter_mut()
     }
 
-    /// Clears all entries in this jump table.
+    /// Clears all entries in this jump table, except for the default block.
     pub fn clear(&mut self) {
-        self.table.clear();
+        self.table.drain(0..self.table.len() - 1);
     }
 }
 
 impl Display for JumpTableData {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
-        write!(fmt, "[")?;
-        match self.table.first() {
-            None => (),
-            Some(first) => write!(fmt, "{}", first)?,
-        }
-        for block in self.table.iter().skip(1) {
-            write!(fmt, ", {}", block)?;
+        write!(fmt, "{}, [", self.default_block())?;
+        if let Some((first, rest)) = self.table_slice().split_first() {
+            write!(fmt, "{}", first)?;
+            for block in rest {
+                write!(fmt, ", {}", block)?;
+            }
         }
         write!(fmt, "]")
     }
@@ -102,31 +122,41 @@ mod tests {
 
     #[test]
     fn empty() {
-        let jt = JumpTableData::new();
+        let def = Block::new(0);
 
-        assert_eq!(jt.as_slice().get(0), None);
+        let jt = JumpTableData::new(def);
+
+        assert_eq!(jt.table_slice().get(0), None);
+
+        assert_eq!(jt.as_slice().get(0), Some(&def));
         assert_eq!(jt.as_slice().get(10), None);
 
-        assert_eq!(jt.to_string(), "[]");
+        assert_eq!(jt.to_string(), "block0, []");
 
-        let v = jt.as_slice();
-        assert_eq!(v, []);
+        assert_eq!(jt.as_slice(), [def]);
+
+        assert_eq!(jt.table_slice(), []);
     }
 
     #[test]
     fn insert() {
+        let def = Block::new(0);
         let e1 = Block::new(1);
         let e2 = Block::new(2);
 
-        let mut jt = JumpTableData::new();
+        let mut jt = JumpTableData::new(def);
 
         jt.push_entry(e1);
         jt.push_entry(e2);
         jt.push_entry(e1);
 
-        assert_eq!(jt.to_string(), "[block1, block2, block1]");
+        assert_eq!(jt.default_block(), def);
+        assert_eq!(jt.to_string(), "block0, [block1, block2, block1]");
 
-        let v = jt.as_slice();
-        assert_eq!(v, [e1, e2, e1]);
+        assert_eq!(jt.as_slice(), [e1, e2, e1, def]);
+        assert_eq!(jt.table_slice(), [e1, e2, e1]);
+
+        jt.clear();
+        assert_eq!(jt.default_block(), def);
     }
 }

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -126,7 +126,7 @@ mod tests {
         let e1 = Block::new(1);
         let e2 = Block::new(2);
 
-        let mut jt = JumpTableData::new(def, vec![e1, e2, e1]);
+        let jt = JumpTableData::new(def, vec![e1, e2, e1]);
 
         assert_eq!(jt.default_block(), def);
         assert_eq!(jt.to_string(), "block0, [block1, block2, block1]");

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -66,13 +66,13 @@ impl JumpTableData {
     }
 
     /// Returns an iterator to the jump table, excluding the default block.
-    #[deprecated(since = "0.7.0", note = "please use `.as_slice()` instead")]
+    #[deprecated(since = "7.0.0", note = "please use `.as_slice()` instead")]
     pub fn iter(&self) -> Iter<Block> {
         self.as_slice().iter()
     }
 
     /// Returns an iterator that allows modifying each value, excluding the default block.
-    #[deprecated(since = "0.7.0", note = "please use `.as_mut_slice()` instead")]
+    #[deprecated(since = "7.0.0", note = "please use `.as_mut_slice()` instead")]
     pub fn iter_mut(&mut self) -> IterMut<Block> {
         self.as_mut_slice().iter_mut()
     }

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2515,7 +2515,7 @@
 
 ;; `targets` contains the default target with the list of branch targets
 ;; concatenated.
-(rule (lower_branch (br_table idx _ _) targets)
+(rule (lower_branch (br_table idx _) targets)
       (let ((jt_size u32 (targets_jt_size targets))
             (_ InstOutput (side_effect
                   (emit_island (targets_jt_space targets))))

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -361,10 +361,9 @@ mod test {
         let mut pos = FuncCursor::new(&mut func);
 
         pos.insert_block(bb0);
-        let mut jt_data = JumpTableData::new(bb3);
-        jt_data.push_entry(bb1);
-        jt_data.push_entry(bb2);
-        let jt = pos.func.create_jump_table(jt_data);
+        let jt = pos
+            .func
+            .create_jump_table(JumpTableData::new(bb3, vec![bb1, bb2]));
         pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -361,11 +361,11 @@ mod test {
         let mut pos = FuncCursor::new(&mut func);
 
         pos.insert_block(bb0);
-        let mut jt_data = JumpTableData::new();
+        let mut jt_data = JumpTableData::new(bb3);
         jt_data.push_entry(bb1);
         jt_data.push_entry(bb2);
         let jt = pos.func.create_jump_table(jt_data);
-        pos.ins().br_table(arg0, bb3, jt);
+        pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);
         let v1 = pos.ins().iconst(I32, 1);

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1942,7 +1942,7 @@
 (extern constructor lower_br_table lower_br_table)
 
 (rule
-  (lower_branch (br_table index _ _) targets)
+  (lower_branch (br_table index _) targets)
   (lower_br_table index targets))
 
 (decl load_ra () Reg)

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3725,7 +3725,7 @@
 
 ;; Jump table.  `targets` contains the default target followed by the
 ;; list of branch targets per index value.
-(rule (lower_branch (br_table val_idx _ _) targets)
+(rule (lower_branch (br_table val_idx _) targets)
       (let ((idx Reg (put_in_reg_zext64 val_idx))
             ;; Bounds-check the index and branch to default.
             ;; This is an internal branch that is not a terminator insn.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2942,7 +2942,7 @@
 
 ;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower_branch (br_table idx @ (value_type ty) _ _) (jump_table_targets default_target jt_targets))
+(rule (lower_branch (br_table idx @ (value_type ty) _) (jump_table_targets default_target jt_targets))
       (emit_side_effect (jmp_table_seq ty idx default_target jt_targets)))
 
 ;; Rules for `select_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -408,10 +408,9 @@ mod test {
         let mut pos = FuncCursor::new(&mut func);
 
         pos.insert_block(bb0);
-        let mut jt_data = JumpTableData::new(bb3);
-        jt_data.push_entry(bb1);
-        jt_data.push_entry(bb2);
-        let jt = pos.func.create_jump_table(jt_data);
+        let jt = pos
+            .func
+            .create_jump_table(JumpTableData::new(bb3, vec![bb1, bb2]));
         pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -408,11 +408,11 @@ mod test {
         let mut pos = FuncCursor::new(&mut func);
 
         pos.insert_block(bb0);
-        let mut jt_data = JumpTableData::new();
+        let mut jt_data = JumpTableData::new(bb3);
         jt_data.push_entry(bb1);
         jt_data.push_entry(bb2);
         let jt = pos.func.create_jump_table(jt_data);
-        pos.ins().br_table(arg0, bb3, jt);
+        pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);
         let v1 = pos.ins().iconst(I32, 1);

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -849,7 +849,7 @@ impl<'a> Verifier<'a> {
                 format!("invalid jump table reference {}", j),
             ))
         } else {
-            for &block in self.func.stencil.dfg.jump_tables[j].iter() {
+            for &block in self.func.stencil.dfg.jump_tables[j].all_branches() {
                 self.verify_block(inst, block, errors)?;
             }
             Ok(())
@@ -1320,7 +1320,7 @@ impl<'a> Verifier<'a> {
                 self.typecheck_variable_args_iterator(inst, iter, args_else, errors)?;
             }
             ir::InstructionData::BranchTable { table, .. } => {
-                for block in self.func.stencil.dfg.jump_tables[*table].iter() {
+                for block in self.func.stencil.dfg.jump_tables[*table].all_branches() {
                     let arg_count = self.func.dfg.num_block_params(*block);
                     if arg_count != 0 {
                         return errors.nonfatal((

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -421,12 +421,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             write!(w, " {}, {}", arg, block_then.display(pool))?;
             write!(w, ", {}", block_else.display(pool))
         }
-        BranchTable {
-            arg,
-            destination,
-            table,
-            ..
-        } => write!(w, " {}, {}, {}", arg, destination, jump_tables[table]),
+        BranchTable { arg, table, .. } => write!(w, " {}, {}", arg, jump_tables[table]),
         Call {
             func_ref, ref args, ..
         } => write!(w, " {}({})", func_ref, DisplayValues(args.as_slice(pool))),

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -129,9 +129,7 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                 }
             }
 
-            ir::InstructionData::BranchTable {
-                table, destination, ..
-            } => {
+            ir::InstructionData::BranchTable { table, .. } => {
                 // Unlike all other jumps/branches, jump tables are
                 // capable of having the same successor appear
                 // multiple times, so we must deduplicate.
@@ -154,7 +152,6 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                         .ssa
                         .declare_block_predecessor(*dest_block, inst);
                 }
-                self.builder.declare_successor(*destination, inst);
             }
 
             inst => debug_assert!(!inst.opcode().is_branch()),

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -142,9 +142,12 @@ impl<'short, 'long> InstBuilderBase<'short> for FuncInstBuilder<'short, 'long> {
                     .jump_tables
                     .get(*table)
                     .expect("you are referencing an undeclared jump table")
-                    .iter()
-                    .filter(|&dest_block| unique.insert(*dest_block))
+                    .all_branches()
                 {
+                    if !unique.insert(*dest_block) {
+                        continue;
+                    }
+
                     // Call `declare_block_predecessor` instead of `declare_successor` for
                     // avoiding the borrow checker.
                     self.builder

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -591,11 +591,7 @@ impl SSABuilder {
                 }
                 None
             }
-            InstructionData::BranchTable {
-                table: jt,
-                destination,
-                ..
-            } => {
+            InstructionData::BranchTable { table: jt, .. } => {
                 // In the case of a jump table, the situation is tricky because br_table doesn't
                 // support arguments. We have to split the critical edge.
                 let middle_block = dfg.blocks.add();
@@ -606,10 +602,6 @@ impl SSABuilder {
                     if *block == dest_block {
                         *block = middle_block;
                     }
-                }
-
-                if *destination == dest_block {
-                    *destination = middle_block;
                 }
 
                 let mut cur = FuncCursor::new(func).at_bottom(middle_block);
@@ -1001,7 +993,7 @@ mod tests {
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
-        let mut jump_table = JumpTableData::new();
+        let mut jump_table = JumpTableData::new(block2);
         jump_table.push_entry(block2);
         jump_table.push_entry(block1);
         {
@@ -1024,7 +1016,7 @@ mod tests {
         let br_table = {
             let jt = func.create_jump_table(jump_table);
             let mut cur = FuncCursor::new(&mut func).at_bottom(block0);
-            cur.ins().br_table(x1, block2, jt)
+            cur.ins().br_table(x1, jt)
         };
 
         // block1

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -597,8 +597,7 @@ impl SSABuilder {
                 let middle_block = dfg.blocks.add();
                 func.stencil.layout.append_block(middle_block);
 
-                let table = &mut dfg.jump_tables[*jt];
-                for block in table.iter_mut() {
+                for block in dfg.jump_tables[*jt].all_branches_mut() {
                     if *block == dest_block {
                         *block = middle_block;
                     }
@@ -993,9 +992,6 @@ mod tests {
         let block0 = func.dfg.make_block();
         let block1 = func.dfg.make_block();
         let block2 = func.dfg.make_block();
-        let mut jump_table = JumpTableData::new(block2);
-        jump_table.push_entry(block2);
-        jump_table.push_entry(block1);
         {
             let mut cur = FuncCursor::new(&mut func);
             cur.insert_block(block0);
@@ -1014,6 +1010,7 @@ mod tests {
         ssa.def_var(x_var, x1, block0);
         ssa.use_var(&mut func, x_var, I32, block0).0;
         let br_table = {
+            let jump_table = JumpTableData::new(block2, vec![block2, block1]);
             let jt = func.create_jump_table(jump_table);
             let mut cur = FuncCursor::new(&mut func).at_bottom(block0);
             cur.ins().br_table(x1, jt)

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -220,7 +220,7 @@ impl Switch {
             "Jump tables bigger than 2^32-1 are not yet supported"
         );
 
-        let jt_data = JumpTableData::with_blocks(Vec::from(blocks));
+        let jt_data = JumpTableData::with_blocks(otherwise, Vec::from(blocks));
         let jump_table = bx.create_jump_table(jt_data);
 
         let discr = if first_index == 0 {
@@ -256,7 +256,7 @@ impl Switch {
             _ => discr,
         };
 
-        bx.ins().br_table(discr, otherwise, jump_table);
+        bx.ins().br_table(discr, jump_table);
     }
 
     /// Build the switch

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -220,7 +220,7 @@ impl Switch {
             "Jump tables bigger than 2^32-1 are not yet supported"
         );
 
-        let jt_data = JumpTableData::with_blocks(otherwise, Vec::from(blocks));
+        let jt_data = JumpTableData::new(otherwise, Vec::from(blocks));
         let jump_table = bx.create_jump_table(jt_data);
 
         let discr = if first_index == 0 {

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1614,12 +1614,12 @@ where
             }
             BlockTerminator::BrTable(default, targets) => {
                 // Create jump tables on demand
-                let jt = builder.create_jump_table(JumpTableData::with_blocks(targets));
+                let jt = builder.create_jump_table(JumpTableData::with_blocks(default, targets));
 
                 // br_table only supports I32
                 let val = builder.use_var(self.get_variable_of_type(I32)?);
 
-                builder.ins().br_table(val, default, jt);
+                builder.ins().br_table(val, jt);
             }
             BlockTerminator::Switch(_type, default, entries) => {
                 let mut switch = Switch::new();

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1614,7 +1614,7 @@ where
             }
             BlockTerminator::BrTable(default, targets) => {
                 // Create jump tables on demand
-                let jt = builder.create_jump_table(JumpTableData::with_blocks(default, targets));
+                let jt = builder.create_jump_table(JumpTableData::new(default, targets));
 
                 // br_table only supports I32
                 let val = builder.use_var(self.get_variable_of_type(I32)?);

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -379,7 +379,7 @@ where
                 // Convert to usize to remove negative indexes from the following operations
                 let jump_target = usize::try_from(arg(0)?.into_int()?)
                     .ok()
-                    .and_then(|i| jt_data.table_slice().get(i))
+                    .and_then(|i| jt_data.as_slice().get(i))
                     .copied()
                     .unwrap_or(jt_data.default_block());
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -373,18 +373,15 @@ where
             }
         }
         Opcode::BrTable => {
-            if let InstructionData::BranchTable {
-                table, destination, ..
-            } = inst
-            {
+            if let InstructionData::BranchTable { table, .. } = inst {
                 let jt_data = &state.get_current_function().stencil.dfg.jump_tables[table];
 
                 // Convert to usize to remove negative indexes from the following operations
                 let jump_target = usize::try_from(arg(0)?.into_int()?)
                     .ok()
-                    .and_then(|i| jt_data.as_slice().get(i))
+                    .and_then(|i| jt_data.table_slice().get(i))
                     .copied()
-                    .unwrap_or(destination);
+                    .unwrap_or(jt_data.default_block());
 
                 ControlFlow::ContinueAt(jump_target, SmallVec::new())
             } else {

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1767,10 +1767,10 @@ impl<'a> Parser<'a> {
     //
     // jump-table-lit ::= "[" block {"," block } "]"
     //                  | "[]"
-    fn parse_jump_table(&mut self) -> ParseResult<JumpTableData> {
+    fn parse_jump_table(&mut self, def: Block) -> ParseResult<JumpTableData> {
         self.match_token(Token::LBracket, "expected '[' before jump table contents")?;
 
-        let mut data = JumpTableData::new();
+        let mut data = JumpTableData::new(def);
 
         match self.token() {
             Some(Token::Block(dest)) => {
@@ -2571,14 +2571,9 @@ impl<'a> Parser<'a> {
                 self.match_token(Token::Comma, "expected ',' between operands")?;
                 let block_num = self.match_block("expected branch destination block")?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;
-                let table_data = self.parse_jump_table()?;
+                let table_data = self.parse_jump_table(block_num)?;
                 let table = ctx.function.dfg.jump_tables.push(table_data);
-                InstructionData::BranchTable {
-                    opcode,
-                    arg,
-                    destination: block_num,
-                    table,
-                }
+                InstructionData::BranchTable { opcode, arg, table }
             }
             InstructionFormat::TernaryImm8 => {
                 let lhs = self.match_value("expected SSA value first operand")?;

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1770,12 +1770,12 @@ impl<'a> Parser<'a> {
     fn parse_jump_table(&mut self, def: Block) -> ParseResult<JumpTableData> {
         self.match_token(Token::LBracket, "expected '[' before jump table contents")?;
 
-        let mut data = JumpTableData::new(def);
+        let mut data = Vec::new();
 
         match self.token() {
             Some(Token::Block(dest)) => {
                 self.consume();
-                data.push_entry(dest);
+                data.push(dest);
 
                 loop {
                     match self.token() {
@@ -1783,7 +1783,7 @@ impl<'a> Parser<'a> {
                             self.consume();
                             if let Some(Token::Block(dest)) = self.token() {
                                 self.consume();
-                                data.push_entry(dest);
+                                data.push(dest);
                             } else {
                                 return err!(self.loc, "expected jump_table entry");
                             }
@@ -1799,7 +1799,7 @@ impl<'a> Parser<'a> {
 
         self.consume();
 
-        Ok(data)
+        Ok(JumpTableData::new(def, data))
     }
 
     // Parse a constant decl.

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -534,7 +534,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                     frame.set_branched_to_exit();
                     frame.br_destination()
                 };
-                let jt = builder.create_jump_table(JumpTableData::with_blocks(block, data));
+                let jt = builder.create_jump_table(JumpTableData::new(block, data));
                 builder.ins().br_table(val, jt);
             } else {
                 // Here we have jump arguments, but Cranelift's br_table doesn't support them
@@ -562,8 +562,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                         *entry.insert(block)
                     }
                 };
-                let jt = builder
-                    .create_jump_table(JumpTableData::with_blocks(default_branch_block, data));
+                let jt = builder.create_jump_table(JumpTableData::new(default_branch_block, data));
                 builder.ins().br_table(val, jt);
                 for (depth, dest_block) in dest_block_sequence {
                     builder.switch_to_block(dest_block);


### PR DESCRIPTION
While working through #5731, adapting `branch_destination` to return an iterator over multiple slices of `BlockCall` values was a little awkward, and yielded more complicated indexing for heavily used operations like `inst_values`. As the root of the problem is the jump table default target and data not living in contiguous memory, there was a somewhat obvious solution: inline the default block into the `JumpTableData`, and remove it from the `BranchTable` instruction data.

The resulting refactoring is implemented in this PR: jump tables require a default block when they are created, and maintain an invariant that the last element of their internal vector is always the default label. Additionally, they now export slices for both the vector and just the jump table, to make it easy to adapt existing uses of `as_slice`.

For a little bit of additional motivation, consider this [godbolt link](https://godbolt.org/z/qaj7qa5M5). There are three indexing functions implemented: one that indexes into two slices using `nth` on a chained iterator; one that checks which slice the index falls on; and one that indexes into a single slice. By far the best option is indexing into a single slice, followed by choosing the slice to index, followed by using `nth`. Without this refactoring, we would need to pick the approach in either `index1` or `index2` to finish transitioning `br_table` to using `BlockCall` arguments, and both feel like bad options.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
