### PR TITLE
Improve type imports into components

### DIFF
--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -134,8 +134,7 @@ impl<T> Linker<T> {
             let import = self
                 .strings
                 .lookup(name)
-                .and_then(|name| self.map.get(&name))
-                .ok_or_else(|| anyhow!("import `{name}` not defined"))?;
+                .and_then(|name| self.map.get(&name));
             cx.definition(ty, import)
                 .with_context(|| format!("import `{name}` has the wrong type"))?;
         }

--- a/tests/misc_testsuite/component-model/import.wast
+++ b/tests/misc_testsuite/component-model/import.wast
@@ -3,3 +3,18 @@
     (import "host-return-two" (func $f (result u32)))
     (export "x" (func $f)))
   "component export `x` is a reexport of an imported function which is not implemented")
+
+(assert_invalid
+  (component
+    (import "host-return-two" (instance))
+  )
+  "expected instance found func")
+
+;; empty instances don't need to be supplied by the host, even recursively
+;; empty instances.
+(component
+  (import "not-provided-by-the-host" (instance))
+  (import "not-provided-by-the-host2" (instance
+    (export "x" (instance))
+  ))
+)

--- a/tests/misc_testsuite/component-model/linking.wast
+++ b/tests/misc_testsuite/component-model/linking.wast
@@ -2,7 +2,7 @@
   (component
     (import "undefined-name" (core module))
   )
-  "import `undefined-name` not defined")
+  "expected module found nothing")
 (component $i)
 (component
   (import "i" (instance))
@@ -15,4 +15,4 @@
   "expected func found instance")
 (assert_unlinkable
   (component (import "i" (instance (export "x" (func)))))
-  "export `x` not defined")
+  "expected func found nothing")

--- a/tests/misc_testsuite/component-model/types.wast
+++ b/tests/misc_testsuite/component-model/types.wast
@@ -320,3 +320,17 @@
 
   (instance $c (instantiate $c (with "x" (component $x))))
 )
+
+(component
+  (type $t1 u64)
+  (import "a" (type $t2 (eq $t1)))
+  (import "b" (type $t3 (eq $t2)))
+)
+
+(component
+  (import "a" (instance
+    (type $t1 u64)
+    (export $t2 "a" (type (eq $t1)))
+    (export "b" (type (eq $t2)))
+  ))
+)


### PR DESCRIPTION
This commit fixes a panic related to type imports where an import of a type didn't correctly declare the new type index on the Wasmtime side of things. Additionally this plumbs more support throughout Wasmtime to support type imports, namely that they do not need to be supplied through a `Linker`. This additionally implements a feature where empty instances, even transitively, do not need to be supplied by a Wasmtime embedder. This means that instances which only have types, for example, do not need to be supplied into a `Linker` since no runtime information for them is required anyway.

Closes #5775

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
