### PR TITLE
fuzzgen: Refactor name and signature generation

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -30,7 +30,8 @@ pub struct Config {
     pub switch_cases: RangeInclusive<usize>,
     pub switch_max_range_size: RangeInclusive<usize>,
 
-    pub funcrefs_per_function: RangeInclusive<usize>,
+    /// Number of distinct functions in the same testsuite that we allow calling per function.
+    pub usercalls: RangeInclusive<usize>,
 
     /// Stack slots.
     /// The combination of these two determines stack usage per function
@@ -79,7 +80,7 @@ impl Default for Config {
             switch_cases: 0..=64,
             // Ranges smaller than 2 don't make sense.
             switch_max_range_size: 2..=32,
-            funcrefs_per_function: 0..=8,
+            usercalls: 0..=8,
             static_stack_slots_per_function: 0..=8,
             static_stack_slot_size: 0..=128,
             // We need the mix of sizes that allows us to:

--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -1,0 +1,70 @@
+use crate::codegen::ir::{ArgumentExtension, ArgumentPurpose};
+use anyhow::Result;
+use cranelift::codegen::ir::types::*;
+use cranelift::codegen::ir::{AbiParam, Signature, Type};
+use cranelift::codegen::isa::CallConv;
+
+use arbitrary::Unstructured;
+
+/// A trait for generating random Cranelift datastructures.
+pub trait CraneliftArbitrary {
+    fn _type(&mut self) -> Result<Type>;
+    fn callconv(&mut self) -> Result<CallConv>;
+    fn abi_param(&mut self) -> Result<AbiParam>;
+    fn signature(&mut self, max_params: usize, max_rets: usize) -> Result<Signature>;
+}
+
+impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
+    fn _type(&mut self) -> Result<Type> {
+        // TODO: It would be nice if we could get these directly from cranelift
+        let scalars = [
+            I8, I16, I32, I64, I128, F32, F64,
+            // R32, R64,
+        ];
+        // TODO: vector types
+
+        let ty = self.choose(&scalars[..])?;
+        Ok(*ty)
+    }
+
+    fn callconv(&mut self) -> Result<CallConv> {
+        // TODO: Generate random CallConvs per target
+        Ok(CallConv::SystemV)
+    }
+
+    fn abi_param(&mut self) -> Result<AbiParam> {
+        let value_type = self._type()?;
+        // TODO: There are more argument purposes to be explored...
+        let purpose = ArgumentPurpose::Normal;
+        let extension = if value_type.is_int() {
+            *self.choose(&[
+                ArgumentExtension::Sext,
+                ArgumentExtension::Uext,
+                ArgumentExtension::None,
+            ])?
+        } else {
+            ArgumentExtension::None
+        };
+
+        Ok(AbiParam {
+            value_type,
+            purpose,
+            extension,
+        })
+    }
+
+    fn signature(&mut self, max_params: usize, max_rets: usize) -> Result<Signature> {
+        let callconv = self.callconv()?;
+        let mut sig = Signature::new(callconv);
+
+        for _ in 0..max_params {
+            sig.params.push(self.abi_param()?);
+        }
+
+        for _ in 0..max_rets {
+            sig.returns.push(self.abi_param()?);
+        }
+
+        Ok(sig)
+    }
+}

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -21,19 +21,6 @@ mod passes;
 
 pub type TestCaseInput = Vec<DataValue>;
 
-/// Simple wrapper to generate a single Cranelift `Function`.
-#[derive(Debug)]
-pub struct SingleFunction(pub Function);
-
-impl<'a> Arbitrary<'a> for SingleFunction {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        FuzzGen::new(u)
-            .generate_func(Triple::host())
-            .map_err(|_| arbitrary::Error::IncorrectFormat)
-            .map(Self)
-    }
-}
-
 /// Print only non default flags.
 fn write_non_default_flags(f: &mut fmt::Formatter<'_>, flags: &settings::Flags) -> fmt::Result {
     let default_flags = settings::Flags::new(settings::builder());

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -178,27 +178,6 @@ where
         }
     }
 
-    fn generate_datavalue(&mut self, ty: Type) -> Result<DataValue> {
-        Ok(match ty {
-            ty if ty.is_int() => {
-                let imm = match ty {
-                    I8 => self.u.arbitrary::<i8>()? as i128,
-                    I16 => self.u.arbitrary::<i16>()? as i128,
-                    I32 => self.u.arbitrary::<i32>()? as i128,
-                    I64 => self.u.arbitrary::<i64>()? as i128,
-                    I128 => self.u.arbitrary::<i128>()?,
-                    _ => unreachable!(),
-                };
-                DataValue::from_integer(imm, ty)?
-            }
-            // f{32,64}::arbitrary does not generate a bunch of important values
-            // such as Signaling NaN's / NaN's with payload, so generate floats from integers.
-            F32 => DataValue::F32(Ieee32::with_bits(u32::arbitrary(self.u)?)),
-            F64 => DataValue::F64(Ieee64::with_bits(u64::arbitrary(self.u)?)),
-            _ => unimplemented!(),
-        })
-    }
-
     fn generate_test_inputs(mut self, signature: &Signature) -> Result<Vec<TestCaseInput>> {
         let mut inputs = Vec::new();
 
@@ -211,7 +190,7 @@ where
             let test_args = signature
                 .params
                 .iter()
-                .map(|p| self.generate_datavalue(p.value_type))
+                .map(|p| self.u.datavalue(p.value_type))
                 .collect::<Result<TestCaseInput>>()?;
 
             inputs.push(test_args);


### PR DESCRIPTION
👋 Hey,

This PR includes a few refactors to fuzzgen in order to make it easier to generate testcases with multiple functions.

The first part (first 2 commits) are sort of centralizing generation of some cranelift data structures into a trait for arbitrary.

It also moves name, signature and function references generation out of `FunctionGenerator` and into `FuzzGen`. This will allow us to control the call flow graph and avoid recursion and infinite loops when we do generate multiple functions.

This PR by itself gets us generating calls to `LibCall`s on fuzzgen since we no longer just outright block funcref generation.

Ran this in the fuzzer for a while and nothing came up.