### PR TITLE
c-api: wasmtime_store_limiter 

### DIFF
--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -80,6 +80,44 @@ WASM_API_EXTERN wasmtime_store_t *wasmtime_store_new(
 WASM_API_EXTERN wasmtime_context_t *wasmtime_store_context(wasmtime_store_t *store);
 
 /**
+ * \brief Provides limits for a store. Used by hosts to limit resource
+ * consumption of instances. Use negative value to keep the default value
+ * for the limit.
+ *
+ * \param store store where the limits should be set.
+ * \param memory_size the maximum number of bytes a linear memory can grow to.
+ * Growing a linear memory beyond this limit will fail. By default,
+ * linear memory will not be limited.
+ * \param table_elements the maximum number of elements in a table.
+ * Growing a table beyond this limit will fail. By default, table elements
+ * will not be limited.
+ * \param instances the maximum number of instances that can be created
+ * for a Store. Module instantiation will fail if this limit is exceeded.
+ * This value defaults to 10,000.
+ * \param tables the maximum number of tables that can be created for a Store.
+ * Module instantiation will fail if this limit is exceeded. This value
+ * defaults to 10,000.
+ * \param memories the maximum number of linear memories that can be created
+ * for a Store. Instantiation will fail with an error if this limit is exceeded.
+ * This value defaults to 10,000.
+ *
+ * Use any negative value for the parameters that should be kept on
+ * the default values.
+ *
+ * Note that the limits are only used to limit the creation/growth of
+ * resources in the future, this does not retroactively attempt to apply
+ * limits to the store.
+ */
+WASM_API_EXTERN void wasmtime_store_limiter(
+        wasmtime_store_t *store,
+        int64_t memory_size,
+        int64_t table_elements,
+        int64_t instances,
+        int64_t tables,
+        int64_t memories
+);
+
+/**
  * \brief Deletes a store.
  */
 WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t *store);


### PR DESCRIPTION
This was not yet discussed, but as of now, there's no way how to use StoreLimits from the C API. This PR adds `wasmtime_store_limiter` that allows setting supported limits for the Store.

Not sure who to assign for this PR, judging from the past PRs for c-api @alexcrichton maybe?