### PR TITLE
Prevent trampoline entrypoints from being stripped out during LTO

### DIFF
--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -122,6 +122,17 @@ pub mod trampolines {
                         Err(panic) => crate::traphandlers::resume_panic(panic),
                     }
                 }
+
+                // This works around a `rustc` bug where compiling with LTO
+                // will sometimes strip out some of these symbols resulting
+                // in a linking failure.
+                #[allow(non_upper_case_globals)]
+                #[used]
+                static [<impl_ $name _ref>]: unsafe extern "C" fn(
+                    *mut VMContext,
+                    $( $pname : libcall!(@ty $param), )*
+                ) $( -> libcall!(@ty $result))? = [<impl_ $name>];
+
             )*
         }};
 


### PR DESCRIPTION
This PR works around a `rustc` bug where compiling with LTO will sometimes strip out some of the trampoline entrypoint symbols resulting in a linking failure.

Fixes https://github.com/bytecodealliance/wasmtime/issues/5768
