### PR TITLE
c-api: add wasmtime_store_limiter 

### DIFF
--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -80,6 +80,41 @@ WASM_API_EXTERN wasmtime_store_t *wasmtime_store_new(
 WASM_API_EXTERN wasmtime_context_t *wasmtime_store_context(wasmtime_store_t *store);
 
 /**
+ * \brief Provides limits for a store. Used by hosts to limit resource
+ * consumption of instances.
+ *
+ * \param memory_size the maximum number of bytes a linear memory can grow to.
+ * Growing a linear memory beyond this limit will fail. By default,
+ * linear memory will not be limited.
+ * \param table_elements the maximum number of elements in a table.
+ * Growing a table beyond this limit will fail. By default, table elements
+ * will not be limited.
+ * \param instances the maximum number of instances that can be created
+ * for a Store. Module instantiation will fail if this limit is exceeded.
+ * This value defaults to 10,000.
+ * \param tables the maximum number of tables that can be created for a Store.
+ * Module instantiation will fail if this limit is exceeded. This value
+ * defaults to 10,000.
+ * \param memories the maximum number of linear memories that can be created
+ * for a Store. Instantiation will fail with an error if this limit is exceeded.
+ * This value defaults to 10,000.
+ *
+ * Use null for the parameters that should be kept on default values.
+ *
+ * Note that the limits are only used to limit the creation/growth of
+ * resources in the future, this does not retroactively attempt to apply
+ * limits to the store.
+ */
+WASM_API_EXTERN void wasmtime_store_limiter(
+        wasmtime_store_t *store,
+        size_t memory_size,
+        uint32_t table_elements,
+        size_t instances,
+        size_t tables,
+        size_t memories
+);
+
+/**
  * \brief Deletes a store.
  */
 WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t *store);


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

This was not yet discussed, but as of now, there's no way how to use `StoreLimits` from the C API. This PR adds `wasmtime_store_limiter` that allows setting supported limits for the `Store`

Not sure who to assign for this PR, judging from the past PRs for c-api @alexcrichton maybe?