### PR TITLE
Move the default block to the front of the underlying jump table storage

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -363,7 +363,7 @@ mod test {
         pos.insert_block(bb0);
         let jt = pos
             .func
-            .create_jump_table(JumpTableData::new(bb3, vec![bb1, bb2]));
+            .create_jump_table(JumpTableData::new(bb3, &[bb1, bb2]));
         pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -410,7 +410,7 @@ mod test {
         pos.insert_block(bb0);
         let jt = pos
             .func
-            .create_jump_table(JumpTableData::new(bb3, vec![bb1, bb2]));
+            .create_jump_table(JumpTableData::new(bb3, &[bb1, bb2]));
         pos.ins().br_table(arg0, jt);
 
         pos.insert_block(bb1);

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -1010,7 +1010,7 @@ mod tests {
         ssa.def_var(x_var, x1, block0);
         ssa.use_var(&mut func, x_var, I32, block0).0;
         let br_table = {
-            let jump_table = JumpTableData::new(block2, vec![block2, block1]);
+            let jump_table = JumpTableData::new(block2, &[block2, block1]);
             let jt = func.create_jump_table(jump_table);
             let mut cur = FuncCursor::new(&mut func).at_bottom(block0);
             cur.ins().br_table(x1, jt)

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -220,7 +220,7 @@ impl Switch {
             "Jump tables bigger than 2^32-1 are not yet supported"
         );
 
-        let jt_data = JumpTableData::new(otherwise, Vec::from(blocks));
+        let jt_data = JumpTableData::new(otherwise, blocks);
         let jump_table = bx.create_jump_table(jt_data);
 
         let discr = if first_index == 0 {

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1614,7 +1614,7 @@ where
             }
             BlockTerminator::BrTable(default, targets) => {
                 // Create jump tables on demand
-                let jt = builder.create_jump_table(JumpTableData::new(default, targets));
+                let jt = builder.create_jump_table(JumpTableData::new(default, &targets));
 
                 // br_table only supports I32
                 let val = builder.use_var(self.get_variable_of_type(I32)?);

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -1799,7 +1799,7 @@ impl<'a> Parser<'a> {
 
         self.consume();
 
-        Ok(JumpTableData::new(def, data))
+        Ok(JumpTableData::new(def, &data))
     }
 
     // Parse a constant decl.

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -534,7 +534,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                     frame.set_branched_to_exit();
                     frame.br_destination()
                 };
-                let jt = builder.create_jump_table(JumpTableData::new(block, data));
+                let jt = builder.create_jump_table(JumpTableData::new(block, &data));
                 builder.ins().br_table(val, jt);
             } else {
                 // Here we have jump arguments, but Cranelift's br_table doesn't support them
@@ -562,7 +562,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                         *entry.insert(block)
                     }
                 };
-                let jt = builder.create_jump_table(JumpTableData::new(default_branch_block, data));
+                let jt = builder.create_jump_table(JumpTableData::new(default_branch_block, &data));
                 builder.ins().br_table(val, jt);
                 for (depth, dest_block) in dest_block_sequence {
                     builder.switch_to_block(dest_block);


### PR DESCRIPTION
The new api on `JumpTableData` makese it easy to keep the default label first, and that shrinks the diff in #5731 a bit.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
