### PR TITLE
Use capstone to validate precise-output tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,6 @@ name = "cranelift-filetests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "capstone",
  "cranelift",
  "cranelift-codegen",
  "cranelift-frontend",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,11 @@ dependencies = [
 name = "cranelift-codegen"
 version = "0.94.0"
 dependencies = [
+ "anyhow",
  "arrayvec",
  "bincode",
  "bumpalo",
+ "capstone",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -592,6 +594,7 @@ name = "cranelift-filetests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "capstone",
  "cranelift",
  "cranelift-codegen",
  "cranelift-frontend",

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 
 [dependencies]
 cfg-if = "1.0"
-cranelift-codegen = { workspace = true }
+cranelift-codegen = { workspace = true, features = ["disas"] }
 cranelift-entity = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-reader = { workspace = true }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -58,7 +58,7 @@ std = []
 core = []
 
 # Enable the `to_capstone` method on TargetIsa, for constructing a Capstone
-# context.
+# context, and the `disassemble` method on `MachBufferFinalized`.
 disas = ["anyhow", "capstone"]
 
 # This enables some additional functions useful for writing tests, but which

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -14,7 +14,9 @@ edition.workspace = true
 
 [dependencies]
 arrayvec = "0.7"
+anyhow = { workspace = true, optional = true }
 bumpalo = "3"
+capstone = { workspace = true, optional = true }
 cranelift-codegen-shared = { path = "./shared", version = "0.94.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
@@ -54,6 +56,10 @@ std = []
 # no_std build anymore). The feature remains for backward
 # compatibility as a no-op.
 core = []
+
+# Enable the `to_capstone` method on TargetIsa, for constructing a Capstone
+# context.
+disas = ["anyhow", "capstone"]
 
 # This enables some additional functions useful for writing tests, but which
 # can significantly increase the size of the library.

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -199,33 +199,17 @@ impl TargetIsa for AArch64Backend {
     #[cfg(feature = "disas")]
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         use capstone::prelude::*;
-
-        match self.triple().architecture {
-            Architecture::Arm(arm) => {
-                if arm.is_thumb() {
-                    Capstone::new()
-                        .arm()
-                        .mode(arch::arm::ArchMode::Thumb)
-                        .build()
-                } else {
-                    Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build()
-                }
-            }
-            Architecture::Aarch64 { .. } => {
-                let mut cs = Capstone::new()
-                    .arm64()
-                    .mode(arch::arm64::ArchMode::Arm)
-                    .build()?;
-                // AArch64 uses inline constants rather than a separate constant pool right now.
-                // Without this option, Capstone will stop disassembling as soon as it sees
-                // an inline constant that is not also a valid instruction. With this option,
-                // Capstone will print a `.byte` directive with the bytes of the inline constant
-                // and continue to the next instruction.
-                cs.set_skipdata(true)?;
-                Ok(cs)
-            }
-            _ => Err(capstone::Error::UnsupportedArch),
-        }
+        let mut cs = Capstone::new()
+            .arm64()
+            .mode(arch::arm64::ArchMode::Arm)
+            .build()?;
+        // AArch64 uses inline constants rather than a separate constant pool right now.
+        // Without this option, Capstone will stop disassembling as soon as it sees
+        // an inline constant that is not also a valid instruction. With this option,
+        // Capstone will print a `.byte` directive with the bytes of the inline constant
+        // and continue to the next instruction.
+        cs.set_skipdata(true)?;
+        Ok(cs)
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -195,6 +195,38 @@ impl TargetIsa for AArch64Backend {
         // 4-byte alignment.
         32
     }
+
+    #[cfg(feature = "disas")]
+    fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
+        use capstone::prelude::*;
+
+        match self.triple().architecture {
+            Architecture::Arm(arm) => {
+                if arm.is_thumb() {
+                    Capstone::new()
+                        .arm()
+                        .mode(arch::arm::ArchMode::Thumb)
+                        .build()
+                } else {
+                    Capstone::new().arm().mode(arch::arm::ArchMode::Arm).build()
+                }
+            }
+            Architecture::Aarch64 { .. } => {
+                let mut cs = Capstone::new()
+                    .arm64()
+                    .mode(arch::arm64::ArchMode::Arm)
+                    .build()?;
+                // AArch64 uses inline constants rather than a separate constant pool right now.
+                // Without this option, Capstone will stop disassembling as soon as it sees
+                // an inline constant that is not also a valid instruction. With this option,
+                // Capstone will print a `.byte` directive with the bytes of the inline constant
+                // and continue to the next instruction.
+                cs.set_skipdata(true)?;
+                Ok(cs)
+            }
+            _ => Err(capstone::Error::UnsupportedArch),
+        }
+    }
 }
 
 impl fmt::Display for AArch64Backend {

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -90,7 +90,7 @@ impl TargetIsa for AArch64Backend {
         Ok(CompiledCodeStencil {
             buffer,
             frame_size,
-            disasm: emit_result.disasm,
+            vcode: emit_result.disasm,
             value_labels_ranges,
             sized_stackslot_offsets,
             dynamic_stackslot_offsets,

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -307,6 +307,12 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     {
         Arc::new(self)
     }
+
+    /// Generate a `Capstone` context for disassembling bytecode for this architecture.
+    #[cfg(feature = "disas")]
+    fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
+        Err(capstone::Error::UnsupportedArch)
+    }
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -91,7 +91,7 @@ impl TargetIsa for Riscv64Backend {
         Ok(CompiledCodeStencil {
             buffer,
             frame_size,
-            disasm: emit_result.disasm,
+            vcode: emit_result.disasm,
             value_labels_ranges,
             sized_stackslot_offsets,
             dynamic_stackslot_offsets,

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -169,6 +169,26 @@ impl TargetIsa for Riscv64Backend {
     fn function_alignment(&self) -> u32 {
         4
     }
+
+    #[cfg(feature = "disas")]
+    fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
+        use capstone::prelude::*;
+
+        match self.triple().architecture {
+            Architecture::Riscv64 { .. } => {
+                let mut cs = Capstone::new()
+                    .riscv()
+                    .mode(arch::riscv::ArchMode::RiscV64)
+                    .build()?;
+                // Similar to AArch64, RISC-V uses inline constants rather than a separate
+                // constant pool. We want to skip dissasembly over inline constants instead
+                // of stopping on invalid bytes.
+                cs.set_skipdata(true)?;
+                Ok(cs)
+            }
+            _ => Err(capstone::Error::UnsupportedArch),
+        }
+    }
 }
 
 impl fmt::Display for Riscv64Backend {

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -173,21 +173,15 @@ impl TargetIsa for Riscv64Backend {
     #[cfg(feature = "disas")]
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         use capstone::prelude::*;
-
-        match self.triple().architecture {
-            Architecture::Riscv64 { .. } => {
-                let mut cs = Capstone::new()
-                    .riscv()
-                    .mode(arch::riscv::ArchMode::RiscV64)
-                    .build()?;
-                // Similar to AArch64, RISC-V uses inline constants rather than a separate
-                // constant pool. We want to skip dissasembly over inline constants instead
-                // of stopping on invalid bytes.
-                cs.set_skipdata(true)?;
-                Ok(cs)
-            }
-            _ => Err(capstone::Error::UnsupportedArch),
-        }
+        let mut cs = Capstone::new()
+            .riscv()
+            .mode(arch::riscv::ArchMode::RiscV64)
+            .build()?;
+        // Similar to AArch64, RISC-V uses inline constants rather than a separate
+        // constant pool. We want to skip dissasembly over inline constants instead
+        // of stopping on invalid bytes.
+        cs.set_skipdata(true)?;
+        Ok(cs)
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -174,10 +174,14 @@ impl TargetIsa for S390xBackend {
     #[cfg(feature = "disas")]
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         use capstone::prelude::*;
-        Capstone::new()
+        let mut cs = Capstone::new()
             .sysz()
             .mode(arch::sysz::ArchMode::Default)
-            .build()
+            .build()?;
+
+        cs.set_skipdata(true)?;
+
+        Ok(cs)
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -174,14 +174,10 @@ impl TargetIsa for S390xBackend {
     #[cfg(feature = "disas")]
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         use capstone::prelude::*;
-
-        match self.triple().architecture {
-            Architecture::S390x { .. } => Capstone::new()
-                .sysz()
-                .mode(arch::sysz::ArchMode::Default)
-                .build(),
-            _ => Err(capstone::Error::UnsupportedArch),
-        }
+        Capstone::new()
+            .sysz()
+            .mode(arch::sysz::ArchMode::Default)
+            .build()
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -87,7 +87,7 @@ impl TargetIsa for S390xBackend {
         Ok(CompiledCodeStencil {
             buffer,
             frame_size,
-            disasm: emit_result.disasm,
+            vcode: emit_result.disasm,
             value_labels_ranges,
             sized_stackslot_offsets,
             dynamic_stackslot_offsets,

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -170,6 +170,19 @@ impl TargetIsa for S390xBackend {
     fn function_alignment(&self) -> u32 {
         4
     }
+
+    #[cfg(feature = "disas")]
+    fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
+        use capstone::prelude::*;
+
+        match self.triple().architecture {
+            Architecture::S390x { .. } => Capstone::new()
+                .sysz()
+                .mode(arch::sysz::ArchMode::Default)
+                .build(),
+            _ => Err(capstone::Error::UnsupportedArch),
+        }
+    }
 }
 
 impl fmt::Display for S390xBackend {

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -175,19 +175,11 @@ impl TargetIsa for X64Backend {
     #[cfg(feature = "disas")]
     fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
         use capstone::prelude::*;
-        use target_lexicon::Architecture;
-
-        match self.triple().architecture {
-            Architecture::X86_32(_) => Capstone::new()
-                .x86()
-                .mode(arch::x86::ArchMode::Mode32)
-                .build(),
-            Architecture::X86_64 => Capstone::new()
-                .x86()
-                .mode(arch::x86::ArchMode::Mode64)
-                .build(),
-            _ => Err(capstone::Error::UnsupportedArch),
-        }
+        Capstone::new()
+            .x86()
+            .mode(arch::x86::ArchMode::Mode64)
+            .syntax(arch::x86::ArchSyntax::Att)
+            .build()
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -171,6 +171,24 @@ impl TargetIsa for X64Backend {
     fn function_alignment(&self) -> u32 {
         16
     }
+
+    #[cfg(feature = "disas")]
+    fn to_capstone(&self) -> Result<capstone::Capstone, capstone::Error> {
+        use capstone::prelude::*;
+        use target_lexicon::Architecture;
+
+        match self.triple().architecture {
+            Architecture::X86_32(_) => Capstone::new()
+                .x86()
+                .mode(arch::x86::ArchMode::Mode32)
+                .build(),
+            Architecture::X86_64 => Capstone::new()
+                .x86()
+                .mode(arch::x86::ArchMode::Mode64)
+                .build(),
+            _ => Err(capstone::Error::UnsupportedArch),
+        }
+    }
 }
 
 impl fmt::Display for X64Backend {

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -84,7 +84,7 @@ impl TargetIsa for X64Backend {
         Ok(CompiledCodeStencil {
             buffer,
             frame_size,
-            disasm: emit_result.disasm,
+            vcode: emit_result.disasm,
             value_labels_ranges,
             sized_stackslot_offsets,
             dynamic_stackslot_offsets,

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1487,7 +1487,10 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
             write!(buf, "  ")?;
 
             if let Some(s) = i.mnemonic() {
-                write!(buf, "{}\t", s)?;
+                write!(buf, "{}", s)?;
+                if i.op_str().is_some() {
+                    write!(buf, " ")?;
+                }
             }
 
             if let Some(s) = i.op_str() {
@@ -1511,7 +1514,7 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
                 write!(buf, " ; trap: {}", trap.code)?;
             }
 
-            writeln!(buf, "")?;
+            writeln!(buf)?;
         }
 
         return Ok(buf);

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1486,16 +1486,15 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
         for i in insns.iter() {
             write!(buf, "  ")?;
 
+            let op_str = i.op_str().unwrap_or("");
             if let Some(s) = i.mnemonic() {
                 write!(buf, "{}", s)?;
-                if i.op_str().is_some() {
+                if !op_str.is_empty() {
                     write!(buf, " ")?;
                 }
             }
 
-            if let Some(s) = i.op_str() {
-                write!(buf, "{}", s)?;
-            }
+            write!(buf, "{}", op_str)?;
 
             let end = i.address() + i.bytes().len() as u64;
             let contains = |off| i.address() <= off && off < end;

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1467,6 +1467,59 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
     pub fn call_sites(&self) -> &[MachCallSite] {
         &self.call_sites[..]
     }
+
+    /// Get the disassembly of the buffer, using the given capstone context.
+    #[cfg(feature = "disas")]
+    pub fn disassemble(
+        &self,
+        params: Option<&crate::ir::function::FunctionParameters>,
+        cs: &capstone::Capstone,
+    ) -> Result<String, anyhow::Error> {
+        use std::fmt::Write;
+
+        let mut buf = String::new();
+
+        let relocs = self.relocs.as_slice();
+        let traps = self.traps.as_slice();
+
+        let insns = cs.disasm_all(&self.data, 0x0).map_err(map_caperr)?;
+        for i in insns.iter() {
+            write!(buf, "  ")?;
+
+            if let Some(s) = i.mnemonic() {
+                write!(buf, "{}\t", s)?;
+            }
+
+            if let Some(s) = i.op_str() {
+                write!(buf, "{}", s)?;
+            }
+
+            let end = i.address() + i.bytes().len() as u64;
+            let contains = |off| i.address() <= off && off < end;
+
+            if let Some(reloc) = relocs.iter().find(|reloc| contains(reloc.offset as u64)) {
+                write!(
+                    buf,
+                    " ; reloc_external {} {} {}",
+                    reloc.kind,
+                    reloc.name.display(params),
+                    reloc.addend,
+                )?;
+            }
+
+            if let Some(trap) = traps.iter().find(|trap| contains(trap.offset as u64)) {
+                write!(buf, " ; trap: {}", trap.code)?;
+            }
+
+            writeln!(buf, "")?;
+        }
+
+        return Ok(buf);
+
+        fn map_caperr(err: capstone::Error) -> anyhow::Error {
+            anyhow::format_err!("{}", err)
+        }
+    }
 }
 
 /// A constant that is deferred to the next constant-pool opportunity.

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -354,9 +354,19 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
 
         let relocs = self.buffer.relocs();
         let traps = self.buffer.traps();
+        let labels = self.bb_starts.as_slice();
 
         let insns = cs.disasm_all(self.buffer.data(), 0x0).map_err(map_caperr)?;
         for i in insns.iter() {
+            if let Some((n, off)) = labels
+                .iter()
+                .copied()
+                .enumerate()
+                .find(|(_, val)| *val == i.address() as u32)
+            {
+                writeln!(buf, "block{}: ; offset 0x{:x}", n, off)?;
+            }
+
             write!(buf, "  ")?;
 
             let op_str = i.op_str().unwrap_or("");

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -10,13 +10,14 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-cranelift-codegen = { workspace = true, features = ["testing_hooks"] }
+cranelift-codegen = { workspace = true, features = ["testing_hooks", "disas"] }
 cranelift-frontend = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-native = { workspace = true }
 cranelift-reader = { workspace = true }
 cranelift-jit = { workspace = true, features = ["selinux-fix"] }
 cranelift-module = { workspace = true }
+capstone = { workspace = true }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"
 gimli = { workspace = true }

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -17,7 +17,6 @@ cranelift-native = { workspace = true }
 cranelift-reader = { workspace = true }
 cranelift-jit = { workspace = true, features = ["selinux-fix"] }
 cranelift-module = { workspace = true }
-capstone = { workspace = true }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.5.0"
 gimli = { workspace = true }

--- a/cranelift/filetests/filetests/egraph/multivalue.clif
+++ b/cranelift/filetests/filetests/egraph/multivalue.clif
@@ -1,6 +1,7 @@
 test compile precise-output
 set opt_level=speed
 set use_egraphs=true
+set machine_code_cfg_info=true
 target x86_64
 
 ;; We want to make sure that this compiles successfully, so we are properly
@@ -15,6 +16,7 @@ function u0:359(i64) -> i8, i8 system_v {
 		return v3, v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -22,4 +24,13 @@ function u0:359(i64) -> i8, i8 system_v {
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   callq 9 ; reloc_external CallPCRel4 u0:521 -4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/egraph/not_a_load.clif
+++ b/cranelift/filetests/filetests/egraph/not_a_load.clif
@@ -13,6 +13,7 @@ function u0:1302(i64) -> i64 system_v {
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -21,4 +22,18 @@ function u0:1302(i64) -> i64 system_v {
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq %rax, %rcx
+;   addq %rdi, %rcx
+;   lock cmpxchgq %rcx, (%rdi) ; trap: heap_oob
+;   jne 7
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -10,8 +10,14 @@ block0(v0: i64, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   ldr w0, [x0, w1, SXTW]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr w0, [x0, w1, sxtw]
 ;   ret
 
 function %f6(i64, i32) -> i32 {
@@ -22,8 +28,14 @@ block0(v0: i64, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   ldr w0, [x0, w1, SXTW]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr w0, [x0, w1, sxtw]
 ;   ret
 
 function %f7(i32, i32) -> i32 {
@@ -35,9 +47,16 @@ block0(v0: i32, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   mov w3, w0
 ;   ldr w0, [x3, w1, UXTW]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, w0
+;   ldr w0, [x3, w1, uxtw]
 ;   ret
 
 function %f8(i64, i32) -> i32 {
@@ -51,11 +70,20 @@ block0(v0: i64, v1: i32):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   add x3, x0, #68
 ;   add x5, x3, x0
 ;   add x7, x5, x1, SXTW
 ;   ldr w0, [x7, w1, SXTW]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x3, x0, #0x44
+;   add x5, x3, x0
+;   add x7, x5, w1, sxtw
+;   ldr w0, [x7, w1, sxtw]
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -68,10 +96,18 @@ block0(v0: i64, v1: i64, v2: i64):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   add x4, x0, x2
 ;   add x6, x4, x1
 ;   ldr w0, [x6, #48]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x4, x0, x2
+;   add x6, x4, x1
+;   ldur w0, [x6, #0x30]
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -84,8 +120,17 @@ block0(v0: i64, v1: i64, v2: i64):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   movz x5, #4100
+;   add x5, x5, x1
+;   add x8, x5, x2
+;   ldr w0, [x8, x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, #0x1004
 ;   add x5, x5, x1
 ;   add x8, x5, x2
 ;   ldr w0, [x8, x0]
@@ -98,8 +143,15 @@ block0:
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #1234
+;   ldr w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0x4d2
 ;   ldr w0, [x0]
 ;   ret
 
@@ -111,8 +163,15 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   add x2, x0, #8388608
+;   ldr w0, [x2]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x2, x0, #0x800, lsl #12
 ;   ldr w0, [x2]
 ;   ret
 
@@ -124,7 +183,14 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sub x2, x0, #4
+;   ldr w0, [x2]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sub x2, x0, #4
 ;   ldr w0, [x2]
 ;   ret
@@ -137,9 +203,18 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #51712
 ;   movk w3, w3, #15258, LSL #16
+;   add x4, x3, x0
+;   ldr w0, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0xca00
+;   movk w3, #0x3b9a, lsl #16
 ;   add x4, x3, x0
 ;   ldr w0, [x4]
 ;   ret
@@ -151,7 +226,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sxtw x2, w0
+;   ldr w0, [x2]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtw x2, w0
 ;   ldr w0, [x2]
 ;   ret
@@ -165,9 +247,16 @@ block0(v0: i32, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   sxtw x3, w0
 ;   ldr w0, [x3, w1, SXTW]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtw x3, w0
+;   ldr w0, [x3, w1, sxtw]
 ;   ret
 
 function %f18(i64, i64, i64) -> i32 {
@@ -178,8 +267,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   movn w4, #4097
+;   ldrsh x0, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w4, #-0x1002
 ;   ldrsh x0, [x4]
 ;   ret
 
@@ -191,8 +287,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   movz x4, #4098
+;   ldrsh x0, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x4, #0x1002
 ;   ldrsh x0, [x4]
 ;   ret
 
@@ -204,8 +307,16 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   movn w4, #4097
+;   sxtw x6, w4
+;   ldrsh x0, [x6]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w4, #-0x1002
 ;   sxtw x6, w4
 ;   ldrsh x0, [x6]
 ;   ret
@@ -218,8 +329,16 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   movz x4, #4098
+;   sxtw x6, w4
+;   ldrsh x0, [x6]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x4, #0x1002
 ;   sxtw x6, w4
 ;   ldrsh x0, [x6]
 ;   ret
@@ -231,7 +350,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   mov x5, x0
+;   ldp x0, x1, [x5]
+;   stp x0, x1, [x5]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x5, x0
 ;   ldp x0, x1, [x5]
 ;   stp x0, x1, [x5]
@@ -244,10 +371,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   mov x5, x0
 ;   ldp x0, x1, [x5, #16]
 ;   stp x0, x1, [x5, #16]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, x0
+;   ldp x0, x1, [x5, #0x10]
+;   stp x0, x1, [x5, #0x10]
 ;   ret
 
 function %i128_imm_offset_large(i64) -> i128 {
@@ -257,10 +392,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   mov x5, x0
 ;   ldp x0, x1, [x5, #504]
 ;   stp x0, x1, [x5, #504]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, x0
+;   ldp x0, x1, [x5, #0x1f8]
+;   stp x0, x1, [x5, #0x1f8]
 ;   ret
 
 function %i128_imm_offset_negative_large(i64) -> i128 {
@@ -270,10 +413,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   mov x5, x0
 ;   ldp x0, x1, [x5, #-512]
 ;   stp x0, x1, [x5, #-512]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, x0
+;   ldp x0, x1, [x5, #-0x200]
+;   stp x0, x1, [x5, #-0x200]
 ;   ret
 
 function %i128_add_offset(i64) -> i128 {
@@ -284,10 +435,18 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mov x5, x0
 ;   ldp x0, x1, [x5, #32]
 ;   stp x0, x1, [x5, #32]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, x0
+;   ldp x0, x1, [x5, #0x20]
+;   stp x0, x1, [x5, #0x20]
 ;   ret
 
 function %i128_32bit_sextend_simple(i32) -> i128 {
@@ -298,7 +457,17 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sxtw x3, w0
+;   mov x8, x0
+;   ldp x0, x1, [x3]
+;   sxtw x4, w8
+;   stp x0, x1, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtw x3, w0
 ;   mov x8, x0
 ;   ldp x0, x1, [x3]
@@ -316,6 +485,7 @@ block0(v0: i64, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   add x4, x0, x1, SXTW
 ;   mov x11, x0
@@ -323,5 +493,15 @@ block0(v0: i64, v1: i32):
 ;   ldp x0, x1, [x4, #24]
 ;   add x5, x11, x9, SXTW
 ;   stp x0, x1, [x5, #24]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x4, x0, w1, sxtw
+;   mov x11, x0
+;   mov x9, x1
+;   ldp x0, x1, [x4, #0x18]
+;   add x5, x11, w9, sxtw
+;   stp x0, x1, [x5, #0x18]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -8,7 +8,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add x0, x0, x1
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sub x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sub x0, x0, x1
 ;   ret
 
@@ -28,8 +40,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   madd x0, x0, x1, xzr
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul x0, x0, x1
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -38,7 +56,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umulh x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umulh x0, x0, x1
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smulh x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smulh x0, x0, x1
 ;   ret
 
@@ -58,11 +88,23 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cbnz x1, 8 ; udf
 ;   adds xzr, x1, #1
 ;   ccmp x0, #1, #nzcv, eq
 ;   b.vc 8 ; udf
+;   sdiv x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cbnz x1, #8
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
+;   cmn x1, #1
+;   ccmp x0, #1, #0, eq
+;   b.vc #0x18
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
 ;   sdiv x0, x0, x1
 ;   ret
 
@@ -73,8 +115,15 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w2, #2
+;   sdiv x0, x0, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #2
 ;   sdiv x0, x0, x2
 ;   ret
 
@@ -84,8 +133,16 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cbnz x1, 8 ; udf
+;   udiv x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cbnz x1, #8
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   udiv x0, x0, x1
 ;   ret
 
@@ -96,8 +153,15 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #2
+;   udiv x0, x0, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #2
 ;   udiv x0, x0, x2
 ;   ret
 
@@ -107,8 +171,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cbnz x1, 8 ; udf
+;   sdiv x4, x0, x1
+;   msub x0, x4, x1, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cbnz x1, #8
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   sdiv x4, x0, x1
 ;   msub x0, x4, x1, x0
 ;   ret
@@ -119,8 +192,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cbnz x1, 8 ; udf
+;   udiv x4, x0, x1
+;   msub x0, x4, x1, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cbnz x1, #8
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   udiv x4, x0, x1
 ;   msub x0, x4, x1, x0
 ;   ret
@@ -131,6 +213,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sxtw x3, w0
 ;   sxtw x5, w1
@@ -138,6 +221,19 @@ block0(v0: i32, v1: i32):
 ;   adds wzr, w5, #1
 ;   ccmp w3, #1, #nzcv, eq
 ;   b.vc 8 ; udf
+;   sdiv x0, x3, x5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtw x3, w0
+;   sxtw x5, w1
+;   cbnz x5, #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
+;   cmn w5, #1
+;   ccmp w3, #1, #0, eq
+;   b.vc #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
 ;   sdiv x0, x3, x5
 ;   ret
 
@@ -148,9 +244,17 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sxtw x2, w0
 ;   movz w4, #2
+;   sdiv x0, x2, x4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtw x2, w0
+;   mov w4, #2
 ;   sdiv x0, x2, x4
 ;   ret
 
@@ -160,10 +264,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mov w3, w0
 ;   mov w5, w1
 ;   cbnz x5, 8 ; udf
+;   udiv x0, x3, x5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, w0
+;   mov w5, w1
+;   cbnz x5, #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   udiv x0, x3, x5
 ;   ret
 
@@ -174,9 +288,17 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mov w2, w0
 ;   movz w4, #2
+;   udiv x0, x2, x4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, w0
+;   mov w4, #2
 ;   udiv x0, x2, x4
 ;   ret
 
@@ -186,10 +308,21 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sxtw x3, w0
 ;   sxtw x5, w1
 ;   cbnz x5, 8 ; udf
+;   sdiv x8, x3, x5
+;   msub x0, x8, x5, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtw x3, w0
+;   sxtw x5, w1
+;   cbnz x5, #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   sdiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret
@@ -200,10 +333,21 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mov w3, w0
 ;   mov w5, w1
 ;   cbnz x5, 8 ; udf
+;   udiv x8, x3, x5
+;   msub x0, x8, x5, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, w0
+;   mov w5, w1
+;   cbnz x5, #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_divz
 ;   udiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret
@@ -214,7 +358,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   and x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and x0, x0, x1
 ;   ret
 
@@ -224,7 +374,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   orr x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr x0, x0, x1
 ;   ret
 
@@ -234,7 +390,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   eor x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor x0, x0, x1
 ;   ret
 
@@ -244,7 +406,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   bic x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic x0, x0, x1
 ;   ret
 
@@ -254,7 +422,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   orn x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orn x0, x0, x1
 ;   ret
 
@@ -264,7 +438,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   eon x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon x0, x0, x1
 ;   ret
 
@@ -274,8 +454,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   orn x0, xzr, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvn x0, x0
 ;   ret
 
 function %f25(i32, i32) -> i32 {
@@ -286,8 +472,14 @@ block0(v0: i32, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   sub w0, w1, w0, LSL 21
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sub w0, w1, w0, lsl #21
 ;   ret
 
 function %f26(i32) -> i32 {
@@ -297,7 +489,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sub w0, w0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sub w0, w0, #1
 ;   ret
 
@@ -308,7 +506,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add w0, w0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add w0, w0, #1
 ;   ret
 
@@ -319,7 +523,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add x0, x0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add x0, x0, #1
 ;   ret
 
@@ -330,9 +540,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #1
 ;   sub x0, xzr, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #1
+;   neg x0, x2
 ;   ret
 
 function %f30(i8x16) -> i8x16 {
@@ -342,10 +559,20 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #1
 ;   and w4, w2, #7
 ;   sub x6, xzr, x4
+;   dup v16.16b, w6
+;   ushl v0.16b, v0.16b, v16.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #1
+;   and w4, w2, #7
+;   neg x6, x4
 ;   dup v16.16b, w6
 ;   ushl v0.16b, v0.16b, v16.16b
 ;   ret
@@ -356,7 +583,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   adds x0, x0, x2
+;   adc x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   adds x0, x0, x2
 ;   adc x1, x1, x3
 ;   ret
@@ -367,7 +601,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   subs x0, x0, x2
+;   sbc x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   subs x0, x0, x2
 ;   sbc x1, x1, x3
 ;   ret
@@ -378,11 +619,20 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   umulh x5, x0, x2
 ;   madd x7, x0, x3, x5
 ;   madd x1, x1, x2, x7
 ;   madd x0, x0, x2, xzr
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   umulh x5, x0, x2
+;   madd x7, x0, x3, x5
+;   madd x1, x1, x2, x7
+;   mul x0, x0, x2
 ;   ret
 
 function %add_mul_1(i32, i32, i32) -> i32 {
@@ -392,7 +642,13 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
+;   madd w0, w1, w2, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   madd w0, w1, w2, w0
 ;   ret
 
@@ -403,7 +659,13 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
+;   madd w0, w1, w2, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   madd w0, w1, w2, w0
 ;   ret
 
@@ -414,7 +676,13 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
+;   msub w0, w1, w2, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msub w0, w1, w2, w0
 ;   ret
 
@@ -425,7 +693,13 @@ block0(v0: i64, v1: i64, v2: i64):
     return v4
 }
 
+; VCode:
 ; block0:
+;   msub x0, x1, x2, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msub x0, x1, x2, x0
 ;   ret
 
@@ -436,8 +710,15 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   madd w5, w1, w2, wzr
+;   sub w0, w5, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul w5, w1, w2
 ;   sub w0, w5, w0
 ;   ret
 
@@ -448,8 +729,15 @@ block0(v0: i64, v1: i64, v2: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   madd x5, x1, x2, xzr
+;   sub x0, x5, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul x5, x1, x2
 ;   sub x0, x5, x0
 ;   ret
 
@@ -460,8 +748,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w2, #2
+;   sdiv x4, x0, x2
+;   msub x0, x4, x2, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #2
 ;   sdiv x4, x0, x2
 ;   msub x0, x4, x2, x0
 ;   ret
@@ -473,8 +769,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #2
+;   udiv x4, x0, x2
+;   msub x0, x4, x2, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #2
 ;   udiv x4, x0, x2
 ;   msub x0, x4, x2, x0
 ;   ret
@@ -486,11 +790,22 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movn x2, #0
 ;   adds xzr, x2, #1
 ;   ccmp x0, #1, #nzcv, eq
 ;   b.vc 8 ; udf
+;   sdiv x0, x0, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #-1
+;   cmn x2, #1
+;   ccmp x0, #1, #0, eq
+;   b.vc #0x14
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
 ;   sdiv x0, x0, x2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
@@ -10,6 +10,7 @@ block0(v0: i64, v1: i32, v2: i32):
     return v7
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -26,5 +27,28 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   ldp x26, x27, [sp], #16
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   mov x28, x2
+;   ldaxr w27, [x25]
+;   cmp x27, x26
+;   b.ne #0x34
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x20
+;   cmp w27, w26
+;   cset x0, eq
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
@@ -7,7 +7,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldaddal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldaddal x1, x3, [x0]
 ;   ret
 
@@ -17,7 +23,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldaddal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldaddal w1, w3, [x0]
 ;   ret
 
@@ -27,7 +39,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldaddalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldaddalh w1, w3, [x0]
 ;   ret
 
@@ -37,7 +55,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldaddalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldaddalb w1, w3, [x0]
 ;   ret
 
@@ -47,8 +71,15 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub x3, xzr, x1
+;   ldaddal x3, x5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg x3, x1
 ;   ldaddal x3, x5, [x0]
 ;   ret
 
@@ -58,8 +89,15 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
+;   ldaddal w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
 ;   ldaddal w3, w5, [x0]
 ;   ret
 
@@ -69,8 +107,15 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
+;   ldaddalh w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
 ;   ldaddalh w3, w5, [x0]
 ;   ret
 
@@ -80,8 +125,15 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
+;   ldaddalb w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
 ;   ldaddalb w3, w5, [x0]
 ;   ret
 
@@ -91,7 +143,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   eon x3, x1, xzr
+;   ldclral x3, x5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon x3, x1, xzr
 ;   ldclral x3, x5, [x0]
 ;   ret
@@ -102,7 +161,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   eon w3, w1, wzr
+;   ldclral w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon w3, w1, wzr
 ;   ldclral w3, w5, [x0]
 ;   ret
@@ -113,7 +179,14 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   eon w3, w1, wzr
+;   ldclralh w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon w3, w1, wzr
 ;   ldclralh w3, w5, [x0]
 ;   ret
@@ -124,7 +197,14 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   eon w3, w1, wzr
+;   ldclralb w3, w5, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon w3, w1, wzr
 ;   ldclralb w3, w5, [x0]
 ;   ret
@@ -135,6 +215,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -149,6 +230,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   and x28, x27, x26
+;   mvn x28, x28
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -156,6 +257,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -170,6 +272,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -177,6 +299,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -191,6 +314,26 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -198,6 +341,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -212,6 +356,26 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_or_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -219,7 +383,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsetal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsetal x1, x3, [x0]
 ;   ret
 
@@ -229,7 +399,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsetal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsetal w1, w3, [x0]
 ;   ret
 
@@ -239,7 +415,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsetalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsetalh w1, w3, [x0]
 ;   ret
 
@@ -249,7 +431,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsetalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsetalb w1, w3, [x0]
 ;   ret
 
@@ -259,7 +447,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldeoral x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldeoral x1, x3, [x0]
 ;   ret
 
@@ -269,7 +463,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldeoral w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldeoral w1, w3, [x0]
 ;   ret
 
@@ -279,7 +479,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldeoralh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldeoralh w1, w3, [x0]
 ;   ret
 
@@ -289,7 +495,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldeoralb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldeoralb w1, w3, [x0]
 ;   ret
 
@@ -299,7 +511,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsmaxal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsmaxal x1, x3, [x0]
 ;   ret
 
@@ -309,7 +527,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsmaxal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsmaxal w1, w3, [x0]
 ;   ret
 
@@ -319,7 +543,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsmaxalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsmaxalh w1, w3, [x0]
 ;   ret
 
@@ -329,7 +559,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsmaxalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsmaxalb w1, w3, [x0]
 ;   ret
 
@@ -339,7 +575,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldumaxal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldumaxal x1, x3, [x0]
 ;   ret
 
@@ -349,7 +591,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldumaxal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldumaxal w1, w3, [x0]
 ;   ret
 
@@ -359,7 +607,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldumaxalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldumaxalh w1, w3, [x0]
 ;   ret
 
@@ -369,7 +623,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldumaxalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldumaxalb w1, w3, [x0]
 ;   ret
 
@@ -379,7 +639,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsminal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsminal x1, x3, [x0]
 ;   ret
 
@@ -389,7 +655,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsminal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsminal w1, w3, [x0]
 ;   ret
 
@@ -399,7 +671,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsminalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsminalh w1, w3, [x0]
 ;   ret
 
@@ -409,7 +687,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   ldsminalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldsminalb w1, w3, [x0]
 ;   ret
 
@@ -419,7 +703,13 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   lduminal x1, x3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lduminal x1, x3, [x0]
 ;   ret
 
@@ -429,7 +719,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
+;   lduminal w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lduminal w1, w3, [x0]
 ;   ret
 
@@ -439,7 +735,13 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ; block0:
+;   lduminalh w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lduminalh w1, w3, [x0]
 ;   ret
 
@@ -449,7 +751,13 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ; block0:
+;   lduminalb w1, w3, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lduminalb w1, w3, [x0]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
@@ -7,6 +7,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -21,6 +22,25 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   add x28, x27, x26
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_add_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -28,6 +48,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -42,6 +63,25 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   add w28, w27, w26
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_add_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -49,6 +89,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -63,6 +104,25 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   add w28, w27, w26
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_add_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -70,6 +130,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -84,6 +145,25 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   add w28, w27, w26
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_sub_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -91,6 +171,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -105,6 +186,25 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   sub x28, x27, x26
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_sub_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -112,6 +212,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -126,6 +227,25 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   sub w28, w27, w26
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_sub_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -133,6 +253,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -147,6 +268,25 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   sub w28, w27, w26
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_sub_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -154,6 +294,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -168,6 +309,25 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   sub w28, w27, w26
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_and_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -175,6 +335,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -189,6 +350,25 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   and x28, x27, x26
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_and_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -196,6 +376,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -210,6 +391,25 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   and w28, w27, w26
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_and_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -217,6 +417,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -231,6 +432,25 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   and w28, w27, w26
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_and_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -238,6 +458,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -252,6 +473,25 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   and w28, w27, w26
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -259,6 +499,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -273,6 +514,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   and x28, x27, x26
+;   mvn x28, x28
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -280,6 +541,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -294,6 +556,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -301,6 +583,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -315,6 +598,26 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_nand_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -322,6 +625,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -336,6 +640,26 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   and w28, w27, w26
+;   mvn w28, w28
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_or_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -343,6 +667,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -357,6 +682,25 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   orr x28, x27, x26
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_or_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -364,6 +708,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -378,6 +723,25 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   orr w28, w27, w26
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_or_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -385,6 +749,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -399,6 +764,25 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   orr w28, w27, w26
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_or_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -406,6 +790,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -420,6 +805,25 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   orr w28, w27, w26
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_xor_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -427,6 +831,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -441,6 +846,25 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   eor x28, x27, x26
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_xor_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -448,6 +872,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -462,6 +887,25 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   eor w28, w27, w26
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_xor_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -469,6 +913,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -483,6 +928,25 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   eor w28, w27, w26
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_xor_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -490,6 +954,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -504,6 +969,25 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   eor w28, w27, w26
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smax_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -511,6 +995,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -525,6 +1010,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   cmp x27, x26
+;   csel x28, x27, x26, gt
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smax_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -532,6 +1037,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -546,6 +1052,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, gt
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smax_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -553,6 +1079,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -567,6 +1094,27 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   sxth w27, w27
+;   cmp w27, w26, sxth
+;   csel x28, x27, x26, gt
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smax_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -574,6 +1122,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -588,6 +1137,27 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   sxtb w27, w27
+;   cmp w27, w26, sxtb
+;   csel x28, x27, x26, gt
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umax_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -595,6 +1165,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -609,6 +1180,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   cmp x27, x26
+;   csel x28, x27, x26, hi
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umax_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -616,6 +1207,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -630,6 +1222,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, hi
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umax_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -637,6 +1249,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -651,6 +1264,26 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, hi
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umax_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -658,6 +1291,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -672,6 +1306,26 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, hi
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smin_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -679,6 +1333,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -693,6 +1348,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   cmp x27, x26
+;   csel x28, x27, x26, lt
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smin_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -700,6 +1375,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -714,6 +1390,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, lt
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smin_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -721,6 +1417,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -735,6 +1432,27 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   sxth w27, w27
+;   cmp w27, w26, sxth
+;   csel x28, x27, x26, lt
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_smin_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -742,6 +1460,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -756,6 +1475,27 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   sxtb w27, w27
+;   cmp w27, w26, sxtb
+;   csel x28, x27, x26, lt
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umin_i64(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -763,6 +1503,7 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -777,6 +1518,26 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr x27, [x25]
+;   cmp x27, x26
+;   csel x28, x27, x26, lo
+;   stlxr w24, x28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umin_i32(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -784,6 +1545,7 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -798,6 +1560,26 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxr w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, lo
+;   stlxr w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umin_i16(i64, i16) {
 block0(v0: i64, v1: i16):
@@ -805,6 +1587,7 @@ block0(v0: i64, v1: i16):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -819,6 +1602,26 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrh w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, lo
+;   stlxrh w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %atomic_rmw_umin_i8(i64, i8) {
 block0(v0: i64, v1: i8):
@@ -826,6 +1629,7 @@ block0(v0: i64, v1: i8):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -839,5 +1643,25 @@ block0(v0: i64, v1: i8):
 ;   ldp x26, x27, [sp], #16
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x26, x27, [sp, #-0x10]!
+;   stp x24, x25, [sp, #-0x10]!
+; block0: ; offset 0x14
+;   mov x25, x0
+;   mov x26, x1
+;   ldaxrb w27, [x25]
+;   cmp w27, w26
+;   csel x28, x27, x26, lo
+;   stlxrb w24, w28, [x25]
+;   cbnz x24, #0x1c
+;   ldp x24, x25, [sp], #0x10
+;   ldp x26, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic_load.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldar x0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldar x0, [x0]
 ;   ret
 
@@ -17,7 +23,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldar w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldar w0, [x0]
 ;   ret
 
@@ -27,7 +39,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldarh w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarh w0, [x0]
 ;   ret
 
@@ -37,7 +55,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldarb w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarb w0, [x0]
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ldar w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldar w0, [x0]
 ;   ret
 
@@ -59,7 +89,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ldarh w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarh w0, [x0]
 ;   ret
 
@@ -70,7 +106,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ldarb w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarb w0, [x0]
 ;   ret
 
@@ -81,7 +123,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ldarh w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarh w0, [x0]
 ;   ret
 
@@ -92,7 +140,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ldarb w0, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldarb w0, [x0]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic_store.clif
@@ -7,7 +7,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlr x0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlr x0, [x1]
 ;   ret
 
@@ -17,7 +23,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlr w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlr w0, [x1]
 ;   ret
 
@@ -27,7 +39,13 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrh w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrh w0, [x1]
 ;   ret
 
@@ -37,7 +55,13 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrb w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrb w0, [x1]
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlr w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlr w0, [x1]
 ;   ret
 
@@ -59,7 +89,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrh w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrh w0, [x1]
 ;   ret
 
@@ -70,7 +106,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrb w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrb w0, [x1]
 ;   ret
 
@@ -81,7 +123,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrh w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrh w0, [x1]
 ;   ret
 
@@ -92,7 +140,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stlrb w0, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stlrb w0, [x1]
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/basic1.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/basic1.clif
@@ -8,7 +8,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   add w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add w0, w0, w1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
@@ -7,7 +7,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   mov w0, v0.s[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov w0, v0.s[0]
 ;   ret
 
@@ -17,7 +23,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s0, w0
 ;   ret
 
@@ -27,7 +39,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   mov x0, v0.d[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x0, v0.d[0]
 ;   ret
 
@@ -37,7 +55,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fmov d0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov d0, x0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitops.clif
@@ -8,9 +8,16 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rbit w2, w0
 ;   lsr w0, w2, #24
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rbit w2, w0
+;   lsr w0, w2, #0x18
 ;   ret
 
 function %a(i16) -> i16 {
@@ -19,9 +26,16 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rbit w2, w0
 ;   lsr w0, w2, #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rbit w2, w0
+;   lsr w0, w2, #0x10
 ;   ret
 
 function %a(i32) -> i32 {
@@ -30,7 +44,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   rbit w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rbit w0, w0
 ;   ret
 
@@ -40,7 +60,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   rbit x0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rbit x0, x0
 ;   ret
 
@@ -50,7 +76,15 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
+;   mov x6, x1
+;   rbit x1, x0
+;   rbit x0, x6
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x6, x1
 ;   rbit x1, x0
 ;   rbit x0, x6
@@ -62,10 +96,18 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uxtb w2, w0
 ;   clz w4, w2
 ;   sub w0, w4, #24
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w2, w0
+;   clz w4, w2
+;   sub w0, w4, #0x18
 ;   ret
 
 function %b(i16) -> i16 {
@@ -74,10 +116,18 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uxth w2, w0
 ;   clz w4, w2
 ;   sub w0, w4, #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w2, w0
+;   clz w4, w2
+;   sub w0, w4, #0x10
 ;   ret
 
 function %b(i32) -> i32 {
@@ -86,7 +136,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   clz w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clz w0, w0
 ;   ret
 
@@ -96,7 +152,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   clz x0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clz x0, x0
 ;   ret
 
@@ -106,12 +168,22 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   clz x3, x1
 ;   clz x5, x0
 ;   lsr x7, x3, #6
 ;   madd x0, x5, x7, x3
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clz x3, x1
+;   clz x5, x0
+;   lsr x7, x3, #6
+;   madd x0, x5, x7, x3
+;   mov x1, #0
 ;   ret
 
 function %c(i8) -> i8 {
@@ -120,10 +192,18 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sxtb w2, w0
 ;   cls w4, w2
 ;   sub w0, w4, #24
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtb w2, w0
+;   cls w4, w2
+;   sub w0, w4, #0x18
 ;   ret
 
 function %c(i16) -> i16 {
@@ -132,10 +212,18 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sxth w2, w0
 ;   cls w4, w2
 ;   sub w0, w4, #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxth w2, w0
+;   cls w4, w2
+;   sub w0, w4, #0x10
 ;   ret
 
 function %c(i32) -> i32 {
@@ -144,7 +232,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   cls w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cls w0, w0
 ;   ret
 
@@ -154,7 +248,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   cls x0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cls x0, x0
 ;   ret
 
@@ -164,6 +264,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   cls x3, x0
 ;   cls x5, x1
@@ -175,6 +276,19 @@ block0(v0: i128):
 ;   add x0, x14, x5
 ;   movz x1, #0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cls x3, x0
+;   cls x5, x1
+;   eon x7, x1, x0
+;   lsr x9, x7, #0x3f
+;   madd x11, x3, x9, x9
+;   cmp x5, #0x3f
+;   csel x14, x11, xzr, eq
+;   add x0, x14, x5
+;   mov x1, #0
+;   ret
 
 function %d(i8) -> i8 {
 block0(v0: i8):
@@ -182,9 +296,17 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rbit w2, w0
 ;   orr w4, w2, #8388608
+;   clz w0, w4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rbit w2, w0
+;   orr w4, w2, #0x800000
 ;   clz w0, w4
 ;   ret
 
@@ -194,9 +316,17 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rbit w2, w0
 ;   orr w4, w2, #32768
+;   clz w0, w4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rbit w2, w0
+;   orr w4, w2, #0x8000
 ;   clz w0, w4
 ;   ret
 
@@ -206,7 +336,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   rbit w2, w0
+;   clz w0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rbit w2, w0
 ;   clz w0, w2
 ;   ret
@@ -217,7 +354,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   rbit x2, x0
+;   clz x0, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rbit x2, x0
 ;   clz x0, x2
 ;   ret
@@ -228,6 +372,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rbit x3, x0
 ;   rbit x5, x1
@@ -237,6 +382,17 @@ block0(v0: i128):
 ;   madd x0, x9, x11, x7
 ;   movz x1, #0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rbit x3, x0
+;   rbit x5, x1
+;   clz x7, x3
+;   clz x9, x5
+;   lsr x11, x7, #6
+;   madd x0, x9, x11, x7
+;   mov x1, #0
+;   ret
 
 function %d(i128) -> i128 {
 block0(v0: i128):
@@ -244,6 +400,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fmov d4, x0
 ;   mov v4.d[1], v4.d[1], x1
@@ -252,6 +409,16 @@ block0(v0: i128):
 ;   umov w0, v17.b[0]
 ;   movz x1, #0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d4, x0
+;   mov v4.d[1], x1
+;   cnt v7.16b, v4.16b
+;   addv b17, v7.16b
+;   umov w0, v17.b[0]
+;   mov x1, #0
+;   ret
 
 function %d(i64) -> i64 {
 block0(v0: i64):
@@ -259,7 +426,16 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov d2, x0
+;   cnt v4.8b, v2.8b
+;   addv b6, v4.8b
+;   umov w0, v6.b[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov d2, x0
 ;   cnt v4.8b, v2.8b
 ;   addv b6, v4.8b
@@ -272,7 +448,16 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s2, w0
+;   cnt v4.8b, v2.8b
+;   addv b6, v4.8b
+;   umov w0, v6.b[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s2, w0
 ;   cnt v4.8b, v2.8b
 ;   addv b6, v4.8b
@@ -285,7 +470,16 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s2, w0
+;   cnt v4.8b, v2.8b
+;   addp v6.8b, v4.8b, v4.8b
+;   umov w0, v6.b[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s2, w0
 ;   cnt v4.8b, v2.8b
 ;   addp v6.8b, v4.8b, v4.8b
@@ -298,7 +492,15 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s2, w0
+;   cnt v4.8b, v2.8b
+;   umov w0, v4.b[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s2, w0
 ;   cnt v4.8b, v2.8b
 ;   umov w0, v4.b[0]
@@ -311,8 +513,15 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #255
+;   sxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0xff
 ;   sxtb w0, w0
 ;   ret
 
@@ -323,8 +532,15 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #255
+;   sxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0xff
 ;   sxtb w0, w0
 ;   ret
 
@@ -334,8 +550,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   orn w0, wzr, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvn w0, w0
 ;   ret
 
 function %bnot_i64(i64) -> i64 {
@@ -344,8 +566,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   orn x0, xzr, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvn x0, x0
 ;   ret
 
 function %bnot_i64_with_shift(i64) -> i64 {
@@ -356,8 +584,14 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   orn x0, xzr, x0, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvn x0, x0, lsl #3
 ;   ret
 
 function %bnot_i128(i128) -> i128 {
@@ -366,9 +600,16 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   orn x0, xzr, x0
 ;   orn x1, xzr, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvn x0, x0
+;   mvn x1, x1
 ;   ret
 
 function %bnot_i8x16(i8x16) -> i8x16 {
@@ -377,7 +618,13 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   mvn v0.16b, v0.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mvn v0.16b, v0.16b
 ;   ret
 
@@ -387,7 +634,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and w0, w0, w1
 ;   ret
 
@@ -397,7 +650,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and x0, x0, x1
 ;   ret
 
@@ -407,7 +666,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and x0, x0, x2
+;   and x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and x0, x0, x2
 ;   and x1, x1, x3
 ;   ret
@@ -418,7 +684,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -429,7 +701,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and x0, x0, #3
 ;   ret
 
@@ -440,7 +718,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and x0, x0, #3
 ;   ret
 
@@ -452,8 +736,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   and x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and x0, x0, x1, lsl #3
 ;   ret
 
 function %band_i64_constant_shift2(i64, i64) -> i64 {
@@ -464,8 +754,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   and x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and x0, x0, x1, lsl #3
 ;   ret
 
 function %bor_i32(i32, i32) -> i32 {
@@ -474,7 +770,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr w0, w0, w1
 ;   ret
 
@@ -484,7 +786,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr x0, x0, x1
 ;   ret
 
@@ -494,7 +802,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr x0, x0, x2
+;   orr x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr x0, x0, x2
 ;   orr x1, x1, x3
 ;   ret
@@ -505,7 +820,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -516,7 +837,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr x0, x0, #3
 ;   ret
 
@@ -527,7 +854,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr x0, x0, #3
 ;   ret
 
@@ -539,8 +872,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   orr x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x0, x0, x1, lsl #3
 ;   ret
 
 function %bor_i64_constant_shift2(i64, i64) -> i64 {
@@ -551,8 +890,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   orr x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x0, x0, x1, lsl #3
 ;   ret
 
 function %bxor_i32(i32, i32) -> i32 {
@@ -561,7 +906,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor w0, w0, w1
 ;   ret
 
@@ -571,7 +922,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor x0, x0, x1
 ;   ret
 
@@ -581,7 +938,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor x0, x0, x2
+;   eor x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor x0, x0, x2
 ;   eor x1, x1, x3
 ;   ret
@@ -592,7 +956,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -603,7 +973,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor x0, x0, #3
 ;   ret
 
@@ -614,7 +990,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor x0, x0, #3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor x0, x0, #3
 ;   ret
 
@@ -626,8 +1008,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   eor x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   eor x0, x0, x1, lsl #3
 ;   ret
 
 function %bxor_i64_constant_shift2(i64, i64) -> i64 {
@@ -638,8 +1026,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   eor x0, x0, x1, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   eor x0, x0, x1, lsl #3
 ;   ret
 
 function %band_not_i32(i32, i32) -> i32 {
@@ -648,7 +1042,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   bic w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic w0, w0, w1
 ;   ret
 
@@ -658,7 +1058,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   bic x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic x0, x0, x1
 ;   ret
 
@@ -668,7 +1074,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   bic x0, x0, x2
+;   bic x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic x0, x0, x2
 ;   bic x1, x1, x3
 ;   ret
@@ -679,7 +1092,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   bic v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -690,8 +1109,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   bic x0, x0, #4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and x0, x0, #0xfffffffffffffffb
 ;   ret
 
 function %band_not_i64_constant_shift(i64, i64) -> i64 {
@@ -702,8 +1127,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   bic x0, x0, x1, LSL 4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bic x0, x0, x1, lsl #4
 ;   ret
 
 function %bor_not_i32(i32, i32) -> i32 {
@@ -712,7 +1143,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orn w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orn w0, w0, w1
 ;   ret
 
@@ -722,7 +1159,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orn x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orn x0, x0, x1
 ;   ret
 
@@ -732,7 +1175,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orn x0, x0, x2
+;   orn x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orn x0, x0, x2
 ;   orn x1, x1, x3
 ;   ret
@@ -744,8 +1194,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   orn x0, x0, #4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x0, x0, #0xfffffffffffffffb
 ;   ret
 
 function %bor_not_i64_constant_shift(i64, i64) -> i64 {
@@ -756,8 +1212,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   orn x0, x0, x1, LSL 4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orn x0, x0, x1, lsl #4
 ;   ret
 
 function %bxor_not_i32(i32, i32) -> i32 {
@@ -766,7 +1228,13 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eon w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon w0, w0, w1
 ;   ret
 
@@ -776,7 +1244,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eon x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon x0, x0, x1
 ;   ret
 
@@ -786,7 +1260,14 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eon x0, x0, x2
+;   eon x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon x0, x0, x2
 ;   eon x1, x1, x3
 ;   ret
@@ -798,8 +1279,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   eon x0, x0, #4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   eor x0, x0, #0xfffffffffffffffb
 ;   ret
 
 function %bxor_not_i64_constant_shift(i64, i64) -> i64 {
@@ -810,8 +1297,14 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   eon x0, x0, x1, LSL 4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   eon x0, x0, x1, lsl #4
 ;   ret
 
 function %ishl_i128_i8(i128, i8) -> i128 {
@@ -820,6 +1313,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsl x4, x0, x2
 ;   lsl x6, x1, x2
@@ -831,6 +1325,19 @@ block0(v0: i128, v1: i8):
 ;   csel x0, xzr, x4, ne
 ;   csel x1, x4, x14, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsl x4, x0, x2
+;   lsl x6, x1, x2
+;   mvn w8, w2
+;   lsr x10, x0, #1
+;   lsr x12, x10, x8
+;   orr x14, x6, x12
+;   tst x2, #0x40
+;   csel x0, xzr, x4, ne
+;   csel x1, x4, x14, ne
+;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -838,6 +1345,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsl x5, x0, x2
 ;   lsl x7, x1, x2
@@ -849,6 +1357,19 @@ block0(v0: i128, v1: i128):
 ;   csel x0, xzr, x5, ne
 ;   csel x1, x5, x15, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsl x5, x0, x2
+;   lsl x7, x1, x2
+;   mvn w9, w2
+;   lsr x11, x0, #1
+;   lsr x13, x11, x9
+;   orr x15, x7, x13
+;   tst x2, #0x40
+;   csel x0, xzr, x5, ne
+;   csel x1, x5, x15, ne
+;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -856,6 +1377,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsr x4, x0, x2
 ;   lsr x6, x1, x2
@@ -867,6 +1389,19 @@ block0(v0: i128, v1: i8):
 ;   csel x0, x6, x14, ne
 ;   csel x1, xzr, x6, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsr x4, x0, x2
+;   lsr x6, x1, x2
+;   mvn w8, w2
+;   lsl x10, x1, #1
+;   lsl x12, x10, x8
+;   orr x14, x4, x12
+;   tst x2, #0x40
+;   csel x0, x6, x14, ne
+;   csel x1, xzr, x6, ne
+;   ret
 
 function %ushr_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -874,6 +1409,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsr x5, x0, x2
 ;   lsr x7, x1, x2
@@ -885,6 +1421,19 @@ block0(v0: i128, v1: i128):
 ;   csel x0, x7, x15, ne
 ;   csel x1, xzr, x7, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsr x5, x0, x2
+;   lsr x7, x1, x2
+;   mvn w9, w2
+;   lsl x11, x1, #1
+;   lsl x13, x11, x9
+;   orr x15, x5, x13
+;   tst x2, #0x40
+;   csel x0, x7, x15, ne
+;   csel x1, xzr, x7, ne
+;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -892,6 +1441,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsr x4, x0, x2
 ;   asr x6, x1, x2
@@ -904,6 +1454,20 @@ block0(v0: i128, v1: i8):
 ;   csel x0, x6, x0, ne
 ;   csel x1, x14, x6, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsr x4, x0, x2
+;   asr x6, x1, x2
+;   mvn w8, w2
+;   lsl x10, x1, #1
+;   lsl x12, x10, x8
+;   asr x14, x1, #0x3f
+;   orr x0, x4, x12
+;   tst x2, #0x40
+;   csel x0, x6, x0, ne
+;   csel x1, x14, x6, ne
+;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -911,6 +1475,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   lsr x5, x0, x2
 ;   asr x7, x1, x2
@@ -923,6 +1488,20 @@ block0(v0: i128, v1: i128):
 ;   csel x0, x7, x1, ne
 ;   csel x1, x15, x7, ne
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsr x5, x0, x2
+;   asr x7, x1, x2
+;   mvn w9, w2
+;   lsl x11, x1, #1
+;   lsl x13, x11, x9
+;   asr x15, x1, #0x3f
+;   orr x1, x5, x13
+;   tst x2, #0x40
+;   csel x0, x7, x1, ne
+;   csel x1, x15, x7, ne
+;   ret
 
 function %bnot_of_bxor(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -931,7 +1510,13 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   eon w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon w0, w0, w1
 ;   ret
 
@@ -942,7 +1527,14 @@ block0(v0: i128, v1: i128):
   return v3
 }
 
+; VCode:
 ; block0:
+;   eon x0, x0, x2
+;   eon x1, x1, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eon x0, x0, x2
 ;   eon x1, x1, x3
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/bitopts-optimized.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitopts-optimized.clif
@@ -10,7 +10,13 @@ block0(v0: i32, v1: i32):
     return v3
 }
 
+; VCode:
 ; block0:
+;   bic w0, w1, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   bic w0, w1, w0
 ;   ret
 
@@ -21,7 +27,13 @@ block0(v0: i32, v1: i32):
     return v3
 }
 
+; VCode:
 ; block0:
+;   orn w0, w1, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orn w0, w1, w0
 ;   ret
 
@@ -32,6 +44,13 @@ block0(v0: i32, v1: i32):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   eon w0, w1, w0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   eon w0, w1, w0
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bmask.clif
@@ -8,8 +8,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -19,8 +26,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -30,8 +44,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -41,8 +62,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -52,8 +80,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -63,8 +98,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -74,8 +116,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -85,8 +134,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -96,9 +152,17 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #65535
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xffff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -108,9 +172,17 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #65535
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xffff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -120,9 +192,17 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #65535
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xffff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -132,9 +212,17 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #65535
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xffff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -144,9 +232,17 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #255
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -156,9 +252,17 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #255
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -168,9 +272,17 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #255
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -180,9 +292,17 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #255
 ;   subs wzr, w2, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xff
+;   cmp w2, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -192,9 +312,18 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   subs xzr, x3, #0
+;   csetm x1, ne
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+;   cmp x3, #0
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
@@ -205,9 +334,17 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   subs xzr, x3, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+;   cmp x3, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -217,9 +354,17 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   subs xzr, x3, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+;   cmp x3, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -229,9 +374,17 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   subs xzr, x3, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+;   cmp x3, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -241,9 +394,17 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   subs xzr, x3, #0
+;   csetm x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+;   cmp x3, #0
 ;   csetm x0, ne
 ;   ret
 
@@ -253,8 +414,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   csetm x1, ne
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
@@ -265,8 +434,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
+;   csetm x1, ne
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
@@ -277,9 +454,18 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #65535
 ;   subs wzr, w2, #0
+;   csetm x1, ne
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xffff
+;   cmp w2, #0
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
@@ -290,9 +476,18 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   and w2, w0, #255
 ;   subs wzr, w2, #0
+;   csetm x1, ne
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w2, w0, #0xff
+;   cmp w2, #0
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bswap.clif
@@ -8,8 +8,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rev64 x0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rev x0, x0
 ;   ret
 
 function %f1(i32) -> i32 {
@@ -18,8 +24,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   rev32 w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rev w0, w0
 ;   ret
 
 function %f2(i16) -> i16 {
@@ -28,7 +40,13 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   rev16 w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rev16 w0, w0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -27,6 +27,7 @@ block5(v5: i32):
     return v6
 }
 
+; VCode:
 ;   bti c
 ; block0:
 ;   emit_island 44
@@ -58,6 +59,41 @@ block5(v5: i32):
 ; block9:
 ;   add w0, w0, w5
 ;   ret
+; 
+; Disassembled:
+;   hint #0x22
+; block0: ; offset 0x4
+;   cmp w0, #3
+;   b.hs #0x30
+;   csel x15, xzr, x0, hs
+;   csdb
+;   adr x14, #0x24
+;   ldrsw x15, [x14, w15, uxtw #2]
+;   add x14, x14, x15
+;   br x14
+;   .byte 0x14, 0x00, 0x00, 0x00
+;   .byte 0x20, 0x00, 0x00, 0x00
+;   .byte 0x2c, 0x00, 0x00, 0x00
+; block1: ; offset 0x30
+;   mov w5, #4
+; block2: ; offset 0x34
+;   b #0x58
+; block3: ; offset 0x38
+;   hint #0x24
+;   mov w5, #1
+; block4: ; offset 0x40
+;   b #0x58
+; block5: ; offset 0x44
+;   hint #0x24
+;   mov w5, #2
+; block6: ; offset 0x4c
+;   b #0x58
+; block7: ; offset 0x50
+;   hint #0x24
+;   mov w5, #3
+; block8: ; offset 0x58
+;   add w0, w0, w5
+;   ret
 
 function %f2(i64) -> i64 {
 block0(v0: i64):
@@ -74,6 +110,7 @@ block2:
     return v4
 }
 
+; VCode:
 ;   bti c
 ; block0:
 ;   ldr x5, [x0]
@@ -89,6 +126,29 @@ block2:
 ;   mov x0, x8
 ;   add x0, x0, #42
 ;   ret
+; 
+; Disassembled:
+;   hint #0x22
+; block0: ; offset 0x4
+;   ldr x5, [x0]
+;   mov x8, x5
+;   cmp w0, #1
+;   b.hs #0x30
+;   csel x7, xzr, x0, hs
+;   csdb
+;   adr x6, #0x2c
+;   ldrsw x7, [x6, w7, uxtw #2]
+;   add x6, x6, x7
+;   br x6
+;   .byte 0x0c, 0x00, 0x00, 0x00
+; block1: ; offset 0x30
+;   mov x0, x8
+;   ret
+; block2: ; offset 0x38
+;   hint #0x24
+;   mov x0, x8
+;   add x0, x0, #0x2a
+;   ret
 
 function %f3(i64) -> i64 {
     fn0 = %g(i64) -> i64
@@ -98,6 +158,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   bti c
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
@@ -105,5 +166,18 @@ block0(v0: i64):
 ;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   hint #0x22
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0xc
+;   ldr x3, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
@@ -9,10 +9,19 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   blr x1
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   blr x1
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -10,6 +10,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   paciasp
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
@@ -18,6 +19,20 @@ block0(v0: i64):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
+; 
+; Disassembled:
+;   paciasp
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0xc
+;   ldr x3, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
+;   autiasp
+;   ret
 
 function %f2(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -25,6 +40,13 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   add x0, x0, x1
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x0, x0, x1
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -11,12 +11,25 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %f2(i32) -> i64 {
@@ -27,6 +40,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -34,13 +48,30 @@ block0(v0: i32):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f3(i32) -> i32 uext {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %f4(i32) -> i64 {
@@ -51,6 +82,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -58,13 +90,30 @@ block0(v0: i32):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f5(i32) -> i32 sext {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %f6(i8) -> i64 {
@@ -76,6 +125,7 @@ block0(v0: i8):
     return v2
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -97,6 +147,30 @@ block0(v0: i8):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x8, x0
+;   sub sp, sp, #0x10
+;   mov w0, #0x2a
+;   mov w1, #0x2a
+;   mov w2, #0x2a
+;   mov w3, #0x2a
+;   mov w4, #0x2a
+;   mov w5, #0x2a
+;   mov w6, #0x2a
+;   mov w7, #0x2a
+;   sturb w8, [sp]
+;   ldr x8, #0x3c
+;   b #0x44
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x8
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f7(i8) -> i32, i32, i32, i32, i32, i32, i32, i32, i8 sext {
 block0(v0: i8):
@@ -104,6 +178,7 @@ block0(v0: i8):
     return v1, v1, v1, v1, v1, v1, v1, v1, v0
 }
 
+; VCode:
 ; block0:
 ;   mov x9, x0
 ;   mov x8, x1
@@ -116,6 +191,21 @@ block0(v0: i8):
 ;   movz w6, #42
 ;   movz w7, #42
 ;   strb w9, [x8]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x9, x0
+;   mov x8, x1
+;   mov w0, #0x2a
+;   mov w1, #0x2a
+;   mov w2, #0x2a
+;   mov w3, #0x2a
+;   mov w4, #0x2a
+;   mov w5, #0x2a
+;   mov w6, #0x2a
+;   mov w7, #0x2a
+;   sturb w9, [x8]
 ;   ret
 
 function %f8() {
@@ -136,6 +226,7 @@ block0:
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #48
@@ -163,6 +254,56 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x30
+; block0: ; offset 0xc
+;   ldr x9, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x20]
+;   ldr x9, #0x2c
+;   b #0x34
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x10]
+;   ldr x9, #0x44
+;   b #0x4c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp]
+;   ldr x9, #0x5c
+;   b #0x64
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   ldr x10, #0x70
+;   b #0x78
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g3 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x20]
+;   blr x10
+;   ldr x11, #0x88
+;   b #0x90
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g4 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x10]
+;   blr x11
+;   ldr x12, #0xa0
+;   b #0xa8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g4 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp]
+;   blr x12
+;   add sp, sp, #0x30
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f9() {
     fn0 = %g0() -> i8x16
@@ -180,6 +321,7 @@ block0:
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #48
@@ -207,6 +349,56 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x30
+; block0: ; offset 0xc
+;   ldr x9, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x20]
+;   ldr x9, #0x2c
+;   b #0x34
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x10]
+;   ldr x9, #0x44
+;   b #0x4c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp]
+;   ldr x9, #0x5c
+;   b #0x64
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   ldr x10, #0x70
+;   b #0x78
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x20]
+;   blr x10
+;   ldr x11, #0x88
+;   b #0x90
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x10]
+;   blr x11
+;   ldr x12, #0xa0
+;   b #0xa8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp]
+;   blr x12
+;   add sp, sp, #0x30
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f10() {
     fn0 = %g0() -> f32
@@ -228,6 +420,7 @@ block0:
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #48
@@ -255,6 +448,56 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x30
+; block0: ; offset 0xc
+;   ldr x9, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x20]
+;   ldr x9, #0x2c
+;   b #0x34
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp, #0x10]
+;   ldr x9, #0x44
+;   b #0x4c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   stur q0, [sp]
+;   ldr x9, #0x5c
+;   b #0x64
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g3 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x9
+;   ldr x10, #0x70
+;   b #0x78
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g4 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x20]
+;   blr x10
+;   ldr x11, #0x88
+;   b #0x90
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g5 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp, #0x10]
+;   blr x11
+;   ldr x12, #0xa0
+;   b #0xa8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g6 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldur q0, [sp]
+;   blr x12
+;   add sp, sp, #0x30
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f11(i128, i64) -> i64 {
 block0(v0: i128, v1: i64):
@@ -262,7 +505,13 @@ block0(v0: i128, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x0, x1
 ;   ret
 
@@ -276,6 +525,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -286,6 +536,21 @@ block0(v0: i64):
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x1, x0
+;   mov x0, #0x2a
+;   mov x2, #0x2a
+;   ldr x6, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f11 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x6
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f12(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -293,7 +558,13 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   mov x0, x2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x0, x2
 ;   ret
 
@@ -307,6 +578,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -317,6 +589,21 @@ block0(v0: i64):
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x2, x0
+;   mov x3, #0x2a
+;   mov x0, #0x2a
+;   ldr x6, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f12 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x6
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f13(i64, i128) -> i64 apple_aarch64 {
 block0(v0: i64, v1: i128):
@@ -324,7 +611,13 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
+;   mov x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x0, x1
 ;   ret
 
@@ -338,6 +631,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -348,18 +642,43 @@ block0(v0: i64):
 ;   blr x6
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x1, x0
+;   mov x2, #0x2a
+;   mov x0, #0x2a
+;   ldr x6, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f13 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x6
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f14(i128, i128, i128, i64, i128) -> i128 {
 block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
     return v4
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   ldr x0, [fp, #16]
 ;   ldr x1, [fp, #24]
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldur x0, [x29, #0x10]
+;   ldur x1, [x29, #0x18]
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %f14_call(i128, i64) -> i128 {
@@ -370,6 +689,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -390,18 +710,51 @@ block0(v0: i128, v1: i64):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x6, x2
+;   sub sp, sp, #0x10
+;   stur x0, [sp]
+;   mov x4, x0
+;   stur x1, [sp, #8]
+;   mov x5, x1
+;   ldr x10, #0x28
+;   b #0x30
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f14 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   mov x0, x4
+;   mov x2, x4
+;   mov x1, x5
+;   mov x3, x5
+;   blr x10
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f15(i128, i128, i128, i64, i128) -> i128 apple_aarch64{
 block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
     return v4
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   ldr x0, [fp, #16]
 ;   ldr x1, [fp, #24]
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldur x0, [x29, #0x10]
+;   ldur x1, [x29, #0x18]
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %f15_call(i128, i64) -> i128 apple_aarch64 {
@@ -412,6 +765,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -432,6 +786,29 @@ block0(v0: i128, v1: i64):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x6, x2
+;   sub sp, sp, #0x10
+;   stur x0, [sp]
+;   mov x4, x0
+;   stur x1, [sp, #8]
+;   mov x5, x1
+;   ldr x10, #0x28
+;   b #0x30
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f15 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   mov x0, x4
+;   mov x2, x4
+;   mov x1, x5
+;   mov x3, x5
+;   blr x10
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f16() -> i32, i32 wasmtime_system_v {
 block0:
@@ -440,11 +817,20 @@ block0:
     return v0, v1
 }
 
+; VCode:
 ; block0:
 ;   mov x6, x0
 ;   movz w0, #0
 ;   movz w4, #1
 ;   str w4, [x6]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, x0
+;   mov w0, #0
+;   mov w4, #1
+;   stur w4, [x6]
 ;   ret
 
 function %f17(i64 sret) {
@@ -454,9 +840,17 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   mov x5, x8
 ;   movz x4, #42
+;   str x4, [x8]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, x8
+;   mov x4, #0x2a
 ;   str x4, [x8]
 ;   ret
 
@@ -468,6 +862,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -475,6 +870,19 @@ block0(v0: i64):
 ;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x8, x0
+;   ldr x3, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %f18(i64 sret) {
@@ -485,6 +893,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x24, [sp, #-16]!
@@ -495,5 +904,21 @@ block0(v0: i64):
 ;   mov x8, x24
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x24, [sp, #-0x10]!
+; block0: ; offset 0xc
+;   mov x24, x8
+;   ldr x4, #0x18
+;   b #0x20
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x4
+;   mov x8, x24
+;   ldr x24, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/compare_zero.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/compare_zero.clif
@@ -10,7 +10,13 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmeq v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v0.16b, v0.16b, #0
 ;   ret
 
@@ -21,7 +27,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmeq v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v0.16b, v0.16b, #0
 ;   ret
 
@@ -33,7 +45,13 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmeq v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v0.8h, v0.8h, #0
 ;   ret
 
@@ -44,7 +62,13 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmeq v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v0.8h, v0.8h, #0
 ;   ret
 
@@ -56,7 +80,14 @@ block0(v0: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.4s, v0.4s, #0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.4s, v0.4s, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -68,7 +99,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.4s, v0.4s, #0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.4s, v0.4s, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -81,7 +119,14 @@ block0(v0: i64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.2d, v0.2d, #0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -93,7 +138,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.2d, v0.2d, #0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -106,7 +158,13 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmle v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmle v0.16b, v0.16b, #0
 ;   ret
 
@@ -117,7 +175,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmle v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmle v0.16b, v0.16b, #0
 ;   ret
 
@@ -129,7 +193,13 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmge v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, #0
 ;   ret
 
@@ -140,7 +210,13 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmge v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, #0
 ;   ret
 
@@ -152,7 +228,13 @@ block0(v0: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmge v0.4s, v0.4s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmge v0.4s, v0.4s, #0
 ;   ret
 
@@ -163,7 +245,13 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmge v0.4s, v0.4s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmge v0.4s, v0.4s, #0
 ;   ret
 
@@ -175,7 +263,13 @@ block0(v0: i64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmle v0.2d, v0.2d, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmle v0.2d, v0.2d, #0
 ;   ret
 
@@ -186,7 +280,13 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmle v0.2d, v0.2d, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmle v0.2d, v0.2d, #0
 ;   ret
 
@@ -198,7 +298,13 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmlt v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmlt v0.16b, v0.16b, #0
 ;   ret
 
@@ -209,7 +315,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmlt v0.16b, v0.16b, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmlt v0.16b, v0.16b, #0
 ;   ret
 
@@ -221,7 +333,13 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmgt v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmgt v0.8h, v0.8h, #0
 ;   ret
 
@@ -232,7 +350,13 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmgt v0.8h, v0.8h, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmgt v0.8h, v0.8h, #0
 ;   ret
 
@@ -244,7 +368,13 @@ block0(v0: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmgt v0.4s, v0.4s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmgt v0.4s, v0.4s, #0
 ;   ret
 
@@ -255,7 +385,13 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmgt v0.4s, v0.4s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmgt v0.4s, v0.4s, #0
 ;   ret
 
@@ -267,7 +403,13 @@ block0(v0: i64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cmlt v0.2d, v0.2d, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmlt v0.2d, v0.2d, #0
 ;   ret
 
@@ -278,7 +420,13 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cmlt v0.2d, v0.2d, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmlt v0.2d, v0.2d, #0
 ;   ret
 
@@ -290,7 +438,13 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmeq v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -301,7 +455,13 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmeq v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -313,7 +473,13 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmeq v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -324,7 +490,13 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmeq v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -336,7 +508,14 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmeq v2.2d, v0.2d, #0.0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v2.2d, v0.2d, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -348,7 +527,14 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmeq v2.2d, v0.2d, #0.0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v2.2d, v0.2d, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -361,7 +547,14 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmeq v2.4s, v0.4s, #0.0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v2.4s, v0.4s, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -373,7 +566,14 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmeq v2.4s, v0.4s, #0.0
+;   mvn v0.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmeq v2.4s, v0.4s, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
@@ -386,7 +586,13 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmle v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -397,7 +603,13 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmle v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -409,7 +621,13 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmge v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -420,7 +638,13 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmge v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -432,7 +656,13 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmge v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -443,7 +673,13 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmge v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -455,7 +691,13 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmle v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -466,7 +708,13 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmle v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -478,7 +726,13 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmlt v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -489,7 +743,13 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmlt v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -501,7 +761,13 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmgt v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -512,7 +778,13 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmgt v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -524,7 +796,13 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmgt v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -535,7 +813,13 @@ block0(v0: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fcmgt v0.2d, v0.2d, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
 
@@ -547,7 +831,13 @@ block0(v0: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fcmlt v0.4s, v0.4s, #0.0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
 
@@ -558,6 +848,13 @@ block0(v0: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmlt v0.4s, v0.4s, #0.0
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -8,8 +8,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x1
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
 ;   cset x0, eq
 ;   ret
 
@@ -19,9 +26,17 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   ccmp x1, x3, #nzcv, eq
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   ccmp x1, x3, #0, eq
 ;   cset x0, eq
 ;   ret
 
@@ -31,9 +46,17 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   ccmp x1, x3, #nzcv, eq
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   ccmp x1, x3, #0, eq
 ;   cset x0, ne
 ;   ret
 
@@ -43,10 +66,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, lo
 ;   subs xzr, x1, x3
+;   cset x9, lt
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, lo
+;   cmp x1, x3
 ;   cset x9, lt
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -57,10 +90,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, lo
 ;   subs xzr, x1, x3
+;   cset x9, lo
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, lo
+;   cmp x1, x3
 ;   cset x9, lo
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -71,10 +114,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, ls
 ;   subs xzr, x1, x3
+;   cset x9, le
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, ls
+;   cmp x1, x3
 ;   cset x9, le
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -85,10 +138,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, ls
 ;   subs xzr, x1, x3
+;   cset x9, ls
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, ls
+;   cmp x1, x3
 ;   cset x9, ls
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -99,10 +162,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hi
 ;   subs xzr, x1, x3
+;   cset x9, gt
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hi
+;   cmp x1, x3
 ;   cset x9, gt
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -113,10 +186,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hi
 ;   subs xzr, x1, x3
+;   cset x9, hi
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hi
+;   cmp x1, x3
 ;   cset x9, hi
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -127,10 +210,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hs
 ;   subs xzr, x1, x3
+;   cset x9, ge
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hs
+;   cmp x1, x3
 ;   cset x9, ge
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -141,10 +234,20 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hs
 ;   subs xzr, x1, x3
+;   cset x9, hs
+;   csel x0, x6, x9, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hs
+;   cmp x1, x3
 ;   cset x9, hs
 ;   csel x0, x6, x9, eq
 ;   ret
@@ -164,6 +267,7 @@ block2:
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x1
 ;   b.eq label1 ; b label2
@@ -172,6 +276,17 @@ block2:
 ;   ret
 ; block2:
 ;   movz x0, #2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+;   b.ne #0x10
+; block1: ; offset 0x8
+;   mov x0, #1
+;   ret
+; block2: ; offset 0x10
+;   mov x0, #2
 ;   ret
 
 function %f(i64, i64) -> i64 {
@@ -185,6 +300,7 @@ block1:
   return v4
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x1
 ;   b.eq label1 ; b label2
@@ -194,6 +310,13 @@ block1:
 ;   b label3
 ; block3:
 ;   movz x0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+; block1: ; offset 0x4
+;   mov x0, #1
 ;   ret
 
 function %i128_brif_false(i128){
@@ -205,6 +328,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   cbnz x3, label1 ; b label2
@@ -213,6 +337,12 @@ block1:
 ; block2:
 ;   b label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+; block1: ; offset 0x4
 ;   ret
 
 function %i128_brif_true(i128){
@@ -224,6 +354,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   orr x3, x0, x1
 ;   cbnz x3, label1 ; b label2
@@ -232,6 +363,12 @@ block1:
 ; block2:
 ;   b label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   orr x3, x0, x1
+; block1: ; offset 0x4
 ;   ret
 
 function %i128_bricmp_eq(i128, i128) {
@@ -244,6 +381,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   ccmp x1, x3, #nzcv, eq
@@ -253,6 +391,13 @@ block1:
 ; block2:
 ;   b label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   ccmp x1, x3, #0, eq
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_ne(i128, i128) {
@@ -265,6 +410,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   ccmp x1, x3, #nzcv, eq
@@ -274,6 +420,13 @@ block1:
 ; block2:
 ;   b label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   ccmp x1, x3, #0, eq
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_slt(i128, i128) {
@@ -286,6 +439,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, lo
@@ -300,6 +454,17 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, lo
+;   cmp x1, x3
+;   cset x9, lt
+;   csel x11, x6, x9, eq
+;   cmp xzr, x11
+; block1: ; offset 0x18
+;   ret
 
 function %i128_bricmp_ult(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -311,6 +476,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, lo
@@ -325,6 +491,17 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, lo
+;   cmp x1, x3
+;   cset x9, lo
+;   csel x11, x6, x9, eq
+;   cmp xzr, x11
+; block1: ; offset 0x18
+;   ret
 
 function %i128_bricmp_sle(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -336,6 +513,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, ls
@@ -351,6 +529,18 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, ls
+;   cmp x1, x3
+;   cset x9, le
+;   csel x11, x6, x9, eq
+;   mov w13, #1
+;   cmp x13, x11
+; block1: ; offset 0x1c
+;   ret
 
 function %i128_bricmp_ule(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -362,6 +552,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, ls
@@ -377,6 +568,18 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, ls
+;   cmp x1, x3
+;   cset x9, ls
+;   csel x11, x6, x9, eq
+;   mov x13, #1
+;   cmp x13, x11
+; block1: ; offset 0x1c
+;   ret
 
 function %i128_bricmp_sgt(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -388,6 +591,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hi
@@ -402,6 +606,17 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hi
+;   cmp x1, x3
+;   cset x9, gt
+;   csel x11, x6, x9, eq
+;   cmp x11, xzr
+; block1: ; offset 0x18
+;   ret
 
 function %i128_bricmp_ugt(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -413,6 +628,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hi
@@ -427,6 +643,17 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hi
+;   cmp x1, x3
+;   cset x9, hi
+;   csel x11, x6, x9, eq
+;   cmp x11, xzr
+; block1: ; offset 0x18
+;   ret
 
 function %i128_bricmp_sge(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -438,6 +665,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hs
@@ -453,6 +681,18 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hs
+;   cmp x1, x3
+;   cset x9, ge
+;   csel x11, x6, x9, eq
+;   mov w13, #1
+;   cmp x11, x13
+; block1: ; offset 0x1c
+;   ret
 
 function %i128_bricmp_uge(i128, i128) {
 block0(v0: i128, v1: i128):
@@ -464,6 +704,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, x2
 ;   cset x6, hs
@@ -478,5 +719,17 @@ block1:
 ; block2:
 ;   b label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x2
+;   cset x6, hs
+;   cmp x1, x3
+;   cset x9, hs
+;   csel x11, x6, x9, eq
+;   mov x13, #1
+;   cmp x11, x13
+; block1: ; offset 0x1c
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/condops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condops.clif
@@ -10,9 +10,17 @@ block0(v0: i8, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -24,9 +32,17 @@ block0(v0: i8, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -38,9 +54,17 @@ block0(v0: i8, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -52,9 +76,17 @@ block0(v0: i8, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -66,9 +98,18 @@ block0(v0: i8, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w6, w0
 ;   subs wzr, w6, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w6, w0
+;   cmp w6, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
@@ -81,9 +122,17 @@ block0(v0: i16, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -95,9 +144,17 @@ block0(v0: i16, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -109,9 +166,17 @@ block0(v0: i16, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -123,9 +188,17 @@ block0(v0: i16, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -137,9 +210,18 @@ block0(v0: i16, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w6, w0
 ;   subs wzr, w6, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w6, w0
+;   cmp w6, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
@@ -152,8 +234,15 @@ block0(v0: i32, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -165,8 +254,15 @@ block0(v0: i32, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -178,8 +274,15 @@ block0(v0: i32, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -191,8 +294,15 @@ block0(v0: i32, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -204,8 +314,16 @@ block0(v0: i32, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
@@ -218,8 +336,15 @@ block0(v0: i64, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -231,8 +356,15 @@ block0(v0: i64, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -244,8 +376,15 @@ block0(v0: i64, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -257,8 +396,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -270,8 +416,16 @@ block0(v0: i64, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
@@ -285,11 +439,21 @@ block0(v0: i128, v1: i8, v2: i8):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   ret
 
@@ -302,11 +466,21 @@ block0(v0: i128, v1: i16, v2: i16):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   ret
 
@@ -319,11 +493,21 @@ block0(v0: i128, v1: i32, v2: i32):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   ret
 
@@ -336,11 +520,21 @@ block0(v0: i128, v1: i64, v2: i64):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   ret
 
@@ -353,11 +547,22 @@ block0(v0: i128, v1: i128, v2: i128):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x9, #42
 ;   movz x11, #0
 ;   subs xzr, x0, x9
 ;   ccmp x1, x11, #nzcv, eq
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x9, #0x2a
+;   mov x11, #0
+;   cmp x0, x9
+;   ccmp x1, x11, #0, eq
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
@@ -370,9 +575,18 @@ block0(v0: i8, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -385,9 +599,18 @@ block0(v0: i8, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -400,9 +623,18 @@ block0(v0: i8, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -415,9 +647,18 @@ block0(v0: i8, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -430,9 +671,19 @@ block0(v0: i8, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxtb w6, w0
 ;   subs wzr, w6, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w6, w0
+;   cmp w6, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   csdb
@@ -446,9 +697,18 @@ block0(v0: i16, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -461,9 +721,18 @@ block0(v0: i16, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -476,9 +745,18 @@ block0(v0: i16, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -491,9 +769,18 @@ block0(v0: i16, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w4, w0
 ;   subs wzr, w4, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w4, w0
+;   cmp w4, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -506,9 +793,19 @@ block0(v0: i16, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uxth w6, w0
 ;   subs wzr, w6, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w6, w0
+;   cmp w6, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   csdb
@@ -522,8 +819,16 @@ block0(v0: i32, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -536,8 +841,16 @@ block0(v0: i32, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -550,8 +863,16 @@ block0(v0: i32, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -564,8 +885,16 @@ block0(v0: i32, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -578,8 +907,17 @@ block0(v0: i32, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   csdb
@@ -593,8 +931,16 @@ block0(v0: i64, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -607,8 +953,16 @@ block0(v0: i64, v1: i16, v2: i16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -621,8 +975,16 @@ block0(v0: i64, v1: i32, v2: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -635,8 +997,16 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x1, x2, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
@@ -649,8 +1019,17 @@ block0(v0: i64, v1: i128, v2: i128):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #42
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0x2a
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   csdb
@@ -665,11 +1044,22 @@ block0(v0: i128, v1: i8, v2: i8):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
@@ -683,11 +1073,22 @@ block0(v0: i128, v1: i16, v2: i16):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
@@ -701,11 +1102,22 @@ block0(v0: i128, v1: i32, v2: i32):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
@@ -719,11 +1131,22 @@ block0(v0: i128, v1: i64, v2: i64):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x6, #42
 ;   movz x8, #0
 ;   subs xzr, x0, x6
 ;   ccmp x1, x8, #nzcv, eq
+;   csel x0, x2, x3, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #0x2a
+;   mov x8, #0
+;   cmp x0, x6
+;   ccmp x1, x8, #0, eq
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
@@ -737,11 +1160,23 @@ block0(v0: i128, v1: i128, v2: i128):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   movz x9, #42
 ;   movz x11, #0
 ;   subs xzr, x0, x9
 ;   ccmp x1, x11, #nzcv, eq
+;   csel x0, x2, x4, eq
+;   csel x1, x3, x5, eq
+;   csdb
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x9, #0x2a
+;   mov x11, #0
+;   cmp x0, x9
+;   ccmp x1, x11, #0, eq
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   csdb
@@ -754,9 +1189,17 @@ block0(v0: i8):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   uxtb w2, w0
 ;   subs wzr, w2, #42
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w2, w0
+;   cmp w2, #0x2a
 ;   cset x0, eq
 ;   ret
 
@@ -766,7 +1209,15 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   and w4, w1, w0
+;   bic w6, w2, w0
+;   orr w0, w4, w6
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and w4, w1, w0
 ;   bic w6, w2, w0
 ;   orr w0, w4, w6
@@ -778,8 +1229,15 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ands wzr, w0, #255
+;   csel x0, x1, x2, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   tst w0, #0xff
 ;   csel x0, x1, x2, ne
 ;   ret
 
@@ -791,8 +1249,15 @@ block0(v0: i32, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #42
+;   csel x0, x1, x2, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x2a
 ;   csel x0, x1, x2, eq
 ;   ret
 
@@ -802,8 +1267,16 @@ block0(v0: i8, v1: i128, v2: i128):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ands wzr, w0, #255
+;   csel x0, x2, x4, ne
+;   csel x1, x3, x5, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   tst w0, #0xff
 ;   csel x0, x2, x4, ne
 ;   csel x1, x3, x5, ne
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/constants.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/constants.clif
@@ -8,8 +8,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #255
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0xff
 ;   ret
 
 function %f() -> i16 {
@@ -18,8 +24,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0
 ;   ret
 
 function %f() -> i64 {
@@ -28,8 +40,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0
 ;   ret
 
 function %f() -> i64 {
@@ -38,8 +56,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #65535
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0xffff
 ;   ret
 
 function %f() -> i64 {
@@ -48,8 +72,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #65535, LSL #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0xffff0000
 ;   ret
 
 function %f() -> i64 {
@@ -58,8 +88,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #65535, LSL #32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0xffff00000000
 ;   ret
 
 function %f() -> i64 {
@@ -68,8 +104,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #65535, LSL #48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-0x1000000000000
 ;   ret
 
 function %f() -> i64 {
@@ -78,8 +120,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-1
 ;   ret
 
 function %f() -> i64 {
@@ -88,8 +136,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #65535
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-0x10000
 ;   ret
 
 function %f() -> i64 {
@@ -98,8 +152,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #65535, LSL #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-0xffff0001
 ;   ret
 
 function %f() -> i64 {
@@ -108,8 +168,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #65535, LSL #32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-0xffff00000001
 ;   ret
 
 function %f() -> i64 {
@@ -118,8 +184,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #65535, LSL #48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0xffffffffffff
 ;   ret
 
 function %f() -> i64 {
@@ -128,11 +200,20 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #58
 ;   movk x0, x0, #4626, LSL #16
 ;   movk x0, x0, #61603, LSL #32
 ;   movk x0, x0, #62283, LSL #48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0x3a
+;   movk x0, #0x1212, lsl #16
+;   movk x0, #0xf0a3, lsl #32
+;   movk x0, #0xf34b, lsl #48
 ;   ret
 
 function %f() -> i64 {
@@ -141,9 +222,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #7924, LSL #16
 ;   movk x0, x0, #4841, LSL #48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0x1ef40000
+;   movk x0, #0x12e9, lsl #48
 ;   ret
 
 function %f() -> i64 {
@@ -152,9 +240,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #57611, LSL #16
 ;   movk x0, x0, #4841, LSL #48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-0xe10b0001
+;   movk x0, #0x12e9, lsl #48
 ;   ret
 
 function %f() -> i32 {
@@ -163,8 +258,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn w0, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #-1
 ;   ret
 
 function %f() -> i32 {
@@ -173,8 +274,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn w0, #8
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #-9
 ;   ret
 
 function %f() -> i64 {
@@ -183,8 +290,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn w0, #8
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #-9
 ;   ret
 
 function %f() -> i64 {
@@ -193,8 +306,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movn x0, #8
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #-9
 ;   ret
 
 function %f() -> f64 {
@@ -203,8 +322,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   fmov d0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d0, #1.00000000
 ;   ret
 
 function %f() -> f32 {
@@ -213,8 +338,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   fmov s0, #5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov s0, #5.00000000
 ;   ret
 
 function %f() -> f64 {
@@ -223,8 +354,15 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #16457, LSL #48
+;   fmov d0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #0x4049000000000000
 ;   fmov d0, x1
 ;   ret
 
@@ -234,8 +372,15 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #16968, LSL #16
+;   fmov s0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #0x42480000
 ;   fmov s0, w1
 ;   ret
 
@@ -245,7 +390,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   movi v0.2s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   movi v0.2s, #0
 ;   ret
 
@@ -255,7 +406,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   movi v0.2s, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   movi v0.2s, #0
 ;   ret
 
@@ -265,8 +422,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   fmov d0, #-16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d0, #-16.00000000
 ;   ret
 
 function %f() -> f32 {
@@ -275,7 +438,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   fmov s0, #-16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov s0, #-16.00000000
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
@@ -14,9 +14,17 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.4h, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   sqxtn v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.4h, w0
+;   mov v3.d[1], v3.d[0]
 ;   sqxtn v0.8b, v3.8h
 ;   ret
 
@@ -33,10 +41,18 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.8h, w0
 ;   sqxtn v0.8b, v5.8h
 ;   sqxtn2 v0.16b, v0.16b, v5.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.8h, w0
+;   sqxtn v0.8b, v5.8h
+;   sqxtn2 v0.16b, v5.8h
 ;   ret
 
 function %snarrow_i32x2(i32) -> i16x4 {
@@ -52,9 +68,17 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.2s, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   sqxtn v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.2s, w0
+;   mov v3.d[1], v3.d[0]
 ;   sqxtn v0.4h, v3.4s
 ;   ret
 
@@ -71,10 +95,18 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.4s, w0
 ;   sqxtn v0.4h, v5.4s
 ;   sqxtn2 v0.8h, v0.8h, v5.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.4s, w0
+;   sqxtn v0.4h, v5.4s
+;   sqxtn2 v0.8h, v5.4s
 ;   ret
 
 function %snarrow_i64x2(i64) -> i32x4 {
@@ -90,10 +122,18 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.2d, x0
 ;   sqxtn v0.2s, v5.2d
 ;   sqxtn2 v0.4s, v0.4s, v5.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.2d, x0
+;   sqxtn v0.2s, v5.2d
+;   sqxtn2 v0.4s, v5.2d
 ;   ret
 
 function %unarrow_i16x4(i16) -> i8x8 {
@@ -109,9 +149,17 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.4h, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   sqxtun v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.4h, w0
+;   mov v3.d[1], v3.d[0]
 ;   sqxtun v0.8b, v3.8h
 ;   ret
 
@@ -128,10 +176,18 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.8h, w0
 ;   sqxtun v0.8b, v5.8h
 ;   sqxtun2 v0.16b, v0.16b, v5.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.8h, w0
+;   sqxtun v0.8b, v5.8h
+;   sqxtun2 v0.16b, v5.8h
 ;   ret
 
 function %unarrow_i32x2(i32) -> i16x4 {
@@ -147,9 +203,17 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.2s, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   sqxtun v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.2s, w0
+;   mov v3.d[1], v3.d[0]
 ;   sqxtun v0.4h, v3.4s
 ;   ret
 
@@ -166,10 +230,18 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.4s, w0
 ;   sqxtun v0.4h, v5.4s
 ;   sqxtun2 v0.8h, v0.8h, v5.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.4s, w0
+;   sqxtun v0.4h, v5.4s
+;   sqxtun2 v0.8h, v5.4s
 ;   ret
 
 function %unarrow_i64x2(i64) -> i32x4 {
@@ -185,10 +257,18 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.2d, x0
 ;   sqxtun v0.2s, v5.2d
 ;   sqxtun2 v0.4s, v0.4s, v5.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.2d, x0
+;   sqxtun v0.2s, v5.2d
+;   sqxtun2 v0.4s, v5.2d
 ;   ret
 
 function %uunarrow_i16x4(i16) -> i8x8 {
@@ -204,9 +284,17 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.4h, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   uqxtn v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.4h, w0
+;   mov v3.d[1], v3.d[0]
 ;   uqxtn v0.8b, v3.8h
 ;   ret
 
@@ -223,10 +311,18 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.8h, w0
 ;   uqxtn v0.8b, v5.8h
 ;   uqxtn2 v0.16b, v0.16b, v5.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.8h, w0
+;   uqxtn v0.8b, v5.8h
+;   uqxtn2 v0.16b, v5.8h
 ;   ret
 
 function %uunarrow_i32x2(i32) -> i16x4 {
@@ -242,9 +338,17 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v3.2s, w0
 ;   mov v3.d[1], v3.d[1], v3.d[0]
+;   uqxtn v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v3.2s, w0
+;   mov v3.d[1], v3.d[0]
 ;   uqxtn v0.4h, v3.4s
 ;   ret
 
@@ -261,10 +365,18 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.4s, w0
 ;   uqxtn v0.4h, v5.4s
 ;   uqxtn2 v0.8h, v0.8h, v5.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.4s, w0
+;   uqxtn v0.4h, v5.4s
+;   uqxtn2 v0.8h, v5.4s
 ;   ret
 
 function %uunarrow_i64x2(i64) -> i32x4 {
@@ -280,9 +392,17 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v5.2d, x0
 ;   uqxtn v0.2s, v5.2d
 ;   uqxtn2 v0.4s, v0.4s, v5.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v5.2d, x0
+;   uqxtn v0.2s, v5.2d
+;   uqxtn2 v0.4s, v5.2d
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
@@ -13,7 +13,15 @@ block0(v0: i8, v1: i8):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.16b, w0
+;   dup v7.16b, w1
+;   add v0.16b, v6.16b, v7.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.16b, w0
 ;   dup v7.16b, w1
 ;   add v0.16b, v6.16b, v7.16b
@@ -31,7 +39,15 @@ block0(v0: i16, v1: i16):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.8h, w0
+;   dup v7.8h, w1
+;   add v0.8h, v6.8h, v7.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.8h, w0
 ;   dup v7.8h, w1
 ;   add v0.8h, v6.8h, v7.8h
@@ -49,7 +65,15 @@ block0(v0: i32, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.4s, w0
+;   dup v7.4s, w1
+;   mul v0.4s, v6.4s, v7.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.4s, w0
 ;   dup v7.4s, w1
 ;   mul v0.4s, v6.4s, v7.4s
@@ -67,7 +91,15 @@ block0(v0: i64, v1: i64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, x0
+;   dup v7.2d, x1
+;   sub v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, x0
 ;   dup v7.2d, x1
 ;   sub v0.2d, v6.2d, v7.2d
@@ -85,7 +117,15 @@ block0(v0: f32, v1: f32):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.4s, v0.s[0]
+;   dup v7.4s, v1.s[0]
+;   fadd v0.4s, v6.4s, v7.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.4s, v0.s[0]
 ;   dup v7.4s, v1.s[0]
 ;   fadd v0.4s, v6.4s, v7.4s
@@ -103,7 +143,15 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, v0.d[0]
+;   dup v7.2d, v1.d[0]
+;   fsub v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
 ;   dup v7.2d, v1.d[0]
 ;   fsub v0.2d, v6.2d, v7.2d
@@ -121,7 +169,15 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, v0.d[0]
+;   dup v7.2d, v1.d[0]
+;   fmul v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
 ;   dup v7.2d, v1.d[0]
 ;   fmul v0.2d, v6.2d, v7.2d
@@ -139,7 +195,15 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, v0.d[0]
+;   dup v7.2d, v1.d[0]
+;   fdiv v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
 ;   dup v7.2d, v1.d[0]
 ;   fdiv v0.2d, v6.2d, v7.2d
@@ -157,7 +221,15 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, v0.d[0]
+;   dup v7.2d, v1.d[0]
+;   fmin v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
 ;   dup v7.2d, v1.d[0]
 ;   fmin v0.2d, v6.2d, v7.2d
@@ -175,7 +247,15 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
+;   dup v6.2d, v0.d[0]
+;   dup v7.2d, v1.d[0]
+;   fmax v0.2d, v6.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
 ;   dup v7.2d, v1.d[0]
 ;   fmax v0.2d, v6.2d, v7.2d
@@ -193,11 +273,20 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   dup v7.2d, v0.d[0]
 ;   dup v16.2d, v1.d[0]
 ;   fcmgt v0.2d, v7.2d, v16.2d
 ;   bsl v0.16b, v0.16b, v16.16b, v7.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fcmgt v0.2d, v7.2d, v16.2d
+;   bsl v0.16b, v16.16b, v7.16b
 ;   ret
 
 function %f64x2_splat_max_pseudo(f64, f64) -> f64x2 {
@@ -212,10 +301,19 @@ block0(v0: f64, v1: f64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   dup v7.2d, v0.d[0]
 ;   dup v16.2d, v1.d[0]
 ;   fcmgt v0.2d, v16.2d, v7.2d
 ;   bsl v0.16b, v0.16b, v16.16b, v7.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v7.2d, v0.d[0]
+;   dup v16.2d, v1.d[0]
+;   fcmgt v0.2d, v16.2d, v7.2d
+;   bsl v0.16b, v16.16b, v7.16b
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
@@ -14,9 +14,16 @@ block0(v0: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.16b, w0
 ;   sxtl2 v0.8h, v4.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.16b, w0
+;   sshll2 v0.8h, v4.16b, #0
 ;   ret
 
 function %swidenhigh_i16x8(i16) -> i32x4 {
@@ -32,9 +39,16 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.8h, w0
 ;   sxtl2 v0.4s, v4.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.8h, w0
+;   sshll2 v0.4s, v4.8h, #0
 ;   ret
 
 function %swidenhigh_i32x4(i32) -> i64x2 {
@@ -50,9 +64,16 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.4s, w0
 ;   sxtl2 v0.2d, v4.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.4s, w0
+;   sshll2 v0.2d, v4.4s, #0
 ;   ret
 
 function %swidenlow_i8x16(i8) -> i16x8 {
@@ -68,9 +89,16 @@ block0(v0: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.16b, w0
 ;   sxtl v0.8h, v4.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.16b, w0
+;   sshll v0.8h, v4.8b, #0
 ;   ret
 
 function %swidenlow_i16x8(i16) -> i32x4 {
@@ -86,9 +114,16 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.8h, w0
 ;   sxtl v0.4s, v4.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.8h, w0
+;   sshll v0.4s, v4.4h, #0
 ;   ret
 
 function %swidenlow_i32x4(i32) -> i64x2 {
@@ -104,8 +139,15 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   dup v4.4s, w0
 ;   sxtl v0.2d, v4.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   dup v4.4s, w0
+;   sshll v0.2d, v4.2s, #0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -11,6 +11,7 @@ block0:
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -20,6 +21,18 @@ block0:
 ;   str x2, [x1]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x1, sp
+;   mov x2, #1
+;   str x2, [x1]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %store_scale_lt_128() {
@@ -32,6 +45,7 @@ block0:
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -41,6 +55,18 @@ block0:
 ;   str x2, [x1]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x1, sp
+;   mov x2, #1
+;   str x2, [x1]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %store_explicit(i32) {
@@ -54,6 +80,7 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -63,6 +90,18 @@ block0(v0: i32):
 ;   str q3, [x3]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   dup v3.4s, w0
+;   mov x3, sp
+;   str q3, [x3]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %load_explicit() -> i32x4 {
@@ -76,6 +115,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -84,6 +124,17 @@ block0:
 ;   ldr q0, [x2]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x2, sp
+;   ldr q0, [x2]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %store_implicit(i32) {
@@ -97,6 +148,7 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -106,6 +158,18 @@ block0(v0: i32):
 ;   str q3, [x3]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   dup v3.4s, w0
+;   mov x3, sp
+;   str q3, [x3]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %addr() -> i64 {
@@ -118,6 +182,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -125,5 +190,15 @@ block0:
 ;   mov x0, sp
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x0, sp
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/extend-op.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/extend-op.clif
@@ -10,9 +10,16 @@ block0(v0: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sxtb x3, w0
 ;   add x0, x3, #42
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtb x3, w0
+;   add x0, x3, #0x2a
 ;   ret
 
 function %f2(i8, i64) -> i64 {
@@ -22,8 +29,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   add x0, x1, x0, SXTB
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x0, x1, w0, sxtb
 ;   ret
 
 function %i128_uextend_i64(i64) -> i128 {
@@ -32,8 +45,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #0
 ;   ret
 
 function %i128_sextend_i64(i64) -> i128 {
@@ -42,8 +61,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i128_uextend_i32(i32) -> i128 {
@@ -52,9 +77,16 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mov w0, w0
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, w0
+;   mov x1, #0
 ;   ret
 
 function %i128_sextend_i32(i32) -> i128 {
@@ -63,9 +95,16 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sxtw x0, w0
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtw x0, w0
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i128_uextend_i16(i16) -> i128 {
@@ -74,9 +113,16 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uxth w0, w0
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w0, w0
+;   mov x1, #0
 ;   ret
 
 function %i128_sextend_i16(i16) -> i128 {
@@ -85,9 +131,16 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sxth x0, w0
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxth x0, w0
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i128_uextend_i8(i8) -> i128 {
@@ -96,9 +149,16 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uxtb w0, w0
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w0, w0
+;   mov x1, #0
 ;   ret
 
 function %i128_sextend_i8(i8) -> i128 {
@@ -107,9 +167,16 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sxtb x0, w0
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtb x0, w0
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i8x16_uextend_i16(i8x16) -> i16 {
@@ -119,7 +186,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   umov w0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
 ;   ret
 
@@ -130,7 +203,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   umov w0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
 ;   ret
 
@@ -141,7 +220,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   umov w0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
 ;   ret
 
@@ -152,9 +237,16 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   umov w0, v0.b[1]
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   umov w0, v0.b[1]
+;   mov x1, #0
 ;   ret
 
 function %i8x16_sextend_i16(i8x16) -> i16 {
@@ -164,7 +256,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov w0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov w0, v0.b[1]
 ;   ret
 
@@ -175,7 +273,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov w0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov w0, v0.b[1]
 ;   ret
 
@@ -186,7 +290,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov x0, v0.b[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov x0, v0.b[1]
 ;   ret
 
@@ -197,9 +307,16 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   smov x0, v0.b[1]
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   smov x0, v0.b[1]
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i16x8_uextend_i32(i16x8) -> i32 {
@@ -209,7 +326,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   umov w0, v0.h[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umov w0, v0.h[1]
 ;   ret
 
@@ -220,7 +343,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   umov w0, v0.h[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umov w0, v0.h[1]
 ;   ret
 
@@ -231,9 +360,16 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   umov w0, v0.h[1]
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   umov w0, v0.h[1]
+;   mov x1, #0
 ;   ret
 
 function %i16x8_sextend_i32(i16x8) -> i32 {
@@ -243,7 +379,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov w0, v0.h[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov w0, v0.h[1]
 ;   ret
 
@@ -254,7 +396,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov x0, v0.h[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov x0, v0.h[1]
 ;   ret
 
@@ -265,9 +413,16 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   smov x0, v0.h[1]
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   smov x0, v0.h[1]
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i32x4_uextend_i64(i32x4) -> i64 {
@@ -277,7 +432,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   mov w0, v0.s[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov w0, v0.s[1]
 ;   ret
 
@@ -288,9 +449,16 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov w0, v0.s[1]
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, v0.s[1]
+;   mov x1, #0
 ;   ret
 
 function %i32x4_sextend_i64(i32x4) -> i64 {
@@ -300,7 +468,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   smov x0, v0.s[1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smov x0, v0.s[1]
 ;   ret
 
@@ -311,9 +485,16 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   smov x0, v0.s[1]
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   smov x0, v0.s[1]
+;   asr x1, x0, #0x3f
 ;   ret
 
 function %i64x2_uextend_i128(i64x2) -> i128 {
@@ -323,9 +504,16 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov x0, v0.d[1]
 ;   movz x1, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, v0.d[1]
+;   mov x1, #0
 ;   ret
 
 function %i64x2_sextend_i128(i64x2) -> i128 {
@@ -335,8 +523,15 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov x0, v0.d[1]
 ;   asr x1, x0, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, v0.d[1]
+;   asr x1, x0, #0x3f
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fcvt-small.clif
@@ -8,7 +8,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   uxtb w2, w0
+;   ucvtf s0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w2, w0
 ;   ucvtf s0, w2
 ;   ret
@@ -19,7 +26,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   uxtb w2, w0
+;   ucvtf d0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w2, w0
 ;   ucvtf d0, w2
 ;   ret
@@ -30,7 +44,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   uxth w2, w0
+;   ucvtf s0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxth w2, w0
 ;   ucvtf s0, w2
 ;   ret
@@ -41,7 +62,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   uxth w2, w0
+;   ucvtf d0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxth w2, w0
 ;   ucvtf d0, w2
 ;   ret
@@ -52,6 +80,7 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -64,6 +93,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x43800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, s0
+;   ret
 
 function u0:0(f64) -> i8 {
 block0(v0: f64):
@@ -71,6 +117,7 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -83,6 +130,23 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x4070000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, d0
+;   ret
 
 function u0:0(f32) -> i16 {
 block0(v0: f32):
@@ -90,6 +154,7 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -102,6 +167,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x47800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, s0
+;   ret
 
 function u0:0(f64) -> i16 {
 block0(v0: f64):
@@ -109,6 +191,7 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -119,6 +202,23 @@ block0(v0: f64):
 ;   fmov d17, x9
 ;   fcmp d0, d17
 ;   b.lt 8 ; udf
+;   fcvtzu w0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x40f0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
 ;   fcvtzu w0, d0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
@@ -7,7 +7,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtb w2, w0
+;   scvtf s0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb w2, w0
 ;   scvtf s0, w2
 ;   ret
@@ -18,7 +25,14 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxth w2, w0
+;   scvtf s0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxth w2, w0
 ;   scvtf s0, w2
 ;   ret
@@ -29,7 +43,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf s0, w0
 ;   ret
 
@@ -39,7 +59,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf s0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf s0, x0
 ;   ret
 
@@ -49,7 +75,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtb w2, w0
+;   scvtf d0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb w2, w0
 ;   scvtf d0, w2
 ;   ret
@@ -60,7 +93,14 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxth w2, w0
+;   scvtf d0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxth w2, w0
 ;   scvtf d0, w2
 ;   ret
@@ -71,7 +111,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf d0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf d0, w0
 ;   ret
 
@@ -81,7 +127,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf d0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf d0, x0
 ;   ret
 
@@ -91,8 +143,15 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sxtl v2.2d, v0.2s
+;   scvtf v0.2d, v2.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sshll v2.2d, v0.2s, #0
 ;   scvtf v0.2d, v2.2d
 ;   ret
 
@@ -108,7 +167,21 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
   return v10
 }
 
+; VCode:
 ; block0:
+;   uxtb w12, w0
+;   ucvtf s22, w12
+;   uxth w12, w1
+;   ucvtf s23, w12
+;   ucvtf s21, w2
+;   ucvtf s24, x3
+;   fadd s22, s22, s23
+;   fadd s21, s22, s21
+;   fadd s0, s21, s24
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w12, w0
 ;   ucvtf s22, w12
 ;   uxth w12, w1
@@ -127,8 +200,15 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uxtl v3.2d, v0.2s
+;   ucvtf v0.2d, v3.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushll v3.2d, v0.2s, #0
 ;   ucvtf v0.2d, v3.2d
 ;   ret
 
@@ -138,7 +218,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ucvtf v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ucvtf v0.4s, v0.4s
 ;   ret
 
@@ -148,6 +234,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -160,6 +247,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x4f800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, s0
+;   ret
 
 function %f14(f32) -> i64 {
 block0(v0: f32):
@@ -167,6 +271,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -179,6 +284,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu x0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x5f800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu x0, s0
+;   ret
 
 function %f15(f64) -> i32 {
 block0(v0: f64):
@@ -186,6 +308,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -198,6 +321,23 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x41f0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, d0
+;   ret
 
 function %f16(f64) -> i64 {
 block0(v0: f64):
@@ -205,6 +345,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -217,6 +358,23 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzu x0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x43f0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu x0, d0
+;   ret
 
 function %f17(f32) -> i32 {
 block0(v0: f32):
@@ -224,7 +382,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzu w0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzu w0, s0
 ;   ret
 
@@ -234,7 +398,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzu x0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzu x0, s0
 ;   ret
 
@@ -244,7 +414,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzu w0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzu w0, d0
 ;   ret
 
@@ -254,7 +430,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzu x0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzu x0, d0
 ;   ret
 
@@ -264,6 +446,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -277,6 +460,24 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzs w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #0xcf000000
+;   fmov s5, w5
+;   fcmp s0, s5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x4f000000
+;   fmov s19, w11
+;   fcmp s0, s19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs w0, s0
+;   ret
 
 function %f22(f32) -> i64 {
 block0(v0: f32):
@@ -284,6 +485,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -297,6 +499,24 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzs x0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #0xdf000000
+;   fmov s5, w5
+;   fcmp s0, s5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x5f000000
+;   fmov s19, w11
+;   fcmp s0, s19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs x0, s0
+;   ret
 
 function %f23(f64) -> i32 {
 block0(v0: f64):
@@ -304,6 +524,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -316,6 +537,26 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzs w0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   ldr d4, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x20, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0xc1
+;   fcmp d0, d4
+;   b.gt #0x28
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x41e0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x3c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs w0, d0
+;   ret
 
 function %f24(f64) -> i64 {
 block0(v0: f64):
@@ -323,6 +564,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -336,6 +578,24 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzs x0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #-0x3c20000000000000
+;   fmov d5, x5
+;   fcmp d0, d5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x43e0000000000000
+;   fmov d19, x11
+;   fcmp d0, d19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs x0, d0
+;   ret
 
 function %f25(f32) -> i32 {
 block0(v0: f32):
@@ -343,7 +603,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzs w0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzs w0, s0
 ;   ret
 
@@ -353,7 +619,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzs x0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzs x0, s0
 ;   ret
 
@@ -363,7 +635,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzs w0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzs w0, d0
 ;   ret
 
@@ -373,7 +651,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzs x0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzs x0, d0
 ;   ret
 
@@ -383,7 +667,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzu v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzu v0.4s, v0.4s
 ;   ret
 
@@ -393,7 +683,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvtzs v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvtzs v0.4s, v0.4s
 ;   ret
 
@@ -403,10 +699,19 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzu w2, s0
 ;   movz w4, #255
 ;   subs wzr, w2, w4
+;   csel x0, x4, x2, hi
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzu w2, s0
+;   mov w4, #0xff
+;   cmp w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
 
@@ -416,6 +721,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzs w2, s0
 ;   movz w4, #127
@@ -423,6 +729,17 @@ block0(v0: f32):
 ;   subs wzr, w2, w4
 ;   csel x9, x4, x2, gt
 ;   subs wzr, w9, w6
+;   csel x0, x6, x9, lt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzs w2, s0
+;   mov w4, #0x7f
+;   mov x6, #-0x80
+;   cmp w2, w4
+;   csel x9, x4, x2, gt
+;   cmp w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
 
@@ -432,10 +749,19 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzu w2, s0
 ;   movz w4, #65535
 ;   subs wzr, w2, w4
+;   csel x0, x4, x2, hi
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzu w2, s0
+;   mov w4, #0xffff
+;   cmp w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
 
@@ -445,6 +771,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzs w2, s0
 ;   movz w4, #32767
@@ -454,6 +781,17 @@ block0(v0: f32):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzs w2, s0
+;   mov w4, #0x7fff
+;   mov x6, #-0x8000
+;   cmp w2, w4
+;   csel x9, x4, x2, gt
+;   cmp w9, w6
+;   csel x0, x6, x9, lt
+;   ret
 
 function %f35(f64) -> i8 {
 block0(v0: f64):
@@ -461,10 +799,19 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzu w2, d0
 ;   movz w4, #255
 ;   subs wzr, w2, w4
+;   csel x0, x4, x2, hi
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzu w2, d0
+;   mov w4, #0xff
+;   cmp w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
 
@@ -474,6 +821,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzs w2, d0
 ;   movz w4, #127
@@ -483,6 +831,17 @@ block0(v0: f64):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzs w2, d0
+;   mov w4, #0x7f
+;   mov x6, #-0x80
+;   cmp w2, w4
+;   csel x9, x4, x2, gt
+;   cmp w9, w6
+;   csel x0, x6, x9, lt
+;   ret
 
 function %f37(f64) -> i16 {
 block0(v0: f64):
@@ -490,10 +849,19 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzu w2, d0
 ;   movz w4, #65535
 ;   subs wzr, w2, w4
+;   csel x0, x4, x2, hi
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzu w2, d0
+;   mov w4, #0xffff
+;   cmp w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
 
@@ -503,6 +871,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvtzs w2, d0
 ;   movz w4, #32767
@@ -510,6 +879,17 @@ block0(v0: f64):
 ;   subs wzr, w2, w4
 ;   csel x9, x4, x2, gt
 ;   subs wzr, w9, w6
+;   csel x0, x6, x9, lt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvtzs w2, d0
+;   mov w4, #0x7fff
+;   mov x6, #-0x8000
+;   cmp w2, w4
+;   csel x9, x4, x2, gt
+;   cmp w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
@@ -8,7 +8,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fadd s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fadd s0, s0, s1
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fadd d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fadd d0, d0, d1
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fsub s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsub s0, s0, s1
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fsub d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsub d0, d0, d1
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmul s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmul s0, s0, s1
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmul d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmul d0, d0, d1
 ;   ret
 
@@ -68,7 +104,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fdiv s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fdiv s0, s0, s1
 ;   ret
 
@@ -78,7 +120,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fdiv d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fdiv d0, d0, d1
 ;   ret
 
@@ -88,7 +136,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmin s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmin s0, s0, s1
 ;   ret
 
@@ -98,7 +152,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmin d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmin d0, d0, d1
 ;   ret
 
@@ -108,7 +168,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmax s0, s0, s1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmax s0, s0, s1
 ;   ret
 
@@ -118,7 +184,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   fmax d0, d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmax d0, d0, d1
 ;   ret
 
@@ -128,7 +200,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fsqrt s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsqrt s0, s0
 ;   ret
 
@@ -138,7 +216,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fsqrt d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsqrt d0, d0
 ;   ret
 
@@ -148,7 +232,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fabs s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fabs s0, s0
 ;   ret
 
@@ -158,7 +248,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fabs d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fabs d0, d0
 ;   ret
 
@@ -168,7 +264,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fneg s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fneg s0, s0
 ;   ret
 
@@ -178,7 +280,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fneg d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fneg d0, d0
 ;   ret
 
@@ -188,7 +296,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvt d0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvt d0, s0
 ;   ret
 
@@ -198,7 +312,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fcvt s0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcvt s0, d0
 ;   ret
 
@@ -208,7 +328,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintp s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintp s0, s0
 ;   ret
 
@@ -218,7 +344,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintp d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintp d0, d0
 ;   ret
 
@@ -228,7 +360,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintm s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintm s0, s0
 ;   ret
 
@@ -238,7 +376,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintm d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintm d0, d0
 ;   ret
 
@@ -248,7 +392,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintz s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintz s0, s0
 ;   ret
 
@@ -258,7 +408,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintz d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintz d0, d0
 ;   ret
 
@@ -268,7 +424,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintn s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintn s0, s0
 ;   ret
 
@@ -278,7 +440,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintn d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintn d0, d0
 ;   ret
 
@@ -288,7 +456,13 @@ block0(v0: f32, v1: f32, v2: f32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fmadd s0, s0, s1, s2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmadd s0, s0, s1, s2
 ;   ret
 
@@ -298,7 +472,13 @@ block0(v0: f64, v1: f64, v2: f64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   fmadd d0, d0, d1, d2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmadd d0, d0, d1, d2
 ;   ret
 
@@ -308,9 +488,16 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ushr v4.2s, v1.2s, #31
 ;   sli v0.2s, v0.2s, v4.2s, #31
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushr v4.2s, v1.2s, #0x1f
+;   sli v0.2s, v4.2s, #0x1f
 ;   ret
 
 function %f32(f64, f64) -> f64 {
@@ -319,9 +506,16 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ushr d4, d1, #63
 ;   sli d0, d0, d4, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushr d4, d1, #0x3f
+;   sli d0, d4, #0x3f
 ;   ret
 
 function %f33(f32) -> i32 {
@@ -330,6 +524,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -342,6 +537,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x4f800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, s0
+;   ret
 
 function %f34(f32) -> i32 {
 block0(v0: f32):
@@ -349,6 +561,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -362,6 +575,24 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzs w0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #0xcf000000
+;   fmov s5, w5
+;   fcmp s0, s5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x4f000000
+;   fmov s19, w11
+;   fcmp s0, s19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs w0, s0
+;   ret
 
 function %f35(f32) -> i64 {
 block0(v0: f32):
@@ -369,6 +600,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -381,6 +613,23 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzu x0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov s4, #-1.00000000
+;   fcmp s0, s4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x5f800000
+;   fmov s17, w9
+;   fcmp s0, s17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu x0, s0
+;   ret
 
 function %f36(f32) -> i64 {
 block0(v0: f32):
@@ -388,6 +637,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp s0, s0
 ;   b.vc 8 ; udf
@@ -401,6 +651,24 @@ block0(v0: f32):
 ;   b.lt 8 ; udf
 ;   fcvtzs x0, s0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp s0, s0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #0xdf000000
+;   fmov s5, w5
+;   fcmp s0, s5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x5f000000
+;   fmov s19, w11
+;   fcmp s0, s19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs x0, s0
+;   ret
 
 function %f37(f64) -> i32 {
 block0(v0: f64):
@@ -408,6 +676,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -420,6 +689,23 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzu w0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x41f0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu w0, d0
+;   ret
 
 function %f38(f64) -> i32 {
 block0(v0: f64):
@@ -427,6 +713,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -439,6 +726,26 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzs w0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   ldr d4, #0x14
+;   b #0x1c
+;   .byte 0x00, 0x00, 0x20, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0xc1
+;   fcmp d0, d4
+;   b.gt #0x28
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x41e0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x3c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs w0, d0
+;   ret
 
 function %f39(f64) -> i64 {
 block0(v0: f64):
@@ -446,6 +753,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -458,6 +766,23 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzu x0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   fmov d4, #-1.00000000
+;   fcmp d0, d4
+;   b.gt #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x9, #0x43f0000000000000
+;   fmov d17, x9
+;   fcmp d0, d17
+;   b.lt #0x30
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzu x0, d0
+;   ret
 
 function %f40(f64) -> i64 {
 block0(v0: f64):
@@ -465,6 +790,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcmp d0, d0
 ;   b.vc 8 ; udf
@@ -478,6 +804,24 @@ block0(v0: f64):
 ;   b.lt 8 ; udf
 ;   fcvtzs x0, d0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d0
+;   b.vc #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: bad_toint
+;   mov x5, #-0x3c20000000000000
+;   fmov d5, x5
+;   fcmp d0, d5
+;   b.ge #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   mov x11, #0x43e0000000000000
+;   fmov d19, x11
+;   fcmp d0, d19
+;   b.lt #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: int_ovf
+;   fcvtzs x0, d0
+;   ret
 
 function %f41(i32) -> f32 {
 block0(v0: i32):
@@ -485,7 +829,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ucvtf s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ucvtf s0, w0
 ;   ret
 
@@ -495,7 +845,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf s0, w0
 ;   ret
 
@@ -505,7 +861,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ucvtf s0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ucvtf s0, x0
 ;   ret
 
@@ -515,7 +877,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf s0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf s0, x0
 ;   ret
 
@@ -525,7 +893,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ucvtf d0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ucvtf d0, w0
 ;   ret
 
@@ -535,7 +909,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf d0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf d0, w0
 ;   ret
 
@@ -545,7 +925,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ucvtf d0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ucvtf d0, x0
 ;   ret
 
@@ -555,7 +941,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   scvtf d0, x0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   scvtf d0, x0
 ;   ret
 
@@ -565,7 +957,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fsqrt v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsqrt v0.2s, v0.2s
 ;   ret
 
@@ -575,7 +973,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fsqrt v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsqrt v0.4s, v0.4s
 ;   ret
 
@@ -585,7 +989,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fsqrt v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fsqrt v0.2d, v0.2d
 ;   ret
 
@@ -595,7 +1005,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fneg v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fneg v0.2s, v0.2s
 ;   ret
 
@@ -605,7 +1021,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fneg v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fneg v0.4s, v0.4s
 ;   ret
 
@@ -615,7 +1037,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fneg v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fneg v0.2d, v0.2d
 ;   ret
 
@@ -625,7 +1053,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fabs v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fabs v0.2s, v0.2s
 ;   ret
 
@@ -635,7 +1069,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fabs v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fabs v0.4s, v0.4s
 ;   ret
 
@@ -645,7 +1085,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fabs v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fabs v0.2d, v0.2d
 ;   ret
 
@@ -655,7 +1101,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintp v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintp v0.2s, v0.2s
 ;   ret
 
@@ -665,7 +1117,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintp v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintp v0.4s, v0.4s
 ;   ret
 
@@ -675,7 +1133,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintp v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintp v0.2d, v0.2d
 ;   ret
 
@@ -685,7 +1149,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintm v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintm v0.2s, v0.2s
 ;   ret
 
@@ -695,7 +1165,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintm v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintm v0.4s, v0.4s
 ;   ret
 
@@ -705,7 +1181,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintm v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintm v0.2d, v0.2d
 ;   ret
 
@@ -715,7 +1197,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintz v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintz v0.2s, v0.2s
 ;   ret
 
@@ -725,7 +1213,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintz v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintz v0.4s, v0.4s
 ;   ret
 
@@ -735,7 +1229,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintz v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintz v0.2d, v0.2d
 ;   ret
 
@@ -745,7 +1245,13 @@ block0(v0: f32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintn v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintn v0.2s, v0.2s
 ;   ret
 
@@ -755,7 +1261,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintn v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintn v0.4s, v0.4s
 ;   ret
 
@@ -765,7 +1277,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   frintn v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   frintn v0.2d, v0.2d
 ;   ret
 
@@ -775,10 +1293,18 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   mov v5.16b, v0.16b
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v5.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v5.16b, v0.16b
+;   mov v0.16b, v2.16b
+;   fmla v0.4s, v5.4s, v1.4s
 ;   ret
 
 function %f71(f32x2, f32x2, f32x2) -> f32x2 {
@@ -787,10 +1313,18 @@ block0(v0: f32x2, v1: f32x2, v2: f32x2):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   mov v5.16b, v0.16b
 ;   mov v0.16b, v2.16b
 ;   fmla v0.2s, v0.2s, v5.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v5.16b, v0.16b
+;   mov v0.16b, v2.16b
+;   fmla v0.2s, v5.2s, v1.2s
 ;   ret
 
 function %f72(f64x2, f64x2, f64x2) -> f64x2 {
@@ -799,10 +1333,18 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   mov v5.16b, v0.16b
 ;   mov v0.16b, v2.16b
 ;   fmla v0.2d, v0.2d, v5.2d, v1.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v5.16b, v0.16b
+;   mov v0.16b, v2.16b
+;   fmla v0.2d, v5.2d, v1.2d
 ;   ret
 
 function %f73(f32x2, f32x2) -> f32x2 {
@@ -811,9 +1353,16 @@ block0(v0: f32x2, v1: f32x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ushr v4.2s, v1.2s, #31
 ;   sli v0.2s, v0.2s, v4.2s, #31
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushr v4.2s, v1.2s, #0x1f
+;   sli v0.2s, v4.2s, #0x1f
 ;   ret
 
 function %f74(f32x4, f32x4) -> f32x4 {
@@ -822,9 +1371,16 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ushr v4.4s, v1.4s, #31
 ;   sli v0.4s, v0.4s, v4.4s, #31
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushr v4.4s, v1.4s, #0x1f
+;   sli v0.4s, v4.4s, #0x1f
 ;   ret
 
 function %f75(f64x2, f64x2) -> f64x2 {
@@ -833,8 +1389,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ushr v4.2d, v1.2d, #63
 ;   sli v0.2d, v0.2d, v4.2d, #63
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ushr v4.2d, v1.2d, #0x3f
+;   sli v0.2d, v4.2d, #0x3f
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
@@ -8,6 +8,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   paciasp
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
@@ -15,6 +16,16 @@ block0:
 ;   mov x0, fp
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
+; 
+; Disassembled:
+;   paciasp
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0xc
+;   mov x0, x29
+;   ldp x29, x30, [sp], #0x10
+;   autiasp
+;   ret
 
 function %sp() -> i64 {
 block0:
@@ -22,6 +33,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   paciasp
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
@@ -29,6 +41,16 @@ block0:
 ;   mov x0, sp
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
+; 
+; Disassembled:
+;   paciasp
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0xc
+;   mov x0, sp
+;   ldp x29, x30, [sp], #0x10
+;   autiasp
+;   ret
 
 function %return_address() -> i64 {
 block0:
@@ -36,6 +58,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   paciasp
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
@@ -45,3 +68,16 @@ block0:
 ;   mov x0, lr
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
+; 
+; Disassembled:
+;   paciasp
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0xc
+;   ldur x30, [x29, #8]
+;   xpaclri
+;   mov x0, x30
+;   ldp x29, x30, [sp], #0x10
+;   autiasp
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
@@ -8,11 +8,20 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   mov x0, fp
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x0, x29
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %sp() -> i64 {
@@ -21,11 +30,20 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   mov x0, sp
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   mov x0, sp
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %return_address() -> i64 {
@@ -34,9 +52,19 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   ldr x0, [fp, #8]
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldur x0, [x29, #8]
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iabs.clif
@@ -8,7 +8,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.16b, v0.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.16b, v0.16b
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i8x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.8b, v0.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.8b, v0.8b
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.8h, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.8h, v0.8h
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: i16x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.4h, v0.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.4h, v0.4h
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.4s, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.4s, v0.4s
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: i32x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.2s, v0.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.2s, v0.2s
 ;   ret
 
@@ -68,7 +104,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   abs v0.2d, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   abs v0.2d, v0.2d
 ;   ret
 
@@ -78,10 +120,18 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sxtb w2, w0
 ;   subs wzr, w2, #0
 ;   csneg x0, x2, x2, gt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxtb w2, w0
+;   cmp w2, #0
+;   cneg x0, x2, le
 ;   ret
 
 function %f9(i16) -> i16 {
@@ -90,10 +140,18 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sxth w2, w0
 ;   subs wzr, w2, #0
 ;   csneg x0, x2, x2, gt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxth w2, w0
+;   cmp w2, #0
+;   cneg x0, x2, le
 ;   ret
 
 function %f10(i32) -> i32 {
@@ -102,9 +160,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #0
 ;   csneg x0, x0, x0, gt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0
+;   cneg x0, x0, le
 ;   ret
 
 function %f11(i64) -> i64 {
@@ -113,7 +178,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
 ;   csneg x0, x0, x0, gt
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
+;   cneg x0, x0, le
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
@@ -12,8 +12,15 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #1118208
+;   cset x0, hi
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x111, lsl #12
 ;   cset x0, hi
 ;   ret
 
@@ -24,8 +31,15 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #1118208
+;   cset x0, hs
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x111, lsl #12
 ;   cset x0, hs
 ;   ret
 
@@ -36,10 +50,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #4369
 ;   movk w3, w3, #17, LSL #16
 ;   subs wzr, w0, w3
+;   cset x0, hs
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0x1111
+;   movk w3, #0x11, lsl #16
+;   cmp w0, w3
 ;   cset x0, hs
 ;   ret
 
@@ -50,10 +73,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #4368
 ;   movk w3, w3, #17, LSL #16
 ;   subs wzr, w0, w3
+;   cset x0, hs
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0x1110
+;   movk w3, #0x11, lsl #16
+;   cmp w0, w3
 ;   cset x0, hs
 ;   ret
 
@@ -64,8 +96,15 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #1118208
+;   cset x0, gt
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x111, lsl #12
 ;   cset x0, gt
 ;   ret
 
@@ -76,8 +115,15 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, #1118208
+;   cset x0, ge
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #0x111, lsl #12
 ;   cset x0, ge
 ;   ret
 
@@ -88,10 +134,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #4369
 ;   movk w3, w3, #17, LSL #16
 ;   subs wzr, w0, w3
+;   cset x0, ge
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0x1111
+;   movk w3, #0x11, lsl #16
+;   cmp w0, w3
 ;   cset x0, ge
 ;   ret
 
@@ -102,10 +157,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #4368
 ;   movk w3, w3, #17, LSL #16
 ;   subs wzr, w0, w3
+;   cset x0, ge
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0x1110
+;   movk w3, #0x11, lsl #16
+;   cmp w0, w3
 ;   cset x0, ge
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/iconst-icmp-small.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iconst-icmp-small.clif
@@ -13,11 +13,21 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #56780
 ;   uxth w2, w0
 ;   movz w4, #56780
 ;   subs wzr, w2, w4, UXTH
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0xddcc
+;   uxth w2, w0
+;   mov w4, #0xddcc
+;   cmp w2, w4, uxth
 ;   cset x0, ne
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
@@ -15,6 +15,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #2048
@@ -22,6 +23,16 @@ block0:
 ;   mov x0, sp
 ;   add sp, sp, #2048
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x800
+; block0: ; offset 0xc
+;   mov x0, sp
+;   add sp, sp, #0x800
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %unrolled() -> i64 system_v {
@@ -32,6 +43,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movn x16, #4095 ; str wzr, [sp, x16, SXTX]
@@ -43,6 +55,22 @@ block0:
 ;   add sp, sp, #12288
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov x16, #-0x1000
+;   str wzr, [sp, x16, sxtx]
+;   mov x16, #-0x2000
+;   str wzr, [sp, x16, sxtx]
+;   mov x16, #-0x3000
+;   str wzr, [sp, x16, sxtx]
+;   sub sp, sp, #3, lsl #12
+; block0: ; offset 0x24
+;   mov x0, sp
+;   add sp, sp, #3, lsl #12
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %large() -> i64 system_v {
 ss0 = explicit_slot 100000
@@ -52,6 +80,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz x16, #0
@@ -67,5 +96,26 @@ block0:
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov x16, #0
+;   mov w17, #0x86a0
+;   movk w17, #1, lsl #16
+;   sub x16, x16, #1, lsl #12
+;   str wzr, [sp, x16]
+;   cmn x16, x17
+;   b.gt #0x14
+;   mov w16, #0x86a0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x30
+;   mov x0, sp
+;   mov w16, #0x86a0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
@@ -27,6 +27,7 @@ block5(v5: i32):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   emit_island 44
 ;   subs wzr, w0, #3
@@ -52,6 +53,37 @@ block5(v5: i32):
 ; block8:
 ;   b label9
 ; block9:
+;   add w0, w0, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, #3
+;   b.hs #0x2c
+;   csel x15, xzr, x0, hs
+;   csdb
+;   adr x14, #0x20
+;   ldrsw x15, [x14, w15, uxtw #2]
+;   add x14, x14, x15
+;   br x14
+;   .byte 0x14, 0x00, 0x00, 0x00
+;   .byte 0x1c, 0x00, 0x00, 0x00
+;   .byte 0x24, 0x00, 0x00, 0x00
+; block1: ; offset 0x2c
+;   mov w5, #4
+; block2: ; offset 0x30
+;   b #0x48
+; block3: ; offset 0x34
+;   mov w5, #1
+; block4: ; offset 0x38
+;   b #0x48
+; block5: ; offset 0x3c
+;   mov w5, #2
+; block6: ; offset 0x40
+;   b #0x48
+; block7: ; offset 0x44
+;   mov w5, #3
+; block8: ; offset 0x48
 ;   add w0, w0, w5
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf.clif
@@ -10,6 +10,11 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
@@ -10,9 +10,17 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block0: ; offset 0x8
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/multivalue-ret.clif
@@ -9,8 +9,15 @@ block1:
   return v0, v1
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #1
 ;   movz x1, #2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #1
+;   mov x1, #2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/narrow-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/narrow-arithmetic.clif
@@ -8,7 +8,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add w0, w0, w1
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add w0, w0, w1
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   add w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   add w0, w0, w1
 ;   ret
 
@@ -39,8 +57,14 @@ block0(v0: i32, v1: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   add w0, w0, w1, SXTB
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add w0, w0, w1, sxtb
 ;   ret
 
 function %add64_32(i64, i32) -> i64 {
@@ -50,7 +74,13 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   add x0, x0, x1, SXTW
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x0, x0, w1, sxtw
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
@@ -10,7 +10,15 @@ block0:
     return
 }
 
+; VCode:
 ; block0:
+;   mov x1, x21
+;   add x1, x1, #1
+;   mov x21, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov x1, x21
 ;   add x1, x1, #1
 ;   mov x21, x1

--- a/cranelift/filetests/filetests/isa/aarch64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/prologue.clif
@@ -75,6 +75,7 @@ block0(v0: f64):
     return v62
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   stp d14, d15, [sp, #-16]!
@@ -150,6 +151,83 @@ block0(v0: f64):
 ;   ldp d14, d15, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+; block0: ; offset 0x18
+;   fadd d23, d0, d0
+;   fadd d24, d0, d0
+;   fadd d25, d0, d0
+;   fadd d26, d0, d0
+;   fadd d27, d0, d0
+;   fadd d28, d0, d0
+;   fadd d29, d0, d0
+;   fadd d30, d0, d0
+;   fadd d31, d0, d0
+;   fadd d1, d0, d0
+;   fadd d2, d0, d0
+;   fadd d3, d0, d0
+;   fadd d4, d0, d0
+;   fadd d5, d0, d0
+;   fadd d6, d0, d0
+;   fadd d7, d0, d0
+;   fadd d16, d0, d0
+;   fadd d17, d0, d0
+;   fadd d18, d0, d0
+;   fadd d19, d0, d0
+;   fadd d20, d0, d0
+;   fadd d21, d0, d0
+;   fadd d22, d0, d0
+;   fadd d15, d0, d0
+;   fadd d8, d0, d0
+;   fadd d9, d0, d0
+;   fadd d10, d0, d0
+;   fadd d11, d0, d0
+;   fadd d12, d0, d0
+;   fadd d13, d0, d0
+;   fadd d14, d0, d0
+;   fadd d23, d0, d23
+;   fadd d24, d24, d25
+;   fadd d25, d26, d27
+;   fadd d26, d28, d29
+;   fadd d27, d30, d31
+;   fadd d28, d1, d2
+;   fadd d29, d3, d4
+;   fadd d30, d5, d6
+;   fadd d31, d7, d16
+;   fadd d0, d17, d18
+;   fadd d1, d19, d20
+;   fadd d2, d21, d22
+;   fadd d3, d15, d8
+;   fadd d4, d9, d10
+;   fadd d5, d11, d12
+;   fadd d6, d13, d14
+;   fadd d23, d23, d24
+;   fadd d24, d25, d26
+;   fadd d25, d27, d28
+;   fadd d26, d29, d30
+;   fadd d27, d31, d0
+;   fadd d28, d1, d2
+;   fadd d29, d3, d4
+;   fadd d30, d5, d6
+;   fadd d23, d23, d24
+;   fadd d24, d25, d26
+;   fadd d25, d27, d28
+;   fadd d26, d29, d30
+;   fadd d23, d23, d24
+;   fadd d24, d25, d26
+;   fadd d0, d23, d24
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %f2(i64) -> i64 {
 block0(v0: i64):
@@ -197,6 +275,7 @@ block0(v0: i64):
     return v36
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x28, [sp, #-16]!
@@ -241,5 +320,52 @@ block0(v0: i64):
 ;   ldp x21, x27, [sp], #16
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x28, [sp, #-0x10]!
+;   stp x21, x27, [sp, #-0x10]!
+; block0: ; offset 0x10
+;   add x5, x0, x0
+;   add x6, x0, x5
+;   add x7, x0, x6
+;   add x8, x0, x7
+;   add x9, x0, x8
+;   add x10, x0, x9
+;   add x11, x0, x10
+;   add x12, x0, x11
+;   add x13, x0, x12
+;   add x14, x0, x13
+;   add x15, x0, x14
+;   add x1, x0, x15
+;   add x2, x0, x1
+;   add x3, x0, x2
+;   add x4, x0, x3
+;   add x27, x0, x4
+;   add x28, x0, x27
+;   add x21, x0, x28
+;   add x5, x0, x5
+;   add x6, x6, x7
+;   add x7, x8, x9
+;   add x8, x10, x11
+;   add x9, x12, x13
+;   add x10, x14, x15
+;   add x11, x1, x2
+;   add x12, x3, x4
+;   add x13, x27, x28
+;   add x5, x21, x5
+;   add x6, x6, x7
+;   add x7, x8, x9
+;   add x8, x10, x11
+;   add x9, x12, x13
+;   add x5, x5, x6
+;   add x6, x7, x8
+;   add x5, x9, x5
+;   add x0, x6, x5
+;   ldp x21, x27, [sp], #0x10
+;   ldr x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/reduce.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reduce.clif
@@ -8,7 +8,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_32(i128) -> i32 {
@@ -17,7 +22,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_16(i128) -> i16 {
@@ -26,7 +36,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_8(i128) -> i8 {
@@ -35,6 +50,11 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -7,7 +7,12 @@ block0(v0: r64):
   return v0
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %f1(r64) -> i8 {
@@ -16,8 +21,15 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   subs xzr, x0, #0
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, #0
 ;   cset x0, eq
 ;   ret
 
@@ -27,8 +39,15 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   adds xzr, x0, #1
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmn x0, #1
 ;   cset x0, eq
 ;   ret
 
@@ -38,8 +57,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   movz x0, #0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x0, #0
 ;   ret
 
 function %f4(r64, r64) -> r64, r64, r64 {
@@ -62,6 +87,7 @@ block3(v7: r64, v8: r64):
     return v7, v8, v9
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #32
@@ -92,5 +118,36 @@ block3(v7: r64, v8: r64):
 ;   ldr x2, [x2]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x20
+; block0: ; offset 0xc
+;   stur x0, [sp, #8]
+;   stur x1, [sp, #0x10]
+;   ldr x1, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x1
+;   mov x15, sp
+;   ldur x6, [sp, #8]
+;   str x6, [x15]
+;   uxtb w0, w0
+;   cbz x0, #0x48
+; block1: ; offset 0x3c
+;   mov x0, x6
+;   ldur x1, [sp, #0x10]
+;   b #0x50
+; block2: ; offset 0x48
+;   mov x1, x6
+;   ldur x0, [sp, #0x10]
+; block3: ; offset 0x50
+;   mov x2, sp
+;   ldr x2, [x2]
+;   add sp, sp, #0x20
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/select.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/select.clif
@@ -9,8 +9,15 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
     return v6
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, w1
+;   csel x0, x2, x3, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, w1
 ;   csel x0, x2, x3, eq
 ;   ret
 
@@ -22,7 +29,14 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
     return v6
 }
 
+; VCode:
 ; block0:
+;   fcmp s0, s1
+;   csel x0, x0, x1, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fcmp s0, s1
 ;   csel x0, x0, x1, eq
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/shift-op.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-op.clif
@@ -10,8 +10,14 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   add x0, x0, x0, LSL 3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x0, x0, x0, lsl #3
 ;   ret
 
 function %f(i32) -> i32 {
@@ -21,7 +27,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lsl w0, w0, #21
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsl w0, w0, #0x15
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
@@ -12,6 +12,7 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x5, #128
 ;   sub x7, x5, x2
@@ -36,6 +37,32 @@ block0(v0: i128, v1: i128):
 ;   orr x1, x8, x9
 ;   orr x0, x6, x7
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, #0x80
+;   sub x7, x5, x2
+;   lsr x9, x0, x2
+;   lsr x11, x1, x2
+;   mvn w13, w2
+;   lsl x15, x1, #1
+;   lsl x3, x15, x13
+;   orr x3, x9, x3
+;   tst x2, #0x40
+;   csel x6, x11, x3, ne
+;   csel x8, xzr, x11, ne
+;   lsl x10, x0, x7
+;   lsl x12, x1, x7
+;   mvn w14, w7
+;   lsr x0, x0, #1
+;   lsr x2, x0, x14
+;   orr x4, x12, x2
+;   tst x7, #0x40
+;   csel x7, xzr, x10, ne
+;   csel x9, x10, x4, ne
+;   orr x1, x8, x9
+;   orr x0, x6, x7
+;   ret
 
 function %f0(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -43,7 +70,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ror x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ror x0, x0, x1
 ;   ret
 
@@ -53,7 +86,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ror w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ror w0, w0, w1
 ;   ret
 
@@ -63,11 +102,23 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uxth w3, w0
 ;   and w5, w1, #15
 ;   sub w7, w5, #16
 ;   sub w9, wzr, w7
+;   lsr w11, w3, w5
+;   lsl w13, w3, w9
+;   orr w0, w13, w11
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w3, w0
+;   and w5, w1, #0xf
+;   sub w7, w5, #0x10
+;   neg w9, w7
 ;   lsr w11, w3, w5
 ;   lsl w13, w3, w9
 ;   orr w0, w13, w11
@@ -79,11 +130,23 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uxtb w3, w0
 ;   and w5, w1, #7
 ;   sub w7, w5, #8
 ;   sub w9, wzr, w7
+;   lsr w11, w3, w5
+;   lsl w13, w3, w9
+;   orr w0, w13, w11
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w3, w0
+;   and w5, w1, #7
+;   sub w7, w5, #8
+;   neg w9, w7
 ;   lsr w11, w3, w5
 ;   lsl w13, w3, w9
 ;   orr w0, w13, w11
@@ -95,6 +158,7 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x5, #128
 ;   sub x7, x5, x2
@@ -119,6 +183,32 @@ block0(v0: i128, v1: i128):
 ;   orr x0, x6, x7
 ;   orr x1, x8, x9
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x5, #0x80
+;   sub x7, x5, x2
+;   lsl x9, x0, x2
+;   lsl x11, x1, x2
+;   mvn w13, w2
+;   lsr x15, x0, #1
+;   lsr x3, x15, x13
+;   orr x3, x11, x3
+;   tst x2, #0x40
+;   csel x6, xzr, x9, ne
+;   csel x8, x9, x3, ne
+;   lsr x10, x0, x7
+;   lsr x12, x1, x7
+;   mvn w14, w7
+;   lsl x0, x1, #1
+;   lsl x2, x0, x14
+;   orr x4, x10, x2
+;   tst x7, #0x40
+;   csel x7, x12, x4, ne
+;   csel x9, xzr, x12, ne
+;   orr x0, x6, x7
+;   orr x1, x8, x9
+;   ret
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -126,8 +216,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sub x3, xzr, x1
+;   ror x0, x0, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg x3, x1
 ;   ror x0, x0, x3
 ;   ret
 
@@ -137,8 +234,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
+;   ror w0, w0, w3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
 ;   ror w0, w0, w3
 ;   ret
 
@@ -148,12 +252,25 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
 ;   uxth w5, w0
 ;   and w7, w3, #15
 ;   sub w9, w7, #16
 ;   sub w11, wzr, w9
+;   lsr w13, w5, w7
+;   lsl w15, w5, w11
+;   orr w0, w15, w13
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
+;   uxth w5, w0
+;   and w7, w3, #0xf
+;   sub w9, w7, #0x10
+;   neg w11, w9
 ;   lsr w13, w5, w7
 ;   lsl w15, w5, w11
 ;   orr w0, w15, w13
@@ -165,12 +282,25 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sub w3, wzr, w1
 ;   uxtb w5, w0
 ;   and w7, w3, #7
 ;   sub w9, w7, #8
 ;   sub w11, wzr, w9
+;   lsr w13, w5, w7
+;   lsl w15, w5, w11
+;   orr w0, w15, w13
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg w3, w1
+;   uxtb w5, w0
+;   and w7, w3, #7
+;   sub w9, w7, #8
+;   neg w11, w9
 ;   lsr w13, w5, w7
 ;   lsl w15, w5, w11
 ;   orr w0, w15, w13
@@ -182,7 +312,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lsr x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lsr x0, x0, x1
 ;   ret
 
@@ -192,7 +328,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lsr w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lsr w0, w0, w1
 ;   ret
 
@@ -202,9 +344,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uxth w3, w0
 ;   and w5, w1, #15
+;   lsr w0, w3, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w3, w0
+;   and w5, w1, #0xf
 ;   lsr w0, w3, w5
 ;   ret
 
@@ -214,7 +364,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   uxtb w3, w0
+;   and w5, w1, #7
+;   lsr w0, w3, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w3, w0
 ;   and w5, w1, #7
 ;   lsr w0, w3, w5
@@ -226,7 +384,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lsl x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lsl x0, x0, x1
 ;   ret
 
@@ -236,7 +400,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lsl w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lsl w0, w0, w1
 ;   ret
 
@@ -246,8 +416,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   and w3, w1, #15
+;   lsl w0, w0, w3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w3, w1, #0xf
 ;   lsl w0, w0, w3
 ;   ret
 
@@ -257,7 +434,14 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   and w3, w1, #7
+;   lsl w0, w0, w3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and w3, w1, #7
 ;   lsl w0, w0, w3
 ;   ret
@@ -268,7 +452,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   asr x0, x0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   asr x0, x0, x1
 ;   ret
 
@@ -278,7 +468,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   asr w0, w0, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   asr w0, w0, w1
 ;   ret
 
@@ -288,9 +484,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sxth w3, w0
 ;   and w5, w1, #15
+;   asr w0, w3, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sxth w3, w0
+;   and w5, w1, #0xf
 ;   asr w0, w3, w5
 ;   ret
 
@@ -300,7 +504,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sxtb w3, w0
+;   and w5, w1, #7
+;   asr w0, w3, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb w3, w0
 ;   and w5, w1, #7
 ;   asr w0, w3, w5
@@ -313,8 +525,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ror x0, x0, #17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ror x0, x0, #0x11
 ;   ret
 
 function %f21(i64) -> i64 {
@@ -324,8 +542,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ror x0, x0, #47
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ror x0, x0, #0x2f
 ;   ret
 
 function %f22(i32) -> i32 {
@@ -335,8 +559,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ror w0, w0, #15
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ror w0, w0, #0xf
 ;   ret
 
 function %f23(i16) -> i16 {
@@ -346,10 +576,19 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uxth w2, w0
 ;   lsr w4, w2, #6
 ;   lsl w6, w2, #10
+;   orr w0, w6, w4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uxth w2, w0
+;   lsr w4, w2, #6
+;   lsl w6, w2, #0xa
 ;   orr w0, w6, w4
 ;   ret
 
@@ -360,7 +599,16 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   uxtb w2, w0
+;   lsr w4, w2, #5
+;   lsl w6, w2, #3
+;   orr w0, w6, w4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w2, w0
 ;   lsr w4, w2, #5
 ;   lsl w6, w2, #3
@@ -374,8 +622,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lsr x0, x0, #17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsr x0, x0, #0x11
 ;   ret
 
 function %f26(i64) -> i64 {
@@ -385,8 +639,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   asr x0, x0, #17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   asr x0, x0, #0x11
 ;   ret
 
 function %f27(i64) -> i64 {
@@ -396,7 +656,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lsl x0, x0, #17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lsl x0, x0, #0x11
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
@@ -8,7 +8,13 @@ block0(v0: i8x8, v1: i8x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.8b, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.8b, v0.8b, v1.8b
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i16x4, v1: i16x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.4h, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.4h, v0.4h, v1.4h
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i32x2, v1: i32x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.2s, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.2s, v0.2s, v1.2s
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   urhadd v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   urhadd v0.4s, v0.4s, v1.4s
 ;   ret
 
@@ -68,8 +104,21 @@ block0(v0: i64x2, v1: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x4, #1
+;   dup v4.2d, x4
+;   orr v7.16b, v0.16b, v1.16b
+;   and v17.16b, v7.16b, v4.16b
+;   ushr v19.2d, v0.2d, #1
+;   ushr v21.2d, v1.2d, #1
+;   add v23.2d, v19.2d, v21.2d
+;   add v0.2d, v17.2d, v23.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x4, #1
 ;   dup v4.2d, x4
 ;   orr v7.16b, v0.16b, v1.16b
 ;   and v17.16b, v7.16b, v4.16b

--- a/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
@@ -8,7 +8,13 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   and v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   orr v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -68,7 +104,13 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -78,7 +120,13 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -88,7 +136,13 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   eor v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -101,11 +155,20 @@ block0:
     return v3
 }
 
+; VCode:
 ; block0:
 ;   movi v0.16b, #0
 ;   movi v3.16b, #0
 ;   movi v4.16b, #0
 ;   bsl v0.16b, v0.16b, v3.16b, v4.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   movi v0.16b, #0
+;   movi v3.16b, #0
+;   movi v4.16b, #0
+;   bsl v0.16b, v3.16b, v4.16b
 ;   ret
 
 function %vselect_i16x8(i16x8, i16x8, i16x8) -> i16x8 {
@@ -114,8 +177,14 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bsl v0.16b, v1.16b, v2.16b
 ;   ret
 
 function %vselect_f32x4(i32x4, f32x4, f32x4) -> f32x4 {
@@ -124,8 +193,14 @@ block0(v0: i32x4, v1: f32x4, v2: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bsl v0.16b, v1.16b, v2.16b
 ;   ret
 
 function %vselect_f64x2(i64x2, f64x2, f64x2) -> f64x2 {
@@ -134,8 +209,14 @@ block0(v0: i64x2, v1: f64x2, v2: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bsl v0.16b, v1.16b, v2.16b
 ;   ret
 
 function %ishl_i8x16(i32) -> i8x16 {
@@ -145,8 +226,22 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ldr q5, pc+8 ; b 20 ; data.f128 0x0f0e0d0c0b0a09080706050403020100
+;   and w3, w0, #7
+;   dup v6.16b, w3
+;   sshl v0.16b, v5.16b, v6.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr q5, #8
+;   b #0x18
+;   .byte 0x00, 0x01, 0x02, 0x03
+;   .byte 0x04, 0x05, 0x06, 0x07
+;   add w8, w8, w10, lsl #2
+;   .byte 0x0c, 0x0d, 0x0e, 0x0f
 ;   and w3, w0, #7
 ;   dup v6.16b, w3
 ;   sshl v0.16b, v5.16b, v6.16b
@@ -160,11 +255,27 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ldr q5, pc+8 ; b 20 ; data.f128 0x0f0e0d0c0b0a09080706050403020100
 ;   movz w1, #1
 ;   and w3, w1, #7
 ;   sub x5, xzr, x3
+;   dup v7.16b, w5
+;   ushl v0.16b, v5.16b, v7.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr q5, #8
+;   b #0x18
+;   .byte 0x00, 0x01, 0x02, 0x03
+;   .byte 0x04, 0x05, 0x06, 0x07
+;   add w8, w8, w10, lsl #2
+;   .byte 0x0c, 0x0d, 0x0e, 0x0f
+;   mov w1, #1
+;   and w3, w1, #7
+;   neg x5, x3
 ;   dup v7.16b, w5
 ;   ushl v0.16b, v5.16b, v7.16b
 ;   ret
@@ -176,10 +287,25 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ldr q6, pc+8 ; b 20 ; data.f128 0x0f0e0d0c0b0a09080706050403020100
 ;   and w3, w0, #7
 ;   sub x5, xzr, x3
+;   dup v7.16b, w5
+;   sshl v0.16b, v6.16b, v7.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr q6, #8
+;   b #0x18
+;   .byte 0x00, 0x01, 0x02, 0x03
+;   .byte 0x04, 0x05, 0x06, 0x07
+;   add w8, w8, w10, lsl #2
+;   .byte 0x0c, 0x0d, 0x0e, 0x0f
+;   and w3, w0, #7
+;   neg x5, x3
 ;   dup v7.16b, w5
 ;   sshl v0.16b, v6.16b, v7.16b
 ;   ret
@@ -190,10 +316,20 @@ block0(v0: i8x16, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w3, #3
 ;   and w5, w3, #7
 ;   sub x7, xzr, x5
+;   dup v17.16b, w7
+;   sshl v0.16b, v0.16b, v17.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #3
+;   and w5, w3, #7
+;   neg x7, x5
 ;   dup v17.16b, w7
 ;   sshl v0.16b, v0.16b, v17.16b
 ;   ret
@@ -204,9 +340,18 @@ block0(v0: i64x2, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   and w3, w0, #63
 ;   sub x5, xzr, x3
+;   dup v7.2d, x5
+;   sshl v0.2d, v0.2d, v7.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and w3, w0, #0x3f
+;   neg x5, x3
 ;   dup v7.2d, x5
 ;   sshl v0.2d, v0.2d, v7.2d
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
@@ -8,7 +8,14 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   cmeq v3.4s, v0.4s, v1.4s
+;   mvn v0.16b, v3.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v3.4s, v0.4s, v1.4s
 ;   mvn v0.16b, v3.16b
 ;   ret
@@ -19,7 +26,13 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   cmhi v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmhi v0.4s, v0.4s, v1.4s
 ;   ret
 
@@ -29,7 +42,13 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   cmge v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -39,7 +58,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   cmhs v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmhs v0.16b, v0.16b, v1.16b
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
@@ -10,7 +10,13 @@ block0(v0: i8x16, v1: i8x16):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull v0.8h, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull v0.8h, v0.8b, v1.8b
 ;   ret
 
@@ -22,7 +28,13 @@ block0(v0: i8x16, v1: i8x16):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull2 v0.8h, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull2 v0.8h, v0.16b, v1.16b
 ;   ret
 
@@ -34,7 +46,13 @@ block0(v0: i16x8, v1: i16x8):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull v0.4s, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull v0.4s, v0.4h, v1.4h
 ;   ret
 
@@ -46,7 +64,13 @@ block0(v0: i16x8, v1: i16x8):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull2 v0.4s, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull2 v0.4s, v0.8h, v1.8h
 ;   ret
 
@@ -58,7 +82,13 @@ block0(v0: i32x4, v1: i32x4):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull v0.2d, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull v0.2d, v0.2s, v1.2s
 ;   ret
 
@@ -70,7 +100,13 @@ block0(v0: i32x4, v1: i32x4):
   return v4
 }
 
+; VCode:
 ; block0:
+;   smull2 v0.2d, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smull2 v0.2d, v0.4s, v1.4s
 ;   ret
 
@@ -82,7 +118,13 @@ block0(v0: i8x16, v1: i8x16):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull v0.8h, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull v0.8h, v0.8b, v1.8b
 ;   ret
 
@@ -94,7 +136,13 @@ block0(v0: i8x16, v1: i8x16):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull2 v0.8h, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull2 v0.8h, v0.16b, v1.16b
 ;   ret
 
@@ -106,7 +154,13 @@ block0(v0: i16x8, v1: i16x8):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull v0.4s, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull v0.4s, v0.4h, v1.4h
 ;   ret
 
@@ -118,7 +172,13 @@ block0(v0: i16x8, v1: i16x8):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull2 v0.4s, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull2 v0.4s, v0.8h, v1.8h
 ;   ret
 
@@ -130,7 +190,13 @@ block0(v0: i32x4, v1: i32x4):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull v0.2d, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull v0.2d, v0.2s, v1.2s
 ;   ret
 
@@ -142,7 +208,13 @@ block0(v0: i32x4, v1: i32x4):
   return v4
 }
 
+; VCode:
 ; block0:
+;   umull2 v0.2d, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umull2 v0.2d, v0.4s, v1.4s
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
@@ -12,12 +12,27 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movi v30.16b, #0
 ;   movz x4, #1
 ;   fmov s31, w4
 ;   ldr q3, pc+8 ; b 20 ; data.f128 0x11000000000000000000000000000000
 ;   tbl v0.16b, { v30.16b, v31.16b }, v3.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   movi v30.16b, #0
+;   mov x4, #1
+;   fmov s31, w4
+;   ldr q3, #0x14
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   add w0, w0, #0
+;   tbl v0.16b, {v30.16b, v31.16b}, v3.16b
 ;   ret
 
 function %shuffle_same_ssa_value() -> i8x16 {
@@ -27,12 +42,27 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x3, #1
 ;   fmov s31, w3
 ;   ldr q2, pc+8 ; b 20 ; data.f128 0x13000000000000000000000000000000
 ;   mov v30.16b, v31.16b
 ;   tbl v0.16b, { v30.16b, v31.16b }, v2.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x3, #1
+;   fmov s31, w3
+;   ldr q2, #0x10
+;   b #0x20
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   sbfx w0, w0, #0, #1
+;   mov v30.16b, v31.16b
+;   tbl v0.16b, {v30.16b, v31.16b}, v2.16b
 ;   ret
 
 function %swizzle() -> i8x16 {
@@ -43,10 +73,28 @@ block0:
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ldr q2, pc+8 ; b 20 ; data.f128 0x0f0e0d0c0b0a09080706050403020100
 ;   ldr q3, pc+8 ; b 20 ; data.f128 0x0f0e0d0c0b0a09080706050403020100
 ;   tbl v0.16b, { v2.16b }, v3.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr q2, #8
+;   b #0x18
+;   .byte 0x00, 0x01, 0x02, 0x03
+;   .byte 0x04, 0x05, 0x06, 0x07
+;   add w8, w8, w10, lsl #2
+;   .byte 0x0c, 0x0d, 0x0e, 0x0f
+;   ldr q3, #0x20
+;   b #0x30
+;   .byte 0x00, 0x01, 0x02, 0x03
+;   .byte 0x04, 0x05, 0x06, 0x07
+;   add w8, w8, w10, lsl #2
+;   .byte 0x0c, 0x0d, 0x0e, 0x0f
+;   tbl v0.16b, {v2.16b}, v3.16b
 ;   ret
 
 function %splat_i8(i8) -> i8x16 {
@@ -55,7 +103,13 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   dup v0.16b, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v0.16b, w0
 ;   ret
 
@@ -66,8 +120,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   movi v0.16b, #255
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   movi v0.16b, #0xff
 ;   ret
 
 function %splat_i32(i32) -> i32x4 {
@@ -76,7 +136,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   dup v0.4s, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v0.4s, w0
 ;   ret
 
@@ -86,7 +152,13 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   dup v0.2d, v0.d[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   dup v0.2d, v0.d[0]
 ;   ret
 
@@ -97,7 +169,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   ldr w3, [x0]
+;   fmov s0, w3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldr w3, [x0]
 ;   fmov s0, w3
 ;   ret
@@ -108,7 +187,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s0, w0
 ;   ret
 
@@ -118,7 +203,13 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   fmov s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fmov s0, s0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
@@ -8,7 +8,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   mvn v0.16b, v0.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mvn v0.16b, v0.16b
 ;   ret
 
@@ -18,10 +24,19 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   umaxp v2.4s, v0.4s, v0.4s
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   umaxp v2.4s, v0.4s, v0.4s
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -31,7 +46,16 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.2d, v0.2d, #0
+;   addp v4.2d, v2.2d, v2.2d
+;   fcmp d4, d4
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
 ;   addp v4.2d, v2.2d, v2.2d
 ;   fcmp d4, d4

--- a/cranelift/filetests/filetests/isa/aarch64/simd-min-max.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-min-max.clif
@@ -8,7 +8,13 @@ block0(v0: i8x8, v1: i8x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.8b, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.8b, v0.8b, v1.8b
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i16x4, v1: i16x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.4h, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.4h, v0.4h, v1.4h
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i32x2, v1: i32x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.2s, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.2s, v0.2s, v1.2s
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smin v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smin v0.4s, v0.4s, v1.4s
 ;   ret
 
@@ -68,7 +104,13 @@ block0(v0: i8x8, v1: i8x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.8b, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.8b, v0.8b, v1.8b
 ;   ret
 
@@ -78,7 +120,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -88,7 +136,13 @@ block0(v0: i16x4, v1: i16x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.4h, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.4h, v0.4h, v1.4h
 ;   ret
 
@@ -98,7 +152,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -108,7 +168,13 @@ block0(v0: i32x2, v1: i32x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.2s, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.2s, v0.2s, v1.2s
 ;   ret
 
@@ -118,7 +184,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umin v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umin v0.4s, v0.4s, v1.4s
 ;   ret
 
@@ -128,7 +200,13 @@ block0(v0: i8x8, v1: i8x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.8b, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.8b, v0.8b, v1.8b
 ;   ret
 
@@ -138,7 +216,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -148,7 +232,13 @@ block0(v0: i16x4, v1: i16x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.4h, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.4h, v0.4h, v1.4h
 ;   ret
 
@@ -158,7 +248,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -168,7 +264,13 @@ block0(v0: i32x2, v1: i32x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.2s, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.2s, v0.2s, v1.2s
 ;   ret
 
@@ -178,7 +280,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   smax v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   smax v0.4s, v0.4s, v1.4s
 ;   ret
 
@@ -188,7 +296,13 @@ block0(v0: i8x8, v1: i8x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.8b, v0.8b, v1.8b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.8b, v0.8b, v1.8b
 ;   ret
 
@@ -198,7 +312,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.16b, v0.16b, v1.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.16b, v0.16b, v1.16b
 ;   ret
 
@@ -208,7 +328,13 @@ block0(v0: i16x4, v1: i16x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.4h, v0.4h, v1.4h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.4h, v0.4h, v1.4h
 ;   ret
 
@@ -218,7 +344,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.8h, v0.8h, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.8h, v0.8h, v1.8h
 ;   ret
 
@@ -228,7 +360,13 @@ block0(v0: i32x2, v1: i32x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.2s, v0.2s, v1.2s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.2s, v0.2s, v1.2s
 ;   ret
 
@@ -238,7 +376,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   umax v0.4s, v0.4s, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   umax v0.4s, v0.4s, v1.4s
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
@@ -8,9 +8,17 @@ block0(v0: i16x4, v1: i16x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   sqxtn v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   sqxtn v0.8b, v3.8h
 ;   ret
 
@@ -20,9 +28,16 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtn v0.8b, v0.8h
 ;   sqxtn2 v0.16b, v0.16b, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtn v0.8b, v0.8h
+;   sqxtn2 v0.16b, v1.8h
 ;   ret
 
 function %snarrow_i32x2(i32x2, i32x2) -> i16x4 {
@@ -31,9 +46,17 @@ block0(v0: i32x2, v1: i32x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   sqxtn v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   sqxtn v0.4h, v3.4s
 ;   ret
 
@@ -43,9 +66,16 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtn v0.4h, v0.4s
 ;   sqxtn2 v0.8h, v0.8h, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtn v0.4h, v0.4s
+;   sqxtn2 v0.8h, v1.4s
 ;   ret
 
 function %snarrow_i64x2(i64x2, i64x2) -> i32x4 {
@@ -54,9 +84,16 @@ block0(v0: i64x2, v1: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtn v0.2s, v0.2d
 ;   sqxtn2 v0.4s, v0.4s, v1.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtn v0.2s, v0.2d
+;   sqxtn2 v0.4s, v1.2d
 ;   ret
 
 function %unarrow_i16x4(i16x4, i16x4) -> i8x8 {
@@ -65,9 +102,17 @@ block0(v0: i16x4, v1: i16x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   sqxtun v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   sqxtun v0.8b, v3.8h
 ;   ret
 
@@ -77,9 +122,16 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtun v0.8b, v0.8h
 ;   sqxtun2 v0.16b, v0.16b, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtun v0.8b, v0.8h
+;   sqxtun2 v0.16b, v1.8h
 ;   ret
 
 function %unarrow_i32x2(i32x2, i32x2) -> i16x4 {
@@ -88,9 +140,17 @@ block0(v0: i32x2, v1: i32x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   sqxtun v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   sqxtun v0.4h, v3.4s
 ;   ret
 
@@ -100,9 +160,16 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtun v0.4h, v0.4s
 ;   sqxtun2 v0.8h, v0.8h, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtun v0.4h, v0.4s
+;   sqxtun2 v0.8h, v1.4s
 ;   ret
 
 function %unarrow_i64x2(i64x2, i64x2) -> i32x4 {
@@ -111,9 +178,16 @@ block0(v0: i64x2, v1: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sqxtun v0.2s, v0.2d
 ;   sqxtun2 v0.4s, v0.4s, v1.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sqxtun v0.2s, v0.2d
+;   sqxtun2 v0.4s, v1.2d
 ;   ret
 
 function %uunarrow_i16x4(i16x4, i16x4) -> i8x8 {
@@ -122,9 +196,17 @@ block0(v0: i16x4, v1: i16x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   uqxtn v0.8b, v3.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   uqxtn v0.8b, v3.8h
 ;   ret
 
@@ -134,9 +216,16 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   uqxtn v0.8b, v0.8h
 ;   uqxtn2 v0.16b, v0.16b, v1.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uqxtn v0.8b, v0.8h
+;   uqxtn2 v0.16b, v1.8h
 ;   ret
 
 function %uunarrow_i32x2(i32x2, i32x2) -> i16x4 {
@@ -145,9 +234,17 @@ block0(v0: i32x2, v1: i32x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mov v3.16b, v0.16b
 ;   mov v3.d[1], v3.d[1], v1.d[0]
+;   uqxtn v0.4h, v3.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov v3.16b, v0.16b
+;   mov v3.d[1], v1.d[0]
 ;   uqxtn v0.4h, v3.4s
 ;   ret
 
@@ -157,9 +254,16 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   uqxtn v0.4h, v0.4s
 ;   uqxtn2 v0.8h, v0.8h, v1.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uqxtn v0.4h, v0.4s
+;   uqxtn2 v0.8h, v1.4s
 ;   ret
 
 function %uunarrow_i64x2(i64x2, i64x2) -> i32x4 {
@@ -168,9 +272,16 @@ block0(v0: i64x2, v1: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   uqxtn v0.2s, v0.2d
 ;   uqxtn2 v0.4s, v0.4s, v1.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uqxtn v0.2s, v0.2d
+;   uqxtn2 v0.4s, v1.2d
 ;   ret
 
 function %snarrow_i16x8_zero(i16x8) -> i8x16 {
@@ -180,7 +291,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtn v0.8b, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtn v0.8b, v0.8h
 ;   ret
 
@@ -191,7 +308,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtn v0.4h, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtn v0.4h, v0.4s
 ;   ret
 
@@ -202,7 +325,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtn v0.2s, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtn v0.2s, v0.2d
 ;   ret
 
@@ -213,7 +342,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtun v0.8b, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtun v0.8b, v0.8h
 ;   ret
 
@@ -224,7 +359,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtun v0.4h, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtun v0.4h, v0.4s
 ;   ret
 
@@ -235,7 +376,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   sqxtun v0.2s, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqxtun v0.2s, v0.2d
 ;   ret
 
@@ -246,7 +393,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   uqxtn v0.8b, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uqxtn v0.8b, v0.8h
 ;   ret
 
@@ -257,7 +410,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   uqxtn v0.4h, v0.4s
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uqxtn v0.4h, v0.4s
 ;   ret
 
@@ -268,7 +427,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   uqxtn v0.2s, v0.2d
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uqxtn v0.2s, v0.2d
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
@@ -9,7 +9,13 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   saddlp v0.8h, v0.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   saddlp v0.8h, v0.16b
 ;   ret
 
@@ -21,7 +27,13 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   saddlp v0.4s, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   saddlp v0.4s, v0.8h
 ;   ret
 
@@ -33,7 +45,13 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   uaddlp v0.8h, v0.16b
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uaddlp v0.8h, v0.16b
 ;   ret
 
@@ -45,7 +63,13 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   uaddlp v0.4s, v0.8h
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uaddlp v0.4s, v0.8h
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-valltrue.clif
@@ -8,10 +8,19 @@ block0(v0: i8x8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uminv b2, v0.8b
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uminv b2, v0.8b
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -21,10 +30,19 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uminv b2, v0.16b
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uminv b2, v0.16b
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -34,10 +52,19 @@ block0(v0: i16x4):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uminv h2, v0.4h
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uminv h2, v0.4h
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -47,10 +74,19 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uminv h2, v0.8h
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uminv h2, v0.8h
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -60,10 +96,19 @@ block0(v0: i32x2):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mov x2, v0.d[0]
 ;   subs xzr, xzr, x2, LSR 32
 ;   ccmp w2, #0, #nZcv, ne
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, v0.d[0]
+;   cmp xzr, x2, lsr #32
+;   ccmp w2, #0, #4, ne
 ;   cset x0, ne
 ;   ret
 
@@ -73,10 +118,19 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uminv s2, v0.4s
 ;   mov x4, v2.d[0]
 ;   subs xzr, x4, #0
+;   cset x0, ne
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   uminv s2, v0.4s
+;   mov x4, v2.d[0]
+;   cmp x4, #0
 ;   cset x0, ne
 ;   ret
 
@@ -86,7 +140,16 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   cmeq v2.2d, v0.2d, #0
+;   addp v4.2d, v2.2d, v2.2d
+;   fcmp d4, d4
+;   cset x0, eq
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
 ;   addp v4.2d, v2.2d, v2.2d
 ;   fcmp d4, d4

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -9,9 +9,17 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #1
 ;   movk x1, x1, #1, LSL #48
+;   dup v0.2d, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #1
+;   movk x1, #1, lsl #48
 ;   dup v0.2d, x1
 ;   ret
 
@@ -23,8 +31,15 @@ block0:
   return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #42679
+;   dup v0.8h, w1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #0xa6b7
 ;   dup v0.8h, w1
 ;   ret
 
@@ -34,9 +49,19 @@ block0(v0: i32, v1: i8x16, v2: i8x16):
    return v3
 }
 
+; VCode:
 ; block0:
 ;   subs wzr, w0, wzr
 ;   vcsel v0.16b, v0.16b, v1.16b, ne (if-then-else diamond)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp w0, wzr
+;   b.ne #0x10
+;   mov v0.16b, v1.16b
+;   b #0x14
+;   mov v0.16b, v0.16b
 ;   ret
 
 function %f5(i64) -> i8x16 {
@@ -46,8 +71,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ld1r { v0.16b }, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld1r {v0.16b}, [x0]
 ;   ret
 
 function %f6(i64, i64) -> i8x16, i8x16 {
@@ -59,9 +90,16 @@ block0(v0: i64, v1: i64):
   return v4, v5
 }
 
+; VCode:
 ; block0:
 ;   ld1r { v0.16b }, [x0]
 ;   ld1r { v1.16b }, [x1]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld1r {v0.16b}, [x0]
+;   ld1r {v1.16b}, [x1]
 ;   ret
 
 function %f7(i64, i64) -> i8x16, i8x16 {
@@ -73,9 +111,17 @@ block0(v0: i64, v1: i64):
   return v4, v5
 }
 
+; VCode:
 ; block0:
 ;   ldrb w5, [x0]
 ;   ld1r { v0.16b }, [x1]
+;   dup v1.16b, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldrb w5, [x0]
+;   ld1r {v0.16b}, [x1]
 ;   dup v1.16b, w5
 ;   ret
 
@@ -87,7 +133,15 @@ block0(v0: i64, v1: i64):
   return v3, v4
 }
 
+; VCode:
 ; block0:
+;   ldrb w5, [x0]
+;   dup v0.16b, w5
+;   dup v1.16b, w5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldrb w5, [x0]
 ;   dup v0.16b, w5
 ;   dup v1.16b, w5
@@ -100,8 +154,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   movi v1.2d, #18374687579166474495
+;   fmov d0, d1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   movi v1.2d, #0xff0000ffff0000ff
 ;   fmov d0, d1
 ;   ret
 
@@ -112,8 +173,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   mvni v0.4s, #15, MSL #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvni v0.4s, #0xf, msl #16
 ;   ret
 
 function %f11() -> f32x4 {
@@ -123,7 +190,13 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmov v0.4s, #1.3125
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov v0.4s, #1.31250000
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/simd_load_zero.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd_load_zero.clif
@@ -9,9 +9,17 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   movz x1, #1
 ;   movk x1, x1, #1, LSL #48
+;   fmov d0, x1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x1, #1
+;   movk x1, #1, lsl #48
 ;   fmov d0, x1
 ;   ret
 
@@ -22,8 +30,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   movz w0, #42679
+;   fmov s0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w0, #0xa6b7
 ;   fmov s0, w0
 ;   ret
 
@@ -34,8 +49,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmov s0, #1
+;   fmov s0, s0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov s0, #1.00000000
 ;   fmov s0, s0
 ;   ret
 
@@ -46,8 +68,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmov d0, #1
+;   fmov d0, d0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d0, #1.00000000
 ;   fmov d0, d0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -7,7 +7,12 @@ block0:
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_leaf_zero(i64 stack_limit) {
@@ -15,7 +20,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
@@ -27,7 +37,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_call_zero(i64 stack_limit) {
@@ -37,6 +52,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   subs xzr, sp, x0, UXTX
@@ -45,6 +61,21 @@ block0(v0: i64):
 ;   load_ext_name x2, TestCase(%foo)+0
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   cmp sp, x0
+;   b.hs #0x14
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+; block0: ; offset 0x14
+;   ldr x2, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x2
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
@@ -58,6 +89,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   ldr x16, [x0]
@@ -69,6 +101,23 @@ block0(v0: i64):
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   ldur x16, [x0]
+;   ldur x16, [x16, #4]
+;   cmp sp, x16
+;   b.hs #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+; block0: ; offset 0x1c
+;   ldr x2, #0x24
+;   b #0x2c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x2
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %stack_limit(i64 stack_limit) {
     ss0 = explicit_slot 168
@@ -76,6 +125,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   add x16, x0, #176
@@ -86,6 +136,19 @@ block0(v0: i64):
 ;   add sp, sp, #176
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   add x16, x0, #0xb0
+;   cmp sp, x16
+;   b.hs #0x18
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   sub sp, sp, #0xb0
+; block0: ; offset 0x1c
+;   add sp, sp, #0xb0
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %huge_stack_limit(i64 stack_limit) {
     ss0 = explicit_slot 400000
@@ -93,6 +156,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   subs xzr, sp, x0, UXTX
@@ -111,6 +175,28 @@ block0(v0: i64):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   cmp sp, x0
+;   b.hs #0x14
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   mov w17, #0x1a80
+;   movk w17, #6, lsl #16
+;   add x16, x0, x17, uxtx
+;   cmp sp, x16
+;   b.hs #0x2c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   mov w16, #0x1a80
+;   movk w16, #6, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x38
+;   mov w16, #0x1a80
+;   movk w16, #6, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %limit_preamble(i64 vmctx) {
     gv0 = vmctx
@@ -122,6 +208,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   ldr x16, [x0]
@@ -134,6 +221,21 @@ block0(v0: i64):
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   ldur x16, [x0]
+;   ldur x16, [x16, #4]
+;   add x16, x16, #0x20
+;   cmp sp, x16
+;   b.hs #0x20
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   sub sp, sp, #0x20
+; block0: ; offset 0x24
+;   add sp, sp, #0x20
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %limit_preamble_huge(i64 vmctx) {
     gv0 = vmctx
@@ -145,6 +247,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   ldr x16, [x0]
@@ -165,6 +268,30 @@ block0(v0: i64):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   ldur x16, [x0]
+;   ldur x16, [x16, #4]
+;   cmp sp, x16
+;   b.hs #0x1c
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   mov w17, #0x1a80
+;   movk w17, #6, lsl #16
+;   add x16, x16, x17, uxtx
+;   cmp sp, x16
+;   b.hs #0x34
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   mov w16, #0x1a80
+;   movk w16, #6, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x40
+;   mov w16, #0x1a80
+;   movk w16, #6, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %limit_preamble_huge_offset(i64 vmctx) {
     gv0 = vmctx
@@ -175,6 +302,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #6784 ; movk w16, w16, #6, LSL #16 ; ldr x16, [x0, x16, SXTX]
@@ -185,5 +313,21 @@ block0(v0: i64):
 ; block0:
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x1a80
+;   movk w16, #6, lsl #16
+;   ldr x16, [x0, x16, sxtx]
+;   add x16, x16, #0x20
+;   cmp sp, x16
+;   b.hs #0x24
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
+;   sub sp, sp, #0x20
+; block0: ; offset 0x28
+;   add sp, sp, #0x20
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -10,6 +10,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -17,6 +18,16 @@ block0:
 ;   mov x0, sp
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x0, sp
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %stack_addr_big() -> i64 {
@@ -28,6 +39,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #34480
@@ -40,6 +52,20 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x14
+;   mov x0, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %stack_load_small() -> i64 {
 ss0 = explicit_slot 8
@@ -49,6 +75,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -57,6 +84,17 @@ block0:
 ;   ldr x0, [x1]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x1, sp
+;   ldr x0, [x1]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %stack_load_big() -> i64 {
@@ -68,6 +106,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #34480
@@ -81,6 +120,21 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x14
+;   mov x1, sp
+;   ldr x0, [x1]
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %stack_store_small(i64) {
 ss0 = explicit_slot 8
@@ -90,6 +144,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -98,6 +153,17 @@ block0(v0: i64):
 ;   str x0, [x2]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x2, sp
+;   str x0, [x2]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %stack_store_big(i64) {
@@ -109,6 +175,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #34480
@@ -121,6 +188,21 @@ block0(v0: i64):
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x14
+;   mov x2, sp
+;   str x0, [x2]
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %i8_spill_slot(i8) -> i8, i64 {
@@ -274,6 +356,7 @@ block0(v0: i8):
   return v0, v137
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   stp x27, x28, [sp, #-16]!
@@ -429,6 +512,163 @@ block0(v0: i8):
 ;   ldp x27, x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   sub sp, sp, #0x480
+; block0: ; offset 0x20
+;   str x0, [sp, #0x3e8]
+;   mov x6, #2
+;   add x9, x6, #1
+;   str x9, [sp, #0x470]
+;   mov x6, #4
+;   add x10, x6, #3
+;   str x10, [sp, #0x468]
+;   mov x6, #6
+;   add x11, x6, #5
+;   str x11, [sp, #0x460]
+;   mov x6, #8
+;   add x12, x6, #7
+;   str x12, [sp, #0x458]
+;   mov x6, #0xa
+;   add x13, x6, #9
+;   str x13, [sp, #0x450]
+;   mov x6, #0xc
+;   add x14, x6, #0xb
+;   str x14, [sp, #0x448]
+;   mov x6, #0xe
+;   add x15, x6, #0xd
+;   str x15, [sp, #0x440]
+;   mov x6, #0x10
+;   add x1, x6, #0xf
+;   str x1, [sp, #0x438]
+;   mov x6, #0x12
+;   add x2, x6, #0x11
+;   str x2, [sp, #0x430]
+;   mov x6, #0x14
+;   add x3, x6, #0x13
+;   str x3, [sp, #0x428]
+;   mov x6, #0x16
+;   add x4, x6, #0x15
+;   str x4, [sp, #0x420]
+;   mov x6, #0x18
+;   add x5, x6, #0x17
+;   str x5, [sp, #0x418]
+;   mov x6, #0x1a
+;   add x6, x6, #0x19
+;   str x6, [sp, #0x410]
+;   mov x6, #0x1c
+;   add x7, x6, #0x1b
+;   str x7, [sp, #0x408]
+;   mov x6, #0x1e
+;   add x24, x6, #0x1d
+;   str x24, [sp, #0x400]
+;   mov x6, #0x20
+;   add x25, x6, #0x1f
+;   str x25, [sp, #0x3f8]
+;   mov x6, #0x22
+;   add x26, x6, #0x21
+;   mov x6, #0x24
+;   add x27, x6, #0x23
+;   str x27, [sp, #0x3f0]
+;   mov x6, #0x26
+;   add x27, x6, #0x25
+;   mov x6, #0x1e
+;   add x28, x6, #0x27
+;   mov x6, #0x20
+;   add x21, x6, #0x1f
+;   mov x6, #0x22
+;   add x19, x6, #0x21
+;   mov x6, #0x24
+;   add x20, x6, #0x23
+;   mov x6, #0x26
+;   add x22, x6, #0x25
+;   mov x6, #0x1e
+;   add x23, x6, #0x27
+;   mov x6, #0x20
+;   add x0, x6, #0x1f
+;   mov x6, #0x22
+;   add x8, x6, #0x21
+;   mov x6, #0x24
+;   add x9, x6, #0x23
+;   mov x6, #0x26
+;   add x10, x6, #0x25
+;   mov x6, #0x1e
+;   add x11, x6, #0x27
+;   mov x6, #0x20
+;   add x12, x6, #0x1f
+;   mov x6, #0x22
+;   add x13, x6, #0x21
+;   mov x6, #0x24
+;   add x14, x6, #0x23
+;   mov x6, #0x26
+;   add x15, x6, #0x25
+;   ldr x1, [sp, #0x470]
+;   add x1, x1, #0x27
+;   ldr x3, [sp, #0x460]
+;   ldr x2, [sp, #0x468]
+;   add x2, x2, x3
+;   ldr x3, [sp, #0x450]
+;   ldr x6, [sp, #0x458]
+;   add x3, x6, x3
+;   ldr x4, [sp, #0x440]
+;   ldr x5, [sp, #0x448]
+;   add x4, x5, x4
+;   ldr x5, [sp, #0x430]
+;   ldr x6, [sp, #0x438]
+;   add x5, x6, x5
+;   ldr x7, [sp, #0x420]
+;   ldr x6, [sp, #0x428]
+;   add x6, x6, x7
+;   ldr x7, [sp, #0x410]
+;   ldr x24, [sp, #0x418]
+;   add x7, x24, x7
+;   ldr x24, [sp, #0x400]
+;   ldr x25, [sp, #0x408]
+;   add x24, x25, x24
+;   ldr x25, [sp, #0x3f8]
+;   add x25, x25, x26
+;   ldr x26, [sp, #0x3f0]
+;   add x26, x26, x27
+;   add x27, x28, x21
+;   add x28, x19, x20
+;   add x23, x22, x23
+;   add x8, x0, x8
+;   add x9, x9, x10
+;   add x10, x11, x12
+;   add x11, x13, x14
+;   add x12, x15, x1
+;   add x13, x2, x3
+;   add x14, x4, x5
+;   add x7, x6, x7
+;   add x15, x24, x25
+;   add x0, x26, x27
+;   add x1, x28, x23
+;   add x8, x8, x9
+;   add x9, x10, x11
+;   add x10, x12, x13
+;   add x7, x14, x7
+;   add x11, x15, x0
+;   add x8, x1, x8
+;   add x9, x9, x10
+;   add x7, x7, x11
+;   add x8, x8, x9
+;   add x1, x7, x8
+;   ldr x0, [sp, #0x3e8]
+;   add sp, sp, #0x480
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %i128_stack_store(i128) {
 ss0 = explicit_slot 16
@@ -438,6 +678,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -446,6 +687,17 @@ block0(v0: i128):
 ;   stp x0, x1, [x3]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x3, sp
+;   stp x0, x1, [x3]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %i128_stack_store_inst_offset(i128) {
@@ -457,6 +709,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #32
@@ -465,6 +718,17 @@ block0(v0: i128):
 ;   stp x0, x1, [x3]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x20
+; block0: ; offset 0xc
+;   add x3, sp, #0x20
+;   stp x0, x1, [x3]
+;   add sp, sp, #0x20
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %i128_stack_store_big(i128) {
@@ -476,6 +740,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #34480
@@ -489,6 +754,21 @@ block0(v0: i128):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x14
+;   mov x3, sp
+;   stp x0, x1, [x3]
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
+;   ret
 
 function %i128_stack_load() -> i128 {
 ss0 = explicit_slot 16
@@ -498,6 +778,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #16
@@ -506,6 +787,17 @@ block0:
 ;   ldp x0, x1, [x2]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block0: ; offset 0xc
+;   mov x2, sp
+;   ldp x0, x1, [x2]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %i128_stack_load_inst_offset() -> i128 {
@@ -517,6 +809,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   sub sp, sp, #32
@@ -525,6 +818,17 @@ block0:
 ;   ldp x0, x1, [x2]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x20
+; block0: ; offset 0xc
+;   add x2, sp, #0x20
+;   ldp x0, x1, [x2]
+;   add sp, sp, #0x20
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %i128_stack_load_big() -> i128 {
@@ -536,6 +840,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   movz w16, #34480
@@ -548,5 +853,20 @@ block0:
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   sub sp, sp, x16
+; block0: ; offset 0x14
+;   mov x2, sp
+;   ldp x0, x1, [x2]
+;   mov w16, #0x86b0
+;   movk w16, #1, lsl #16
+;   add sp, sp, x16
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
@@ -11,7 +11,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   load_ext_name x0, TestCase(%my_global)+0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   adrp x0, #0 ; reloc_external Aarch64AdrGotPage21 %my_global 0
+;   ldr x0, [x0] ; reloc_external Aarch64AdrGotLo12Nc %my_global 0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
@@ -10,7 +10,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   load_ext_name x0, TestCase(%my_global)+0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr x0, #8
+;   b #0x10
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %my_global 0
+;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
@@ -10,6 +10,7 @@ block0(v0: i32):
     return v0, v1
 }
 
+; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ;   str x24, [sp, #-16]!
@@ -28,5 +29,29 @@ block0(v0: i32):
 ;   ldp d14, d15, [sp], #16
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   str x24, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+; block0: ; offset 0x1c
+;   mov x24, x0
+;   adrp x0, #0 ; reloc_external Aarch64TlsGdAdrPage21 u1:0 0
+;   add x0, x0, #0 ; reloc_external Aarch64TlsGdAddLo12Nc u1:0 0
+;   bl #0x28 ; reloc_external Call %ElfTlsGetAddr 0
+;   nop
+;   mov x1, x0
+;   mov x0, x24
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldr x24, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/traps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/traps.clif
@@ -6,8 +6,13 @@ block0:
   trap user0
 }
 
+; VCode:
 ; block0:
 ;   udf #0xc11f
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 
 function %trap_iadd_ifcout(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -15,8 +20,16 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   adds x3, x0, x1
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   adds x3, x0, x1
+;   b.lo #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/uadd_overflow_trap.clif
@@ -8,10 +8,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w2, #127
 ;   adds w0, w0, w2
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #0x7f
+;   adds w0, w0, w2
+;   b.lo #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f1(i32) -> i32 {
@@ -21,10 +30,19 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz w2, #127
 ;   adds w0, w2, w0
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #0x7f
+;   adds w0, w2, w0
+;   b.lo #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f2(i32, i32) -> i32 {
@@ -33,9 +51,17 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   adds w0, w0, w1
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   adds w0, w0, w1
+;   b.lo #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -45,10 +71,19 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #127
 ;   adds x0, x0, x2
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #0x7f
+;   adds x0, x0, x2
+;   b.lo #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -58,10 +93,19 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   movz x2, #127
 ;   adds x0, x2, x0
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #0x7f
+;   adds x0, x2, x0
+;   b.lo #0x10
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -70,8 +114,16 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   adds x0, x0, x1
 ;   b.lo 8 ; udf
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   adds x0, x0, x1
+;   b.lo #0xc
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/uextend-sextend.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/uextend-sextend.clif
@@ -8,7 +8,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   uxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w0, w0
 ;   ret
 
@@ -18,7 +24,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   uxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w0, w0
 ;   ret
 
@@ -28,7 +40,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   uxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxtb w0, w0
 ;   ret
 
@@ -38,7 +56,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtb x0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb x0, w0
 ;   ret
 
@@ -48,7 +72,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb w0, w0
 ;   ret
 
@@ -58,7 +88,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtb w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtb w0, w0
 ;   ret
 
@@ -68,7 +104,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   uxth w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxth w0, w0
 ;   ret
 
@@ -78,7 +120,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   uxth w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   uxth w0, w0
 ;   ret
 
@@ -88,7 +136,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxth x0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxth x0, w0
 ;   ret
 
@@ -98,7 +152,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxth w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxth w0, w0
 ;   ret
 
@@ -108,7 +168,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   mov w0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mov w0, w0
 ;   ret
 
@@ -118,7 +184,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sxtw x0, w0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sxtw x0, w0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
@@ -7,12 +7,28 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sshr v2.16b, v0.16b, #7
 ;   movz x5, #513
 ;   movk x5, x5, #2052, LSL #16
 ;   movk x5, x5, #8208, LSL #32
 ;   movk x5, x5, #32832, LSL #48
+;   dup v16.2d, x5
+;   and v22.16b, v2.16b, v16.16b
+;   ext v24.16b, v22.16b, v22.16b, #8
+;   zip1 v26.16b, v22.16b, v24.16b
+;   addv h28, v26.8h
+;   umov w0, v28.h[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sshr v2.16b, v0.16b, #7
+;   mov x5, #0x201
+;   movk x5, #0x804, lsl #16
+;   movk x5, #0x2010, lsl #32
+;   movk x5, #0x8040, lsl #48
 ;   dup v16.2d, x5
 ;   and v22.16b, v2.16b, v16.16b
 ;   ext v24.16b, v22.16b, v22.16b, #8
@@ -27,12 +43,28 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sshr v2.16b, v0.16b, #7
 ;   movz x5, #513
 ;   movk x5, x5, #2052, LSL #16
 ;   movk x5, x5, #8208, LSL #32
 ;   movk x5, x5, #32832, LSL #48
+;   dup v16.2d, x5
+;   and v22.16b, v2.16b, v16.16b
+;   ext v24.16b, v22.16b, v22.16b, #8
+;   zip1 v26.16b, v22.16b, v24.16b
+;   addv h28, v26.8h
+;   umov w0, v28.h[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sshr v2.16b, v0.16b, #7
+;   mov x5, #0x201
+;   movk x5, #0x804, lsl #16
+;   movk x5, #0x2010, lsl #32
+;   movk x5, #0x8040, lsl #48
 ;   dup v16.2d, x5
 ;   and v22.16b, v2.16b, v16.16b
 ;   ext v24.16b, v22.16b, v22.16b, #8
@@ -47,9 +79,24 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sshr v2.8h, v0.8h, #15
 ;   ldr q4, pc+8 ; b 20 ; data.f128 0x00800040002000100008000400020001
+;   and v6.16b, v2.16b, v4.16b
+;   addv h16, v6.8h
+;   umov w0, v16.h[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sshr v2.8h, v0.8h, #0xf
+;   ldr q4, #0xc
+;   b #0x1c
+;   .byte 0x01, 0x00, 0x02, 0x00
+;   .byte 0x04, 0x00, 0x08, 0x00
+;   .byte 0x10, 0x00, 0x20, 0x00
+;   .byte 0x40, 0x00, 0x80, 0x00
 ;   and v6.16b, v2.16b, v4.16b
 ;   addv h16, v6.8h
 ;   umov w0, v16.h[0]
@@ -61,9 +108,24 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sshr v2.4s, v0.4s, #31
 ;   ldr q4, pc+8 ; b 20 ; data.f128 0x00000008000000040000000200000001
+;   and v6.16b, v2.16b, v4.16b
+;   addv s16, v6.4s
+;   mov w0, v16.s[0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sshr v2.4s, v0.4s, #0x1f
+;   ldr q4, #0xc
+;   b #0x1c
+;   .byte 0x01, 0x00, 0x00, 0x00
+;   .byte 0x02, 0x00, 0x00, 0x00
+;   .byte 0x04, 0x00, 0x00, 0x00
+;   .byte 0x08, 0x00, 0x00, 0x00
 ;   and v6.16b, v2.16b, v4.16b
 ;   addv s16, v6.4s
 ;   mov w0, v16.s[0]
@@ -75,11 +137,21 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   mov x2, v0.d[1]
 ;   mov x4, v0.d[0]
 ;   lsr x6, x2, #63
 ;   lsr x8, x4, #63
 ;   add x0, x8, x6, LSL 1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, v0.d[1]
+;   mov x4, v0.d[0]
+;   lsr x6, x2, #0x3f
+;   lsr x8, x4, #0x3f
+;   add x0, x8, x6, lsl #1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -10,10 +10,19 @@ block0(v0: i64, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   sext.w a2,a1
 ;   add a2,a0,a2
 ;   lw a0,0(a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a1, 0x20
+;   srai a2, a2, 0x20
+;   add a2, a0, a2
+;   lw a0, 0(a2)
 ;   ret
 
 function %f6(i64, i32) -> i32 {
@@ -24,10 +33,19 @@ block0(v0: i64, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   sext.w a2,a1
 ;   add a2,a2,a0
 ;   lw a0,0(a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a1, 0x20
+;   srai a2, a2, 0x20
+;   add a2, a2, a0
+;   lw a0, 0(a2)
 ;   ret
 
 function %f7(i32, i32) -> i32 {
@@ -39,11 +57,22 @@ block0(v0: i32, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   uext.w a3,a0
 ;   uext.w a4,a1
 ;   add a3,a3,a4
 ;   lw a0,0(a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a3, a0, 0x20
+;   srli a3, a3, 0x20
+;   slli a4, a1, 0x20
+;   srli a4, a4, 0x20
+;   add a3, a3, a4
+;   lw a0, 0(a3)
 ;   ret
 
 function %f8(i64, i32) -> i32 {
@@ -57,12 +86,23 @@ block0(v0: i64, v1: i32):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   sext.w a4,a1
 ;   addi a4,a4,32
 ;   add a4,a4,a0
 ;   add a4,a4,a4
 ;   lw a0,4(a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a4, a1, 0x20
+;   srai a4, a4, 0x20
+;   addi a4, a4, 0x20
+;   add a4, a4, a0
+;   add a4, a4, a4
+;   lw a0, 4(a4)
 ;   ret
 
 function %f9(i64, i64, i64) -> i32 {
@@ -75,11 +115,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   add a4,a0,a1
 ;   add a4,a4,a2
 ;   addi a4,a4,48
 ;   lw a0,0(a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add a4, a0, a1
+;   add a4, a4, a2
+;   addi a4, a4, 0x30
+;   lw a0, 0(a4)
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -92,6 +141,7 @@ block0(v0: i64, v1: i64, v2: i64):
   return v7
 }
 
+; VCode:
 ; block0:
 ;   add a6,a0,a1
 ;   add a6,a6,a2
@@ -99,6 +149,16 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   addi a5,a5,4
 ;   add t3,a6,a5
 ;   lw a0,0(t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add a6, a0, a1
+;   add a6, a6, a2
+;   lui a5, 1
+;   addi a5, a5, 4
+;   add t3, a6, a5
+;   lw a0, 0(t3)
 ;   ret
 
 function %f10() -> i32 {
@@ -108,9 +168,16 @@ block0:
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t0,1234
 ;   lw a0,0(t0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t0, zero, 0x4d2
+;   lw a0, 0(t0)
 ;   ret
 
 function %f11(i64) -> i32 {
@@ -121,10 +188,18 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lui a1,2048
 ;   add a2,a0,a1
 ;   lw a0,0(a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 0x800
+;   add a2, a0, a1
+;   lw a0, 0(a2)
 ;   ret
 
 function %f12(i64) -> i32 {
@@ -135,9 +210,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   addi a0,a0,-4
 ;   lw a0,0(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, a0, -4
+;   lw a0, 0(a0)
 ;   ret
 
 function %f13(i64) -> i32 {
@@ -148,11 +230,20 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lui a1,244141
 ;   addi a1,a1,2560
 ;   add a4,a0,a1
 ;   lw a0,0(a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 0x3b9ad
+;   addi a1, a1, -0x600
+;   add a4, a0, a1
+;   lw a0, 0(a4)
 ;   ret
 
 function %f14(i32) -> i32 {
@@ -162,9 +253,17 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.w a0,a0
 ;   lw a0,0(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
+;   lw a0, 0(a0)
 ;   ret
 
 function %f15(i32, i32) -> i32 {
@@ -176,11 +275,22 @@ block0(v0: i32, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   sext.w a3,a0
 ;   sext.w a4,a1
 ;   add a3,a3,a4
 ;   lw a0,0(a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a3, a0, 0x20
+;   srai a3, a3, 0x20
+;   slli a4, a1, 0x20
+;   srai a4, a4, 0x20
+;   add a3, a3, a4
+;   lw a0, 0(a3)
 ;   ret
 
 function %f18(i64, i64, i64) -> i32 {
@@ -191,11 +301,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   lui a3,1048575
 ;   addi a3,a3,4094
 ;   uext.w a6,a3
 ;   lh a0,0(a6)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a3, 0xfffff
+;   addi a3, a3, -2
+;   slli a6, a3, 0x20
+;   srli a6, a6, 0x20
+;   lh a0, 0(a6)
 ;   ret
 
 function %f19(i64, i64, i64) -> i32 {
@@ -206,11 +326,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   lui a3,1
 ;   addi a3,a3,2
 ;   uext.w a6,a3
 ;   lh a0,0(a6)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a3, 1
+;   addi a3, a3, 2
+;   slli a6, a3, 0x20
+;   srli a6, a6, 0x20
+;   lh a0, 0(a6)
 ;   ret
 
 function %f20(i64, i64, i64) -> i32 {
@@ -221,11 +351,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   lui a3,1048575
 ;   addi a3,a3,4094
 ;   sext.w a6,a3
 ;   lh a0,0(a6)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a3, 0xfffff
+;   addi a3, a3, -2
+;   slli a6, a3, 0x20
+;   srai a6, a6, 0x20
+;   lh a0, 0(a6)
 ;   ret
 
 function %f21(i64, i64, i64) -> i32 {
@@ -236,11 +376,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   lui a3,1
 ;   addi a3,a3,2
 ;   sext.w a6,a3
 ;   lh a0,0(a6)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a3, 1
+;   addi a3, a3, 2
+;   slli a6, a3, 0x20
+;   srai a6, a6, 0x20
+;   lh a0, 0(a6)
 ;   ret
 
 function %i128(i64) -> i128 {
@@ -250,6 +400,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld t2,0(a0)
 ;   mv a2,t2
@@ -259,6 +410,17 @@ block0(v0: i64):
 ;   sd a1,8(a0)
 ;   mv a0,a2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld t2, 0(a0)
+;   ori a2, t2, 0
+;   ld a1, 8(a0)
+;   ori a3, a2, 0
+;   sd a3, 0(a0)
+;   sd a1, 8(a0)
+;   ori a0, a2, 0
+;   ret
 
 function %i128_imm_offset(i64) -> i128 {
 block0(v0: i64):
@@ -267,6 +429,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld t2,16(a0)
 ;   mv a2,t2
@@ -276,6 +439,17 @@ block0(v0: i64):
 ;   sd a1,24(a0)
 ;   mv a0,a2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld t2, 0x10(a0)
+;   ori a2, t2, 0
+;   ld a1, 0x18(a0)
+;   ori a3, a2, 0
+;   sd a3, 0x10(a0)
+;   sd a1, 0x18(a0)
+;   ori a0, a2, 0
+;   ret
 
 function %i128_imm_offset_large(i64) -> i128 {
 block0(v0: i64):
@@ -284,6 +458,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld t2,504(a0)
 ;   mv a2,t2
@@ -293,6 +468,17 @@ block0(v0: i64):
 ;   sd a1,512(a0)
 ;   mv a0,a2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld t2, 0x1f8(a0)
+;   ori a2, t2, 0
+;   ld a1, 0x200(a0)
+;   ori a3, a2, 0
+;   sd a3, 0x1f8(a0)
+;   sd a1, 0x200(a0)
+;   ori a0, a2, 0
+;   ret
 
 function %i128_imm_offset_negative_large(i64) -> i128 {
 block0(v0: i64):
@@ -301,6 +487,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld t2,-512(a0)
 ;   mv a2,t2
@@ -309,6 +496,17 @@ block0(v0: i64):
 ;   sd a3,-512(a0)
 ;   sd a1,-504(a0)
 ;   mv a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld t2, -0x200(a0)
+;   ori a2, t2, 0
+;   ld a1, -0x1f8(a0)
+;   ori a3, a2, 0
+;   sd a3, -0x200(a0)
+;   sd a1, -0x1f8(a0)
+;   ori a0, a2, 0
 ;   ret
 
 function %i128_add_offset(i64) -> i128 {
@@ -319,12 +517,22 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   addi a2,a0,32
 ;   ld a0,0(a2)
 ;   ld a1,8(a2)
 ;   sd a0,0(a2)
 ;   sd a1,8(a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a2, a0, 0x20
+;   ld a0, 0(a2)
+;   ld a1, 8(a2)
+;   sd a0, 0(a2)
+;   sd a1, 8(a2)
 ;   ret
 
 function %i128_32bit_sextend_simple(i32) -> i128 {
@@ -335,12 +543,23 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.w a2,a0
 ;   ld a0,0(a2)
 ;   ld a1,8(a2)
 ;   sd a0,0(a2)
 ;   sd a1,8(a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a0, 0x20
+;   srai a2, a2, 0x20
+;   ld a0, 0(a2)
+;   ld a1, 8(a2)
+;   sd a0, 0(a2)
+;   sd a1, 8(a2)
 ;   ret
 
 function %i128_32bit_sextend(i64, i32) -> i128 {
@@ -353,6 +572,7 @@ block0(v0: i64, v1: i32):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   sext.w a4,a1
 ;   add a4,a0,a4
@@ -361,5 +581,17 @@ block0(v0: i64, v1: i32):
 ;   ld a1,8(a4)
 ;   sd a0,0(a4)
 ;   sd a1,8(a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a4, a1, 0x20
+;   srai a4, a4, 0x20
+;   add a4, a0, a4
+;   addi a4, a4, 0x18
+;   ld a0, 0(a4)
+;   ld a1, 8(a4)
+;   sd a0, 0(a4)
+;   sd a1, 8(a4)
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -8,8 +8,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   add a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add a0, a0, a1
 ;   ret
 
 function %f2(i64, i64) -> i64 {
@@ -18,8 +24,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sub a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sub a0, a0, a1
 ;   ret
 
 function %f3(i64, i64) -> i64 {
@@ -28,8 +40,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mul a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul a0, a0, a1
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -38,8 +56,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mulhu a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mulhu a0, a0, a1
 ;   ret
 
 function %f5(i64, i64) -> i64 {
@@ -48,8 +72,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mulh a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mulh a0, a0, a1
 ;   ret
 
 function %f6(i64, i64) -> i64 {
@@ -58,6 +88,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li a2,-1
 ;   li a3,1
@@ -69,6 +100,27 @@ block0(v0: i64, v1: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   div a0,a0,a1
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a2, zero, -1
+;   addi a3, zero, 1
+;   slli a4, a3, 0x3f
+;   bne a2, a1, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   bne a4, a0, 0xc
+;   addi t3, zero, 1
+;   j 8
+;   mv t3, zero
+;   and t0, a6, t3
+;   beqz t0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   div a0, a0, a1
+;   ret
 
 function %f7(i64) -> i64 {
 block0(v0: i64):
@@ -77,6 +129,7 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,2
 ;   li a1,-1
@@ -91,6 +144,30 @@ block0(v0: i64):
 ;   li a4,2
 ;   div a0,a0,a4
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 2
+;   addi a1, zero, -1
+;   addi a3, zero, 1
+;   slli a5, a3, 0x3f
+;   bne a1, t2, 0xc
+;   addi a7, zero, 1
+;   j 8
+;   mv a7, zero
+;   bne a5, a0, 0xc
+;   addi t4, zero, 1
+;   j 8
+;   mv t4, zero
+;   and t1, a7, t4
+;   beqz t1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   addi a1, zero, 2
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a4, zero, 2
+;   div a0, a0, a4
+;   ret
 
 function %f8(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -98,9 +175,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   trap_ifc int_divz##(zero eq a1)
 ;   divu a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   divu a0, a0, a1
 ;   ret
 
 function %f9(i64) -> i64 {
@@ -110,11 +195,21 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,2
 ;   trap_ifc int_divz##(zero eq t2)
 ;   li a2,2
 ;   divu a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 2
+;   bne zero, t2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a2, zero, 2
+;   divu a0, a0, a2
 ;   ret
 
 function %f10(i64, i64) -> i64 {
@@ -123,9 +218,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   trap_ifc int_divz##(zero eq a1)
 ;   rem a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   rem a0, a0, a1
 ;   ret
 
 function %f11(i64, i64) -> i64 {
@@ -134,9 +237,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remu a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   remu a0, a0, a1
 ;   ret
 
 function %f12(i32, i32) -> i32 {
@@ -145,6 +256,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.w a0,a0
 ;   sext.w a2,a1
@@ -159,6 +271,32 @@ block0(v0: i32, v1: i32):
 ;   trap_ifc int_divz##(zero eq a2)
 ;   divw a0,a0,a2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
+;   slli a2, a1, 0x20
+;   srai a2, a2, 0x20
+;   addi a4, zero, -1
+;   addi a6, zero, 1
+;   slli t3, a6, 0x3f
+;   slli t0, a0, 0x20
+;   bne a4, a2, 0xc
+;   addi t2, zero, 1
+;   j 8
+;   mv t2, zero
+;   bne t3, t0, 0xc
+;   addi a1, zero, 1
+;   j 8
+;   mv a1, zero
+;   and a3, t2, a1
+;   beqz a3, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bne zero, a2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   divw a0, a0, a2
+;   ret
 
 function %f13(i32) -> i32 {
 block0(v0: i32):
@@ -167,6 +305,7 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.w t2,a0
 ;   li a1,2
@@ -182,6 +321,33 @@ block0(v0: i32):
 ;   trap_ifc int_divz##(zero eq a3)
 ;   divw a0,t2,a3
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x20
+;   srai t2, t2, 0x20
+;   addi a1, zero, 2
+;   slli a3, a1, 0x20
+;   srai a3, a3, 0x20
+;   addi a5, zero, -1
+;   addi a7, zero, 1
+;   slli t4, a7, 0x3f
+;   slli t1, t2, 0x20
+;   bne a5, a3, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   bne t4, t1, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+;   and a4, a0, a2
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bne zero, a3, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   divw a0, t2, a3
+;   ret
 
 function %f14(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -189,12 +355,25 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a5,a0
 ;   uext.w a0,a1
 ;   trap_ifc int_divz##(zero eq a0)
 ;   uext.w a3,a5
 ;   divuw a0,a3,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a5, a0, 0
+;   slli a0, a1, 0x20
+;   srli a0, a0, 0x20
+;   bne zero, a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   slli a3, a5, 0x20
+;   srli a3, a3, 0x20
+;   divuw a0, a3, a0
 ;   ret
 
 function %f15(i32) -> i32 {
@@ -204,12 +383,25 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,2
 ;   uext.w a1,t2
 ;   trap_ifc int_divz##(zero eq a1)
 ;   uext.w a4,a0
 ;   divuw a0,a4,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 2
+;   slli a1, t2, 0x20
+;   srli a1, a1, 0x20
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   slli a4, a0, 0x20
+;   srli a4, a4, 0x20
+;   divuw a0, a4, a1
 ;   ret
 
 function %f16(i32, i32) -> i32 {
@@ -218,10 +410,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.w a1,a1
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 0x20
+;   srai a1, a1, 0x20
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   remw a0, a0, a1
 ;   ret
 
 function %f17(i32, i32) -> i32 {
@@ -230,10 +432,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.w a1,a1
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remuw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 0x20
+;   srli a1, a1, 0x20
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   remuw a0, a0, a1
 ;   ret
 
 function %f18(i64, i64) -> i64 {
@@ -242,8 +454,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and a0, a0, a1
 ;   ret
 
 function %f19(i64, i64) -> i64 {
@@ -252,8 +470,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
 ;   ret
 
 function %f20(i64, i64) -> i64 {
@@ -262,8 +486,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xor a0, a0, a1
 ;   ret
 
 function %f21(i64, i64) -> i64 {
@@ -272,9 +502,16 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   and a0, a0, a1
 ;   ret
 
 function %f22(i64, i64) -> i64 {
@@ -283,9 +520,16 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   or a0, a0, a1
 ;   ret
 
 function %f23(i64, i64) -> i64 {
@@ -294,9 +538,16 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   xor a0, a0, a1
 ;   ret
 
 function %f24(i64, i64) -> i64 {
@@ -305,8 +556,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   not a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a0, a0
 ;   ret
 
 function %f25(i32, i32) -> i32 {
@@ -317,9 +574,16 @@ block0(v0: i32, v1: i32):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   slliw a2,a0,53
 ;   subw a0,a1,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slliw a2, a0, 0x15
+;   subw a0, a1, a2
 ;   ret
 
 function %f26(i32) -> i32 {
@@ -329,8 +593,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   addiw a0,a0,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addiw a0, a0, -1
 ;   ret
 
 function %f27(i32) -> i32 {
@@ -340,9 +610,16 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,-1
 ;   subw a0,a0,t2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, -1
+;   subw a0, a0, t2
 ;   ret
 
 function %f28(i64) -> i64 {
@@ -352,9 +629,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,-1
 ;   sub a0,a0,t2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, -1
+;   sub a0, a0, t2
 ;   ret
 
 function %f29(i64) -> i64 {
@@ -364,9 +648,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,1
 ;   sub a0,zero,t2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 1
+;   neg a0, t2
 ;   ret
 
 function %add_i128(i128, i128) -> i128 {
@@ -375,11 +666,20 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   add a0,a0,a2
 ;   sltu a4,a0,a2
 ;   add a6,a1,a3
 ;   add a1,a6,a4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add a0, a0, a2
+;   sltu a4, a0, a2
+;   add a6, a1, a3
+;   add a1, a6, a4
 ;   ret
 
 function %sub_i128(i128, i128) -> i128 {
@@ -388,6 +688,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   sub a2,a0,a2
 ;   mv a7,a2
@@ -395,6 +696,16 @@ block0(v0: i128, v1: i128):
 ;   mv a0,a7
 ;   sub a6,a1,a3
 ;   sub a1,a6,a4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sub a2, a0, a2
+;   ori a7, a2, 0
+;   sltu a4, a0, a7
+;   ori a0, a7, 0
+;   sub a6, a1, a3
+;   sub a1, a6, a4
 ;   ret
 
 function %add_mul_2(i32, i32, i32) -> i32 {
@@ -404,9 +715,16 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   mulw a2,a1,a2
 ;   addw a0,a2,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mulw a2, a1, a2
+;   addw a0, a2, a0
 ;   ret
 
 function %msub_i32(i32, i32, i32) -> i32 {
@@ -416,9 +734,16 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   mulw a2,a1,a2
 ;   subw a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mulw a2, a1, a2
+;   subw a0, a0, a2
 ;   ret
 
 function %msub_i64(i64, i64, i64) -> i64 {
@@ -428,9 +753,16 @@ block0(v0: i64, v1: i64, v2: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   mul a2,a1,a2
 ;   sub a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul a2, a1, a2
+;   sub a0, a0, a2
 ;   ret
 
 function %imul_sub_i32(i32, i32, i32) -> i32 {
@@ -440,9 +772,16 @@ block0(v0: i32, v1: i32, v2: i32):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   mulw a2,a1,a2
 ;   subw a0,a2,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mulw a2, a1, a2
+;   subw a0, a2, a0
 ;   ret
 
 function %imul_sub_i64(i64, i64, i64) -> i64 {
@@ -452,9 +791,16 @@ block0(v0: i64, v1: i64, v2: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   mul a2,a1,a2
 ;   sub a0,a2,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mul a2, a1, a2
+;   sub a0, a2, a0
 ;   ret
 
 function %srem_const (i64) -> i64 {
@@ -464,11 +810,21 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,2
 ;   trap_ifc int_divz##(zero eq t2)
 ;   li a2,2
 ;   rem a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 2
+;   bne zero, t2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a2, zero, 2
+;   rem a0, a0, a2
 ;   ret
 
 function %urem_const (i64) -> i64 {
@@ -478,11 +834,21 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,2
 ;   trap_ifc int_divz##(zero eq t2)
 ;   li a2,2
 ;   remu a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 2
+;   bne zero, t2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a2, zero, 2
+;   remu a0, a0, a2
 ;   ret
 
 function %sdiv_minus_one(i64) -> i64 {
@@ -492,6 +858,7 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,-1
 ;   li a1,-1
@@ -505,5 +872,29 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   li a4,-1
 ;   div a0,a0,a4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, -1
+;   addi a1, zero, -1
+;   addi a3, zero, 1
+;   slli a5, a3, 0x3f
+;   bne a1, t2, 0xc
+;   addi a7, zero, 1
+;   j 8
+;   mv a7, zero
+;   bne a5, a0, 0xc
+;   addi t4, zero, 1
+;   j 8
+;   mv t4, zero
+;   and t1, a7, t4
+;   beqz t1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   addi a1, zero, -1
+;   bne zero, a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a4, zero, -1
+;   div a0, a0, a4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
@@ -8,8 +8,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoadd.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoadd.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_add_i32(i64, i32) {
@@ -18,8 +24,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoadd.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoadd.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_sub_i64(i64, i64) {
@@ -28,9 +40,16 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub a1,zero,a1
 ;   amoadd.d.aqrl a2,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg a1, a1
+;   amoadd.d.aqrl a2, a1, (a0)
 ;   ret
 
 function %atomic_rmw_sub_i32(i64, i32) {
@@ -39,9 +58,16 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   sub a1,zero,a1
 ;   amoadd.w.aqrl a2,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg a1, a1
+;   amoadd.w.aqrl a2, a1, (a0)
 ;   ret
 
 function %atomic_rmw_and_i64(i64, i64) {
@@ -50,8 +76,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoand.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoand.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_and_i32(i64, i32) {
@@ -60,8 +92,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoand.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoand.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_nand_i64(i64, i64) {
@@ -70,10 +108,22 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   mv a3,a0
 ;   mv a2,a1
 ;   atomic_rmw.i64 nand a0,a2,(a3)##t0=a1 offset=zero
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a3, a0, 0
+;   ori a2, a1, 0
+;   lr.d.aqrl a0, (a3)
+;   and a1, a2, a0
+;   not a1, a1
+;   sc.d.aqrl a1, a1, (a3)
+;   bnez a1, -0x10
 ;   ret
 
 function %atomic_rmw_nand_i32(i64, i32) {
@@ -82,10 +132,22 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   mv a3,a0
 ;   mv a2,a1
 ;   atomic_rmw.i32 nand a0,a2,(a3)##t0=a1 offset=zero
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a3, a0, 0
+;   ori a2, a1, 0
+;   lr.w.aqrl a0, (a3)
+;   and a1, a2, a0
+;   not a1, a1
+;   sc.w.aqrl a1, a1, (a3)
+;   bnez a1, -0x10
 ;   ret
 
 function %atomic_rmw_or_i64(i64, i64) {
@@ -94,8 +156,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoor.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoor.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_or_i32(i64, i32) {
@@ -104,8 +172,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoor.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoor.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_xor_i64(i64, i64) {
@@ -114,8 +188,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoxor.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoxor.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_xor_i32(i64, i32) {
@@ -124,8 +204,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amoxor.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amoxor.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_smax_i64(i64, i64) {
@@ -134,8 +220,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomax.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomax.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_smax_i32(i64, i32) {
@@ -144,8 +236,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomax.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomax.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_umax_i64(i64, i64) {
@@ -154,8 +252,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomaxu.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomaxu.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_umax_i32(i64, i32) {
@@ -164,8 +268,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomaxu.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomaxu.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_smin_i64(i64, i64) {
@@ -174,8 +284,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomin.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomin.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_smin_i32(i64, i32) {
@@ -184,8 +300,14 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amomin.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amomin.w.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_umin_i64(i64, i64) {
@@ -194,8 +316,14 @@ block0(v0: i64, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   amominu.d.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amominu.d.aqrl a0, a1, (a0)
 ;   ret
 
 function %atomic_rmw_umin_i32(i64, i32) {
@@ -204,7 +332,13 @@ block0(v0: i64, v1: i32):
     return
 }
 
+; VCode:
 ; block0:
 ;   amominu.w.aqrl a0,a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   amominu.w.aqrl a0, a1, (a0)
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic_load.clif
@@ -8,8 +8,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   atomic_load.i64 a0,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, rw
+;   ld a0, 0(a0)
+;   fence r, rw
 ;   ret
 
 function %atomic_load_i32(i64) -> i32 {
@@ -18,8 +26,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   atomic_load.i32 a0,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, rw
+;   lw a0, 0(a0)
+;   fence r, rw
 ;   ret
 
 function %atomic_load_i32_i64(i64) -> i64 {
@@ -29,8 +45,18 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   atomic_load.i32 a0,(a0)
 ;   uext.w a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, rw
+;   lw a0, 0(a0)
+;   fence r, rw
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
@@ -8,8 +8,15 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   atomic_store.i64 a0,(a1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, w
+;   sd a0, 0(a1)
 ;   ret
 
 function %atomic_store_i64_sym(i64) {
@@ -20,9 +27,21 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   load_sym t2,%sym+0
 ;   atomic_store.i64 a0,(t2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t2, 0
+;   ld t2, 0xc(t2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %sym 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   fence rw, w
+;   sd a0, 0(t2)
 ;   ret
 
 function %atomic_store_imm_i64(i64) {
@@ -32,10 +51,19 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lui a1,3
 ;   addi a1,a1,57
 ;   atomic_store.i64 a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 3
+;   addi a1, a1, 0x39
+;   fence rw, w
+;   sd a1, 0(a0)
 ;   ret
 
 function %atomic_store_i32(i32, i64) {
@@ -44,8 +72,15 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   atomic_store.i32 a0,(a1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, w
+;   sw a0, 0(a1)
 ;   ret
 
 function %atomic_store_i32_sym(i32) {
@@ -56,9 +91,21 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   load_sym t2,%sym+0
 ;   atomic_store.i32 a0,(t2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t2, 0
+;   ld t2, 0xc(t2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %sym 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   fence rw, w
+;   sw a0, 0(t2)
 ;   ret
 
 function %atomic_store_imm_i32(i64) {
@@ -68,9 +115,18 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lui a1,3
 ;   addi a1,a1,57
 ;   atomic_store.i32 a1,(a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 3
+;   addi a1, a1, 0x39
+;   fence rw, w
+;   sw a1, 0(a0)
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-optimized.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-optimized.clif
@@ -8,8 +8,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   andn a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x33, 0x75, 0xb5, 0x40
 ;   ret
 
 function %band_not_i32_reversed(i32, i32) -> i32 {
@@ -19,8 +25,14 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   andn a0,a1,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x33, 0xf5, 0xa5, 0x40
 ;   ret
 
 function %bor_not_i32(i32, i32) -> i32 {
@@ -29,8 +41,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   orn a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x33, 0x65, 0xb5, 0x40
 ;   ret
 
 function %bor_not_i32_reversed(i32, i32) -> i32 {
@@ -40,6 +58,13 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   orn a0,a1,a0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x33, 0xe5, 0xa5, 0x40
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops.clif
@@ -8,9 +8,34 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a3,a0
 ;   brev8 a0,a3##tmp=t2 tmp2=a2 step=a1 ty=i8
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a3, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 8
+;   addi t2, zero, 1
+;   slli t2, t2, 7
+;   addi a2, zero, 1
+;   slli a2, a2, 0
+;   blez a1, 0x34
+;   and t5, t2, a3
+;   beq zero, t5, 8
+;   or a0, a0, a2
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   addi t5, zero, 8
+;   rem t5, a1, t5
+;   bnez t5, 0xc
+;   srli a2, a2, 0xf
+;   j -0x28
+;   slli a2, a2, 1
+;   j -0x30
 ;   ret
 
 function %a(i16) -> i16 {
@@ -19,11 +44,47 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a7,a0
 ;   brev8 a2,a7##tmp=t2 tmp2=a0 step=a1 ty=i16
 ;   rev8 a4,a2##step=a6 tmp=a5
 ;   srli a0,a4,48
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a7, a0, 0
+;   ori a2, zero, 0
+;   addi a1, zero, 0x10
+;   addi t2, zero, 1
+;   slli t2, t2, 0xf
+;   addi a0, zero, 1
+;   slli a0, a0, 8
+;   blez a1, 0x34
+;   and t5, t2, a7
+;   beq zero, t5, 8
+;   or a2, a2, a0
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   addi t5, zero, 8
+;   rem t5, a1, t5
+;   bnez t5, 0xc
+;   srli a0, a0, 0xf
+;   j -0x28
+;   slli a0, a0, 1
+;   j -0x30
+;   ori a4, zero, 0
+;   ori a5, a2, 0
+;   addi a6, zero, 0x38
+;   bltz a6, 0x1c
+;   andi t6, a5, 0xff
+;   sll t6, t6, a6
+;   or a4, a4, t6
+;   addi a6, a6, -8
+;   srli a5, a5, 8
+;   j -0x18
+;   srli a0, a4, 0x30
 ;   ret
 
 function %a(i32) -> i32 {
@@ -32,11 +93,47 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a7,a0
 ;   brev8 a2,a7##tmp=t2 tmp2=a0 step=a1 ty=i32
 ;   rev8 a4,a2##step=a6 tmp=a5
 ;   srli a0,a4,32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a7, a0, 0
+;   ori a2, zero, 0
+;   addi a1, zero, 0x20
+;   addi t2, zero, 1
+;   slli t2, t2, 0x1f
+;   addi a0, zero, 1
+;   slli a0, a0, 0x18
+;   blez a1, 0x34
+;   and t5, t2, a7
+;   beq zero, t5, 8
+;   or a2, a2, a0
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   addi t5, zero, 8
+;   rem t5, a1, t5
+;   bnez t5, 0xc
+;   srli a0, a0, 0xf
+;   j -0x28
+;   slli a0, a0, 1
+;   j -0x30
+;   ori a4, zero, 0
+;   ori a5, a2, 0
+;   addi a6, zero, 0x38
+;   bltz a6, 0x1c
+;   andi t6, a5, 0xff
+;   sll t6, t6, a6
+;   or a4, a4, t6
+;   addi a6, a6, -8
+;   srli a5, a5, 8
+;   j -0x18
+;   srli a0, a4, 0x20
 ;   ret
 
 function %a(i64) -> i64 {
@@ -45,10 +142,45 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a6,a0
 ;   rev8 t2,a6##step=a1 tmp=a0
 ;   brev8 a0,t2##tmp=a3 tmp2=a4 step=a5 ty=i64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a6, a0, 0
+;   ori t2, zero, 0
+;   ori a0, a6, 0
+;   addi a1, zero, 0x38
+;   bltz a1, 0x1c
+;   andi t6, a0, 0xff
+;   sll t6, t6, a1
+;   or t2, t2, t6
+;   addi a1, a1, -8
+;   srli a0, a0, 8
+;   j -0x18
+;   ori a0, zero, 0
+;   addi a5, zero, 0x40
+;   addi a3, zero, 1
+;   slli a3, a3, 0x3f
+;   addi a4, zero, 1
+;   slli a4, a4, 0x38
+;   blez a5, 0x34
+;   and t5, a3, t2
+;   beq zero, t5, 8
+;   or a0, a0, a4
+;   addi a5, a5, -1
+;   srli a3, a3, 1
+;   addi t5, zero, 8
+;   rem t5, a5, t5
+;   bnez t5, 0xc
+;   srli a4, a4, 0xf
+;   j -0x28
+;   slli a4, a4, 1
+;   j -0x30
 ;   ret
 
 function %a(i128) -> i128 {
@@ -57,6 +189,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a3,a0
 ;   mv a7,a1
@@ -66,6 +199,71 @@ block0(v0: i128):
 ;   rev8 t4,a3##step=t1 tmp=t0
 ;   brev8 a0,t4##tmp=a4 tmp2=a3 step=a2 ty=i64
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a3, a0, 0
+;   ori a7, a1, 0
+;   ori a0, zero, 0
+;   ori a1, a3, 0
+;   addi a2, zero, 0x38
+;   bltz a2, 0x1c
+;   andi t6, a1, 0xff
+;   sll t6, t6, a2
+;   or a0, a0, t6
+;   addi a2, a2, -8
+;   srli a1, a1, 8
+;   j -0x18
+;   ori a1, zero, 0
+;   addi a6, zero, 0x40
+;   addi a4, zero, 1
+;   slli a4, a4, 0x3f
+;   addi a5, zero, 1
+;   slli a5, a5, 0x38
+;   blez a6, 0x34
+;   and t5, a4, a0
+;   beq zero, t5, 8
+;   or a1, a1, a5
+;   addi a6, a6, -1
+;   srli a4, a4, 1
+;   addi t5, zero, 8
+;   rem t5, a6, t5
+;   bnez t5, 0xc
+;   srli a5, a5, 0xf
+;   j -0x28
+;   slli a5, a5, 1
+;   j -0x30
+;   ori a3, a7, 0
+;   ori t4, zero, 0
+;   ori t0, a3, 0
+;   addi t1, zero, 0x38
+;   bltz t1, 0x1c
+;   andi t6, t0, 0xff
+;   sll t6, t6, t1
+;   or t4, t4, t6
+;   addi t1, t1, -8
+;   srli t0, t0, 8
+;   j -0x18
+;   ori a0, zero, 0
+;   addi a2, zero, 0x40
+;   addi a4, zero, 1
+;   slli a4, a4, 0x3f
+;   addi a3, zero, 1
+;   slli a3, a3, 0x38
+;   blez a2, 0x34
+;   and t5, a4, t4
+;   beq zero, t5, 8
+;   or a0, a0, a3
+;   addi a2, a2, -1
+;   srli a4, a4, 1
+;   addi t5, zero, 8
+;   rem t5, a2, t5
+;   bnez t5, 0xc
+;   srli a3, a3, 0xf
+;   j -0x28
+;   slli a3, a3, 1
+;   j -0x30
+;   ret
 
 function %b(i8) -> i8 {
 block0(v0: i8):
@@ -73,9 +271,26 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   clz a0,a2##ty=i8 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 8
+;   addi t2, zero, 1
+;   slli t2, t2, 7
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %b(i16) -> i16 {
@@ -84,9 +299,26 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   clz a0,a2##ty=i16 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x10
+;   addi t2, zero, 1
+;   slli t2, t2, 0xf
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %b(i32) -> i32 {
@@ -95,9 +327,26 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   clz a0,a2##ty=i32 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x20
+;   addi t2, zero, 1
+;   slli t2, t2, 0x1f
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %b(i64) -> i64 {
@@ -106,9 +355,26 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   clz a0,a2##ty=i64 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x40
+;   addi t2, zero, 1
+;   slli t2, t2, 0x3f
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %b(i128) -> i128 {
@@ -117,6 +383,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv t0,a1
 ;   clz a2,t0##ty=i64 tmp=a3 step=a1
@@ -126,6 +393,40 @@ block0(v0: i128):
 ;   add a0,a2,t0
 ;   li a1,0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori t0, a1, 0
+;   ori a2, zero, 0
+;   addi a1, zero, 0x40
+;   addi a3, zero, 1
+;   slli a3, a3, 0x3f
+;   blez a1, 0x1c
+;   and t5, a3, t0
+;   bne zero, t5, 0x14
+;   addi a2, a2, 1
+;   addi a1, a1, -1
+;   srli a3, a3, 1
+;   j -0x18
+;   ori a6, zero, 0
+;   addi a5, zero, 0x40
+;   addi a4, zero, 1
+;   slli a4, a4, 0x3f
+;   blez a5, 0x1c
+;   and t5, a4, a0
+;   bne zero, t5, 0x14
+;   addi a6, a6, 1
+;   addi a5, a5, -1
+;   srli a4, a4, 1
+;   j -0x18
+;   addi t3, zero, 0x40
+;   beq t3, a2, 0xc
+;   ori t0, zero, 0
+;   j 8
+;   ori t0, a6, 0
+;   add a0, a2, t0
+;   mv a1, zero
+;   ret
 
 function %c(i8) -> i8 {
 block0(v0: i8):
@@ -133,12 +434,36 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b t2,a0
 ;   not a1,a0
 ;   select_reg a3,a1,a0##condition=(t2 slt zero)
 ;   clz a7,a3##ty=i8 tmp=a5 step=a6
 ;   addi a0,a7,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x38
+;   srai t2, t2, 0x38
+;   not a1, a0
+;   bltz t2, 0xc
+;   ori a3, a0, 0
+;   j 8
+;   ori a3, a1, 0
+;   ori a7, zero, 0
+;   addi a6, zero, 8
+;   addi a5, zero, 1
+;   slli a5, a5, 7
+;   blez a6, 0x1c
+;   and t5, a5, a3
+;   bne zero, t5, 0x14
+;   addi a7, a7, 1
+;   addi a6, a6, -1
+;   srli a5, a5, 1
+;   j -0x18
+;   addi a0, a7, -1
 ;   ret
 
 function %c(i16) -> i16 {
@@ -147,12 +472,36 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h t2,a0
 ;   not a1,a0
 ;   select_reg a3,a1,a0##condition=(t2 slt zero)
 ;   clz a7,a3##ty=i16 tmp=a5 step=a6
 ;   addi a0,a7,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x30
+;   srai t2, t2, 0x30
+;   not a1, a0
+;   bltz t2, 0xc
+;   ori a3, a0, 0
+;   j 8
+;   ori a3, a1, 0
+;   ori a7, zero, 0
+;   addi a6, zero, 0x10
+;   addi a5, zero, 1
+;   slli a5, a5, 0xf
+;   blez a6, 0x1c
+;   and t5, a5, a3
+;   bne zero, t5, 0x14
+;   addi a7, a7, 1
+;   addi a6, a6, -1
+;   srli a5, a5, 1
+;   j -0x18
+;   addi a0, a7, -1
 ;   ret
 
 function %c(i32) -> i32 {
@@ -161,12 +510,36 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.w t2,a0
 ;   not a1,a0
 ;   select_reg a3,a1,a0##condition=(t2 slt zero)
 ;   clz a7,a3##ty=i32 tmp=a5 step=a6
 ;   addi a0,a7,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x20
+;   srai t2, t2, 0x20
+;   not a1, a0
+;   bltz t2, 0xc
+;   ori a3, a0, 0
+;   j 8
+;   ori a3, a1, 0
+;   ori a7, zero, 0
+;   addi a6, zero, 0x20
+;   addi a5, zero, 1
+;   slli a5, a5, 0x1f
+;   blez a6, 0x1c
+;   and t5, a5, a3
+;   bne zero, t5, 0x14
+;   addi a7, a7, 1
+;   addi a6, a6, -1
+;   srli a5, a5, 1
+;   j -0x18
+;   addi a0, a7, -1
 ;   ret
 
 function %c(i64) -> i64 {
@@ -175,11 +548,33 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   not t2,a0
 ;   select_reg a1,t2,a0##condition=(a0 slt zero)
 ;   clz a5,a1##ty=i64 tmp=a3 step=a4
 ;   addi a0,a5,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not t2, a0
+;   bltz a0, 0xc
+;   ori a1, a0, 0
+;   j 8
+;   ori a1, t2, 0
+;   ori a5, zero, 0
+;   addi a4, zero, 0x40
+;   addi a3, zero, 1
+;   slli a3, a3, 0x3f
+;   blez a4, 0x1c
+;   and t5, a3, a1
+;   bne zero, t5, 0x14
+;   addi a5, a5, 1
+;   addi a4, a4, -1
+;   srli a3, a3, 1
+;   j -0x18
+;   addi a0, a5, -1
 ;   ret
 
 function %c(i128) -> i128 {
@@ -188,6 +583,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   not a2,a0
 ;   select_reg a2,a2,a0##condition=(a1 slt zero)
@@ -202,6 +598,49 @@ block0(v0: i128):
 ;   addi a0,a7,-1
 ;   li a1,0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a2, a0
+;   bltz a1, 8
+;   ori a2, a0, 0
+;   not a4, a1
+;   bltz a1, 0xc
+;   ori a6, a1, 0
+;   j 8
+;   ori a6, a4, 0
+;   ori t0, zero, 0
+;   addi t4, zero, 0x40
+;   addi t3, zero, 1
+;   slli t3, t3, 0x3f
+;   blez t4, 0x1c
+;   and t5, t3, a6
+;   bne zero, t5, 0x14
+;   addi t0, t0, 1
+;   addi t4, t4, -1
+;   srli t3, t3, 1
+;   j -0x18
+;   ori a1, zero, 0
+;   addi a0, zero, 0x40
+;   addi t2, zero, 1
+;   slli t2, t2, 0x3f
+;   blez a0, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a1, a1, 1
+;   addi a0, a0, -1
+;   srli t2, t2, 1
+;   j -0x18
+;   addi a3, zero, 0x40
+;   beq a3, t0, 0xc
+;   ori a5, zero, 0
+;   j 8
+;   ori a5, a1, 0
+;   add a7, t0, a5
+;   mv t4, zero
+;   addi a0, a7, -1
+;   mv a1, zero
+;   ret
 
 function %d(i8) -> i8 {
 block0(v0: i8):
@@ -209,9 +648,25 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i8 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 8
+;   addi t2, zero, 1
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   slli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i16) -> i16 {
@@ -220,9 +675,25 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i16 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x10
+;   addi t2, zero, 1
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   slli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i32) -> i32 {
@@ -231,9 +702,25 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i32 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x20
+;   addi t2, zero, 1
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   slli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i64) -> i64 {
@@ -242,9 +729,25 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i64 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x40
+;   addi t2, zero, 1
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   bne zero, t5, 0x14
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   slli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i128) -> i128 {
@@ -253,6 +756,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv t0,a0
 ;   ctz a2,t0##ty=i64 tmp=a0 step=a3
@@ -262,6 +766,38 @@ block0(v0: i128):
 ;   add a0,a2,t0
 ;   li a1,0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori t0, a0, 0
+;   ori a2, zero, 0
+;   addi a3, zero, 0x40
+;   addi a0, zero, 1
+;   blez a3, 0x1c
+;   and t5, a0, t0
+;   bne zero, t5, 0x14
+;   addi a2, a2, 1
+;   addi a3, a3, -1
+;   slli a0, a0, 1
+;   j -0x18
+;   ori a6, zero, 0
+;   addi a5, zero, 0x40
+;   addi a4, zero, 1
+;   blez a5, 0x1c
+;   and t5, a4, a1
+;   bne zero, t5, 0x14
+;   addi a6, a6, 1
+;   addi a5, a5, -1
+;   slli a4, a4, 1
+;   j -0x18
+;   addi t3, zero, 0x40
+;   beq t3, a2, 0xc
+;   ori t0, zero, 0
+;   j 8
+;   ori t0, a6, 0
+;   add a0, a2, t0
+;   mv a1, zero
+;   ret
 
 function %d(i128) -> i128 {
 block0(v0: i128):
@@ -269,12 +805,42 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv t3,a0
 ;   popcnt a2,t3##ty=i64 tmp=a0 step=a3
 ;   popcnt a6,a1##ty=i64 tmp=a4 step=a5
 ;   add a0,a2,a6
 ;   li a1,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori t3, a0, 0
+;   ori a2, zero, 0
+;   addi a3, zero, 0x40
+;   addi a0, zero, 1
+;   slli a0, a0, 0x3f
+;   blez a3, 0x1c
+;   and t5, a0, t3
+;   beq zero, t5, 8
+;   addi a2, a2, 1
+;   addi a3, a3, -1
+;   srli a0, a0, 1
+;   j -0x18
+;   ori a6, zero, 0
+;   addi a5, zero, 0x40
+;   addi a4, zero, 1
+;   slli a4, a4, 0x3f
+;   blez a5, 0x1c
+;   and t5, a4, a1
+;   beq zero, t5, 8
+;   addi a6, a6, 1
+;   addi a5, a5, -1
+;   srli a4, a4, 1
+;   j -0x18
+;   add a0, a2, a6
+;   mv a1, zero
 ;   ret
 
 function %d(i64) -> i64 {
@@ -283,9 +849,26 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i64 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x40
+;   addi t2, zero, 1
+;   slli t2, t2, 0x3f
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   beq zero, t5, 8
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i32) -> i32 {
@@ -294,9 +877,26 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i32 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x20
+;   addi t2, zero, 1
+;   slli t2, t2, 0x1f
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   beq zero, t5, 8
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i16) -> i16 {
@@ -305,9 +905,26 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i16 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 0x10
+;   addi t2, zero, 1
+;   slli t2, t2, 0xf
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   beq zero, t5, 8
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %d(i8) -> i8 {
@@ -316,9 +933,26 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i8 tmp=t2 step=a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a2, a0, 0
+;   ori a0, zero, 0
+;   addi a1, zero, 8
+;   addi t2, zero, 1
+;   slli t2, t2, 7
+;   blez a1, 0x1c
+;   and t5, t2, a2
+;   beq zero, t5, 8
+;   addi a0, a0, 1
+;   addi a1, a1, -1
+;   srli t2, t2, 1
+;   j -0x18
 ;   ret
 
 function %bnot_i32(i32) -> i32 {
@@ -327,8 +961,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   not a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a0, a0
 ;   ret
 
 function %bnot_i64(i64) -> i64 {
@@ -337,8 +977,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   not a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a0, a0
 ;   ret
 
 function %bnot_i64_with_shift(i64) -> i64 {
@@ -349,9 +995,16 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   slli a0,a0,3
 ;   not a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 3
+;   not a0, a0
 ;   ret
 
 function %bnot_i128(i128) -> i128 {
@@ -360,9 +1013,16 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   not a0,a0
 ;   not a1,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a0, a0
+;   not a1, a1
 ;   ret
 
 function %band_i32(i32, i32) -> i32 {
@@ -371,8 +1031,14 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and a0, a0, a1
 ;   ret
 
 function %band_i64(i64, i64) -> i64 {
@@ -381,8 +1047,14 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and a0, a0, a1
 ;   ret
 
 function %band_i128(i128, i128) -> i128 {
@@ -391,9 +1063,16 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   and a0,a0,a2
 ;   and a1,a1,a3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and a0, a0, a2
+;   and a1, a1, a3
 ;   ret
 
 function %band_i64_constant(i64) -> i64 {
@@ -403,8 +1082,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 3
 ;   ret
 
 function %band_i64_constant2(i64) -> i64 {
@@ -414,8 +1099,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 3
 ;   ret
 
 function %band_i64_constant_shift(i64, i64) -> i64 {
@@ -426,9 +1117,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   and a0, a0, a1
 ;   ret
 
 function %band_i64_constant_shift2(i64, i64) -> i64 {
@@ -439,9 +1137,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   and a0,a1,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   and a0, a1, a0
 ;   ret
 
 function %bor_i32(i32, i32) -> i32 {
@@ -450,8 +1155,14 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
 ;   ret
 
 function %bor_i64(i64, i64) -> i64 {
@@ -460,8 +1171,14 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
 ;   ret
 
 function %bor_i128(i128, i128) -> i128 {
@@ -470,9 +1187,16 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a2
 ;   or a1,a1,a3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a2
+;   or a1, a1, a3
 ;   ret
 
 function %bor_i64_constant(i64) -> i64 {
@@ -482,8 +1206,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ori a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a0, a0, 3
 ;   ret
 
 function %bor_i64_constant2(i64) -> i64 {
@@ -493,8 +1223,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   ori a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a0, a0, 3
 ;   ret
 
 function %bor_i64_constant_shift(i64, i64) -> i64 {
@@ -505,9 +1241,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   or a0, a0, a1
 ;   ret
 
 function %bor_i64_constant_shift2(i64, i64) -> i64 {
@@ -518,9 +1261,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   or a0,a1,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   or a0, a1, a0
 ;   ret
 
 function %bxor_i32(i32, i32) -> i32 {
@@ -529,8 +1279,14 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xor a0, a0, a1
 ;   ret
 
 function %bxor_i64(i64, i64) -> i64 {
@@ -539,8 +1295,14 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xor a0, a0, a1
 ;   ret
 
 function %bxor_i128(i128, i128) -> i128 {
@@ -549,9 +1311,16 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   xor a0,a0,a2
 ;   xor a1,a1,a3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xor a0, a0, a2
+;   xor a1, a1, a3
 ;   ret
 
 function %bxor_i64_constant(i64) -> i64 {
@@ -561,8 +1330,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   xori a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xori a0, a0, 3
 ;   ret
 
 function %bxor_i64_constant2(i64) -> i64 {
@@ -572,8 +1347,14 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   xori a0,a0,3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xori a0, a0, 3
 ;   ret
 
 function %bxor_i64_constant_shift(i64, i64) -> i64 {
@@ -584,9 +1365,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   xor a0, a0, a1
 ;   ret
 
 function %bxor_i64_constant_shift2(i64, i64) -> i64 {
@@ -597,9 +1385,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a1,3
 ;   xor a0,a1,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 3
+;   xor a0, a1, a0
 ;   ret
 
 function %band_not_i32(i32, i32) -> i32 {
@@ -608,9 +1403,16 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   and a0, a0, a1
 ;   ret
 
 function %band_not_i64(i64, i64) -> i64 {
@@ -619,9 +1421,16 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   and a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   and a0, a0, a1
 ;   ret
 
 function %band_not_i128(i128, i128) -> i128 {
@@ -630,11 +1439,20 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a4,a2
 ;   not a6,a3
 ;   and a0,a0,a4
 ;   and a1,a1,a6
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a4, a2
+;   not a6, a3
+;   and a0, a0, a4
+;   and a1, a1, a6
 ;   ret
 
 function %band_not_i64_constant(i64) -> i64 {
@@ -644,10 +1462,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li a1,4
 ;   not a2,a1
 ;   and a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 4
+;   not a2, a1
+;   and a0, a0, a2
 ;   ret
 
 function %band_not_i64_constant_shift(i64, i64) -> i64 {
@@ -658,10 +1484,18 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a2,a1,4
 ;   not a2,a2
 ;   and a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a1, 4
+;   not a2, a2
+;   and a0, a0, a2
 ;   ret
 
 function %bor_not_i32(i32, i32) -> i32 {
@@ -670,9 +1504,16 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   or a0, a0, a1
 ;   ret
 
 function %bor_not_i64(i64, i64) -> i64 {
@@ -681,9 +1522,16 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   or a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   or a0, a0, a1
 ;   ret
 
 function %bor_not_i128(i128, i128) -> i128 {
@@ -692,11 +1540,20 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a4,a2
 ;   not a6,a3
 ;   or a0,a0,a4
 ;   or a1,a1,a6
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a4, a2
+;   not a6, a3
+;   or a0, a0, a4
+;   or a1, a1, a6
 ;   ret
 
 function %bor_not_i64_constant(i64) -> i64 {
@@ -706,10 +1563,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li a1,4
 ;   not a2,a1
 ;   or a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 4
+;   not a2, a1
+;   or a0, a0, a2
 ;   ret
 
 function %bor_not_i64_constant_shift(i64, i64) -> i64 {
@@ -720,10 +1585,18 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a2,a1,4
 ;   not a2,a2
 ;   or a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a1, 4
+;   not a2, a2
+;   or a0, a0, a2
 ;   ret
 
 function %bxor_not_i32(i32, i32) -> i32 {
@@ -732,9 +1605,16 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   xor a0, a0, a1
 ;   ret
 
 function %bxor_not_i64(i64, i64) -> i64 {
@@ -743,9 +1623,16 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a1,a1
 ;   xor a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a1, a1
+;   xor a0, a0, a1
 ;   ret
 
 function %bxor_not_i128(i128, i128) -> i128 {
@@ -754,11 +1641,20 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   not a4,a2
 ;   not a6,a3
 ;   xor a0,a0,a4
 ;   xor a1,a1,a6
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   not a4, a2
+;   not a6, a3
+;   xor a0, a0, a4
+;   xor a1, a1, a6
 ;   ret
 
 function %bxor_not_i64_constant(i64) -> i64 {
@@ -768,10 +1664,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li a1,4
 ;   not a2,a1
 ;   xor a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 4
+;   not a2, a1
+;   xor a0, a0, a2
 ;   ret
 
 function %bxor_not_i64_constant_shift(i64, i64) -> i64 {
@@ -782,10 +1686,18 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
 ;   slli a2,a1,4
 ;   not a2,a2
 ;   xor a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a1, 4
+;   not a2, a2
+;   xor a0, a0, a2
 ;   ret
 
 function %ishl_i128_i8(i128, i8) -> i128 {
@@ -794,6 +1706,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -808,6 +1721,31 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,zero,a7##condition=(a6 uge a4)
 ;   select_reg a1,a7,a3##condition=(a6 uge a4)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a5, a4, a3
+;   sll a7, a0, a3
+;   srl t4, a0, a5
+;   beqz a3, 0xc
+;   ori t1, t4, 0
+;   j 8
+;   ori t1, zero, 0
+;   sll a0, a1, a3
+;   or a3, t1, a0
+;   addi a4, zero, 0x40
+;   andi a6, a2, 0x7f
+;   bgeu a6, a4, 0xc
+;   ori a0, a7, 0
+;   j 8
+;   ori a0, zero, 0
+;   bgeu a6, a4, 0xc
+;   ori a1, a3, 0
+;   j 8
+;   ori a1, a7, 0
+;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -815,6 +1753,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -829,6 +1768,31 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,zero,t3##condition=(a7 uge a5)
 ;   select_reg a1,t3,a3##condition=(a7 uge a5)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a6, a4, a3
+;   sll t3, a0, a3
+;   srl t0, a0, a6
+;   beqz a3, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   sll a1, a1, a3
+;   or a3, t2, a1
+;   addi a5, zero, 0x40
+;   andi a7, a2, 0x7f
+;   bgeu a7, a5, 0xc
+;   ori a0, t3, 0
+;   j 8
+;   ori a0, zero, 0
+;   bgeu a7, a5, 0xc
+;   ori a1, a3, 0
+;   j 8
+;   ori a1, t3, 0
+;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -836,6 +1800,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -850,6 +1815,30 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,a5,a0##condition=(a6 uge a4)
 ;   select_reg a1,zero,a5##condition=(a6 uge a4)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a5, a4, a3
+;   sll a7, a1, a5
+;   beqz a3, 0xc
+;   ori t4, a7, 0
+;   j 8
+;   ori t4, zero, 0
+;   srl t1, a0, a3
+;   or a0, t4, t1
+;   addi a4, zero, 0x40
+;   srl a5, a1, a3
+;   andi a6, a2, 0x7f
+;   bgeu a6, a4, 8
+;   j 8
+;   ori a0, a5, 0
+;   bgeu a6, a4, 0xc
+;   ori a1, a5, 0
+;   j 8
+;   ori a1, zero, 0
+;   ret
 
 function %ushr_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -857,6 +1846,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -871,6 +1861,31 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,a6,a5##condition=(a7 uge a4)
 ;   select_reg a1,zero,a6##condition=(a7 uge a4)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a6, a4, a3
+;   sll t3, a1, a6
+;   beqz a3, 0xc
+;   ori t0, t3, 0
+;   j 8
+;   ori t0, zero, 0
+;   srl t2, a0, a3
+;   or a5, t0, t2
+;   addi a4, zero, 0x40
+;   srl a6, a1, a3
+;   andi a7, a2, 0x7f
+;   bgeu a7, a4, 0xc
+;   ori a0, a5, 0
+;   j 8
+;   ori a0, a6, 0
+;   bgeu a7, a4, 0xc
+;   ori a1, a6, 0
+;   j 8
+;   ori a1, zero, 0
+;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -878,6 +1893,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -895,6 +1911,36 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,a4,a0##condition=(t2 uge t0)
 ;   select_reg a1,t3,a4##condition=(t2 uge t0)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a5, a4, a3
+;   sll a7, a1, a5
+;   beqz a3, 0xc
+;   ori t4, a7, 0
+;   j 8
+;   ori t4, zero, 0
+;   srl t1, a0, a3
+;   or a0, t4, t1
+;   addi a4, zero, 0x40
+;   sra a4, a1, a3
+;   addi a6, zero, -1
+;   bltz a1, 0xc
+;   ori t3, zero, 0
+;   j 8
+;   ori t3, a6, 0
+;   addi t0, zero, 0x40
+;   andi t2, a2, 0x7f
+;   bgeu t2, t0, 8
+;   j 8
+;   ori a0, a4, 0
+;   bgeu t2, t0, 0xc
+;   ori a1, a4, 0
+;   j 8
+;   ori a1, t3, 0
+;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -902,6 +1948,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -918,5 +1965,36 @@ block0(v0: i128, v1: i128):
 ;   andi a1,a2,127
 ;   select_reg a0,a5,a4##condition=(a1 uge t1)
 ;   select_reg a1,t4,a5##condition=(a1 uge t1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a6, a4, a3
+;   sll t3, a1, a6
+;   beqz a3, 0xc
+;   ori t0, t3, 0
+;   j 8
+;   ori t0, zero, 0
+;   srl t2, a0, a3
+;   or a4, t0, t2
+;   addi a5, zero, 0x40
+;   sra a5, a1, a3
+;   addi a7, zero, -1
+;   bltz a1, 0xc
+;   ori t4, zero, 0
+;   j 8
+;   ori t4, a7, 0
+;   addi t1, zero, 0x40
+;   andi a1, a2, 0x7f
+;   bgeu a1, t1, 0xc
+;   ori a0, a4, 0
+;   j 8
+;   ori a0, a5, 0
+;   bgeu a1, t1, 0xc
+;   ori a1, a5, 0
+;   j 8
+;   ori a1, t4, 0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
@@ -9,6 +9,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -18,5 +19,17 @@ block0(v0: i64, v1: i64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   jalr a1
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -10,6 +10,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -21,6 +22,23 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   auipc a1, 0
+;   ld a1, 0xc(a1)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a1
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f2(i32) -> i64 {
     fn0 = %g(i32 uext) -> i64 
@@ -30,6 +48,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -42,14 +61,40 @@ block0(v0: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a2
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f3(i32) -> i32 uext  {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
 ;   ret
 
 function %f4(i32) -> i64 {
@@ -60,6 +105,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -72,14 +118,40 @@ block0(v0: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a2
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f5(i32) -> i32 sext  {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
 ;   sext.w a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
 ;   ret
 
 function %f6(i8) -> i64 {
@@ -91,6 +163,7 @@ block0(v0: i8):
     return v2
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -117,6 +190,37 @@ block0(v0: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori t3, a0, 0
+;   addi sp, sp, -0x10
+;   addi a0, zero, 0x2a
+;   addi a1, zero, 0x2a
+;   addi a2, zero, 0x2a
+;   addi a3, zero, 0x2a
+;   addi a4, zero, 0x2a
+;   addi a5, zero, 0x2a
+;   addi a6, zero, 0x2a
+;   addi a7, zero, 0x2a
+;   slli t3, t3, 0x38
+;   srai t3, t3, 0x38
+;   sd t3, 0(sp)
+;   auipc t3, 0
+;   ld t3, 0xc(t3)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t3
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f7(i8) -> i32, i32, i32, i32, i32, i32, i32, i32, i8 sext {
 block0(v0: i8):
@@ -124,6 +228,7 @@ block0(v0: i8):
     return v1, v1, v1, v1, v1, v1, v1, v1, v0
 }
 
+; VCode:
 ; block0:
 ;   li a2,42
 ;   mv t1,a2
@@ -146,6 +251,31 @@ block0(v0: i8):
 ;   mv a0,t1
 ;   mv a1,a3
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a2, zero, 0x2a
+;   ori t1, a2, 0
+;   addi a2, zero, 0x2a
+;   ori a3, a2, 0
+;   addi a4, zero, 0x2a
+;   addi a6, zero, 0x2a
+;   addi t3, zero, 0x2a
+;   addi t0, zero, 0x2a
+;   addi t2, zero, 0x2a
+;   addi a2, zero, 0x2a
+;   sw a4, 0(a1)
+;   sw a6, 8(a1)
+;   sw t3, 0x10(a1)
+;   sw t0, 0x18(a1)
+;   sw t2, 0x20(a1)
+;   sw a2, 0x28(a1)
+;   slli t4, a0, 0x38
+;   srai t4, t4, 0x38
+;   sd a0, 0x30(a1)
+;   ori a0, t1, 0
+;   ori a1, a3, 0
+;   ret
 
 function %f8() {
     fn0 = %g0() -> f32
@@ -165,6 +295,7 @@ block0:
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -202,6 +333,73 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   fsd fs2, -8(sp)
+;   fsd fs3, -0x10(sp)
+;   fsd fs11, -0x18(sp)
+;   addi sp, sp, -0x20
+; block0: ; offset 0x20
+;   auipc a6, 0
+;   ld a6, 0xc(a6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a6
+;   fmv.d fs11, fa0
+;   auipc a6, 0
+;   ld a6, 0xc(a6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a6
+;   fmv.d fs2, fa0
+;   auipc a6, 0
+;   ld a6, 0xc(a6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g1 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a6
+;   fmv.d fs3, fa0
+;   auipc a6, 0
+;   ld a6, 0xc(a6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g2 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a6
+;   auipc a7, 0
+;   ld a7, 0xc(a7)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g3 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   fmv.d fa0, fs11
+;   jalr a7
+;   auipc t3, 0
+;   ld t3, 0xc(t3)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g4 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   fmv.d fa0, fs2
+;   jalr t3
+;   auipc t4, 0
+;   ld t4, 0xc(t4)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g4 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   fmv.d fa0, fs3
+;   jalr t4
+;   addi sp, sp, 0x20
+;   fld fs2, -8(sp)
+;   fld fs3, -0x10(sp)
+;   fld fs11, -0x18(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f11(i128, i64) -> i64 {
 block0(v0: i128, v1: i64):
@@ -209,8 +407,14 @@ block0(v0: i128, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   mv a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a0, a1, 0
 ;   ret
 
 function %f11_call(i64) -> i64 {
@@ -223,6 +427,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -238,6 +443,27 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a5, a0, 0
+;   addi a0, zero, 0x2a
+;   ori a1, a5, 0
+;   addi a2, zero, 0x2a
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f11 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a5
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f12(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -245,9 +471,16 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a0,a1
 ;   mv a1,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a0, a1, 0
+;   ori a1, a2, 0
 ;   ret
 
 function %f12_call(i64) -> i64 {
@@ -260,6 +493,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -274,6 +508,26 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a1, a0, 0
+;   addi a2, zero, 0x2a
+;   addi a0, zero, 0x2a
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f12 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a5
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f13(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -281,9 +535,16 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a0,a1
 ;   mv a1,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a0, a1, 0
+;   ori a1, a2, 0
 ;   ret
 
 function %f13_call(i64) -> i64 {
@@ -296,6 +557,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -310,12 +572,33 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a1, a0, 0
+;   addi a2, zero, 0x2a
+;   addi a0, zero, 0x2a
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f13 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a5
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f14(i128, i128, i128, i64, i128) -> i128 {
 block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
     return v4
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -327,6 +610,19 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a0, a7, 0
+;   ld a1, 0x10(s0)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f14_call(i128, i64) -> i128 {
     fn0 = %f14(i128, i128, i128, i64, i128) -> i128
@@ -336,6 +632,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -360,12 +657,41 @@ block0(v0: i128, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a7, a0, 0
+;   ori a6, a2, 0
+;   addi sp, sp, -0x10
+;   sd a1, 0(sp)
+;   ori a5, a1, 0
+;   auipc t3, 0
+;   ld t3, 0xc(t3)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f14 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ori a1, a5, 0
+;   ori a3, a5, 0
+;   ori a0, a7, 0
+;   ori a2, a7, 0
+;   ori a4, a7, 0
+;   jalr t3
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f15(i128, i128, i128, i64, i128) -> i128{
 block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
     return v4
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -377,6 +703,19 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a0, a7, 0
+;   ld a1, 0x10(s0)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f15_call(i128, i64) -> i128 {
     fn0 = %f15(i128, i128, i128, i64, i128) -> i128
@@ -386,6 +725,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -410,6 +750,34 @@ block0(v0: i128, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block0: ; offset 0x10
+;   ori a7, a0, 0
+;   ori a6, a2, 0
+;   addi sp, sp, -0x10
+;   sd a1, 0(sp)
+;   ori a5, a1, 0
+;   auipc t3, 0
+;   ld t3, 0xc(t3)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f15 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ori a1, a5, 0
+;   ori a3, a5, 0
+;   ori a0, a7, 0
+;   ori a2, a7, 0
+;   ori a4, a7, 0
+;   jalr t3
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f16() -> i32, i32 {
 block0:
@@ -418,8 +786,15 @@ block0:
     return v0, v1
 }
 
+; VCode:
 ; block0:
 ;   li a0,0
 ;   li a1,1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a0, zero
+;   addi a1, zero, 1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condbr.clif
@@ -8,8 +8,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   eq a0,a0,a1##ty=i64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a0, a1, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_eq_i128(i128, i128) -> i8 {
@@ -18,8 +27,18 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   eq a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a1, a3, 0x10
+;   bne a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_ne_i128(i128, i128) -> i8 {
@@ -28,8 +47,18 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ne a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a1, a3, 8
+;   beq a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_slt_i128(i128, i128) -> i8 {
@@ -38,8 +67,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   slt a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_ult_i128(i128, i128) -> i8 {
@@ -48,8 +88,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ult a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_sle_i128(i128, i128) -> i8 {
@@ -58,8 +109,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sle a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bltu a2, a0, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_ule_i128(i128, i128) -> i8 {
@@ -68,8 +130,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ule a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bltu a2, a0, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_sgt_i128(i128, i128) -> i8 {
@@ -78,8 +151,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sgt a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a2, a0, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_ugt_i128(i128, i128) -> i8 {
@@ -88,8 +172,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ugt a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a2, a0, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_sge_i128(i128, i128) -> i8 {
@@ -98,8 +193,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sge a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bltu a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %icmp_uge_i128(i128, i128) -> i8 {
@@ -108,8 +214,19 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uge a0,[a0,a1],[a2,a3]##ty=i128
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bltu a0, a2, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f(i64, i64) -> i64 {
@@ -126,6 +243,7 @@ block2:
   return v5
 }
 
+; VCode:
 ; block0:
 ;   eq a2,a0,a1##ty=i64
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -134,6 +252,20 @@ block2:
 ;   ret
 ; block2:
 ;   li a0,2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a0, a1, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+;   beqz a2, 0xc
+; block1: ; offset 0x14
+;   addi a0, zero, 1
+;   ret
+; block2: ; offset 0x1c
+;   addi a0, zero, 2
 ;   ret
 
 function %f(i64, i64) -> i64 {
@@ -146,6 +278,7 @@ block1:
   return v4
 }
 
+; VCode:
 ; block0:
 ;   eq a1,a0,a1##ty=i64
 ;   bne a1,zero,taken(label1),not_taken(label2)
@@ -155,6 +288,16 @@ block1:
 ;   j label3
 ; block3:
 ;   li a0,1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a0, a1, 0xc
+;   addi a1, zero, 1
+;   j 8
+;   mv a1, zero
+; block1: ; offset 0x10
+;   addi a0, zero, 1
 ;   ret
 
 function %i128_brif(i128){
@@ -166,6 +309,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   ne a0,[a0,a1],[zerozero]##ty=i128
 ;   bne a0,zero,taken(label1),not_taken(label2)
@@ -174,6 +318,16 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bnez a1, 8
+;   beqz a0, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+; block1: ; offset 0x14
 ;   ret
 
 function %i128_bricmp_eq(i128, i128) {
@@ -185,6 +339,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   eq a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -193,6 +348,16 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a1, a3, 0x10
+;   bne a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x14
 ;   ret
 
 function %i128_bricmp_ne(i128, i128) {
@@ -204,6 +369,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   ne a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -212,6 +378,16 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bne a1, a3, 8
+;   beq a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x14
 ;   ret
 
 function %i128_bricmp_slt(i128, i128) {
@@ -223,6 +399,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   slt a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -231,6 +408,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_ult(i128, i128) {
@@ -242,6 +430,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   ult a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -250,6 +439,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_sle(i128, i128) {
@@ -261,6 +461,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   sle a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -269,6 +470,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bltu a2, a0, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_ule(i128, i128) {
@@ -280,6 +492,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   ule a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -288,6 +501,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a1, a3, 0xc
+;   bne a1, a3, 0x10
+;   bltu a2, a0, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_sgt(i128, i128) {
@@ -299,6 +523,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   sgt a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -307,6 +532,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a2, a0, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_ugt(i128, i128) {
@@ -318,6 +554,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   ugt a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -326,6 +563,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bgeu a2, a0, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_sge(i128, i128) {
@@ -337,6 +585,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   sge a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -345,6 +594,17 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   blt a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bltu a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
 ;   ret
 
 function %i128_bricmp_uge(i128, i128) {
@@ -356,6 +616,7 @@ block1:
   return
 }
 
+; VCode:
 ; block0:
 ;   uge a2,[a0,a1],[a2,a3]##ty=i128
 ;   bne a2,zero,taken(label1),not_taken(label2)
@@ -365,8 +626,17 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-
-
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bltu a3, a1, 0xc
+;   bne a1, a3, 0x10
+;   bltu a0, a2, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+; block1: ; offset 0x18
+;   ret
 
 function %i8_brif(i8){
 block0(v0: i8):
@@ -377,6 +647,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   andi t2,a0,255
 ;   bne t2,zero,taken(label1),not_taken(label2)
@@ -385,6 +656,12 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi t2, a0, 0xff
+; block1: ; offset 0x4
 ;   ret
 
 function %i16_brif(i16){
@@ -396,6 +673,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   lui a1,16
 ;   addi a1,a1,4095
@@ -407,6 +685,14 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 0x10
+;   addi a1, a1, -1
+;   and a3, a0, a1
+; block1: ; offset 0xc
+;   ret
 
 function %i32_brif(i32){
 block0(v0: i32):
@@ -417,6 +703,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   addiw t2,a0,0
 ;   bne t2,zero,taken(label1),not_taken(label2)
@@ -425,6 +712,12 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sext.w t2, a0
+; block1: ; offset 0x4
 ;   ret
 
 function %i64_brif(i64){
@@ -436,6 +729,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   bne a0,zero,taken(label1),not_taken(label2)
 ; block1:
@@ -443,5 +737,9 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/condops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condops.clif
@@ -10,11 +10,23 @@ block0(v0: i8, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a0,255
 ;   li a4,42
 ;   andi a5,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a5)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a0, 0xff
+;   addi a4, zero, 0x2a
+;   andi a5, a4, 0xff
+;   beq a3, a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
 ;   ret
 
 function %g(i8) -> i8 {
@@ -24,11 +36,23 @@ block0(v0: i8):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   li t2,42
 ;   uext.b a1,a0
 ;   uext.b a3,t2
 ;   eq a0,a1,a3##ty=i8
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x2a
+;   andi a1, a0, 0xff
+;   andi a3, t2, 0xff
+;   bne a1, a3, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %h(i8, i8, i8) -> i8 {
@@ -37,11 +61,20 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   and a1,a0,a1
 ;   not a3,a0
 ;   and a5,a3,a2
 ;   or a0,a1,a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   and a1, a0, a1
+;   not a3, a0
+;   and a5, a3, a2
+;   or a0, a1, a5
 ;   ret
 
 function %i(i8, i8, i8) -> i8 {
@@ -50,9 +83,19 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a0,255
 ;   select_i8 a0,a1,a2##condition=a3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a0, 0xff
+;   beqz a3, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, a2, 0
 ;   ret
 
 function %i(i32, i8, i8) -> i8 {
@@ -63,11 +106,23 @@ block0(v0: i32, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   addiw a3,a0,0
 ;   li a4,42
 ;   addiw a5,a4,0
 ;   select_reg a0,a1,a2##condition=(a3 eq a5)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sext.w a3, a0
+;   addi a4, zero, 0x2a
+;   sext.w a5, a4
+;   beq a3, a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
 ;   ret
 
 function %i128_select(i8, i128, i128) -> i128 {
@@ -76,9 +131,22 @@ block0(v0: i8, v1: i128, v2: i128):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   mv a7,a1
 ;   andi a5,a0,255
 ;   select_i128 [a0,a1],[a7,a2],[a3,a4]##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a7, a1, 0
+;   andi a5, a0, 0xff
+;   beqz a5, 0x10
+;   ori a0, a7, 0
+;   ori a1, a2, 0
+;   j 0xc
+;   ori a0, a3, 0
+;   ori a1, a4, 0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -8,8 +8,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, -1
 ;   ret
 
 function %f() -> i16 {
@@ -18,8 +24,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a0, zero
 ;   ret
 
 function %f() -> i64 {
@@ -28,8 +40,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a0, zero
 ;   ret
 
 function %f() -> i64 {
@@ -38,9 +56,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lui t1,16
 ;   addi a0,t1,4095
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t1, 0x10
+;   addi a0, t1, -1
 ;   ret
 
 function %f() -> i64 {
@@ -49,8 +74,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x00, 0x00, 0xff, 0xff
+;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ret
 
 function %f() -> i64 {
@@ -59,8 +94,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff00000000
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0xff, 0xff, 0x00, 0x00
 ;   ret
 
 function %f() -> i64 {
@@ -69,8 +114,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff000000000000
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xff, 0xff
 ;   ret
 
 function %f() -> i64 {
@@ -79,8 +134,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, -1
 ;   ret
 
 function %f() -> i64 {
@@ -89,8 +150,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lui a0,1048560
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a0, 0xffff0
 ;   ret
 
 function %f() -> i64 {
@@ -99,8 +166,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffffffff0000ffff
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xff, 0xff, 0x00, 0x00
+;   .byte 0xff, 0xff, 0xff, 0xff
 ;   ret
 
 function %f() -> i64 {
@@ -109,8 +186,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000ffffffff
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xff, 0xff, 0xff, 0xff
+;   .byte 0x00, 0x00, 0xff, 0xff
 ;   ret
 
 function %f() -> i64 {
@@ -119,8 +206,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffffffffffff
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xff, 0xff, 0xff, 0xff
+;   .byte 0xff, 0xff, 0x00, 0x00
 ;   ret
 
 function %f() -> i64 {
@@ -129,8 +226,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xf34bf0a31212003a
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x3a, 0x00, 0x12, 0x12
+;   .byte 0xa3, 0xf0, 0x4b, 0xf3
 ;   ret
 
 function %f() -> i64 {
@@ -139,8 +246,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0x12e900001ef40000
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x00, 0x00, 0xf4, 0x1e
+;   .byte 0x00, 0x00, 0xe9, 0x12
 ;   ret
 
 function %f() -> i64 {
@@ -149,8 +266,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0x12e9ffff1ef4ffff
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xff, 0xff, 0xf4, 0x1e
+;   .byte 0xff, 0xff, 0xe9, 0x12
 ;   ret
 
 function %f() -> i32 {
@@ -159,8 +286,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,-1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, -1
 ;   ret
 
 function %f() -> i32 {
@@ -169,8 +302,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xfffffff7
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xf7, 0xff, 0xff, 0xff
+;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ret
 
 function %f() -> i64 {
@@ -179,8 +322,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xfffffff7
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0xf7, 0xff, 0xff, 0xff
+;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ret
 
 function %f() -> i64 {
@@ -189,8 +342,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,-9
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, -9
 ;   ret
 
 function %f() -> f64 {
@@ -199,9 +358,20 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x3ff0000000000000
 ;   fmv.d.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t1, 0
+;   ld t1, 0xc(t1)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0x3f
+;   fmv.d.x fa0, t1
 ;   ret
 
 function %f() -> f32 {
@@ -210,9 +380,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lui t1,264704
 ;   fmv.w.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t1, 0x40a00
+;   fmv.w.x fa0, t1
 ;   ret
 
 function %f() -> f64 {
@@ -221,9 +398,20 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x4049000000000000
 ;   fmv.d.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t1, 0
+;   ld t1, 0xc(t1)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x49, 0x40
+;   fmv.d.x fa0, t1
 ;   ret
 
 function %f() -> f32 {
@@ -232,9 +420,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lui t1,271488
 ;   fmv.w.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t1, 0x42480
+;   fmv.w.x fa0, t1
 ;   ret
 
 function %f() -> f64 {
@@ -243,9 +438,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li t1,0
 ;   fmv.d.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv t1, zero
+;   fmv.d.x fa0, t1
 ;   ret
 
 function %f() -> f32 {
@@ -254,9 +456,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li t1,0
 ;   fmv.w.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv t1, zero
+;   fmv.w.x fa0, t1
 ;   ret
 
 function %f() -> f64 {
@@ -265,9 +474,20 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xc030000000000000
 ;   fmv.d.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t1, 0
+;   ld t1, 0xc(t1)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x30, 0xc0
+;   fmv.d.x fa0, t1
 ;   ret
 
 function %f() -> f32 {
@@ -276,8 +496,18 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   auipc t1,0; ld t1,12(t1); j 8; .4byte 0xc1800000
 ;   fmv.w.x fa0,t1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc t1, 0
+;   lwu t1, 0xc(t1)
+;   j 8
+;   .byte 0x00, 0x00, 0x80, 0xc1
+;   fmv.w.x fa0, t1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/extend-op.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend-op.clif
@@ -10,9 +10,17 @@ block0(v0: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
 ;   addi a0,a0,42
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
+;   addi a0, a0, 0x2a
 ;   ret
 
 function %f2(i8, i64) -> i64 {
@@ -22,9 +30,17 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sext.b a2,a0
 ;   add a0,a2,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a2, a0, 0x38
+;   srai a2, a2, 0x38
+;   add a0, a2, a1
 ;   ret
 
 function %i128_uextend_i64(i64) -> i128 {
@@ -33,8 +49,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   li a1,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a1, zero
 ;   ret
 
 function %i128_sextend_i64(i64) -> i128 {
@@ -43,9 +65,17 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   slt t2,a0,zero
 ;   sext.b1 a1,t2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sltz t2, a0
+;   slli a1, t2, 0x3f
+;   srai a1, a1, 0x3f
 ;   ret
 
 function %i128_uextend_i32(i32) -> i128 {
@@ -54,9 +84,17 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
 ;   li a1,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   mv a1, zero
 ;   ret
 
 function %i128_sextend_i32(i32) -> i128 {
@@ -65,10 +103,20 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.w a0,a0
 ;   slt a1,a0,zero
 ;   sext.b1 a1,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
+;   sltz a1, a0
+;   slli a1, a1, 0x3f
+;   srai a1, a1, 0x3f
 ;   ret
 
 function %i128_uextend_i16(i16) -> i128 {
@@ -77,9 +125,17 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
 ;   li a1,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
+;   mv a1, zero
 ;   ret
 
 function %i128_sextend_i16(i16) -> i128 {
@@ -88,10 +144,20 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h a0,a0
 ;   slt a1,a0,zero
 ;   sext.b1 a1,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srai a0, a0, 0x30
+;   sltz a1, a0
+;   slli a1, a1, 0x3f
+;   srai a1, a1, 0x3f
 ;   ret
 
 function %i128_uextend_i8(i8) -> i128 {
@@ -100,9 +166,16 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
 ;   li a1,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
+;   mv a1, zero
 ;   ret
 
 function %i128_sextend_i8(i8) -> i128 {
@@ -111,9 +184,19 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
 ;   slt a1,a0,zero
 ;   sext.b1 a1,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
+;   sltz a1, a0
+;   slli a1, a1, 0x3f
+;   srai a1, a1, 0x3f
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -12,6 +12,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   li t1,0
 ;   fmv.d.x ft1,t1
@@ -25,6 +26,16 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv t1, zero
+;   fmv.d.x ft1, t1
+;   mv a2, zero
+;   fmv.d.x ft5, a2
+;   fle.d a5, ft5, ft1
+; block1: ; offset 0x14
+;   ret
 
 function %f1() {
 block0:
@@ -36,6 +47,7 @@ block1:
     return
 }
 
+; VCode:
 ; block0:
 ;   li t1,0
 ;   fmv.d.x ft1,t1
@@ -48,5 +60,15 @@ block1:
 ; block2:
 ;   j label3
 ; block3:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv t1, zero
+;   fmv.d.x ft1, t1
+;   mv a2, zero
+;   fmv.d.x ft5, a2
+;   fle.d a5, ft5, ft1
+; block1: ; offset 0x14
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
@@ -8,8 +8,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.lu fa0, a0
 ;   ret
 
 function u0:0(i8) -> f64 {
@@ -18,8 +24,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.lu fa0, a0
 ;   ret
 
 function u0:0(i16) -> f32 {
@@ -28,8 +40,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.lu fa0, a0
 ;   ret
 
 function u0:0(i16) -> f64 {
@@ -38,8 +56,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.lu fa0, a0
 ;   ret
 
 function u0:0(f32) -> i8 {
@@ -48,8 +72,31 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i8 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x00, 0x00, 0x80, 0xbf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x43800
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function u0:0(f64) -> i8 {
@@ -58,8 +105,36 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i8 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0xbf
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x70, 0x40
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function u0:0(f32) -> i16 {
@@ -68,8 +143,31 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i16 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x00, 0x00, 0x80, 0xbf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x47800
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function u0:0(f64) -> i16 {
@@ -78,7 +176,35 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i16 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0xbf
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0x40
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -8,8 +8,14 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fadd.s fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fadd.s fa0, fa0, fa1
 ;   ret
 
 function %f2(f64, f64) -> f64 {
@@ -18,8 +24,14 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fadd.d fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fadd.d fa0, fa0, fa1
 ;   ret
 
 function %f3(f32, f32) -> f32 {
@@ -28,8 +40,14 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fsub.s fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsub.s fa0, fa0, fa1
 ;   ret
 
 function %f4(f64, f64) -> f64 {
@@ -38,8 +56,14 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fsub.d fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsub.d fa0, fa0, fa1
 ;   ret
 
 function %f5(f32, f32) -> f32 {
@@ -48,8 +72,14 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmul.s fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmul.s fa0, fa0, fa1
 ;   ret
 
 function %f6(f64, f64) -> f64 {
@@ -58,8 +88,14 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmul.d fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmul.d fa0, fa0, fa1
 ;   ret
 
 function %f7(f32, f32) -> f32 {
@@ -68,8 +104,14 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fdiv.s fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fdiv.s fa0, fa0, fa1
 ;   ret
 
 function %f8(f64, f64) -> f64 {
@@ -78,8 +120,14 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fdiv.d fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fdiv.d fa0, fa0, fa1
 ;   ret
 
 function %f9(f32, f32) -> f32 {
@@ -88,9 +136,35 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   fmin.s fa0,ft5,fa1##tmp=a1 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a1, ft5, ft5
+;   beqz a1, 0x3c
+;   feq.s a1, fa1, fa1
+;   beqz a1, 0x34
+;   fmin.s fa0, ft5, fa1
+;   fclass.s a1, ft5
+;   andi a1, a1, 0x18
+;   beqz a1, 0x34
+;   fclass.s a1, fa1
+;   andi a1, a1, 0x18
+;   beqz a1, 0x28
+;   fmv.x.w a1, ft5
+;   fmv.x.w t6, fa1
+;   or a1, a1, t6
+;   fmv.w.x fa0, a1
+;   j 0x14
+;   addi a1, zero, -1
+;   srli a1, a1, 0x16
+;   slli a1, a1, 0x16
+;   fmv.w.x fa0, a1
 ;   ret
 
 function %f10(f64, f64) -> f64 {
@@ -99,9 +173,35 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   fmin.d fa0,ft5,fa1##tmp=a1 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a1, ft5, ft5
+;   beqz a1, 0x3c
+;   feq.d a1, fa1, fa1
+;   beqz a1, 0x34
+;   fmin.d fa0, ft5, fa1
+;   fclass.d a1, ft5
+;   andi a1, a1, 0x18
+;   beqz a1, 0x34
+;   fclass.d a1, fa1
+;   andi a1, a1, 0x18
+;   beqz a1, 0x28
+;   fmv.x.d a1, ft5
+;   fmv.x.d t6, fa1
+;   or a1, a1, t6
+;   fmv.d.x fa0, a1
+;   j 0x14
+;   addi a1, zero, -1
+;   srli a1, a1, 0x33
+;   slli a1, a1, 0x33
+;   fmv.d.x fa0, a1
 ;   ret
 
 function %f11(f32, f32) -> f32 {
@@ -110,9 +210,35 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   fmax.s fa0,ft5,fa1##tmp=a1 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a1, ft5, ft5
+;   beqz a1, 0x3c
+;   feq.s a1, fa1, fa1
+;   beqz a1, 0x34
+;   fmax.s fa0, ft5, fa1
+;   fclass.s a1, ft5
+;   andi a1, a1, 0x18
+;   beqz a1, 0x34
+;   fclass.s a1, fa1
+;   andi a1, a1, 0x18
+;   beqz a1, 0x28
+;   fmv.x.w a1, ft5
+;   fmv.x.w t6, fa1
+;   and a1, a1, t6
+;   fmv.w.x fa0, a1
+;   j 0x14
+;   addi a1, zero, -1
+;   srli a1, a1, 0x16
+;   slli a1, a1, 0x16
+;   fmv.w.x fa0, a1
 ;   ret
 
 function %f12(f64, f64) -> f64 {
@@ -121,9 +247,35 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   fmax.d fa0,ft5,fa1##tmp=a1 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a1, ft5, ft5
+;   beqz a1, 0x3c
+;   feq.d a1, fa1, fa1
+;   beqz a1, 0x34
+;   fmax.d fa0, ft5, fa1
+;   fclass.d a1, ft5
+;   andi a1, a1, 0x18
+;   beqz a1, 0x34
+;   fclass.d a1, fa1
+;   andi a1, a1, 0x18
+;   beqz a1, 0x28
+;   fmv.x.d a1, ft5
+;   fmv.x.d t6, fa1
+;   and a1, a1, t6
+;   fmv.d.x fa0, a1
+;   j 0x14
+;   addi a1, zero, -1
+;   srli a1, a1, 0x33
+;   slli a1, a1, 0x33
+;   fmv.d.x fa0, a1
 ;   ret
 
 function %f13(f32) -> f32 {
@@ -132,8 +284,14 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fsqrt.s fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsqrt.s fa0, fa0
 ;   ret
 
 function %f15(f64) -> f64 {
@@ -142,8 +300,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fsqrt.d fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsqrt.d fa0, fa0
 ;   ret
 
 function %f16(f32) -> f32 {
@@ -152,8 +316,14 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fabs.s fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fabs.s fa0, fa0
 ;   ret
 
 function %f17(f64) -> f64 {
@@ -162,8 +332,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fabs.d fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fabs.d fa0, fa0
 ;   ret
 
 function %f18(f32) -> f32 {
@@ -172,8 +348,14 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fneg.s fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fneg.s fa0, fa0
 ;   ret
 
 function %f19(f64) -> f64 {
@@ -182,8 +364,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fneg.d fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fneg.d fa0, fa0
 ;   ret
 
 function %f20(f32) -> f64 {
@@ -192,8 +380,14 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.s fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x75, 0x05, 0x42
 ;   ret
 
 function %f21(f64) -> f32 {
@@ -202,8 +396,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.d fa0,fa0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.d fa0, fa0
 ;   ret
 
 function %f22(f32) -> f32 {
@@ -212,9 +412,29 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   ceil fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a0, ft5, ft5
+;   beqz a0, 0x28
+;   lui t6, 0x4b800
+;   fmv.w.x ft4, t6
+;   fabs.s fa0, ft5
+;   flt.s a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.s a0, ft5, rup
+;   fcvt.s.l fa0, a0, rup
+;   fsgnj.s fa0, fa0, ft5
+;   j 0x10
+;   fadd.s fa0, ft5, ft5
+;   j 8
+;   fmv.s fa0, ft5
 ;   ret
 
 function %f22(f64) -> f64 {
@@ -223,9 +443,33 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   ceil fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a0, ft5, ft5
+;   beqz a0, 0x38
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x40, 0x43
+;   fmv.d.x ft4, t6
+;   fabs.d fa0, ft5
+;   flt.d a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.d a0, ft5, rup
+;   fcvt.d.l fa0, a0, rup
+;   fsgnj.d fa0, fa0, ft5
+;   j 0x10
+;   fadd.d fa0, ft5, ft5
+;   j 8
+;   fmv.d fa0, ft5
 ;   ret
 
 function %f23(f32) -> f32 {
@@ -234,9 +478,29 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   floor fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a0, ft5, ft5
+;   beqz a0, 0x28
+;   lui t6, 0x4b800
+;   fmv.w.x ft4, t6
+;   fabs.s fa0, ft5
+;   flt.s a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.s a0, ft5, rdn
+;   fcvt.s.l fa0, a0, rdn
+;   fsgnj.s fa0, fa0, ft5
+;   j 0x10
+;   fadd.s fa0, ft5, ft5
+;   j 8
+;   fmv.s fa0, ft5
 ;   ret
 
 function %f24(f64) -> f64 {
@@ -245,9 +509,33 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   floor fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a0, ft5, ft5
+;   beqz a0, 0x38
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x40, 0x43
+;   fmv.d.x ft4, t6
+;   fabs.d fa0, ft5
+;   flt.d a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.d a0, ft5, rdn
+;   fcvt.d.l fa0, a0, rdn
+;   fsgnj.d fa0, fa0, ft5
+;   j 0x10
+;   fadd.d fa0, ft5, ft5
+;   j 8
+;   fmv.d fa0, ft5
 ;   ret
 
 function %f25(f32) -> f32 {
@@ -256,9 +544,29 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   trunc fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a0, ft5, ft5
+;   beqz a0, 0x28
+;   lui t6, 0x4b800
+;   fmv.w.x ft4, t6
+;   fabs.s fa0, ft5
+;   flt.s a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.s a0, ft5, rtz
+;   fcvt.s.l fa0, a0, rtz
+;   fsgnj.s fa0, fa0, ft5
+;   j 0x10
+;   fadd.s fa0, ft5, ft5
+;   j 8
+;   fmv.s fa0, ft5
 ;   ret
 
 function %f26(f64) -> f64 {
@@ -267,9 +575,33 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   trunc fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a0, ft5, ft5
+;   beqz a0, 0x38
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x40, 0x43
+;   fmv.d.x ft4, t6
+;   fabs.d fa0, ft5
+;   flt.d a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.d a0, ft5, rtz
+;   fcvt.d.l fa0, a0, rtz
+;   fsgnj.d fa0, fa0, ft5
+;   j 0x10
+;   fadd.d fa0, ft5, ft5
+;   j 8
+;   fmv.d fa0, ft5
 ;   ret
 
 function %f27(f32) -> f32 {
@@ -278,9 +610,29 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   nearest fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.s a0, ft5, ft5
+;   beqz a0, 0x28
+;   lui t6, 0x4b800
+;   fmv.w.x ft4, t6
+;   fabs.s fa0, ft5
+;   flt.s a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.s a0, ft5, rne
+;   fcvt.s.l fa0, a0, rne
+;   fsgnj.s fa0, fa0, ft5
+;   j 0x10
+;   fadd.s fa0, ft5, ft5
+;   j 8
+;   fmv.s fa0, ft5
 ;   ret
 
 function %f28(f64) -> f64 {
@@ -289,9 +641,33 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fmv.d ft5,fa0
 ;   nearest fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d ft5, fa0
+;   feq.d a0, ft5, ft5
+;   beqz a0, 0x38
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0x40, 0x43
+;   fmv.d.x ft4, t6
+;   fabs.d fa0, ft5
+;   flt.d a0, ft4, fa0
+;   bnez a0, 0x1c
+;   fcvt.l.d a0, ft5, rne
+;   fcvt.d.l fa0, a0, rne
+;   fsgnj.d fa0, fa0, ft5
+;   j 0x10
+;   fadd.d fa0, ft5, ft5
+;   j 8
+;   fmv.d fa0, ft5
 ;   ret
 
 function %f29(f32, f32, f32) -> f32 {
@@ -300,8 +676,14 @@ block0(v0: f32, v1: f32, v2: f32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   fmadd.s fa0,fa0,fa1,fa2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmadd.s fa0, fa0, fa1, fa2
 ;   ret
 
 function %f30(f64, f64, f64) -> f64 {
@@ -310,8 +692,14 @@ block0(v0: f64, v1: f64, v2: f64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   fmadd.d fa0,fa0,fa1,fa2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmadd.d fa0, fa0, fa1, fa2
 ;   ret
 
 function %f31(f32, f32) -> f32 {
@@ -320,8 +708,14 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fsgnj.s fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsgnj.s fa0, fa0, fa1
 ;   ret
 
 function %f32(f64, f64) -> f64 {
@@ -330,8 +724,14 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   fsgnj.d fa0,fa0,fa1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fsgnj.d fa0, fa0, fa1
 ;   ret
 
 function %f33(f32) -> i32 {
@@ -340,8 +740,31 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i32 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x00, 0x00, 0x80, 0xbf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x4f800
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f34(f32) -> i32 {
@@ -350,8 +773,31 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint.i32 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x01, 0x00, 0x00, 0xcf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x4f000
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.w.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f35(f32) -> i64 {
@@ -360,8 +806,31 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i64 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x00, 0x00, 0x80, 0xbf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x5f800
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.lu.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f36(f32) -> i64 {
@@ -370,8 +839,31 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint.i64 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0x40
+;   auipc t6, 0
+;   lwu t6, 0xc(t6)
+;   j 8
+;   .byte 0x01, 0x00, 0x00, 0xdf
+;   fmv.w.x ft3, t6
+;   fle.s a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   lui t6, 0x5f000
+;   fmv.w.x ft3, t6
+;   fle.s a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.l.s a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f37(f64) -> i32 {
@@ -380,8 +872,36 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i32 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0xbf
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0x41
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.wu.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f38(f64) -> i32 {
@@ -390,8 +910,36 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint.i32 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x20, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0xc1
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0x41
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.w.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f39(f64) -> i64 {
@@ -400,8 +948,36 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint.i64 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0xbf
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xf0, 0x43
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.lu.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f40(f64) -> i64 {
@@ -410,8 +986,36 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint.i64 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0x54
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x01, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0xc3
+;   fmv.d.x ft3, t6
+;   fle.d a0, fa0, ft3
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   .byte 0x00, 0x00, 0xe0, 0x43
+;   fmv.d.x ft3, t6
+;   fle.d a0, ft3, fa0
+;   beqz a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fcvt.l.d a0, fa0, rtz
+;   j 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
 ;   ret
 
 function %f41(i32) -> f32 {
@@ -420,8 +1024,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.wu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.wu fa0, a0
 ;   ret
 
 function %f42(i32) -> f32 {
@@ -430,8 +1040,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.w fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.w fa0, a0
 ;   ret
 
 function %f43(i64) -> f32 {
@@ -440,8 +1056,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.lu fa0, a0
 ;   ret
 
 function %f44(i64) -> f32 {
@@ -450,8 +1072,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.s.l fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.l fa0, a0
 ;   ret
 
 function %f45(i32) -> f64 {
@@ -460,8 +1088,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.wu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.wu fa0, a0
 ;   ret
 
 function %f46(i32) -> f64 {
@@ -470,8 +1104,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.w fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x75, 0x05, 0xd2
 ;   ret
 
 function %f47(i64) -> f64 {
@@ -480,8 +1120,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.lu fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.lu fa0, a0
 ;   ret
 
 function %f48(i64) -> f64 {
@@ -490,8 +1136,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt.d.l fa0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.l fa0, a0
 ;   ret
 
 function %f49(f32) -> i32 {
@@ -500,8 +1152,18 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint_sat.i32 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.wu.s a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f50(f32) -> i32 {
@@ -510,8 +1172,18 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint_sat.i32 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.w.s a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f51(f32) -> i64 {
@@ -520,8 +1192,18 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint_sat.i64 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.lu.s a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f52(f32) -> i64 {
@@ -530,8 +1212,18 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint_sat.i64 a0,fa0##in_ty=f32 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.l.s a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f53(f64) -> i32 {
@@ -540,8 +1232,18 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint_sat.i32 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.wu.d a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f54(f64) -> i32 {
@@ -550,8 +1252,18 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint_sat.i32 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.w.d a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f55(f64) -> i64 {
@@ -560,8 +1272,18 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_uint_sat.i64 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.lu.d a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 
 function %f56(f64) -> i64 {
@@ -570,7 +1292,17 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   fcvt_to_sint_sat.i64 a0,fa0##in_ty=f64 tmp=ft3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a0, fa0, fa0
+;   beqz a0, 0xc
+;   fcvt.l.d a0, fa0, rtz
+;   j 8
+;   mv a0, zero
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
@@ -8,11 +8,23 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
 ;   li a2,-1
 ;   select_reg a1,zero,a2##condition=(zero eq a0)
 ;   mv a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
+;   addi a2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a1, a2, 0
+;   j 8
+;   ori a1, zero, 0
+;   ori a0, a1, 0
 ;   ret
 
 function %bmask_i128_i64(i128) -> i64 {
@@ -21,10 +33,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
 ;   li a2,-1
 ;   select_reg a0,zero,a2##condition=(zero eq a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
+;   addi a2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, zero, 0
 ;   ret
 
 function %bmask_i128_i32(i128) -> i32 {
@@ -33,10 +56,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
 ;   li a2,-1
 ;   select_reg a0,zero,a2##condition=(zero eq a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
+;   addi a2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, zero, 0
 ;   ret
 
 function %bmask_i128_i16(i128) -> i16 {
@@ -45,10 +79,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
 ;   li a2,-1
 ;   select_reg a0,zero,a2##condition=(zero eq a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
+;   addi a2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, zero, 0
 ;   ret
 
 function %bmask_i128_i8(i128) -> i8 {
@@ -57,10 +102,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   or a0,a0,a1
 ;   li a2,-1
 ;   select_reg a0,zero,a2##condition=(zero eq a0)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   or a0, a0, a1
+;   addi a2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, zero, 0
 ;   ret
 
 function %bmask_i64_i128(i64) -> i128 {
@@ -69,10 +125,21 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   li t2,-1
 ;   select_reg a1,zero,t2##condition=(zero eq a0)
 ;   mv a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, -1
+;   beq zero, a0, 0xc
+;   ori a1, t2, 0
+;   j 8
+;   ori a1, zero, 0
+;   ori a0, a1, 0
 ;   ret
 
 function %bmask_i32_i128(i32) -> i128 {
@@ -81,11 +148,22 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   addiw t2,a0,0
 ;   li a1,-1
 ;   select_reg a1,zero,a1##condition=(zero eq t2)
 ;   mv a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sext.w t2, a0
+;   addi a1, zero, -1
+;   beq zero, t2, 8
+;   j 8
+;   ori a1, zero, 0
+;   ori a0, a1, 0
 ;   ret
 
 function %bmask_i16_i128(i16) -> i128 {
@@ -94,6 +172,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lui a1,16
 ;   addi a1,a1,4095
@@ -102,6 +181,19 @@ block0(v0: i16):
 ;   select_reg a1,zero,a5##condition=(zero eq a3)
 ;   mv a0,a1
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a1, 0x10
+;   addi a1, a1, -1
+;   and a3, a0, a1
+;   addi a5, zero, -1
+;   beq zero, a3, 0xc
+;   ori a1, a5, 0
+;   j 8
+;   ori a1, zero, 0
+;   ori a0, a1, 0
+;   ret
 
 function %bmask_i8_i128(i8) -> i128 {
 block0(v0: i8):
@@ -109,10 +201,21 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   andi t2,a0,255
 ;   li a1,-1
 ;   select_reg a1,zero,a1##condition=(zero eq t2)
 ;   mv a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi t2, a0, 0xff
+;   addi a1, zero, -1
+;   beq zero, t2, 8
+;   j 8
+;   ori a1, zero, 0
+;   ori a0, a1, 0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/iabs-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iabs-zbb.clif
@@ -7,10 +7,19 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b t2,a0
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x38
+;   srai t2, t2, 0x38
+;   neg a1, t2
+;   .byte 0x33, 0xe5, 0xb3, 0x0a
 ;   ret
 
 function %iabs_i16(i16) -> i16 {
@@ -19,10 +28,19 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h t2,a0
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x30
+;   srai t2, t2, 0x30
+;   neg a1, t2
+;   .byte 0x33, 0xe5, 0xb3, 0x0a
 ;   ret
 
 function %iabs_i32(i32) -> i32 {
@@ -31,10 +49,19 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.w t2,a0
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x20
+;   srai t2, t2, 0x20
+;   neg a1, t2
+;   .byte 0x33, 0xe5, 0xb3, 0x0a
 ;   ret
 
 function %iabs_i64(i64) -> i64 {
@@ -43,8 +70,15 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sub t2,zero,a0
 ;   max a0,a0,t2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg t2, a0
+;   .byte 0x33, 0x65, 0x75, 0x0a
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iabs.clif
@@ -7,10 +7,22 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b t2,a0
 ;   sub a1,zero,t2
 ;   select_reg a0,t2,a1##condition=(t2 sgt a1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x38
+;   srai t2, t2, 0x38
+;   neg a1, t2
+;   blt a1, t2, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, t2, 0
 ;   ret
 
 function %iabs_i16(i16) -> i16 {
@@ -19,10 +31,22 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h t2,a0
 ;   sub a1,zero,t2
 ;   select_reg a0,t2,a1##condition=(t2 sgt a1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x30
+;   srai t2, t2, 0x30
+;   neg a1, t2
+;   blt a1, t2, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, t2, 0
 ;   ret
 
 function %iabs_i32(i32) -> i32 {
@@ -31,10 +55,22 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.w t2,a0
 ;   sub a1,zero,t2
 ;   select_reg a0,t2,a1##condition=(t2 sgt a1)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x20
+;   srai t2, t2, 0x20
+;   neg a1, t2
+;   blt a1, t2, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, t2, 0
 ;   ret
 
 function %iabs_i64(i64) -> i64 {
@@ -43,8 +79,16 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   sub t2,zero,a0
 ;   select_reg a0,a0,t2##condition=(a0 sgt t2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   neg t2, a0
+;   blt t2, a0, 8
+;   ori a0, t2, 0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
@@ -10,6 +10,7 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lui t1,14
 ;   addi t1,t1,3532
@@ -18,5 +19,21 @@ block0:
 ;   uext.h a5,t1
 ;   uext.h a7,a2
 ;   ne a0,a5,a7##ty=i16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t1, 0xe
+;   addi t1, t1, -0x234
+;   lui a2, 0xe
+;   addi a2, a2, -0x234
+;   slli a5, t1, 0x30
+;   srli a5, a5, 0x30
+;   slli a7, a2, 0x30
+;   srli a7, a7, 0x30
+;   beq a5, a7, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/multivalue-ret.clif
@@ -10,8 +10,15 @@ block1:
   return v0, v1
 }
 
+; VCode:
 ; block0:
 ;   li a0,1
 ;   li a1,2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, 1
+;   addi a1, zero, 2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
@@ -8,8 +8,14 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   addw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addw a0, a0, a1
 ;   ret
 
 function %add16(i16, i16) -> i16 {
@@ -18,8 +24,14 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   addw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addw a0, a0, a1
 ;   ret
 
 function %add32(i32, i32) -> i32 {
@@ -28,8 +40,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   addw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addw a0, a0, a1
 ;   ret
 
 function %add32_8(i32, i8) -> i32 {
@@ -39,9 +57,17 @@ block0(v0: i32, v1: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sext.b a1,a1
 ;   addw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 0x38
+;   srai a1, a1, 0x38
+;   addw a0, a0, a1
 ;   ret
 
 function %add64_32(i64, i32) -> i64 {
@@ -51,8 +77,16 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sext.w a1,a1
 ;   add a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a1, 0x20
+;   srai a1, a1, 0x20
+;   add a0, a0, a1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/prologue.clif
@@ -75,6 +75,7 @@ block0(v0: f64):
     return v62
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -170,6 +171,103 @@ block0(v0: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   fsd fs0, -8(sp)
+;   fsd fs2, -0x10(sp)
+;   fsd fs3, -0x18(sp)
+;   fsd fs4, -0x20(sp)
+;   fsd fs5, -0x28(sp)
+;   fsd fs6, -0x30(sp)
+;   fsd fs7, -0x38(sp)
+;   fsd fs8, -0x40(sp)
+;   fsd fs9, -0x48(sp)
+;   fsd fs10, -0x50(sp)
+;   fsd fs11, -0x58(sp)
+;   addi sp, sp, -0x60
+; block0: ; offset 0x40
+;   fadd.d ft3, fa0, fa0
+;   fadd.d ft4, fa0, fa0
+;   fadd.d ft5, fa0, fa0
+;   fadd.d ft6, fa0, fa0
+;   fadd.d ft7, fa0, fa0
+;   fadd.d fa1, fa0, fa0
+;   fadd.d fa2, fa0, fa0
+;   fadd.d fa3, fa0, fa0
+;   fadd.d fa4, fa0, fa0
+;   fadd.d fa5, fa0, fa0
+;   fadd.d fa6, fa0, fa0
+;   fadd.d fa7, fa0, fa0
+;   fadd.d ft8, fa0, fa0
+;   fadd.d ft9, fa0, fa0
+;   fadd.d ft10, fa0, fa0
+;   fadd.d ft11, fa0, fa0
+;   fadd.d ft0, fa0, fa0
+;   fadd.d ft1, fa0, fa0
+;   fadd.d ft2, fa0, fa0
+;   fadd.d fs3, fa0, fa0
+;   fadd.d fs4, fa0, fa0
+;   fadd.d fs5, fa0, fa0
+;   fadd.d fs6, fa0, fa0
+;   fadd.d fs7, fa0, fa0
+;   fadd.d fs8, fa0, fa0
+;   fadd.d fs9, fa0, fa0
+;   fadd.d fs10, fa0, fa0
+;   fadd.d fs11, fa0, fa0
+;   fadd.d fs0, fa0, fa0
+;   fadd.d fs1, fa0, fa0
+;   fadd.d fs2, fa0, fa0
+;   fadd.d ft3, fa0, ft3
+;   fadd.d ft4, ft4, ft5
+;   fadd.d ft5, ft6, ft7
+;   fadd.d ft6, fa1, fa2
+;   fadd.d ft7, fa3, fa4
+;   fadd.d fa0, fa5, fa6
+;   fadd.d fa1, fa7, ft8
+;   fadd.d fa2, ft9, ft10
+;   fadd.d fa3, ft11, ft0
+;   fadd.d fa4, ft1, ft2
+;   fadd.d fa5, fs3, fs4
+;   fadd.d fa6, fs5, fs6
+;   fadd.d fa7, fs7, fs8
+;   fadd.d ft8, fs9, fs10
+;   fadd.d ft9, fs11, fs0
+;   fadd.d ft10, fs1, fs2
+;   fadd.d ft3, ft3, ft4
+;   fadd.d ft4, ft5, ft6
+;   fadd.d ft5, ft7, fa0
+;   fadd.d ft6, fa1, fa2
+;   fadd.d ft7, fa3, fa4
+;   fadd.d fa0, fa5, fa6
+;   fadd.d fa1, fa7, ft8
+;   fadd.d fa2, ft9, ft10
+;   fadd.d ft3, ft3, ft4
+;   fadd.d ft4, ft5, ft6
+;   fadd.d ft5, ft7, fa0
+;   fadd.d ft6, fa1, fa2
+;   fadd.d ft3, ft3, ft4
+;   fadd.d ft4, ft5, ft6
+;   fadd.d fa0, ft3, ft4
+;   addi sp, sp, 0x60
+;   fld fs0, -8(sp)
+;   fld fs2, -0x10(sp)
+;   fld fs3, -0x18(sp)
+;   fld fs4, -0x20(sp)
+;   fld fs5, -0x28(sp)
+;   fld fs6, -0x30(sp)
+;   fld fs7, -0x38(sp)
+;   fld fs8, -0x40(sp)
+;   fld fs9, -0x48(sp)
+;   fld fs10, -0x50(sp)
+;   fld fs11, -0x58(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %f2(i64) -> i64 {
 block0(v0: i64):
@@ -217,6 +315,7 @@ block0(v0: i64):
     return v36
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -275,5 +374,66 @@ block0(v0: i64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   sd s5, -8(sp)
+;   sd s6, -0x10(sp)
+;   sd s7, -0x18(sp)
+;   sd s8, -0x20(sp)
+;   sd s9, -0x28(sp)
+;   sd s10, -0x30(sp)
+;   addi sp, sp, -0x30
+; block0: ; offset 0x2c
+;   add t3, a0, a0
+;   add t4, a0, t3
+;   add t0, a0, t4
+;   add t1, a0, t0
+;   add t2, a0, t1
+;   add a1, a0, t2
+;   add a2, a0, a1
+;   add a3, a0, a2
+;   add a4, a0, a3
+;   add a5, a0, a4
+;   add a6, a0, a5
+;   add a7, a0, a6
+;   add s5, a0, a7
+;   add s6, a0, s5
+;   add s7, a0, s6
+;   add s8, a0, s7
+;   add s9, a0, s8
+;   add s10, a0, s9
+;   add t3, a0, t3
+;   add t4, t4, t0
+;   add t0, t1, t2
+;   add t1, a1, a2
+;   add t2, a3, a4
+;   add a0, a5, a6
+;   add a1, a7, s5
+;   add a2, s6, s7
+;   add a3, s8, s9
+;   add t3, s10, t3
+;   add t4, t4, t0
+;   add t0, t1, t2
+;   add t1, a0, a1
+;   add t2, a2, a3
+;   add t3, t3, t4
+;   add t4, t0, t1
+;   add t3, t2, t3
+;   add a0, t4, t3
+;   addi sp, sp, 0x30
+;   ld s5, -8(sp)
+;   ld s6, -0x10(sp)
+;   ld s7, -0x18(sp)
+;   ld s8, -0x20(sp)
+;   ld s9, -0x28(sp)
+;   ld s10, -0x30(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/reduce.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reduce.clif
@@ -8,7 +8,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_32(i128) -> i32 {
@@ -17,7 +22,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_16(i128) -> i16 {
@@ -26,7 +36,12 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %ireduce_128_8(i128) -> i8 {
@@ -35,6 +50,11 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -7,7 +7,12 @@ block0(v0: r64):
   return v0
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %f1(r64) -> i8 {
@@ -16,8 +21,17 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   is_null a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   beq zero, a0, 0xc
+;   mv a0, zero
+;   j 8
+;   addi a0, zero, 1
 ;   ret
 
 function %f2(r64) -> i8 {
@@ -26,8 +40,17 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   is_invalid a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   beq zero, a0, 0xc
+;   mv a0, zero
+;   j 8
+;   addi a0, zero, 1
 ;   ret
 
 function %f3() -> r64 {
@@ -36,8 +59,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   li a0,0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a0, zero
 ;   ret
 
 function %f4(r64, r64) -> r64, r64, r64 {
@@ -60,6 +89,7 @@ block3(v7: r64, v8: r64):
     return v7, v8, v9
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -99,5 +129,46 @@ block3(v7: r64, v8: r64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   sd s7, -8(sp)
+;   addi sp, sp, -0x30
+; block0: ; offset 0x18
+;   sd a0, 8(sp)
+;   sd a1, 0x10(sp)
+;   ori s7, a2, 0
+;   auipc a1, 0
+;   ld a1, 0xc(a1)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a1
+;   mv a1, sp
+;   ld t4, 8(sp)
+;   sd t4, 0(a1)
+;   andi a1, a0, 0xff
+;   beqz a1, 0x10
+; block1: ; offset 0x50
+;   ori a0, t4, 0
+;   ld a1, 0x10(sp)
+;   j 0xc
+; block2: ; offset 0x5c
+;   ori a1, t4, 0
+;   ld a0, 0x10(sp)
+; block3: ; offset 0x64
+;   mv a2, sp
+;   ld a2, 0(a2)
+;   ori a3, s7, 0
+;   sd a2, 0(a3)
+;   addi sp, sp, 0x30
+;   ld s7, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/shift-op.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/shift-op.clif
@@ -10,9 +10,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   slli a1,a0,3
 ;   add a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a1, a0, 3
+;   add a0, a0, a1
 ;   ret
 
 function %f(i32) -> i32 {
@@ -22,7 +29,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   slliw a0,a0,53
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slliw a0, a0, 0x15
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
@@ -12,6 +12,7 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -30,6 +31,36 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,t4,a1##condition=(a2 uge t1)
 ;   select_reg a1,a1,t4##condition=(a2 uge t1)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a6, a4, a3
+;   srl t3, a0, a3
+;   sll t0, a1, a6
+;   ori t1, a1, 0
+;   beqz a3, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a1, t3, t2
+;   srl a4, t1, a3
+;   sll a5, a0, a6
+;   beqz a3, 0xc
+;   ori a7, a5, 0
+;   j 8
+;   ori a7, zero, 0
+;   or t4, a4, a7
+;   addi t1, zero, 0x40
+;   andi a2, a2, 0x7f
+;   bgeu a2, t1, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, t4, 0
+;   bgeu a2, t1, 8
+;   ori a1, t4, 0
+;   ret
 
 function %f0(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -37,6 +68,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a7,a0
 ;   andi a0,a1,63
@@ -48,6 +80,22 @@ block0(v0: i64, v1: i64):
 ;   select_reg t0,zero,t3##condition=(a0 eq zero)
 ;   or a0,a6,t0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a7, a0, 0
+;   andi a0, a1, 0x3f
+;   addi a2, zero, 0x40
+;   sub a4, a2, a0
+;   ori t0, a7, 0
+;   srl a6, t0, a0
+;   sll t3, t0, a4
+;   beqz a0, 0xc
+;   ori t0, t3, 0
+;   j 8
+;   ori t0, zero, 0
+;   or a0, a6, t0
+;   ret
 
 function %f1(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -55,6 +103,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
 ;   andi a2,a1,31
@@ -65,6 +114,22 @@ block0(v0: i32, v1: i32):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   andi a2, a1, 0x1f
+;   addi a4, zero, 0x20
+;   sub a6, a4, a2
+;   srl t3, a0, a2
+;   sll t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %f2(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -72,6 +137,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
 ;   andi a2,a1,15
@@ -82,6 +148,22 @@ block0(v0: i16, v1: i16):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
+;   andi a2, a1, 0xf
+;   addi a4, zero, 0x10
+;   sub a6, a4, a2
+;   srl t3, a0, a2
+;   sll t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %f3(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -89,6 +171,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
 ;   andi a2,a1,7
@@ -99,6 +182,21 @@ block0(v0: i8, v1: i8):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
+;   andi a2, a1, 7
+;   addi a4, zero, 8
+;   sub a6, a4, a2
+;   srl t3, a0, a2
+;   sll t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %i128_rotl(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -106,6 +204,7 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a3,a2,63
 ;   li a4,64
@@ -124,6 +223,36 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,t4,a1##condition=(a2 uge t1)
 ;   select_reg a1,a1,t4##condition=(a2 uge t1)
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a3, a2, 0x3f
+;   addi a4, zero, 0x40
+;   sub a6, a4, a3
+;   sll t3, a0, a3
+;   srl t0, a1, a6
+;   ori t1, a1, 0
+;   beqz a3, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a1, t3, t2
+;   sll a4, t1, a3
+;   srl a5, a0, a6
+;   beqz a3, 0xc
+;   ori a7, a5, 0
+;   j 8
+;   ori a7, zero, 0
+;   or t4, a4, a7
+;   addi t1, zero, 0x40
+;   andi a2, a2, 0x7f
+;   bgeu a2, t1, 0xc
+;   ori a0, a1, 0
+;   j 8
+;   ori a0, t4, 0
+;   bgeu a2, t1, 8
+;   ori a1, t4, 0
+;   ret
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -131,6 +260,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a7,a0
 ;   andi a0,a1,63
@@ -142,6 +272,22 @@ block0(v0: i64, v1: i64):
 ;   select_reg t0,zero,t3##condition=(a0 eq zero)
 ;   or a0,a6,t0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a7, a0, 0
+;   andi a0, a1, 0x3f
+;   addi a2, zero, 0x40
+;   sub a4, a2, a0
+;   ori t0, a7, 0
+;   sll a6, t0, a0
+;   srl t3, t0, a4
+;   beqz a0, 0xc
+;   ori t0, t3, 0
+;   j 8
+;   ori t0, zero, 0
+;   or a0, a6, t0
+;   ret
 
 function %f5(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -149,6 +295,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
 ;   andi a2,a1,31
@@ -159,6 +306,22 @@ block0(v0: i32, v1: i32):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   andi a2, a1, 0x1f
+;   addi a4, zero, 0x20
+;   sub a6, a4, a2
+;   sll t3, a0, a2
+;   srl t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %f6(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -166,6 +329,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
 ;   andi a2,a1,15
@@ -176,6 +340,22 @@ block0(v0: i16, v1: i16):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
+;   andi a2, a1, 0xf
+;   addi a4, zero, 0x10
+;   sub a6, a4, a2
+;   sll t3, a0, a2
+;   srl t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %f7(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -183,6 +363,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
 ;   andi a2,a1,7
@@ -193,6 +374,21 @@ block0(v0: i8, v1: i8):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
+;   andi a2, a1, 7
+;   addi a4, zero, 8
+;   sub a6, a4, a2
+;   sll t3, a0, a2
+;   srl t0, a0, a6
+;   beqz a2, 0xc
+;   ori t2, t0, 0
+;   j 8
+;   ori t2, zero, 0
+;   or a0, t3, t2
+;   ret
 
 function %f8(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -200,8 +396,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srl a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srl a0, a0, a1
 ;   ret
 
 function %f9(i32, i32) -> i32 {
@@ -210,8 +412,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srlw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srlw a0, a0, a1
 ;   ret
 
 function %f10(i16, i16) -> i16 {
@@ -220,10 +428,19 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
 ;   andi a2,a1,15
 ;   srlw a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
+;   andi a2, a1, 0xf
+;   srlw a0, a0, a2
 ;   ret
 
 function %f11(i8, i8) -> i8 {
@@ -232,10 +449,18 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
 ;   andi a2,a1,7
 ;   srlw a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
+;   andi a2, a1, 7
+;   srlw a0, a0, a2
 ;   ret
 
 function %f12(i64, i64) -> i64 {
@@ -244,8 +469,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sll a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sll a0, a0, a1
 ;   ret
 
 function %f13(i32, i32) -> i32 {
@@ -254,8 +485,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sllw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllw a0, a0, a1
 ;   ret
 
 function %f14(i16, i16) -> i16 {
@@ -264,9 +501,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a1,a1,15
 ;   sllw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a1, a1, 0xf
+;   sllw a0, a0, a1
 ;   ret
 
 function %f15(i8, i8) -> i8 {
@@ -275,9 +519,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   andi a1,a1,7
 ;   sllw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a1, a1, 7
+;   sllw a0, a0, a1
 ;   ret
 
 function %f16(i64, i64) -> i64 {
@@ -286,8 +537,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sra a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sra a0, a0, a1
 ;   ret
 
 function %f17(i32, i32) -> i32 {
@@ -296,8 +553,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sraw a0,a0,a1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sraw a0, a0, a1
 ;   ret
 
 function %f18(i16, i16) -> i16 {
@@ -306,10 +569,19 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.h a0,a0
 ;   andi a2,a1,15
 ;   sra a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srai a0, a0, 0x30
+;   andi a2, a1, 0xf
+;   sra a0, a0, a2
 ;   ret
 
 function %f19(i8, i8) -> i8 {
@@ -318,10 +590,19 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
 ;   andi a2,a1,7
 ;   sra a0,a0,a2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
+;   andi a2, a1, 7
+;   sra a0, a0, a2
 ;   ret
 
 function %f20(i64) -> i64 {
@@ -331,6 +612,7 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,17
 ;   andi a1,t2,63
@@ -341,6 +623,21 @@ block0(v0: i64):
 ;   select_reg t1,zero,t4##condition=(a1 eq zero)
 ;   or a0,a7,t1
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x11
+;   andi a1, t2, 0x3f
+;   addi a3, zero, 0x40
+;   sub a5, a3, a1
+;   srl a7, a0, a1
+;   sll t4, a0, a5
+;   beqz a1, 0xc
+;   ori t1, t4, 0
+;   j 8
+;   ori t1, zero, 0
+;   or a0, a7, t1
+;   ret
 
 function %f21(i64) -> i64 {
 block0(v0: i64):
@@ -349,6 +646,7 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,17
 ;   andi a1,t2,63
@@ -359,6 +657,21 @@ block0(v0: i64):
 ;   select_reg t1,zero,t4##condition=(a1 eq zero)
 ;   or a0,a7,t1
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x11
+;   andi a1, t2, 0x3f
+;   addi a3, zero, 0x40
+;   sub a5, a3, a1
+;   sll a7, a0, a1
+;   srl t4, a0, a5
+;   beqz a1, 0xc
+;   ori t1, t4, 0
+;   j 8
+;   ori t1, zero, 0
+;   or a0, a7, t1
+;   ret
 
 function %f22(i32) -> i32 {
 block0(v0: i32):
@@ -367,6 +680,7 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.w t2,a0
 ;   li a1,17
@@ -378,6 +692,23 @@ block0(v0: i32):
 ;   select_reg a0,zero,t1##condition=(a3 eq zero)
 ;   or a0,t4,a0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x20
+;   srli t2, t2, 0x20
+;   addi a1, zero, 0x11
+;   andi a3, a1, 0x1f
+;   addi a5, zero, 0x20
+;   sub a7, a5, a3
+;   sll t4, t2, a3
+;   srl t1, t2, a7
+;   beqz a3, 0xc
+;   ori a0, t1, 0
+;   j 8
+;   ori a0, zero, 0
+;   or a0, t4, a0
+;   ret
 
 function %f23(i16) -> i16 {
 block0(v0: i16):
@@ -386,6 +717,7 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.h t2,a0
 ;   li a1,10
@@ -397,6 +729,23 @@ block0(v0: i16):
 ;   select_reg a0,zero,t1##condition=(a3 eq zero)
 ;   or a0,t4,a0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 0x30
+;   srli t2, t2, 0x30
+;   addi a1, zero, 0xa
+;   andi a3, a1, 0xf
+;   addi a5, zero, 0x10
+;   sub a7, a5, a3
+;   sll t4, t2, a3
+;   srl t1, t2, a7
+;   beqz a3, 0xc
+;   ori a0, t1, 0
+;   j 8
+;   ori a0, zero, 0
+;   or a0, t4, a0
+;   ret
 
 function %f24(i8) -> i8 {
 block0(v0: i8):
@@ -405,6 +754,7 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.b t2,a0
 ;   li a1,3
@@ -416,6 +766,22 @@ block0(v0: i8):
 ;   select_reg a0,zero,t1##condition=(a3 eq zero)
 ;   or a0,t4,a0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi t2, a0, 0xff
+;   addi a1, zero, 3
+;   andi a3, a1, 7
+;   addi a5, zero, 8
+;   sub a7, a5, a3
+;   sll t4, t2, a3
+;   srl t1, t2, a7
+;   beqz a3, 0xc
+;   ori a0, t1, 0
+;   j 8
+;   ori a0, zero, 0
+;   or a0, t4, a0
+;   ret
 
 function %f25(i64) -> i64 {
 block0(v0: i64):
@@ -424,8 +790,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srli a0,a0,17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srli a0, a0, 0x11
 ;   ret
 
 function %f26(i64) -> i64 {
@@ -435,8 +807,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srai a0,a0,17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srai a0, a0, 0x11
 ;   ret
 
 function %f27(i64) -> i64 {
@@ -446,7 +824,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   slli a0,a0,17
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x11
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -8,7 +8,12 @@ block0:
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_leaf_zero(i64 stack_limit) {
@@ -16,7 +21,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
@@ -28,7 +38,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ret
 
 function %stack_limit_call_zero(i64 stack_limit) {
@@ -38,6 +53,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -49,6 +65,25 @@ block0(v0: i64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   bgeu sp, a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+; block0: ; offset 0x18
+;   auipc t2, 0
+;   ld t2, 0xc(t2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t2
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
@@ -62,6 +97,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -76,6 +112,27 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   ld t6, 0(a0)
+;   ld t6, 4(t6)
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+; block0: ; offset 0x20
+;   auipc t2, 0
+;   ld t2, 0xc(t2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t2
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %stack_limit(i64 stack_limit) {
     ss0 = explicit_slot 168
@@ -83,6 +140,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -96,6 +154,22 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   andi t6, a0, 0xb0
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   addi sp, sp, -0xb0
+; block0: ; offset 0x20
+;   addi sp, sp, 0xb0
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %huge_stack_limit(i64 stack_limit) {
     ss0 = explicit_slot 400000
@@ -103,6 +177,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -122,6 +197,38 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   bgeu sp, a0, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   lui t5, 0x62
+;   addi t5, t5, -0x580
+;   add t6, t5, a0
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   lui a0, 0x62
+;   addi a0, a0, -0x580
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfff9e
+;   addi t6, t6, 0x580
+;   add sp, t6, sp
+; block0: ; offset 0x58
+;   lui t6, 0x62
+;   addi t6, t6, -0x580
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %limit_preamble(i64 vmctx) {
     gv0 = vmctx
@@ -133,6 +240,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -148,6 +256,24 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   ld t6, 0(a0)
+;   ld t6, 4(t6)
+;   andi t6, t6, 0x20
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   addi sp, sp, -0x20
+; block0: ; offset 0x28
+;   addi sp, sp, 0x20
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %limit_preamble_huge(i64 vmctx) {
     gv0 = vmctx
@@ -159,6 +285,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -180,6 +307,40 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   ld t6, 0(a0)
+;   ld t6, 4(t6)
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   lui t5, 0x62
+;   addi t5, t5, -0x580
+;   add t6, t5, t6
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   lui a0, 0x62
+;   addi a0, a0, -0x580
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfff9e
+;   addi t6, t6, 0x580
+;   add sp, t6, sp
+; block0: ; offset 0x60
+;   lui t6, 0x62
+;   addi t6, t6, -0x580
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %limit_preamble_huge_offset(i64 vmctx) {
     gv0 = vmctx
@@ -190,6 +351,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -203,5 +365,28 @@ block0(v0: i64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   auipc t6, 0
+;   ld t6, 0xc(t6)
+;   j 0xc
+;   .byte 0x80, 0x1a, 0x06, 0x00
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   add t6, t6, a0
+;   ld t6, 0(t6)
+;   andi t6, t6, 0x20
+;   bgeu sp, t6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   addi sp, sp, -0x20
+; block0: ; offset 0x3c
+;   addi sp, sp, 0x20
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -11,6 +11,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -22,6 +23,20 @@ block0:
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x10
+; block0: ; offset 0x14
+;   mv a0, sp
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 
 function %stack_addr_big() -> i64 {
@@ -33,6 +48,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -48,6 +64,32 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   lui a0, 0x18
+;   addi a0, a0, 0x6b0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6b0
+;   add sp, t6, sp
+; block0: ; offset 0x3c
+;   mv a0, sp
+;   lui t6, 0x18
+;   addi t6, t6, 0x6b0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %stack_load_small() -> i64 {
 ss0 = explicit_slot 8
@@ -57,6 +99,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -69,6 +112,21 @@ block0:
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x10
+; block0: ; offset 0x14
+;   mv t1, sp
+;   ld a0, 0(t1)
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 
 function %stack_load_big() -> i64 {
@@ -80,6 +138,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -96,6 +155,33 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   lui a0, 0x18
+;   addi a0, a0, 0x6b0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6b0
+;   add sp, t6, sp
+; block0: ; offset 0x3c
+;   mv t1, sp
+;   ld a0, 0(t1)
+;   lui t6, 0x18
+;   addi t6, t6, 0x6b0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %stack_store_small(i64) {
 ss0 = explicit_slot 8
@@ -105,6 +191,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -118,6 +205,21 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x10
+; block0: ; offset 0x14
+;   mv t2, sp
+;   sd a0, 0(t2)
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %stack_store_big(i64) {
 ss0 = explicit_slot 100000
@@ -128,6 +230,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -143,6 +246,33 @@ block0(v0: i64):
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   lui a0, 0x18
+;   addi a0, a0, 0x6b0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6b0
+;   add sp, t6, sp
+; block0: ; offset 0x3c
+;   mv t2, sp
+;   sd a0, 0(t2)
+;   lui t6, 0x18
+;   addi t6, t6, 0x6b0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 
 function %i8_spill_slot(i8) -> i8, i64 {
@@ -296,6 +426,7 @@ block0(v0: i8):
   return v0, v137
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -477,6 +608,189 @@ block0(v0: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   sd s1, -8(sp)
+;   sd s2, -0x10(sp)
+;   sd s3, -0x18(sp)
+;   sd s4, -0x20(sp)
+;   sd s5, -0x28(sp)
+;   sd s6, -0x30(sp)
+;   sd s7, -0x38(sp)
+;   sd s8, -0x40(sp)
+;   sd s9, -0x48(sp)
+;   sd s10, -0x50(sp)
+;   sd s11, -0x58(sp)
+;   addi sp, sp, -0x500
+; block0: ; offset 0x40
+;   sd a0, 0x3e8(sp)
+;   addi t3, zero, 2
+;   addi t1, t3, 1
+;   sd t1, 0x498(sp)
+;   addi t3, zero, 4
+;   addi t2, t3, 3
+;   sd t2, 0x490(sp)
+;   addi t3, zero, 6
+;   addi a1, t3, 5
+;   sd a1, 0x488(sp)
+;   addi t3, zero, 8
+;   addi a2, t3, 7
+;   sd a2, 0x480(sp)
+;   addi t3, zero, 0xa
+;   addi a3, t3, 9
+;   sd a3, 0x478(sp)
+;   addi t3, zero, 0xc
+;   addi a4, t3, 0xb
+;   sd a4, 0x470(sp)
+;   addi t3, zero, 0xe
+;   addi a5, t3, 0xd
+;   sd a5, 0x468(sp)
+;   addi t3, zero, 0x10
+;   addi a6, t3, 0xf
+;   sd a6, 0x460(sp)
+;   addi t3, zero, 0x12
+;   addi a7, t3, 0x11
+;   sd a7, 0x458(sp)
+;   addi t3, zero, 0x14
+;   addi t3, t3, 0x13
+;   sd t3, 0x450(sp)
+;   addi t3, zero, 0x16
+;   addi t4, t3, 0x15
+;   sd t4, 0x448(sp)
+;   addi t3, zero, 0x18
+;   addi s6, t3, 0x17
+;   sd s6, 0x440(sp)
+;   addi t3, zero, 0x1a
+;   addi s7, t3, 0x19
+;   sd s7, 0x438(sp)
+;   addi t3, zero, 0x1c
+;   addi s8, t3, 0x1b
+;   sd s8, 0x430(sp)
+;   addi t3, zero, 0x1e
+;   addi s9, t3, 0x1d
+;   sd s9, 0x428(sp)
+;   addi t3, zero, 0x20
+;   addi s10, t3, 0x1f
+;   sd s10, 0x420(sp)
+;   addi t3, zero, 0x22
+;   addi s11, t3, 0x21
+;   sd s11, 0x418(sp)
+;   addi t3, zero, 0x24
+;   addi s1, t3, 0x23
+;   sd s1, 0x410(sp)
+;   addi t3, zero, 0x26
+;   addi s2, t3, 0x25
+;   sd s2, 0x408(sp)
+;   addi t3, zero, 0x1e
+;   addi s3, t3, 0x27
+;   sd s3, 0x400(sp)
+;   addi t3, zero, 0x20
+;   addi s4, t3, 0x1f
+;   sd s4, 0x3f8(sp)
+;   addi t3, zero, 0x22
+;   addi s5, t3, 0x21
+;   sd s5, 0x3f0(sp)
+;   addi t3, zero, 0x24
+;   addi s5, t3, 0x23
+;   addi t3, zero, 0x26
+;   addi a0, t3, 0x25
+;   addi t3, zero, 0x1e
+;   addi t0, t3, 0x27
+;   addi t3, zero, 0x20
+;   addi t1, t3, 0x1f
+;   addi t3, zero, 0x22
+;   addi t2, t3, 0x21
+;   addi t3, zero, 0x24
+;   addi a1, t3, 0x23
+;   addi t3, zero, 0x26
+;   addi a2, t3, 0x25
+;   addi t3, zero, 0x1e
+;   addi a3, t3, 0x27
+;   addi t3, zero, 0x20
+;   addi a4, t3, 0x1f
+;   addi t3, zero, 0x22
+;   addi a5, t3, 0x21
+;   addi t3, zero, 0x24
+;   addi a6, t3, 0x23
+;   addi t3, zero, 0x26
+;   addi a7, t3, 0x25
+;   ld t3, 0x498(sp)
+;   addi t3, t3, 0x27
+;   ld t4, 0x488(sp)
+;   ld s2, 0x490(sp)
+;   add t4, s2, t4
+;   ld s9, 0x478(sp)
+;   ld s7, 0x480(sp)
+;   add s6, s7, s9
+;   ld s3, 0x468(sp)
+;   ld s1, 0x470(sp)
+;   add s7, s1, s3
+;   ld s8, 0x458(sp)
+;   ld s9, 0x460(sp)
+;   add s8, s9, s8
+;   ld s2, 0x448(sp)
+;   ld s11, 0x450(sp)
+;   add s9, s11, s2
+;   ld s10, 0x438(sp)
+;   ld s11, 0x440(sp)
+;   add s10, s11, s10
+;   ld s1, 0x428(sp)
+;   ld s11, 0x430(sp)
+;   add s11, s11, s1
+;   ld s1, 0x418(sp)
+;   ld s4, 0x420(sp)
+;   add s1, s4, s1
+;   ld s2, 0x408(sp)
+;   ld s3, 0x410(sp)
+;   add s2, s3, s2
+;   ld s4, 0x3f8(sp)
+;   ld s3, 0x400(sp)
+;   add s3, s3, s4
+;   ld s4, 0x3f0(sp)
+;   add s5, s4, s5
+;   add t0, a0, t0
+;   add t1, t1, t2
+;   add t2, a1, a2
+;   add a0, a3, a4
+;   add a1, a5, a6
+;   add a2, a7, t3
+;   add t4, t4, s6
+;   add a3, s7, s8
+;   add a4, s9, s10
+;   add a5, s11, s1
+;   add a6, s2, s3
+;   add t0, s5, t0
+;   add t1, t1, t2
+;   add t2, a0, a1
+;   add t4, a2, t4
+;   add a0, a3, a4
+;   add a1, a5, a6
+;   add t0, t0, t1
+;   add t4, t2, t4
+;   add t1, a0, a1
+;   add t4, t0, t4
+;   add a1, t1, t4
+;   ld a0, 0x3e8(sp)
+;   addi sp, sp, 0x500
+;   ld s1, -8(sp)
+;   ld s2, -0x10(sp)
+;   ld s3, -0x18(sp)
+;   ld s4, -0x20(sp)
+;   ld s5, -0x28(sp)
+;   ld s6, -0x30(sp)
+;   ld s7, -0x38(sp)
+;   ld s8, -0x40(sp)
+;   ld s9, -0x48(sp)
+;   ld s10, -0x50(sp)
+;   ld s11, -0x58(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_store(i128) {
 ss0 = explicit_slot 16
@@ -486,6 +800,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -501,6 +816,23 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x10
+; block0: ; offset 0x14
+;   ori a2, a0, 0
+;   mv a0, sp
+;   sd a2, 0(a0)
+;   sd a1, 8(a0)
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_store_inst_offset(i128) {
 ss0 = explicit_slot 16
@@ -511,6 +843,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -526,6 +859,23 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x20
+; block0: ; offset 0x14
+;   ori a2, a0, 0
+;   addi a0, sp, 0x20
+;   sd a2, 0(a0)
+;   sd a1, 8(a0)
+;   addi sp, sp, 0x20
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_store_big(i128) {
 ss0 = explicit_slot 100000
@@ -536,6 +886,7 @@ block0(v0: i128):
   return
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -554,6 +905,35 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   lui a0, 0x18
+;   addi a0, a0, 0x6b0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6b0
+;   add sp, t6, sp
+; block0: ; offset 0x3c
+;   ori a2, a0, 0
+;   mv a0, sp
+;   sd a2, 0(a0)
+;   sd a1, 8(a0)
+;   lui t6, 0x18
+;   addi t6, t6, 0x6b0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_load() -> i128 {
 ss0 = explicit_slot 16
@@ -563,6 +943,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -577,6 +958,22 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x10
+; block0: ; offset 0x14
+;   mv t2, sp
+;   ld a0, 0(t2)
+;   ld a1, 8(t2)
+;   addi sp, sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_load_inst_offset() -> i128 {
 ss0 = explicit_slot 16
@@ -587,6 +984,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -601,6 +999,22 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   addi sp, sp, -0x20
+; block0: ; offset 0x14
+;   addi t2, sp, 0x20
+;   ld a0, 0(t2)
+;   ld a1, 8(t2)
+;   addi sp, sp, 0x20
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
 
 function %i128_stack_load_big() -> i128 {
 ss0 = explicit_slot 100000
@@ -611,6 +1025,7 @@ block0:
   return v0
 }
 
+; VCode:
 ;   add sp,-16
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
@@ -627,5 +1042,33 @@ block0:
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
+;   ret
+; 
+; Disassembled:
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   lui a0, 0x18
+;   addi a0, a0, 0x6b0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %Probestack 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6b0
+;   add sp, t6, sp
+; block0: ; offset 0x3c
+;   mv t2, sp
+;   ld a0, 0(t2)
+;   ld a1, 8(t2)
+;   lui t6, 0x18
+;   addi t6, t6, 0x6b0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
@@ -10,7 +10,17 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   load_sym a0,%my_global+0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %my_global 0
+;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/traps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/traps.clif
@@ -7,8 +7,13 @@ block0:
   trap user0
 }
 
+; VCode:
 ; block0:
 ;   udf##trap_code=user0
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 
 function %g(i64) {
 block0(v0: i64):
@@ -18,6 +23,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   li t2,42
 ;   eq a1,a0,t2##ty=i64
@@ -26,6 +32,19 @@ block0(v0: i64):
 ;   ret
 ; block1:
 ;   udf##trap_code=user0
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x2a
+;   bne a0, t2, 0xc
+;   addi a1, zero, 1
+;   j 8
+;   mv a1, zero
+;   bnez a1, 8
+; block1: ; offset 0x18
+;   ret
+; block2: ; offset 0x1c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 
 function %h() {
 block0:
@@ -33,7 +52,13 @@ block0:
   return
 }
 
+; VCode:
 ; block0:
+;   ebreak
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ebreak
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
@@ -8,6 +8,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,127
 ;   uext.w a1,a0
@@ -15,6 +16,19 @@ block0(v0: i32):
 ;   add a0,a1,a3
 ;   srli a7,a0,32
 ;   trap_if a7,user0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x7f
+;   slli a1, a0, 0x20
+;   srli a1, a1, 0x20
+;   slli a3, t2, 0x20
+;   srli a3, a3, 0x20
+;   add a0, a1, a3
+;   srli a7, a0, 0x20
+;   beqz a7, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f1(i32) -> i32 {
@@ -24,6 +38,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,127
 ;   uext.w a1,t2
@@ -32,6 +47,19 @@ block0(v0: i32):
 ;   srli a7,a0,32
 ;   trap_if a7,user0
 ;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x7f
+;   slli a1, t2, 0x20
+;   srli a1, a1, 0x20
+;   slli a3, a0, 0x20
+;   srli a3, a3, 0x20
+;   add a0, a1, a3
+;   srli a7, a0, 0x20
+;   beqz a7, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
+;   ret
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -39,12 +67,25 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
 ;   uext.w a2,a1
 ;   add a0,a0,a2
 ;   srli a6,a0,32
 ;   trap_if a6,user0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   slli a2, a1, 0x20
+;   srli a2, a2, 0x20
+;   add a0, a0, a2
+;   srli a6, a0, 0x20
+;   beqz a6, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -54,12 +95,26 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   mv a4,a0
 ;   li t2,127
 ;   add a0,a4,t2
 ;   ult a3,a0,a4##ty=i64
 ;   trap_if a3,user0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a4, a0, 0
+;   addi t2, zero, 0x7f
+;   add a0, a4, t2
+;   bgeu a0, a4, 0xc
+;   addi a3, zero, 1
+;   j 8
+;   mv a3, zero
+;   beqz a3, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f3(i64) -> i64 {
@@ -69,11 +124,24 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   li t2,127
 ;   add a0,t2,a0
 ;   ult a3,a0,t2##ty=i64
 ;   trap_if a3,user0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t2, zero, 0x7f
+;   add a0, t2, a0
+;   bgeu a0, t2, 0xc
+;   addi a3, zero, 1
+;   j 8
+;   mv a3, zero
+;   beqz a3, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -82,11 +150,25 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   add a1,a0,a1
 ;   mv a3,a1
 ;   ult a2,a3,a0##ty=i64
 ;   mv a0,a3
 ;   trap_if a2,user0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add a1, a0, a1
+;   ori a3, a1, 0
+;   bgeu a3, a0, 0xc
+;   addi a2, zero, 1
+;   j 8
+;   mv a2, zero
+;   ori a0, a3, 0
+;   beqz a2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/uextend-sextend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uextend-sextend.clif
@@ -8,8 +8,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
 ;   ret
 
 function %f_u_8_32(i8) -> i32 {
@@ -18,8 +24,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
 ;   ret
 
 function %f_u_8_16(i8) -> i16 {
@@ -28,8 +40,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 0xff
 ;   ret
 
 function %f_s_8_64(i8) -> i64 {
@@ -38,8 +56,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
 ;   ret
 
 function %f_s_8_32(i8) -> i32 {
@@ -48,8 +73,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
 ;   ret
 
 function %f_s_8_16(i8) -> i16 {
@@ -58,8 +90,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.b a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x38
+;   srai a0, a0, 0x38
 ;   ret
 
 function %f_u_16_64(i16) -> i64 {
@@ -68,8 +107,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
 ;   ret
 
 function %f_u_16_32(i16) -> i32 {
@@ -78,8 +124,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.h a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
 ;   ret
 
 function %f_s_16_64(i16) -> i64 {
@@ -88,8 +141,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srai a0, a0, 0x30
 ;   ret
 
 function %f_s_16_32(i16) -> i32 {
@@ -98,8 +158,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.h a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x30
+;   srai a0, a0, 0x30
 ;   ret
 
 function %f_u_32_64(i32) -> i64 {
@@ -108,8 +175,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   uext.w a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
 ;   ret
 
 function %f_s_32_64(i32) -> i64 {
@@ -118,7 +192,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   sext.w a0,a0
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   slli a0, a0, 0x20
+;   srai a0, a0, 0x20
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -7,7 +7,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vaq %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vaq %v6, %v1, %v3
@@ -20,7 +29,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   agr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   agr %r2, %r3
 ;   br %r14
 
@@ -31,7 +46,13 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   agfr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   agfr %r2, %r3
 ;   br %r14
 
@@ -42,7 +63,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   aghi %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   aghi %r2, 1
 ;   br %r14
 
@@ -53,8 +80,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   agfi %r2, 32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   agfi %r2, 0x8000
 ;   br %r14
 
 function %iadd_i64_mem(i64, i64) -> i64 {
@@ -64,7 +97,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ag %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ag %r2, 0(%r3)
 ;   br %r14
 
@@ -75,7 +114,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   agh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   agh %r2, 0(%r3)
 ;   br %r14
 
@@ -86,7 +131,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   agf %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   agf %r2, 0(%r3)
 ;   br %r14
 
@@ -96,7 +147,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ar %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ar %r2, %r3
 ;   br %r14
 
@@ -107,7 +164,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, 1
 ;   br %r14
 
@@ -118,8 +181,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   afi %r2, 32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   afi %r2, 0x8000
 ;   br %r14
 
 function %iadd_i32_mem(i32, i64) -> i32 {
@@ -129,7 +198,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   a %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   a %r2, 0(%r3)
 ;   br %r14
 
@@ -140,8 +215,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ay %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ay %r2, 0x1000(%r3)
 ;   br %r14
 
 function %iadd_i32_mem_ext16(i32, i64) -> i32 {
@@ -151,7 +232,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ah %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ah %r2, 0(%r3)
 ;   br %r14
 
@@ -162,8 +249,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ahy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ahy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %iadd_i16(i16, i16) -> i16 {
@@ -172,7 +265,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ar %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ar %r2, %r3
 ;   br %r14
 
@@ -183,7 +282,13 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, 1
 ;   br %r14
 
@@ -194,7 +299,13 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ah %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ah %r2, 0(%r3)
 ;   br %r14
 
@@ -204,7 +315,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ar %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ar %r2, %r3
 ;   br %r14
 
@@ -215,7 +332,13 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, 1
 ;   br %r14
 
@@ -226,7 +349,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   ar %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   ar %r2, %r3
 ;   br %r14
@@ -237,7 +367,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vsq %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vsq %v6, %v1, %v3
@@ -250,7 +389,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sgr %r2, %r3
 ;   br %r14
 
@@ -261,7 +406,13 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sgfr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sgfr %r2, %r3
 ;   br %r14
 
@@ -272,7 +423,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   aghi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   aghi %r2, -1
 ;   br %r14
 
@@ -283,8 +440,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   agfi %r2, -32769
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   agfi %r2, -0x8001
 ;   br %r14
 
 function %isub_i64_mem(i64, i64) -> i64 {
@@ -294,7 +457,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sg %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sg %r2, 0(%r3)
 ;   br %r14
 
@@ -305,7 +474,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sgh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sgh %r2, 0(%r3)
 ;   br %r14
 
@@ -316,7 +491,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sgf %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sgf %r2, 0(%r3)
 ;   br %r14
 
@@ -326,7 +507,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sr %r2, %r3
 ;   br %r14
 
@@ -337,7 +524,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, -1
 ;   br %r14
 
@@ -348,8 +541,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   afi %r2, -32769
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   afi %r2, -0x8001
 ;   br %r14
 
 function %isub_i32_mem(i32, i64) -> i32 {
@@ -359,7 +558,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   s %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   s %r2, 0(%r3)
 ;   br %r14
 
@@ -370,8 +575,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %isub_i32_mem_ext16(i32, i64) -> i32 {
@@ -381,7 +592,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sh %r2, 0(%r3)
 ;   br %r14
 
@@ -392,8 +609,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   shy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   shy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %isub_i16(i16, i16) -> i16 {
@@ -402,7 +625,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sr %r2, %r3
 ;   br %r14
 
@@ -413,7 +642,13 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, -1
 ;   br %r14
 
@@ -424,7 +659,13 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   sh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sh %r2, 0(%r3)
 ;   br %r14
 
@@ -434,7 +675,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sr %r2, %r3
 ;   br %r14
 
@@ -445,7 +692,13 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ahi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ahi %r2, -1
 ;   br %r14
 
@@ -456,7 +709,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   sr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   sr %r2, %r3
 ;   br %r14
@@ -467,9 +727,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
+;   vsq %v6, %v4, %v1
+;   vrepg %v16, %v1, 0
+;   vchg %v18, %v4, %v16
+;   vsel %v20, %v6, %v1, %v18
+;   vst %v20, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vzero %v4
 ;   vsq %v6, %v4, %v1
 ;   vrepg %v16, %v1, 0
 ;   vchg %v18, %v4, %v16
@@ -483,7 +755,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lpgr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lpgr %r2, %r2
 ;   br %r14
 
@@ -494,7 +772,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lpgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lpgfr %r2, %r2
 ;   br %r14
 
@@ -504,7 +788,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lpr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lpr %r2, %r2
 ;   br %r14
 
@@ -514,7 +804,14 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lhr %r4, %r2
+;   lpr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r4, %r2
 ;   lpr %r2, %r4
 ;   br %r14
@@ -525,7 +822,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lbr %r4, %r2
+;   lpr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r4, %r2
 ;   lpr %r2, %r4
 ;   br %r14
@@ -536,9 +840,18 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
+;   vsq %v6, %v4, %v1
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vzero %v4
 ;   vsq %v6, %v4, %v1
 ;   vst %v6, 0(%r2)
 ;   br %r14
@@ -549,7 +862,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcgr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcgr %r2, %r2
 ;   br %r14
 
@@ -560,7 +879,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcgfr %r2, %r2
 ;   br %r14
 
@@ -570,7 +895,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r2, %r2
 ;   br %r14
 
@@ -580,7 +911,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r2, %r2
 ;   br %r14
 
@@ -590,7 +927,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r2, %r2
 ;   br %r14
 
@@ -600,6 +943,7 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
 ;   lgr %r10, %r2
@@ -621,6 +965,29 @@ block0(v0: i128, v1: i128):
 ;   vst %v5, 0(%r2)
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r7, %r15, 0x38(%r15)
+; block0: ; offset 0x6
+;   lgr %r10, %r2
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   lgdr %r4, %f1
+;   vlgvg %r5, %v1, 1
+;   lgdr %r7, %f3
+;   vlgvg %r9, %v3, 1
+;   lgr %r3, %r5
+;   mlgr %r2, %r9
+;   lgr %r8, %r2
+;   msgrkc %r2, %r5, %r7
+;   msgrkc %r5, %r4, %r9
+;   agrk %r4, %r2, %r8
+;   agr %r5, %r4
+;   vlvgp %v5, %r5, %r3
+;   lgr %r2, %r10
+;   vst %v5, 0(%r2)
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
 
 function %imul_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -628,7 +995,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   msgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msgr %r2, %r3
 ;   br %r14
 
@@ -639,7 +1012,13 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mghi %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mghi %r2, 3
 ;   br %r14
 
@@ -650,8 +1029,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   msgfi %r2, 32769
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   msgfi %r2, 0x8001
 ;   br %r14
 
 function %imul_i64_mem(i64, i64) -> i64 {
@@ -661,7 +1046,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   msg %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msg %r2, 0(%r3)
 ;   br %r14
 
@@ -672,7 +1063,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   mgh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mgh %r2, 0(%r3)
 ;   br %r14
 
@@ -683,7 +1080,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   msgf %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msgf %r2, 0(%r3)
 ;   br %r14
 
@@ -693,7 +1096,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   msr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msr %r2, %r3
 ;   br %r14
 
@@ -704,7 +1113,13 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mhi %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mhi %r2, 3
 ;   br %r14
 
@@ -715,8 +1130,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   msfi %r2, 32769
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   msfi %r2, 0x8001
 ;   br %r14
 
 function %imul_i32_mem(i32, i64) -> i32 {
@@ -726,7 +1147,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ms %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ms %r2, 0(%r3)
 ;   br %r14
 
@@ -737,8 +1164,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   msy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   msy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %imul_i32_mem_ext16(i32, i64) -> i32 {
@@ -748,7 +1181,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   mh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mh %r2, 0(%r3)
 ;   br %r14
 
@@ -759,8 +1198,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   mhy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mhy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %imul_i16(i16, i16) -> i16 {
@@ -769,7 +1214,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   msr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msr %r2, %r3
 ;   br %r14
 
@@ -780,7 +1231,13 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mhi %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mhi %r2, 3
 ;   br %r14
 
@@ -791,7 +1248,13 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   mh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mh %r2, 0(%r3)
 ;   br %r14
 
@@ -801,7 +1264,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   msr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   msr %r2, %r3
 ;   br %r14
 
@@ -812,7 +1281,13 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mhi %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mhi %r2, 3
 ;   br %r14
 
@@ -823,7 +1298,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   msr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   msr %r2, %r3
 ;   br %r14
@@ -834,7 +1316,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r5, %r3
+;   lgr %r3, %r2
+;   mlgr %r2, %r5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r5, %r3
 ;   lgr %r3, %r2
 ;   mlgr %r2, %r5
@@ -846,11 +1336,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llgfr %r5, %r2
 ;   llgfr %r3, %r3
 ;   msgr %r5, %r3
 ;   srlg %r2, %r5, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfr %r5, %r2
+;   llgfr %r3, %r3
+;   msgr %r5, %r3
+;   srlg %r2, %r5, 0x20
 ;   br %r14
 
 function %umulhi_i16(i16, i16) -> i16 {
@@ -859,11 +1358,20 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r5, %r2
 ;   llhr %r3, %r3
 ;   msr %r5, %r3
 ;   srlk %r2, %r5, 16
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r5, %r2
+;   llhr %r3, %r3
+;   msr %r5, %r3
+;   srlk %r2, %r5, 0x10
 ;   br %r14
 
 function %umulhi_i8(i8, i8) -> i8 {
@@ -872,7 +1380,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   llcr %r3, %r3
+;   msr %r5, %r3
+;   srlk %r2, %r5, 8
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   llcr %r3, %r3
 ;   msr %r5, %r3
@@ -885,7 +1402,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mgrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mgrk %r2, %r2, %r3
 ;   br %r14
 
@@ -895,11 +1418,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgfr %r5, %r2
 ;   lgfr %r3, %r3
 ;   msgr %r5, %r3
 ;   srag %r2, %r5, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfr %r5, %r2
+;   lgfr %r3, %r3
+;   msgr %r5, %r3
+;   srag %r2, %r5, 0x20
 ;   br %r14
 
 function %smulhi_i16(i16, i16) -> i16 {
@@ -908,11 +1440,20 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhr %r5, %r2
 ;   lhr %r3, %r3
 ;   msr %r5, %r3
 ;   srak %r2, %r5, 16
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r5, %r2
+;   lhr %r3, %r3
+;   msr %r5, %r3
+;   srak %r2, %r5, 0x10
 ;   br %r14
 
 function %smulhi_i8(i8, i8) -> i8 {
@@ -921,7 +1462,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   lbr %r3, %r3
+;   msr %r5, %r3
+;   srak %r2, %r5, 8
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   lbr %r3, %r3
 ;   msr %r5, %r3
@@ -934,6 +1484,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llihf %r4, 2147483647
 ;   iilf %r4, 4294967295
@@ -945,6 +1496,19 @@ block0(v0: i64, v1: i64):
 ;   dsgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llihf %r4, 0x7fffffff
+;   iilf %r4, 0xffffffff
+;   xgrk %r5, %r4, %r2
+;   ngrk %r4, %r5, %r3
+;   cgite %r4, -1 ; trap: int_ovf
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   dsgr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i64_imm(i64) -> i64 {
 block0(v0: i64):
@@ -953,10 +1517,19 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lghi %r4, 2
 ;   dsgr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lghi %r4, 2
+;   dsgr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -966,6 +1539,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
 ;   lgr %r7, %r3
@@ -979,6 +1553,21 @@ block0(v0: i32, v1: i32):
 ;   lgr %r2, %r3
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r7, %r15, 0x38(%r15)
+; block0: ; offset 0x6
+;   lgr %r7, %r3
+;   lgfr %r3, %r2
+;   iilf %r4, 0x7fffffff
+;   xrk %r5, %r4, %r3
+;   lgr %r4, %r7
+;   nr %r5, %r4
+;   cite %r5, -1 ; trap: int_ovf
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
 
 function %sdiv_i32_imm(i32) -> i32 {
 block0(v0: i32):
@@ -987,10 +1576,19 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgfr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1000,6 +1598,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lghr %r5, %r2
 ;   lgr %r2, %r5
@@ -1012,6 +1611,20 @@ block0(v0: i16, v1: i16):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r5, %r2
+;   lgr %r2, %r5
+;   lhr %r4, %r3
+;   lhi %r5, 0x7fff
+;   lgr %r3, %r2
+;   xr %r5, %r3
+;   nr %r5, %r4
+;   cite %r5, -1 ; trap: int_ovf
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i16_imm(i16) -> i16 {
 block0(v0: i16):
@@ -1020,10 +1633,19 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lghr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1033,6 +1655,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r5, %r2
 ;   lgr %r2, %r5
@@ -1045,6 +1668,20 @@ block0(v0: i8, v1: i8):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r5, %r2
+;   lgr %r2, %r5
+;   lbr %r4, %r3
+;   lhi %r5, 0x7f
+;   lgr %r3, %r2
+;   xr %r5, %r3
+;   nr %r5, %r4
+;   cite %r5, -1 ; trap: int_ovf
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i8_imm(i8) -> i8 {
 block0(v0: i8):
@@ -1053,10 +1690,19 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1066,11 +1712,21 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lgr %r3, %r2
 ;   lghi %r2, 0
 ;   dlgr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   lghi %r2, 0
+;   dlgr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1081,11 +1737,21 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lghi %r2, 0
 ;   lghi %r4, 2
 ;   dlgr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lghi %r2, 0
+;   lghi %r4, 2
+;   dlgr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1095,11 +1761,21 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lgr %r3, %r2
 ;   lhi %r2, 0
 ;   dlr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   lhi %r2, 0
+;   dlr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1110,11 +1786,21 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lhi %r2, 0
 ;   lhi %r4, 2
 ;   dlr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lhi %r2, 0
+;   lhi %r4, 2
+;   dlr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -1124,6 +1810,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -1136,6 +1823,21 @@ block0(v0: i16, v1: i16):
 ;   dlr %r2, %r5
 ;   lgr %r2, %r3
 ;   lmg %r8, %r15, 64(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llhr %r3, %r2
+;   lgr %r5, %r4
+;   llhr %r5, %r5
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r8, %r15, 0x40(%r15)
 ;   br %r14
 
 function %udiv_i16_imm(i16) -> i16 {
@@ -1145,6 +1847,7 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 0
 ;   lgr %r5, %r4
@@ -1154,6 +1857,17 @@ block0(v0: i16):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0
+;   lgr %r5, %r4
+;   llhr %r3, %r2
+;   lhi %r4, 2
+;   lgr %r2, %r5
+;   dlr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %udiv_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -1161,6 +1875,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -1174,6 +1889,21 @@ block0(v0: i8, v1: i8):
 ;   lgr %r2, %r3
 ;   lmg %r8, %r15, 64(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llcr %r3, %r2
+;   lgr %r5, %r4
+;   llcr %r5, %r5
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r8, %r15, 0x40(%r15)
+;   br %r14
 
 function %udiv_i8_imm(i8) -> i8 {
 block0(v0: i8):
@@ -1182,6 +1912,7 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 0
 ;   lgr %r5, %r4
@@ -1191,6 +1922,17 @@ block0(v0: i8):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0
+;   lgr %r5, %r4
+;   llcr %r3, %r2
+;   lhi %r4, 2
+;   lgr %r2, %r5
+;   dlr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %srem_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -1198,12 +1940,22 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cghi %r3, -1
 ;   lgr %r4, %r3
 ;   lgr %r3, %r2
 ;   locghie %r3, 0
 ;   dsgr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cghi %r3, -1
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   locghie %r3, 0
+;   dsgr %r2, %r4 ; trap: int_divz
 ;   br %r14
 
 function %srem_i32(i32, i32) -> i32 {
@@ -1212,11 +1964,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   lgfr %r3, %r2
 ;   lgr %r2, %r5
 ;   dsgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   lgfr %r3, %r2
+;   lgr %r2, %r5
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   br %r14
 
 function %srem_i16(i16, i16) -> i16 {
@@ -1225,11 +1986,20 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lghr %r3, %r2
 ;   lhr %r4, %r4
 ;   dsgfr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lghr %r3, %r2
+;   lhr %r4, %r4
+;   dsgfr %r2, %r4 ; trap: int_divz
 ;   br %r14
 
 function %srem_i8(i8, i8) -> i8 {
@@ -1238,11 +2008,20 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lgbr %r3, %r2
 ;   lbr %r4, %r4
 ;   dsgfr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgbr %r3, %r2
+;   lbr %r4, %r4
+;   dsgfr %r2, %r4 ; trap: int_divz
 ;   br %r14
 
 function %urem_i64(i64, i64) -> i64 {
@@ -1251,11 +2030,20 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lgr %r3, %r2
 ;   lghi %r2, 0
 ;   dlgr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   lghi %r2, 0
+;   dlgr %r2, %r4 ; trap: int_divz
 ;   br %r14
 
 function %urem_i32(i32, i32) -> i32 {
@@ -1264,11 +2052,20 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r3
 ;   lgr %r3, %r2
 ;   lhi %r2, 0
 ;   dlr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   lhi %r2, 0
+;   dlr %r2, %r4 ; trap: int_divz
 ;   br %r14
 
 function %urem_i16(i16, i16) -> i16 {
@@ -1277,6 +2074,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -1289,6 +2087,20 @@ block0(v0: i16, v1: i16):
 ;   dlr %r2, %r5
 ;   lmg %r8, %r15, 64(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llhr %r3, %r2
+;   lgr %r5, %r4
+;   llhr %r5, %r5
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lmg %r8, %r15, 0x40(%r15)
+;   br %r14
 
 function %urem_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -1296,6 +2108,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -1307,5 +2120,19 @@ block0(v0: i8, v1: i8):
 ;   lgr %r2, %r8
 ;   dlr %r2, %r5
 ;   lmg %r8, %r15, 64(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llcr %r3, %r2
+;   lgr %r5, %r4
+;   llcr %r5, %r5
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lmg %r8, %r15, 0x40(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
@@ -11,7 +11,16 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvgr %r5, %r2
+;   lrvgr %r2, %r3
+;   csg %r5, %r2, 0(%r4)
+;   lrvgr %r2, %r5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvgr %r5, %r2
 ;   lrvgr %r2, %r3
 ;   csg %r5, %r2, 0(%r4)
@@ -24,7 +33,16 @@ block0(v0: i32, v1: i32, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvr %r5, %r2
+;   lrvr %r2, %r3
+;   cs %r5, %r2, 0(%r4)
+;   lrvr %r2, %r5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvr %r5, %r2
 ;   lrvr %r2, %r3
 ;   cs %r5, %r2, 0(%r4)
@@ -37,6 +55,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
   return v4
 }
 
+; VCode:
 ;   stmg %r11, %r15, 88(%r15)
 ; block0:
 ;   sllk %r11, %r5, 3
@@ -49,6 +68,26 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   lrvr %r2, %r5
 ;   lmg %r11, %r15, 88(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r11, %r15, 0x58(%r15)
+; block0: ; offset 0x6
+;   sllk %r11, %r5, 3
+;   nill %r5, 0xfffc
+;   lrvr %r2, %r3
+;   lrvr %r3, %r4
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0x10(%r11)
+;   rxsbg %r1, %r2, 0xb0, 0x40, 0x30
+;   jglh 0x44
+;   risbgn %r1, %r3, 0x30, 0x40, 0x30
+;   rll %r1, %r1, 0x10(%r11)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1c
+;   rll %r5, %r0, 0(%r11)
+;   lrvr %r2, %r5
+;   lmg %r11, %r15, 0x58(%r15)
+;   br %r14
 
 function %atomic_cas_i8(i64, i8, i8, i64) -> i8 {
 block0(v0: i64, v1: i8, v2: i8, v3: i64):
@@ -56,6 +95,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
   return v4
 }
 
+; VCode:
 ;   stmg %r10, %r15, 80(%r15)
 ; block0:
 ;   lgr %r10, %r3
@@ -66,5 +106,24 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   0: rll %r1, %r0, 0(%r3) ; rxsbg %r1, %r10, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r3)
 ;   lmg %r10, %r15, 80(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r10, %r15, 0x50(%r15)
+; block0: ; offset 0x6
+;   lgr %r10, %r3
+;   sllk %r3, %r5, 3
+;   nill %r5, 0xfffc
+;   lcr %r2, %r3
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r3)
+;   rxsbg %r1, %r10, 0xa0, 0x28, 0x18
+;   jglh 0x42
+;   risbgn %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r3)
+;   lmg %r10, %r15, 0x50(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
@@ -11,7 +11,13 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   csg %r2, %r3, 0(%r4)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   csg %r2, %r3, 0(%r4)
 ;   br %r14
 
@@ -21,7 +27,13 @@ block0(v0: i32, v1: i32, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cs %r2, %r3, 0(%r4)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cs %r2, %r3, 0(%r4)
 ;   br %r14
 
@@ -31,6 +43,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
   return v4
 }
 
+; VCode:
 ; block0:
 ;   lgr %r2, %r3
 ;   sllk %r3, %r5, 3
@@ -39,6 +52,22 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   0: rll %r1, %r0, 0(%r3) ; rxsbg %r1, %r2, 160, 48, 16 ; jglh 1f ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r3)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r2, %r3
+;   sllk %r3, %r5, 3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r3)
+;   rxsbg %r1, %r2, 0xa0, 0x30, 0x10
+;   jglh 0x3a
+;   risbgn %r1, %r4, 0x20, 0x30, 0x10
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r3)
+;   br %r14
 
 function %atomic_cas_i8(i64, i8, i8, i64) -> i8 {
 block0(v0: i64, v1: i8, v2: i8, v3: i64):
@@ -46,6 +75,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
   return v4
 }
 
+; VCode:
 ;   stmg %r10, %r15, 80(%r15)
 ; block0:
 ;   lgr %r10, %r3
@@ -56,5 +86,24 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   0: rll %r1, %r0, 0(%r3) ; rxsbg %r1, %r10, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r3)
 ;   lmg %r10, %r15, 80(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r10, %r15, 0x50(%r15)
+; block0: ; offset 0x6
+;   lgr %r10, %r3
+;   sllk %r3, %r5, 3
+;   nill %r5, 0xfffc
+;   lcr %r2, %r3
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r3)
+;   rxsbg %r1, %r10, 0xa0, 0x28, 0x18
+;   jglh 0x42
+;   risbgn %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r3)
+;   lmg %r10, %r15, 0x50(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_load-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_load-little.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r2, 0(%r2)
 ;   br %r14
 
@@ -19,8 +25,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvg %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvg %r2, 0(%r1)
 ;   br %r14
 
 function %atomic_load_i32(i64) -> i32 {
@@ -29,7 +42,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrv %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r2, 0(%r2)
 ;   br %r14
 
@@ -41,8 +60,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrv %r2, 0(%r1)
 ;   br %r14
 
 function %atomic_load_i16(i64) -> i16 {
@@ -51,7 +77,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r2, 0(%r2)
 ;   br %r14
 
@@ -63,8 +95,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   br %r14
 
 function %atomic_load_i8(i64) -> i8 {
@@ -73,7 +112,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_load.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lg %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r2, 0(%r2)
 ;   br %r14
 
@@ -19,8 +25,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lgrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %atomic_load_i32(i64) -> i32 {
@@ -29,7 +41,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   l %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   l %r2, 0(%r2)
 ;   br %r14
 
@@ -41,8 +59,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %atomic_load_i16(i64) -> i16 {
@@ -51,7 +75,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
 ;   br %r14
 
@@ -63,8 +93,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llhrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %atomic_load_i8(i64) -> i8 {
@@ -73,7 +109,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
@@ -7,9 +7,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: nngrk %r1, %r0, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   .byte 0xb9, 0x64
+;   sth %r1, 0xb01(%r14)
+;   lper %f0, %f0
+;   .byte 0x00, 0x30
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -19,9 +31,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: nnrk %r1, %r0, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   .byte 0xb9, 0x74
+;   sth %r1, 0xa01(%r11)
+;   lper %f0, %f0
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -31,6 +54,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -39,6 +63,21 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
+;   xilf %r1, 0xffff0000
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -46,6 +85,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -55,6 +95,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   xilf %r1, 0xff000000
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_nand_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -62,10 +118,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvgr %r2, %r4
 ;   lg %r0, 0(%r3)
 ;   0: nngrk %r1, %r0, %r2 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvgr %r2, %r4
+;   lg %r0, 0(%r3)
+;   .byte 0xb9, 0x64
+;   lpdr %f1, %f0
+;   csg %r0, %r1, 0(%r3)
+;   jglh 0xa
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -75,10 +143,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvr %r2, %r4
 ;   l %r0, 0(%r3)
 ;   0: nnrk %r1, %r0, %r2 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvr %r2, %r4
+;   l %r0, 0(%r3)
+;   .byte 0xb9, 0x74
+;   lpdr %f1, %f0
+;   cs %r0, %r1, 0(%r3)
+;   jglh 8
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -88,6 +168,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -99,6 +180,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   xilf %r1, 0xffff
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -106,6 +205,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -113,6 +213,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r3, %r2
 ;   l %r0, 0(%r5)
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   xilf %r1, 0xff000000
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
@@ -11,10 +11,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvgr %r2, %r4
 ;   lg %r0, 0(%r3)
 ;   0: csg %r0, %r2, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvgr %r2, %r4
+;   lg %r0, 0(%r3)
+;   csg %r0, %r2, 0(%r3)
+;   jglh 0xa
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -24,10 +34,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvr %r2, %r4
 ;   l %r0, 0(%r3)
 ;   0: cs %r0, %r2, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvr %r2, %r4
+;   l %r0, 0(%r3)
+;   cs %r0, %r2, 0(%r3)
+;   jglh 8
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -37,6 +57,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -48,6 +69,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   risbgn %r1, %r3, 0x30, 0x40, 0x30
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_xchg_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -55,6 +93,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -64,6 +103,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   risbgn %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_add_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -71,9 +125,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; agr %r1, %r4 ; lrvgr %r1, %r1 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   agr %r1, %r4
+;   lrvgr %r1, %r1
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -83,9 +149,21 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; ar %r1, %r4 ; lrvr %r1, %r1 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   ar %r1, %r4
+;   lrvr %r1, %r1
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -95,6 +173,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -106,6 +185,25 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   ar %r1, %r3
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_add_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -113,6 +211,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -123,6 +222,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   ar %r1, %r3
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_sub_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -130,9 +245,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; sgr %r1, %r4 ; lrvgr %r1, %r1 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   sgr %r1, %r4
+;   lrvgr %r1, %r1
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -142,9 +269,21 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; sr %r1, %r4 ; lrvr %r1, %r1 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   sr %r1, %r4
+;   lrvr %r1, %r1
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -154,6 +293,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -165,6 +305,25 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   sr %r1, %r3
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_sub_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -172,6 +331,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -182,6 +342,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   sr %r1, %r3
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_and_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -189,7 +365,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvgr %r2, %r4
+;   lang %r4, %r2, 0(%r3)
+;   lrvgr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
 ;   lang %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
@@ -201,7 +385,15 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvr %r2, %r4
+;   lan %r4, %r2, 0(%r3)
+;   lrvr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvr %r2, %r4
 ;   lan %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
@@ -213,6 +405,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -224,6 +417,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_and_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -231,6 +441,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -240,6 +451,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_or_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -247,7 +473,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvgr %r2, %r4
+;   laog %r4, %r2, 0(%r3)
+;   lrvgr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
 ;   laog %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
@@ -259,7 +493,15 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvr %r2, %r4
+;   lao %r4, %r2, 0(%r3)
+;   lrvr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvr %r2, %r4
 ;   lao %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
@@ -271,6 +513,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -282,6 +525,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   rosbg %r1, %r3, 0x30, 0x40, 0x30
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_or_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -289,6 +549,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -298,6 +559,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rosbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_xor_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -305,7 +581,15 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvgr %r2, %r4
+;   laxg %r4, %r2, 0(%r3)
+;   lrvgr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
 ;   laxg %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
@@ -317,7 +601,15 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lrvr %r2, %r4
+;   lax %r4, %r2, 0(%r3)
+;   lrvr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvr %r2, %r4
 ;   lax %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
@@ -329,6 +621,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -340,6 +633,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   rxsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_xor_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -347,6 +657,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -356,6 +667,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rxsbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_nand_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -363,10 +689,23 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvgr %r2, %r4
 ;   lg %r0, 0(%r3)
 ;   0: ngrk %r1, %r0, %r2 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvgr %r2, %r4
+;   lg %r0, 0(%r3)
+;   ngrk %r1, %r0, %r2
+;   xilf %r1, 0xffffffff
+;   xihf %r1, 0xffffffff
+;   csg %r0, %r1, 0(%r3)
+;   jglh 0xa
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -376,10 +715,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvr %r2, %r4
 ;   l %r0, 0(%r3)
 ;   0: nrk %r1, %r0, %r2 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvr %r2, %r4
+;   l %r0, 0(%r3)
+;   nrk %r1, %r0, %r2
+;   xilf %r1, 0xffffffff
+;   cs %r0, %r1, 0(%r3)
+;   jglh 8
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -389,6 +740,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -400,6 +752,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   lrvr %r3, %r5
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   xilf %r1, 0xffff
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1a
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -407,6 +777,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -416,6 +787,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   xilf %r1, 0xff000000
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_smin_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -423,9 +810,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; cgr %r4, %r1 ; jgnl 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   cgr %r4, %r1
+;   jgnl 0x24
+;   lrvgr %r1, %r4
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -435,9 +835,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; cr %r4, %r1 ; jgnl 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   cr %r4, %r1
+;   jgnl 0x1e
+;   lrvr %r1, %r4
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -447,6 +860,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -458,6 +872,27 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   cr %r3, %r1
+;   jgnl 0x48
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_smin_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -465,6 +900,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -475,6 +911,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnl 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_smax_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -482,9 +936,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; cgr %r4, %r1 ; jgnh 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   cgr %r4, %r1
+;   jgnh 0x24
+;   lrvgr %r1, %r4
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -494,9 +961,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; cr %r4, %r1 ; jgnh 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   cr %r4, %r1
+;   jgnh 0x1e
+;   lrvr %r1, %r4
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -506,6 +986,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -517,6 +998,27 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   cr %r3, %r1
+;   jgnh 0x48
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_smax_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -524,6 +1026,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -534,6 +1037,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnh 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_umin_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -541,9 +1062,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; clgr %r4, %r1 ; jgnl 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   clgr %r4, %r1
+;   jgnl 0x24
+;   lrvgr %r1, %r4
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -553,9 +1087,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; clr %r4, %r1 ; jgnl 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   clr %r4, %r1
+;   jgnl 0x1e
+;   lrvr %r1, %r4
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -565,6 +1112,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -576,6 +1124,27 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   clr %r3, %r1
+;   jgnl 0x48
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_umin_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -583,6 +1152,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -593,6 +1163,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnl 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_umax_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -600,9 +1188,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: lrvgr %r1, %r0 ; clgr %r4, %r1 ; jgnh 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   lrvgr %r1, %r0
+;   clgr %r4, %r1
+;   jgnh 0x24
+;   lrvgr %r1, %r4
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lrvgr %r2, %r0
 ;   br %r14
 
@@ -612,9 +1213,22 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: lrvr %r1, %r0 ; clr %r4, %r1 ; jgnh 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lrvr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   lrvr %r1, %r0
+;   clr %r4, %r1
+;   jgnh 0x1e
+;   lrvr %r1, %r4
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lrvr %r2, %r0
 ;   br %r14
 
@@ -624,6 +1238,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -635,6 +1250,27 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0x10(%r2)
+;   lrvr %r1, %r1
+;   clr %r3, %r1
+;   jgnh 0x48
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   lrvr %r1, %r1
+;   rll %r1, %r1, 0x10(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0(%r2)
+;   lrvr %r2, %r2
+;   br %r14
 
 function %atomic_rmw_umax_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -642,6 +1278,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -650,6 +1287,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r4, %r2
 ;   l %r0, 0(%r5)
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnh 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
@@ -11,9 +11,18 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   csg %r0, %r4, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -23,9 +32,18 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   cs %r0, %r4, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -35,6 +53,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -43,6 +62,20 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   risbgn %r1, %r4, 0x20, 0x30, 0x10
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_xchg_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -50,6 +83,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -59,6 +93,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   risbgn %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_add_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -66,7 +115,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   laag %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   laag %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -76,7 +131,13 @@ block0(v0: i64, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   laa %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   laa %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -86,6 +147,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -96,6 +158,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   ar %r1, %r3
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_add_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -103,6 +181,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -113,6 +192,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   ar %r1, %r3
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_sub_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -120,7 +215,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcgr %r5, %r3
+;   laag %r2, %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcgr %r5, %r3
 ;   laag %r2, %r5, 0(%r2)
 ;   br %r14
@@ -131,7 +233,14 @@ block0(v0: i64, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r3
+;   laa %r2, %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r3
 ;   laa %r2, %r5, 0(%r2)
 ;   br %r14
@@ -142,6 +251,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -152,6 +262,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   sr %r1, %r3
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_sub_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -159,6 +285,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -169,6 +296,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   sr %r1, %r3
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_and_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -176,7 +319,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lang %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lang %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -186,7 +335,13 @@ block0(v0: i64, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lan %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lan %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -196,6 +351,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -204,6 +360,20 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_and_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -211,6 +381,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -220,6 +391,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_or_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -227,7 +413,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   laog %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   laog %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -237,7 +429,13 @@ block0(v0: i64, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lao %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lao %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -247,6 +445,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -255,6 +454,20 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rosbg %r1, %r4, 0x20, 0x30, 0x10
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_or_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -262,6 +475,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -271,6 +485,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rosbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_xor_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -278,7 +507,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   laxg %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   laxg %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -288,7 +523,13 @@ block0(v0: i64, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lax %r2, %r3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lax %r2, %r3, 0(%r2)
 ;   br %r14
 
@@ -298,6 +539,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -306,6 +548,20 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rxsbg %r1, %r4, 0x20, 0x30, 0x10
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_xor_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -313,6 +569,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -322,6 +579,21 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rxsbg %r1, %r4, 0x20, 0x28, 0x18
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_nand_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -329,9 +601,21 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: ngrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   ngrk %r1, %r0, %r4
+;   xilf %r1, 0xffffffff
+;   xihf %r1, 0xffffffff
+;   csg %r0, %r1, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -341,9 +625,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: nrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   nrk %r1, %r0, %r4
+;   xilf %r1, 0xffffffff
+;   cs %r0, %r1, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -353,6 +648,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -361,6 +657,21 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
+;   xilf %r1, 0xffff0000
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x12
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_nand_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -368,6 +679,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -377,6 +689,22 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   lcr %r3, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
+;   xilf %r1, 0xff000000
+;   rll %r1, %r1, 0(%r3)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x14
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_smin_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -384,9 +712,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: cgr %r4, %r0 ; jgnl 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   cgr %r4, %r0
+;   jgnl 0x1c
+;   csg %r0, %r4, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -396,9 +735,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: cr %r4, %r0 ; jgnl 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   cr %r4, %r0
+;   jgnl 0x16
+;   cs %r0, %r4, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -408,6 +758,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -418,6 +769,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnl 0x40
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_smin_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -425,6 +794,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -435,6 +805,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnl 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_smax_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -442,9 +830,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: cgr %r4, %r0 ; jgnh 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   cgr %r4, %r0
+;   jgnh 0x1c
+;   csg %r0, %r4, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -454,9 +853,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: cr %r4, %r0 ; jgnh 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   cr %r4, %r0
+;   jgnh 0x16
+;   cs %r0, %r4, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -466,6 +876,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -476,6 +887,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnh 0x40
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_smax_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -483,6 +912,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -493,6 +923,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   cr %r3, %r1
+;   jgnh 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_umin_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -500,9 +948,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: clgr %r4, %r0 ; jgnl 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   clgr %r4, %r0
+;   jgnl 0x1c
+;   csg %r0, %r4, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -512,9 +971,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: clr %r4, %r0 ; jgnl 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   clr %r4, %r0
+;   jgnl 0x16
+;   cs %r0, %r4, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -524,6 +994,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -534,6 +1005,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnl 0x40
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_umin_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -541,6 +1030,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -551,6 +1041,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnl 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
 
 function %atomic_rmw_umax_i64(i64, i64, i64) -> i64 {
 block0(v0: i64, v1: i64, v2: i64):
@@ -558,9 +1066,20 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lg %r0, 0(%r3)
 ;   0: clgr %r4, %r0 ; jgnh 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r0, 0(%r3)
+;   clgr %r4, %r0
+;   jgnh 0x1c
+;   csg %r0, %r4, 0(%r3)
+;   jglh 6
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -570,9 +1089,20 @@ block0(v0: i64, v1: i64, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   l %r0, 0(%r3)
 ;   0: clr %r4, %r0 ; jgnh 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
+;   lgr %r2, %r0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   l %r0, 0(%r3)
+;   clr %r4, %r0
+;   jgnh 0x16
+;   cs %r0, %r4, 0(%r3)
+;   jglh 4
 ;   lgr %r2, %r0
 ;   br %r14
 
@@ -582,6 +1112,7 @@ block0(v0: i64, v1: i64, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
@@ -592,6 +1123,24 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r4
+;   sllk %r2, %r3, 3
+;   lgr %r4, %r3
+;   nill %r4, 0xfffc
+;   sllk %r3, %r5, 0x10
+;   l %r0, 0(%r4)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnh 0x40
+;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   rll %r1, %r1, 0(%r2)
+;   cs %r0, %r1, 0(%r4)
+;   jglh 0x1c
+;   rll %r2, %r0, 0x10(%r2)
+;   br %r14
 
 function %atomic_rmw_umax_i8(i64, i64, i8) -> i8 {
 block0(v0: i64, v1: i64, v2: i8):
@@ -599,6 +1148,7 @@ block0(v0: i64, v1: i64, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
 ;   lgr %r5, %r3
@@ -607,6 +1157,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r4, %r2
 ;   l %r0, 0(%r5)
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   rll %r2, %r0, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r3, 3
+;   lgr %r5, %r3
+;   nill %r5, 0xfffc
+;   sllk %r3, %r4, 0x18
+;   lcr %r4, %r2
+;   l %r0, 0(%r5)
+;   rll %r1, %r0, 0(%r2)
+;   clr %r3, %r1
+;   jgnh 0x3e
+;   risbgn %r1, %r3, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r4)
+;   cs %r0, %r1, 0(%r5)
+;   jglh 0x1a
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_store-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_store-little.clif
@@ -7,9 +7,16 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   strvg %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strvg %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i64_sym(i64) {
@@ -20,9 +27,17 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvg %r2, 0(%r1)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvg %r2, 0(%r1)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i64(i64) {
@@ -32,10 +47,18 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lghi %r4, 12345
 ;   strvg %r4, 0(%r2)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghi %r4, 0x3039
+;   strvg %r4, 0(%r2)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i32(i32, i64) {
@@ -44,9 +67,16 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   strv %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strv %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i32_sym(i32) {
@@ -57,9 +87,17 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strv %r2, 0(%r1)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i32(i64) {
@@ -69,10 +107,18 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 12345
 ;   strv %r4, 0(%r2)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0x3039
+;   strv %r4, 0(%r2)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i16(i16, i64) {
@@ -81,9 +127,16 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   strvh %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strvh %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i16_sym(i16) {
@@ -94,9 +147,17 @@ block0(v0: i16):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvh %r2, 0(%r1)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i16(i64) {
@@ -106,9 +167,16 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 14640
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3930
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i8(i8, i64) {
@@ -117,9 +185,16 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stc %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i8(i64) {
@@ -129,8 +204,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
+;   bnor %r0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_store.clif
@@ -7,9 +7,16 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stg %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stg %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i64_sym(i64) {
@@ -20,9 +27,16 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stgrl %r2, %sym + 0
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i64(i64) {
@@ -32,9 +46,16 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvghi 0(%r2), 12345
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvghi 0(%r2), 0x3039
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i32(i32, i64) {
@@ -43,9 +64,16 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   st %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   st %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i32_sym(i32) {
@@ -56,9 +84,16 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   strl %r2, %sym + 0
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i32(i64) {
@@ -68,9 +103,16 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhi 0(%r2), 12345
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhi 0(%r2), 0x3039
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i16(i16, i64) {
@@ -79,9 +121,16 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   sth %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sth %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i16_sym(i16) {
@@ -92,9 +141,16 @@ block0(v0: i16):
   return
 }
 
+; VCode:
 ; block0:
 ;   sthrl %r2, %sym + 0
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i16(i64) {
@@ -104,9 +160,16 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 12345
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3039
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_i8(i8, i64) {
@@ -115,9 +178,16 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stc %r2, 0(%r3)
+;   bnor %r0
 ;   br %r14
 
 function %atomic_store_imm_i8(i64) {
@@ -127,8 +197,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
+;   bnor %r0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitcast.clif
@@ -9,7 +9,12 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i16_i16(i16) -> i16 {
@@ -18,7 +23,12 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i32_i32(i32) -> i32 {
@@ -27,7 +37,12 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64_i64(i64) -> i64 {
@@ -36,7 +51,12 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i128_i128(i128) -> i128 {
@@ -45,7 +65,14 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vst %v1, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vst %v1, 0(%r2)
 ;   br %r14
@@ -56,7 +83,12 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64_r64(i64) -> r64 {
@@ -65,7 +97,12 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_r64_r64(r64) -> r64 {
@@ -74,6 +111,11 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitops-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops-arch13.clif
@@ -11,8 +11,15 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   popcnt %r2, %r2, 8
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xe1
+;   .byte 0x80, 0x22
 ;   br %r14
 
 function %popcnt_i32(i32) -> i32 {
@@ -21,9 +28,17 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   llgfr %r4, %r2
 ;   popcnt %r2, %r4, 8
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfr %r4, %r2
+;   .byte 0xb9, 0xe1
+;   .byte 0x80, 0x24
 ;   br %r14
 
 function %popcnt_i16(i16) -> i16 {
@@ -32,9 +47,17 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   llghr %r4, %r2
 ;   popcnt %r2, %r4, 8
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llghr %r4, %r2
+;   .byte 0xb9, 0xe1
+;   .byte 0x80, 0x24
 ;   br %r14
 
 function %popcnt_i8(i8) -> i8 {
@@ -43,7 +66,13 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   popcnt %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   popcnt %r2, %r2
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
@@ -8,8 +8,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ncrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xf5
+;   lper %f2, %f2
 ;   br %r14
 
 function %band_not_i32_reversed(i32, i32) -> i32 {
@@ -19,8 +26,15 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ncrk %r2, %r3, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xf5
+;   lpdr %f2, %f3
 ;   br %r14
 
 function %bor_not_i32(i32, i32) -> i32 {
@@ -29,8 +43,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ocrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x75
+;   lper %f2, %f2
 ;   br %r14
 
 function %bor_not_i32_reversed(i32, i32) -> i32 {
@@ -40,8 +61,15 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ocrk %r2, %r3, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x75
+;   lpdr %f2, %f3
 ;   br %r14
 
 function %bxor_not_i32(i32, i32) -> i32 {
@@ -50,8 +78,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lper %f2, %f2
 ;   br %r14
 
 function %bxor_not_i32_reversed(i32, i32) -> i32 {
@@ -61,8 +96,15 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r3, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lpdr %f2, %f3
 ;   br %r14
 
 function %bnot_of_bxor(i32, i32) -> i32 {
@@ -72,6 +114,14 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lper %f2, %f2
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -7,6 +7,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 170
@@ -28,6 +29,38 @@ block0(v0: i128):
 ;   vperm %v20, %v16, %v16, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0xaa
+;   vrepib %v6, 1
+;   vsl %v16, %v1, %v6
+;   vsrl %v18, %v1, %v6
+;   vsel %v20, %v16, %v18, %v4
+;   vrepib %v22, 0xcc
+;   vrepib %v24, 2
+;   vsl %v26, %v20, %v24
+;   vsrl %v28, %v20, %v24
+;   vsel %v30, %v26, %v28, %v22
+;   vrepib %v0, 0xf0
+;   vrepib %v2, 4
+;   vsl %v4, %v30, %v2
+;   vsrl %v6, %v30, %v2
+;   vsel %v16, %v4, %v6, %v0
+;   bras %r1, 0x74
+;   clcl %r0, %r14
+;   basr %r0, %r12
+;   bsm %r0, %r10
+;   .byte 0x09, 0x08
+;   bcr 0, %r6
+;   balr %r0, %r4
+;   .byte 0x03, 0x02
+;   .byte 0x01, 0x00
+;   vl %v18, 0(%r1)
+;   vperm %v20, %v16, %v16, %v18
+;   vst %v20, 0(%r2)
+;   br %r14
 
 function %bitrev_i64(i64) -> i64 {
 block0(v0: i64):
@@ -35,6 +68,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r2
 ;   llihf %r2, 2863311530
@@ -67,6 +101,40 @@ block0(v0: i64):
 ;   ogr %r4, %r2
 ;   lrvgr %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r2
+;   llihf %r2, 0xaaaaaaaa
+;   iilf %r2, 0xaaaaaaaa
+;   lgr %r3, %r4
+;   sllg %r4, %r3, 1
+;   srlg %r3, %r3, 1
+;   ngr %r4, %r2
+;   xilf %r2, 0xffffffff
+;   xihf %r2, 0xffffffff
+;   ngrk %r2, %r3, %r2
+;   ogrk %r5, %r4, %r2
+;   llihf %r4, 0xcccccccc
+;   iilf %r4, 0xcccccccc
+;   sllg %r2, %r5, 2
+;   srlg %r5, %r5, 2
+;   ngr %r2, %r4
+;   xilf %r4, 0xffffffff
+;   xihf %r4, 0xffffffff
+;   ngrk %r4, %r5, %r4
+;   ogrk %r3, %r2, %r4
+;   llihf %r2, 0xf0f0f0f0
+;   iilf %r2, 0xf0f0f0f0
+;   sllg %r4, %r3, 4
+;   srlg %r3, %r3, 4
+;   ngr %r4, %r2
+;   xilf %r2, 0xffffffff
+;   xihf %r2, 0xffffffff
+;   ngrk %r2, %r3, %r2
+;   ogr %r4, %r2
+;   lrvgr %r2, %r4
+;   br %r14
 
 function %bitrev_i32(i32) -> i32 {
 block0(v0: i32):
@@ -74,6 +142,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   iilf %r4, 2863311530
 ;   sllk %r3, %r2, 1
@@ -98,6 +167,32 @@ block0(v0: i32):
 ;   ork %r4, %r2, %r3
 ;   lrvr %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   iilf %r4, 0xaaaaaaaa
+;   sllk %r3, %r2, 1
+;   srlk %r5, %r2, 1
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   ork %r4, %r2, %r3
+;   iilf %r2, 0xcccccccc
+;   sllk %r5, %r4, 2
+;   srlk %r3, %r4, 2
+;   nrk %r4, %r5, %r2
+;   xilf %r2, 0xffffffff
+;   nrk %r5, %r3, %r2
+;   ork %r2, %r4, %r5
+;   iilf %r4, 0xf0f0f0f0
+;   sllk %r3, %r2, 4
+;   srlk %r5, %r2, 4
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   ork %r4, %r2, %r3
+;   lrvr %r2, %r4
+;   br %r14
 
 function %bitrev_i16(i16) -> i16 {
 block0(v0: i16):
@@ -105,6 +200,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, -21846
 ;   sllk %r3, %r2, 1
@@ -130,6 +226,33 @@ block0(v0: i16):
 ;   lrvr %r2, %r4
 ;   srlk %r2, %r2, 16
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, -0x5556
+;   sllk %r3, %r2, 1
+;   srlk %r5, %r2, 1
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   ork %r4, %r2, %r3
+;   lhi %r2, -0x3334
+;   sllk %r5, %r4, 2
+;   srlk %r3, %r4, 2
+;   nrk %r4, %r5, %r2
+;   xilf %r2, 0xffffffff
+;   nrk %r5, %r3, %r2
+;   ork %r2, %r4, %r5
+;   lhi %r4, -0xf10
+;   sllk %r3, %r2, 4
+;   srlk %r5, %r2, 4
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   ork %r4, %r2, %r3
+;   lrvr %r2, %r4
+;   srlk %r2, %r2, 0x10
+;   br %r14
 
 function %bitrev_i8(i8) -> i8 {
 block0(v0: i8):
@@ -137,6 +260,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, -21846
 ;   sllk %r3, %r2, 1
@@ -160,6 +284,31 @@ block0(v0: i8):
 ;   nrk %r3, %r5, %r4
 ;   or %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, -0x5556
+;   sllk %r3, %r2, 1
+;   srlk %r5, %r2, 1
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   ork %r4, %r2, %r3
+;   lhi %r2, -0x3334
+;   sllk %r5, %r4, 2
+;   srlk %r3, %r4, 2
+;   nrk %r4, %r5, %r2
+;   xilf %r2, 0xffffffff
+;   nrk %r5, %r3, %r2
+;   ork %r2, %r4, %r5
+;   lhi %r4, -0xf10
+;   sllk %r3, %r2, 4
+;   srlk %r5, %r2, 4
+;   nrk %r2, %r3, %r4
+;   xilf %r4, 0xffffffff
+;   nrk %r3, %r5, %r4
+;   or %r2, %r3
+;   br %r14
 
 function %clz_i128(i128) -> i128 {
 block0(v0: i128):
@@ -167,6 +316,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vclzg %v4, %v1
@@ -179,6 +329,20 @@ block0(v0: i128):
 ;   vsel %v26, %v20, %v16, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vclzg %v4, %v1
+;   vzero %v6
+;   vpdi %v16, %v6, %v4, 0
+;   vpdi %v18, %v6, %v4, 1
+;   vag %v20, %v16, %v18
+;   vrepig %v22, 0x40
+;   vceqg %v24, %v16, %v22
+;   vsel %v26, %v20, %v16, %v24
+;   vst %v26, 0(%r2)
+;   br %r14
 
 function %clz_i64(i64) -> i64 {
 block0(v0: i64):
@@ -186,7 +350,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   flogr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   flogr %r2, %r2
 ;   br %r14
 
@@ -196,10 +366,18 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   llgfr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x20
 ;   br %r14
 
 function %clz_i16(i16) -> i16 {
@@ -208,10 +386,18 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   llghr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -48
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llghr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x30
 ;   br %r14
 
 function %clz_i8(i8) -> i8 {
@@ -220,10 +406,18 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   llgcr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -56
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgcr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x38
 ;   br %r14
 
 function %cls_i128(i128) -> i128 {
@@ -232,6 +426,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 255
@@ -249,6 +444,25 @@ block0(v0: i128):
 ;   vaq %v4, %v2, %v4
 ;   vst %v4, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0xff
+;   vsrab %v6, %v1, %v4
+;   vsra %v16, %v6, %v4
+;   vx %v18, %v1, %v16
+;   vclzg %v20, %v18
+;   vzero %v22
+;   vpdi %v24, %v22, %v20, 0
+;   vpdi %v26, %v22, %v20, 1
+;   vag %v28, %v24, %v26
+;   vrepig %v30, 0x40
+;   vceqg %v0, %v24, %v30
+;   vsel %v2, %v28, %v24, %v0
+;   vaq %v4, %v2, %v4
+;   vst %v4, 0(%r2)
+;   br %r14
 
 function %cls_i64(i64) -> i64 {
 block0(v0: i64):
@@ -256,8 +470,17 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   srag %r4, %r2, 63
+;   xgr %r2, %r4
+;   flogr %r2, %r2
+;   aghi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srag %r4, %r2, 0x3f
 ;   xgr %r2, %r4
 ;   flogr %r2, %r2
 ;   aghi %r2, -1
@@ -269,12 +492,22 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgfr %r4, %r2
 ;   srag %r2, %r4, 63
 ;   xgr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -33
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfr %r4, %r2
+;   srag %r2, %r4, 0x3f
+;   xgr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x21
 ;   br %r14
 
 function %cls_i16(i16) -> i16 {
@@ -283,12 +516,22 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lghr %r4, %r2
 ;   srag %r2, %r4, 63
 ;   xgr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -49
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r4, %r2
+;   srag %r2, %r4, 0x3f
+;   xgr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x31
 ;   br %r14
 
 function %cls_i8(i8) -> i8 {
@@ -297,12 +540,22 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r4, %r2
 ;   srag %r2, %r4, 63
 ;   xgr %r4, %r2
 ;   flogr %r2, %r4
 ;   ahi %r2, -57
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r4, %r2
+;   srag %r2, %r4, 0x3f
+;   xgr %r4, %r2
+;   flogr %r2, %r4
+;   ahi %r2, -0x39
 ;   br %r14
 
 function %ctz_i128(i128) -> i128 {
@@ -311,6 +564,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vctzg %v4, %v1
@@ -323,6 +577,20 @@ block0(v0: i128):
 ;   vsel %v26, %v20, %v18, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vctzg %v4, %v1
+;   vzero %v6
+;   vpdi %v16, %v6, %v4, 0
+;   vpdi %v18, %v6, %v4, 1
+;   vag %v20, %v16, %v18
+;   vrepig %v22, 0x40
+;   vceqg %v24, %v18, %v22
+;   vsel %v26, %v20, %v18, %v24
+;   vst %v26, 0(%r2)
+;   br %r14
 
 function %ctz_i64(i64) -> i64 {
 block0(v0: i64):
@@ -330,6 +598,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lcgr %r4, %r2
 ;   ngr %r2, %r4
@@ -339,6 +608,17 @@ block0(v0: i64):
 ;   lghi %r5, 63
 ;   sgrk %r2, %r5, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lcgr %r4, %r2
+;   ngr %r2, %r4
+;   flogr %r2, %r2
+;   lgr %r3, %r2
+;   locghie %r3, -1
+;   lghi %r5, 0x3f
+;   sgrk %r2, %r5, %r3
+;   br %r14
 
 function %ctz_i32(i32) -> i32 {
 block0(v0: i32):
@@ -346,6 +626,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r2
 ;   oihl %r4, 1
@@ -355,6 +636,17 @@ block0(v0: i32):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r2
+;   oihl %r4, 1
+;   lcgr %r2, %r4
+;   ngr %r4, %r2
+;   flogr %r2, %r4
+;   lhi %r5, 0x3f
+;   srk %r2, %r5, %r2
+;   br %r14
 
 function %ctz_i16(i16) -> i16 {
 block0(v0: i16):
@@ -362,6 +654,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r2
 ;   oilh %r4, 1
@@ -371,6 +664,17 @@ block0(v0: i16):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r2
+;   oilh %r4, 1
+;   lcgr %r2, %r4
+;   ngr %r4, %r2
+;   flogr %r2, %r4
+;   lhi %r5, 0x3f
+;   srk %r2, %r5, %r2
+;   br %r14
 
 function %ctz_i8(i8) -> i8 {
 block0(v0: i8):
@@ -378,6 +682,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lgr %r4, %r2
 ;   oill %r4, 256
@@ -387,6 +692,17 @@ block0(v0: i8):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r4, %r2
+;   oill %r4, 0x100
+;   lcgr %r2, %r4
+;   ngr %r4, %r2
+;   flogr %r2, %r4
+;   lhi %r5, 0x3f
+;   srk %r2, %r5, %r2
+;   br %r14
 
 function %popcnt_i128(i128) -> i128 {
 block0(v0: i128):
@@ -394,10 +710,22 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vpopctg %v4, %v1
 ;   vgbm %v6, 0
+;   vpdi %v16, %v6, %v4, 0
+;   vpdi %v18, %v6, %v4, 1
+;   vag %v20, %v16, %v18
+;   vst %v20, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vpopctg %v4, %v1
+;   vzero %v6
 ;   vpdi %v16, %v6, %v4, 0
 ;   vpdi %v18, %v6, %v4, 1
 ;   vag %v20, %v16, %v18
@@ -410,6 +738,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   popcnt %r4, %r2
 ;   sllg %r2, %r4, 32
@@ -420,6 +749,18 @@ block0(v0: i64):
 ;   agr %r4, %r2
 ;   srlg %r2, %r4, 56
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   popcnt %r4, %r2
+;   sllg %r2, %r4, 0x20
+;   agr %r4, %r2
+;   sllg %r2, %r4, 0x10
+;   agr %r4, %r2
+;   sllg %r2, %r4, 8
+;   agr %r4, %r2
+;   srlg %r2, %r4, 0x38
+;   br %r14
 
 function %popcnt_i32(i32) -> i32 {
 block0(v0: i32):
@@ -427,6 +768,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   popcnt %r4, %r2
 ;   sllk %r2, %r4, 16
@@ -435,6 +777,16 @@ block0(v0: i32):
 ;   ar %r4, %r2
 ;   srlk %r2, %r4, 24
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   popcnt %r4, %r2
+;   sllk %r2, %r4, 0x10
+;   ar %r4, %r2
+;   sllk %r2, %r4, 8
+;   ar %r4, %r2
+;   srlk %r2, %r4, 0x18
+;   br %r14
 
 function %popcnt_i16(i16) -> i16 {
 block0(v0: i16):
@@ -442,11 +794,20 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   popcnt %r4, %r2
 ;   srlk %r2, %r4, 8
 ;   ark %r2, %r4, %r2
 ;   nill %r2, 255
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   popcnt %r4, %r2
+;   srlk %r2, %r4, 8
+;   ark %r2, %r4, %r2
+;   nill %r2, 0xff
 ;   br %r14
 
 function %popcnt_i8(i8) -> i8 {
@@ -455,7 +816,13 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   popcnt %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   popcnt %r2, %r2
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
@@ -12,8 +12,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ncgrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xe5
+;   lper %f2, %f2
 ;   br %r14
 
 function %band_not_i32(i32, i32) -> i32 {
@@ -22,8 +29,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ncrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xf5
+;   lper %f2, %f2
 ;   br %r14
 
 function %band_not_i16(i16, i16) -> i16 {
@@ -32,8 +46,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ncrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xf5
+;   lper %f2, %f2
 ;   br %r14
 
 function %band_not_i8(i8, i8) -> i8 {
@@ -42,8 +63,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ncrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0xf5
+;   lper %f2, %f2
 ;   br %r14
 
 function %bor_not_i64(i64, i64) -> i64 {
@@ -52,8 +80,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ocgrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x65
+;   lper %f2, %f2
 ;   br %r14
 
 function %bor_not_i32(i32, i32) -> i32 {
@@ -62,8 +97,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ocrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x75
+;   lper %f2, %f2
 ;   br %r14
 
 function %bor_not_i16(i16, i16) -> i16 {
@@ -72,8 +114,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ocrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x75
+;   lper %f2, %f2
 ;   br %r14
 
 function %bor_not_i8(i8, i8) -> i8 {
@@ -82,8 +131,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   ocrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x75
+;   lper %f2, %f2
 ;   br %r14
 
 function %bxor_not_i64(i64, i64) -> i64 {
@@ -92,8 +148,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   nxgrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x67
+;   lper %f2, %f2
 ;   br %r14
 
 function %bxor_not_i32(i32, i32) -> i32 {
@@ -102,8 +165,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lper %f2, %f2
 ;   br %r14
 
 function %bxor_not_i16(i16, i16) -> i16 {
@@ -112,8 +182,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lper %f2, %f2
 ;   br %r14
 
 function %bxor_not_i8(i8, i8) -> i8 {
@@ -122,8 +199,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   nxrk %r2, %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x77
+;   lper %f2, %f2
 ;   br %r14
 
 function %bnot_i64(i64) -> i64 {
@@ -132,8 +216,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   nogrk %r2, %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x66
+;   lpdr %f2, %f2
 ;   br %r14
 
 function %bnot_i32(i32) -> i32 {
@@ -142,8 +233,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   nork %r2, %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x76
+;   lpdr %f2, %f2
 ;   br %r14
 
 function %bnot_i16(i16) -> i16 {
@@ -152,8 +250,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   nork %r2, %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x76
+;   lpdr %f2, %f2
 ;   br %r14
 
 function %bnot_i8(i8) -> i8 {
@@ -162,8 +267,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   nork %r2, %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xb9, 0x76
+;   lpdr %f2, %f2
 ;   br %r14
 
 function %bitselect_i64(i64, i64, i64) -> i64 {
@@ -172,9 +284,18 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ngr %r3, %r2
 ;   ncgrk %r4, %r4, %r2
+;   ogrk %r2, %r4, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ngr %r3, %r2
+;   .byte 0xb9, 0xe5
+;   lpdr %f4, %f4
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
 
@@ -184,9 +305,18 @@ block0(v0: i32, v1: i32, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   ncrk %r4, %r4, %r2
+;   ork %r2, %r4, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   .byte 0xb9, 0xf5
+;   lpdr %f4, %f4
 ;   ork %r2, %r4, %r3
 ;   br %r14
 
@@ -196,9 +326,18 @@ block0(v0: i16, v1: i16, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   ncrk %r4, %r4, %r2
+;   ork %r2, %r4, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   .byte 0xb9, 0xf5
+;   lpdr %f4, %f4
 ;   ork %r2, %r4, %r3
 ;   br %r14
 
@@ -208,9 +347,18 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   ncrk %r4, %r4, %r2
+;   ork %r2, %r4, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   .byte 0xb9, 0xf5
+;   lpdr %f4, %f4
 ;   ork %r2, %r4, %r3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -10,7 +10,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vn %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vn %v6, %v1, %v3
@@ -23,7 +32,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ngr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ngr %r2, %r3
 ;   br %r14
 
@@ -34,7 +49,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ng %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ng %r2, 0(%r3)
 ;   br %r14
 
@@ -44,7 +65,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -55,7 +82,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   n %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   n %r2, 0(%r3)
 ;   br %r14
 
@@ -66,8 +99,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ny %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ny %r2, 0x1000(%r3)
 ;   br %r14
 
 function %band_i16(i16, i16) -> i16 {
@@ -76,7 +115,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -87,7 +132,14 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llh %r3, 0(%r3)
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
 ;   nr %r2, %r3
 ;   br %r14
@@ -98,7 +150,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -109,7 +167,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   nr %r2, %r3
 ;   br %r14
@@ -120,7 +185,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vo %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vo %v6, %v1, %v3
@@ -133,7 +207,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ogr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ogr %r2, %r3
 ;   br %r14
 
@@ -144,7 +224,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   og %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   og %r2, 0(%r3)
 ;   br %r14
 
@@ -154,7 +240,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   or %r2, %r3
 ;   br %r14
 
@@ -165,7 +257,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   o %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   o %r2, 0(%r3)
 ;   br %r14
 
@@ -176,8 +274,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   oy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   oy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %bor_i16(i16, i16) -> i16 {
@@ -186,7 +290,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   or %r2, %r3
 ;   br %r14
 
@@ -197,7 +307,14 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llh %r3, 0(%r3)
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
@@ -208,7 +325,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   or %r2, %r3
 ;   br %r14
 
@@ -219,7 +342,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
@@ -230,7 +360,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vx %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vx %v6, %v1, %v3
@@ -243,7 +382,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   xgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   xgr %r2, %r3
 ;   br %r14
 
@@ -254,7 +399,13 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   xg %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   xg %r2, 0(%r3)
 ;   br %r14
 
@@ -264,7 +415,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -275,7 +432,13 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   x %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   x %r2, 0(%r3)
 ;   br %r14
 
@@ -286,8 +449,14 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   xy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %bxor_i16(i16, i16) -> i16 {
@@ -296,7 +465,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -307,7 +482,14 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llh %r3, 0(%r3)
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
 ;   xr %r2, %r3
 ;   br %r14
@@ -318,7 +500,13 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -329,7 +517,14 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   xr %r2, %r3
 ;   br %r14
@@ -340,7 +535,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vnc %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vnc %v6, %v1, %v3
@@ -353,9 +557,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
 ;   xihf %r3, 4294967295
+;   ngr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
+;   xihf %r3, 0xffffffff
 ;   ngr %r2, %r3
 ;   br %r14
 
@@ -365,8 +577,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -376,8 +595,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -387,8 +613,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   nr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   nr %r2, %r3
 ;   br %r14
 
@@ -398,7 +631,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   voc %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   voc %v6, %v1, %v3
@@ -411,9 +653,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
 ;   xihf %r3, 4294967295
+;   ogr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
+;   xihf %r3, 0xffffffff
 ;   ogr %r2, %r3
 ;   br %r14
 
@@ -423,8 +673,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   or %r2, %r3
 ;   br %r14
 
@@ -434,8 +691,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   or %r2, %r3
 ;   br %r14
 
@@ -445,8 +709,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   or %r2, %r3
 ;   br %r14
 
@@ -456,7 +727,16 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vnx %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vnx %v6, %v1, %v3
@@ -469,9 +749,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
 ;   xihf %r3, 4294967295
+;   xgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
+;   xihf %r3, 0xffffffff
 ;   xgr %r2, %r3
 ;   br %r14
 
@@ -481,8 +769,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -492,8 +787,15 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -503,8 +805,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   xilf %r3, 4294967295
+;   xr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r3, 0xffffffff
 ;   xr %r2, %r3
 ;   br %r14
 
@@ -514,7 +823,15 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vno %v4, %v1, %v1
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vno %v4, %v1, %v1
 ;   vst %v4, 0(%r2)
@@ -526,9 +843,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   xilf %r2, 4294967295
 ;   xihf %r2, 4294967295
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r2, 0xffffffff
+;   xihf %r2, 0xffffffff
 ;   br %r14
 
 function %bnot_i32(i32) -> i32 {
@@ -537,8 +861,14 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   xilf %r2, 4294967295
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r2, 0xffffffff
 ;   br %r14
 
 function %bnot_i16(i16) -> i16 {
@@ -547,8 +877,14 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   xilf %r2, 4294967295
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r2, 0xffffffff
 ;   br %r14
 
 function %bnot_i8(i8) -> i8 {
@@ -557,8 +893,14 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   xilf %r2, 4294967295
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xilf %r2, 0xffffffff
 ;   br %r14
 
 function %bitselect_i128(i128, i128, i128) -> i128 {
@@ -567,7 +909,17 @@ block0(v0: i128, v1: i128, v2: i128):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   vsel %v16, %v3, %v5, %v1
+;   vst %v16, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vl %v5, 0(%r5)
@@ -581,11 +933,22 @@ block0(v0: i64, v1: i64, v2: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   ngr %r3, %r2
 ;   lgr %r5, %r2
 ;   xilf %r5, 4294967295
 ;   xihf %r5, 4294967295
+;   ngr %r4, %r5
+;   ogrk %r2, %r4, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ngr %r3, %r2
+;   lgr %r5, %r2
+;   xilf %r5, 0xffffffff
+;   xihf %r5, 0xffffffff
 ;   ngr %r4, %r5
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
@@ -596,10 +959,20 @@ block0(v0: i32, v1: i32, v2: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   lgr %r5, %r2
 ;   xilf %r5, 4294967295
+;   nrk %r2, %r4, %r5
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   lgr %r5, %r2
+;   xilf %r5, 0xffffffff
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
@@ -610,10 +983,20 @@ block0(v0: i16, v1: i16, v2: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   lgr %r5, %r2
 ;   xilf %r5, 4294967295
+;   nrk %r2, %r4, %r5
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   lgr %r5, %r2
+;   xilf %r5, 0xffffffff
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
@@ -624,10 +1007,20 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   nr %r3, %r2
 ;   lgr %r5, %r2
 ;   xilf %r5, 4294967295
+;   nrk %r2, %r4, %r5
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   nr %r3, %r2
+;   lgr %r5, %r2
+;   xilf %r5, 0xffffffff
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
@@ -639,9 +1032,16 @@ block0(v0: i32, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   xr %r2, %r3
 ;   xilf %r2, 4294967295
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   xr %r2, %r3
+;   xilf %r2, 0xffffffff
 ;   br %r14
 
 function %bnot_of_bxor(i128, i128) -> i128 {
@@ -651,7 +1051,16 @@ block0(v0: i128, v1: i128):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vnx %v6, %v1, %v3
+;   vst %v6, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vnx %v6, %v1, %v3
@@ -665,7 +1074,13 @@ block0(v0: i32x4, v1: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vnx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bswap.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bswap.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   lrvgr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvgr %r2, %r2
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   lrvr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvr %r2, %r2
 ;   br %r14
 
@@ -27,8 +39,15 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvr %r4, %r2
 ;   srlk %r2, %r4, 16
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvr %r4, %r2
+;   srlk %r2, %r4, 0x10
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -13,6 +13,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -20,6 +21,20 @@ block0(v0: i64):
 ;   bras %r1, 12 ; data %g + 0 ; lg %r5, 0(%r1)
 ;   basr %r14, %r5
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   bras %r1, 0x16
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r5, 0(%r1)
+;   basr %r14, %r5
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %call_uext(i32) -> i64 {
@@ -30,6 +45,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -39,13 +55,34 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   llgfr %r2, %r2
+;   bras %r1, 0x1a
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r3, 0(%r1)
+;   basr %r14, %r3
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %ret_uext(i32) -> i32 uext {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
+;   llgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgfr %r2, %r2
 ;   br %r14
 
@@ -57,6 +94,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -66,13 +104,34 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   lgfr %r2, %r2
+;   bras %r1, 0x1a
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r3, 0(%r1)
+;   basr %r14, %r3
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %ret_uext(i32) -> i32 sext {
 block0(v0: i32):
     return v0
 }
 
+; VCode:
 ; block0:
+;   lgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgfr %r2, %r2
 ;   br %r14
 
@@ -84,12 +143,21 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
 ; block0:
 ;   brasl %r14, %g
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   brasl %r14, 0xa ; reloc_external PLTRel32Dbl %g 2
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %f2(i32) -> i64 {
@@ -100,6 +168,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -109,6 +178,21 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   llgfr %r2, %r2
+;   bras %r1, 0x1a
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r3, 0(%r1)
+;   basr %r14, %r3
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %call_indirect(i64, i64) -> i64 {
     sig0 = (i64) -> i64
@@ -117,12 +201,21 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
 ; block0:
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   basr %r14, %r3
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %incoming_args(i64, i32, i32 uext, i32 sext, i16, i16 uext, i16 sext, i8, i8 uext, i8 sext) -> i64 {
@@ -148,6 +241,7 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
     return v27
 }
 
+; VCode:
 ;   stmg %r6, %r15, 48(%r15)
 ; block0:
 ;   lg %r12, 160(%r15)
@@ -175,6 +269,35 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
 ;   agrk %r2, %r4, %r3
 ;   lmg %r6, %r15, 48(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r6, %r15, 0x30(%r15)
+; block0: ; offset 0x6
+;   lg %r12, 0xa0(%r15)
+;   lg %r14, 0xa8(%r15)
+;   llgc %r7, 0xb7(%r15)
+;   lg %r9, 0xb8(%r15)
+;   lg %r11, 0xc0(%r15)
+;   llgfr %r3, %r3
+;   llgfr %r4, %r4
+;   llgfr %r13, %r5
+;   llghr %r6, %r6
+;   llghr %r5, %r12
+;   llghr %r12, %r14
+;   llgcr %r14, %r7
+;   llgcr %r7, %r9
+;   llgcr %r8, %r11
+;   agrk %r3, %r2, %r3
+;   agr %r4, %r13
+;   agrk %r5, %r6, %r5
+;   agrk %r2, %r12, %r14
+;   agrk %r12, %r7, %r8
+;   agr %r3, %r4
+;   agrk %r4, %r5, %r2
+;   agrk %r3, %r12, %r3
+;   agrk %r2, %r4, %r3
+;   lmg %r6, %r15, 0x30(%r15)
+;   br %r14
 
 function %incoming_args_i128(i128, i128, i128, i128, i128, i128, i128, i128) -> i128 {
 block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7: i128):
@@ -188,6 +311,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
     return v14
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
@@ -210,6 +334,30 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
 ;   vaq %v16, %v16, %v17
 ;   vst %v16, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vl %v5, 0(%r5)
+;   vl %v7, 0(%r6)
+;   lg %r3, 0xa0(%r15)
+;   vl %v18, 0(%r3)
+;   lg %r3, 0xa8(%r15)
+;   vl %v21, 0(%r3)
+;   lg %r5, 0xb0(%r15)
+;   vl %v24, 0(%r5)
+;   lg %r4, 0xb8(%r15)
+;   vl %v27, 0(%r4)
+;   vaq %v16, %v1, %v3
+;   vaq %v17, %v5, %v7
+;   vaq %v18, %v18, %v21
+;   vaq %v19, %v24, %v27
+;   vaq %v16, %v16, %v17
+;   vaq %v17, %v18, %v19
+;   vaq %v16, %v16, %v17
+;   vst %v16, 0(%r2)
+;   br %r14
 
 function %call_sret() -> i64 {
     fn0 = colocated %g(i64 sret)
@@ -220,6 +368,7 @@ block0:
     trap user0
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -227,4 +376,12 @@ block0:
 ;   lghi %r2, 0
 ;   brasl %r14, %g
 ;   trap
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   lghi %r2, 0
+;   brasl %r14, 0xe ; reloc_external PLTRel32Dbl %g 2
+;   .byte 0x00, 0x00 ; trap: user0
 

--- a/cranelift/filetests/filetests/isa/s390x/concat-split.clif
+++ b/cranelift/filetests/filetests/isa/s390x/concat-split.clif
@@ -7,7 +7,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgp %v4, %r4, %r3
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgp %v4, %r4, %r3
 ;   vst %v4, 0(%r2)
 ;   br %r14
@@ -18,7 +25,15 @@ block0(v0: i128):
   return v1, v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   lgdr %r3, %f1
+;   vlgvg %r2, %v1, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   lgdr %r3, %f1
 ;   vlgvg %r2, %v1, 1

--- a/cranelift/filetests/filetests/isa/s390x/condbr.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condbr.clif
@@ -7,7 +7,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clgr %r2, %r3
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgr %r2, %r3
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -27,6 +35,7 @@ block2:
   return v5
 }
 
+; VCode:
 ; block0:
 ;   clgr %r2, %r3
 ;   jge label1 ; jg label2
@@ -34,6 +43,17 @@ block2:
 ;   lghi %r2, 1
 ;   br %r14
 ; block2:
+;   lghi %r2, 2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgr %r2, %r3
+;   jgne 0x10
+; block1: ; offset 0xa
+;   lghi %r2, 1
+;   br %r14
+; block2: ; offset 0x10
 ;   lghi %r2, 2
 ;   br %r14
 
@@ -47,6 +67,7 @@ block1:
   return v4
 }
 
+; VCode:
 ; block0:
 ;   clgr %r2, %r3
 ;   jge label1 ; jg label2
@@ -55,6 +76,13 @@ block1:
 ; block2:
 ;   jg label3
 ; block3:
+;   lghi %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgr %r2, %r3
+; block1: ; offset 0x4
 ;   lghi %r2, 1
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/condops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condops.clif
@@ -9,9 +9,18 @@ block0(v0: i8, v1: i64, v2: i64):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   llcr %r2, %r2
 ;   clfi %r2, 42
+;   lgr %r2, %r4
+;   locgre %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llcr %r2, %r2
+;   clfi %r2, 0x2a
 ;   lgr %r2, %r4
 ;   locgre %r2, %r3
 ;   br %r14
@@ -22,7 +31,16 @@ block0(v0: i8, v1: i8, v2: i8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lbr %r2, %r2
+;   chi %r2, 0
+;   lgr %r2, %r4
+;   locrlh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r2, %r2
 ;   chi %r2, 0
 ;   lgr %r2, %r4
@@ -37,8 +55,16 @@ block0(v0: i32, v1: i8, v2: i8):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   clfi %r2, 42
+;   lgr %r2, %r4
+;   locre %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clfi %r2, 0x2a
 ;   lgr %r2, %r4
 ;   locre %r2, %r3
 ;   br %r14
@@ -51,10 +77,20 @@ block0(v0: i32, v1: i8x16, v2: i8x16):
   return v5
 }
 
+; VCode:
 ; block0:
 ;   clfi %r2, 42
 ;   vlr %v6, %v24
 ;   vlr %v24, %v25
 ;   jne 10 ; vlr %v24, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clfi %r2, 0x2a
+;   vlr %v6, %v24
+;   vlr %v24, %v25
+;   jne 0x1c
+;   vlr %v24, %v6
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/constants.clif
@@ -7,7 +7,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lhi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhi %r2, -1
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lhi %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhi %r2, 0
 ;   br %r14
 
@@ -27,7 +39,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lghi %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghi %r2, 0
 ;   br %r14
 
@@ -37,8 +55,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lgfi %r2, 65535
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfi %r2, 0xffff
 ;   br %r14
 
 function %f() -> i64 {
@@ -47,8 +71,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   llilh %r2, 65535
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llilh %r2, 0xffff
 ;   br %r14
 
 function %f() -> i64 {
@@ -57,8 +87,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   llihl %r2, 65535
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llihl %r2, 0xffff
 ;   br %r14
 
 function %f() -> i64 {
@@ -67,8 +103,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   llihh %r2, 65535
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llihh %r2, 0xffff
 ;   br %r14
 
 function %f() -> i64 {
@@ -77,7 +119,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lghi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghi %r2, -1
 ;   br %r14
 
@@ -87,8 +135,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   lgfi %r2, -65536
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfi %r2, -0x10000
 ;   br %r14
 
 function %f() -> i64 {
@@ -97,9 +151,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   llihf %r2, 4081840291
 ;   iilf %r2, 303169594
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llihf %r2, 0xf34bf0a3
+;   iilf %r2, 0x1212003a
 ;   br %r14
 
 function %f() -> i64 {
@@ -108,9 +169,16 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   llihh %r2, 4841
 ;   iilh %r2, 7924
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llihh %r2, 0x12e9
+;   iilh %r2, 0x1ef4
 ;   br %r14
 
 function %f() -> i32 {
@@ -119,7 +187,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lhi %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhi %r2, -1
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -7,8 +7,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v4, 0
+;   vlvgg %v4, %r3, 1
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v4
 ;   vlvgg %v4, %r3, 1
 ;   vst %v4, 0(%r2)
 ;   br %r14
@@ -19,8 +27,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v4, 0
+;   vlvgf %v4, %r3, 3
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v4
 ;   vlvgf %v4, %r3, 3
 ;   vst %v4, 0(%r2)
 ;   br %r14
@@ -31,7 +47,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgfr %r2, %r2
 ;   br %r14
 
@@ -41,8 +63,16 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v4, 0
+;   vlvgh %v4, %r3, 7
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v4
 ;   vlvgh %v4, %r3, 7
 ;   vst %v4, 0(%r2)
 ;   br %r14
@@ -53,7 +83,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llghr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llghr %r2, %r2
 ;   br %r14
 
@@ -63,7 +99,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llhr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r2, %r2
 ;   br %r14
 
@@ -73,9 +115,17 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v4, 0
 ;   vlvgb %v4, %r3, 15
+;   vst %v4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v4
+;   vlvgb %v4, %r3, 0xf
 ;   vst %v4, 0(%r2)
 ;   br %r14
 
@@ -85,7 +135,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgcr %r2, %r2
 ;   br %r14
 
@@ -95,7 +151,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r2, %r2
 ;   br %r14
 
@@ -105,7 +167,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llcr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r2, %r2
 ;   br %r14
 
@@ -115,8 +183,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   srag %r5, %r3, 63
+;   vlvgp %v5, %r5, %r3
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srag %r5, %r3, 0x3f
 ;   vlvgp %v5, %r5, %r3
 ;   vst %v5, 0(%r2)
 ;   br %r14
@@ -127,9 +203,18 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lgfr %r5, %r3
 ;   srag %r3, %r5, 63
+;   vlvgp %v7, %r3, %r5
+;   vst %v7, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfr %r5, %r3
+;   srag %r3, %r5, 0x3f
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
@@ -140,7 +225,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgfr %r2, %r2
 ;   br %r14
 
@@ -150,9 +241,18 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lghr %r5, %r3
 ;   srag %r3, %r5, 63
+;   vlvgp %v7, %r3, %r5
+;   vst %v7, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r5, %r3
+;   srag %r3, %r5, 0x3f
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
@@ -163,7 +263,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lghr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghr %r2, %r2
 ;   br %r14
 
@@ -173,7 +279,13 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lhr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r2, %r2
 ;   br %r14
 
@@ -183,9 +295,18 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r5, %r3
 ;   srag %r3, %r5, 63
+;   vlvgp %v7, %r3, %r5
+;   vst %v7, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r5, %r3
+;   srag %r3, %r5, 0x3f
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
@@ -196,7 +317,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgbr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgbr %r2, %r2
 ;   br %r14
 
@@ -206,7 +333,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lbr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r2, %r2
 ;   br %r14
 
@@ -216,7 +349,13 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lbr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r2, %r2
 ;   br %r14
 
@@ -226,7 +365,14 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
@@ -237,7 +383,14 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
@@ -248,7 +401,14 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
@@ -259,7 +419,14 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
@@ -270,7 +437,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -280,7 +453,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -290,7 +469,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -300,7 +485,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -310,7 +501,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -320,7 +517,13 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -330,9 +533,21 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vgbm %v4, 0
+;   vceqgs %v6, %v1, %v4
+;   lghi %r3, 0
+;   locghine %r3, -1
+;   vlvgp %v20, %r3, %r3
+;   vst %v20, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vzero %v4
 ;   vceqgs %v6, %v1, %v4
 ;   lghi %r3, 0
 ;   locghine %r3, -1
@@ -346,9 +561,19 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
+;   vceqgs %v5, %v1, %v3
+;   lghi %r2, 0
+;   locghine %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vzero %v3
 ;   vceqgs %v5, %v1, %v3
 ;   lghi %r2, 0
 ;   locghine %r2, -1
@@ -360,9 +585,19 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
+;   vceqgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochine %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vzero %v3
 ;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
@@ -374,9 +609,19 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
+;   vceqgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochine %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vzero %v3
 ;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
@@ -388,9 +633,19 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vgbm %v3, 0
+;   vceqgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochine %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vzero %v3
 ;   vceqgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochine %r2, -1
@@ -402,7 +657,17 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r4, 0
+;   lghi %r4, 0
+;   locghilh %r4, -1
+;   vlvgp %v17, %r4, %r4
+;   vst %v17, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r4, 0
 ;   lghi %r4, 0
 ;   locghilh %r4, -1
@@ -416,7 +681,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r3, 0
+;   lghi %r2, 0
+;   locghilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r3, 0
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
@@ -428,7 +701,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -440,7 +721,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -452,7 +741,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -464,7 +761,17 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r4, 0
+;   lghi %r4, 0
+;   locghilh %r4, -1
+;   vlvgp %v17, %r4, %r4
+;   vst %v17, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r4, 0
 ;   lghi %r4, 0
 ;   locghilh %r4, -1
@@ -478,7 +785,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r3, 0
+;   lghi %r2, 0
+;   locghilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r3, 0
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
@@ -490,7 +805,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -502,7 +825,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -514,7 +845,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r3, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r3, 0
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
@@ -526,7 +865,18 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r3, %r4
+;   chi %r3, 0
+;   lghi %r3, 0
+;   locghilh %r3, -1
+;   vlvgp %v19, %r3, %r3
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r3, %r4
 ;   chi %r3, 0
 ;   lghi %r3, 0
@@ -541,7 +891,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r3
+;   chi %r5, 0
+;   lghi %r2, 0
+;   locghilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r3
 ;   chi %r5, 0
 ;   lghi %r2, 0
@@ -554,7 +913,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -567,7 +935,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -580,7 +957,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -593,7 +979,18 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r3, %r4
+;   chi %r3, 0
+;   lghi %r3, 0
+;   locghilh %r3, -1
+;   vlvgp %v19, %r3, %r3
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r3, %r4
 ;   chi %r3, 0
 ;   lghi %r3, 0
@@ -608,7 +1005,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lghi %r2, 0
+;   locghilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lghi %r2, 0
@@ -621,7 +1027,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -634,7 +1049,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -647,7 +1071,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -660,7 +1093,18 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r3, %r4
+;   chi %r3, 0
+;   lghi %r3, 0
+;   locghilh %r3, -1
+;   vlvgp %v19, %r3, %r3
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r3, %r4
 ;   chi %r3, 0
 ;   lghi %r3, 0
@@ -675,7 +1119,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lghi %r2, 0
+;   locghilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lghi %r2, 0
@@ -688,7 +1141,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -701,7 +1163,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0
@@ -714,7 +1185,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r3
+;   chi %r5, 0
+;   lhi %r2, 0
+;   lochilh %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r3
 ;   chi %r5, 0
 ;   lhi %r2, 0

--- a/cranelift/filetests/filetests/isa/s390x/div-traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/div-traps.clif
@@ -12,6 +12,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cgite %r3, 0
 ;   llihf %r4, 2147483647
@@ -26,6 +27,22 @@ block0(v0: i64, v1: i64):
 ;   dsgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cgite %r3, 0 ; trap: int_divz
+;   llihf %r4, 0x7fffffff
+;   iilf %r4, 0xffffffff
+;   xgr %r4, %r2
+;   lgr %r5, %r2
+;   ngr %r4, %r3
+;   lgr %r2, %r3
+;   cgite %r4, -1 ; trap: int_ovf
+;   lgr %r4, %r2
+;   lgr %r3, %r5
+;   dsgr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i64_imm(i64) -> i64 {
 block0(v0: i64):
@@ -34,10 +51,19 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lghi %r4, 2
 ;   dsgr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lghi %r4, 2
+;   dsgr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -47,6 +73,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
 ;   lgfr %r5, %r2
@@ -63,6 +90,24 @@ block0(v0: i32, v1: i32):
 ;   lgr %r2, %r3
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r7, %r15, 0x38(%r15)
+; block0: ; offset 0x6
+;   lgfr %r5, %r2
+;   lgr %r7, %r5
+;   cite %r3, 0 ; trap: int_divz
+;   iilf %r5, 0x7fffffff
+;   lgr %r4, %r7
+;   xrk %r2, %r5, %r4
+;   nrk %r4, %r2, %r3
+;   lgr %r5, %r3
+;   cite %r4, -1 ; trap: int_ovf
+;   lgr %r3, %r7
+;   dsgfr %r2, %r5 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
 
 function %sdiv_i32_imm(i32) -> i32 {
 block0(v0: i32):
@@ -71,10 +116,19 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgfr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -84,6 +138,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lghr %r5, %r2
 ;   lhr %r4, %r3
@@ -96,6 +151,20 @@ block0(v0: i16, v1: i16):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r5, %r2
+;   lhr %r4, %r3
+;   cite %r4, 0 ; trap: int_divz
+;   lhi %r2, 0x7fff
+;   lgr %r3, %r5
+;   xrk %r5, %r2, %r3
+;   nrk %r2, %r5, %r4
+;   cite %r2, -1 ; trap: int_ovf
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i16_imm(i16) -> i16 {
 block0(v0: i16):
@@ -104,10 +173,19 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lghr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -117,6 +195,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r5, %r2
 ;   lbr %r4, %r3
@@ -129,6 +208,20 @@ block0(v0: i8, v1: i8):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r5, %r2
+;   lbr %r4, %r3
+;   cite %r4, 0 ; trap: int_divz
+;   lhi %r2, 0x7f
+;   lgr %r3, %r5
+;   xrk %r5, %r2, %r3
+;   nrk %r2, %r5, %r4
+;   cite %r2, -1 ; trap: int_ovf
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %sdiv_i8_imm(i8) -> i8 {
 block0(v0: i8):
@@ -137,10 +230,19 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r3, %r2
 ;   lhi %r2, 2
 ;   dsgfr %r2, %r2
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r3, %r2
+;   lhi %r2, 2
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -150,6 +252,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r2
 ;   lghi %r2, 0
@@ -158,6 +261,18 @@ block0(v0: i64, v1: i64):
 ;   lgr %r3, %r5
 ;   lgr %r5, %r4
 ;   dlgr %r2, %r5
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r2
+;   lghi %r2, 0
+;   cgite %r3, 0 ; trap: int_divz
+;   lgr %r4, %r3
+;   lgr %r3, %r5
+;   lgr %r5, %r4
+;   dlgr %r2, %r5 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -168,11 +283,21 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lghi %r2, 0
 ;   lghi %r4, 2
 ;   dlgr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lghi %r2, 0
+;   lghi %r4, 2
+;   dlgr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -182,6 +307,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r2
 ;   lhi %r2, 0
@@ -190,6 +316,18 @@ block0(v0: i32, v1: i32):
 ;   lgr %r3, %r5
 ;   lgr %r5, %r4
 ;   dlr %r2, %r5
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r2
+;   lhi %r2, 0
+;   cite %r3, 0 ; trap: int_divz
+;   lgr %r4, %r3
+;   lgr %r3, %r5
+;   lgr %r5, %r4
+;   dlr %r2, %r5 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -200,11 +338,21 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r3, %r2
 ;   lhi %r2, 0
 ;   lhi %r4, 2
 ;   dlr %r2, %r4
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   lhi %r2, 0
+;   lhi %r4, 2
+;   dlr %r2, %r4 ; trap: int_divz
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -214,6 +362,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -227,6 +376,22 @@ block0(v0: i16, v1: i16):
 ;   dlr %r2, %r5
 ;   lgr %r2, %r3
 ;   lmg %r8, %r15, 64(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llhr %r3, %r2
+;   lgr %r5, %r4
+;   llhr %r5, %r5
+;   cite %r5, 0 ; trap: int_divz
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r8, %r15, 0x40(%r15)
 ;   br %r14
 
 function %udiv_i16_imm(i16) -> i16 {
@@ -236,6 +401,7 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 0
 ;   lgr %r5, %r4
@@ -245,6 +411,17 @@ block0(v0: i16):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0
+;   lgr %r5, %r4
+;   llhr %r3, %r2
+;   lhi %r4, 2
+;   lgr %r2, %r5
+;   dlr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %udiv_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -252,6 +429,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -266,6 +444,22 @@ block0(v0: i8, v1: i8):
 ;   lgr %r2, %r3
 ;   lmg %r8, %r15, 64(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llcr %r3, %r2
+;   lgr %r5, %r4
+;   llcr %r5, %r5
+;   cite %r5, 0 ; trap: int_divz
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lgr %r2, %r3
+;   lmg %r8, %r15, 0x40(%r15)
+;   br %r14
 
 function %udiv_i8_imm(i8) -> i8 {
 block0(v0: i8):
@@ -274,6 +468,7 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 0
 ;   lgr %r5, %r4
@@ -283,6 +478,17 @@ block0(v0: i8):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0
+;   lgr %r5, %r4
+;   llcr %r3, %r2
+;   lhi %r4, 2
+;   lgr %r2, %r5
+;   dlr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   br %r14
 
 function %srem_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -290,6 +496,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cgite %r3, 0
 ;   cghi %r3, -1
@@ -298,6 +505,16 @@ block0(v0: i64, v1: i64):
 ;   locghie %r3, 0
 ;   dsgr %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cgite %r3, 0 ; trap: int_divz
+;   cghi %r3, -1
+;   lgr %r4, %r3
+;   lgr %r3, %r2
+;   locghie %r3, 0
+;   dsgr %r2, %r4 ; trap: int_divz
+;   br %r14
 
 function %srem_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -305,12 +522,22 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   lgfr %r3, %r2
 ;   lgr %r2, %r5
 ;   cite %r2, 0
 ;   dsgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   lgfr %r3, %r2
+;   lgr %r2, %r5
+;   cite %r2, 0 ; trap: int_divz
+;   dsgfr %r2, %r2 ; trap: int_divz
 ;   br %r14
 
 function %srem_i16(i16, i16) -> i16 {
@@ -319,6 +546,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lghr %r5, %r2
 ;   lgr %r2, %r5
@@ -327,6 +555,16 @@ block0(v0: i16, v1: i16):
 ;   lgr %r3, %r2
 ;   dsgfr %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghr %r5, %r2
+;   lgr %r2, %r5
+;   lhr %r4, %r3
+;   cite %r4, 0 ; trap: int_divz
+;   lgr %r3, %r2
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   br %r14
 
 function %srem_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -334,6 +572,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgbr %r5, %r2
 ;   lgr %r2, %r5
@@ -342,6 +581,16 @@ block0(v0: i8, v1: i8):
 ;   lgr %r3, %r2
 ;   dsgfr %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgbr %r5, %r2
+;   lgr %r2, %r5
+;   lbr %r4, %r3
+;   cite %r4, 0 ; trap: int_divz
+;   lgr %r3, %r2
+;   dsgfr %r2, %r4 ; trap: int_divz
+;   br %r14
 
 function %urem_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -349,6 +598,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r2
 ;   lghi %r2, 0
@@ -358,6 +608,17 @@ block0(v0: i64, v1: i64):
 ;   lgr %r5, %r4
 ;   dlgr %r2, %r5
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r2
+;   lghi %r2, 0
+;   cgite %r3, 0 ; trap: int_divz
+;   lgr %r4, %r3
+;   lgr %r3, %r5
+;   lgr %r5, %r4
+;   dlgr %r2, %r5 ; trap: int_divz
+;   br %r14
 
 function %urem_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -365,6 +626,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r2
 ;   lhi %r2, 0
@@ -374,6 +636,17 @@ block0(v0: i32, v1: i32):
 ;   lgr %r5, %r4
 ;   dlr %r2, %r5
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r2
+;   lhi %r2, 0
+;   cite %r3, 0 ; trap: int_divz
+;   lgr %r4, %r3
+;   lgr %r3, %r5
+;   lgr %r5, %r4
+;   dlr %r2, %r5 ; trap: int_divz
+;   br %r14
 
 function %urem_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -381,6 +654,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -394,6 +668,21 @@ block0(v0: i16, v1: i16):
 ;   dlr %r2, %r5
 ;   lmg %r8, %r15, 64(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llhr %r3, %r2
+;   lgr %r5, %r4
+;   llhr %r5, %r5
+;   cite %r5, 0 ; trap: int_divz
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lmg %r8, %r15, 0x40(%r15)
+;   br %r14
 
 function %urem_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -401,6 +690,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   stmg %r8, %r15, 64(%r15)
 ; block0:
 ;   lgr %r4, %r3
@@ -413,5 +703,20 @@ block0(v0: i8, v1: i8):
 ;   lgr %r2, %r8
 ;   dlr %r2, %r5
 ;   lmg %r8, %r15, 64(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r8, %r15, 0x40(%r15)
+; block0: ; offset 0x6
+;   lgr %r4, %r3
+;   lhi %r5, 0
+;   lgr %r8, %r5
+;   llcr %r3, %r2
+;   lgr %r5, %r4
+;   llcr %r5, %r5
+;   cite %r5, 0 ; trap: int_divz
+;   lgr %r2, %r8
+;   dlr %r2, %r5 ; trap: int_divz
+;   lmg %r8, %r15, 0x40(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/fence.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fence.clif
@@ -11,7 +11,13 @@ block0:
   return
 }
 
+; VCode:
 ; block0:
 ;   bcr 14, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bnor %r0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -19,6 +20,27 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   ic %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vclgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -26,6 +48,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -38,6 +61,28 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   ic %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   .byte 0xc3, 0x01
+;   .byte 0x00, 0x00
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vcgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -45,6 +90,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -57,6 +103,27 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   be 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vclgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -64,6 +131,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -76,6 +144,28 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   bc 0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   bpp 0, -0x31dc, 0x100
+;   lpr %r0, %r0
+;   .byte 0x08, 0x03
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vcgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -83,6 +173,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -95,6 +186,27 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   cvb %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vclgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -102,6 +214,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -114,6 +227,28 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   cvb %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   .byte 0xcf, 0x00
+;   .byte 0x00, 0x01
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   vcgd %v20, %v0, 2, 8, 5
+;   vlgvf %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -121,6 +256,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -134,6 +270,28 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   sl %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wclgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -141,6 +299,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -154,6 +313,29 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   sl %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   edmk 1(1), 0x700(%r14)
+;   lpr %r0, %r0
+;   .byte 0x08, 0x03
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wcgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -161,6 +343,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -173,6 +356,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r7, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -180,6 +388,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -192,6 +401,30 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r6, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   larl %r6, 0x40000028
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -199,6 +432,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -211,6 +445,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -218,6 +477,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -230,6 +490,30 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   larl %r14, 0x400028
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -237,6 +521,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -249,6 +534,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   la %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -256,6 +566,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -268,6 +579,32 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   la %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   .byte 0xc1, 0xe0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x20
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -275,6 +612,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -287,6 +625,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   ic %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -294,6 +657,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -306,6 +670,32 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   ic %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   .byte 0xc3, 0xe0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_from_uint_i8_f32(i8) -> f32 {
 block0(v0: i8):
@@ -313,10 +703,18 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llcr %r4, %r2
 ;   vlvgf %v4, %r4, 0
 ;   wcelfb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llcr %r4, %r2
+;   vlvgf %v4, %r4, 0
+;   vcdlg %v0, %v4, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_sint_i8_f32(i8) -> f32 {
@@ -325,10 +723,18 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lbr %r4, %r2
 ;   vlvgf %v4, %r4, 0
 ;   wcefb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lbr %r4, %r2
+;   vlvgf %v4, %r4, 0
+;   vcdg %v0, %v4, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_uint_i16_f32(i16) -> f32 {
@@ -337,10 +743,18 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llhr %r4, %r2
 ;   vlvgf %v4, %r4, 0
 ;   wcelfb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r4, %r2
+;   vlvgf %v4, %r4, 0
+;   vcdlg %v0, %v4, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_sint_i16_f32(i16) -> f32 {
@@ -349,10 +763,18 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lhr %r4, %r2
 ;   vlvgf %v4, %r4, 0
 ;   wcefb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r4, %r2
+;   vlvgf %v4, %r4, 0
+;   vcdg %v0, %v4, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_uint_i32_f32(i32) -> f32 {
@@ -361,9 +783,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlvgf %v2, %r2, 0
 ;   wcelfb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlvgf %v2, %r2, 0
+;   vcdlg %v0, %v2, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_sint_i32_f32(i32) -> f32 {
@@ -372,9 +801,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlvgf %v2, %r2, 0
 ;   wcefb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlvgf %v2, %r2, 0
+;   vcdg %v0, %v2, 2, 8, 4
 ;   br %r14
 
 function %fcvt_from_uint_i64_f32(i64) -> f32 {
@@ -383,7 +819,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdlgb %f4, %f2, 0, 3
+;   ledbra %f0, 4, %f4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdlgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
@@ -395,7 +839,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdgb %f4, %f2, 0, 3
+;   ledbra %f0, 4, %f4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
@@ -407,7 +859,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgcr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgcr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -419,7 +879,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgbr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgbr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -431,7 +899,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -443,7 +919,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -455,7 +939,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -467,7 +959,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -479,7 +979,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdlgb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdlgb %f0, %f2, 0, 4
 ;   br %r14
@@ -490,7 +997,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdgb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdgb %f0, %f2, 0, 4
 ;   br %r14
@@ -501,11 +1015,20 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclfeb %f2, %f0, 0, 5
 ;   vlgvf %r2, %v2, 0
 ;   clfi %r2, 256
 ;   lochih %r2, 255
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vclgd %v2, %v0, 2, 8, 5
+;   vlgvf %r2, %v2, 0
+;   clfi %r2, 0x100
+;   lochih %r2, 0xff
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32_i8(f32) -> i8 {
@@ -514,6 +1037,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcfeb %f2, %f0, 0, 5
 ;   vlgvf %r2, %v2, 0
@@ -524,6 +1048,18 @@ block0(v0: f32):
 ;   chi %r2, -128
 ;   lochil %r2, -128
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgd %v2, %v0, 2, 8, 5
+;   vlgvf %r2, %v2, 0
+;   cebr %f0, %f0
+;   lochio %r2, 0
+;   chi %r2, 0x7f
+;   lochih %r2, 0x7f
+;   chi %r2, -0x80
+;   lochil %r2, -0x80
+;   br %r14
 
 function %fcvt_to_uint_sat_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -531,10 +1067,19 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclfeb %f2, %f0, 0, 5
 ;   vlgvf %r2, %v2, 0
 ;   clfi %r2, 65535
+;   lochih %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vclgd %v2, %v0, 2, 8, 5
+;   vlgvf %r2, %v2, 0
+;   clfi %r2, 0xffff
 ;   lochih %r2, -1
 ;   br %r14
 
@@ -544,6 +1089,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcfeb %f2, %f0, 0, 5
 ;   vlgvf %r2, %v2, 0
@@ -554,6 +1100,18 @@ block0(v0: f32):
 ;   chi %r2, -32768
 ;   lochil %r2, -32768
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgd %v2, %v0, 2, 8, 5
+;   vlgvf %r2, %v2, 0
+;   cebr %f0, %f0
+;   lochio %r2, 0
+;   chi %r2, 0x7fff
+;   lochih %r2, 0x7fff
+;   chi %r2, -0x8000
+;   lochil %r2, -0x8000
+;   br %r14
 
 function %fcvt_to_uint_sat_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -561,8 +1119,15 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclfeb %f2, %f0, 0, 5
+;   vlgvf %r2, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vclgd %v2, %v0, 2, 8, 5
 ;   vlgvf %r2, %v2, 0
 ;   br %r14
 
@@ -572,8 +1137,17 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcfeb %f2, %f0, 0, 5
+;   vlgvf %r2, %v2, 0
+;   cebr %f0, %f0
+;   lochio %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgd %v2, %v0, 2, 8, 5
 ;   vlgvf %r2, %v2, 0
 ;   cebr %f0, %f0
 ;   lochio %r2, 0
@@ -585,7 +1159,15 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldebr %f2, %f0
+;   wclgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldebr %f2, %f0
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
@@ -597,7 +1179,17 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldebr %f2, %f0
+;   wcgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   cebr %f0, %f0
+;   locghio %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldebr %f2, %f0
 ;   wcgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
@@ -611,11 +1203,20 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   clgfi %r2, 0x100
+;   locghih %r2, 0xff
 ;   br %r14
 
 function %fcvt_to_sint_sat_f64_i8(f64) -> i8 {
@@ -624,6 +1225,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -634,6 +1236,18 @@ block0(v0: f64):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7f
+;   locghih %r2, 0x7f
+;   cghi %r2, -0x80
+;   locghil %r2, -0x80
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -641,10 +1255,19 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   clgfi %r2, 65535
+;   locghih %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   clgfi %r2, 0xffff
 ;   locghih %r2, -1
 ;   br %r14
 
@@ -654,6 +1277,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -664,6 +1288,18 @@ block0(v0: f64):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7fff
+;   locghih %r2, 0x7fff
+;   cghi %r2, -0x8000
+;   locghil %r2, -0x8000
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -671,10 +1307,20 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   llilf %r4, 4294967295
+;   clgr %r2, %r4
+;   locgrh %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   llilf %r4, 0xffffffff
 ;   clgr %r2, %r4
 ;   locgrh %r2, %r4
 ;   br %r14
@@ -685,6 +1331,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -697,6 +1344,20 @@ block0(v0: f64):
 ;   cgr %r2, %r4
 ;   locgrl %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   lgfi %r3, 0x7fffffff
+;   cgr %r2, %r3
+;   locgrh %r2, %r3
+;   lgfi %r4, -0x80000000
+;   cgr %r2, %r4
+;   locgrl %r2, %r4
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -704,7 +1365,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   br %r14
@@ -715,7 +1383,16 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   cdbr %f0, %f0

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -14,8 +14,17 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   le %f0, 0(%r1)
 ;   br %r14
 
 function %f64const_zero() -> f64 {
@@ -24,8 +33,19 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f0, 0(%r1)
 ;   br %r14
 
 function %f32const_one() -> f32 {
@@ -34,8 +54,17 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.f32 1 ; le %f0, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   sur %f8, %f0
+;   .byte 0x00, 0x00
+;   le %f0, 0(%r1)
 ;   br %r14
 
 function %f64const_one() -> f64 {
@@ -44,8 +73,19 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.f64 1 ; ld %f0, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f0, 0(%r1)
 ;   br %r14
 
 function %fadd_f32(f32, f32) -> f32 {
@@ -54,7 +94,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   aebr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   aebr %f0, %f2
 ;   br %r14
 
@@ -64,7 +110,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   adbr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   adbr %f0, %f2
 ;   br %r14
 
@@ -74,7 +126,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sebr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sebr %f0, %f2
 ;   br %r14
 
@@ -84,7 +142,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sdbr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sdbr %f0, %f2
 ;   br %r14
 
@@ -94,7 +158,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   meebr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   meebr %f0, %f2
 ;   br %r14
 
@@ -104,7 +174,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   mdbr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   mdbr %f0, %f2
 ;   br %r14
 
@@ -114,7 +190,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   debr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   debr %f0, %f2
 ;   br %r14
 
@@ -124,7 +206,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   ddbr %f0, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ddbr %f0, %f2
 ;   br %r14
 
@@ -134,7 +222,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfminsb %f0, %f0, %f2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfminsb %f0, %f0, %f2, 1
 ;   br %r14
 
@@ -144,7 +238,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmindb %f0, %f0, %f2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmindb %f0, %f0, %f2, 1
 ;   br %r14
 
@@ -154,7 +254,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmaxsb %f0, %f0, %f2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmaxsb %f0, %f0, %f2, 1
 ;   br %r14
 
@@ -164,7 +270,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmaxdb %f0, %f0, %f2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmaxdb %f0, %f0, %f2, 1
 ;   br %r14
 
@@ -174,7 +286,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfminsb %f0, %f0, %f2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfminsb %f0, %f0, %f2, 3
 ;   br %r14
 
@@ -184,7 +302,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmindb %f0, %f0, %f2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmindb %f0, %f0, %f2, 3
 ;   br %r14
 
@@ -194,7 +318,13 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmaxsb %f0, %f0, %f2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmaxsb %f0, %f0, %f2, 3
 ;   br %r14
 
@@ -204,7 +334,13 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   wfmaxdb %f0, %f0, %f2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmaxdb %f0, %f0, %f2, 3
 ;   br %r14
 
@@ -214,7 +350,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sqebr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqebr %f0, %f0
 ;   br %r14
 
@@ -224,7 +366,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   sqdbr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sqdbr %f0, %f0
 ;   br %r14
 
@@ -234,7 +382,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lpebr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lpebr %f0, %f0
 ;   br %r14
 
@@ -244,7 +398,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lpdbr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lpdbr %f0, %f0
 ;   br %r14
 
@@ -254,7 +414,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcebr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcebr %f0, %f0
 ;   br %r14
 
@@ -264,7 +430,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lcdbr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcdbr %f0, %f0
 ;   br %r14
 
@@ -274,7 +446,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldebr %f0, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldebr %f0, %f0
 ;   br %r14
 
@@ -284,8 +462,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ledbra %f0, 0, %f0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ledbr %f0, %f0
 ;   br %r14
 
 function %ceil_f32(f32) -> f32 {
@@ -294,7 +478,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fiebr %f0, 6, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fiebr %f0, 6, %f0
 ;   br %r14
 
@@ -304,7 +494,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fidbr %f0, 6, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fidbr %f0, 6, %f0
 ;   br %r14
 
@@ -314,7 +510,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fiebr %f0, 7, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fiebr %f0, 7, %f0
 ;   br %r14
 
@@ -324,7 +526,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fidbr %f0, 7, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fidbr %f0, 7, %f0
 ;   br %r14
 
@@ -334,7 +542,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fiebr %f0, 5, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fiebr %f0, 5, %f0
 ;   br %r14
 
@@ -344,7 +558,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fidbr %f0, 5, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fidbr %f0, 5, %f0
 ;   br %r14
 
@@ -354,7 +574,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fiebr %f0, 4, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fiebr %f0, 4, %f0
 ;   br %r14
 
@@ -364,7 +590,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   fidbr %f0, 4, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   fidbr %f0, 4, %f0
 ;   br %r14
 
@@ -374,7 +606,13 @@ block0(v0: f32, v1: f32, v2: f32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   wfmasb %f0, %f0, %f2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmasb %f0, %f0, %f2, %f4
 ;   br %r14
 
@@ -384,7 +622,13 @@ block0(v0: f64, v1: f64, v2: f64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   wfmadb %f0, %f0, %f2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wfmadb %f0, %f0, %f2, %f4
 ;   br %r14
 
@@ -394,8 +638,17 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.f32 NaN ; le %f3, 0(%r1)
+;   vsel %v0, %v0, %v2, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   su %f15, 0xfff(%r15, %r15)
+;   le %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
 
@@ -405,8 +658,19 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.f64 NaN ; ld %f3, 0(%r1)
+;   vsel %v0, %v0, %v2, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   su %f15, 0xfff(%r15, %r15)
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   ld %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
 
@@ -416,6 +680,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -429,6 +694,28 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   ic %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wclgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i8(f32) -> i8 {
 block0(v0: f32):
@@ -436,6 +723,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -449,6 +737,29 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   ic %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   .byte 0xc3, 0x01
+;   .byte 0x00, 0x00
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wcgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -456,6 +767,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -469,6 +781,28 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   be 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wclgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -476,6 +810,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -489,6 +824,29 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   bc 0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   bpp 0, -0x31dc, 0x100
+;   lpr %r0, %r0
+;   .byte 0x08, 0x03
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wcgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -496,6 +854,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -509,6 +868,28 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   cvb %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wclgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -516,6 +897,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -529,6 +911,29 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   cvb %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   .byte 0xcf, 0x00
+;   .byte 0x00, 0x01
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wcgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_uint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -536,6 +941,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -549,6 +955,28 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   sl %r8, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   icm %r8, 0, 0
+;   vlef %v16, 0(%r1), 0
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wclgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_sint_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -556,6 +984,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cebr %f0, %f0
 ;   jno 6 ; trap
@@ -569,6 +998,29 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cebr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x12
+;   sl %r0, 0
+;   le %f4, 0(%r1)
+;   cebr %f0, %f4
+;   jnhe 0x20
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x28
+;   edmk 1(1), 0x700(%r14)
+;   lpr %r0, %r0
+;   .byte 0x08, 0x03
+;   wfcsb %f0, %v16
+;   jnle 0x3a
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wldeb %v20, %f0
+;   wcgdb %v22, %v20, 0, 5
+;   vlgvg %r2, %v22, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -576,6 +1028,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -588,6 +1041,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r7, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i8(f64) -> i8 {
 block0(v0: f64):
@@ -595,6 +1073,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -607,6 +1086,30 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r6, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   larl %r6, 0x40000028
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -614,6 +1117,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -626,6 +1130,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -633,6 +1162,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -645,6 +1175,30 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   sth %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   larl %r14, 0x400028
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -652,6 +1206,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -664,6 +1219,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   la %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -671,6 +1251,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -683,6 +1264,32 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   la %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   .byte 0xc1, 0xe0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x20
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_uint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -690,6 +1297,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -702,6 +1310,31 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   ic %r15, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   icm %r15, 0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wclgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_to_sint_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -709,6 +1342,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   cdbr %f0, %f0
 ;   jno 6 ; trap
@@ -721,6 +1355,32 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cdbr %f0, %f0
+;   jno 0xa
+;   .byte 0x00, 0x00 ; trap: bad_toint
+;   bras %r1, 0x16
+;   ic %r14, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   cdbr %f0, %f4
+;   jnhe 0x24
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   bras %r1, 0x30
+;   .byte 0xc3, 0xe0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   vleg %v16, 0(%r1), 0
+;   wfcdb %f0, %v16
+;   jnle 0x42
+;   .byte 0x00, 0x00 ; trap: int_ovf
+;   wcgdb %v20, %f0, 0, 5
+;   vlgvg %r2, %v20, 0
+;   br %r14
 
 function %fcvt_from_uint_i8_f32(i8) -> f32 {
 block0(v0: i8):
@@ -728,7 +1388,16 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgcr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgcr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f6, %f4, 0, 3
@@ -741,7 +1410,16 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgbr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgbr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f6, %f4, 0, 3
@@ -754,7 +1432,16 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f6, %f4, 0, 3
@@ -767,7 +1454,16 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f6, %f4, 0, 3
@@ -780,7 +1476,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f6, %f4, 0, 3
@@ -793,7 +1498,16 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f6, %f4, 0, 3
+;   ledbra %f0, 4, %f6, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f6, %f4, 0, 3
@@ -806,7 +1520,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdlgb %f4, %f2, 0, 3
+;   ledbra %f0, 4, %f4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdlgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
@@ -818,7 +1540,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdgb %f4, %f2, 0, 3
+;   ledbra %f0, 4, %f4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
@@ -830,7 +1560,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgcr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgcr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -842,7 +1580,15 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgbr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgbr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -854,7 +1600,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -866,7 +1620,15 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lghr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -878,7 +1640,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdlgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
@@ -890,7 +1660,15 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgfr %r4, %r2
+;   ldgr %f4, %r4
+;   wcdgb %f0, %f4, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgfr %r4, %r2
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
@@ -902,7 +1680,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdlgb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdlgb %f0, %f2, 0, 4
 ;   br %r14
@@ -913,7 +1698,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   wcdgb %f0, %f2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   wcdgb %f0, %f2, 0, 4
 ;   br %r14
@@ -924,12 +1716,22 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wclgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   clgfi %r2, 0x100
+;   locghih %r2, 0xff
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32_i8(f32) -> i8 {
@@ -938,6 +1740,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wcgdb %f4, %f2, 0, 5
@@ -949,6 +1752,19 @@ block0(v0: f32):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wcgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   cebr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7f
+;   locghih %r2, 0x7f
+;   cghi %r2, -0x80
+;   locghil %r2, -0x80
+;   br %r14
 
 function %fcvt_to_uint_sat_f32_i16(f32) -> i16 {
 block0(v0: f32):
@@ -956,11 +1772,21 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
 ;   clgfi %r2, 65535
+;   locghih %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wclgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   clgfi %r2, 0xffff
 ;   locghih %r2, -1
 ;   br %r14
 
@@ -970,6 +1796,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wcgdb %f4, %f2, 0, 5
@@ -981,6 +1808,19 @@ block0(v0: f32):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wcgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   cebr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7fff
+;   locghih %r2, 0x7fff
+;   cghi %r2, -0x8000
+;   locghil %r2, -0x8000
+;   br %r14
 
 function %fcvt_to_uint_sat_f32_i32(f32) -> i32 {
 block0(v0: f32):
@@ -988,11 +1828,22 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
 ;   llilf %r3, 4294967295
+;   clgr %r2, %r3
+;   locgrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wclgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   llilf %r3, 0xffffffff
 ;   clgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
@@ -1003,6 +1854,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ldebr %f2, %f0
 ;   wcgdb %f4, %f2, 0, 5
@@ -1016,6 +1868,21 @@ block0(v0: f32):
 ;   cgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ldebr %f2, %f0
+;   wcgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   cebr %f0, %f0
+;   locghio %r2, 0
+;   lgfi %r5, 0x7fffffff
+;   cgr %r2, %r5
+;   locgrh %r2, %r5
+;   lgfi %r3, -0x80000000
+;   cgr %r2, %r3
+;   locgrl %r2, %r3
+;   br %r14
 
 function %fcvt_to_uint_sat_f32_i64(f32) -> i64 {
 block0(v0: f32):
@@ -1023,7 +1890,15 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldebr %f2, %f0
+;   wclgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldebr %f2, %f0
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
@@ -1035,7 +1910,17 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldebr %f2, %f0
+;   wcgdb %f4, %f2, 0, 5
+;   lgdr %r2, %f4
+;   cebr %f0, %f0
+;   locghio %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldebr %f2, %f0
 ;   wcgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
@@ -1049,11 +1934,20 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   clgfi %r2, 0x100
+;   locghih %r2, 0xff
 ;   br %r14
 
 function %fcvt_to_sint_sat_f64_i8(f64) -> i8 {
@@ -1062,6 +1956,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -1072,6 +1967,18 @@ block0(v0: f64):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7f
+;   locghih %r2, 0x7f
+;   cghi %r2, -0x80
+;   locghil %r2, -0x80
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i16(f64) -> i16 {
 block0(v0: f64):
@@ -1079,10 +1986,19 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   clgfi %r2, 65535
+;   locghih %r2, -1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   clgfi %r2, 0xffff
 ;   locghih %r2, -1
 ;   br %r14
 
@@ -1092,6 +2008,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -1102,6 +2019,18 @@ block0(v0: f64):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   cghi %r2, 0x7fff
+;   locghih %r2, 0x7fff
+;   cghi %r2, -0x8000
+;   locghil %r2, -0x8000
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i32(f64) -> i32 {
 block0(v0: f64):
@@ -1109,10 +2038,20 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   llilf %r4, 4294967295
+;   clgr %r2, %r4
+;   locgrh %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   llilf %r4, 0xffffffff
 ;   clgr %r2, %r4
 ;   locgrh %r2, %r4
 ;   br %r14
@@ -1123,6 +2062,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
@@ -1135,6 +2075,20 @@ block0(v0: f64):
 ;   cgr %r2, %r4
 ;   locgrl %r2, %r4
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   lgfi %r3, 0x7fffffff
+;   cgr %r2, %r3
+;   locgrh %r2, %r3
+;   lgfi %r4, -0x80000000
+;   cgr %r2, %r4
+;   locgrl %r2, %r4
+;   br %r14
 
 function %fcvt_to_uint_sat_f64_i64(f64) -> i64 {
 block0(v0: f64):
@@ -1142,7 +2096,14 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   wclgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   br %r14
@@ -1153,7 +2114,16 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   wcgdb %f2, %f0, 0, 5
+;   lgdr %r2, %f2
+;   cdbr %f0, %f0
+;   locghio %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   cdbr %f0, %f0
@@ -1166,7 +2136,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f0, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f0, %r2
 ;   br %r14
 
@@ -1176,7 +2152,13 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgdr %r2, %f0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgdr %r2, %f0
 ;   br %r14
 
@@ -1186,7 +2168,13 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v0, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v0, %r2, 0
 ;   br %r14
 
@@ -1196,7 +2184,13 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r2, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r2, %v0, 0
 ;   br %r14
 
@@ -1206,7 +2200,12 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_f64_f64(f64) -> f64 {
@@ -1215,6 +2214,11 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
@@ -8,6 +8,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -160
@@ -17,6 +18,16 @@ block0:
 ;   lg %r2, 0(%r15)
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   lgr %r1, %r15
+;   aghi %r15, -0xa0
+;   stg %r1, 0(%r15)
+; block0: ; offset 0x14
+;   lg %r2, 0(%r15)
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %sp() -> i64 {
 block0:
@@ -24,6 +35,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -160
@@ -33,6 +45,16 @@ block0:
 ;   lgr %r2, %r15
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   lgr %r1, %r15
+;   aghi %r15, -0xa0
+;   stg %r1, 0(%r15)
+; block0: ; offset 0x14
+;   lgr %r2, %r15
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %return_address() -> i64 {
 block0:
@@ -40,6 +62,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -160
@@ -48,5 +71,15 @@ block0:
 ; block0:
 ;   lg %r2, 272(%r15)
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   lgr %r1, %r15
+;   aghi %r15, -0xa0
+;   stg %r1, 0(%r15)
+; block0: ; offset 0x14
+;   lg %r2, 0x110(%r15)
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/fpmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem-arch13.clif
@@ -7,8 +7,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v0, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x00
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   br %r14
 
 function %load_f32_little(i64) -> f32 {
@@ -17,8 +25,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v0, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x00
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x03
 ;   br %r14
 
 function %store_f64_little(f64, i64) {
@@ -27,8 +43,16 @@ block0(v0: f64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v0, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x00
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x0a
 ;   br %r14
 
 function %store_f32_little(f32, i64) {
@@ -37,7 +61,15 @@ block0(v0: f32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v0, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x00
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x0b
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/fpmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f0, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f0, 0(%r2)
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   le %f0, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   le %f0, 0(%r2)
 ;   br %r14
 
@@ -27,7 +39,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f0, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f0, %r4
 ;   br %r14
@@ -38,7 +57,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   vlvgf %v0, %r4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v0, %r4, 0
 ;   br %r14
@@ -49,7 +75,13 @@ block0(v0: f64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   std %f0, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   std %f0, 0(%r2)
 ;   br %r14
 
@@ -59,7 +91,13 @@ block0(v0: f32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   ste %f0, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ste %f0, 0(%r2)
 ;   br %r14
 
@@ -69,7 +107,14 @@ block0(v0: f64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   lgdr %r5, %f0
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgdr %r5, %f0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -80,7 +125,14 @@ block0(v0: f32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v0, 0
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v0, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
@@ -7,7 +7,17 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vceqgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vceqgs %v5, %v1, %v3
@@ -21,7 +31,17 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vceqgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vceqgs %v5, %v1, %v3
@@ -35,10 +55,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vecg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v1, %v3
+;   jne 0x1c
+;   vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -49,10 +81,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vecg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v3, %v1
+;   jne 0x1c
+;   vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -63,10 +107,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vecg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochinl %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v3, %v1
+;   jne 0x1c
+;   vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -77,10 +133,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   vecg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
+;   lhi %r2, 0
+;   lochinl %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   vecg %v1, %v3
+;   jne 0x1c
+;   vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -91,10 +159,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   veclg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v1, %v3
+;   jne 0x1c
+;   vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -105,10 +185,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   veclg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v3, %v1
+;   jne 0x1c
+;   vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -119,10 +211,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   veclg %v3, %v1 ; jne 10 ; vchlgs %v5, %v1, %v3
+;   lhi %r2, 0
+;   lochinl %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v3, %v1
+;   jne 0x1c
+;   vchlgs %v5, %v1, %v3
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
@@ -133,10 +237,22 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vl %v3, 0(%r3)
 ;   veclg %v1, %v3 ; jne 10 ; vchlgs %v5, %v3, %v1
+;   lhi %r2, 0
+;   lochinl %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   vl %v3, 0(%r3)
+;   veclg %v1, %v3
+;   jne 0x1c
+;   vchlgs %v5, %v3, %v1
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp.clif
@@ -7,7 +7,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cgr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -20,7 +28,15 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cgfr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgfr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -33,7 +49,15 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cghi %r2, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r2, 1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -46,8 +70,16 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cgfi %r2, 32768
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cgfi %r2, 0x8000
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -59,7 +91,15 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cg %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cg %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -74,8 +114,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   cgrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -87,7 +135,15 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cgh %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgh %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -102,8 +158,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   cghrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -115,7 +179,15 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cgf %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgf %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -130,8 +202,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   cgfrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -142,7 +222,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -155,7 +243,15 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   chi %r2, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   chi %r2, 1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -168,8 +264,16 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   cfi %r2, 32768
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cfi %r2, 0x8000
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -181,7 +285,15 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   c %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   c %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -194,8 +306,16 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   cy %r2, 4096(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cy %r2, 0x1000(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -209,8 +329,16 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   crl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   crl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -222,7 +350,15 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   ch %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ch %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -235,8 +371,16 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   chy %r2, 4096(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   chy %r2, 0x1000(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -250,8 +394,16 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   chrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   chrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -262,7 +414,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r2
+;   lhr %r3, %r3
+;   cr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r2
 ;   lhr %r3, %r3
 ;   cr %r5, %r3
@@ -277,7 +439,16 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r4, %r2
+;   chi %r4, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r4, %r2
 ;   chi %r4, 1
 ;   lhi %r2, 0
@@ -291,7 +462,16 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r2
+;   ch %r5, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r2
 ;   ch %r5, 0(%r3)
 ;   lhi %r2, 0
@@ -307,9 +487,18 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lhr %r4, %r2
 ;   chrl %r4, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r4, %r2
+;   chrl %r4, 4 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -320,7 +509,17 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   lbr %r3, %r3
+;   cr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   lbr %r3, %r3
 ;   cr %r5, %r3
@@ -335,7 +534,16 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r4, %r2
+;   chi %r4, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r4, %r2
 ;   chi %r4, 1
 ;   lhi %r2, 0
@@ -349,7 +557,17 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   lb %r3, 0(%r3)
+;   cr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   lb %r3, 0(%r3)
 ;   cr %r5, %r3
@@ -363,7 +581,15 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clgr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -376,7 +602,15 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ; block0:
+;   clgfr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgfr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -389,7 +623,15 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clgfi %r2, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgfi %r2, 1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -402,7 +644,15 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   clg %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clg %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -417,8 +667,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   clgrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -430,7 +688,15 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   clgf %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgf %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -445,8 +711,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   clgfrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -458,7 +732,16 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llgh %r3, 0(%r3)
+;   clgr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgh %r3, 0(%r3)
 ;   clgr %r2, %r3
 ;   lhi %r2, 0
@@ -474,8 +757,16 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   clghrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -486,7 +777,15 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clr %r2, %r3
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -499,7 +798,15 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clfi %r2, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clfi %r2, 1
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -512,7 +819,15 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   cl %r2, 0(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cl %r2, 0(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
@@ -525,8 +840,16 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   cly %r2, 4096(%r3)
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   cly %r2, 0x1000(%r3)
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -540,8 +863,16 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   clrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -553,7 +884,16 @@ block0(v0: i32, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llh %r3, 0(%r3)
+;   clr %r2, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
 ;   clr %r2, %r3
 ;   lhi %r2, 0
@@ -569,8 +909,16 @@ block0(v0: i32):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   clhrl %r2, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -581,7 +929,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llhr %r5, %r2
+;   llhr %r3, %r3
+;   clr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r5, %r2
 ;   llhr %r3, %r3
 ;   clr %r5, %r3
@@ -596,7 +954,16 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llhr %r4, %r2
+;   clfi %r4, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r4, %r2
 ;   clfi %r4, 1
 ;   lhi %r2, 0
@@ -610,7 +977,17 @@ block0(v0: i16, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llhr %r5, %r2
+;   llh %r3, 0(%r3)
+;   clr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r5, %r2
 ;   llh %r3, 0(%r3)
 ;   clr %r5, %r3
@@ -627,9 +1004,18 @@ block0(v0: i16):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   llhr %r4, %r2
 ;   clhrl %r4, %sym + 0
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r4, %r2
+;   clhrl %r4, 4 ; reloc_external PCRel32Dbl %sym 2
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
@@ -640,7 +1026,17 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   llcr %r3, %r3
+;   clr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   llcr %r3, %r3
 ;   clr %r5, %r3
@@ -655,7 +1051,16 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r4, %r2
+;   clfi %r4, 1
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r4, %r2
 ;   clfi %r4, 1
 ;   lhi %r2, 0
@@ -669,7 +1074,17 @@ block0(v0: i8, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   llc %r3, 0(%r3)
+;   clr %r5, %r3
+;   lhi %r2, 0
+;   lochil %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   llc %r3, 0(%r3)
 ;   clr %r5, %r3

--- a/cranelift/filetests/filetests/isa/s390x/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/s390x/jumptable.clif
@@ -26,6 +26,7 @@ block5(v5: i32):
   return v6
 }
 
+; VCode:
 ; block0:
 ;   llgfr %r3, %r2
 ;   clgfi %r3, 3
@@ -53,6 +54,39 @@ block5(v5: i32):
 ; block8:
 ;   jg label9
 ; block9:
+;   ar %r2, %r5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfr %r3, %r2
+;   clgfi %r3, 3
+;   jghe 0x30
+;   sllg %r3, %r3, 2
+;   larl %r1, 0x24
+;   agf %r1, 0(%r3, %r1)
+;   br %r1
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x16
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x20
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x2a
+; block1: ; offset 0x30
+;   lhi %r5, 4
+; block2: ; offset 0x34
+;   jg 0x52
+; block3: ; offset 0x3a
+;   lhi %r5, 1
+; block4: ; offset 0x3e
+;   jg 0x52
+; block5: ; offset 0x44
+;   lhi %r5, 2
+; block6: ; offset 0x48
+;   jg 0x52
+; block7: ; offset 0x4e
+;   lhi %r5, 3
+; block8: ; offset 0x52
 ;   ar %r2, %r5
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/leaf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf.clif
@@ -10,6 +10,11 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
@@ -10,6 +10,7 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -160
@@ -17,5 +18,14 @@ block0(v0: i64):
 ;   stg %r1, 0(%r15)
 ; block0:
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   lgr %r1, %r15
+;   aghi %r15, -0xa0
+;   stg %r1, 0(%r15)
+; block0: ; offset 0x14
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/load-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/load-little.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r2, 0(%r2)
 ;   br %r14
 
@@ -19,8 +25,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvg %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvg %r2, 0(%r1)
 ;   br %r14
 
 function %uload8_i64(i64) -> i64 {
@@ -29,7 +42,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgc %r2, 0(%r2)
 ;   br %r14
 
@@ -39,7 +58,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgb %r2, 0(%r2)
 ;   br %r14
 
@@ -49,7 +74,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   llghr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   llghr %r2, %r4
 ;   br %r14
@@ -62,8 +94,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   llghr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   llghr %r2, %r2
 ;   br %r14
 
@@ -73,7 +113,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   lghr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   lghr %r2, %r4
 ;   br %r14
@@ -86,8 +133,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   lghr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   lghr %r2, %r2
 ;   br %r14
 
@@ -97,7 +152,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   llgfr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   llgfr %r2, %r4
 ;   br %r14
@@ -110,8 +172,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
+;   llgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrv %r2, 0(%r1)
 ;   llgfr %r2, %r2
 ;   br %r14
 
@@ -121,7 +191,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   lgfr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   lgfr %r2, %r4
 ;   br %r14
@@ -134,8 +211,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
+;   lgfr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrv %r2, 0(%r1)
 ;   lgfr %r2, %r2
 ;   br %r14
 
@@ -145,7 +230,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrv %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r2, 0(%r2)
 ;   br %r14
 
@@ -157,8 +248,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrv %r2, 0(%r1)
 ;   br %r14
 
 function %uload8_i32(i64) -> i32 {
@@ -167,7 +265,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 
@@ -177,7 +281,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
 ;   br %r14
 
@@ -187,7 +297,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   llhr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   llhr %r2, %r4
 ;   br %r14
@@ -200,8 +317,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   llhr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   llhr %r2, %r2
 ;   br %r14
 
@@ -211,7 +336,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   lhr %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   lhr %r2, %r4
 ;   br %r14
@@ -224,8 +356,16 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   lhr %r2, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   lhr %r2, %r2
 ;   br %r14
 
@@ -235,7 +375,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r2, 0(%r2)
 ;   br %r14
 
@@ -247,8 +393,15 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   lrvh %r2, 0(%r1)
 ;   br %r14
 
 function %uload8_i16(i64) -> i16 {
@@ -257,7 +410,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 
@@ -267,7 +426,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
 ;   br %r14
 
@@ -277,7 +442,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/load.clif
+++ b/cranelift/filetests/filetests/isa/s390x/load.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lg %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r2, 0(%r2)
 ;   br %r14
 
@@ -19,8 +25,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lgrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %uload8_i64(i64) -> i64 {
@@ -29,7 +41,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgc %r2, 0(%r2)
 ;   br %r14
 
@@ -39,7 +57,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgb %r2, 0(%r2)
 ;   br %r14
 
@@ -49,7 +73,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgh %r2, 0(%r2)
 ;   br %r14
 
@@ -61,8 +91,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llghrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %sload16_i64(i64) -> i64 {
@@ -71,7 +107,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgh %r2, 0(%r2)
 ;   br %r14
 
@@ -83,8 +125,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lghrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %uload32_i64(i64) -> i64 {
@@ -93,7 +141,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llgf %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llgf %r2, 0(%r2)
 ;   br %r14
 
@@ -105,8 +159,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llgfrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %sload32_i64(i64) -> i64 {
@@ -115,7 +175,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgf %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgf %r2, 0(%r2)
 ;   br %r14
 
@@ -127,8 +193,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lgfrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %load_i32(i64) -> i32 {
@@ -137,7 +209,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   l %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   l %r2, 0(%r2)
 ;   br %r14
 
@@ -149,8 +227,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %load_i32_off(i64) -> i32 {
@@ -159,8 +243,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ly %r2, 4096(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ly %r2, 0x1000(%r2)
 ;   br %r14
 
 function %uload8_i32(i64) -> i32 {
@@ -169,7 +259,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 
@@ -179,7 +275,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
 ;   br %r14
 
@@ -189,7 +291,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
 ;   br %r14
 
@@ -201,8 +309,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llhrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %sload16_i32(i64) -> i32 {
@@ -211,7 +325,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lh %r2, 0(%r2)
 ;   br %r14
 
@@ -221,8 +341,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lhy %r2, 4096(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhy %r2, 0x1000(%r2)
 ;   br %r14
 
 function %sload16_i32_sym() -> i32 {
@@ -233,8 +359,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lhrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %load_i16(i64) -> i16 {
@@ -243,7 +375,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llh %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
 ;   br %r14
 
@@ -255,8 +393,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   llhrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %uload8_i16(i64) -> i16 {
@@ -265,7 +409,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 
@@ -275,7 +425,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lb %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
 ;   br %r14
 
@@ -285,7 +441,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/minmax.clif
+++ b/cranelift/filetests/filetests/isa/s390x/minmax.clif
@@ -7,11 +7,24 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v5, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   veclg %v5, %v3 ; jne 10 ; vchlgs %v6, %v3, %v5
 ;   jnl 10 ; vlr %v5, %v3
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v5, 0(%r3)
+;   vl %v3, 0(%r4)
+;   veclg %v5, %v3
+;   jne 0x1c
+;   vchlgs %v6, %v3, %v5
+;   jnl 0x26
+;   vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -21,7 +34,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clgr %r2, %r3
+;   locgrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
@@ -32,7 +52,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clr %r2, %r3
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
@@ -43,7 +70,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llhr %r5, %r2
+;   llhr %r4, %r3
+;   clr %r5, %r4
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r5, %r2
 ;   llhr %r4, %r3
 ;   clr %r5, %r4
@@ -56,7 +92,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   llcr %r4, %r3
+;   clr %r5, %r4
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   llcr %r4, %r3
 ;   clr %r5, %r4
@@ -69,11 +114,24 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v5, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   veclg %v3, %v5 ; jne 10 ; vchlgs %v6, %v5, %v3
 ;   jnl 10 ; vlr %v5, %v3
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v5, 0(%r3)
+;   vl %v3, 0(%r4)
+;   veclg %v3, %v5
+;   jne 0x1c
+;   vchlgs %v6, %v5, %v3
+;   jnl 0x26
+;   vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -83,7 +141,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clgr %r2, %r3
+;   locgrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
@@ -94,7 +159,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   clr %r2, %r3
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
@@ -105,7 +177,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llhr %r5, %r2
+;   llhr %r4, %r3
+;   clr %r5, %r4
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llhr %r5, %r2
 ;   llhr %r4, %r3
 ;   clr %r5, %r4
@@ -118,7 +199,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   llcr %r4, %r3
+;   clr %r5, %r4
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   llcr %r4, %r3
 ;   clr %r5, %r4
@@ -131,11 +221,24 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v5, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vecg %v5, %v3 ; jne 10 ; vchlgs %v6, %v3, %v5
 ;   jnl 10 ; vlr %v5, %v3
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v5, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vecg %v5, %v3
+;   jne 0x1c
+;   vchlgs %v6, %v3, %v5
+;   jnl 0x26
+;   vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -145,7 +248,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cgr %r2, %r3
+;   locgrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
@@ -156,7 +266,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cr %r2, %r3
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
@@ -167,7 +284,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r2
+;   lhr %r4, %r3
+;   cr %r5, %r4
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r2
 ;   lhr %r4, %r3
 ;   cr %r5, %r4
@@ -180,7 +306,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   lbr %r4, %r3
+;   cr %r5, %r4
+;   locrl %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   lbr %r4, %r3
 ;   cr %r5, %r4
@@ -193,11 +328,24 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v5, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vecg %v3, %v5 ; jne 10 ; vchlgs %v6, %v5, %v3
 ;   jnl 10 ; vlr %v5, %v3
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v5, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vecg %v3, %v5
+;   jne 0x1c
+;   vchlgs %v6, %v5, %v3
+;   jnl 0x26
+;   vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -207,7 +355,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cgr %r2, %r3
+;   locgrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
@@ -218,7 +373,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   cr %r2, %r3
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
@@ -229,7 +391,16 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lhr %r5, %r2
+;   lhr %r4, %r3
+;   cr %r5, %r4
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lhr %r5, %r2
 ;   lhr %r4, %r3
 ;   cr %r5, %r4
@@ -242,7 +413,16 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   lbr %r4, %r3
+;   cr %r5, %r4
+;   locrh %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   lbr %r4, %r3
 ;   cr %r5, %r4

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -10,7 +10,16 @@ block1:
   return v0, v1, v2, v3
 }
 
+; VCode:
 ; block0:
+;   lghi %r2, 1
+;   lghi %r3, 2
+;   lghi %r4, 3
+;   lghi %r5, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghi %r2, 1
 ;   lghi %r3, 2
 ;   lghi %r4, 3
@@ -28,6 +37,7 @@ block1:
   return v0, v1, v2, v3, v4, v5
 }
 
+; VCode:
 ;   stmg %r7, %r15, 56(%r15)
 ; block0:
 ;   lghi %r4, 1
@@ -42,6 +52,22 @@ block1:
 ;   lgr %r2, %r14
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r7, %r15, 0x38(%r15)
+; block0: ; offset 0x6
+;   lghi %r4, 1
+;   lgr %r14, %r4
+;   lghi %r3, 2
+;   lghi %r4, 3
+;   lghi %r5, 4
+;   lghi %r7, 5
+;   lghi %r9, 6
+;   stg %r7, 0(%r2)
+;   stg %r9, 8(%r2)
+;   lgr %r2, %r14
+;   lmg %r7, %r15, 0x38(%r15)
+;   br %r14
 
 function %f3() -> f64, f64, f64, f64 {
 block1:
@@ -52,11 +78,38 @@ block1:
   return v0, v1, v2, v3
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
 ;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
 ;   bras %r1, 12 ; data.f64 2 ; ld %f4, 0(%r1)
 ;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f0, 0(%r1)
+;   bras %r1, 0x1c
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f2, 0(%r1)
+;   bras %r1, 0x2c
+;   sth %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   bras %r1, 0x3c
+;   sth %r0, 0(%r8)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f6, 0(%r1)
 ;   br %r14
 
 function %f4() -> f64, f64, f64, f64, f64, f64 {
@@ -70,6 +123,7 @@ block1:
   return v0, v1, v2, v3, v4, v5
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
 ;   bras %r1, 12 ; data.f64 1 ; ld %f2, 0(%r1)
@@ -77,6 +131,44 @@ block1:
 ;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
 ;   bras %r1, 12 ; data.f64 4 ; vleg %v18, 0(%r1), 0
 ;   bras %r1, 12 ; data.f64 5 ; vleg %v20, 0(%r1), 0
+;   vsteg %v18, 0(%r2), 0
+;   vsteg %v20, 8(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f0, 0(%r1)
+;   bras %r1, 0x1c
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f2, 0(%r1)
+;   bras %r1, 0x2c
+;   sth %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f4, 0(%r1)
+;   bras %r1, 0x3c
+;   sth %r0, 0(%r8)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ld %f6, 0(%r1)
+;   bras %r1, 0x4c
+;   sth %r1, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v18, 0(%r1), 0
+;   bras %r1, 0x5e
+;   sth %r1, 0(%r4)
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vleg %v20, 0(%r1), 0
 ;   vsteg %v18, 0(%r2), 0
 ;   vsteg %v20, 8(%r2), 0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -6,7 +6,13 @@ block0(v0: r64, v1: r64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lgr %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r2, %r3
 ;   br %r14
 
@@ -16,7 +22,15 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   cghi %r2, 0
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r2, 0
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -28,7 +42,15 @@ block0(v0: r64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   cghi %r2, -1
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   cghi %r2, -1
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -40,7 +62,13 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
+;   lghi %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghi %r2, 0
 ;   br %r14
 
@@ -64,6 +92,7 @@ block3(v7: r64, v8: r64):
     return v7, v8, v9
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -184
 ;   virtual_sp_offset_adjust 160
@@ -94,5 +123,37 @@ block3(v7: r64, v8: r64):
 ;   la %r4, 160(%r15)
 ;   lg %r4, 0(%r4)
 ;   lmg %r14, %r15, 296(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xb8
+; block0: ; offset 0xa
+;   stg %r2, 0xa8(%r15)
+;   stg %r3, 0xb0(%r15)
+;   bras %r1, 0x22
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %f 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r3, 0(%r1)
+;   basr %r14, %r3
+;   la %r5, 0xa0(%r15)
+;   lg %r4, 0xa8(%r15)
+;   stg %r4, 0(%r5)
+;   lbr %r2, %r2
+;   chi %r2, 0
+;   jgnlh 0x58
+; block1: ; offset 0x48
+;   lgr %r2, %r4
+;   lg %r3, 0xb0(%r15)
+;   jg 0x62
+; block2: ; offset 0x58
+;   lgr %r3, %r4
+;   lg %r2, 0xb0(%r15)
+; block3: ; offset 0x62
+;   la %r4, 0xa0(%r15)
+;   lg %r4, 0(%r4)
+;   lmg %r14, %r15, 0x128(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/saturating-ops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/saturating-ops.clif
@@ -10,7 +10,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lghi %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lghi %r2, 0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -7,10 +7,25 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vrepb %v6, %v3, 15
+;   vlcb %v16, %v6
+;   vslb %v18, %v1, %v16
+;   vsl %v20, %v18, %v16
+;   vsrlb %v22, %v1, %v6
+;   vsrl %v24, %v22, %v6
+;   vo %v26, %v20, %v24
+;   vst %v26, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 0xf
 ;   vlcb %v16, %v6
 ;   vslb %v18, %v1, %v16
 ;   vsl %v20, %v18, %v16
@@ -26,7 +41,22 @@ block0(v0: i128, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vlvgb %v5, %r4, 0
+;   vrepb %v7, %v5, 0
+;   vlcb %v17, %v7
+;   vslb %v19, %v1, %v17
+;   vsl %v21, %v19, %v17
+;   vsrlb %v23, %v1, %v7
+;   vsrl %v25, %v23, %v7
+;   vo %v27, %v21, %v25
+;   vst %v27, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
@@ -46,9 +76,23 @@ block0(v0: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
+;   vlcb %v6, %v4
+;   vslb %v16, %v1, %v6
+;   vsl %v18, %v16, %v6
+;   vsrlb %v20, %v1, %v4
+;   vsrl %v22, %v20, %v4
+;   vo %v24, %v18, %v22
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0x11
 ;   vlcb %v6, %v4
 ;   vslb %v16, %v1, %v6
 ;   vsl %v18, %v16, %v6
@@ -64,7 +108,16 @@ block0(v0: i64, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   rllg %r2, %r2, 0(%r4)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
@@ -77,7 +130,14 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r3
+;   rllg %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r3
 ;   rllg %r2, %r2, 0(%r5)
 ;   br %r14
@@ -89,8 +149,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   rllg %r2, %r2, 47
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rllg %r2, %r2, 0x2f
 ;   br %r14
 
 function %rotr_i32_vr(i32, i128) -> i32 {
@@ -99,7 +165,16 @@ block0(v0: i32, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   rll %r2, %r2, 0(%r4)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   lcr %r4, %r3
@@ -112,7 +187,14 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r3
+;   rll %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r3
 ;   rll %r2, %r2, 0(%r5)
 ;   br %r14
@@ -124,8 +206,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   rll %r2, %r2, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rll %r2, %r2, 0xf
 ;   br %r14
 
 function %rotr_i16_vr(i16, i128) -> i16 {
@@ -134,6 +222,7 @@ block0(v0: i16, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
@@ -145,6 +234,19 @@ block0(v0: i16, v1: i128):
 ;   srlk %r2, %r2, 0(%r3)
 ;   ork %r2, %r4, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   llhr %r2, %r2
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   nill %r3, 0xf
+;   nill %r4, 0xf
+;   sllk %r4, %r2, 0(%r4)
+;   srlk %r2, %r2, 0(%r3)
+;   ork %r2, %r4, %r2
+;   br %r14
 
 function %rotr_i16_reg(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -152,11 +254,23 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r5, %r2
 ;   lcr %r2, %r3
 ;   nill %r3, 15
 ;   nill %r2, 15
+;   sllk %r2, %r5, 0(%r2)
+;   srlk %r3, %r5, 0(%r3)
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r5, %r2
+;   lcr %r2, %r3
+;   nill %r3, 0xf
+;   nill %r2, 0xf
 ;   sllk %r2, %r5, 0(%r2)
 ;   srlk %r3, %r5, 0(%r3)
 ;   or %r2, %r3
@@ -169,10 +283,19 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r4, %r2
 ;   sllk %r2, %r4, 6
 ;   srlk %r4, %r4, 10
+;   or %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r4, %r2
+;   sllk %r2, %r4, 6
+;   srlk %r4, %r4, 0xa
 ;   or %r2, %r4
 ;   br %r14
 
@@ -182,7 +305,21 @@ block0(v0: i8, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   llcr %r2, %r2
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   nill %r3, 7
+;   nill %r4, 7
+;   sllk %r4, %r2, 0(%r4)
+;   srlk %r2, %r2, 0(%r3)
+;   ork %r2, %r4, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
 ;   vlgvg %r3, %v2, 1
@@ -200,7 +337,19 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   lcr %r2, %r3
+;   nill %r3, 7
+;   nill %r2, 7
+;   sllk %r2, %r5, 0(%r2)
+;   srlk %r3, %r5, 0(%r3)
+;   or %r2, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   lcr %r2, %r3
 ;   nill %r3, 7
@@ -217,7 +366,16 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r4, %r2
+;   sllk %r2, %r4, 5
+;   srlk %r4, %r4, 3
+;   or %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r4, %r2
 ;   sllk %r2, %r4, 5
 ;   srlk %r4, %r4, 3
@@ -230,10 +388,25 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vrepb %v6, %v3, 15
+;   vlcb %v16, %v6
+;   vslb %v18, %v1, %v6
+;   vsl %v20, %v18, %v6
+;   vsrlb %v22, %v1, %v16
+;   vsrl %v24, %v22, %v16
+;   vo %v26, %v20, %v24
+;   vst %v26, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 0xf
 ;   vlcb %v16, %v6
 ;   vslb %v18, %v1, %v6
 ;   vsl %v20, %v18, %v6
@@ -249,7 +422,22 @@ block0(v0: i128, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vlvgb %v5, %r4, 0
+;   vrepb %v7, %v5, 0
+;   vlcb %v17, %v7
+;   vslb %v19, %v1, %v7
+;   vsl %v21, %v19, %v7
+;   vsrlb %v23, %v1, %v17
+;   vsrl %v25, %v23, %v17
+;   vo %v27, %v21, %v25
+;   vst %v27, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
@@ -269,9 +457,23 @@ block0(v0: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
+;   vlcb %v6, %v4
+;   vslb %v16, %v1, %v4
+;   vsl %v18, %v16, %v4
+;   vsrlb %v20, %v1, %v6
+;   vsrl %v22, %v20, %v6
+;   vo %v24, %v18, %v22
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0x11
 ;   vlcb %v6, %v4
 ;   vslb %v16, %v1, %v4
 ;   vsl %v18, %v16, %v4
@@ -287,7 +489,15 @@ block0(v0: i64, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   rllg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   rllg %r2, %r2, 0(%r3)
@@ -299,7 +509,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   rllg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rllg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -310,8 +526,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   rllg %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rllg %r2, %r2, 0x11
 ;   br %r14
 
 function %rotl_i32_vr(i32, i128) -> i32 {
@@ -320,7 +542,15 @@ block0(v0: i32, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   rll %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   rll %r2, %r2, 0(%r3)
@@ -332,7 +562,13 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   rll %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   rll %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -343,8 +579,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   rll %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   rll %r2, %r2, 0x11
 ;   br %r14
 
 function %rotl_i16_vr(i16, i128) -> i16 {
@@ -353,6 +595,7 @@ block0(v0: i16, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
@@ -364,6 +607,19 @@ block0(v0: i16, v1: i128):
 ;   srlk %r2, %r2, 0(%r4)
 ;   ork %r2, %r5, %r2
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   llhr %r2, %r2
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   nill %r3, 0xf
+;   nill %r4, 0xf
+;   sllk %r5, %r2, 0(%r3)
+;   srlk %r2, %r2, 0(%r4)
+;   ork %r2, %r5, %r2
+;   br %r14
 
 function %rotl_i16_reg(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -371,11 +627,23 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r5, %r2
 ;   lcr %r2, %r3
 ;   nill %r3, 15
 ;   nill %r2, 15
+;   sllk %r3, %r5, 0(%r3)
+;   srlk %r4, %r5, 0(%r2)
+;   ork %r2, %r3, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r5, %r2
+;   lcr %r2, %r3
+;   nill %r3, 0xf
+;   nill %r2, 0xf
 ;   sllk %r3, %r5, 0(%r3)
 ;   srlk %r4, %r5, 0(%r2)
 ;   ork %r2, %r3, %r4
@@ -388,9 +656,18 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r4, %r2
 ;   sllk %r2, %r4, 10
+;   srlk %r4, %r4, 6
+;   or %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r4, %r2
+;   sllk %r2, %r4, 0xa
 ;   srlk %r4, %r4, 6
 ;   or %r2, %r4
 ;   br %r14
@@ -401,7 +678,21 @@ block0(v0: i8, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   llcr %r2, %r2
+;   vlgvg %r3, %v2, 1
+;   lcr %r4, %r3
+;   nill %r3, 7
+;   nill %r4, 7
+;   sllk %r5, %r2, 0(%r3)
+;   srlk %r2, %r2, 0(%r4)
+;   ork %r2, %r5, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
 ;   vlgvg %r3, %v2, 1
@@ -419,7 +710,19 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   lcr %r2, %r3
+;   nill %r3, 7
+;   nill %r2, 7
+;   sllk %r3, %r5, 0(%r3)
+;   srlk %r4, %r5, 0(%r2)
+;   ork %r2, %r3, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   lcr %r2, %r3
 ;   nill %r3, 7
@@ -436,7 +739,16 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r4, %r2
+;   sllk %r2, %r4, 3
+;   srlk %r4, %r4, 5
+;   or %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r4, %r2
 ;   sllk %r2, %r4, 3
 ;   srlk %r4, %r4, 5
@@ -449,10 +761,21 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vrepb %v6, %v3, 15
+;   vsrlb %v16, %v1, %v6
+;   vsrl %v18, %v16, %v6
+;   vst %v18, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 0xf
 ;   vsrlb %v16, %v1, %v6
 ;   vsrl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
@@ -464,7 +787,18 @@ block0(v0: i128, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vlvgb %v5, %r4, 0
+;   vrepb %v7, %v5, 0
+;   vsrlb %v17, %v1, %v7
+;   vsrl %v19, %v17, %v7
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
@@ -480,9 +814,19 @@ block0(v0: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
+;   vsrlb %v6, %v1, %v4
+;   vsrl %v16, %v6, %v4
+;   vst %v16, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0x11
 ;   vsrlb %v6, %v1, %v4
 ;   vsrl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
@@ -494,7 +838,15 @@ block0(v0: i64, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   srlg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   srlg %r2, %r2, 0(%r3)
@@ -506,7 +858,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   srlg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   srlg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -517,8 +875,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srlg %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srlg %r2, %r2, 0x11
 ;   br %r14
 
 function %ushr_i32_vr(i32, i128) -> i32 {
@@ -527,10 +891,19 @@ block0(v0: i32, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
+;   srlk %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   nill %r3, 0x1f
 ;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -540,9 +913,17 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   nill %r5, 31
+;   srlk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   nill %r5, 0x1f
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -553,8 +934,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srlk %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srlk %r2, %r2, 0x11
 ;   br %r14
 
 function %ushr_i16_vr(i16, i128) -> i16 {
@@ -563,11 +950,21 @@ block0(v0: i16, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   llhr %r2, %r2
 ;   vlgvg %r5, %v2, 1
 ;   nill %r5, 15
+;   srlk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   llhr %r2, %r2
+;   vlgvg %r5, %v2, 1
+;   nill %r5, 0xf
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -577,9 +974,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r5, %r2
 ;   nill %r3, 15
+;   srlk %r2, %r5, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r5, %r2
+;   nill %r3, 0xf
 ;   srlk %r2, %r5, 0(%r3)
 ;   br %r14
 
@@ -590,9 +995,16 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   llhr %r4, %r2
 ;   srlk %r2, %r4, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   llhr %r4, %r2
+;   srlk %r2, %r4, 0xa
 ;   br %r14
 
 function %ushr_i8_vr(i8, i128) -> i8 {
@@ -601,7 +1013,17 @@ block0(v0: i8, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   llcr %r2, %r2
+;   vlgvg %r5, %v2, 1
+;   nill %r5, 7
+;   srlk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   llcr %r2, %r2
 ;   vlgvg %r5, %v2, 1
@@ -615,7 +1037,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r5, %r2
+;   nill %r3, 7
+;   srlk %r2, %r5, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r5, %r2
 ;   nill %r3, 7
 ;   srlk %r2, %r5, 0(%r3)
@@ -628,7 +1058,14 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   llcr %r4, %r2
+;   srlk %r2, %r4, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llcr %r4, %r2
 ;   srlk %r2, %r4, 3
 ;   br %r14
@@ -639,10 +1076,21 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vrepb %v6, %v3, 15
+;   vslb %v16, %v1, %v6
+;   vsl %v18, %v16, %v6
+;   vst %v18, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 0xf
 ;   vslb %v16, %v1, %v6
 ;   vsl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
@@ -654,7 +1102,18 @@ block0(v0: i128, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vlvgb %v5, %r4, 0
+;   vrepb %v7, %v5, 0
+;   vslb %v17, %v1, %v7
+;   vsl %v19, %v17, %v7
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
@@ -670,9 +1129,19 @@ block0(v0: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
+;   vslb %v6, %v1, %v4
+;   vsl %v16, %v6, %v4
+;   vst %v16, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0x11
 ;   vslb %v6, %v1, %v4
 ;   vsl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
@@ -684,7 +1153,15 @@ block0(v0: i64, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   sllg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   sllg %r2, %r2, 0(%r3)
@@ -696,7 +1173,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sllg %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sllg %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -707,8 +1190,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sllg %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllg %r2, %r2, 0x11
 ;   br %r14
 
 function %ishl_i32_vr(i32, i128) -> i32 {
@@ -717,10 +1206,19 @@ block0(v0: i32, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
+;   sllk %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   nill %r3, 0x1f
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -730,9 +1228,17 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   nill %r5, 31
+;   sllk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   nill %r5, 0x1f
 ;   sllk %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -743,8 +1249,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r2, 0x11
 ;   br %r14
 
 function %ishl_i16_vr(i16, i128) -> i16 {
@@ -753,10 +1265,19 @@ block0(v0: i16, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   nill %r3, 15
+;   sllk %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   nill %r3, 0xf
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -766,9 +1287,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   nill %r5, 15
+;   sllk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   nill %r5, 0xf
 ;   sllk %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -779,8 +1308,14 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   sllk %r2, %r2, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sllk %r2, %r2, 0xa
 ;   br %r14
 
 function %ishl_i8_vr(i8, i128) -> i8 {
@@ -789,7 +1324,16 @@ block0(v0: i8, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   nill %r3, 7
+;   sllk %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   nill %r3, 7
@@ -802,7 +1346,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lgr %r5, %r3
+;   nill %r5, 7
+;   sllk %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r5, %r3
 ;   nill %r5, 7
 ;   sllk %r2, %r2, 0(%r5)
@@ -815,7 +1367,13 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   sllk %r2, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sllk %r2, %r2, 3
 ;   br %r14
 
@@ -825,10 +1383,21 @@ block0(v0: i128, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
 ;   vrepb %v6, %v3, 15
+;   vsrab %v16, %v1, %v6
+;   vsra %v18, %v16, %v6
+;   vst %v18, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vl %v3, 0(%r4)
+;   vrepb %v6, %v3, 0xf
 ;   vsrab %v16, %v1, %v6
 ;   vsra %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
@@ -840,7 +1409,18 @@ block0(v0: i128, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r3)
+;   vlvgb %v5, %r4, 0
+;   vrepb %v7, %v5, 0
+;   vsrab %v17, %v1, %v7
+;   vsra %v19, %v17, %v7
+;   vst %v19, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
 ;   vlvgb %v5, %r4, 0
 ;   vrepb %v7, %v5, 0
@@ -856,9 +1436,19 @@ block0(v0: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r3)
 ;   vrepib %v4, 17
+;   vsrab %v6, %v1, %v4
+;   vsra %v16, %v6, %v4
+;   vst %v16, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r3)
+;   vrepib %v4, 0x11
 ;   vsrab %v6, %v1, %v4
 ;   vsra %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
@@ -870,7 +1460,15 @@ block0(v0: i64, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   srag %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   srag %r2, %r2, 0(%r3)
@@ -882,7 +1480,13 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   srag %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   srag %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -893,8 +1497,14 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srag %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srag %r2, %r2, 0x11
 ;   br %r14
 
 function %sshr_i32_vr(i32, i128) -> i32 {
@@ -903,10 +1513,19 @@ block0(v0: i32, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   vlgvg %r3, %v2, 1
 ;   nill %r3, 31
+;   srak %r2, %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   vlgvg %r3, %v2, 1
+;   nill %r3, 0x1f
 ;   srak %r2, %r2, 0(%r3)
 ;   br %r14
 
@@ -916,9 +1535,17 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lgr %r5, %r3
 ;   nill %r5, 31
+;   srak %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r5, %r3
+;   nill %r5, 0x1f
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -929,8 +1556,14 @@ block0(v0: i32):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   srak %r2, %r2, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   srak %r2, %r2, 0x11
 ;   br %r14
 
 function %sshr_i16_vr(i16, i128) -> i16 {
@@ -939,11 +1572,21 @@ block0(v0: i16, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r3)
 ;   lhr %r2, %r2
 ;   vlgvg %r5, %v2, 1
 ;   nill %r5, 15
+;   srak %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r3)
+;   lhr %r2, %r2
+;   vlgvg %r5, %v2, 1
+;   nill %r5, 0xf
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
 
@@ -953,9 +1596,17 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhr %r5, %r2
 ;   nill %r3, 15
+;   srak %r2, %r5, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r5, %r2
+;   nill %r3, 0xf
 ;   srak %r2, %r5, 0(%r3)
 ;   br %r14
 
@@ -966,9 +1617,16 @@ block0(v0: i16):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   lhr %r4, %r2
 ;   srak %r2, %r4, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhr %r4, %r2
+;   srak %r2, %r4, 0xa
 ;   br %r14
 
 function %sshr_i8_vr(i8, i128) -> i8 {
@@ -977,7 +1635,17 @@ block0(v0: i8, v1: i128):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r3)
+;   lbr %r2, %r2
+;   vlgvg %r5, %v2, 1
+;   nill %r5, 7
+;   srak %r2, %r2, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
 ;   lbr %r2, %r2
 ;   vlgvg %r5, %v2, 1
@@ -991,7 +1659,15 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r5, %r2
+;   nill %r3, 7
+;   srak %r2, %r5, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r5, %r2
 ;   nill %r3, 7
 ;   srak %r2, %r5, 0(%r3)
@@ -1004,7 +1680,14 @@ block0(v0: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lbr %r4, %r2
+;   srak %r2, %r4, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lbr %r4, %r2
 ;   srak %r2, %r4, 3
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
@@ -6,7 +6,12 @@ block0:
     return
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %stack_limit_leaf_zero(i64 stack_limit) {
@@ -14,7 +19,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %stack_limit_gv_leaf_zero(i64 vmctx) {
@@ -26,7 +36,12 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %stack_limit_call_zero(i64 stack_limit) {
@@ -36,6 +51,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   clgrtle %r15, %r2
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
@@ -44,6 +60,21 @@ block0(v0: i64):
 ;   bras %r1, 12 ; data %foo + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   clgrtle %r15, %r2 ; trap: stk_ovf
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xe
+;   bras %r1, 0x1a
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %stack_limit_gv_call_zero(i64 vmctx) {
@@ -57,6 +88,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1
@@ -68,6 +100,23 @@ block0(v0: i64):
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   lg %r1, 0(%r2)
+;   lg %r1, 4(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0x1a
+;   bras %r1, 0x26
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
 
 function %stack_limit(i64 stack_limit) {
     ss0 = explicit_slot 168
@@ -75,11 +124,20 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   la %r1, 168(%r2)
 ;   clgrtle %r15, %r1
 ;   aghi %r15, -168
 ; block0:
 ;   aghi %r15, 168
+;   br %r14
+; 
+; Disassembled:
+;   la %r1, 0xa8(%r2)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   aghi %r15, -0xa8
+; block0: ; offset 0xc
+;   aghi %r15, 0xa8
 ;   br %r14
 
 function %large_stack_limit(i64 stack_limit) {
@@ -88,12 +146,22 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   clgrtle %r15, %r2
 ;   lay %r1, 400000(%r2)
 ;   clgrtle %r15, %r1
 ;   agfi %r15, -400000
 ; block0:
 ;   agfi %r15, 400000
+;   br %r14
+; 
+; Disassembled:
+;   clgrtle %r15, %r2 ; trap: stk_ovf
+;   lay %r1, 0x61a80(%r2)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   agfi %r15, -0x61a80
+; block0: ; offset 0x14
+;   agfi %r15, 0x61a80
 ;   br %r14
 
 function %huge_stack_limit(i64 stack_limit) {
@@ -102,6 +170,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   clgrtle %r15, %r2
 ;   lgr %r1, %r2
 ;   algfi %r1, 4000000
@@ -109,6 +178,16 @@ block0(v0: i64):
 ;   agfi %r15, -4000000
 ; block0:
 ;   agfi %r15, 4000000
+;   br %r14
+; 
+; Disassembled:
+;   clgrtle %r15, %r2 ; trap: stk_ovf
+;   lgr %r1, %r2
+;   algfi %r1, 0x3d0900
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   agfi %r15, -0x3d0900
+; block0: ; offset 0x18
+;   agfi %r15, 0x3d0900
 ;   br %r14
 
 function %limit_preamble(i64 vmctx) {
@@ -121,6 +200,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   la %r1, 24(%r1)
@@ -128,6 +208,16 @@ block0(v0: i64):
 ;   aghi %r15, -24
 ; block0:
 ;   aghi %r15, 24
+;   br %r14
+; 
+; Disassembled:
+;   lg %r1, 0(%r2)
+;   lg %r1, 4(%r1)
+;   la %r1, 0x18(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   aghi %r15, -0x18
+; block0: ; offset 0x18
+;   aghi %r15, 0x18
 ;   br %r14
 
 function %limit_preamble_large(i64 vmctx) {
@@ -140,6 +230,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1
@@ -148,6 +239,17 @@ block0(v0: i64):
 ;   agfi %r15, -400000
 ; block0:
 ;   agfi %r15, 400000
+;   br %r14
+; 
+; Disassembled:
+;   lg %r1, 0(%r2)
+;   lg %r1, 4(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   lay %r1, 0x61a80(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   agfi %r15, -0x61a80
+; block0: ; offset 0x20
+;   agfi %r15, 0x61a80
 ;   br %r14
 
 function %limit_preamble_huge(i64 vmctx) {
@@ -160,6 +262,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1
@@ -168,6 +271,17 @@ block0(v0: i64):
 ;   agfi %r15, -4000000
 ; block0:
 ;   agfi %r15, 4000000
+;   br %r14
+; 
+; Disassembled:
+;   lg %r1, 0(%r2)
+;   lg %r1, 4(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   algfi %r1, 0x3d0900
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   agfi %r15, -0x3d0900
+; block0: ; offset 0x20
+;   agfi %r15, 0x3d0900
 ;   br %r14
 
 function %limit_preamble_huge_offset(i64 vmctx) {
@@ -179,11 +293,22 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   lgfi %r1, 1000000 ; lg %r1, 0(%r1,%r2)
 ;   la %r1, 24(%r1)
 ;   clgrtle %r15, %r1
 ;   aghi %r15, -24
 ; block0:
 ;   aghi %r15, 24
+;   br %r14
+; 
+; Disassembled:
+;   lgfi %r1, 0xf4240
+;   lg %r1, 0(%r1, %r2)
+;   la %r1, 0x18(%r1)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
+;   aghi %r15, -0x18
+; block0: ; offset 0x18
+;   aghi %r15, 0x18
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/stack.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack.clif
@@ -11,8 +11,16 @@ block0:
   return v0
 }
 
+; VCode:
 ;   aghi %r15, -8
 ; block0:
+;   la %r2, 0(%r15)
+;   aghi %r15, 8
+;   br %r14
+; 
+; Disassembled:
+;   aghi %r15, -8
+; block0: ; offset 0x4
 ;   la %r2, 0(%r15)
 ;   aghi %r15, 8
 ;   br %r14
@@ -26,10 +34,18 @@ block0:
   return v0
 }
 
+; VCode:
 ;   agfi %r15, -100008
 ; block0:
 ;   la %r2, 0(%r15)
 ;   agfi %r15, 100008
+;   br %r14
+; 
+; Disassembled:
+;   agfi %r15, -0x186a8
+; block0: ; offset 0x6
+;   la %r2, 0(%r15)
+;   agfi %r15, 0x186a8
 ;   br %r14
 
 function %stack_load_small() -> i64 {
@@ -40,8 +56,17 @@ block0:
   return v0
 }
 
+; VCode:
 ;   aghi %r15, -8
 ; block0:
+;   la %r3, 0(%r15)
+;   lg %r2, 0(%r3)
+;   aghi %r15, 8
+;   br %r14
+; 
+; Disassembled:
+;   aghi %r15, -8
+; block0: ; offset 0x4
 ;   la %r3, 0(%r15)
 ;   lg %r2, 0(%r3)
 ;   aghi %r15, 8
@@ -56,11 +81,20 @@ block0:
   return v0
 }
 
+; VCode:
 ;   agfi %r15, -100008
 ; block0:
 ;   la %r3, 0(%r15)
 ;   lg %r2, 0(%r3)
 ;   agfi %r15, 100008
+;   br %r14
+; 
+; Disassembled:
+;   agfi %r15, -0x186a8
+; block0: ; offset 0x6
+;   la %r3, 0(%r15)
+;   lg %r2, 0(%r3)
+;   agfi %r15, 0x186a8
 ;   br %r14
 
 function %stack_store_small(i64) {
@@ -71,8 +105,17 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   aghi %r15, -8
 ; block0:
+;   la %r4, 0(%r15)
+;   stg %r2, 0(%r4)
+;   aghi %r15, 8
+;   br %r14
+; 
+; Disassembled:
+;   aghi %r15, -8
+; block0: ; offset 0x4
 ;   la %r4, 0(%r15)
 ;   stg %r2, 0(%r4)
 ;   aghi %r15, 8
@@ -87,10 +130,19 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ;   agfi %r15, -100008
 ; block0:
 ;   la %r4, 0(%r15)
 ;   stg %r2, 0(%r4)
 ;   agfi %r15, 100008
+;   br %r14
+; 
+; Disassembled:
+;   agfi %r15, -0x186a8
+; block0: ; offset 0x6
+;   la %r4, 0(%r15)
+;   stg %r2, 0(%r4)
+;   agfi %r15, 0x186a8
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/store-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/store-little.clif
@@ -7,7 +7,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strvg %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strvg %r2, 0(%r3)
 ;   br %r14
 
@@ -19,8 +25,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvg %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvg %r2, 0(%r1)
 ;   br %r14
 
 function %store_imm_i64(i64) {
@@ -30,8 +43,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lghi %r4, 12345
+;   strvg %r4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghi %r4, 0x3039
 ;   strvg %r4, 0(%r2)
 ;   br %r14
 
@@ -41,7 +61,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -52,8 +78,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %istore16_i64(i64, i64) {
@@ -62,7 +94,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strvh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
 ;   br %r14
 
@@ -74,8 +112,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvh %r2, 0(%r1)
 ;   br %r14
 
 function %istore16_imm_i64(i64) {
@@ -85,8 +130,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 14640
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3930
 ;   br %r14
 
 function %istore32_i64(i64, i64) {
@@ -95,7 +146,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strv %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strv %r2, 0(%r3)
 ;   br %r14
 
@@ -107,8 +164,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strv %r2, 0(%r1)
 ;   br %r14
 
 function %istore32_imm_i64(i64) {
@@ -118,8 +182,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lghi %r4, 12345
+;   strv %r4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lghi %r4, 0x3039
 ;   strv %r4, 0(%r2)
 ;   br %r14
 
@@ -129,7 +200,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strv %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strv %r2, 0(%r3)
 ;   br %r14
 
@@ -141,8 +218,15 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strv %r2, 0(%r1)
 ;   br %r14
 
 function %store_imm_i32(i64) {
@@ -152,8 +236,15 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   lhi %r4, 12345
+;   strv %r4, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r4, 0x3039
 ;   strv %r4, 0(%r2)
 ;   br %r14
 
@@ -163,7 +254,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -174,8 +271,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %istore16_i32(i32, i64) {
@@ -184,7 +287,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strvh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
 ;   br %r14
 
@@ -196,8 +305,15 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvh %r2, 0(%r1)
 ;   br %r14
 
 function %istore16_imm_i32(i64) {
@@ -207,8 +323,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 14640
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3930
 ;   br %r14
 
 function %store_i16(i16, i64) {
@@ -217,7 +339,13 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   strvh %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
 ;   br %r14
 
@@ -229,8 +357,15 @@ block0(v0: i16):
   return
 }
 
+; VCode:
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
+;   strvh %r2, 0(%r1)
 ;   br %r14
 
 function %store_imm_i16(i64) {
@@ -240,8 +375,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 14640
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3930
 ;   br %r14
 
 function %istore8_i16(i16, i64) {
@@ -250,7 +391,13 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -261,8 +408,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %store_i8(i8, i64) {
@@ -271,7 +424,13 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -281,8 +440,14 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stcy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stcy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %store_imm_i8(i64) {
@@ -292,8 +457,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %store_imm_i8_off(i64) {
@@ -303,7 +474,13 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mviy 4096(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mviy 0x1000(%r2), 0x7b
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/store.clif
+++ b/cranelift/filetests/filetests/isa/s390x/store.clif
@@ -7,7 +7,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stg %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stg %r2, 0(%r3)
 ;   br %r14
 
@@ -19,8 +25,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stgrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %store_imm_i64(i64) {
@@ -30,8 +42,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvghi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvghi 0(%r2), 0x3039
 ;   br %r14
 
 function %istore8_i64(i64, i64) {
@@ -40,7 +58,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -51,8 +75,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %istore16_i64(i64, i64) {
@@ -61,7 +91,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   sth %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
 ;   br %r14
 
@@ -73,8 +109,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   sthrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %istore16_imm_i64(i64) {
@@ -84,8 +126,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3039
 ;   br %r14
 
 function %istore32_i64(i64, i64) {
@@ -94,7 +142,13 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   st %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   st %r2, 0(%r3)
 ;   br %r14
 
@@ -106,8 +160,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   strl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %istore32_imm_i64(i64) {
@@ -117,8 +177,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhi 0(%r2), 0x3039
 ;   br %r14
 
 function %store_i32(i32, i64) {
@@ -127,7 +193,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   st %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   st %r2, 0(%r3)
 ;   br %r14
 
@@ -139,8 +211,14 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   strl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %store_i32_off(i32, i64) {
@@ -149,8 +227,14 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   sty %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sty %r2, 0x1000(%r3)
 ;   br %r14
 
 function %store_imm_i32(i64) {
@@ -160,8 +244,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhi 0(%r2), 0x3039
 ;   br %r14
 
 function %istore8_i32(i32, i64) {
@@ -170,7 +260,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -181,8 +277,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %istore16_i32(i32, i64) {
@@ -191,7 +293,13 @@ block0(v0: i32, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   sth %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
 ;   br %r14
 
@@ -203,8 +311,14 @@ block0(v0: i32):
   return
 }
 
+; VCode:
 ; block0:
 ;   sthrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %istore16_imm_i32(i64) {
@@ -214,8 +328,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3039
 ;   br %r14
 
 function %store_i16(i16, i64) {
@@ -224,7 +344,13 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   sth %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
 ;   br %r14
 
@@ -236,8 +362,14 @@ block0(v0: i16):
   return
 }
 
+; VCode:
 ; block0:
 ;   sthrl %r2, %sym + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
 ;   br %r14
 
 function %store_i16_off(i16, i64) {
@@ -246,8 +378,14 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   sthy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sthy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %store_imm_i16(i64) {
@@ -257,8 +395,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvhhi 0(%r2), 12345
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvhhi 0(%r2), 0x3039
 ;   br %r14
 
 function %istore8_i16(i16, i64) {
@@ -267,7 +411,13 @@ block0(v0: i16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -278,8 +428,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %store_i8(i8, i64) {
@@ -288,7 +444,13 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   stc %r2, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
 ;   br %r14
 
@@ -298,8 +460,14 @@ block0(v0: i8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   stcy %r2, 4096(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stcy %r2, 0x1000(%r3)
 ;   br %r14
 
 function %store_imm_i8(i64) {
@@ -309,8 +477,14 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mvi 0(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mvi 0(%r2), 0x7b
 ;   br %r14
 
 function %store_imm_i8_off(i64) {
@@ -320,7 +494,13 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   mviy 4096(%r2), 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mviy 0x1000(%r2), 0x7b
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
@@ -7,7 +7,13 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   llc %r2, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
 ;   br %r14
 
@@ -19,7 +25,15 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
+;   llc %r3, 0(%r3)
+;   llc %r4, 0(%r2)
+;   ark %r2, %r3, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
 ;   llc %r4, 0(%r2)
 ;   ark %r2, %r3, %r4
@@ -33,6 +47,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
 ;   virtual_sp_offset_adjust 224
@@ -41,6 +56,16 @@ block0(v0: i64):
 ;   la %r2, 160(%r15)
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 336(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xe0
+; block0: ; offset 0xa
+;   mvc 0xa0(0x40, %r15), 0(%r2)
+;   la %r2, 0xa0(%r15)
+;   brasl %r14, 0x14 ; reloc_external PLTRel32Dbl u0:0 2
+;   lmg %r14, %r15, 0x150(%r15)
 ;   br %r14
 
 function u0:3(i64, i64) -> i8 system_v {
@@ -51,6 +76,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
 ;   virtual_sp_offset_adjust 224
@@ -59,6 +85,16 @@ block0(v0: i64, v1: i64):
 ;   la %r3, 160(%r15)
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 336(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xe0
+; block0: ; offset 0xa
+;   mvc 0xa0(0x40, %r15), 0(%r3)
+;   la %r3, 0xa0(%r15)
+;   brasl %r14, 0x14 ; reloc_external PLTRel32Dbl u0:0 2
+;   lmg %r14, %r15, 0x150(%r15)
 ;   br %r14
 
 function u0:4(i64 sarg(256), i64 sarg(64)) -> i8 system_v {
@@ -69,7 +105,16 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ; block0:
+;   lgr %r5, %r3
+;   llc %r3, 0(%r2)
+;   llc %r4, 0(%r5)
+;   ark %r2, %r3, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lgr %r5, %r3
 ;   llc %r3, 0(%r2)
 ;   llc %r4, 0(%r5)
@@ -84,6 +129,7 @@ block0(v0: i64, v1: i64, v2: i64):
     return v3
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -480
 ;   virtual_sp_offset_adjust 480
@@ -95,6 +141,18 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 592(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0x1e0
+; block0: ; offset 0xa
+;   mvc 0xa0(0x100, %r15), 0(%r3)
+;   mvc 0x1a0(0x40, %r15), 0(%r4)
+;   la %r3, 0xa0(%r15)
+;   la %r4, 0x1a0(%r15)
+;   brasl %r14, 0x1e ; reloc_external PLTRel32Dbl u0:0 2
+;   lmg %r14, %r15, 0x250(%r15)
+;   br %r14
 
 function u0:6(i64, i64, i64) -> i8 system_v {
 fn1 = colocated u0:0(i64, i64 sarg(1024), i64 sarg(64)) -> i8 system_v
@@ -104,6 +162,7 @@ block0(v0: i64, v1: i64, v2: i64):
     return v3
 }
 
+; VCode:
 ;   stmg %r7, %r15, 56(%r15)
 ;   aghi %r15, -1248
 ;   virtual_sp_offset_adjust 1248
@@ -121,5 +180,24 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   lgr %r2, %r7
 ;   brasl %r14, userextname0
 ;   lmg %r7, %r15, 1304(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r7, %r15, 0x38(%r15)
+;   aghi %r15, -0x4e0
+; block0: ; offset 0xa
+;   lgr %r7, %r2
+;   lgr %r9, %r4
+;   la %r2, 0xa0(%r15)
+;   la %r3, 0(%r3)
+;   lghi %r4, 0x400
+;   brasl %r14, 0x1e ; reloc_external PLTRel32Dbl %Memcpy 2
+;   lgr %r4, %r9
+;   mvc 0x4a0(0x40, %r15), 0(%r4)
+;   la %r3, 0xa0(%r15)
+;   la %r4, 0x4a0(%r15)
+;   lgr %r2, %r7
+;   brasl %r14, 0x3a ; reloc_external PLTRel32Dbl u0:0 2
+;   lmg %r7, %r15, 0x518(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/symbols.clif
+++ b/cranelift/filetests/filetests/isa/s390x/symbols.clif
@@ -13,8 +13,19 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data %my_global + 0 ; lg %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %my_global 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r2, 0(%r1)
 ;   br %r14
 
 function %symbol_value_colocated() -> i64 {
@@ -25,8 +36,14 @@ block0:
   return v0
 }
 
+; VCode:
 ; block0:
 ;   larl %r2, %my_global_colo + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r2, 0 ; reloc_external PCRel32Dbl %my_global_colo 2
 ;   br %r14
 
 function %func_addr() -> i64 {
@@ -37,8 +54,19 @@ block0:
     return v0
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data %my_func + 0 ; lg %r2, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %my_func 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r2, 0(%r1)
 ;   br %r14
 
 function %func_addr_colocated() -> i64 {
@@ -49,7 +77,13 @@ block0:
     return v0
 }
 
+; VCode:
 ; block0:
 ;   larl %r2, %my_func_colo + 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   larl %r2, 0 ; reloc_external PCRel32Dbl %my_func_colo 2
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -10,6 +10,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   stmg %r12, %r15, 96(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -22,5 +23,24 @@ block0(v0: i32):
 ;   ear %r5, %a1
 ;   agr %r2, %r5
 ;   lmg %r12, %r15, 256(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r12, %r15, 0x60(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   larl %r12, 0xa ; reloc_external PCRel32Dbl %ElfGlobalOffsetTable 2
+;   bras %r1, 0x1c
+;   .byte 0x00, 0x00 ; reloc_external TlsGd64 u1:0 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r2, 0(%r1)
+;   brasl %r14, 0x22 ; reloc_external TlsGdCall u1:0 0
+;   ear %r3, %a0
+;   sllg %r5, %r3, 0x20
+;   ear %r5, %a1
+;   agr %r2, %r5
+;   lmg %r12, %r15, 0x100(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/traps.clif
@@ -10,16 +10,26 @@ block0:
   trap user0
 }
 
+; VCode:
 ; block0:
 ;   trap
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x00, 0x00 ; trap: user0
 
 function %resumable_trap() {
 block0:
   trap user0
 }
 
+; VCode:
 ; block0:
 ;   trap
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x00, 0x00 ; trap: user0
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -29,6 +39,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   clgfi %r2, 42
 ;   jge label1 ; jg label2
@@ -36,6 +47,15 @@ block0(v0: i64):
 ;   br %r14
 ; block2:
 ;   trap
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgfi %r2, 0x2a
+;   jgne 0xe
+; block1: ; offset 0xc
+;   br %r14
+; block2: ; offset 0xe
+;   .byte 0x00, 0x00 ; trap: user0
 
 function %trapnz(i64) {
 block0(v0: i64):
@@ -45,6 +65,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   clgfi %r2, 42
 ;   jge label1 ; jg label2
@@ -52,6 +73,15 @@ block0(v0: i64):
 ;   br %r14
 ; block1:
 ;   trap
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgfi %r2, 0x2a
+;   jge 0xe
+; block1: ; offset 0xc
+;   br %r14
+; block2: ; offset 0xe
+;   .byte 0x00, 0x00 ; trap: user0
 
 function %resumable_trapnz(i64) {
 block0(v0: i64):
@@ -61,6 +91,7 @@ block0(v0: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   clgfi %r2, 42
 ;   jge label1 ; jg label2
@@ -68,6 +99,15 @@ block0(v0: i64):
 ;   br %r14
 ; block1:
 ;   trap
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   clgfi %r2, 0x2a
+;   jge 0xe
+; block1: ; offset 0xc
+;   br %r14
+; block2: ; offset 0xe
+;   .byte 0x00, 0x00 ; trap: user0
 
 function %h() {
 block0:
@@ -75,7 +115,13 @@ block0:
   return
 }
 
+; VCode:
 ; block0:
 ;   debugtrap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x00, 0x01
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
@@ -8,9 +8,17 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   alfi %r2, 127
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   alfi %r2, 0x7f
+;   jle 0xc
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f1(i32) -> i32 {
@@ -20,9 +28,17 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   alfi %r2, 127
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   alfi %r2, 0x7f
+;   jle 0xc
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f2(i32, i32) -> i32 {
@@ -31,9 +47,17 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   alr %r2, %r3
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   alr %r2, %r3
+;   jle 8
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f3(i64) -> i64 {
@@ -43,9 +67,17 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   algfi %r2, 127
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   algfi %r2, 0x7f
+;   jle 0xc
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f3(i64) -> i64 {
@@ -55,9 +87,17 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   algfi %r2, 127
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   algfi %r2, 0x7f
+;   jle 0xc
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f4(i64, i64) -> i64 {
@@ -66,9 +106,17 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   algr %r2, %r3
 ;   jle 6 ; trap
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   algr %r2, %r3
+;   jle 0xa
+;   .byte 0x00, 0x00 ; trap: user0
 ;   br %r14
 
 function %f5(i64, i32) -> i64 {
@@ -78,7 +126,16 @@ block0(v0: i64, v1: i32):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   algfr %r2, %r3
 ;   jle 6 ; trap
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   algfr %r2, %r3
+;   jle 0xa
+;   .byte 0x00, 0x00 ; trap: user0
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -9,6 +9,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
     return v4
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -16,6 +17,20 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   bras %r1, 0x16
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 
 function %caller_be_to_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 {
@@ -26,6 +41,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
     return v4
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
 ;   virtual_sp_offset_adjust 160
@@ -62,6 +78,48 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xe0
+;   std %f8, 0xa0(%r15)
+;   std %f9, 0xa8(%r15)
+;   std %f10, 0xb0(%r15)
+;   std %f11, 0xb8(%r15)
+;   std %f12, 0xc0(%r15)
+;   std %f13, 0xc8(%r15)
+;   std %f14, 0xd0(%r15)
+;   std %f15, 0xd8(%r15)
+; block0: ; offset 0x2a
+;   vpdi %v24, %v24, %v24, 4
+;   vpdi %v7, %v25, %v25, 4
+;   verllg %v25, %v7, 0x20
+;   vpdi %v19, %v26, %v26, 4
+;   verllg %v21, %v19, 0x20
+;   verllf %v26, %v21, 0x10
+;   vpdi %v27, %v27, %v27, 4
+;   verllg %v27, %v27, 0x20
+;   verllf %v29, %v27, 0x10
+;   verllh %v27, %v29, 8
+;   bras %r1, 0x72
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v5, %v24, %v24, 4
+;   verllg %v24, %v5, 0x20
+;   ld %f8, 0xa0(%r15)
+;   ld %f9, 0xa8(%r15)
+;   ld %f10, 0xb0(%r15)
+;   ld %f11, 0xb8(%r15)
+;   ld %f12, 0xc0(%r15)
+;   ld %f13, 0xc8(%r15)
+;   ld %f14, 0xd0(%r15)
+;   ld %f15, 0xd8(%r15)
+;   lmg %r14, %r15, 0x150(%r15)
+;   br %r14
 
 function %caller_le_to_be(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
     fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16) -> i32x4
@@ -71,6 +129,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
     return v4
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
 ;   virtual_sp_offset_adjust 160
@@ -107,6 +166,48 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xe0
+;   std %f8, 0xa0(%r15)
+;   std %f9, 0xa8(%r15)
+;   std %f10, 0xb0(%r15)
+;   std %f11, 0xb8(%r15)
+;   std %f12, 0xc0(%r15)
+;   std %f13, 0xc8(%r15)
+;   std %f14, 0xd0(%r15)
+;   std %f15, 0xd8(%r15)
+; block0: ; offset 0x2a
+;   vpdi %v24, %v24, %v24, 4
+;   vpdi %v7, %v25, %v25, 4
+;   verllg %v25, %v7, 0x20
+;   vpdi %v19, %v26, %v26, 4
+;   verllg %v21, %v19, 0x20
+;   verllf %v26, %v21, 0x10
+;   vpdi %v27, %v27, %v27, 4
+;   verllg %v27, %v27, 0x20
+;   verllf %v29, %v27, 0x10
+;   verllh %v27, %v29, 8
+;   bras %r1, 0x72
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v5, %v24, %v24, 4
+;   verllg %v24, %v5, 0x20
+;   ld %f8, 0xa0(%r15)
+;   ld %f9, 0xa8(%r15)
+;   ld %f10, 0xb0(%r15)
+;   ld %f11, 0xb8(%r15)
+;   ld %f12, 0xc0(%r15)
+;   ld %f13, 0xc8(%r15)
+;   ld %f14, 0xd0(%r15)
+;   ld %f15, 0xd8(%r15)
+;   lmg %r14, %r15, 0x150(%r15)
+;   br %r14
 
 function %caller_le_to_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
     fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
@@ -116,6 +217,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
     return v4
 }
 
+; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -123,5 +225,19 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+; 
+; Disassembled:
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block0: ; offset 0xa
+;   bras %r1, 0x16
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vag %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vag %v24, %v24, %v25
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vaf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vaf %v24, %v24, %v25
 ;   br %r14
 
@@ -27,7 +39,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vah %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vah %v24, %v24, %v25
 ;   br %r14
 
@@ -37,7 +55,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vab %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vab %v24, %v24, %v25
 ;   br %r14
 
@@ -47,7 +71,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsg %v24, %v24, %v25
 ;   br %r14
 
@@ -57,7 +87,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsf %v24, %v24, %v25
 ;   br %r14
 
@@ -67,7 +103,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsh %v24, %v24, %v25
 ;   br %r14
 
@@ -77,7 +119,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsb %v24, %v24, %v25
 ;   br %r14
 
@@ -87,7 +135,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlpg %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlpg %v24, %v24
 ;   br %r14
 
@@ -97,7 +151,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlpf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlpf %v24, %v24
 ;   br %r14
 
@@ -107,7 +167,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlph %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlph %v24, %v24
 ;   br %r14
 
@@ -117,7 +183,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlpb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlpb %v24, %v24
 ;   br %r14
 
@@ -127,7 +199,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlcg %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlcg %v24, %v24
 ;   br %r14
 
@@ -137,7 +215,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlcf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlcf %v24, %v24
 ;   br %r14
 
@@ -147,7 +231,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlch %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlch %v24, %v24
 ;   br %r14
 
@@ -157,7 +247,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vlcb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlcb %v24, %v24
 ;   br %r14
 
@@ -167,7 +263,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxlg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxlg %v24, %v24, %v25
 ;   br %r14
 
@@ -177,7 +279,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxlf %v24, %v24, %v25
 ;   br %r14
 
@@ -187,7 +295,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxlh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxlh %v24, %v24, %v25
 ;   br %r14
 
@@ -197,7 +311,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxlb %v24, %v24, %v25
 ;   br %r14
 
@@ -207,7 +327,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnlg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnlg %v24, %v24, %v25
 ;   br %r14
 
@@ -217,7 +343,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnlf %v24, %v24, %v25
 ;   br %r14
 
@@ -227,7 +359,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnlh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnlh %v24, %v24, %v25
 ;   br %r14
 
@@ -237,7 +375,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnlb %v24, %v24, %v25
 ;   br %r14
 
@@ -247,7 +391,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxg %v24, %v24, %v25
 ;   br %r14
 
@@ -257,7 +407,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxf %v24, %v24, %v25
 ;   br %r14
 
@@ -267,7 +423,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxh %v24, %v24, %v25
 ;   br %r14
 
@@ -277,7 +439,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmxb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmxb %v24, %v24, %v25
 ;   br %r14
 
@@ -287,7 +455,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmng %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmng %v24, %v24, %v25
 ;   br %r14
 
@@ -297,7 +471,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnf %v24, %v24, %v25
 ;   br %r14
 
@@ -307,7 +487,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnh %v24, %v24, %v25
 ;   br %r14
 
@@ -317,7 +503,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmnb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmnb %v24, %v24, %v25
 ;   br %r14
 
@@ -327,7 +519,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vavglg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vavglg %v24, %v24, %v25
 ;   br %r14
 
@@ -337,7 +535,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vavglf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vavglf %v24, %v24, %v25
 ;   br %r14
 
@@ -347,7 +551,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vavglh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vavglh %v24, %v24, %v25
 ;   br %r14
 
@@ -357,7 +567,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vavglb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vavglb %v24, %v24, %v25
 ;   br %r14
 
@@ -367,7 +583,15 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vag %v3, %v24, %v25
+;   vchlg %v5, %v24, %v3
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vag %v3, %v24, %v25
 ;   vchlg %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
@@ -379,7 +603,15 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vaf %v3, %v24, %v25
+;   vchlf %v5, %v24, %v3
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vaf %v3, %v24, %v25
 ;   vchlf %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
@@ -391,7 +623,15 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vah %v3, %v24, %v25
+;   vchlh %v5, %v24, %v3
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vah %v3, %v24, %v25
 ;   vchlh %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
@@ -403,7 +643,15 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vab %v3, %v24, %v25
+;   vchlb %v5, %v24, %v3
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vab %v3, %v24, %v25
 ;   vchlb %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
@@ -415,7 +663,19 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vuphf %v3, %v24
+;   vuphf %v5, %v25
+;   vag %v7, %v3, %v5
+;   vuplf %v17, %v24
+;   vuplf %v19, %v25
+;   vag %v21, %v17, %v19
+;   vpksg %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphf %v3, %v24
 ;   vuphf %v5, %v25
 ;   vag %v7, %v3, %v5
@@ -431,12 +691,24 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vuphh %v3, %v24
 ;   vuphh %v5, %v25
 ;   vaf %v7, %v3, %v5
 ;   vuplh %v17, %v24
 ;   vuplh %v19, %v25
+;   vaf %v21, %v17, %v19
+;   vpksf %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuphh %v3, %v24
+;   vuphh %v5, %v25
+;   vaf %v7, %v3, %v5
+;   vuplhw %v17, %v24
+;   vuplhw %v19, %v25
 ;   vaf %v21, %v17, %v19
 ;   vpksf %v24, %v7, %v21
 ;   br %r14
@@ -447,7 +719,19 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vuphb %v3, %v24
+;   vuphb %v5, %v25
+;   vah %v7, %v3, %v5
+;   vuplb %v17, %v24
+;   vuplb %v19, %v25
+;   vah %v21, %v17, %v19
+;   vpksh %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphb %v3, %v24
 ;   vuphb %v5, %v25
 ;   vah %v7, %v3, %v5
@@ -463,7 +747,15 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsg %v3, %v24, %v25
+;   vchlg %v5, %v24, %v25
+;   vn %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsg %v3, %v24, %v25
 ;   vchlg %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
@@ -475,7 +767,15 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsf %v3, %v24, %v25
+;   vchlf %v5, %v24, %v25
+;   vn %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsf %v3, %v24, %v25
 ;   vchlf %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
@@ -487,7 +787,15 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsh %v3, %v24, %v25
+;   vchlh %v5, %v24, %v25
+;   vn %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsh %v3, %v24, %v25
 ;   vchlh %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
@@ -499,7 +807,15 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vsb %v3, %v24, %v25
+;   vchlb %v5, %v24, %v25
+;   vn %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsb %v3, %v24, %v25
 ;   vchlb %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
@@ -511,7 +827,19 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vuphf %v3, %v24
+;   vuphf %v5, %v25
+;   vsg %v7, %v3, %v5
+;   vuplf %v17, %v24
+;   vuplf %v19, %v25
+;   vsg %v21, %v17, %v19
+;   vpksg %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphf %v3, %v24
 ;   vuphf %v5, %v25
 ;   vsg %v7, %v3, %v5
@@ -527,12 +855,24 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vuphh %v3, %v24
 ;   vuphh %v5, %v25
 ;   vsf %v7, %v3, %v5
 ;   vuplh %v17, %v24
 ;   vuplh %v19, %v25
+;   vsf %v21, %v17, %v19
+;   vpksf %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuphh %v3, %v24
+;   vuphh %v5, %v25
+;   vsf %v7, %v3, %v5
+;   vuplhw %v17, %v24
+;   vuplhw %v19, %v25
 ;   vsf %v21, %v17, %v19
 ;   vpksf %v24, %v7, %v21
 ;   br %r14
@@ -543,7 +883,19 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vuphb %v3, %v24
+;   vuphb %v5, %v25
+;   vsh %v7, %v3, %v5
+;   vuplb %v17, %v24
+;   vuplb %v19, %v25
+;   vsh %v21, %v17, %v19
+;   vpksh %v24, %v7, %v21
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphb %v3, %v24
 ;   vuphb %v5, %v25
 ;   vsh %v7, %v3, %v5
@@ -559,8 +911,19 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v3, 32
+;   vsrlb %v5, %v24, %v3
+;   vaf %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vaf %v19, %v25, %v17
+;   vpkg %v24, %v7, %v19
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v3, 0x20
 ;   vsrlb %v5, %v24, %v3
 ;   vaf %v7, %v24, %v5
 ;   vsrlb %v17, %v25, %v3
@@ -574,8 +937,19 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v3, 16
+;   vsrlb %v5, %v24, %v3
+;   vah %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vah %v19, %v25, %v17
+;   vpkf %v24, %v7, %v19
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v3, 0x10
 ;   vsrlb %v5, %v24, %v3
 ;   vah %v7, %v24, %v5
 ;   vsrlb %v17, %v25, %v3
@@ -589,7 +963,18 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vrepib %v3, 8
+;   vsrlb %v5, %v24, %v3
+;   vab %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vab %v19, %v25, %v17
+;   vpkh %v24, %v7, %v19
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepib %v3, 8
 ;   vsrlb %v5, %v24, %v3
 ;   vab %v7, %v24, %v5
@@ -604,8 +989,19 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v3, 32
+;   vsrlb %v5, %v24, %v3
+;   vaf %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vaf %v19, %v25, %v17
+;   vpkg %v24, %v19, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v3, 0x20
 ;   vsrlb %v5, %v24, %v3
 ;   vaf %v7, %v24, %v5
 ;   vsrlb %v17, %v25, %v3
@@ -619,8 +1015,19 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v3, 16
+;   vsrlb %v5, %v24, %v3
+;   vah %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vah %v19, %v25, %v17
+;   vpkf %v24, %v19, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v3, 0x10
 ;   vsrlb %v5, %v24, %v3
 ;   vah %v7, %v24, %v5
 ;   vsrlb %v17, %v25, %v3
@@ -634,7 +1041,18 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vrepib %v3, 8
+;   vsrlb %v5, %v24, %v3
+;   vab %v7, %v24, %v5
+;   vsrlb %v17, %v25, %v3
+;   vab %v19, %v25, %v17
+;   vpkh %v24, %v19, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepib %v3, 8
 ;   vsrlb %v5, %v24, %v3
 ;   vab %v7, %v24, %v5
@@ -649,7 +1067,19 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   vlgvg %r3, %v25, 0
+;   msgr %r5, %r3
+;   vlgvg %r3, %v24, 1
+;   vlgvg %r2, %v25, 1
+;   msgr %r3, %r2
+;   vlvgp %v24, %r5, %r3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   vlgvg %r3, %v25, 0
 ;   msgr %r5, %r3
@@ -665,7 +1095,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlf %v24, %v24, %v25
 ;   br %r14
 
@@ -675,7 +1111,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlhw %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlhw %v24, %v24, %v25
 ;   br %r14
 
@@ -685,7 +1127,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlb %v24, %v24, %v25
 ;   br %r14
 
@@ -695,7 +1143,20 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r3, %v24, 0
+;   vlgvg %r4, %v25, 0
+;   mlgr %r2, %r4
+;   lgr %r5, %r2
+;   vlgvg %r3, %v24, 1
+;   vlgvg %r4, %v25, 1
+;   mlgr %r2, %r4
+;   vlvgp %v24, %r5, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r3, %v24, 0
 ;   vlgvg %r4, %v25, 0
 ;   mlgr %r2, %r4
@@ -712,7 +1173,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlhf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlhf %v24, %v24, %v25
 ;   br %r14
 
@@ -722,7 +1189,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlhh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlhh %v24, %v24, %v25
 ;   br %r14
 
@@ -732,7 +1205,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmlhb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmlhb %v24, %v24, %v25
 ;   br %r14
 
@@ -742,7 +1221,20 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   vlgvg %r3, %v25, 0
+;   mgrk %r2, %r5, %r3
+;   lgr %r5, %r2
+;   vlgvg %r2, %v24, 1
+;   vlgvg %r4, %v25, 1
+;   mgrk %r2, %r2, %r4
+;   vlvgp %v24, %r5, %r2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   vlgvg %r3, %v25, 0
 ;   mgrk %r2, %r5, %r3
@@ -759,7 +1251,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmhf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmhf %v24, %v24, %v25
 ;   br %r14
 
@@ -769,7 +1267,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmhh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmhh %v24, %v24, %v25
 ;   br %r14
 
@@ -779,7 +1283,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmhb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmhb %v24, %v24, %v25
 ;   br %r14
 
@@ -789,7 +1299,15 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vmeh %v3, %v24, %v25
+;   vmoh %v5, %v24, %v25
+;   vaf %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmeh %v3, %v24, %v25
 ;   vmoh %v5, %v24, %v25
 ;   vaf %v24, %v3, %v5
@@ -801,6 +1319,7 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vuphh %v3, %v24
 ;   vuphh %v5, %v25
@@ -816,6 +1335,23 @@ block0(v0: i16x8, v1: i16x8):
 ;   vesraf %v1, %v31, 15
 ;   vpksf %v24, %v21, %v1
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuphh %v3, %v24
+;   vuphh %v5, %v25
+;   vmlf %v7, %v3, %v5
+;   vgmf %v17, 0x11, 0x11
+;   vaf %v19, %v7, %v17
+;   vesraf %v21, %v19, 0xf
+;   vuplhw %v23, %v24
+;   vuplhw %v25, %v25
+;   vmlf %v27, %v23, %v25
+;   vgmf %v29, 0x11, 0x11
+;   vaf %v31, %v27, %v29
+;   vesraf %v1, %v31, 0xf
+;   vpksf %v24, %v21, %v1
+;   br %r14
 
 function %sqmul_round_sat(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):
@@ -823,6 +1359,7 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vuphf %v3, %v24
 ;   vuphf %v5, %v25
@@ -848,6 +1385,35 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgmg %v29, 33, 33
 ;   vag %v31, %v27, %v29
 ;   vesrag %v2, %v31, 31
+;   vpksg %v24, %v1, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuphf %v3, %v24
+;   vuphf %v5, %v25
+;   lgdr %r5, %f3
+;   lgdr %r3, %f5
+;   msgr %r5, %r3
+;   vlgvg %r3, %v3, 1
+;   vlgvg %r2, %v5, 1
+;   msgr %r3, %r2
+;   vlvgp %v27, %r5, %r3
+;   vgmg %v29, 0x21, 0x21
+;   vag %v31, %v27, %v29
+;   vesrag %v1, %v31, 0x1f
+;   vuplf %v3, %v24
+;   vuplf %v5, %v25
+;   lgdr %r5, %f3
+;   lgdr %r3, %f5
+;   msgr %r5, %r3
+;   vlgvg %r3, %v3, 1
+;   vlgvg %r2, %v5, 1
+;   msgr %r3, %r2
+;   vlvgp %v27, %r5, %r3
+;   vgmg %v29, 0x21, 0x21
+;   vag %v31, %v27, %v29
+;   vesrag %v2, %v31, 0x1f
 ;   vpksg %v24, %v1, %v2
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
@@ -11,7 +11,12 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64x2_i32x4(i64x2) -> i32x4 {
@@ -20,10 +25,18 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v2, %v24, %v24, 4
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v2, %v24, %v24, 4
+;   vpdi %v4, %v2, %v2, 4
+;   verllg %v24, %v4, 0x20
 ;   br %r14
 
 function %bitcast_i64x2_i32x4(i64x2) -> i32x4 wasmtime_system_v {
@@ -32,10 +45,18 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v2, %v24, %v24, 4
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v2, %v24, %v24, 4
+;   vpdi %v4, %v2, %v2, 4
+;   verllg %v24, %v4, 0x20
 ;   br %r14
 
 function %bitcast_i64x2_i32x4(i64x2) -> i32x4 wasmtime_system_v {
@@ -44,7 +65,12 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64x2_f64x2(i64x2) -> f64x2 {
@@ -53,7 +79,12 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64x2_f64x2(i64x2) -> f64x2 {
@@ -62,7 +93,12 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 
 function %bitcast_i64x2_f64x2(i64x2) -> f64x2 wasmtime_system_v {
@@ -71,6 +107,11 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitops.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vpopctg %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpopctg %v24, %v24
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vpopctf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpopctf %v24, %v24
 ;   br %r14
 
@@ -27,7 +39,13 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vpopcth %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpopcth %v24, %v24
 ;   br %r14
 
@@ -37,7 +55,13 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vpopctb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpopctb %v24, %v24
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitwise.clif
@@ -8,7 +8,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vn %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
 ;   br %r14
 
@@ -18,7 +24,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vn %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
 ;   br %r14
 
@@ -28,7 +40,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vn %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
 ;   br %r14
 
@@ -38,7 +56,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vn %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
 ;   br %r14
 
@@ -48,7 +72,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vo %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
 ;   br %r14
 
@@ -58,7 +88,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vo %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
 ;   br %r14
 
@@ -68,7 +104,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vo %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
 ;   br %r14
 
@@ -78,7 +120,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vo %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
 ;   br %r14
 
@@ -88,7 +136,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
 ;   br %r14
 
@@ -98,7 +152,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
 ;   br %r14
 
@@ -108,7 +168,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
 ;   br %r14
 
@@ -118,7 +184,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
 ;   br %r14
 
@@ -128,7 +200,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
 ;   br %r14
 
@@ -138,7 +216,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
 ;   br %r14
 
@@ -148,7 +232,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
 ;   br %r14
 
@@ -158,7 +248,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
 ;   br %r14
 
@@ -168,7 +264,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   voc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
 ;   br %r14
 
@@ -178,7 +280,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   voc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
 ;   br %r14
 
@@ -188,7 +296,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   voc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
 ;   br %r14
 
@@ -198,7 +312,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   voc %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
 ;   br %r14
 
@@ -208,7 +328,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
 ;   br %r14
 
@@ -218,7 +344,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
 ;   br %r14
 
@@ -228,7 +360,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
 ;   br %r14
 
@@ -238,7 +376,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vnx %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
 ;   br %r14
 
@@ -248,7 +392,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vno %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
 ;   br %r14
 
@@ -258,7 +408,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vno %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
 ;   br %r14
 
@@ -268,7 +424,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vno %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
 ;   br %r14
 
@@ -278,7 +440,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vno %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
 ;   br %r14
 
@@ -288,7 +456,13 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -298,7 +472,13 @@ block0(v0: i32x4, v1: i32x4, v2: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -308,7 +488,13 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -318,7 +504,13 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -328,7 +520,13 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -338,7 +536,13 @@ block0(v0: i32x4, v1: i32x4, v2: i32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -348,7 +552,13 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 
@@ -358,7 +568,13 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vsel %v24, %v25, %v26, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
@@ -7,8 +7,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i64x2_splat1() -> i64x2 wasmtime_system_v {
@@ -17,8 +23,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i64x2_splat2() -> i64x2 wasmtime_system_v {
@@ -27,8 +39,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, -0x8000
 ;   br %r14
 
 function %vconst_i64x2_splat3() -> i64x2 wasmtime_system_v {
@@ -37,8 +55,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ssm 0x780(%r14)
+;   lpr %r0, %r0
+;   ler %f0, %f5
 ;   br %r14
 
 function %vconst_i64x2_splat4() -> i64x2 wasmtime_system_v {
@@ -47,8 +77,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   su %f15, 0x780(%r15, %r14)
+;   lpr %r0, %r0
+;   ler %f0, %f5
 ;   br %r14
 
 function %vconst_i64x2_mixed() -> i64x2 wasmtime_system_v {
@@ -57,8 +99,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000000000000020000000000000001 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i32x4_zero() -> i32x4 wasmtime_system_v {
@@ -67,8 +124,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i32x4_splat1() -> i32x4 wasmtime_system_v {
@@ -77,8 +140,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i32x4_splat2() -> i32x4 wasmtime_system_v {
@@ -87,8 +156,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, -0x8000
 ;   br %r14
 
 function %vconst_i32x4_splat3() -> i32x4 wasmtime_system_v {
@@ -97,8 +172,18 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   .byte 0x00, 0x00
+;   ssm 0x780(%r14)
+;   lpr %r0, %r0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %vconst_i32x4_splat4() -> i32x4 wasmtime_system_v {
@@ -107,8 +192,18 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   .byte 0xff, 0xff
+;   su %f15, 0x780(%r15, %r14)
+;   lpr %r0, %r0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %vconst_i32x4_splat_i64() -> i32x4 wasmtime_system_v {
@@ -117,8 +212,19 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000200000001 ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i32x4_mixed() -> i32x4 wasmtime_system_v {
@@ -127,8 +233,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000004000000030000000200000001 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x04
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x03
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i16x8_zero() -> i16x8 wasmtime_system_v {
@@ -137,8 +258,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i16x8_splat1() -> i16x8 wasmtime_system_v {
@@ -147,8 +274,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i16x8_splat2() -> i16x8 wasmtime_system_v {
@@ -157,8 +290,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, -0x8000
 ;   br %r14
 
 function %vconst_i16x8_mixed() -> i16x8 wasmtime_system_v {
@@ -167,8 +306,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00080007000600050004000300020001 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x08
+;   .byte 0x00, 0x07
+;   .byte 0x00, 0x06
+;   .byte 0x00, 0x05
+;   .byte 0x00, 0x04
+;   .byte 0x00, 0x03
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x01
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i8x16_zero() -> i8x16 wasmtime_system_v {
@@ -177,8 +331,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i8x16_splat1() -> i8x16 wasmtime_system_v {
@@ -187,8 +347,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 127
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x7f
 ;   br %r14
 
 function %vconst_i8x16_splat2() -> i8x16 wasmtime_system_v {
@@ -197,8 +363,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 128
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x80
 ;   br %r14
 
 function %vconst_i8x16_mixed() -> i8x16 wasmtime_system_v {
@@ -207,7 +379,22 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x100f0e0d0c0b0a090807060504030201 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   lpr %r0, %r15
+;   .byte 0x0e, 0x0d
+;   bassm %r0, %r11
+;   svc 9
+;   .byte 0x08, 0x07
+;   bctr %r0, %r5
+;   .byte 0x04, 0x03
+;   .byte 0x02, 0x01
+;   vl %v24, 0(%r1)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
@@ -7,8 +7,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i64x2_splat1() -> i64x2 {
@@ -17,8 +23,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i64x2_splat2() -> i64x2 {
@@ -27,8 +39,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, -0x8000
 ;   br %r14
 
 function %vconst_i64x2_splat3() -> i64x2 {
@@ -37,8 +55,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   ssm 0x780(%r14)
+;   lpr %r0, %r0
+;   ler %f0, %f5
 ;   br %r14
 
 function %vconst_i64x2_splat4() -> i64x2 {
@@ -47,8 +77,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   .byte 0xff, 0xff
+;   su %f15, 0x780(%r15, %r14)
+;   lpr %r0, %r0
+;   ler %f0, %f5
 ;   br %r14
 
 function %vconst_i64x2_mixed() -> i64x2 {
@@ -57,8 +99,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000000000000010000000000000002 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i32x4_zero() -> i32x4 {
@@ -67,8 +124,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i32x4_splat1() -> i32x4 {
@@ -77,8 +140,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i32x4_splat2() -> i32x4 {
@@ -87,8 +156,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, -0x8000
 ;   br %r14
 
 function %vconst_i32x4_splat3() -> i32x4 {
@@ -97,8 +172,18 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   .byte 0x00, 0x00
+;   ssm 0x780(%r14)
+;   lpr %r0, %r0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %vconst_i32x4_splat4() -> i32x4 {
@@ -107,8 +192,18 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 8
+;   .byte 0xff, 0xff
+;   su %f15, 0x780(%r15, %r14)
+;   lpr %r0, %r0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %vconst_i32x4_splat_i64() -> i32x4 {
@@ -117,8 +212,19 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000100000002 ; vlrepg %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0xc
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   vlrepg %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i32x4_mixed() -> i32x4 {
@@ -127,8 +233,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000001000000020000000300000004 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x03
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x04
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i16x8_zero() -> i16x8 {
@@ -137,8 +258,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i16x8_splat1() -> i16x8 {
@@ -147,8 +274,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, 32767
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, 0x7fff
 ;   br %r14
 
 function %vconst_i16x8_splat2() -> i16x8 {
@@ -157,8 +290,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, -32768
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, -0x8000
 ;   br %r14
 
 function %vconst_i16x8_mixed() -> i16x8 {
@@ -167,8 +306,23 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00010002000300040005000600070008 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x01
+;   .byte 0x00, 0x02
+;   .byte 0x00, 0x03
+;   .byte 0x00, 0x04
+;   .byte 0x00, 0x05
+;   .byte 0x00, 0x06
+;   .byte 0x00, 0x07
+;   .byte 0x00, 0x08
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_i8x16_zero() -> i8x16 {
@@ -177,8 +331,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_i8x16_splat1() -> i8x16 {
@@ -187,8 +347,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 127
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x7f
 ;   br %r14
 
 function %vconst_i8x16_splat2() -> i8x16 {
@@ -197,8 +363,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 128
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x80
 ;   br %r14
 
 function %vconst_i8x16_mixed() -> i8x16 {
@@ -207,7 +379,22 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x0102030405060708090a0b0c0d0e0f10 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   upt
+;   .byte 0x03, 0x04
+;   balr %r0, %r6
+;   bcr 0, %r8
+;   .byte 0x09, 0x0a
+;   bsm %r0, %r12
+;   basr %r0, %r14
+;   .byte 0x0f, 0x10
+;   vl %v24, 0(%r1)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksg %v24, %v25, %v24
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksf %v24, %v25, %v24
 ;   br %r14
 
@@ -27,7 +39,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksh %v24, %v25, %v24
 ;   br %r14
 
@@ -37,8 +55,17 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxg %v5, %v24, %v3
+;   vmxg %v7, %v25, %v3
+;   vpklsg %v24, %v7, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxg %v5, %v24, %v3
 ;   vmxg %v7, %v25, %v3
 ;   vpklsg %v24, %v7, %v5
@@ -50,8 +77,17 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxf %v5, %v24, %v3
+;   vmxf %v7, %v25, %v3
+;   vpklsf %v24, %v7, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxf %v5, %v24, %v3
 ;   vmxf %v7, %v25, %v3
 ;   vpklsf %v24, %v7, %v5
@@ -63,8 +99,17 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxh %v5, %v24, %v3
+;   vmxh %v7, %v25, %v3
+;   vpklsh %v24, %v7, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxh %v5, %v24, %v3
 ;   vmxh %v7, %v25, %v3
 ;   vpklsh %v24, %v7, %v5
@@ -76,7 +121,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsg %v24, %v25, %v24
 ;   br %r14
 
@@ -86,7 +137,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsf %v24, %v25, %v24
 ;   br %r14
 
@@ -96,7 +153,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsh %v24, %v25, %v24
 ;   br %r14
 
@@ -106,7 +169,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplf %v24, %v24
 ;   br %r14
 
@@ -116,8 +185,14 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vuplh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuplhw %v24, %v24
 ;   br %r14
 
 function %swiden_low_i8x16_i16x8(i8x16) -> i16x8 wasmtime_system_v {
@@ -126,7 +201,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplb %v24, %v24
 ;   br %r14
 
@@ -136,7 +217,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphf %v24, %v24
 ;   br %r14
 
@@ -146,7 +233,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphh %v24, %v24
 ;   br %r14
 
@@ -156,7 +249,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphb %v24, %v24
 ;   br %r14
 
@@ -166,7 +265,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllf %v24, %v24
 ;   br %r14
 
@@ -176,7 +281,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllh %v24, %v24
 ;   br %r14
 
@@ -186,7 +297,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllb %v24, %v24
 ;   br %r14
 
@@ -196,7 +313,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhf %v24, %v24
 ;   br %r14
 
@@ -206,7 +329,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhh %v24, %v24
 ;   br %r14
 
@@ -216,7 +345,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhb %v24, %v24
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksg %v24, %v24, %v25
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksf %v24, %v24, %v25
 ;   br %r14
 
@@ -27,7 +39,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpksh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpksh %v24, %v24, %v25
 ;   br %r14
 
@@ -37,8 +55,17 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxg %v5, %v24, %v3
+;   vmxg %v7, %v25, %v3
+;   vpklsg %v24, %v5, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxg %v5, %v24, %v3
 ;   vmxg %v7, %v25, %v3
 ;   vpklsg %v24, %v5, %v7
@@ -50,8 +77,17 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxf %v5, %v24, %v3
+;   vmxf %v7, %v25, %v3
+;   vpklsf %v24, %v5, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxf %v5, %v24, %v3
 ;   vmxf %v7, %v25, %v3
 ;   vpklsf %v24, %v5, %v7
@@ -63,8 +99,17 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vmxh %v5, %v24, %v3
+;   vmxh %v7, %v25, %v3
+;   vpklsh %v24, %v5, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vmxh %v5, %v24, %v3
 ;   vmxh %v7, %v25, %v3
 ;   vpklsh %v24, %v5, %v7
@@ -76,7 +121,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsg %v24, %v24, %v25
 ;   br %r14
 
@@ -86,7 +137,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsf %v24, %v24, %v25
 ;   br %r14
 
@@ -96,7 +153,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vpklsh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpklsh %v24, %v24, %v25
 ;   br %r14
 
@@ -106,7 +169,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphf %v24, %v24
 ;   br %r14
 
@@ -116,7 +185,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphh %v24, %v24
 ;   br %r14
 
@@ -126,7 +201,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphb %v24, %v24
 ;   br %r14
 
@@ -136,7 +217,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplf %v24, %v24
 ;   br %r14
 
@@ -146,8 +233,14 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vuplh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuplhw %v24, %v24
 ;   br %r14
 
 function %swiden_high_i8x16_i16x8(i8x16) -> i16x8 {
@@ -156,7 +249,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplb %v24, %v24
 ;   br %r14
 
@@ -166,7 +265,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhf %v24, %v24
 ;   br %r14
 
@@ -176,7 +281,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhh %v24, %v24
 ;   br %r14
 
@@ -186,7 +297,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplhb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplhb %v24, %v24
 ;   br %r14
 
@@ -196,7 +313,13 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllf %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllf %v24, %v24
 ;   br %r14
 
@@ -206,7 +329,13 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllh %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllh %v24, %v24
 ;   br %r14
 
@@ -216,7 +345,13 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vupllb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vupllb %v24, %v24
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
@@ -7,7 +7,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfcedb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedb %v24, %v24, %v25
 ;   br %r14
 
@@ -17,7 +23,14 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfcedb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -28,7 +41,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v24, %v24, %v25
 ;   br %r14
 
@@ -38,7 +57,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v24, %v25, %v24
 ;   br %r14
 
@@ -48,7 +73,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v24, %v24, %v25
 ;   br %r14
 
@@ -58,7 +89,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v24, %v25, %v24
 ;   br %r14
 
@@ -68,7 +105,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v3, %v24, %v25
+;   vfchdb %v5, %v25, %v24
+;   vno %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
 ;   vfchdb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
@@ -80,7 +125,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v3, %v24, %v25
+;   vfchdb %v5, %v25, %v24
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
 ;   vfchdb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
@@ -92,7 +145,14 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -103,7 +163,14 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -114,7 +181,14 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -125,7 +199,14 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchdb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -136,7 +217,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v3, %v24, %v25
+;   vfchedb %v5, %v25, %v24
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
 ;   vfchedb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
@@ -148,7 +237,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchedb %v3, %v24, %v25
+;   vfchedb %v5, %v25, %v24
+;   vno %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
 ;   vfchedb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
@@ -160,7 +257,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfcesb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcesb %v24, %v24, %v25
 ;   br %r14
 
@@ -170,7 +273,14 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfcesb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcesb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -181,7 +291,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v24, %v24, %v25
 ;   br %r14
 
@@ -191,7 +307,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v24, %v25, %v24
 ;   br %r14
 
@@ -201,7 +323,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v24, %v24, %v25
 ;   br %r14
 
@@ -211,7 +339,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v24, %v25, %v24
 ;   br %r14
 
@@ -221,7 +355,15 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v3, %v24, %v25
+;   vfchsb %v5, %v25, %v24
+;   vno %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
 ;   vfchsb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
@@ -233,7 +375,15 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v3, %v24, %v25
+;   vfchsb %v5, %v25, %v24
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
 ;   vfchsb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
@@ -245,7 +395,14 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -256,7 +413,14 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -267,7 +431,14 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -278,7 +449,14 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchsb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -289,7 +467,15 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v3, %v24, %v25
+;   vfchesb %v5, %v25, %v24
+;   vo %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25
 ;   vfchesb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
@@ -301,7 +487,15 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfchesb %v3, %v24, %v25
+;   vfchesb %v5, %v25, %v24
+;   vno %v24, %v3, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25
 ;   vfchesb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp-arch13.clif
@@ -7,8 +7,14 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcelfb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcdlg %v24, %v24, 2, 0, 4
 ;   br %r14
 
 function %fcvt_from_sint_i32x4_f32x4(i32x4) -> f32x4 {
@@ -17,8 +23,14 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcefb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcdg %v24, %v24, 2, 0, 4
 ;   br %r14
 
 function %fcvt_from_uint_i64x2_f64x2(i64x2) -> f64x2 {
@@ -27,7 +39,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vcdlgb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vcdlgb %v24, %v24, 0, 4
 ;   br %r14
 
@@ -37,10 +55,15 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcdgb %v24, %v24, 0, 4
 ;   br %r14
-
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcdgb %v24, %v24, 0, 4
+;   br %r14
 
 function %fcvt_to_uint_sat_f32x4_i32x4(f32x4) -> i32x4 {
 block0(v0: f32x4):
@@ -48,8 +71,14 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vclfeb %v24, %v24, 0, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vclgd %v24, %v24, 2, 0, 5
 ;   br %r14
 
 function %fcvt_to_sint_sat_f32x4_i32x4(f32x4) -> i32x4 {
@@ -58,9 +87,18 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcfeb %v2, %v24, 0, 5
 ;   vgbm %v4, 0
+;   vfcesb %v6, %v24, %v24
+;   vsel %v24, %v2, %v4, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgd %v2, %v24, 2, 0, 5
+;   vzero %v4
 ;   vfcesb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14
@@ -71,7 +109,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vclgdb %v24, %v24, 0, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vclgdb %v24, %v24, 0, 5
 ;   br %r14
 
@@ -81,9 +125,18 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcgdb %v2, %v24, 0, 5
 ;   vgbm %v4, 0
+;   vfcedb %v6, %v24, %v24
+;   vsel %v24, %v2, %v4, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgdb %v2, %v24, 0, 5
+;   vzero %v4
 ;   vfcedb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
@@ -7,8 +7,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_f64x2_zero() -> f64x2 {
@@ -17,8 +23,14 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   br %r14
 
 function %vconst_f32x4_mixed_be() -> f32x4 {
@@ -27,8 +39,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x3f800000400000004040000040800000 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   sur %f8, %f0
+;   .byte 0x00, 0x00
+;   sth %r0, 0
+;   sth %r4, 0
+;   sth %r8, 0
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_f32x4_mixed_le() -> f32x4 wasmtime_system_v {
@@ -37,8 +61,20 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x4080000040400000400000003f800000 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   sth %r8, 0
+;   sth %r4, 0
+;   sth %r0, 0
+;   sur %f8, %f0
+;   .byte 0x00, 0x00
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_f64x2_mixed_be() -> f64x2 {
@@ -47,8 +83,22 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x3ff00000000000004000000000000000 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sth %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %vconst_f64x2_mixed_le() -> f64x2 wasmtime_system_v {
@@ -57,8 +107,22 @@ block0:
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x40000000000000003ff0000000000000 ; vl %v24, 0(%r1)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   sth %r0, 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   sur %f15, %f0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   vl %v24, 0(%r1)
 ;   br %r14
 
 function %fadd_f32x4(f32x4, f32x4) -> f32x4 {
@@ -67,7 +131,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfasb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfasb %v24, %v24, %v25
 ;   br %r14
 
@@ -77,7 +147,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfadb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfadb %v24, %v24, %v25
 ;   br %r14
 
@@ -87,7 +163,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfssb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfssb %v24, %v24, %v25
 ;   br %r14
 
@@ -97,7 +179,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfsdb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfsdb %v24, %v24, %v25
 ;   br %r14
 
@@ -107,7 +195,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmsb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmsb %v24, %v24, %v25
 ;   br %r14
 
@@ -117,7 +211,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmdb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmdb %v24, %v24, %v25
 ;   br %r14
 
@@ -127,7 +227,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfdsb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfdsb %v24, %v24, %v25
 ;   br %r14
 
@@ -137,7 +243,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfddb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfddb %v24, %v24, %v25
 ;   br %r14
 
@@ -147,7 +259,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfminsb %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfminsb %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -157,7 +275,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmindb %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmindb %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -167,7 +291,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmaxsb %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmaxsb %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -177,7 +307,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmaxdb %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmaxdb %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -187,7 +323,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfminsb %v24, %v24, %v25, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfminsb %v24, %v24, %v25, 3
 ;   br %r14
 
@@ -197,7 +339,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmindb %v24, %v24, %v25, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmindb %v24, %v24, %v25, 3
 ;   br %r14
 
@@ -207,7 +355,13 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmaxsb %v24, %v24, %v25, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmaxsb %v24, %v24, %v25, 3
 ;   br %r14
 
@@ -217,7 +371,13 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vfmaxdb %v24, %v24, %v25, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmaxdb %v24, %v24, %v25, 3
 ;   br %r14
 
@@ -227,7 +387,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfsqsb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfsqsb %v24, %v24
 ;   br %r14
 
@@ -237,7 +403,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfsqdb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfsqdb %v24, %v24
 ;   br %r14
 
@@ -247,7 +419,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vflpsb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vflpsb %v24, %v24
 ;   br %r14
 
@@ -257,7 +435,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vflpdb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vflpdb %v24, %v24
 ;   br %r14
 
@@ -267,7 +451,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vflcsb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vflcsb %v24, %v24
 ;   br %r14
 
@@ -277,7 +467,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vflcdb %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vflcdb %v24, %v24
 ;   br %r14
 
@@ -287,7 +483,14 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v2, %v24, %v24
+;   vldeb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v2, %v24, %v24
 ;   vldeb %v24, %v2
 ;   br %r14
@@ -298,7 +501,14 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v2, %v24, %v24
+;   vldeb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v2, %v24, %v24
 ;   vldeb %v24, %v2
 ;   br %r14
@@ -309,10 +519,19 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vledb %v2, %v24, 0, 0
 ;   vesrlg %v4, %v2, 32
 ;   vgbm %v6, 0
+;   vpkg %v24, %v4, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vledb %v2, %v24, 0, 0
+;   vesrlg %v4, %v2, 0x20
+;   vzero %v6
 ;   vpkg %v24, %v4, %v6
 ;   br %r14
 
@@ -322,10 +541,19 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vledb %v2, %v24, 0, 0
 ;   vesrlg %v4, %v2, 32
 ;   vgbm %v6, 0
+;   vpkg %v24, %v6, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vledb %v2, %v24, 0, 0
+;   vesrlg %v4, %v2, 0x20
+;   vzero %v6
 ;   vpkg %v24, %v6, %v4
 ;   br %r14
 
@@ -335,7 +563,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfisb %v24, %v24, 0, 6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 6
 ;   br %r14
 
@@ -345,7 +579,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfidb %v24, %v24, 0, 6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 6
 ;   br %r14
 
@@ -355,7 +595,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfisb %v24, %v24, 0, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 7
 ;   br %r14
 
@@ -365,7 +611,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfidb %v24, %v24, 0, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 7
 ;   br %r14
 
@@ -375,7 +627,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfisb %v24, %v24, 0, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 5
 ;   br %r14
 
@@ -385,7 +643,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfidb %v24, %v24, 0, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 5
 ;   br %r14
 
@@ -395,7 +659,13 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfisb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 4
 ;   br %r14
 
@@ -405,7 +675,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vfidb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 4
 ;   br %r14
 
@@ -415,7 +691,13 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vfmasb %v24, %v24, %v25, %v26
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmasb %v24, %v24, %v25, %v26
 ;   br %r14
 
@@ -425,7 +707,13 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
   return v3
 }
 
+; VCode:
 ; block0:
+;   vfmadb %v24, %v24, %v25, %v26
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfmadb %v24, %v24, %v25, %v26
 ;   br %r14
 
@@ -435,8 +723,15 @@ block0(v0: f32x4, v1: f32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgmf %v3, 1, 31
+;   vsel %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgmf %v3, 1, 0x1f
 ;   vsel %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -446,8 +741,15 @@ block0(v0: f64x2, v1: f64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vgmg %v3, 1, 63
+;   vsel %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgmg %v3, 1, 0x3f
 ;   vsel %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -457,6 +759,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vuplhf %v2, %v24
 ;   vcdlgb %v4, %v2, 0, 3
@@ -467,6 +770,27 @@ block0(v0: i32x4):
 ;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuplhf %v2, %v24
+;   vcdlgb %v4, %v2, 0, 3
+;   vledb %v6, %v4, 0, 4
+;   vupllf %v16, %v24
+;   vcdlgb %v18, %v16, 0, 3
+;   vledb %v20, %v18, 0, 4
+;   bras %r1, 0x38
+;   .byte 0x00, 0x01
+;   .byte 0x02, 0x03
+;   .byte 0x08, 0x09
+;   svc 0xb
+;   lpr %r1, %r1
+;   ltr %r1, %r3
+;   lr %r1, %r9
+;   ar %r1, %r11
+;   vl %v22, 0(%r1)
+;   vperm %v24, %v6, %v20, %v22
+;   br %r14
 
 function %fcvt_from_sint_i32x4_f32x4(i32x4) -> f32x4 {
 block0(v0: i32x4):
@@ -474,6 +798,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vuphf %v2, %v24
 ;   vcdgb %v4, %v2, 0, 3
@@ -484,6 +809,27 @@ block0(v0: i32x4):
 ;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vuphf %v2, %v24
+;   vcdgb %v4, %v2, 0, 3
+;   vledb %v6, %v4, 0, 4
+;   vuplf %v16, %v24
+;   vcdgb %v18, %v16, 0, 3
+;   vledb %v20, %v18, 0, 4
+;   bras %r1, 0x38
+;   .byte 0x00, 0x01
+;   .byte 0x02, 0x03
+;   .byte 0x08, 0x09
+;   svc 0xb
+;   lpr %r1, %r1
+;   ltr %r1, %r3
+;   lr %r1, %r9
+;   ar %r1, %r11
+;   vl %v22, 0(%r1)
+;   vperm %v24, %v6, %v20, %v22
+;   br %r14
 
 function %fcvt_from_uint_i64x2_f64x2(i64x2) -> f64x2 {
 block0(v0: i64x2):
@@ -491,7 +837,13 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vcdlgb %v24, %v24, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vcdlgb %v24, %v24, 0, 4
 ;   br %r14
 
@@ -501,10 +853,15 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcdgb %v24, %v24, 0, 4
 ;   br %r14
-
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcdgb %v24, %v24, 0, 4
+;   br %r14
 
 function %fcvt_low_from_sint_i32x4_f64x2_be(i32x4) -> f64x2 {
 block0(v0: i32x4):
@@ -512,7 +869,14 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuphf %v2, %v24
+;   vcdgb %v24, %v2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuphf %v2, %v24
 ;   vcdgb %v24, %v2, 0, 4
 ;   br %r14
@@ -523,7 +887,14 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vuplf %v2, %v24
+;   vcdgb %v24, %v2, 0, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vuplf %v2, %v24
 ;   vcdgb %v24, %v2, 0, 4
 ;   br %r14
@@ -534,7 +905,19 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v2, %v24, %v24
+;   vldeb %v4, %v2
+;   vclgdb %v6, %v4, 0, 5
+;   vmrlf %v16, %v24, %v24
+;   vldeb %v18, %v16
+;   vclgdb %v20, %v18, 0, 5
+;   vpklsg %v24, %v6, %v20
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v2, %v24, %v24
 ;   vldeb %v4, %v2
 ;   vclgdb %v6, %v4, 0, 5
@@ -550,6 +933,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vmrhf %v2, %v24, %v24
 ;   vldeb %v4, %v2
@@ -562,6 +946,20 @@ block0(v0: f32x4):
 ;   vfcesb %v26, %v24, %v24
 ;   vsel %v24, %v22, %v25, %v26
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vmrhf %v2, %v24, %v24
+;   vldeb %v4, %v2
+;   vcgdb %v6, %v4, 0, 5
+;   vmrlf %v16, %v24, %v24
+;   vldeb %v18, %v16
+;   vcgdb %v20, %v18, 0, 5
+;   vpksg %v22, %v6, %v20
+;   vzero %v25
+;   vfcesb %v26, %v24, %v24
+;   vsel %v24, %v22, %v25, %v26
+;   br %r14
 
 function %fcvt_to_uint_sat_f64x2_i64x2(f64x2) -> i64x2 {
 block0(v0: f64x2):
@@ -569,7 +967,13 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vclgdb %v24, %v24, 0, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vclgdb %v24, %v24, 0, 5
 ;   br %r14
 
@@ -579,9 +983,18 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vcgdb %v2, %v24, 0, 5
 ;   vgbm %v4, 0
+;   vfcedb %v6, %v24, %v24
+;   vsel %v24, %v2, %v4, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vcgdb %v2, %v24, 0, 5
+;   vzero %v4
 ;   vfcedb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqg %v24, %v24, %v25
 ;   br %r14
 
@@ -17,7 +23,14 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqg %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -28,7 +41,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchg %v24, %v24, %v25
 ;   br %r14
 
@@ -38,7 +57,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchg %v24, %v25, %v24
 ;   br %r14
 
@@ -48,7 +73,14 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchg %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchg %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -59,7 +91,14 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchg %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -70,7 +109,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlg %v24, %v24, %v25
 ;   br %r14
 
@@ -80,7 +125,13 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlg %v24, %v25, %v24
 ;   br %r14
 
@@ -90,7 +141,14 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlg %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlg %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -101,7 +159,14 @@ block0(v0: i64x2, v1: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlg %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -112,7 +177,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqf %v24, %v24, %v25
 ;   br %r14
 
@@ -122,7 +193,14 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqf %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -133,7 +211,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchf %v24, %v24, %v25
 ;   br %r14
 
@@ -143,7 +227,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchf %v24, %v25, %v24
 ;   br %r14
 
@@ -153,7 +243,14 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchf %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchf %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -164,7 +261,14 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchf %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -175,7 +279,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlf %v24, %v24, %v25
 ;   br %r14
 
@@ -185,7 +295,13 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlf %v24, %v25, %v24
 ;   br %r14
 
@@ -195,7 +311,14 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlf %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlf %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -206,7 +329,14 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlf %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -217,7 +347,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqh %v24, %v24, %v25
 ;   br %r14
 
@@ -227,7 +363,14 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqh %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -238,7 +381,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchh %v24, %v24, %v25
 ;   br %r14
 
@@ -248,7 +397,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchh %v24, %v25, %v24
 ;   br %r14
 
@@ -258,7 +413,14 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchh %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchh %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -269,7 +431,14 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchh %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -280,7 +449,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlh %v24, %v24, %v25
 ;   br %r14
 
@@ -290,7 +465,13 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlh %v24, %v25, %v24
 ;   br %r14
 
@@ -300,7 +481,14 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlh %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlh %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -311,7 +499,14 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlh %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -322,7 +517,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqb %v24, %v24, %v25
 ;   br %r14
 
@@ -332,7 +533,14 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vceqb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -343,7 +551,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchb %v24, %v24, %v25
 ;   br %r14
 
@@ -353,7 +567,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchb %v24, %v25, %v24
 ;   br %r14
 
@@ -363,7 +583,14 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -374,7 +601,14 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -385,7 +619,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlb %v24, %v24, %v25
 ;   br %r14
 
@@ -395,7 +635,13 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlb %v24, %v25, %v24
 ;   br %r14
 
@@ -405,7 +651,14 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlb %v3, %v25, %v24
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
@@ -416,7 +669,14 @@ block0(v0: i8x16, v1: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vchlb %v3, %v24, %v25
+;   vno %v24, %v3, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-arch13.clif
@@ -8,7 +8,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -19,7 +25,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -30,8 +42,16 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 {
@@ -41,8 +61,16 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 {
@@ -52,7 +80,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -63,7 +97,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -74,8 +114,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 {
@@ -85,8 +133,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 
 function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 {
@@ -96,7 +152,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -107,7 +169,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -118,8 +186,16 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x01
 ;   br %r14
 
 function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 {
@@ -129,9 +205,16 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   le %f0, 0x7fe(%r1)
 
 function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 {
 block0(v0: i8x16, v1: i64):
@@ -140,7 +223,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -151,8 +240,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 {
@@ -162,7 +257,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -173,8 +274,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_f64x2_mem_0(f64x2, i64) -> f64x2 {
@@ -184,7 +291,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -195,7 +308,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -206,8 +325,16 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 {
@@ -217,8 +344,16 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 {
@@ -228,7 +363,13 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -239,7 +380,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -250,8 +397,16 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 {
@@ -261,8 +416,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 
 function %extractlane_i64x2_mem_0(i64x2, i64) {
@@ -272,7 +435,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -283,7 +452,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -294,8 +469,16 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0a
 ;   br %r14
 
 function %extractlane_i64x2_mem_little_1(i64x2, i64) {
@@ -305,8 +488,16 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r10
 ;   br %r14
 
 function %extractlane_i32x4_mem_0(i32x4, i64) {
@@ -316,7 +507,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -327,7 +524,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -338,8 +541,16 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0b
 ;   br %r14
 
 function %extractlane_i32x4_mem_little_3(i32x4, i64) {
@@ -349,8 +560,16 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f11
 ;   br %r14
 
 function %extractlane_i16x8_mem_0(i16x8, i64) {
@@ -360,7 +579,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -371,7 +596,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -382,8 +613,16 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x09
 ;   br %r14
 
 function %extractlane_i16x8_mem_little_7(i16x8, i64) {
@@ -393,9 +632,16 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrh %v24, 0(%r2), 7
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   le %f0, 0x7fe(%r9)
 
 function %extractlane_i8x16_mem_0(i8x16, i64) {
 block0(v0: i8x16, v1: i64):
@@ -404,7 +650,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -415,8 +667,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_little_0(i8x16, i64) {
@@ -426,7 +684,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -437,8 +701,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_f64x2_mem_0(f64x2, i64) {
@@ -448,7 +718,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -459,7 +735,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -470,8 +752,16 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0a
 ;   br %r14
 
 function %extractlane_f64x2_mem_little_1(f64x2, i64) {
@@ -481,8 +771,16 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r10
 ;   br %r14
 
 function %extractlane_f32x4_mem_0(f32x4, i64) {
@@ -492,7 +790,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -503,7 +807,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -514,8 +824,16 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0b
 ;   br %r14
 
 function %extractlane_f32x4_mem_little_3(f32x4, i64) {
@@ -525,8 +843,16 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f11
 ;   br %r14
 
 function %splat_i64x2_mem(i64) -> i64x2 {
@@ -536,7 +862,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -547,8 +879,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f5
 ;   br %r14
 
 function %splat_i32x4_mem(i64) -> i32x4 {
@@ -558,7 +898,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -569,8 +915,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %splat_i16x8_mem(i64) -> i16x8 {
@@ -580,7 +934,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
 
@@ -591,8 +951,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r5
 ;   br %r14
 
 function %splat_i8x16_mem(i64) -> i8x16 {
@@ -602,7 +970,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -613,7 +987,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -624,7 +1004,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -635,8 +1021,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f5
 ;   br %r14
 
 function %splat_f32x4_mem(i64) -> f32x4 {
@@ -646,7 +1040,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -657,8 +1057,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %scalar_to_vector_i64x2_mem(i64) -> i64x2 {
@@ -668,8 +1076,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -680,9 +1095,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %scalar_to_vector_i32x4_mem(i64) -> i32x4 {
@@ -692,8 +1116,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -704,9 +1135,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 
 function %scalar_to_vector_i16x8_mem(i64) -> i16x8 {
@@ -716,8 +1156,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -728,9 +1175,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x01
 ;   br %r14
 
 function %scalar_to_vector_i8x16_mem(i64) -> i8x16 {
@@ -740,8 +1196,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -752,8 +1215,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -764,8 +1234,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -776,9 +1253,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %scalar_to_vector_f32x4_mem(i64) -> f32x4 {
@@ -788,8 +1274,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -800,8 +1293,17 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
@@ -8,7 +8,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -19,7 +25,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -30,8 +42,16 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %insertlane_i64x2_mem_little_1(i64x2, i64) -> i64x2 wasmtime_system_v {
@@ -41,8 +61,16 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %insertlane_i32x4_mem_0(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -52,7 +80,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -63,7 +97,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -74,8 +114,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -85,8 +133,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 
 function %insertlane_i16x8_mem_0(i16x8, i64) -> i16x8 wasmtime_system_v {
@@ -96,7 +152,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -107,7 +169,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -118,9 +186,16 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   le %f0, 0x7fe(%r1)
 
 function %insertlane_i16x8_mem_little_7(i16x8, i64) -> i16x8 wasmtime_system_v {
 block0(v0: i16x8, v1: i64):
@@ -129,8 +204,16 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x01
 ;   br %r14
 
 function %insertlane_i8x16_mem_0(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -140,8 +223,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -151,7 +240,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -162,8 +257,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -173,7 +274,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -184,7 +291,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -195,7 +308,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -206,8 +325,16 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %insertlane_f64x2_mem_little_1(f64x2, i64) -> f64x2 wasmtime_system_v {
@@ -217,8 +344,16 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x02
 ;   br %r14
 
 function %insertlane_f32x4_mem_0(f32x4, i64) -> f32x4 wasmtime_system_v {
@@ -228,7 +363,13 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -239,7 +380,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -250,8 +397,16 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 
 function %insertlane_i32x4_mem_little_3(i32x4, i64) -> i32x4 wasmtime_system_v {
@@ -261,8 +416,16 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x03
 ;   br %r14
 
 function %extractlane_i64x2_mem_0(i64x2, i64) wasmtime_system_v {
@@ -272,7 +435,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -283,7 +452,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -294,8 +469,16 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r10
 ;   br %r14
 
 function %extractlane_i64x2_mem_little_1(i64x2, i64) wasmtime_system_v {
@@ -305,8 +488,16 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0a
 ;   br %r14
 
 function %extractlane_i32x4_mem_0(i32x4, i64) wasmtime_system_v {
@@ -316,7 +507,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -327,7 +524,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -338,8 +541,16 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f11
 ;   br %r14
 
 function %extractlane_i32x4_mem_little_3(i32x4, i64) wasmtime_system_v {
@@ -349,8 +560,16 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0b
 ;   br %r14
 
 function %extractlane_i16x8_mem_0(i16x8, i64) wasmtime_system_v {
@@ -360,7 +579,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -371,7 +596,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -382,9 +613,16 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrh %v24, 0(%r2), 7
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   le %f0, 0x7fe(%r9)
 
 function %extractlane_i16x8_mem_little_7(i16x8, i64) wasmtime_system_v {
 block0(v0: i16x8, v1: i64):
@@ -393,8 +631,16 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x09
 ;   br %r14
 
 function %extractlane_i8x16_mem_0(i8x16, i64) wasmtime_system_v {
@@ -404,8 +650,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_15(i8x16, i64) wasmtime_system_v {
@@ -415,7 +667,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -426,8 +684,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_little_15(i8x16, i64) wasmtime_system_v {
@@ -437,7 +701,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -448,7 +718,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -459,7 +735,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -470,8 +752,16 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r10
 ;   br %r14
 
 function %extractlane_f64x2_mem_little_1(f64x2, i64) wasmtime_system_v {
@@ -481,8 +771,16 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0a
 ;   br %r14
 
 function %extractlane_f32x4_mem_0(f32x4, i64) wasmtime_system_v {
@@ -492,7 +790,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -503,7 +807,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -514,8 +824,16 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f11
 ;   br %r14
 
 function %extractlane_f32x4_mem_little_3(f32x4, i64) wasmtime_system_v {
@@ -525,8 +843,16 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   .byte 0x08, 0x0b
 ;   br %r14
 
 function %splat_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
@@ -536,7 +862,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -547,8 +879,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f5
 ;   br %r14
 
 function %splat_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
@@ -558,7 +898,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -569,8 +915,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %splat_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
@@ -580,7 +934,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
 
@@ -591,8 +951,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r5
 ;   br %r14
 
 function %splat_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
@@ -602,7 +970,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -613,7 +987,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -624,7 +1004,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -635,8 +1021,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f5
 ;   br %r14
 
 function %splat_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
@@ -646,7 +1040,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -657,8 +1057,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f5
 ;   br %r14
 
 function %scalar_to_vector_i64x2_mem(i64) -> i64x2 wasmtime_system_v {
@@ -668,8 +1076,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -680,9 +1095,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %scalar_to_vector_i32x4_mem(i64) -> i32x4 wasmtime_system_v {
@@ -692,8 +1116,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -704,9 +1135,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 
 function %scalar_to_vector_i16x8_mem(i64) -> i16x8 wasmtime_system_v {
@@ -716,8 +1156,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -728,10 +1175,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   le %f0, 0x7fe(%r1)
 
 function %scalar_to_vector_i8x16_mem(i64) -> i8x16 wasmtime_system_v {
 block0(v0: i64):
@@ -740,9 +1195,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
@@ -752,9 +1214,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %scalar_to_vector_f64x2_mem(i64) -> f64x2 wasmtime_system_v {
@@ -764,8 +1233,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -776,9 +1252,18 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r2
 ;   br %r14
 
 function %scalar_to_vector_f32x4_mem(i64) -> f32x4 wasmtime_system_v {
@@ -788,8 +1273,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -800,8 +1292,17 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgg %v24, %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i64x2, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgg %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
 
@@ -28,8 +40,14 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleig %v24, 123, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleig %v24, 0x7b, 1
 ;   br %r14
 
 function %insertlane_i64x2_imm_1(i64x2) -> i64x2 wasmtime_system_v {
@@ -39,8 +57,14 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleig %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleig %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i64x2_lane_0_0(i64x2, i64x2) -> i64x2 wasmtime_system_v {
@@ -50,7 +74,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -61,7 +91,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
@@ -72,7 +108,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
@@ -83,7 +125,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
@@ -94,7 +142,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -105,7 +159,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -116,7 +176,14 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
@@ -128,7 +195,14 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
@@ -139,7 +213,13 @@ block0(v0: i32x4, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v24, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
 
@@ -149,7 +229,13 @@ block0(v0: i32x4, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
 
@@ -160,8 +246,14 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleif %v24, 123, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleif %v24, 0x7b, 3
 ;   br %r14
 
 function %insertlane_i32x4_imm_3(i32x4) -> i32x4 wasmtime_system_v {
@@ -171,8 +263,14 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleif %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleif %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i32x4_lane_0_0(i32x4, i32x4) -> i32x4 wasmtime_system_v {
@@ -182,8 +280,15 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 15
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -194,9 +299,17 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 3
 ;   vgbm %v5, 61440
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 3
+;   vgbm %v5, 0xf000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -207,9 +320,17 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -220,8 +341,15 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -232,7 +360,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -243,7 +377,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -254,7 +394,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
@@ -266,7 +413,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
@@ -277,7 +431,13 @@ block0(v0: i16x8, v1: i16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v24, %r2, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
 
@@ -287,7 +447,13 @@ block0(v0: i16x8, v1: i16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
 
@@ -298,8 +464,14 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleih %v24, 123, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleih %v24, 0x7b, 7
 ;   br %r14
 
 function %insertlane_i16x8_imm_7(i16x8) -> i16x8 wasmtime_system_v {
@@ -309,8 +481,14 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleih %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleih %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i16x8_lane_0_0(i16x8, i16x8) -> i16x8 wasmtime_system_v {
@@ -320,7 +498,14 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vgbm %v3, 3
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v3, 3
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
@@ -332,9 +517,17 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vreph %v3, %v25, 7
 ;   vgbm %v5, 49152
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vreph %v3, %v25, 7
+;   vgbm %v5, 0xc000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -345,7 +538,15 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vreph %v3, %v25, 0
+;   vgbm %v5, 3
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v3, %v25, 0
 ;   vgbm %v5, 3
 ;   vsel %v24, %v3, %v24, %v5
@@ -358,8 +559,15 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 49152
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xc000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -370,7 +578,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -381,7 +595,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -392,7 +612,14 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvh %r5, 0(%r2)
+;   vlvgh %v24, %r5, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 7
 ;   br %r14
@@ -404,7 +631,14 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvh %r5, 0(%r2)
+;   vlvgh %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 0
 ;   br %r14
@@ -415,8 +649,14 @@ block0(v0: i8x16, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlvgb %v24, %r2, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlvgb %v24, %r2, 0xf
 ;   br %r14
 
 function %insertlane_i8x16_15(i8x16, i8) -> i8x16 wasmtime_system_v {
@@ -425,7 +665,13 @@ block0(v0: i8x16, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgb %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
 
@@ -436,8 +682,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleib %v24, 123, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleib %v24, 0x7b, 0xf
 ;   br %r14
 
 function %insertlane_i8x16_imm_15(i8x16) -> i8x16 wasmtime_system_v {
@@ -447,8 +699,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleib %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleib %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i8x16_lane_0_0(i8x16, i8x16) -> i8x16 wasmtime_system_v {
@@ -458,7 +716,14 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vgbm %v3, 1
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v3, 1
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
@@ -470,9 +735,17 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepb %v3, %v25, 15
 ;   vgbm %v5, 32768
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepb %v3, %v25, 0xf
+;   vgbm %v5, 0x8000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -483,7 +756,15 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vrepb %v3, %v25, 0
+;   vgbm %v5, 1
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0
 ;   vgbm %v5, 1
 ;   vsel %v24, %v3, %v24, %v5
@@ -496,8 +777,15 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 32768
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0x8000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -508,8 +796,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_15(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -519,7 +813,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -530,8 +830,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_little_15(i8x16, i64) -> i8x16 wasmtime_system_v {
@@ -541,7 +847,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -551,7 +863,13 @@ block0(v0: f64x2, v1: f64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v0, 0
 ;   br %r14
 
@@ -561,7 +879,13 @@ block0(v0: f64x2, v1: f64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v0, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v0, %v24, 1
 ;   br %r14
 
@@ -572,7 +896,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -583,7 +913,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
@@ -594,7 +930,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
@@ -605,7 +947,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
@@ -616,7 +964,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -627,7 +981,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -638,7 +998,14 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
@@ -650,7 +1017,14 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
@@ -661,9 +1035,17 @@ block0(v0: f32x4, v1: f32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v0, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v0, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -673,8 +1055,15 @@ block0(v0: f32x4, v1: f32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v0, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v0, %v24, %v3
 ;   br %r14
 
@@ -685,8 +1074,15 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 15
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -697,9 +1093,17 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 3
 ;   vgbm %v5, 61440
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 3
+;   vgbm %v5, 0xf000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -710,9 +1114,17 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -723,8 +1135,15 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -735,7 +1154,13 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -746,7 +1171,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -757,7 +1188,14 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
@@ -769,7 +1207,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
@@ -780,7 +1225,13 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r2, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 1
 ;   br %r14
 
@@ -790,7 +1241,13 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 0
 ;   br %r14
 
@@ -801,7 +1258,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -812,7 +1275,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -823,7 +1292,14 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -835,7 +1311,14 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -846,7 +1329,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r2, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 3
 ;   br %r14
 
@@ -856,7 +1345,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 0
 ;   br %r14
 
@@ -867,7 +1362,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -878,7 +1379,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -889,7 +1396,14 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -901,7 +1415,14 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -912,7 +1433,13 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r2, %v24, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 7
 ;   br %r14
 
@@ -922,7 +1449,13 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 0
 ;   br %r14
 
@@ -933,7 +1466,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -944,7 +1483,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -955,7 +1500,14 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r5, %v24, 7
+;   strvh %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 7
 ;   strvh %r5, 0(%r2)
 ;   br %r14
@@ -967,7 +1519,14 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r5, %v24, 0
+;   strvh %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 0
 ;   strvh %r5, 0(%r2)
 ;   br %r14
@@ -978,8 +1537,14 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vlgvb %r2, %v24, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlgvb %r2, %v24, 0xf
 ;   br %r14
 
 function %extractlane_i8x16_15(i8x16) -> i8 wasmtime_system_v {
@@ -988,7 +1553,13 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvb %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0
 ;   br %r14
 
@@ -999,8 +1570,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_15(i8x16, i64) wasmtime_system_v {
@@ -1010,7 +1587,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1021,8 +1604,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_little_15(i8x16, i64) wasmtime_system_v {
@@ -1032,7 +1621,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1042,7 +1637,13 @@ block0(v0: f64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v0, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 1
 ;   br %r14
 
@@ -1052,7 +1653,13 @@ block0(v0: f64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v0, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 0
 ;   br %r14
 
@@ -1063,7 +1670,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -1074,7 +1687,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1085,7 +1704,14 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -1097,7 +1723,14 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -1108,7 +1741,13 @@ block0(v0: f32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v0, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 3
 ;   br %r14
 
@@ -1118,7 +1757,13 @@ block0(v0: f32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v0, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 0
 ;   br %r14
 
@@ -1129,7 +1774,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -1140,7 +1791,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1151,7 +1808,14 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -1163,7 +1827,14 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -1174,7 +1845,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   vrepg %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   vrepg %v24, %v2, 0
 ;   br %r14
@@ -1186,8 +1864,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, 0x7b
 ;   br %r14
 
 function %splat_i64x2_lane_0(i64x2) -> i64x2 wasmtime_system_v {
@@ -1197,7 +1881,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
@@ -1208,7 +1898,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
@@ -1219,7 +1915,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -1230,7 +1932,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vrepg %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
@@ -1242,7 +1952,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v2, %r2, 0
+;   vrepf %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
 ;   vrepf %v24, %v2, 0
 ;   br %r14
@@ -1254,8 +1971,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, 0x7b
 ;   br %r14
 
 function %splat_i32x4_lane_0(i32x4) -> i32x4 wasmtime_system_v {
@@ -1265,7 +1988,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
@@ -1276,7 +2005,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
@@ -1287,7 +2022,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -1298,7 +2039,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   vlvgf %v4, %r4, 0
+;   vrepf %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
@@ -1310,7 +2059,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v2, %r2, 0
+;   vreph %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v2, %r2, 0
 ;   vreph %v24, %v2, 0
 ;   br %r14
@@ -1322,8 +2078,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, 0x7b
 ;   br %r14
 
 function %splat_i16x8_lane_0(i16x8) -> i16x8 wasmtime_system_v {
@@ -1333,7 +2095,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vreph %v24, %v24, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v24, %v24, 7
 ;   br %r14
 
@@ -1344,7 +2112,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vreph %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v24, %v24, 0
 ;   br %r14
 
@@ -1355,7 +2129,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
 
@@ -1366,7 +2146,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   vlvgh %v4, %r4, 0
+;   vreph %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   vlvgh %v4, %r4, 0
 ;   vreph %v24, %v4, 0
@@ -1378,7 +2166,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgb %v2, %r2, 0
+;   vrepb %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgb %v2, %r2, 0
 ;   vrepb %v24, %v2, 0
 ;   br %r14
@@ -1390,8 +2185,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x7b
 ;   br %r14
 
 function %splat_i8x16_lane_0(i8x16) -> i8x16 wasmtime_system_v {
@@ -1401,8 +2202,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepb %v24, %v24, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepb %v24, %v24, 0xf
 ;   br %r14
 
 function %splat_i8x16_lane_15(i8x16) -> i8x16 wasmtime_system_v {
@@ -1412,7 +2219,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepb %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0
 ;   br %r14
 
@@ -1423,7 +2236,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -1434,7 +2253,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -1444,7 +2269,13 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v0, 0
 ;   br %r14
 
@@ -1455,7 +2286,13 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
@@ -1466,7 +2303,13 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
@@ -1477,7 +2320,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -1488,7 +2337,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vrepg %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
@@ -1500,7 +2357,13 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v0, 0
 ;   br %r14
 
@@ -1511,7 +2374,13 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
@@ -1522,7 +2391,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
@@ -1533,7 +2408,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -1544,7 +2425,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   vlvgf %v4, %r4, 0
+;   vrepf %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
@@ -1556,8 +2445,15 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgg %v24, %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
 
@@ -1568,9 +2464,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleig %v24, 123, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleig %v24, 0x7b, 1
 ;   br %r14
 
 function %scalar_to_vector_i64x2_lane_0(i64x2) -> i64x2 wasmtime_system_v {
@@ -1580,8 +2483,15 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v2, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
 
@@ -1592,8 +2502,15 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
 
@@ -1604,8 +2521,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -1616,8 +2540,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
@@ -1628,8 +2560,15 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgf %v24, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
 
@@ -1640,9 +2579,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleif %v24, 123, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleif %v24, 0x7b, 3
 ;   br %r14
 
 function %scalar_to_vector_i32x4_lane_0(i32x4) -> i32x4 wasmtime_system_v {
@@ -1652,8 +2598,15 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 15
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xf
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1664,9 +2617,17 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v2, %v24, 0
 ;   vgbm %v4, 15
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v2, %v24, 0
+;   vgbm %v4, 0xf
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1677,8 +2638,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -1689,8 +2657,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
@@ -1701,8 +2677,15 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgh %v24, %r2, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
 
@@ -1713,9 +2696,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleih %v24, 123, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleih %v24, 0x7b, 7
 ;   br %r14
 
 function %scalar_to_vector_i16x8_lane_0(i16x8) -> i16x8 wasmtime_system_v {
@@ -1725,7 +2715,14 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vgbm %v2, 3
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v2, 3
 ;   vn %v24, %v24, %v2
 ;   br %r14
@@ -1737,7 +2734,15 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vreph %v2, %v24, 0
+;   vgbm %v4, 3
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v2, %v24, 0
 ;   vgbm %v4, 3
 ;   vn %v24, %v2, %v4
@@ -1750,8 +2755,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -1762,8 +2774,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvh %r2, 0(%r2)
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
@@ -1774,9 +2794,16 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vlvgb %v24, %r2, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vlvgb %v24, %r2, 0xf
 ;   br %r14
 
 function %scalar_to_vector_i8x16_imm() -> i8x16 wasmtime_system_v {
@@ -1786,9 +2813,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleib %v24, 123, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleib %v24, 0x7b, 0xf
 ;   br %r14
 
 function %scalar_to_vector_i8x16_lane_0(i8x16) -> i8x16 wasmtime_system_v {
@@ -1798,7 +2832,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vgbm %v2, 1
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v2, 1
 ;   vn %v24, %v24, %v2
 ;   br %r14
@@ -1810,7 +2851,15 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepb %v2, %v24, 0
+;   vgbm %v4, 1
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepb %v2, %v24, 0
 ;   vgbm %v4, 1
 ;   vn %v24, %v2, %v4
@@ -1823,9 +2872,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %scalar_to_vector_i8x16_mem_little(i64) -> i8x16 wasmtime_system_v {
@@ -1835,9 +2891,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %scalar_to_vector_f64x2(f64) -> f64x2 wasmtime_system_v {
@@ -1846,8 +2909,15 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v2, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v2, %v0, 0
 ;   br %r14
 
@@ -1858,8 +2928,15 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v2, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
 
@@ -1870,8 +2947,15 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
 
@@ -1882,8 +2966,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -1894,8 +2985,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
@@ -1906,9 +3005,17 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v2, %v0, 0
 ;   vgbm %v4, 15
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v2, %v0, 0
+;   vgbm %v4, 0xf
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1919,8 +3026,15 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 15
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xf
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1931,9 +3045,17 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v2, %v24, 0
 ;   vgbm %v4, 15
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v2, %v24, 0
+;   vgbm %v4, 0xf
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1944,8 +3066,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -1956,8 +3085,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 3
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
@@ -7,7 +7,13 @@ block0(v0: i64x2, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgg %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
 
@@ -17,7 +23,13 @@ block0(v0: i64x2, v1: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgg %v24, %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
 
@@ -28,8 +40,14 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleig %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleig %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i64x2_imm_1(i64x2) -> i64x2 {
@@ -39,8 +57,14 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleig %v24, 123, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleig %v24, 0x7b, 1
 ;   br %r14
 
 function %insertlane_i64x2_lane_0_0(i64x2, i64x2) -> i64x2 {
@@ -50,7 +74,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
@@ -61,7 +91,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
@@ -72,7 +108,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
@@ -83,7 +125,13 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -94,7 +142,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -105,7 +159,13 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -116,7 +176,14 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
@@ -128,7 +195,14 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
@@ -139,7 +213,13 @@ block0(v0: i32x4, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
 
@@ -149,7 +229,13 @@ block0(v0: i32x4, v1: i32):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v24, %r2, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
 
@@ -160,8 +246,14 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleif %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleif %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i32x4_imm_3(i32x4) -> i32x4 {
@@ -171,8 +263,14 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleif %v24, 123, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleif %v24, 0x7b, 3
 ;   br %r14
 
 function %insertlane_i32x4_lane_0_0(i32x4, i32x4) -> i32x4 {
@@ -182,8 +280,15 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -194,9 +299,17 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -207,9 +320,17 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 3
 ;   vgbm %v5, 61440
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 3
+;   vgbm %v5, 0xf000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -220,8 +341,15 @@ block0(v0: i32x4, v1: i32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 15
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -232,7 +360,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -243,7 +377,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -254,7 +394,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
@@ -266,7 +413,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
@@ -277,7 +431,13 @@ block0(v0: i16x8, v1: i16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
 
@@ -287,7 +447,13 @@ block0(v0: i16x8, v1: i16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v24, %r2, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
 
@@ -298,8 +464,14 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleih %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleih %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i16x8_imm_7(i16x8) -> i16x8 {
@@ -309,8 +481,14 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleih %v24, 123, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleih %v24, 0x7b, 7
 ;   br %r14
 
 function %insertlane_i16x8_lane_0_0(i16x8, i16x8) -> i16x8 {
@@ -320,8 +498,15 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 49152
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xc000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -332,7 +517,15 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vreph %v3, %v25, 0
+;   vgbm %v5, 3
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v3, %v25, 0
 ;   vgbm %v5, 3
 ;   vsel %v24, %v3, %v24, %v5
@@ -345,9 +538,17 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vreph %v3, %v25, 7
 ;   vgbm %v5, 49152
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vreph %v3, %v25, 7
+;   vgbm %v5, 0xc000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -358,7 +559,14 @@ block0(v0: i16x8, v1: i16x8):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vgbm %v3, 3
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v3, 3
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
@@ -370,7 +578,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -381,7 +595,13 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -392,7 +612,14 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvh %r5, 0(%r2)
+;   vlvgh %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 0
 ;   br %r14
@@ -404,7 +631,14 @@ block0(v0: i16x8, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvh %r5, 0(%r2)
+;   vlvgh %v24, %r5, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 7
 ;   br %r14
@@ -415,7 +649,13 @@ block0(v0: i8x16, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlvgb %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
 
@@ -425,8 +665,14 @@ block0(v0: i8x16, v1: i8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vlvgb %v24, %r2, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlvgb %v24, %r2, 0xf
 ;   br %r14
 
 function %insertlane_i8x16_imm_0(i8x16) -> i8x16 {
@@ -436,8 +682,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleib %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleib %v24, 0x7b, 0
 ;   br %r14
 
 function %insertlane_i8x16_imm_15(i8x16) -> i8x16 {
@@ -447,8 +699,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vleib %v24, 123, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleib %v24, 0x7b, 0xf
 ;   br %r14
 
 function %insertlane_i8x16_lane_0_0(i8x16, i8x16) -> i8x16 {
@@ -458,8 +716,15 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 32768
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0x8000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -470,7 +735,15 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vrepb %v3, %v25, 0
+;   vgbm %v5, 1
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0
 ;   vgbm %v5, 1
 ;   vsel %v24, %v3, %v24, %v5
@@ -483,9 +756,17 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepb %v3, %v25, 15
 ;   vgbm %v5, 32768
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepb %v3, %v25, 0xf
+;   vgbm %v5, 0x8000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -496,7 +777,14 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vgbm %v3, 1
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vgbm %v3, 1
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
@@ -508,7 +796,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -519,8 +813,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_i8x16_mem_little_0(i8x16, i64) -> i8x16 {
@@ -530,7 +830,13 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -541,8 +847,14 @@ block0(v0: i8x16, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vleb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vleb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %insertlane_f64x2_0(f64x2, f64) -> f64x2 {
@@ -551,7 +863,13 @@ block0(v0: f64x2, v1: f64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v0, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v0, %v24, 1
 ;   br %r14
 
@@ -561,7 +879,13 @@ block0(v0: f64x2, v1: f64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v0, 0
 ;   br %r14
 
@@ -572,7 +896,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
 
@@ -583,7 +913,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
 
@@ -594,7 +930,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v25, %v24, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
 
@@ -605,7 +947,13 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vpdi %v24, %v24, %v25, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
 
@@ -616,7 +964,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -627,7 +981,13 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vleg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -638,7 +998,14 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
@@ -650,7 +1017,14 @@ block0(v0: f64x2, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r2)
+;   vlvgg %v24, %r5, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
@@ -661,8 +1035,15 @@ block0(v0: f32x4, v1: f32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v0, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v0, %v24, %v3
 ;   br %r14
 
@@ -672,9 +1053,17 @@ block0(v0: f32x4, v1: f32):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v0, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v0, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -685,8 +1074,15 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 61440
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf000
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -697,9 +1093,17 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 0
 ;   vgbm %v5, 15
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 0
+;   vgbm %v5, 0xf
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -710,9 +1114,17 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v3, %v25, 3
 ;   vgbm %v5, 61440
+;   vsel %v24, %v3, %v24, %v5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v3, %v25, 3
+;   vgbm %v5, 0xf000
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
 
@@ -723,8 +1135,15 @@ block0(v0: f32x4, v1: f32x4):
     return v3
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 15
+;   vsel %v24, %v25, %v24, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0xf
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
 
@@ -735,7 +1154,13 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -746,7 +1171,13 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vlef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -757,7 +1188,14 @@ block0(v0: f32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
@@ -769,7 +1207,14 @@ block0(v0: i32x4, v1: i64):
     return v3
 }
 
+; VCode:
 ; block0:
+;   lrv %r5, 0(%r2)
+;   vlvgf %v24, %r5, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
@@ -780,7 +1225,13 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 0
 ;   br %r14
 
@@ -790,7 +1241,13 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r2, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 1
 ;   br %r14
 
@@ -801,7 +1258,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -812,7 +1275,13 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -823,7 +1292,14 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -835,7 +1311,14 @@ block0(v0: i64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -846,7 +1329,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 0
 ;   br %r14
 
@@ -856,7 +1345,13 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r2, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 3
 ;   br %r14
 
@@ -867,7 +1362,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -878,7 +1379,13 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -889,7 +1396,14 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -901,7 +1415,14 @@ block0(v0: i32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -912,7 +1433,13 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 0
 ;   br %r14
 
@@ -922,7 +1449,13 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r2, %v24, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 7
 ;   br %r14
 
@@ -933,7 +1466,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -944,7 +1483,13 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteh %v24, 0(%r2), 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
 
@@ -955,7 +1500,14 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r5, %v24, 0
+;   strvh %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 0
 ;   strvh %r5, 0(%r2)
 ;   br %r14
@@ -967,7 +1519,14 @@ block0(v0: i16x8, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvh %r5, %v24, 7
+;   strvh %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 7
 ;   strvh %r5, 0(%r2)
 ;   br %r14
@@ -978,7 +1537,13 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlgvb %r2, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0
 ;   br %r14
 
@@ -988,8 +1553,14 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vlgvb %r2, %v24, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlgvb %r2, %v24, 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_0(i8x16, i64) {
@@ -999,7 +1570,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1010,8 +1587,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_i8x16_mem_little_0(i8x16, i64) {
@@ -1021,7 +1604,13 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1032,8 +1621,14 @@ block0(v0: i8x16, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vsteb %v24, 0(%r2), 0xf
 ;   br %r14
 
 function %extractlane_f64x2_0(f64x2) -> f64 {
@@ -1042,7 +1637,13 @@ block0(v0: f64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v0, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 0
 ;   br %r14
 
@@ -1052,7 +1653,13 @@ block0(v0: f64x2):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v0, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 1
 ;   br %r14
 
@@ -1063,7 +1670,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1074,7 +1687,13 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vsteg %v24, 0(%r2), 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
 
@@ -1085,7 +1704,14 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 0
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -1097,7 +1723,14 @@ block0(v0: f64x2, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   strvg %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
@@ -1108,7 +1741,13 @@ block0(v0: f32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v0, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 0
 ;   br %r14
 
@@ -1118,7 +1757,13 @@ block0(v0: f32x4):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v0, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 3
 ;   br %r14
 
@@ -1129,7 +1774,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1140,7 +1791,13 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vstef %v24, 0(%r2), 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
 
@@ -1151,7 +1808,14 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 0
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -1163,7 +1827,14 @@ block0(v0: f32x4, v1: i64):
     return
 }
 
+; VCode:
 ; block0:
+;   vlgvf %r5, %v24, 3
+;   strv %r5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
@@ -1174,7 +1845,14 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   ldgr %f2, %r2
+;   vrepg %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ldgr %f2, %r2
 ;   vrepg %v24, %v2, 0
 ;   br %r14
@@ -1186,8 +1864,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepig %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepig %v24, 0x7b
 ;   br %r14
 
 function %splat_i64x2_lane_0(i64x2) -> i64x2 {
@@ -1197,7 +1881,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
@@ -1208,7 +1898,13 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
@@ -1219,7 +1915,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -1230,7 +1932,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vrepg %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
@@ -1242,7 +1952,14 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgf %v2, %r2, 0
+;   vrepf %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
 ;   vrepf %v24, %v2, 0
 ;   br %r14
@@ -1254,8 +1971,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepif %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepif %v24, 0x7b
 ;   br %r14
 
 function %splat_i32x4_lane_0(i32x4) -> i32x4 {
@@ -1265,7 +1988,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
@@ -1276,7 +2005,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
@@ -1287,7 +2022,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -1298,7 +2039,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   vlvgf %v4, %r4, 0
+;   vrepf %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
@@ -1310,7 +2059,14 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgh %v2, %r2, 0
+;   vreph %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgh %v2, %r2, 0
 ;   vreph %v24, %v2, 0
 ;   br %r14
@@ -1322,8 +2078,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepih %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepih %v24, 0x7b
 ;   br %r14
 
 function %splat_i16x8_lane_0(i16x8) -> i16x8 {
@@ -1333,7 +2095,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vreph %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v24, %v24, 0
 ;   br %r14
 
@@ -1344,7 +2112,13 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vreph %v24, %v24, 7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vreph %v24, %v24, 7
 ;   br %r14
 
@@ -1355,7 +2129,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlreph %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
 
@@ -1366,7 +2146,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvh %r4, 0(%r2)
+;   vlvgh %v4, %r4, 0
+;   vreph %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
 ;   vlvgh %v4, %r4, 0
 ;   vreph %v24, %v4, 0
@@ -1378,7 +2166,14 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vlvgb %v2, %r2, 0
+;   vrepb %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlvgb %v2, %r2, 0
 ;   vrepb %v24, %v2, 0
 ;   br %r14
@@ -1390,8 +2185,14 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v24, 123
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v24, 0x7b
 ;   br %r14
 
 function %splat_i8x16_lane_0(i8x16) -> i8x16 {
@@ -1401,7 +2202,13 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepb %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0
 ;   br %r14
 
@@ -1412,8 +2219,14 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepb %v24, %v24, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepb %v24, %v24, 0xf
 ;   br %r14
 
 function %splat_i8x16_mem(i64) -> i8x16 {
@@ -1423,7 +2236,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -1434,7 +2253,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepb %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
 
@@ -1444,7 +2269,13 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v0, 0
 ;   br %r14
 
@@ -1455,7 +2286,13 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
 ;   br %r14
 
@@ -1466,7 +2303,13 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepg %v24, %v24, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
 ;   br %r14
 
@@ -1477,7 +2320,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
 
@@ -1488,7 +2337,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vrepg %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
@@ -1500,7 +2357,13 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v0, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v0, 0
 ;   br %r14
 
@@ -1511,7 +2374,13 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
 ;   br %r14
 
@@ -1522,7 +2391,13 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vrepf %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
 ;   br %r14
 
@@ -1533,7 +2408,13 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vlrepf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
 
@@ -1544,7 +2425,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
+;   lrv %r4, 0(%r2)
+;   vlvgf %v4, %r4, 0
+;   vrepf %v24, %v4, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
@@ -1556,8 +2445,15 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgg %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
 
@@ -1568,9 +2464,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleig %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleig %v24, 0x7b, 0
 ;   br %r14
 
 function %scalar_to_vector_i64x2_lane_0(i64x2) -> i64x2 {
@@ -1580,8 +2483,15 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v24, %v2, 0
 ;   br %r14
 
@@ -1592,8 +2502,15 @@ block0(v0: i64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v24, %v2, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v24, %v2, 4
 ;   br %r14
 
@@ -1604,8 +2521,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1616,8 +2540,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
@@ -1628,8 +2560,15 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgf %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
 
@@ -1640,9 +2579,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleif %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleif %v24, 0x7b, 0
 ;   br %r14
 
 function %scalar_to_vector_i32x4_lane_0(i32x4) -> i32x4 {
@@ -1652,8 +2598,15 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 61440
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xf000
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1664,9 +2617,17 @@ block0(v0: i32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v2, %v24, 3
 ;   vgbm %v4, 61440
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v2, %v24, 3
+;   vgbm %v4, 0xf000
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1677,8 +2638,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1689,8 +2657,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
@@ -1701,8 +2677,15 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgh %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
 
@@ -1713,9 +2696,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleih %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleih %v24, 0x7b, 0
 ;   br %r14
 
 function %scalar_to_vector_i16x8_lane_0(i16x8) -> i16x8 {
@@ -1725,8 +2715,15 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 49152
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xc000
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1737,9 +2734,17 @@ block0(v0: i16x8):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vreph %v2, %v24, 7
 ;   vgbm %v4, 49152
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vreph %v2, %v24, 7
+;   vgbm %v4, 0xc000
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1750,8 +2755,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleh %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1762,8 +2774,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvh %r2, 0(%r2)
+;   vlvgh %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvh %r2, 0(%r2)
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
@@ -1774,8 +2794,15 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlvgb %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
 
@@ -1786,9 +2813,16 @@ block0:
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
 ;   vleib %v24, 123, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
+;   vleib %v24, 0x7b, 0
 ;   br %r14
 
 function %scalar_to_vector_i8x16_lane_0(i8x16) -> i8x16 {
@@ -1798,8 +2832,15 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 32768
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0x8000
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1810,9 +2851,17 @@ block0(v0: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepb %v2, %v24, 15
 ;   vgbm %v4, 32768
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepb %v2, %v24, 0xf
+;   vgbm %v4, 0x8000
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1823,8 +2872,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1835,8 +2891,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleb %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1846,8 +2909,15 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v0, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v0, %v2, 0
 ;   br %r14
 
@@ -1858,8 +2928,15 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v24, %v2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v24, %v2, 0
 ;   br %r14
 
@@ -1870,8 +2947,15 @@ block0(v0: f64x2):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vpdi %v24, %v24, %v2, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vpdi %v24, %v24, %v2, 4
 ;   br %r14
 
@@ -1882,8 +2966,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vleg %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1894,8 +2985,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrvg %r2, 0(%r2)
+;   vlvgg %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
@@ -1906,8 +3005,15 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 61440
+;   vn %v24, %v0, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xf000
 ;   vn %v24, %v0, %v2
 ;   br %r14
 
@@ -1918,8 +3024,15 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 61440
+;   vn %v24, %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v2, 0xf000
 ;   vn %v24, %v24, %v2
 ;   br %r14
 
@@ -1930,9 +3043,17 @@ block0(v0: f32x4):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepf %v2, %v24, 3
 ;   vgbm %v4, 61440
+;   vn %v24, %v2, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepf %v2, %v24, 3
+;   vgbm %v4, 0xf000
 ;   vn %v24, %v2, %v4
 ;   br %r14
 
@@ -1943,8 +3064,15 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   vlef %v24, 0(%r2), 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
 
@@ -1955,8 +3083,16 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v24, 0
+;   lrv %r2, 0(%r2)
+;   vlvgf %v24, %r2, 0
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v24
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
@@ -7,8 +7,17 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqgs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqgs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -20,8 +29,17 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqfs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqfs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -33,8 +51,17 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqhs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqhs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -46,8 +73,17 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqbs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqbs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -59,8 +95,17 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqgs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqgs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -72,8 +117,17 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqfs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqfs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -85,8 +139,17 @@ block0(v0: i16x8):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqhs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqhs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -98,8 +161,17 @@ block0(v0: i8x16):
     return v1
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v2, 0
+;   vceqbs %v4, %v24, %v2
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v2
 ;   vceqbs %v4, %v24, %v2
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -112,7 +184,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vceqgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -125,7 +205,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vceqgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -138,7 +226,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -151,7 +247,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -164,7 +268,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -177,7 +289,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -190,7 +310,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -203,7 +331,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -216,7 +352,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -229,7 +373,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -242,7 +394,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfcedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -255,7 +415,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfcedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -268,7 +436,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -281,7 +457,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -294,7 +478,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -307,7 +499,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -320,7 +520,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -333,7 +541,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -346,7 +562,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochino %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochino %r2, 1
@@ -359,7 +583,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochine %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochine %r2, 1
@@ -372,7 +604,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vceqgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -385,7 +625,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vceqgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -398,7 +646,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -411,7 +667,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -424,7 +688,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -437,7 +709,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -450,7 +730,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -463,7 +751,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -476,7 +772,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -489,7 +793,15 @@ block0(v0: i64x2, v1: i64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vchlgs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -502,7 +814,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfcedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -515,7 +835,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfcedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -528,7 +856,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -541,7 +877,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -554,7 +898,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -567,7 +919,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v24, %v25
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -580,7 +940,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -593,7 +961,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchdbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -606,7 +982,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochie %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochie %r2, 1
@@ -619,7 +1003,15 @@ block0(v0: f64x2, v1: f64x2):
     return v3
 }
 
+; VCode:
 ; block0:
+;   vfchedbs %v3, %v25, %v24
+;   lhi %r2, 0
+;   lochio %r2, 1
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
 ;   lhi %r2, 0
 ;   lochio %r2, 1
@@ -631,8 +1023,26 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080808080808080804000 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   sth %r0, 0x720(%r14)
+;   lpr %r0, %r0
+;   .byte 0x00, 0x06
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -643,8 +1053,24 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080808080808060402000 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   std %f4, 0(%r2)
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -655,8 +1081,24 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080807060504030201000 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   ste %f6, 0x40(%r5)
+;   lper %f2, %f0
+;   lpr %r0, %r0
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -667,8 +1109,23 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x78706860585048403830282018100800 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   le %f7, 0x860(%r6)
+;   l %r5, 0x840(%r4)
+;   ler %f3, %f0
+;   ldr %f2, %f0
+;   lr %r1, %r0
+;   .byte 0x08, 0x00
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -679,8 +1136,25 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080808080808080800040 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x00, 0x40
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -691,8 +1165,26 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080808080808000204060 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x00, 0x20
+;   sth %r6, 0x720(%r14)
+;   lpr %r0, %r0
+;   .byte 0x00, 0x06
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -703,8 +1195,24 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x80808080808080800010203040506070 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x00, 0x10
+;   lpdr %f3, %f0
+;   sth %r5, 0x70(%r6)
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
@@ -715,8 +1223,23 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00081018202830384048505860687078 ; vl %v2, 0(%r1)
+;   vbperm %v4, %v24, %v2
+;   lgdr %r2, %f4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x00, 0x08
+;   lpr %r1, %r8
+;   lpdr %f2, %f8
+;   lper %f3, %f8
+;   sth %r4, 0x58(%r8, %r5)
+;   std %f6, 0x78(%r8, %r7)
+;   vl %v2, 0(%r1)
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -7,9 +7,19 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
 ;   vrepib %v5, 239
+;   vno %v7, %v25, %v25
+;   vmxlb %v17, %v5, %v7
+;   vperm %v24, %v3, %v24, %v17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
+;   vrepib %v5, 0xef
 ;   vno %v7, %v25, %v25
 ;   vmxlb %v17, %v5, %v7
 ;   vperm %v24, %v3, %v24, %v17
@@ -21,8 +31,15 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vrepib %v3, 15
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vrepib %v3, 0xf
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -32,8 +49,24 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x0a1e000d0b1702180403090b15100f0c ; vl %v3, 0(%r1)
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   svc 0x1e
+;   .byte 0x00, 0x0d
+;   bsm %r1, %r7
+;   .byte 0x02, 0x18
+;   .byte 0x04, 0x03
+;   .byte 0x09, 0x0b
+;   clr %r1, %r0
+;   clcl %r0, %r12
+;   vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -43,9 +76,27 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 1
 ;   bras %r1, 20 ; data.u128 0x8080808080808080808080808080800f ; vl %v5, 0(%r1)
+;   vperm %v7, %v24, %v25, %v5
+;   vn %v24, %v3, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 1
+;   bras %r1, 0x1a
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x0f
+;   vl %v5, 0(%r1)
 ;   vperm %v7, %v24, %v25, %v5
 ;   vn %v24, %v3, %v7
 ;   br %r14
@@ -56,7 +107,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v25
 ;   br %r14
 
@@ -66,7 +123,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v25
 ;   br %r14
 
@@ -76,7 +139,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v25
 ;   br %r14
 
@@ -86,7 +155,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v25
 ;   br %r14
 
@@ -96,7 +171,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v24
 ;   br %r14
 
@@ -106,7 +187,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v24
 ;   br %r14
 
@@ -116,7 +203,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v24
 ;   br %r14
 
@@ -126,7 +219,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v24
 ;   br %r14
 
@@ -136,7 +235,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v24
 ;   br %r14
 
@@ -146,7 +251,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v24
 ;   br %r14
 
@@ -156,7 +267,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v24
 ;   br %r14
 
@@ -166,7 +283,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v24
 ;   br %r14
 
@@ -176,7 +299,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v25
 ;   br %r14
 
@@ -186,7 +315,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v25
 ;   br %r14
 
@@ -196,7 +331,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v25
 ;   br %r14
 
@@ -206,7 +347,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v25
 ;   br %r14
 
@@ -216,7 +363,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v25
 ;   br %r14
 
@@ -226,7 +379,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v25
 ;   br %r14
 
@@ -236,7 +395,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v25
 ;   br %r14
 
@@ -246,7 +411,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v25
 ;   br %r14
 
@@ -256,7 +427,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v24
 ;   br %r14
 
@@ -266,7 +443,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v24
 ;   br %r14
 
@@ -276,7 +459,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v24
 ;   br %r14
 
@@ -286,7 +475,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v24
 ;   br %r14
 
@@ -296,7 +491,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v24
 ;   br %r14
 
@@ -306,7 +507,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v24
 ;   br %r14
 
@@ -316,7 +523,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v24
 ;   br %r14
 
@@ -326,7 +539,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v24
 ;   br %r14
 
@@ -336,7 +555,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v25
 ;   br %r14
 
@@ -346,7 +571,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v25
 ;   br %r14
 
@@ -356,7 +587,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v25
 ;   br %r14
 
@@ -366,7 +603,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v25
 ;   br %r14
 
@@ -377,7 +620,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v25
 ;   br %r14
 
@@ -387,7 +636,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v25
 ;   br %r14
 
@@ -397,7 +652,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v25
 ;   br %r14
 
@@ -407,7 +668,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v24
 ;   br %r14
 
@@ -417,7 +684,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v24
 ;   br %r14
 
@@ -427,7 +700,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v24
 ;   br %r14
 
@@ -437,7 +716,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v24
 ;   br %r14
 
@@ -447,7 +732,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v24
 ;   br %r14
 
@@ -457,7 +748,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v24
 ;   br %r14
 
@@ -467,7 +764,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v25
 ;   br %r14
 
@@ -477,7 +780,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v25
 ;   br %r14
 
@@ -487,7 +796,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v25
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
@@ -7,9 +7,18 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
 ;   vrepib %v5, 16
+;   vmnlb %v7, %v5, %v25
+;   vperm %v24, %v24, %v3, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
+;   vrepib %v5, 0x10
 ;   vmnlb %v7, %v5, %v25
 ;   vperm %v24, %v24, %v3, %v7
 ;   br %r14
@@ -20,8 +29,15 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 0
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vzero %v3
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -31,8 +47,24 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x03001f1a04060c0b170d1804020f1105 ; vl %v3, 0(%r1)
+;   vperm %v24, %v24, %v25, %v3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   bras %r1, 0x14
+;   .byte 0x03, 0x00
+;   slr %r1, %r10
+;   .byte 0x04, 0x06
+;   bassm %r0, %r11
+;   xr %r0, %r13
+;   lr %r0, %r4
+;   .byte 0x02, 0x0f
+;   lnr %r0, %r5
+;   vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
 
@@ -42,9 +74,27 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
 ;   vgbm %v3, 32768
 ;   bras %r1, 20 ; data.u128 0x00808080808080808080808080808080 ; vl %v5, 0(%r1)
+;   vperm %v7, %v24, %v25, %v5
+;   vn %v24, %v3, %v7
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vgbm %v3, 0x8000
+;   bras %r1, 0x1a
+;   .byte 0x00, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   .byte 0x80, 0x80
+;   vl %v5, 0(%r1)
 ;   vperm %v7, %v24, %v25, %v5
 ;   vn %v24, %v3, %v7
 ;   br %r14
@@ -55,7 +105,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v25
 ;   br %r14
 
@@ -65,7 +121,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v25
 ;   br %r14
 
@@ -75,7 +137,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v25
 ;   br %r14
 
@@ -85,7 +153,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v25
 ;   br %r14
 
@@ -95,7 +169,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v24
 ;   br %r14
 
@@ -105,7 +185,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v24
 ;   br %r14
 
@@ -115,7 +201,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v24
 ;   br %r14
 
@@ -125,7 +217,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v24
 ;   br %r14
 
@@ -135,7 +233,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v24
 ;   br %r14
 
@@ -145,7 +249,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v24
 ;   br %r14
 
@@ -155,7 +265,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v24
 ;   br %r14
 
@@ -165,7 +281,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v24
 ;   br %r14
 
@@ -175,7 +297,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v25
 ;   br %r14
 
@@ -185,7 +313,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v25
 ;   br %r14
 
@@ -195,7 +329,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v25
 ;   br %r14
 
@@ -205,7 +345,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrhb %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v25
 ;   br %r14
 
@@ -215,7 +361,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v25
 ;   br %r14
 
@@ -225,7 +377,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v25
 ;   br %r14
 
@@ -235,7 +393,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v25
 ;   br %r14
 
@@ -245,7 +409,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v25
 ;   br %r14
 
@@ -255,7 +425,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v24
 ;   br %r14
 
@@ -265,7 +441,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v24
 ;   br %r14
 
@@ -275,7 +457,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v24
 ;   br %r14
 
@@ -285,7 +473,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v24
 ;   br %r14
 
@@ -295,7 +489,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v24
 ;   br %r14
 
@@ -305,7 +505,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v24
 ;   br %r14
 
@@ -315,7 +521,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v24
 ;   br %r14
 
@@ -325,7 +537,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v24
 ;   br %r14
 
@@ -335,7 +553,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v25
 ;   br %r14
 
@@ -345,7 +569,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v25
 ;   br %r14
 
@@ -355,7 +585,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v25
 ;   br %r14
 
@@ -365,7 +601,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vmrlb %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v25
 ;   br %r14
 
@@ -376,7 +618,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v25
 ;   br %r14
 
@@ -386,7 +634,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v25
 ;   br %r14
 
@@ -396,7 +650,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v24, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v25
 ;   br %r14
 
@@ -406,7 +666,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v24
 ;   br %r14
 
@@ -416,7 +682,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v24
 ;   br %r14
 
@@ -426,7 +698,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v25, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v24
 ;   br %r14
 
@@ -436,7 +714,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v24
 ;   br %r14
 
@@ -446,7 +730,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v24
 ;   br %r14
 
@@ -456,7 +746,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v24, %v24
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v24
 ;   br %r14
 
@@ -466,7 +762,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkg %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v25
 ;   br %r14
 
@@ -476,7 +778,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkf %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v25
 ;   br %r14
 
@@ -486,7 +794,13 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ; block0:
+;   vpkh %v24, %v25, %v25
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v25
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
@@ -7,7 +7,14 @@ block0(v0: i64x2, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r2
+;   verllg %v24, %v24, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r2
 ;   verllg %v24, %v24, 0(%r5)
 ;   br %r14
@@ -19,8 +26,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   verllg %v24, %v24, 47
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   verllg %v24, %v24, 0x2f
 ;   br %r14
 
 function %rotr_i32x4_reg(i32x4, i32) -> i32x4 {
@@ -29,7 +42,14 @@ block0(v0: i32x4, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r2
+;   verllf %v24, %v24, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r2
 ;   verllf %v24, %v24, 0(%r5)
 ;   br %r14
@@ -41,8 +61,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   verllf %v24, %v24, 15
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   verllf %v24, %v24, 0xf
 ;   br %r14
 
 function %rotr_i16x8_reg(i16x8, i16) -> i16x8 {
@@ -51,7 +77,14 @@ block0(v0: i16x8, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r2
+;   verllh %v24, %v24, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r2
 ;   verllh %v24, %v24, 0(%r5)
 ;   br %r14
@@ -63,7 +96,13 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllh %v24, %v24, 6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllh %v24, %v24, 6
 ;   br %r14
 
@@ -73,7 +112,14 @@ block0(v0: i8x16, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   lcr %r5, %r2
+;   verllb %v24, %v24, 0(%r5)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lcr %r5, %r2
 ;   verllb %v24, %v24, 0(%r5)
 ;   br %r14
@@ -85,7 +131,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllb %v24, %v24, 5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllb %v24, %v24, 5
 ;   br %r14
 
@@ -95,7 +147,13 @@ block0(v0: i64x2, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllg %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllg %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -106,8 +164,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   verllg %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   verllg %v24, %v24, 0x11
 ;   br %r14
 
 function %rotl_i32x4_reg(i32x4, i32) -> i32x4 {
@@ -116,7 +180,13 @@ block0(v0: i32x4, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllf %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllf %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -127,8 +197,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   verllf %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   verllf %v24, %v24, 0x11
 ;   br %r14
 
 function %rotl_i16x8_reg(i16x8, i16) -> i16x8 {
@@ -137,7 +213,13 @@ block0(v0: i16x8, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllh %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllh %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -148,8 +230,14 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   verllh %v24, %v24, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   verllh %v24, %v24, 0xa
 ;   br %r14
 
 function %rotl_i8x16_reg(i8x16, i8) -> i8x16 {
@@ -158,7 +246,13 @@ block0(v0: i8x16, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllb %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllb %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -169,7 +263,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   verllb %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   verllb %v24, %v24, 3
 ;   br %r14
 
@@ -179,7 +279,13 @@ block0(v0: i64x2, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrlg %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrlg %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -190,8 +296,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesrlg %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesrlg %v24, %v24, 0x11
 ;   br %r14
 
 function %ushr_i32x4_reg(i32x4, i32) -> i32x4 {
@@ -200,7 +312,13 @@ block0(v0: i32x4, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrlf %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrlf %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -211,8 +329,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesrlf %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesrlf %v24, %v24, 0x11
 ;   br %r14
 
 function %ushr_i16x8_reg(i16x8, i16) -> i16x8 {
@@ -221,7 +345,13 @@ block0(v0: i16x8, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrlh %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrlh %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -232,8 +362,14 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesrlh %v24, %v24, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesrlh %v24, %v24, 0xa
 ;   br %r14
 
 function %ushr_i8x16_reg(i8x16, i8) -> i8x16 {
@@ -242,7 +378,13 @@ block0(v0: i8x16, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrlb %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrlb %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -253,7 +395,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrlb %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrlb %v24, %v24, 3
 ;   br %r14
 
@@ -263,7 +411,13 @@ block0(v0: i64x2, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   veslg %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   veslg %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -274,8 +428,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   veslg %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   veslg %v24, %v24, 0x11
 ;   br %r14
 
 function %ishl_i32x4_reg(i32x4, i32) -> i32x4 {
@@ -284,7 +444,13 @@ block0(v0: i32x4, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   veslf %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   veslf %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -295,8 +461,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   veslf %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   veslf %v24, %v24, 0x11
 ;   br %r14
 
 function %ishl_i16x8_reg(i16x8, i16) -> i16x8 {
@@ -305,7 +477,13 @@ block0(v0: i16x8, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   veslh %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   veslh %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -316,8 +494,14 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   veslh %v24, %v24, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   veslh %v24, %v24, 0xa
 ;   br %r14
 
 function %ishl_i8x16_reg(i8x16, i8) -> i8x16 {
@@ -326,7 +510,13 @@ block0(v0: i8x16, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   veslb %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   veslb %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -337,7 +527,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   veslb %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   veslb %v24, %v24, 3
 ;   br %r14
 
@@ -347,7 +543,13 @@ block0(v0: i64x2, v1: i64):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrag %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrag %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -358,8 +560,14 @@ block0(v0: i64x2):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesrag %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesrag %v24, %v24, 0x11
 ;   br %r14
 
 function %sshr_i32x4_reg(i32x4, i32) -> i32x4 {
@@ -368,7 +576,13 @@ block0(v0: i32x4, v1: i32):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesraf %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesraf %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -379,8 +593,14 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesraf %v24, %v24, 17
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesraf %v24, %v24, 0x11
 ;   br %r14
 
 function %sshr_i16x8_reg(i16x8, i16) -> i16x8 {
@@ -389,7 +609,13 @@ block0(v0: i16x8, v1: i16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrah %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrah %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -400,8 +626,14 @@ block0(v0: i16x8):
   return v2
 }
 
+; VCode:
 ; block0:
 ;   vesrah %v24, %v24, 10
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vesrah %v24, %v24, 0xa
 ;   br %r14
 
 function %sshr_i8x16_reg(i8x16, i8) -> i8x16 {
@@ -410,7 +642,13 @@ block0(v0: i8x16, v1: i8):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrab %v24, %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrab %v24, %v24, 0(%r2)
 ;   br %r14
 
@@ -421,7 +659,13 @@ block0(v0: i8x16):
   return v2
 }
 
+; VCode:
 ; block0:
+;   vesrab %v24, %v24, 3
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vesrab %v24, %v24, 3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
@@ -7,7 +7,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
@@ -18,7 +25,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhh %v24, %v2
 ;   br %r14
@@ -29,7 +43,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhf %v24, %v2
 ;   br %r14
@@ -40,7 +61,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
@@ -51,7 +79,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphh %v24, %v2
 ;   br %r14
@@ -62,7 +97,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphf %v24, %v2
 ;   br %r14
@@ -73,7 +115,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -83,7 +131,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -93,7 +147,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -103,7 +163,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -113,7 +179,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v3, 0(%r3)
+;   vst %v3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
 ;   br %r14
@@ -124,7 +197,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -134,7 +213,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -144,7 +229,13 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -154,7 +245,13 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -164,7 +261,13 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -174,7 +277,13 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -184,7 +293,14 @@ block0(v0: i128, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vst %v1, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vst %v1, 0(%r3)
 ;   br %r14
@@ -195,7 +311,13 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -205,7 +327,13 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -215,7 +343,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
@@ -226,7 +361,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   verllh %v4, %v2, 8
+;   vuplhh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
@@ -238,9 +381,19 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
 ;   verllg %v4, %v2, 32
+;   vuplhf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
+;   verllg %v4, %v2, 0x20
 ;   vuplhf %v24, %v4
 ;   br %r14
 
@@ -250,7 +403,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
@@ -261,7 +421,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   verllh %v4, %v2, 8
+;   vuphh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
@@ -273,9 +441,19 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
 ;   verllg %v4, %v2, 32
+;   vuphf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
+;   verllg %v4, %v2, 0x20
 ;   vuphf %v24, %v4
 ;   br %r14
 
@@ -285,7 +463,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -295,8 +479,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrh %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r6
 ;   br %r14
 
 function %load_i32x4_little(i64) -> i32x4 {
@@ -305,8 +497,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f6
 ;   br %r14
 
 function %load_i64x2_little(i64) -> i64x2 {
@@ -315,8 +515,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f6
 ;   br %r14
 
 function %load_i128_little(i64) -> i128 {
@@ -325,9 +533,19 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x30
+;   lper %f0, %f0
+;   sth %r0, 0x730(%r6, %r14)
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x0e
 ;   br %r14
 
 function %load_f32x4_little(i64) -> f32x4 {
@@ -336,8 +554,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f6
 ;   br %r14
 
 function %load_f64x2_little(i64) -> f64x2 {
@@ -346,8 +572,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f6
 ;   br %r14
 
 function %store_i8x16_little(i8x16, i64) {
@@ -356,7 +590,13 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -366,8 +606,16 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrh %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r14
 ;   br %r14
 
 function %store_i32x4_little(i32x4, i64) {
@@ -376,8 +624,16 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f14
 ;   br %r14
 
 function %store_i64x2_little(i64x2, i64) {
@@ -386,8 +642,16 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f14
 ;   br %r14
 
 function %store_i128_little(i128, i64) {
@@ -396,10 +660,18 @@ block0(v0: i128, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vl %v1, 0(%r2)
 ;   vstbrq %v1, 0(%r3)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v1, 0(%r2)
+;   .byte 0xe6, 0x10
+;   lper %f0, %f0
+;   sth %r0, 0x7fe(%r14)
 
 function %store_f32x4_little(f32x4, i64) {
 block0(v0: f32x4, v1: i64):
@@ -407,8 +679,16 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f14
 ;   br %r14
 
 function %store_f64x2_little(f64x2, i64) {
@@ -417,7 +697,15 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f14
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
@@ -7,8 +7,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuplhb %v24, %v2
 ;   br %r14
 
@@ -18,8 +27,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   verllh %v4, %v2, 8
+;   vuplhh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
 ;   br %r14
@@ -30,9 +49,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld %f2, 0(%r2)
 ;   verllg %v4, %v2, 32
+;   vuplhf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld %f2, 0(%r2)
+;   verllg %v4, %v2, 0x20
 ;   vuplhf %v24, %v4
 ;   br %r14
 
@@ -42,8 +69,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuphb %v24, %v2
 ;   br %r14
 
@@ -53,8 +89,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   verllh %v4, %v2, 8
+;   vuphh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
 ;   br %r14
@@ -65,9 +111,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld %f2, 0(%r2)
 ;   verllg %v4, %v2, 32
+;   vuphf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld %f2, 0(%r2)
+;   verllg %v4, %v2, 0x20
 ;   vuphf %v24, %v4
 ;   br %r14
 
@@ -77,9 +131,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_i16x8_big(i64) -> i16x8 wasmtime_system_v {
 block0(v0: i64):
@@ -87,8 +148,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlerh %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r7
 ;   br %r14
 
 function %load_i32x4_big(i64) -> i32x4 wasmtime_system_v {
@@ -97,8 +166,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlerf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f7
 ;   br %r14
 
 function %load_i64x2_big(i64) -> i64x2 wasmtime_system_v {
@@ -107,8 +184,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlerg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f7
 ;   br %r14
 
 function %load_f32x4_big(i64) -> f32x4 wasmtime_system_v {
@@ -117,8 +202,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlerf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f7
 ;   br %r14
 
 function %load_f64x2_big(i64) -> f64x2 wasmtime_system_v {
@@ -127,8 +220,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlerg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f7
 ;   br %r14
 
 function %store_i8x16_big(i8x16, i64) wasmtime_system_v {
@@ -137,9 +238,16 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_i16x8_big(i16x8, i64) wasmtime_system_v {
 block0(v0: i16x8, v1: i64):
@@ -147,8 +255,16 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vsterh %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lr %r0, %r15
 ;   br %r14
 
 function %store_i32x4_big(i32x4, i64) wasmtime_system_v {
@@ -157,8 +273,16 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vsterf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f15
 ;   br %r14
 
 function %store_i64x2_big(i64x2, i64) wasmtime_system_v {
@@ -167,8 +291,16 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vsterg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f15
 ;   br %r14
 
 function %store_f32x4_big(f32x4, i64) wasmtime_system_v {
@@ -177,8 +309,16 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vsterf %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ldr %f0, %f15
 ;   br %r14
 
 function %store_f64x2_big(f64x2, i64) wasmtime_system_v {
@@ -187,8 +327,16 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vsterg %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   ler %f0, %f15
 ;   br %r14
 
 function %uload8x8_little(i64) -> i16x8 wasmtime_system_v {
@@ -197,8 +345,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuplhb %v24, %v2
 ;   br %r14
 
@@ -208,8 +365,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuplhh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuplhh %v24, %v2
 ;   br %r14
 
@@ -219,8 +385,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuplhf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuplhf %v24, %v2
 ;   br %r14
 
@@ -230,8 +405,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuphb %v24, %v2
 ;   br %r14
 
@@ -241,8 +425,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuphh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuphh %v24, %v2
 ;   br %r14
 
@@ -252,8 +445,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlebrg %v2, 0(%r2), 0
+;   vuphf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x20
+;   lpdr %f0, %f0
+;   .byte 0x00, 0x02
 ;   vuphf %v24, %v2
 ;   br %r14
 
@@ -263,9 +465,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_i16x8_little(i64) -> i16x8 wasmtime_system_v {
 block0(v0: i64):
@@ -273,9 +482,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_i32x4_little(i64) -> i32x4 wasmtime_system_v {
 block0(v0: i64):
@@ -283,9 +499,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_i64x2_little(i64) -> i64x2 wasmtime_system_v {
 block0(v0: i64):
@@ -293,9 +516,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_f32x4_little(i64) -> f32x4 wasmtime_system_v {
 block0(v0: i64):
@@ -303,9 +533,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %load_f64x2_little(i64) -> f64x2 wasmtime_system_v {
 block0(v0: i64):
@@ -313,9 +550,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r6)
 
 function %store_i8x16_little(i8x16, i64) wasmtime_system_v {
 block0(v0: i8x16, v1: i64):
@@ -323,9 +567,16 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_i16x8_little(i16x8, i64) wasmtime_system_v {
 block0(v0: i16x8, v1: i64):
@@ -333,9 +584,16 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_i32x4_little(i32x4, i64) wasmtime_system_v {
 block0(v0: i32x4, v1: i64):
@@ -343,9 +601,16 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_i64x2_little(i64x2, i64) wasmtime_system_v {
 block0(v0: i64x2, v1: i64):
@@ -353,9 +618,16 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_f32x4_little(f32x4, i64) wasmtime_system_v {
 block0(v0: f32x4, v1: i64):
@@ -363,9 +635,16 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 
 function %store_f64x2_little(f64x2, i64) wasmtime_system_v {
 block0(v0: f64x2, v1: i64):
@@ -373,7 +652,14 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe6, 0x80
+;   lpdr %f0, %f0
+;   lh %r0, 0x7fe(%r14)
 

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
@@ -7,7 +7,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuplhb %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuplhb %v24, %v4
@@ -19,7 +27,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   verllh %v6, %v4, 8
+;   vuplhh %v24, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   verllh %v6, %v4, 8
@@ -32,9 +49,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld %f2, 0(%r2)
 ;   verllg %v4, %v2, 32
+;   vuplhf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld %f2, 0(%r2)
+;   verllg %v4, %v2, 0x20
 ;   vuplhf %v24, %v4
 ;   br %r14
 
@@ -44,7 +69,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuphb %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuphb %v24, %v4
@@ -56,7 +89,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   verllh %v6, %v4, 8
+;   vuphh %v24, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   verllh %v6, %v4, 8
@@ -69,9 +111,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   ld %f2, 0(%r2)
 ;   verllg %v4, %v2, 32
+;   vuphf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld %f2, 0(%r2)
+;   verllg %v4, %v2, 0x20
 ;   vuphf %v24, %v4
 ;   br %r14
 
@@ -81,7 +131,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -93,11 +151,20 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v6, %v4, 32
 ;   verllf %v24, %v6, 16
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r2)
+;   vpdi %v4, %v2, %v2, 4
+;   verllg %v6, %v4, 0x20
+;   verllf %v24, %v6, 0x10
 ;   br %r14
 
 function %load_i32x4_big(i64) -> i32x4 wasmtime_system_v {
@@ -106,10 +173,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r2)
+;   vpdi %v4, %v2, %v2, 4
+;   verllg %v24, %v4, 0x20
 ;   br %r14
 
 function %load_i64x2_big(i64) -> i64x2 wasmtime_system_v {
@@ -118,7 +193,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r2)
+;   vpdi %v24, %v2, %v2, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
@@ -129,10 +211,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   vl %v2, 0(%r2)
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vl %v2, 0(%r2)
+;   vpdi %v4, %v2, %v2, 4
+;   verllg %v24, %v4, 0x20
 ;   br %r14
 
 function %load_f64x2_big(i64) -> f64x2 wasmtime_system_v {
@@ -141,7 +231,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v2, 0(%r2)
+;   vpdi %v24, %v2, %v2, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
@@ -152,7 +249,16 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -165,10 +271,19 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
 ;   verllf %v7, %v5, 16
+;   vst %v7, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
+;   verllf %v7, %v5, 0x10
 ;   vst %v7, 0(%r2)
 ;   br %r14
 
@@ -178,9 +293,17 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -190,7 +313,14 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vpdi %v3, %v24, %v24, 4
+;   vst %v3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
 ;   vst %v3, 0(%r2)
 ;   br %r14
@@ -201,9 +331,17 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
+;   vst %v5, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
 ;   vst %v5, 0(%r2)
 ;   br %r14
 
@@ -213,7 +351,14 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vpdi %v3, %v24, %v24, 4
+;   vst %v3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
 ;   vst %v3, 0(%r2)
 ;   br %r14
@@ -224,7 +369,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuplhb %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuplhb %v24, %v4
@@ -236,7 +389,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuplhh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuplhh %v24, %v4
@@ -248,7 +409,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuplhf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuplhf %v24, %v4
@@ -260,7 +429,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuphb %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuphb %v24, %v4
@@ -272,7 +449,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuphh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuphh %v24, %v4
@@ -284,7 +469,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   vuphf %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   vuphf %v24, %v4
@@ -296,7 +489,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -308,7 +509,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -320,7 +529,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -332,7 +549,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -344,7 +569,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -356,7 +589,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
@@ -369,9 +610,17 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r5, 0(%r3,%r2)
 ;   lrvg %r3, 8(%r3,%r2)
+;   vlvgp %v24, %r3, %r5
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r5, 0(%r3, %r2)
+;   lrvg %r3, 8(%r3, %r2)
 ;   vlvgp %v24, %r3, %r5
 ;   br %r14
 
@@ -381,9 +630,17 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 128(%r2)
 ;   lrvg %r2, 136(%r2)
+;   vlvgp %v24, %r2, %r4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0x80(%r2)
+;   lrvg %r2, 0x88(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
 
@@ -393,7 +650,16 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -406,7 +672,16 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -419,7 +694,16 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -432,7 +716,16 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -445,7 +738,16 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -458,7 +760,16 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 0(%r2)
@@ -472,11 +783,20 @@ block0(v0: f64x2, v1: i64, v2: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r4, %v24, 0
 ;   strvg %r5, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r4, %v24, 0
+;   strvg %r5, 0(%r3, %r2)
+;   strvg %r4, 8(%r3, %r2)
 ;   br %r14
 
 function %store_f64x2_off_little(f64x2, i64) wasmtime_system_v {
@@ -485,10 +805,19 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vlgvg %r5, %v24, 1
 ;   vlgvg %r3, %v24, 0
 ;   strvg %r5, 128(%r2)
 ;   strvg %r3, 136(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vlgvg %r5, %v24, 1
+;   vlgvg %r3, %v24, 0
+;   strvg %r5, 0x80(%r2)
+;   strvg %r3, 0x88(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -7,7 +7,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
@@ -18,7 +25,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhh %v24, %v2
 ;   br %r14
@@ -29,7 +43,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhf %v24, %v2
 ;   br %r14
@@ -40,7 +61,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
@@ -51,7 +79,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphh %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphh %v24, %v2
 ;   br %r14
@@ -62,7 +97,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphf %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphf %v24, %v2
 ;   br %r14
@@ -73,7 +115,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -83,7 +131,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -93,7 +147,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -103,7 +163,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -113,7 +179,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v3, 0(%r3)
+;   vst %v3, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
 ;   br %r14
@@ -124,7 +197,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -134,7 +213,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -144,7 +229,13 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -154,7 +245,13 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -164,7 +261,13 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -174,7 +277,13 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -184,7 +293,14 @@ block0(v0: i128, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vst %v1, 0(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vst %v1, 0(%r3)
 ;   br %r14
@@ -195,7 +311,13 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -205,7 +327,13 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -215,7 +343,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuplhb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
@@ -226,7 +361,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   verllh %v4, %v2, 8
+;   vuplhh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
@@ -238,10 +381,19 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   verllg %v6, %v4, 32
+;   vuplhf %v24, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   verllg %v6, %v4, 0x20
 ;   vuplhf %v24, %v6
 ;   br %r14
 
@@ -251,7 +403,14 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   vuphb %v24, %v2
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
@@ -262,7 +421,15 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   ld %f2, 0(%r2)
+;   verllh %v4, %v2, 8
+;   vuphh %v24, %v4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
@@ -274,10 +441,19 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f4, %r4
 ;   verllg %v6, %v4, 32
+;   vuphf %v24, %v6
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0(%r2)
+;   ldgr %f4, %r4
+;   verllg %v6, %v4, 0x20
 ;   vuphf %v24, %v6
 ;   br %r14
 
@@ -287,7 +463,13 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   vl %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
 ;   br %r14
 
@@ -297,6 +479,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
@@ -305,6 +488,16 @@ block0(v0: i64):
 ;   verllg %v18, %v16, 32
 ;   verllf %v24, %v18, 16
 ;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v16, %v6, %v6, 4
+;   verllg %v18, %v16, 0x20
+;   verllf %v24, %v18, 0x10
+;   br %r14
 
 function %load_i32x4_little(i64) -> i32x4 {
 block0(v0: i64):
@@ -312,12 +505,22 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v16, %v6, %v6, 4
 ;   verllg %v24, %v16, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v16, %v6, %v6, 4
+;   verllg %v24, %v16, 0x20
 ;   br %r14
 
 function %load_i64x2_little(i64) -> i64x2 {
@@ -326,7 +529,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v24, %v6, %v6, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
@@ -339,7 +551,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r5, 0(%r3)
+;   lrvg %r3, 8(%r3)
+;   vlvgp %v7, %r3, %r5
+;   vst %v7, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r3)
 ;   lrvg %r3, 8(%r3)
 ;   vlvgp %v7, %r3, %r5
@@ -352,12 +573,22 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v16, %v6, %v6, 4
 ;   verllg %v24, %v16, 32
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v16, %v6, %v6, 4
+;   verllg %v24, %v16, 0x20
 ;   br %r14
 
 function %load_f64x2_little(i64) -> f64x2 {
@@ -366,7 +597,16 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
+;   lrvg %r4, 0(%r2)
+;   lrvg %r2, 8(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v24, %v6, %v6, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v6, %r2, %r4
@@ -380,9 +620,18 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r5, 0(%r3,%r2)
 ;   lrvg %r3, 8(%r3,%r2)
+;   vlvgp %v7, %r3, %r5
+;   vpdi %v24, %v7, %v7, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r5, 0(%r3, %r2)
+;   lrvg %r3, 8(%r3, %r2)
 ;   vlvgp %v7, %r3, %r5
 ;   vpdi %v24, %v7, %v7, 4
 ;   br %r14
@@ -393,9 +642,18 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ; block0:
 ;   lrvg %r4, 128(%r2)
 ;   lrvg %r2, 136(%r2)
+;   vlvgp %v6, %r2, %r4
+;   vpdi %v24, %v6, %v6, 4
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   lrvg %r4, 0x80(%r2)
+;   lrvg %r2, 0x88(%r2)
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v24, %v6, %v6, 4
 ;   br %r14
@@ -406,7 +664,13 @@ block0(v0: i8x16, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vst %v24, 0(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
 ;   br %r14
 
@@ -416,10 +680,22 @@ block0(v0: i16x8, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
 ;   verllf %v7, %v5, 16
+;   vlgvg %r3, %v7, 1
+;   lgdr %r5, %f7
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
+;   verllf %v7, %v5, 0x10
 ;   vlgvg %r3, %v7, 1
 ;   lgdr %r5, %f7
 ;   strvg %r3, 0(%r2)
@@ -432,9 +708,20 @@ block0(v0: i32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
+;   vlgvg %r5, %v5, 1
+;   lgdr %r3, %f5
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
 ;   vlgvg %r5, %v5, 1
 ;   lgdr %r3, %f5
 ;   strvg %r5, 0(%r2)
@@ -447,7 +734,17 @@ block0(v0: i64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
 ;   vlgvg %r3, %v3, 1
 ;   lgdr %r5, %f3
@@ -461,7 +758,17 @@ block0(v0: i128, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vl %v1, 0(%r2)
+;   vlgvg %r2, %v1, 1
+;   lgdr %r4, %f1
+;   strvg %r2, 0(%r3)
+;   strvg %r4, 8(%r3)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   lgdr %r4, %f1
@@ -475,9 +782,20 @@ block0(v0: f32x4, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   verllg %v5, %v3, 32
+;   vlgvg %r5, %v5, 1
+;   lgdr %r3, %f5
+;   strvg %r5, 0(%r2)
+;   strvg %r3, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   verllg %v5, %v3, 0x20
 ;   vlgvg %r5, %v5, 1
 ;   lgdr %r3, %f5
 ;   strvg %r5, 0(%r2)
@@ -490,7 +808,17 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0(%r2)
+;   strvg %r5, 8(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
 ;   vlgvg %r3, %v3, 1
 ;   lgdr %r5, %f3
@@ -505,12 +833,22 @@ block0(v0: f64x2, v1: i64, v2: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v4, %v24, %v24, 4
 ;   vlgvg %r5, %v4, 1
 ;   lgdr %r4, %f4
 ;   strvg %r5, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v4, %v24, %v24, 4
+;   vlgvg %r5, %v4, 1
+;   lgdr %r4, %f4
+;   strvg %r5, 0(%r3, %r2)
+;   strvg %r4, 8(%r3, %r2)
 ;   br %r14
 
 function %store_f64x2_off_little(f64x2, i64) {
@@ -519,11 +857,21 @@ block0(v0: f64x2, v1: i64):
   return
 }
 
+; VCode:
 ; block0:
 ;   vpdi %v3, %v24, %v24, 4
 ;   vlgvg %r3, %v3, 1
 ;   lgdr %r5, %f3
 ;   strvg %r3, 128(%r2)
 ;   strvg %r5, 136(%r2)
+;   br %r14
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   vpdi %v3, %v24, %v24, 4
+;   vlgvg %r3, %v3, 1
+;   lgdr %r5, %f3
+;   strvg %r3, 0x80(%r2)
+;   strvg %r5, 0x88(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -8,6 +8,7 @@ block0(v0: i64, v1: i64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rdi, %rsi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_add_imm(i64) -> i64 {
 block0(v0: i64):
@@ -24,6 +34,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -31,6 +42,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x2a(%rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_add_imm_order(i64) -> i64 {
 block0(v0: i64):
@@ -40,6 +60,7 @@ block0(v0: i64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -47,6 +68,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x2a(%rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_add_uext_imm(i64) -> i64 {
 block0(v0: i64):
@@ -57,6 +87,7 @@ block0(v0: i64):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,6 +95,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x2a(%rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_reg_reg_imm(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -74,6 +114,7 @@ block0(v0: i64, v1: i64):
     return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -81,6 +122,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x140(%rdi, %rsi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_reg_reg_imm_negative(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -91,6 +141,7 @@ block0(v0: i64, v1: i64):
     return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -98,6 +149,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq -1(%rdi, %rsi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_reg_reg_imm_scaled(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -109,6 +169,7 @@ block0(v0: i64, v1: i64):
     return v6
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -116,7 +177,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq -1(%rdi, %rsi, 8), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_reg_reg_imm_uext_scaled(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):
@@ -129,6 +198,7 @@ block0(v0: i64, v1: i32):
     return v7
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -137,6 +207,16 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl %esi, %ecx
+;   movq -1(%rdi, %rcx, 8), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %amode_reg_reg_imm_uext_scaled_add(i64, i32, i32) -> i64 {
 block0(v0: i64, v1: i32, v2: i32):
@@ -150,6 +230,7 @@ block0(v0: i64, v1: i32, v2: i32):
     return v9
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -159,4 +240,15 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %r8
+;   addl %edx, %r8d
+;   movq -1(%rdi, %r8, 4), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -8,6 +8,7 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,15 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andnl %edi, %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %reversed_operands(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -23,6 +33,7 @@ block0(v0: i8, v1: i8):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +41,13 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andnl %esi, %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -7,6 +7,7 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,4 +16,14 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addl %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movd %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32) -> f32 {
 block0(v0: i32):
@@ -21,6 +31,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movd %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(f64) -> i64 {
 block0(v0: f64):
@@ -35,6 +55,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %xmm0, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64) -> f64 {
 block0(v0: i64):
@@ -49,6 +79,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,4 +87,13 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -9,6 +9,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -19,6 +20,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rdi, %rax
+;   sbbq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i64_i32(i64) -> i32 {
 block0(v0: i64):
@@ -26,6 +39,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -36,6 +50,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i64_i16(i64) -> i16 {
 block0(v0: i64):
@@ -43,6 +69,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -53,6 +80,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i64_i8(i64) -> i8 {
 block0(v0: i64):
@@ -60,6 +99,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -70,6 +110,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i32_i64(i32) -> i64 {
 block0(v0: i32):
@@ -77,6 +129,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -87,6 +140,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   movq %rdi, %rax
+;   sbbq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i32_i32(i32) -> i32 {
 block0(v0: i32):
@@ -94,6 +159,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -104,6 +170,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i32_i16(i32) -> i16 {
 block0(v0: i32):
@@ -111,6 +189,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -121,6 +200,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i32_i8(i32) -> i8 {
 block0(v0: i32):
@@ -128,6 +219,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -138,6 +230,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i16_i64(i16) -> i64 {
 block0(v0: i16):
@@ -145,6 +249,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -155,6 +260,18 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   movq %rdi, %rax
+;   sbbq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i16_i32(i16) -> i32 {
 block0(v0: i16):
@@ -162,6 +279,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -172,6 +290,18 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i16_i16(i16) -> i16 {
 block0(v0: i16):
@@ -179,6 +309,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -189,6 +320,18 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i16_i8(i16) -> i8 {
 block0(v0: i16):
@@ -196,6 +339,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -206,6 +350,18 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i8_i64(i8) -> i64 {
 block0(v0: i8):
@@ -213,6 +369,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -223,6 +380,18 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   movq %rdi, %rax
+;   sbbq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i8_i32(i8) -> i32 {
 block0(v0: i8):
@@ -230,6 +399,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -240,6 +410,18 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i8_i16(i8) -> i16 {
 block0(v0: i8):
@@ -247,6 +429,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -257,6 +440,18 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i8_i8(i8) -> i8 {
 block0(v0: i8):
@@ -264,6 +459,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -274,6 +470,18 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i128_i128(i128) -> i128 {
 block0(v0: i128):
@@ -281,6 +489,7 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -293,6 +502,20 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rdx
+;   orq %rsi, %rdx
+;   movq %rdx, %r8
+;   negq %r8
+;   sbbq %rdx, %rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i128_i64(i128) -> i64 {
 block0(v0: i128):
@@ -300,6 +523,7 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -311,6 +535,19 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   orq %rsi, %rax
+;   movq %rax, %r8
+;   negq %r8
+;   sbbq %rax, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i128_i32(i128) -> i32 {
 block0(v0: i128):
@@ -318,6 +555,7 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -329,6 +567,19 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   orq %rsi, %rax
+;   movq %rax, %r8
+;   negq %r8
+;   sbbl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i128_i16(i128) -> i16 {
 block0(v0: i128):
@@ -336,6 +587,7 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -347,6 +599,19 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   orq %rsi, %rax
+;   movq %rax, %r8
+;   negq %r8
+;   sbbl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i128_i8(i128) -> i8 {
 block0(v0: i128):
@@ -354,6 +619,7 @@ block0(v0: i128):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -365,6 +631,19 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   orq %rsi, %rax
+;   movq %rax, %r8
+;   negq %r8
+;   sbbl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i64_i128(i64) -> i128 {
 block0(v0: i64):
@@ -372,6 +651,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -383,6 +663,19 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rdi, %rdx
+;   sbbq %rdi, %rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i32_i128(i32) -> i128 {
 block0(v0: i32):
@@ -390,6 +683,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -401,6 +695,19 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   movq %rdi, %rdx
+;   sbbq %rdi, %rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i16_i128(i16) -> i128 {
 block0(v0: i16):
@@ -408,6 +715,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -419,6 +727,19 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   movq %rdi, %rdx
+;   sbbq %rdi, %rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bmask_i8_i128(i8) -> i128 {
 block0(v0: i8):
@@ -426,6 +747,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -437,4 +759,17 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   movq %rdi, %rdx
+;   sbbq %rdi, %rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -15,6 +15,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,6 +31,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   jne 0x16
+; block1: ; offset 0xc
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x16
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -45,6 +63,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -60,6 +79,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   jne 0x16
+; block1: ; offset 0xc
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x16
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -75,6 +111,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -90,6 +127,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   jne 0x16
+; block1: ; offset 0xc
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x16
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(f32, f32) -> i32 {
 block0(v0: f32, v1: f32):
@@ -105,6 +159,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -121,6 +176,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   jp 0x1d
+;   jne 0x1d
+; block1: ; offset 0x13
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x1d
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):
@@ -134,6 +207,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -150,6 +224,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   jp 0x1a
+;   jne 0x1a
+; block1: ; offset 0x13
+;   xorl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x1a
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):
@@ -163,6 +255,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -179,6 +272,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   jp 0x13
+;   je 0x1a
+; block1: ; offset 0x13
+;   xorl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x1a
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i32) -> i8 {
 block0(v0: i32):
@@ -193,6 +304,7 @@ block2:
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -212,6 +324,34 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl $2, %edi
+;   jae 0x34
+;   movl %edi, %r9d
+;   movl $0, %r8d
+;   cmovaeq %r8, %r9
+;   leaq 0xb(%rip), %r8
+;   movslq (%r8, %r9, 4), %r9
+;   addq %r9, %r8
+;   jmpq *%r8
+;   orb %al, (%rax)
+;   addb %al, (%rax)
+;   adcb (%rax), %al
+;   addb %al, (%rax)
+; block1: ; offset 0x34
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x3e
+;   xorl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i64) -> i8 {
 block0(v0: i64):
@@ -226,6 +366,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -241,6 +382,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpq $0, %rdi
+;   jge 0x18
+; block1: ; offset 0xe
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x18
+;   xorl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i32) -> i8 {
 block0(v0: i32):
@@ -255,6 +413,7 @@ block2:
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -270,6 +429,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl $0, %edi
+;   jge 0x17
+; block1: ; offset 0xd
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x17
+;   xorl %eax, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %fflags(f32) {
 block200(v0: f32):
@@ -291,6 +467,7 @@ block202:
     trap heap_oob
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -314,7 +491,27 @@ block202:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x42500000, %edx
+;   movd %edx, %xmm6
+;   ucomiss %xmm6, %xmm0
+;   jp 0x1c
+;   je 0x33
+; block1: ; offset 0x1c
+;   movl $0x42500000, %r11d
+;   movd %r11d, %xmm10
+;   ucomiss %xmm10, %xmm0
+;   jp 0x33
+; block2: ; offset 0x31
+;   ud2 ; trap: heap_oob
+; block3: ; offset 0x33
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %br_i8_icmp(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -331,6 +528,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -346,6 +544,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   jne 0x16
+; block1: ; offset 0xc
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x16
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %br_i8_fcmp(f32, f32) -> i32 {
 block0(v0: f32, v1: f32):
@@ -362,6 +577,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -378,6 +594,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   jp 0x1d
+;   jne 0x1d
+; block1: ; offset 0x13
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x1d
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %brif_i8_icmp(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -394,6 +628,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -409,6 +644,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   jne 0x16
+; block1: ; offset 0xc
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x16
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %brif_i8_fcmp(f32, f32) -> i32 {
 block0(v0: f32, v1: f32):
@@ -425,6 +677,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -441,3 +694,22 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   jp 0x1d
+;   jne 0x1d
+; block1: ; offset 0x13
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x1d
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/x64/bswap.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   bswapq %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i32) -> i32 {
 block0(v0: i32):
@@ -22,6 +33,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,6 +42,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   bswapl %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16) -> i16 {
 block0(v0: i16):
@@ -37,6 +59,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -45,4 +68,14 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   rolw $8, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -9,6 +9,7 @@ block0(v0: i32):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -21,6 +22,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rcx
+;   subq $0x20, %rsp
+;   callq *%rcx
+;   addq $0x20, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %two_args(i32, f32) system_v {
     ;; system_v has params in %rdi, %xmm0, fascall in %rcx, %xmm1
@@ -32,6 +45,7 @@ block0(v0: i32, v1: f32):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +62,22 @@ block0(v0: i32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm6
+;   subq $0x20, %rsp
+;   movq %rdi, %rcx
+;   movdqa %xmm6, %xmm1
+;   callq *%rdi
+;   addq $0x20, %rsp
+;   movdqa %xmm6, %xmm0
+;   callq *%rdi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %fastcall_to_systemv(i32) windows_fastcall {
     ;; fastcall preserves xmm6+, rbx, rbp, rdi, rsi, r12-r15
@@ -58,6 +88,7 @@ block0(v0: i32):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $176, %rsp
@@ -91,6 +122,41 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0xb0, %rsp
+;   movq %rsi, (%rsp)
+;   movq %rdi, 8(%rsp)
+;   movdqu %xmm6, 0x10(%rsp)
+;   movdqu %xmm7, 0x20(%rsp)
+;   movdqu %xmm8, 0x30(%rsp)
+;   movdqu %xmm9, 0x40(%rsp)
+;   movdqu %xmm10, 0x50(%rsp)
+;   movdqu %xmm11, 0x60(%rsp)
+;   movdqu %xmm12, 0x70(%rsp)
+;   movdqu %xmm13, 0x80(%rsp)
+;   movdqu %xmm14, 0x90(%rsp)
+;   movdqu %xmm15, 0xa0(%rsp)
+; block0: ; offset 0x61
+;   callq *%rcx
+;   movq (%rsp), %rsi
+;   movq 8(%rsp), %rdi
+;   movdqu 0x10(%rsp), %xmm6
+;   movdqu 0x20(%rsp), %xmm7
+;   movdqu 0x30(%rsp), %xmm8
+;   movdqu 0x40(%rsp), %xmm9
+;   movdqu 0x50(%rsp), %xmm10
+;   movdqu 0x60(%rsp), %xmm11
+;   movdqu 0x70(%rsp), %xmm12
+;   movdqu 0x80(%rsp), %xmm13
+;   movdqu 0x90(%rsp), %xmm14
+;   movdqu 0xa0(%rsp), %xmm15
+;   addq $0xb0, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %many_args(
     ;; rdi, rsi, rdx, rcx, r8, r9,
@@ -122,6 +188,7 @@ block0(
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -159,6 +226,43 @@ block0(
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rcx, %rax
+;   movq %rdx, %rcx
+;   movq %rsi, %rdx
+;   movq %rdi, %rsi
+;   movq %rax, %rdi
+;   movq 0x10(%rbp), %r10
+;   movq 0x18(%rbp), %r11
+;   movss 0x20(%rbp), %xmm9
+;   movsd 0x28(%rbp), %xmm8
+;   subq $0x90, %rsp
+;   movq %r8, 0x20(%rsp)
+;   movq %r9, 0x28(%rsp)
+;   movsd %xmm0, 0x30(%rsp)
+;   movsd %xmm1, 0x38(%rsp)
+;   movsd %xmm2, 0x40(%rsp)
+;   movsd %xmm3, 0x48(%rsp)
+;   movsd %xmm4, 0x50(%rsp)
+;   movsd %xmm5, 0x58(%rsp)
+;   movsd %xmm6, 0x60(%rsp)
+;   movsd %xmm7, 0x68(%rsp)
+;   movq %r10, 0x70(%rsp)
+;   movl %r11d, 0x78(%rsp)
+;   movss %xmm9, 0x80(%rsp)
+;   movsd %xmm8, 0x88(%rsp)
+;   movq %rdi, %r9
+;   movq %rcx, %r8
+;   movq %rsi, %rcx
+;   callq *%rcx
+;   addq $0x90, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %many_ints(i64, i64, i64, i64, i64) system_v {
     ;; rdi => rcx
@@ -172,6 +276,7 @@ block0(v0: i64, v1:i64, v2:i64, v3:i64, v4:i64):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -189,6 +294,23 @@ block0(v0: i64, v1:i64, v2:i64, v3:i64, v4:i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %r11
+;   movq %rcx, %r9
+;   movq %rsi, %rdx
+;   movq %rdi, %rcx
+;   subq $0x30, %rsp
+;   movq %r8, 0x20(%rsp)
+;   movq %r11, %r8
+;   callq *%rcx
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %many_args2(i32, f32, i64, f64, i32, i32, i32, f32, f64, f32, f64) system_v {
     sig0 = (i32, f32, i64, f64, i32, i32, i32, f32, f64, f32, f64) windows_fastcall
@@ -197,6 +319,7 @@ block0(v0: i32, v1: f32, v2: i64, v3: f64, v4: i32, v5: i32, v6: i32, v7: f32, v
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -222,6 +345,31 @@ block0(v0: i32, v1: f32, v2: i64, v3: f64, v4: i32, v5: i32, v6: i32, v7: f32, v
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %r9
+;   movq %rdi, %rsi
+;   movdqa %xmm1, %xmm12
+;   movdqa %xmm0, %xmm1
+;   subq $0x60, %rsp
+;   movl %edx, 0x20(%rsp)
+;   movl %ecx, 0x28(%rsp)
+;   movl %r8d, 0x30(%rsp)
+;   movss %xmm2, 0x38(%rsp)
+;   movsd %xmm3, 0x40(%rsp)
+;   movss %xmm4, 0x48(%rsp)
+;   movsd %xmm5, 0x50(%rsp)
+;   movq %rsi, %rcx
+;   movq %r9, %r8
+;   movdqa %xmm12, %xmm3
+;   callq *%rcx
+;   addq $0x60, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix1(i32) wasmtime_system_v {
     sig0 = (i32) system_v
@@ -230,6 +378,7 @@ block0(v0: i32):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -237,6 +386,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   callq *%rdi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix2(i32) system_v {
     sig0 = (i32) wasmtime_system_v
@@ -245,6 +403,7 @@ block0(v0: i32):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -252,6 +411,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   callq *%rdi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix2() -> i32, i32 system_v {
     sig0 = () -> i32, i32 wasmtime_system_v
@@ -261,6 +429,7 @@ block0:
     return v0, v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -275,6 +444,20 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $1, %esi
+;   subq $0x10, %rsp
+;   leaq (%rsp), %rdi
+;   callq *%rsi
+;   movq (%rsp), %rdx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix3() -> i32, i32 wasmtime_system_v {
     sig0 = () -> i32, i32 system_v
@@ -284,6 +467,7 @@ block0:
     return v0, v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -299,6 +483,23 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rbx, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdi, %rbx
+;   movl $1, %eax
+;   callq *%rax
+;   movq %rbx, %rdi
+;   movl %edx, (%rdi)
+;   movq (%rsp), %rbx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix4() -> i32, i64, i32 wasmtime_system_v {
     sig0 = () -> i32, i64, i32 system_v
@@ -308,6 +509,7 @@ block0:
     return v0, v1, v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -330,6 +532,28 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r13, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdi, %r13
+;   movl $1, %eax
+;   subq $0x10, %rsp
+;   leaq (%rsp), %rdi
+;   callq *%rax
+;   movq (%rsp), %rdi
+;   addq $0x10, %rsp
+;   movq %r13, %r9
+;   movq %rdx, (%r9)
+;   movl %edi, 8(%r9)
+;   movq (%rsp), %r13
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix5() -> f32, i64, i32, f32 wasmtime_system_v {
     sig0 = () -> f32, i64, i32, f32 system_v
@@ -339,6 +563,7 @@ block0:
     return v0, v1, v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -356,6 +581,25 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r13, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdi, %r13
+;   movl $1, %eax
+;   callq *%rax
+;   movq %r13, %rdi
+;   movq %rax, (%rdi)
+;   movl %edx, 8(%rdi)
+;   movss %xmm1, 0xc(%rdi)
+;   movq (%rsp), %r13
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %wasmtime_mix6(f32, i64, i32, f32) -> f32, i64, i32, f32 wasmtime_system_v {
     sig0 = (f32, i64, i32, f32) -> f32, i64, i32, f32 system_v
@@ -365,6 +609,7 @@ block0(v0: f32, v1: i64, v2: i32, v3: f32):
     return v5, v6, v7, v8
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -382,4 +627,23 @@ block0(v0: f32, v1: i64, v2: i32, v3: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r12, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdx, %r12
+;   movl $1, %r9d
+;   callq *%r9
+;   movq %r12, %r8
+;   movq %rax, (%r8)
+;   movl %edx, 8(%r8)
+;   movss %xmm1, 0xc(%r8)
+;   movq (%rsp), %r12
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %CeilF32 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -22,6 +33,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +42,14 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %CeilF64 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundss $2, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -21,6 +31,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundsd $2, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -35,6 +55,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundps $2, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -49,6 +79,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,4 +87,13 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundpd $2, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   lzcntq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %clz(i32) -> i32 {
 block0(v0: i32):
@@ -21,6 +31,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,4 +39,13 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   lzcntl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -10,6 +10,7 @@ block0(v0: i64, v1: i64):
     return v4, v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -23,6 +24,21 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rsi), %r9 ; trap: heap_oob
+;   cmpq %r9, %rdi
+;   sete %r10b
+;   movzbq %r10b, %rax
+;   cmpq %r9, %rdi
+;   movq %rsi, %rdx
+;   cmoveq %rdi, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(f64, i64) -> i64, f64 {
 block0(v0: f64, v1: i64):
@@ -33,6 +49,7 @@ block0(v0: f64, v1: i64):
     return v4, v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -49,4 +66,24 @@ block0(v0: f64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsd (%rdi), %xmm9 ; trap: heap_oob
+;   ucomisd %xmm9, %xmm0
+;   setnp %dil
+;   sete %al
+;   andl %eax, %edi
+;   movzbq %dil, %rax
+;   ucomisd %xmm0, %xmm9
+;   movdqa %xmm0, %xmm2
+;   je 0x2f
+;   movsd %xmm2, %xmm0
+;   jnp 0x39
+;   movsd %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -7,6 +7,7 @@ block0(v0: i8, v1: i32, v2: i32):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   testb %dil, %dil
+;   movq %rdx, %rax
+;   cmovnel %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i8) -> i32 {
 block0(v0: i8):
@@ -28,6 +40,7 @@ block2:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -43,6 +56,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   testb %dil, %dil
+;   je 0x17
+; block1: ; offset 0xd
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x17
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i8) -> i32 {
 block0(v0: i8):
@@ -55,6 +85,7 @@ block2:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -70,6 +101,23 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   testb %dil, %dil
+;   je 0x17
+; block1: ; offset 0xd
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x17
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64) -> i32 {
 block0(v0: i64):
@@ -85,6 +133,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -101,6 +150,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl (%rdi), %edx ; trap: heap_oob
+;   cmpl $1, %edx
+;   jne 0x19
+; block1: ; offset 0xf
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x19
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64) -> i32 {
 block0(v0: i64):
@@ -116,6 +183,7 @@ block2:
   return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -132,6 +200,24 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl (%rdi), %edx ; trap: heap_oob
+;   cmpl $1, %edx
+;   jne 0x19
+; block1: ; offset 0xf
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x19
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_x_slt_0_i64(i64) -> i8 {
 block0(v0: i64):
@@ -140,6 +226,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -148,6 +235,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrq $0x3f, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_x_slt_0_i32f4(i32) -> i8 {
 block0(v0: i32):
@@ -156,6 +253,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -164,6 +262,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrl $0x1f, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_0_sgt_x_i64(i64) -> i8 {
 block0(v0: i64):
@@ -172,6 +280,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -180,6 +289,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrq $0x3f, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_0_sgt_x_i32f4(i32) -> i8 {
 block0(v0: i32):
@@ -188,6 +307,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -196,6 +316,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrl $0x1f, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_0_sle_x_i64(i64) -> i8 {
 block0(v0: i64):
@@ -204,6 +334,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -213,6 +344,17 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   notq %rax
+;   shrq $0x3f, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_0_sle_x_i32f4(i32) -> i8 {
 block0(v0: i32):
@@ -221,6 +363,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -230,6 +373,17 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   notq %rax
+;   shrl $0x1f, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_x_sge_x_i64(i64) -> i8 {
 block0(v0: i64):
@@ -238,6 +392,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -247,6 +402,17 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   notq %rax
+;   shrq $0x3f, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %test_x_sge_x_i32f4(i32) -> i8 {
 block0(v0: i32):
@@ -255,6 +421,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -264,4 +431,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   notq %rax
+;   shrl $0x1f, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   tzcntq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ctz(i32) -> i32 {
 block0(v0: i32):
@@ -21,6 +31,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,4 +39,13 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   tzcntl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -14,6 +14,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -24,6 +25,26 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpb $0, %sil
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpb $0xff, %sil
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cbtw
+;   idivb %sil ; trap: int_divz
+;   shrq $8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -32,6 +53,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +64,26 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpw $0, %si
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpw $-1, %si
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cwtd
+;   idivw %si ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -50,6 +92,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -60,6 +103,26 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpl $0, %esi
+;   jne 0x14
+;   ud2 ; trap: int_divz
+;   cmpl $-1, %esi
+;   jne 0x27
+;   movl $0, %eax
+;   jmp 0x2a
+;   cltd
+;   idivl %esi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -68,6 +131,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -78,4 +142,24 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpq $0, %rsi
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpq $-1, %rsi
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cqto
+;   idivq %rsi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -7,6 +7,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pextrb $1, %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16x8) -> i16 {
 block0(v0: i16x8):
@@ -21,6 +31,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pextrw $1, %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32x4) -> i32 {
 block0(v0: i32x4):
@@ -35,6 +55,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pextrd $1, %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64x2) -> i64 {
 block0(v0: i64x2):
@@ -49,6 +79,7 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,6 +87,15 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pextrq $1, %xmm0, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(f32x4) -> f32 {
 block0(v0: f32x4):
@@ -63,6 +103,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -70,6 +111,15 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $1, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(f64x2) -> f64 {
 block0(v0: f64x2):
@@ -77,6 +127,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -84,4 +135,13 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0xee, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/fabs.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x7fffffff, %eax
+;   movd %eax, %xmm4
+;   andps %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -23,6 +35,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x7fffffffffffffff, %rax
+;   movq %rax, %xmm4
+;   andpd %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -39,6 +63,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +73,17 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm3, %xmm3
+;   psrld $1, %xmm3
+;   andps %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -55,6 +91,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,4 +101,15 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm3, %xmm3
+;   psrlq $1, %xmm3
+;   andpd %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -8,6 +8,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
   return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -17,12 +18,22 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rcx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i64, i64, i64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: i64, v3: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -32,12 +43,22 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i64, i64, i64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: i64, v3: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -47,12 +68,22 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64, i64, i64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: i64, v3: i64):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -62,12 +93,22 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %r9, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64, f64, i64) -> f64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: f64, v3: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -77,12 +118,22 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i64, i64, f64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: f64, v3: i64):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -92,6 +143,15 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %r9, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i64, i64, i64, i64, i64, i64) -> i64 windows_fastcall {
 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
@@ -108,6 +168,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;; TODO(#2704): fix regalloc's register priority ordering!
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -118,12 +179,23 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x30(%rbp), %r8
+;   movq 0x38(%rbp), %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i128, i64, i128, i128) -> i128 windows_fastcall {
 block0(v0: i128, v1: i64, v2: i128, v3: i128):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -135,6 +207,17 @@ block0(v0: i128, v1: i64, v2: i128, v3: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq 0x30(%rbp), %r8
+;   movq 0x38(%rbp), %rax
+;   movq 0x40(%rbp), %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f8(i64) -> i64 windows_fastcall {
   sig0 = (i64, i64, f64, f64, i64, i64) -> i64 windows_fastcall
@@ -146,6 +229,7 @@ block0(v0: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -166,6 +250,24 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtsi2sdq %rcx, %xmm3
+;   subq $0x30, %rsp
+;   movq %rcx, 0x20(%rsp)
+;   movq %rcx, 0x28(%rsp)
+;   movq %rcx, %rdx
+;   movabsq $0, %r11 ; reloc_external Abs8 %g 0
+;   movq %rdx, %rcx
+;   movdqa %xmm3, %xmm2
+;   callq *%r11
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f9(i64) -> f64 windows_fastcall {
 block0(v0: i64):
@@ -217,6 +319,7 @@ block0(v0: i64):
   return v39
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
 ;   movq    %rsp, %rbp
@@ -308,4 +411,85 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x100, %rsp
+;   movdqu %xmm6, 0x60(%rsp)
+;   movdqu %xmm7, 0x70(%rsp)
+;   movdqu %xmm8, 0x80(%rsp)
+;   movdqu %xmm9, 0x90(%rsp)
+;   movdqu %xmm10, 0xa0(%rsp)
+;   movdqu %xmm11, 0xb0(%rsp)
+;   movdqu %xmm12, 0xc0(%rsp)
+;   movdqu %xmm13, 0xd0(%rsp)
+;   movdqu %xmm14, 0xe0(%rsp)
+;   movdqu %xmm15, 0xf0(%rsp)
+; block0: ; offset 0x67
+;   movsd (%rcx), %xmm0 ; trap: heap_oob
+;   movsd 8(%rcx), %xmm10 ; trap: heap_oob
+;   movdqu %xmm10, 0x50(%rsp)
+;   movsd 0x10(%rcx), %xmm2 ; trap: heap_oob
+;   movdqu %xmm2, (%rsp)
+;   movsd 0x18(%rcx), %xmm14 ; trap: heap_oob
+;   movdqu %xmm14, 0x40(%rsp)
+;   movsd 0x20(%rcx), %xmm13 ; trap: heap_oob
+;   movsd 0x28(%rcx), %xmm15 ; trap: heap_oob
+;   movdqu %xmm15, 0x30(%rsp)
+;   movsd 0x30(%rcx), %xmm7 ; trap: heap_oob
+;   movsd 0x38(%rcx), %xmm5 ; trap: heap_oob
+;   movdqu %xmm5, 0x20(%rsp)
+;   movsd 0x40(%rcx), %xmm12 ; trap: heap_oob
+;   movsd 0x48(%rcx), %xmm4 ; trap: heap_oob
+;   movdqu %xmm4, 0x10(%rsp)
+;   movsd 0x50(%rcx), %xmm9 ; trap: heap_oob
+;   movsd 0x58(%rcx), %xmm4 ; trap: heap_oob
+;   movsd 0x60(%rcx), %xmm3 ; trap: heap_oob
+;   movsd 0x68(%rcx), %xmm8 ; trap: heap_oob
+;   movsd 0x70(%rcx), %xmm11 ; trap: heap_oob
+;   movsd 0x78(%rcx), %xmm10 ; trap: heap_oob
+;   movsd 0x80(%rcx), %xmm6 ; trap: heap_oob
+;   movsd 0x88(%rcx), %xmm14 ; trap: heap_oob
+;   movsd 0x90(%rcx), %xmm1 ; trap: heap_oob
+;   movsd 0x98(%rcx), %xmm15 ; trap: heap_oob
+;   movdqu 0x50(%rsp), %xmm2
+;   addsd %xmm2, %xmm0
+;   movdqu (%rsp), %xmm2
+;   movdqu 0x40(%rsp), %xmm5
+;   addsd %xmm5, %xmm2
+;   movdqu 0x30(%rsp), %xmm5
+;   addsd %xmm5, %xmm13
+;   movdqu 0x20(%rsp), %xmm5
+;   addsd %xmm5, %xmm7
+;   movdqu 0x10(%rsp), %xmm5
+;   addsd %xmm5, %xmm12
+;   addsd %xmm4, %xmm9
+;   addsd %xmm8, %xmm3
+;   addsd %xmm10, %xmm11
+;   addsd %xmm14, %xmm6
+;   addsd %xmm15, %xmm1
+;   addsd %xmm2, %xmm0
+;   addsd %xmm7, %xmm13
+;   addsd %xmm9, %xmm12
+;   addsd %xmm11, %xmm3
+;   addsd %xmm1, %xmm6
+;   addsd %xmm13, %xmm0
+;   addsd %xmm3, %xmm12
+;   addsd %xmm12, %xmm0
+;   addsd %xmm6, %xmm0
+;   movdqu 0x60(%rsp), %xmm6
+;   movdqu 0x70(%rsp), %xmm7
+;   movdqu 0x80(%rsp), %xmm8
+;   movdqu 0x90(%rsp), %xmm9
+;   movdqu 0xa0(%rsp), %xmm10
+;   movdqu 0xb0(%rsp), %xmm11
+;   movdqu 0xc0(%rsp), %xmm12
+;   movdqu 0xd0(%rsp), %xmm13
+;   movdqu 0xe0(%rsp), %xmm14
+;   movdqu 0xf0(%rsp), %xmm15
+;   addq $0x100, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -7,6 +7,7 @@ block0(v0: f32, v1: f32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -20,6 +21,21 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x80000000, %ecx
+;   movd %ecx, %xmm7
+;   movdqa %xmm0, %xmm10
+;   movdqa %xmm7, %xmm0
+;   andnps %xmm10, %xmm0
+;   andps %xmm1, %xmm7
+;   orps %xmm7, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(f64, f64) -> f64 {
 block0(v0: f64, v1: f64):
@@ -27,6 +43,7 @@ block0(v0: f64, v1: f64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -40,4 +57,19 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $9223372036854775808, %rcx
+;   movq %rcx, %xmm7
+;   movdqa %xmm0, %xmm10
+;   movdqa %xmm7, %xmm0
+;   andnpd %xmm10, %xmm0
+;   andpd %xmm1, %xmm7
+;   orpd %xmm7, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -8,6 +8,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,4 +16,13 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   vcvtudq2ps %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -7,6 +7,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsbl %dil, %eax
+;   cvtsi2ssl %eax, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16) -> f32 {
 block0(v0: i16):
@@ -22,6 +33,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,6 +42,16 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movswl %di, %eax
+;   cvtsi2ssl %eax, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32) -> f32 {
 block0(v0: i32):
@@ -37,6 +59,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -44,6 +67,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtsi2ssl %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64) -> f32 {
 block0(v0: i64):
@@ -51,6 +83,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -58,6 +91,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtsi2ssq %rdi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i8) -> f64 {
 block0(v0: i8):
@@ -65,6 +107,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -73,6 +116,16 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsbl %dil, %eax
+;   cvtsi2sdl %eax, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i16) -> f64 {
 block0(v0: i16):
@@ -80,6 +133,7 @@ block0(v0: i16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -88,6 +142,16 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movswl %di, %eax
+;   cvtsi2sdl %eax, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i32) -> f64 {
 block0(v0: i32):
@@ -95,6 +159,7 @@ block0(v0: i32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -102,6 +167,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtsi2sdl %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f8(i64) -> f64 {
 block0(v0: i64):
@@ -109,6 +183,7 @@ block0(v0: i64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -116,6 +191,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtsi2sdq %rdi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f9(i32x4) -> f64x2 {
 block0(v0: i32x4):
@@ -123,6 +207,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -130,6 +215,15 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvtdq2pd %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f10(i8, i16, i32, i64) -> f32 {
 block0(v0: i8, v1: i16, v2: i32, v3: i64):
@@ -143,6 +237,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
   return v10
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -159,6 +254,34 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dil, %r9
+;   cvtsi2ssq %r9, %xmm0
+;   movzwq %si, %r9
+;   cvtsi2ssq %r9, %xmm1
+;   movl %edx, %r9d
+;   cvtsi2ssq %r9, %xmm2
+;   cmpq $0, %rcx
+;   jl 0x32
+;   cvtsi2ssq %rcx, %xmm14
+;   jmp 0x4d
+;   movq %rcx, %r9
+;   shrq $1, %r9
+;   movq %rcx, %r10
+;   andq $1, %r10
+;   orq %r9, %r10
+;   cvtsi2ssq %r10, %xmm14
+;   addss %xmm14, %xmm14
+;   addss %xmm1, %xmm0
+;   addss %xmm2, %xmm0
+;   addss %xmm14, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f11(i32x4) -> f64x2 {
 block0(v0: i32x4):
@@ -167,6 +290,7 @@ block0(v0: i32x4):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -177,6 +301,32 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x14(%rip), %xmm2
+;   unpcklps %xmm2, %xmm0
+;   movdqu 0x19(%rip), %xmm6
+;   subpd %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   xorb %al, (%rbx)
+;   addb %dh, (%rax)
+;   addb %al, (%r8)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   xorb %al, (%rbx)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %dh, (%rax)
 
 function %f12(i32x4) -> f32x4 {
 block0(v0: i32x4):
@@ -184,6 +334,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -200,6 +351,24 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm3
+;   pslld $0x10, %xmm3
+;   psrld $0x10, %xmm3
+;   movdqa %xmm0, %xmm9
+;   psubd %xmm3, %xmm9
+;   cvtdq2ps %xmm3, %xmm8
+;   psrld $1, %xmm9
+;   cvtdq2ps %xmm9, %xmm0
+;   addps %xmm0, %xmm0
+;   addps %xmm8, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f13(f32) -> i32 {
 block0(v0: f32):
@@ -207,6 +376,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -214,6 +384,31 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x4f000000, %r8d
+;   movd %r8d, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x2f
+;   jnp 0x20
+;   ud2 ; trap: bad_toint
+;   cvttss2si %xmm0, %eax
+;   cmpl $0, %eax
+;   jge 0x4b
+;   ud2 ; trap: int_ovf
+;   movaps %xmm0, %xmm4
+;   subss %xmm3, %xmm4
+;   cvttss2si %xmm4, %eax
+;   cmpl $0, %eax
+;   jge 0x45
+;   ud2 ; trap: int_ovf
+;   addl $0x80000000, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f14(f32) -> i64 {
 block0(v0: f32):
@@ -221,6 +416,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -228,6 +424,32 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x5f000000, %r8d
+;   movd %r8d, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x31
+;   jnp 0x20
+;   ud2 ; trap: bad_toint
+;   cvttss2si %xmm0, %rax
+;   cmpq $0, %rax
+;   jge 0x56
+;   ud2 ; trap: int_ovf
+;   movaps %xmm0, %xmm4
+;   subss %xmm3, %xmm4
+;   cvttss2si %xmm4, %rax
+;   cmpq $0, %rax
+;   jge 0x49
+;   ud2 ; trap: int_ovf
+;   movabsq $9223372036854775808, %r8
+;   addq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f15(f64) -> i32 {
 block0(v0: f64):
@@ -235,6 +457,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -242,6 +465,31 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x41e0000000000000, %r8
+;   movq %r8, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   jae 0x34
+;   jnp 0x25
+;   ud2 ; trap: bad_toint
+;   cvttsd2si %xmm0, %eax
+;   cmpl $0, %eax
+;   jge 0x50
+;   ud2 ; trap: int_ovf
+;   movaps %xmm0, %xmm4
+;   subsd %xmm3, %xmm4
+;   cvttsd2si %xmm4, %eax
+;   cmpl $0, %eax
+;   jge 0x4a
+;   ud2 ; trap: int_ovf
+;   addl $0x80000000, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f16(f64) -> i64 {
 block0(v0: f64):
@@ -249,6 +497,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -256,6 +505,32 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x43e0000000000000, %r8
+;   movq %r8, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   jae 0x36
+;   jnp 0x25
+;   ud2 ; trap: bad_toint
+;   cvttsd2si %xmm0, %rax
+;   cmpq $0, %rax
+;   jge 0x5b
+;   ud2 ; trap: int_ovf
+;   movaps %xmm0, %xmm4
+;   subsd %xmm3, %xmm4
+;   cvttsd2si %xmm4, %rax
+;   cmpq $0, %rax
+;   jge 0x4e
+;   ud2 ; trap: int_ovf
+;   movabsq $9223372036854775808, %r8
+;   addq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f17(f32) -> i32 {
 block0(v0: f32):
@@ -263,6 +538,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -270,6 +546,34 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x4f000000, %r8d
+;   movd %r8d, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x39
+;   jnp 0x25
+;   xorl %eax, %eax
+;   jmp 0x5d
+;   cvttss2si %xmm0, %eax
+;   cmpl $0, %eax
+;   jge 0x5d
+;   xorl %eax, %eax
+;   jmp 0x5d
+;   movaps %xmm0, %xmm4
+;   subss %xmm3, %xmm4
+;   cvttss2si %xmm4, %eax
+;   cmpl $0, %eax
+;   jge 0x57
+;   movl $0xffffffff, %eax
+;   jmp 0x5d
+;   addl $0x80000000, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f18(f32) -> i64 {
 block0(v0: f32):
@@ -277,6 +581,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -284,6 +589,35 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x5f000000, %r8d
+;   movd %r8d, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x3d
+;   jnp 0x26
+;   xorq %rax, %rax
+;   jmp 0x6c
+;   cvttss2si %xmm0, %rax
+;   cmpq $0, %rax
+;   jge 0x6c
+;   xorq %rax, %rax
+;   jmp 0x6c
+;   movaps %xmm0, %xmm4
+;   subss %xmm3, %xmm4
+;   cvttss2si %xmm4, %rax
+;   cmpq $0, %rax
+;   jge 0x5f
+;   movq $18446744073709551615, %rax
+;   jmp 0x6c
+;   movabsq $9223372036854775808, %r8
+;   addq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f19(f64) -> i32 {
 block0(v0: f64):
@@ -291,6 +625,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -298,6 +633,34 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x41e0000000000000, %r8
+;   movq %r8, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   jae 0x3e
+;   jnp 0x2a
+;   xorl %eax, %eax
+;   jmp 0x62
+;   cvttsd2si %xmm0, %eax
+;   cmpl $0, %eax
+;   jge 0x62
+;   xorl %eax, %eax
+;   jmp 0x62
+;   movaps %xmm0, %xmm4
+;   subsd %xmm3, %xmm4
+;   cvttsd2si %xmm4, %eax
+;   cmpl $0, %eax
+;   jge 0x5c
+;   movl $0xffffffff, %eax
+;   jmp 0x62
+;   addl $0x80000000, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f20(f64) -> i64 {
 block0(v0: f64):
@@ -305,6 +668,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -312,6 +676,35 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x43e0000000000000, %r8
+;   movq %r8, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   jae 0x42
+;   jnp 0x2b
+;   xorq %rax, %rax
+;   jmp 0x71
+;   cvttsd2si %xmm0, %rax
+;   cmpq $0, %rax
+;   jge 0x71
+;   xorq %rax, %rax
+;   jmp 0x71
+;   movaps %xmm0, %xmm4
+;   subsd %xmm3, %xmm4
+;   cvttsd2si %xmm4, %rax
+;   cmpq $0, %rax
+;   jge 0x64
+;   movq $18446744073709551615, %rax
+;   jmp 0x71
+;   movabsq $9223372036854775808, %r8
+;   addq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f21(f32) -> i32 {
 block0(v0: f32):
@@ -319,6 +712,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -326,6 +720,29 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttss2si %xmm0, %eax
+;   cmpl $1, %eax
+;   jno 0x3f
+;   ucomiss %xmm0, %xmm0
+;   jnp 0x1c
+;   ud2 ; trap: bad_toint
+;   movl $0xcf000000, %edx
+;   movd %edx, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x30
+;   ud2 ; trap: int_ovf
+;   xorpd %xmm3, %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jae 0x3f
+;   ud2 ; trap: int_ovf
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f22(f32) -> i64 {
 block0(v0: f32):
@@ -333,6 +750,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -340,6 +758,29 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttss2si %xmm0, %rax
+;   cmpq $1, %rax
+;   jno 0x41
+;   ucomiss %xmm0, %xmm0
+;   jnp 0x1e
+;   ud2 ; trap: bad_toint
+;   movl $0xdf000000, %edx
+;   movd %edx, %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jae 0x32
+;   ud2 ; trap: int_ovf
+;   xorpd %xmm3, %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jae 0x41
+;   ud2 ; trap: int_ovf
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f23(f64) -> i32 {
 block0(v0: f64):
@@ -347,6 +788,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -354,6 +796,29 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttsd2si %xmm0, %eax
+;   cmpl $1, %eax
+;   jno 0x48
+;   ucomisd %xmm0, %xmm0
+;   jnp 0x1d
+;   ud2 ; trap: bad_toint
+;   movabsq $13970166044105375744, %rdx
+;   movq %rdx, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   ja 0x38
+;   ud2 ; trap: int_ovf
+;   xorpd %xmm3, %xmm3
+;   ucomisd %xmm0, %xmm3
+;   jae 0x48
+;   ud2 ; trap: int_ovf
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f24(f64) -> i64 {
 block0(v0: f64):
@@ -361,6 +826,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -368,6 +834,29 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttsd2si %xmm0, %rax
+;   cmpq $1, %rax
+;   jno 0x4a
+;   ucomisd %xmm0, %xmm0
+;   jnp 0x1f
+;   ud2 ; trap: bad_toint
+;   movabsq $14114281232179134464, %rdx
+;   movq %rdx, %xmm3
+;   ucomisd %xmm3, %xmm0
+;   jae 0x3a
+;   ud2 ; trap: int_ovf
+;   xorpd %xmm3, %xmm3
+;   ucomisd %xmm0, %xmm3
+;   jae 0x4a
+;   ud2 ; trap: int_ovf
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f25(f32) -> i32 {
 block0(v0: f32):
@@ -375,6 +864,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -382,6 +872,25 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttss2si %xmm0, %eax
+;   cmpl $1, %eax
+;   jno 0x33
+;   ucomiss %xmm0, %xmm0
+;   jnp 0x21
+;   xorl %eax, %eax
+;   jmp 0x33
+;   xorpd %xmm3, %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jae 0x33
+;   movl $0x7fffffff, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f26(f32) -> i64 {
 block0(v0: f32):
@@ -389,6 +898,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -396,6 +906,25 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttss2si %xmm0, %rax
+;   cmpq $1, %rax
+;   jno 0x3b
+;   ucomiss %xmm0, %xmm0
+;   jnp 0x24
+;   xorq %rax, %rax
+;   jmp 0x3b
+;   xorpd %xmm3, %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jae 0x3b
+;   movabsq $0x7fffffffffffffff, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f27(f64) -> i32 {
 block0(v0: f64):
@@ -403,6 +932,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -410,6 +940,25 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttsd2si %xmm0, %eax
+;   cmpl $1, %eax
+;   jno 0x35
+;   ucomisd %xmm0, %xmm0
+;   jnp 0x22
+;   xorl %eax, %eax
+;   jmp 0x35
+;   xorpd %xmm3, %xmm3
+;   ucomisd %xmm0, %xmm3
+;   jae 0x35
+;   movl $0x7fffffff, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f28(f64) -> i64 {
 block0(v0: f64):
@@ -417,6 +966,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -424,6 +974,25 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cvttsd2si %xmm0, %rax
+;   cmpq $1, %rax
+;   jno 0x3d
+;   ucomisd %xmm0, %xmm0
+;   jnp 0x25
+;   xorq %rax, %rax
+;   jmp 0x3d
+;   xorpd %xmm3, %xmm3
+;   ucomisd %xmm0, %xmm3
+;   jae 0x3d
+;   movabsq $0x7fffffffffffffff, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f29(f32x4) -> i32x4 {
 block0(v0: f32x4):
@@ -431,6 +1000,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -451,6 +1021,28 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pxor %xmm2, %xmm2
+;   movdqa %xmm0, %xmm9
+;   maxps %xmm2, %xmm9
+;   pcmpeqd %xmm7, %xmm7
+;   psrld $1, %xmm7
+;   cvtdq2ps %xmm7, %xmm13
+;   cvttps2dq %xmm9, %xmm12
+;   subps %xmm13, %xmm9
+;   cmpleps %xmm9, %xmm13
+;   cvttps2dq %xmm9, %xmm0
+;   pxor %xmm13, %xmm0
+;   pxor %xmm6, %xmm6
+;   pmaxsd %xmm6, %xmm0
+;   paddd %xmm12, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f30(f32x4) -> i32x4 {
 block0(v0: f32x4):
@@ -458,6 +1050,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -474,4 +1067,22 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm4
+;   cmpeqps %xmm0, %xmm4
+;   movdqa %xmm0, %xmm5
+;   andps %xmm4, %xmm5
+;   pxor %xmm5, %xmm4
+;   cvttps2dq %xmm5, %xmm8
+;   movdqa %xmm8, %xmm0
+;   pand %xmm4, %xmm0
+;   psrad $0x1f, %xmm0
+;   pxor %xmm8, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -7,6 +7,7 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x7fffffffffffffff, %rax
+;   movq %rax, %xmm4
+;   andpd %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f(i64) -> f64 {
 block0(v0: i64):
@@ -24,6 +36,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -34,4 +47,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsd (%rdi), %xmm0 ; trap: heap_oob
+;   movabsq $0x7fffffffffffffff, %rcx
+;   movq %rcx, %xmm5
+;   andpd %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %FloorF32 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -22,6 +33,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +42,14 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %FloorF64 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/floor.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundss $1, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -21,6 +31,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundsd $1, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -35,6 +55,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundps $1, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -49,6 +79,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,4 +87,13 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundpd $1, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -7,6 +7,7 @@ block0(v0: f32, v1: f32, v2: f32):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %r8 ; reloc_external Abs8 %FmaF32 0
+;   callq *%r8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %fma_f64(f64, f64, f64) -> f64 {
 block0(v0: f64, v1: f64, v2: f64):
@@ -22,6 +33,7 @@ block0(v0: f64, v1: f64, v2: f64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +42,14 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %r8 ; reloc_external Abs8 %FmaF64 0
+;   callq *%r8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fma-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-inst.clif
@@ -7,6 +7,7 @@ block0(v0: f32, v1: f32, v2: f32):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   vfmadd213ss %xmm2, %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %fma_f64(f64, f64, f64) -> f64 {
 block0(v0: f64, v1: f64, v2: f64):
@@ -21,6 +31,7 @@ block0(v0: f64, v1: f64, v2: f64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,4 +39,13 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   vfmadd213sd %xmm2, %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fneg.clif
+++ b/cranelift/filetests/filetests/isa/x64/fneg.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x80000000, %eax
+;   movd %eax, %xmm4
+;   xorps %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -23,6 +35,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $9223372036854775808, %rax
+;   movq %rax, %xmm4
+;   xorpd %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -39,6 +63,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +73,17 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm3, %xmm3
+;   pslld $0x1f, %xmm3
+;   xorps %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -55,6 +91,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,4 +101,15 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm3, %xmm3
+;   psllq $0x3f, %xmm3
+;   xorpd %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
@@ -8,6 +8,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,15 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rbp, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sp() -> i64 {
 block0:
@@ -22,6 +32,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -29,6 +40,15 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsp, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %return_address() -> i64 {
 block0:
@@ -36,6 +56,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -44,4 +65,14 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rbp, %rsi
+;   movq 8(%rsi), %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -8,6 +8,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -18,6 +19,18 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addq %rdx, %rax
+;   movq %rsi, %rdx
+;   adcq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -25,6 +38,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -35,6 +49,18 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   subq %rdx, %rax
+;   movq %rsi, %rdx
+;   sbbq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -42,6 +68,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -52,6 +79,18 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   andq %rdx, %rax
+;   movq %rsi, %rdx
+;   andq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -59,6 +98,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -69,6 +109,18 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   orq %rdx, %rax
+;   movq %rsi, %rdx
+;   orq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -76,6 +128,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -86,6 +139,18 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorq %rdx, %rax
+;   movq %rsi, %rdx
+;   xorq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i128) -> i128 {
 block0(v0: i128):
@@ -93,6 +158,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -103,6 +169,18 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   notq %rax
+;   movq %rsi, %rdx
+;   notq %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -110,6 +188,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -129,6 +208,27 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rax
+;   movq %rdi, %rdx
+;   imulq %rcx, %rdx
+;   movq %rax, %rcx
+;   movq %rdi, %rax
+;   movq %rsi, %r10
+;   imulq %rcx, %r10
+;   addq %r10, %rdx
+;   movq %rdx, %r9
+;   mulq %rcx
+;   movq %rdx, %rcx
+;   movq %r9, %rdx
+;   addq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i64, i64) -> i128 {
 block0(v0: i64, v1: i64):
@@ -136,6 +236,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -144,6 +245,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rdx
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f8(i128) -> i64, i64 {
 block0(v0: i128):
@@ -151,6 +262,7 @@ block0(v0: i128):
     return v1, v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -159,6 +271,16 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rdx
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f9(i128, i128) -> i8 {
 block0(v0: i128, v1: i128):
@@ -184,6 +306,7 @@ block0(v0: i128, v1: i128):
     return v20
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $64, %rsp
@@ -299,6 +422,123 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x40, %rsp
+;   movq %rbx, 0x10(%rsp)
+;   movq %r12, 0x18(%rsp)
+;   movq %r13, 0x20(%rsp)
+;   movq %r14, 0x28(%rsp)
+;   movq %r15, 0x30(%rsp)
+; block0: ; offset 0x21
+;   cmpq %rdx, %rdi
+;   sete %r9b
+;   cmpq %rcx, %rsi
+;   sete %r10b
+;   andq %r10, %r9
+;   testq $1, %r9
+;   setne %al
+;   cmpq %rdx, %rdi
+;   setne %r8b
+;   cmpq %rcx, %rsi
+;   setne %r9b
+;   orq %r9, %r8
+;   testq $1, %r8
+;   setne %r9b
+;   movq %r9, (%rsp)
+;   cmpq %rcx, %rsi
+;   setl %r8b
+;   sete %r10b
+;   cmpq %rdx, %rdi
+;   setb %r11b
+;   andq %r11, %r10
+;   orq %r10, %r8
+;   testq $1, %r8
+;   setne %r10b
+;   cmpq %rcx, %rsi
+;   setl %r11b
+;   sete %r8b
+;   cmpq %rdx, %rdi
+;   setbe %r15b
+;   andq %r15, %r8
+;   orq %r8, %r11
+;   testq $1, %r11
+;   setne %r8b
+;   cmpq %rcx, %rsi
+;   setg %r11b
+;   sete %r12b
+;   cmpq %rdx, %rdi
+;   seta %r13b
+;   andq %r13, %r12
+;   orq %r12, %r11
+;   testq $1, %r11
+;   setne %r11b
+;   cmpq %rcx, %rsi
+;   setg %r15b
+;   sete %bl
+;   cmpq %rdx, %rdi
+;   setae %r12b
+;   andq %r12, %rbx
+;   orq %rbx, %r15
+;   testq $1, %r15
+;   setne %r13b
+;   cmpq %rcx, %rsi
+;   setb %r14b
+;   sete %r15b
+;   cmpq %rdx, %rdi
+;   setb %bl
+;   andq %rbx, %r15
+;   orq %r15, %r14
+;   testq $1, %r14
+;   setne %r14b
+;   cmpq %rcx, %rsi
+;   setb %bl
+;   sete %r12b
+;   cmpq %rdx, %rdi
+;   setbe %r15b
+;   andq %r15, %r12
+;   orq %r12, %rbx
+;   testq $1, %rbx
+;   setne %r15b
+;   cmpq %rcx, %rsi
+;   seta %bl
+;   sete %r12b
+;   cmpq %rdx, %rdi
+;   seta %r9b
+;   andq %r9, %r12
+;   orq %r12, %rbx
+;   testq $1, %rbx
+;   setne %bl
+;   cmpq %rcx, %rsi
+;   seta %sil
+;   sete %cl
+;   cmpq %rdx, %rdi
+;   setae %dil
+;   andq %rdi, %rcx
+;   orq %rcx, %rsi
+;   testq $1, %rsi
+;   setne %sil
+;   movq (%rsp), %rcx
+;   andl %ecx, %eax
+;   andl %r8d, %r10d
+;   andl %r13d, %r11d
+;   andl %r15d, %r14d
+;   andl %esi, %ebx
+;   andl %r10d, %eax
+;   andl %r14d, %r11d
+;   andl %r11d, %eax
+;   andl %ebx, %eax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f10(i128) -> i32 {
 block0(v0: i128):
@@ -313,6 +553,7 @@ block2:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -332,6 +573,27 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpq $0, %rdi
+;   sete %r9b
+;   cmpq $0, %rsi
+;   sete %sil
+;   testb %r9b, %sil
+;   jne 0x27
+; block1: ; offset 0x1d
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x27
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f11(i128) -> i32 {
 block0(v0: i128):
@@ -346,6 +608,7 @@ block2:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -365,6 +628,27 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpq $0, %rdi
+;   sete %r9b
+;   cmpq $0, %rsi
+;   sete %sil
+;   testb %r9b, %sil
+;   jne 0x27
+; block1: ; offset 0x1d
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x27
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f12(i64) -> i128 {
 block0(v0: i64):
@@ -372,6 +656,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -380,6 +665,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f13(i64) -> i128 {
 block0(v0: i64):
@@ -387,6 +682,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -396,6 +692,17 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rdx
+;   sarq $0x3f, %rdx
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f14(i8) -> i128 {
 block0(v0: i8):
@@ -403,6 +710,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -412,6 +720,17 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsbq %dil, %rax
+;   movq %rax, %rdx
+;   sarq $0x3f, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f15(i8) -> i128 {
 block0(v0: i8):
@@ -419,6 +738,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -427,6 +747,16 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dil, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f16(i128) -> i64 {
 block0(v0: i128):
@@ -434,6 +764,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -441,6 +772,15 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f17(i128) -> i8 {
 block0(v0: i128):
@@ -448,6 +788,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -455,6 +796,15 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f18(i8) -> i128 {
 block0(v0: i8):
@@ -462,6 +812,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -470,6 +821,16 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dil, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f19(i128) -> i128 {
 block0(v0: i128):
@@ -477,6 +838,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -525,6 +887,56 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrq $1, %rax
+;   movabsq $0x7777777777777777, %r8
+;   andq %r8, %rax
+;   movq %rdi, %r9
+;   subq %rax, %r9
+;   shrq $1, %rax
+;   andq %r8, %rax
+;   subq %rax, %r9
+;   shrq $1, %rax
+;   andq %r8, %rax
+;   subq %rax, %r9
+;   movq %r9, %rax
+;   shrq $4, %rax
+;   addq %r9, %rax
+;   movabsq $0xf0f0f0f0f0f0f0f, %rdi
+;   andq %rdi, %rax
+;   movabsq $0x101010101010101, %rdx
+;   imulq %rdx, %rax
+;   shrq $0x38, %rax
+;   movq %rsi, %rdi
+;   shrq $1, %rdi
+;   movabsq $0x7777777777777777, %rcx
+;   andq %rcx, %rdi
+;   movq %rsi, %rdx
+;   subq %rdi, %rdx
+;   shrq $1, %rdi
+;   andq %rcx, %rdi
+;   subq %rdi, %rdx
+;   shrq $1, %rdi
+;   andq %rcx, %rdi
+;   subq %rdi, %rdx
+;   movq %rdx, %rsi
+;   shrq $4, %rsi
+;   addq %rdx, %rsi
+;   movabsq $0xf0f0f0f0f0f0f0f, %r10
+;   andq %r10, %rsi
+;   movabsq $0x101010101010101, %rcx
+;   imulq %rcx, %rsi
+;   shrq $0x38, %rsi
+;   addq %rsi, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f20(i128) -> i128 {
 block0(v0: i128):
@@ -532,6 +944,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -622,6 +1035,98 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0x5555555555555555, %rcx
+;   movq %rsi, %rdx
+;   andq %rcx, %rdx
+;   movq %rsi, %r11
+;   shrq $1, %r11
+;   andq %rcx, %r11
+;   shlq $1, %rdx
+;   orq %r11, %rdx
+;   movabsq $0x3333333333333333, %r9
+;   movq %rdx, %r10
+;   andq %r9, %r10
+;   shrq $2, %rdx
+;   andq %r9, %rdx
+;   shlq $2, %r10
+;   orq %rdx, %r10
+;   movabsq $0xf0f0f0f0f0f0f0f, %rsi
+;   movq %r10, %rax
+;   andq %rsi, %rax
+;   shrq $4, %r10
+;   andq %rsi, %r10
+;   shlq $4, %rax
+;   orq %r10, %rax
+;   movabsq $0xff00ff00ff00ff, %rcx
+;   movq %rax, %rdx
+;   andq %rcx, %rdx
+;   shrq $8, %rax
+;   andq %rcx, %rax
+;   shlq $8, %rdx
+;   orq %rax, %rdx
+;   movabsq $0xffff0000ffff, %r10
+;   movq %rdx, %r9
+;   andq %r10, %r9
+;   shrq $0x10, %rdx
+;   andq %r10, %rdx
+;   shlq $0x10, %r9
+;   orq %rdx, %r9
+;   movabsq $0xffffffff, %rsi
+;   movq %r9, %rax
+;   andq %rsi, %rax
+;   shrq $0x20, %r9
+;   shlq $0x20, %rax
+;   orq %r9, %rax
+;   movabsq $0x5555555555555555, %rdx
+;   movq %rdi, %rcx
+;   andq %rdx, %rcx
+;   movq %rdi, %r9
+;   shrq $1, %r9
+;   andq %rdx, %r9
+;   shlq $1, %rcx
+;   orq %r9, %rcx
+;   movabsq $0x3333333333333333, %rdx
+;   movq %rcx, %r8
+;   andq %rdx, %r8
+;   shrq $2, %rcx
+;   andq %rdx, %rcx
+;   shlq $2, %r8
+;   orq %rcx, %r8
+;   movabsq $0xf0f0f0f0f0f0f0f, %r10
+;   movq %r8, %r11
+;   andq %r10, %r11
+;   shrq $4, %r8
+;   andq %r10, %r8
+;   shlq $4, %r11
+;   orq %r8, %r11
+;   movabsq $0xff00ff00ff00ff, %rdi
+;   movq %r11, %rcx
+;   andq %rdi, %rcx
+;   shrq $8, %r11
+;   andq %rdi, %r11
+;   shlq $8, %rcx
+;   orq %r11, %rcx
+;   movabsq $0xffff0000ffff, %rdx
+;   movq %rcx, %r8
+;   andq %rdx, %r8
+;   shrq $0x10, %rcx
+;   andq %rdx, %rcx
+;   shlq $0x10, %r8
+;   orq %rcx, %r8
+;   movabsq $0xffffffff, %r10
+;   movq %r8, %rdx
+;   andq %r10, %rdx
+;   shrq $0x20, %r8
+;   shlq $0x20, %rdx
+;   orq %r8, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f21(i128, i64) {
 block0(v0: i128, v1: i64):
@@ -629,6 +1134,7 @@ block0(v0: i128, v1: i64):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -637,6 +1143,16 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, (%rdx) ; trap: heap_oob
+;   movq %rsi, 8(%rdx) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f22(i64) -> i128 {
 block0(v0: i64):
@@ -644,6 +1160,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -652,6 +1169,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rdi), %rax ; trap: heap_oob
+;   movq 8(%rdi), %rdx ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f23(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -672,6 +1199,7 @@ block2(v8: i128):
     return v11
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -697,6 +1225,33 @@ block2(v8: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorq %rax, %rax
+;   xorq %r9, %r9
+;   testb %dl, %dl
+;   je 0x29
+; block1: ; offset 0x12
+;   movl $1, %r8d
+;   xorq %r10, %r10
+;   addq %r8, %rax
+;   movq %r9, %rdx
+;   adcq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x29
+;   movq %r9, %rdx
+;   movl $2, %r9d
+;   xorq %r11, %r11
+;   addq %r9, %rax
+;   adcq %r11, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f24(i128, i128, i64, i128, i128, i128) -> i128 {
 
@@ -710,6 +1265,7 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
     return v11
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $32, %rsp
@@ -750,6 +1306,48 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x20, %rsp
+;   movq %rbx, (%rsp)
+;   movq %r12, 8(%rsp)
+;   movq %r14, 0x10(%rsp)
+;   movq %r15, 0x18(%rsp)
+; block0: ; offset 0x1b
+;   movq %r8, %r14
+;   movq %rcx, %rbx
+;   movq %rdx, %rcx
+;   movq 0x10(%rbp), %r15
+;   movq 0x18(%rbp), %rax
+;   movq 0x20(%rbp), %rdx
+;   movq 0x28(%rbp), %r11
+;   movq 0x30(%rbp), %r10
+;   movq %rdi, %r8
+;   addq %rcx, %r8
+;   movq %rbx, %rdi
+;   movq %rsi, %rcx
+;   adcq %rdi, %rcx
+;   xorq %rdi, %rdi
+;   movq %r14, %r12
+;   movq %r9, %rsi
+;   addq %r12, %rsi
+;   adcq %rdi, %r15
+;   addq %r11, %rax
+;   adcq %r10, %rdx
+;   addq %rsi, %r8
+;   adcq %r15, %rcx
+;   addq %r8, %rax
+;   adcq %rcx, %rdx
+;   movq (%rsp), %rbx
+;   movq 8(%rsp), %r12
+;   movq 0x10(%rsp), %r14
+;   movq 0x18(%rsp), %r15
+;   addq $0x20, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f25(i128) -> i128, i128, i128, i64, i128, i128 {
 block0(v0: i128):
@@ -757,6 +1355,7 @@ block0(v0: i128):
     return v0, v0, v0, v1, v0, v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -774,6 +1373,25 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, (%rdx)
+;   movq %rsi, 8(%rdx)
+;   movq %rdi, 0x10(%rdx)
+;   movq %rsi, 0x18(%rdx)
+;   movq %rdi, 0x20(%rdx)
+;   movq %rdi, 0x28(%rdx)
+;   movq %rsi, 0x30(%rdx)
+;   movq %rdi, 0x38(%rdx)
+;   movq %rdi, %rax
+;   movq %rsi, 0x40(%rdx)
+;   movq %rsi, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f26(i128, i128) -> i128, i128 {
     fn0 = %g(i128, i128) -> i128, i128
@@ -782,6 +1400,7 @@ block0(v0: i128, v1: i128):
     return v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -805,6 +1424,29 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r13, (%rsp)
+; block0: ; offset 0xc
+;   movq %r8, %r13
+;   subq $0x10, %rsp
+;   leaq (%rsp), %r8
+;   movabsq $0, %r9 ; reloc_external Abs8 %g 0
+;   callq *%r9
+;   movq (%rsp), %r8
+;   movq 8(%rsp), %r9
+;   addq $0x10, %rsp
+;   movq %r13, %rcx
+;   movq %r8, (%rcx)
+;   movq %r9, 8(%rcx)
+;   movq (%rsp), %r13
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f27(i128) -> i128 {
 block0(v0: i128):
@@ -812,6 +1454,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -833,6 +1476,29 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %r8
+;   movq $18446744073709551615, %rcx
+;   bsrq %rsi, %r9
+;   cmoveq %rcx, %r9
+;   movl $0x3f, %edi
+;   subq %r9, %rdi
+;   movq $18446744073709551615, %rdx
+;   bsrq %r8, %r10
+;   cmoveq %rdx, %r10
+;   movl $0x3f, %eax
+;   subq %r10, %rax
+;   addq $0x40, %rax
+;   cmpq $0x40, %rdi
+;   cmovneq %rdi, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f28(i128) -> i128 {
 block0(v0: i128):
@@ -840,6 +1506,7 @@ block0(v0: i128):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -856,6 +1523,24 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0x40, %ecx
+;   bsfq %rdi, %rax
+;   cmoveq %rcx, %rax
+;   movl $0x40, %edi
+;   bsfq %rsi, %rdx
+;   cmoveq %rdi, %rdx
+;   addq $0x40, %rdx
+;   cmpq $0x40, %rax
+;   cmoveq %rdx, %rax
+;   xorq %rdx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f29(i8, i128) -> i8 {
 block0(v0: i8, v1: i128):
@@ -863,6 +1548,7 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -873,6 +1559,18 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f30(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -880,6 +1578,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -904,6 +1603,32 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   movq %rcx, %r10
+;   movl $0x40, %ecx
+;   movq %r10, %r8
+;   subq %r8, %rcx
+;   movq %rdi, %r10
+;   shrq %cl, %r10
+;   xorq %rax, %rax
+;   testq $0x7f, %r8
+;   cmoveq %rax, %r10
+;   orq %r11, %r10
+;   testq $0x40, %r8
+;   cmoveq %rdx, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f31(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -911,6 +1636,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -935,6 +1661,32 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r10
+;   shrq %cl, %r10
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r11
+;   orq %r8, %r11
+;   testq $0x40, %rdi
+;   movq %r10, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f32(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -942,6 +1694,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -968,6 +1721,34 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r10
+;   sarq %cl, %r10
+;   movl $0x40, %ecx
+;   movq %rdx, %rax
+;   subq %rax, %rcx
+;   movq %rsi, %r9
+;   shlq %cl, %r9
+;   xorq %r11, %r11
+;   testq $0x7f, %rax
+;   cmoveq %r11, %r9
+;   orq %r9, %r8
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rax
+;   movq %r10, %rax
+;   cmoveq %r8, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f33(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -975,6 +1756,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -1021,6 +1803,54 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   movq %rcx, %r8
+;   movl $0x40, %ecx
+;   subq %r8, %rcx
+;   movq %rdi, %r10
+;   shrq %cl, %r10
+;   xorq %rax, %rax
+;   testq $0x7f, %r8
+;   cmoveq %rax, %r10
+;   orq %r11, %r10
+;   testq $0x40, %r8
+;   cmoveq %rdx, %rax
+;   cmoveq %r10, %rdx
+;   movl $0x80, %ecx
+;   movq %r8, %r10
+;   subq %r10, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r9
+;   shrq %cl, %r9
+;   movq %rcx, %r10
+;   movl $0x40, %ecx
+;   movq %r10, %r11
+;   subq %r11, %rcx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %rsi, %rsi
+;   testq $0x7f, %r11
+;   cmoveq %rsi, %r10
+;   orq %r8, %r10
+;   testq $0x40, %r11
+;   movq %r9, %r8
+;   cmoveq %r10, %r8
+;   cmoveq %r9, %rsi
+;   orq %r8, %rax
+;   orq %rsi, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f34(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):
@@ -1028,6 +1858,7 @@ block0(v0: i128, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -1075,4 +1906,53 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r10
+;   shrq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rax
+;   subq %rax, %rcx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %r11
+;   orq %r8, %r11
+;   testq $0x40, %rax
+;   movq %r10, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r10, %rdx
+;   movl $0x80, %ecx
+;   movq %r9, %r10
+;   subq %r10, %rcx
+;   movq %rdi, %r8
+;   shlq %cl, %r8
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rsi
+;   subq %rsi, %rcx
+;   movq %rdi, %r9
+;   shrq %cl, %r9
+;   xorq %r11, %r11
+;   testq $0x7f, %rsi
+;   cmoveq %r11, %r9
+;   orq %r10, %r9
+;   testq $0x40, %rsi
+;   cmoveq %r8, %r11
+;   cmoveq %r9, %r8
+;   orq %r11, %rax
+;   orq %r8, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/iabs.clif
@@ -7,6 +7,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negb %al
+;   cmovsl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16) -> i16 {
 block0(v0: i16):
@@ -23,6 +35,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negw %ax
+;   cmovsl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32) -> i32 {
 block0(v0: i32):
@@ -39,6 +63,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +73,17 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negl %eax
+;   cmovsl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64) -> i64 {
 block0(v0: i64):
@@ -55,6 +91,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,4 +101,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   negq %rax
+;   cmovsq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -15,6 +15,7 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,4 +33,31 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %r9
+;   addq 0x32(%rip), %r9
+;   movq %r9, (%rsi) ; trap: heap_oob
+;   movq %rdi, %r10
+;   subq 0x25(%rip), %r10
+;   movq %r10, (%rsi) ; trap: heap_oob
+;   movq %rdi, %r11
+;   andq 0x18(%rip), %r11
+;   movq %r11, (%rsi) ; trap: heap_oob
+;   orq 0xe(%rip), %rdi
+;   movq %rdi, (%rsi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   int3
+;   int3
+;   fstp %st(5)
+;   outb %al, %dx
+;   outb %al, %dx
 

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -16,6 +16,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $8192, %rsp
@@ -25,6 +26,17 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x2000, %rsp
+; block0: ; offset 0xb
+;   leaq (%rsp), %rax
+;   addq $0x2000, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %unrolled() -> i64 system_v {
 ss0 = explicit_slot 196608
@@ -34,6 +46,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   movl    %esp, -65536(%rsp)
@@ -46,6 +59,20 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movl %esp, -0x10000(%rsp)
+;   movl %esp, -0x20000(%rsp)
+;   movl %esp, -0x30000(%rsp)
+;   subq $0x30000, %rsp
+; block0: ; offset 0x20
+;   leaq (%rsp), %rax
+;   addq $0x30000, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %large() -> i64 system_v {
 ss0 = explicit_slot 2097152
@@ -55,6 +82,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   stack_probe_loop %r11, frame_size=2097152, guard_size=65536
@@ -65,3 +93,22 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movq %rsp, %r11
+;   subq $0x200000, %r11
+;   subq $0x10000, %rsp
+;   movl %esp, (%rsp)
+;   cmpq %rsp, %r11
+;   jne 0xe
+;   addq $0x200000, %rsp
+;   subq $0x200000, %rsp
+; block0: ; offset 0x2f
+;   leaq (%rsp), %rax
+;   addq $0x200000, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -15,6 +15,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $2048, %rsp
@@ -24,6 +25,17 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x800, %rsp
+; block0: ; offset 0xb
+;   leaq (%rsp), %rax
+;   addq $0x800, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %unrolled() -> i64 system_v {
 ss0 = explicit_slot 12288
@@ -33,6 +45,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   movl    %esp, -4096(%rsp)
@@ -45,6 +58,20 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movl %esp, -0x1000(%rsp)
+;   movl %esp, -0x2000(%rsp)
+;   movl %esp, -0x3000(%rsp)
+;   subq $0x3000, %rsp
+; block0: ; offset 0x20
+;   leaq (%rsp), %rax
+;   addq $0x3000, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %large() -> i64 system_v {
 ss0 = explicit_slot 100000
@@ -54,6 +81,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   stack_probe_loop %r11, frame_size=100000, guard_size=4096
@@ -64,3 +92,22 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movq %rsp, %r11
+;   subq $0x19000, %r11
+;   subq $0x1000, %rsp
+;   movl %esp, (%rsp)
+;   cmpq %rsp, %r11
+;   jne 0xe
+;   addq $0x19000, %rsp
+;   subq $0x186a0, %rsp
+; block0: ; offset 0x2f
+;   leaq (%rsp), %rax
+;   addq $0x186a0, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -14,6 +14,7 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -38,6 +39,32 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dl, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   movq %rdi, %r10
+;   shrq %cl, %r10
+;   xorq %rax, %rax
+;   testq $0x7f, %r8
+;   cmoveq %rax, %r10
+;   orq %r11, %r10
+;   testq $0x40, %r8
+;   cmoveq %rdx, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i128_i64(i128, i64) -> i128 {
 block0(v0: i128, v1: i64):
@@ -45,6 +72,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -69,6 +97,32 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rsi
+;   subq %rsi, %rcx
+;   movq %rdi, %r9
+;   shrq %cl, %r9
+;   xorq %rax, %rax
+;   testq $0x7f, %rsi
+;   cmoveq %rax, %r9
+;   orq %r10, %r9
+;   testq $0x40, %rsi
+;   cmoveq %rdx, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i128_i32(i128, i32) -> i128 {
 block0(v0: i128, v1: i32):
@@ -76,6 +130,7 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -100,6 +155,32 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rsi
+;   subq %rsi, %rcx
+;   movq %rdi, %r9
+;   shrq %cl, %r9
+;   xorq %rax, %rax
+;   testq $0x7f, %rsi
+;   cmoveq %rax, %r9
+;   orq %r10, %r9
+;   testq $0x40, %rsi
+;   cmoveq %rdx, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i128_i16(i128, i16) -> i128 {
 block0(v0: i128, v1: i16):
@@ -107,6 +188,7 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -131,6 +213,32 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rsi
+;   subq %rsi, %rcx
+;   movq %rdi, %r9
+;   shrq %cl, %r9
+;   xorq %rax, %rax
+;   testq $0x7f, %rsi
+;   cmoveq %rax, %r9
+;   orq %r10, %r9
+;   testq $0x40, %rsi
+;   cmoveq %rdx, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -138,6 +246,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -162,6 +271,32 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %rdx
+;   shlq %cl, %rdx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rsi
+;   subq %rsi, %rcx
+;   movq %rdi, %r9
+;   shrq %cl, %r9
+;   xorq %rax, %rax
+;   testq $0x7f, %rsi
+;   cmoveq %rax, %r9
+;   orq %r10, %r9
+;   testq $0x40, %rsi
+;   cmoveq %rdx, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_i128(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -169,6 +304,7 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -178,6 +314,17 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shlq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_i128(i32, i128) -> i32 {
 block0(v0: i32, v1: i128):
@@ -185,6 +332,7 @@ block0(v0: i32, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -194,6 +342,17 @@ block0(v0: i32, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shll %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_i128(i16, i128) -> i16 {
 block0(v0: i16, v1: i128):
@@ -201,6 +360,7 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -211,6 +371,18 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shlw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_i128(i8, i128) -> i8 {
 block0(v0: i8, v1: i128):
@@ -218,6 +390,7 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -228,6 +401,18 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -235,6 +420,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -244,6 +430,17 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shlq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_i32(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):
@@ -251,6 +448,7 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -260,6 +458,17 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shlq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_i16(i64, i16) -> i64 {
 block0(v0: i64, v1: i16):
@@ -267,6 +476,7 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -276,6 +486,17 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shlq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_i8(i64, i8) -> i64 {
 block0(v0: i64, v1: i8):
@@ -283,6 +504,7 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -292,6 +514,17 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shlq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_i64(i32, i64) -> i32 {
 block0(v0: i32, v1: i64):
@@ -299,6 +532,7 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -308,6 +542,17 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shll %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -315,6 +560,7 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -324,6 +570,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shll %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_i16(i32, i16) -> i32 {
 block0(v0: i32, v1: i16):
@@ -331,6 +588,7 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -340,6 +598,17 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shll %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_i8(i32, i8) -> i32 {
 block0(v0: i32, v1: i8):
@@ -347,6 +616,7 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -356,6 +626,17 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shll %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_i64(i16, i64) -> i16 {
 block0(v0: i16, v1: i64):
@@ -363,6 +644,7 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -373,6 +655,18 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shlw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_i32(i16, i32) -> i16 {
 block0(v0: i16, v1: i32):
@@ -380,6 +674,7 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -390,6 +685,18 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shlw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -397,6 +704,7 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -407,6 +715,18 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shlw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_i8(i16, i8) -> i16 {
 block0(v0: i16, v1: i8):
@@ -414,6 +734,7 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -424,6 +745,18 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shlw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_i64(i8, i64) -> i8 {
 block0(v0: i8, v1: i64):
@@ -431,6 +764,7 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -441,6 +775,18 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_i32(i8, i32) -> i8 {
 block0(v0: i8, v1: i32):
@@ -448,6 +794,7 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -458,6 +805,18 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_i16(i8, i16) -> i8 {
 block0(v0: i8, v1: i16):
@@ -465,6 +824,7 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -475,6 +835,18 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -482,6 +854,7 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -492,6 +865,18 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shlb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i64_const(i64) -> i64 {
 block0(v0: i64):
@@ -499,6 +884,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -507,6 +893,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shlq $1, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i32_const(i32) -> i32 {
 block0(v0: i32):
@@ -514,6 +910,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -522,6 +919,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shll $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i16_const(i16) -> i16 {
 block0(v0: i16):
@@ -529,6 +936,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -537,6 +945,16 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shlw $1, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8_const(i8) -> i8 {
 block0(v0: i8):
@@ -544,6 +962,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -552,4 +971,14 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shlb $1, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf.clif
@@ -10,6 +10,7 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,4 +18,13 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
@@ -10,6 +10,7 @@ block0(v0: i64):
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,4 +18,13 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/load-op-store.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op-store.clif
@@ -9,6 +9,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   addl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -25,6 +35,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +43,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   addl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -41,6 +61,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +69,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   subl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -57,6 +87,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,6 +95,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -73,6 +113,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -80,6 +121,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -89,6 +139,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -96,6 +147,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   orl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -105,6 +165,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -112,6 +173,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   orl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -121,6 +191,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -128,6 +199,15 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f8(i64, i32) {
 block0(v0: i64, v1: i32):
@@ -137,6 +217,7 @@ block0(v0: i64, v1: i32):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -144,4 +225,13 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorl %esi, 0x20(%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -8,6 +8,7 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,16 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rax
+;   addl (%rdi), %eax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %add_from_mem_u32_2(i64, i32) -> i32 {
 block0(v0: i64, v1: i32):
@@ -24,6 +35,7 @@ block0(v0: i64, v1: i32):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +44,16 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rax
+;   addl (%rdi), %eax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %add_from_mem_u64_1(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -40,6 +62,7 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +71,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rax
+;   addq (%rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %add_from_mem_u64_2(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -56,6 +89,7 @@ block0(v0: i64, v1: i64):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,6 +98,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rax
+;   addq (%rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %add_from_mem_not_narrow(i64, i8) -> i8 {
 block0(v0: i64, v1: i8):
@@ -72,6 +116,7 @@ block0(v0: i64, v1: i8):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -80,6 +125,16 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   addl %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %no_merge_if_lookback_use(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -90,6 +145,7 @@ block0(v0: i64, v1: i64):
   return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -101,6 +157,19 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rdi), %r8 ; trap: heap_oob
+;   movq %r8, %r9
+;   addq %rdi, %r9
+;   movq %r9, (%rsi) ; trap: heap_oob
+;   movq (%r8, %rdi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %merge_scalar_to_vector(i64) -> i32x4 {
 block0(v0: i64):
@@ -112,6 +181,7 @@ block1:
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -121,6 +191,16 @@ block1:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movss (%rdi), %xmm0 ; trap: heap_oob
+; block1: ; offset 0x8
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %cmp_mem(i64) -> i64 {
 block0(v0: i64):
@@ -130,6 +210,7 @@ block0(v0: i64):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -139,4 +220,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpq (%rdi), %rdi ; trap: heap_oob
+;   sete %dl
+;   movzbq %dl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -13,10 +13,19 @@ block0(v0: i32x4):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -7,6 +7,7 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   packsswb %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32x4, i32x4) -> i16x8 {
 block0(v0: i32x4, v1: i32x4):
@@ -21,6 +31,7 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   packssdw %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(f64x2) -> i32x4 {
 block0(v0: f64x2):
@@ -37,6 +57,7 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -50,6 +71,25 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm4
+;   cmpeqpd %xmm0, %xmm4
+;   movupd 0x1b(%rip), %xmm5
+;   andps %xmm5, %xmm4
+;   movdqa %xmm0, %xmm8
+;   minpd %xmm4, %xmm8
+;   cvttpd2dq %xmm8, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   sarb $0xff, %bh
 
 function %f4(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):
@@ -57,6 +97,7 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,6 +105,15 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   packuswb %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i32x4, i32x4) -> i16x8 {
 block0(v0: i32x4, v1: i32x4):
@@ -71,6 +121,7 @@ block0(v0: i32x4, v1: i32x4):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -78,4 +129,13 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   packusdw %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %NearestF32 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -22,6 +33,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +42,14 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %NearestF64 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundss $0, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -21,6 +31,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundsd $0, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -35,6 +55,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundps $0, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -49,6 +79,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,4 +87,13 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundpd $0, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -10,6 +10,7 @@ block0:
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -19,6 +20,17 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %r15, %rsi
+;   addq $1, %rsi
+;   movq %rsi, %r15
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1() windows_fastcall {
 block0:
@@ -28,6 +40,7 @@ block0:
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -41,4 +54,19 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %rsi, (%rsp)
+; block0: ; offset 0xc
+;   movq %r15, %rsi
+;   addq $1, %rsi
+;   movq %rsi, %r15
+;   movq (%rsp), %rsi
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   popcntq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %popcnt(i32) -> i32 {
 block0(v0: i32):
@@ -21,6 +31,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,4 +39,13 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   popcntl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -33,6 +34,34 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rcx
+;   shrq $1, %rdi
+;   movq %rcx, %r8
+;   movabsq $0x7777777777777777, %rdx
+;   andq %rdx, %rdi
+;   subq %rdi, %r8
+;   shrq $1, %rdi
+;   andq %rdx, %rdi
+;   subq %rdi, %r8
+;   shrq $1, %rdi
+;   andq %rdx, %rdi
+;   subq %rdi, %r8
+;   movq %r8, %rax
+;   shrq $4, %rax
+;   addq %r8, %rax
+;   movabsq $0xf0f0f0f0f0f0f0f, %r11
+;   andq %r11, %rax
+;   movabsq $0x101010101010101, %rcx
+;   imulq %rcx, %rax
+;   shrq $0x38, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %popcnt64load(i64) -> i64 {
 block0(v0: i64):
@@ -41,6 +70,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -67,6 +97,34 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq (%rdi), %rdx ; trap: heap_oob
+;   movq %rdx, %rcx
+;   shrq $1, %rcx
+;   movabsq $0x7777777777777777, %r8
+;   andq %r8, %rcx
+;   subq %rcx, %rdx
+;   shrq $1, %rcx
+;   andq %r8, %rcx
+;   subq %rcx, %rdx
+;   shrq $1, %rcx
+;   andq %r8, %rcx
+;   subq %rcx, %rdx
+;   movq %rdx, %rax
+;   shrq $4, %rax
+;   addq %rdx, %rax
+;   movabsq $0xf0f0f0f0f0f0f0f, %rsi
+;   andq %rsi, %rax
+;   movabsq $0x101010101010101, %rdx
+;   imulq %rdx, %rax
+;   shrq $0x38, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %popcnt32(i32) -> i32 {
 block0(v0: i32):
@@ -74,6 +132,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -98,6 +157,32 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrl $1, %edi
+;   movl $0x77777777, %edx
+;   andl %edx, %edi
+;   movq %rax, %r8
+;   subl %edi, %r8d
+;   shrl $1, %edi
+;   andl %edx, %edi
+;   subl %edi, %r8d
+;   shrl $1, %edi
+;   andl %edx, %edi
+;   subl %edi, %r8d
+;   movq %r8, %rax
+;   shrl $4, %eax
+;   addl %r8d, %eax
+;   andl $0xf0f0f0f, %eax
+;   imull $0x1010101, %eax, %eax
+;   shrl $0x18, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %popcnt32load(i64) -> i32 {
 block0(v0: i64):
@@ -106,6 +191,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -130,4 +216,30 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl (%rdi), %edx ; trap: heap_oob
+;   movq %rdx, %rcx
+;   shrl $1, %ecx
+;   movl $0x77777777, %r8d
+;   andl %r8d, %ecx
+;   subl %ecx, %edx
+;   shrl $1, %ecx
+;   andl %r8d, %ecx
+;   subl %ecx, %edx
+;   shrl $1, %ecx
+;   andl %r8d, %ecx
+;   subl %ecx, %edx
+;   movq %rdx, %rax
+;   shrl $4, %eax
+;   addl %edx, %eax
+;   andl $0xf0f0f0f, %eax
+;   imull $0x1010101, %eax, %eax
+;   shrl $0x18, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/probestack.clif
@@ -10,6 +10,7 @@ block0:
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   movl    $100000, %eax
@@ -21,4 +22,17 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movl $0x186a0, %eax
+;   callq 0xe ; reloc_external CallPCRel4 %Probestack -4
+;   subq $0x186a0, %rsp
+; block0: ; offset 0x15
+;   leaq (%rsp), %rax
+;   addq $0x186a0, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -7,6 +7,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   cbtw
+;   idivb %sil ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -23,6 +35,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   cwtd
+;   idivw %si ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -39,6 +63,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,6 +73,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   cltd
+;   idivl %esi ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -55,6 +91,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -64,4 +101,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   cqto
+;   idivq %rsi ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -10,6 +10,7 @@ block0(v0: i32, v1: i128, v2: i128):
     return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -22,6 +23,20 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl $0x2a, %edi
+;   movq %rcx, %rax
+;   cmoveq %rsi, %rax
+;   movq %rdx, %rdi
+;   movq %r8, %rdx
+;   cmoveq %rdi, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(f32, i128, i128) -> i128 {
 block0(v0: f32, v1: i128, v2: i128):
@@ -30,6 +45,7 @@ block0(v0: f32, v1: i128, v2: i128):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -43,4 +59,19 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm0, %xmm0
+;   movq %rdi, %rax
+;   cmovneq %rdx, %rax
+;   cmovpq %rdx, %rax
+;   movq %rsi, %rdx
+;   cmovneq %rcx, %rdx
+;   cmovpq %rcx, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -9,6 +9,7 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
     return v6
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -18,7 +19,17 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpl %esi, %edi
+;   movq %rcx, %rax
+;   cmoveq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f0(f32, f32, i64, i64) -> i64 {
 block0(v0: f32, v1: f32, v2: i64, v3: i64):
@@ -28,6 +39,7 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
     return v6
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -38,4 +50,16 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ucomiss %xmm0, %xmm1
+;   movq %rdi, %rax
+;   cmovneq %rsi, %rax
+;   cmovpq %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/sextend.clif
+++ b/cranelift/filetests/filetests/isa/x64/sextend.clif
@@ -7,6 +7,7 @@ block0(v0: i8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,4 +15,13 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movsbq %dil, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -9,6 +9,7 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -19,6 +20,26 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   movdqu 0x10(%rip), %xmm0
+;   movdqa %xmm5, %xmm6
+;   vpermi2b %xmm1, %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 
 function %shuffle_out_of_bounds(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
@@ -29,6 +50,7 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -41,6 +63,31 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm7
+;   movdqu 0x30(%rip), %xmm0
+;   movdqu 0x18(%rip), %xmm6
+;   movdqa %xmm7, %xmm9
+;   vpermi2b %xmm1, %xmm9, %xmm6
+;   andps %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   cmpb $0xff, %bh
 
 function %f3(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
@@ -48,6 +95,7 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -58,4 +106,20 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   movdqu 0x10(%rip), %xmm0
+;   movdqa %xmm5, %xmm6
+;   vpermi2b %xmm1, %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rbx)
+;   addb %bl, (%rdi)
+;   sbbb (%rsi, %rax), %al
+;   orb $0xb, %al
 

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -9,6 +9,7 @@ block0(v0: i8x16, v1: i8x16):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -22,6 +23,21 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm4
+;   pcmpeqb %xmm1, %xmm4
+;   movdqa %xmm0, %xmm7
+;   movdqa %xmm4, %xmm0
+;   movdqa %xmm1, %xmm4
+;   pblendvb %xmm0, %xmm7, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %mask_from_fcmp(f32x4, f32x4, i32x4, i32x4) -> i32x4  {
 block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
@@ -30,6 +46,7 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
     return v5
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -40,6 +57,18 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   cmpeqps %xmm1, %xmm0
+;   movdqa %xmm3, %xmm6
+;   pblendvb %xmm0, %xmm2, %xmm6
+;   movdqa %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %mask_casted(i8x16, i8x16, i32x4) -> i8x16 {
 block0(v0: i8x16, v1: i8x16, v2: i32x4):
@@ -48,6 +77,7 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -59,6 +89,19 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm4
+;   pand %xmm2, %xmm4
+;   movdqa %xmm2, %xmm0
+;   pandn %xmm1, %xmm0
+;   por %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %good_const_mask_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
@@ -67,6 +110,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -79,6 +123,33 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   movdqu 0x20(%rip), %xmm0
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm1, %xmm4
+;   pblendvb %xmm0, %xmm6, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   incl (%rax)
+;   addb %bh, %bh
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   incl (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %good_const_mask_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):
@@ -87,6 +158,7 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -99,6 +171,30 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   movdqu 0x20(%rip), %xmm0
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm1, %xmm4
+;   pblendvb %xmm0, %xmm6, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
+;   addb %al, (%rax)
+;   incl (%rax)
+;   addb %al, (%rax)
 
 function %bad_const_mask(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
@@ -107,6 +203,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -119,4 +216,30 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm8
+;   movdqu 0x1f(%rip), %xmm0
+;   movdqa %xmm8, %xmm4
+;   pand %xmm0, %xmm4
+;   pandn %xmm1, %xmm0
+;   por %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %dh, %al
+;   addb %al, (%rax)
+;   incl (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -8,6 +8,7 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,15 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andps %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %band_f64x2(f64x2, f64x2) -> f64x2 {
 block0(v0: f64x2, v1: f64x2):
@@ -22,6 +32,7 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -29,6 +40,15 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   andpd %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %band_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):
@@ -36,6 +56,7 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -43,6 +64,15 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pand %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bor_f32x4(f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4):
@@ -50,6 +80,7 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -57,6 +88,15 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   orps %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bor_f64x2(f64x2, f64x2) -> f64x2 {
 block0(v0: f64x2, v1: f64x2):
@@ -64,6 +104,7 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -71,6 +112,15 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   orpd %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bor_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):
@@ -78,6 +128,7 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -85,6 +136,15 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   por %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bxor_f32x4(f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4):
@@ -92,6 +152,7 @@ block0(v0: f32x4, v1: f32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -99,6 +160,15 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorps %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bxor_f64x2(f64x2, f64x2) -> f64x2 {
 block0(v0: f64x2, v1: f64x2):
@@ -106,6 +176,7 @@ block0(v0: f64x2, v1: f64x2):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -113,6 +184,15 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorpd %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %bxor_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):
@@ -120,6 +200,7 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -127,6 +208,15 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pxor %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %vselect_i16x8(i16x8, i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8, v2: i16x8):
@@ -134,6 +224,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -143,6 +234,17 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm2, %xmm4
+;   pblendvb %xmm0, %xmm1, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %vselect_f32x4(i32x4, f32x4, f32x4) -> f32x4 {
 block0(v0: i32x4, v1: f32x4, v2: f32x4):
@@ -150,6 +252,7 @@ block0(v0: i32x4, v1: f32x4, v2: f32x4):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -159,6 +262,17 @@ block0(v0: i32x4, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm2, %xmm4
+;   blendvps %xmm0, %xmm1, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %vselect_f64x2(i64x2, f64x2, f64x2) -> f64x2 {
 block0(v0: i64x2, v1: f64x2, v2: f64x2):
@@ -166,6 +280,7 @@ block0(v0: i64x2, v1: f64x2, v2: f64x2):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -175,6 +290,17 @@ block0(v0: i64x2, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm2, %xmm4
+;   blendvpd %xmm0, %xmm1, %xmm4
+;   movdqa %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ishl_i8x16(i32) -> i8x16 {
 block0(v0: i32):
@@ -183,6 +309,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -198,6 +325,27 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0xb4(%rip), %xmm0
+;   movq %rdi, %r10
+;   andq $7, %r10
+;   movd %r10d, %xmm5
+;   psllw %xmm5, %xmm0
+;   leaq 0x1d(%rip), %rsi
+;   shlq $4, %r10
+;   movdqu (%rsi, %r10), %xmm13
+;   pand %xmm13, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 
 function %ushr_i8x16_imm() -> i8x16 {
 block0:
@@ -207,6 +355,7 @@ block0:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -222,6 +371,26 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0xb4(%rip), %xmm0
+;   movl $1, %r9d
+;   andq $7, %r9
+;   movd %r9d, %xmm5
+;   psrlw %xmm5, %xmm0
+;   leaq 0x1a(%rip), %rsi
+;   shlq $4, %r9
+;   movdqu (%rsi, %r9), %xmm13
+;   pand %xmm13, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %sshr_i8x16(i32) -> i8x16 {
 block0(v0: i32):
@@ -230,6 +399,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -247,6 +417,28 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x33(%rip), %xmm8
+;   movq %rdi, %r9
+;   andq $7, %r9
+;   movdqa %xmm8, %xmm0
+;   punpcklbw %xmm8, %xmm0
+;   punpckhbw %xmm8, %xmm8
+;   addl $8, %r9d
+;   movd %r9d, %xmm11
+;   psraw %xmm11, %xmm0
+;   psraw %xmm11, %xmm8
+;   packsswb %xmm8, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rcx)
+;   addb (%rbx), %al
+;   addb $5, %al
 
 function %sshr_i8x16_imm(i8x16, i32) -> i8x16 {
 block0(v0: i8x16, v1: i32):
@@ -254,6 +446,7 @@ block0(v0: i8x16, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -273,6 +466,27 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $3, %r10d
+;   andq $7, %r10
+;   movdqa %xmm0, %xmm13
+;   punpcklbw %xmm0, %xmm13
+;   movdqa %xmm13, %xmm12
+;   movdqa %xmm0, %xmm13
+;   punpckhbw %xmm0, %xmm13
+;   addl $8, %r10d
+;   movd %r10d, %xmm14
+;   movdqa %xmm12, %xmm0
+;   psraw %xmm14, %xmm0
+;   psraw %xmm14, %xmm13
+;   packsswb %xmm13, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64x2(i64x2, i32) -> i64x2 {
 block0(v0: i64x2, v1: i32):
@@ -280,6 +494,7 @@ block0(v0: i64x2, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -294,4 +509,19 @@ block0(v0: i64x2, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pextrq $0, %xmm0, %r8
+;   pextrq $1, %xmm0, %r10
+;   movq %rdi, %rcx
+;   sarq %cl, %r8
+;   sarq %cl, %r10
+;   pinsrq $0, %r8, %xmm0
+;   pinsrq $1, %r10, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -8,6 +8,7 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,6 +18,17 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm1, %xmm0
+;   pcmpeqd %xmm5, %xmm5
+;   pxor %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %icmp_ugt_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):
@@ -24,6 +36,7 @@ block0(v0: i32x4, v1: i32x4):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -34,6 +47,18 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmaxud %xmm1, %xmm0
+;   pcmpeqd %xmm1, %xmm0
+;   pcmpeqd %xmm7, %xmm7
+;   pxor %xmm7, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %icmp_sge_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):
@@ -41,6 +66,7 @@ block0(v0: i16x8, v1: i16x8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -50,6 +76,17 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm3
+;   pmaxsw %xmm1, %xmm3
+;   pcmpeqw %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %icmp_uge_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
@@ -57,6 +94,7 @@ block0(v0: i8x16, v1: i8x16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -66,4 +104,15 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm3
+;   pmaxub %xmm1, %xmm3
+;   pcmpeqb %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -12,6 +12,7 @@ block0:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -25,6 +26,50 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x64(%rip), %xmm0
+;   movdqu 0x4c(%rip), %xmm4
+;   movdqu 0x24(%rip), %xmm2
+;   pshufb %xmm2, %xmm0
+;   movdqu 0x27(%rip), %xmm6
+;   pshufb %xmm6, %xmm4
+;   por %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb $0x80, -0x7f7f7f80(%rax)
+;   addb $0x80, -0x7f7f7f80(%rax)
+;   addb $0, 0x101(%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 
 function %shuffle_same_ssa_value() -> i8x16 {
 block0:
@@ -33,6 +78,7 @@ block0:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +88,33 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x24(%rip), %xmm0
+;   movdqu 0xc(%rip), %xmm1
+;   pshufb %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rcx, %rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 
 function %swizzle() -> i8x16 {
 block0:
@@ -51,6 +124,7 @@ block0:
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -62,6 +136,33 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x34(%rip), %xmm0
+;   movdqu 0x2c(%rip), %xmm2
+;   movdqu 0x14(%rip), %xmm3
+;   paddusb %xmm3, %xmm2
+;   pshufb %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   jo 0xa2
+;   jo 0xa4
+;   jo 0xa6
+;   jo 0xa8
+;   jo 0xaa
+;   jo 0xac
+;   jo 0xae
+;   jo 0xb0
+;   addb %al, (%rcx)
+;   addb (%rbx), %al
+;   addb $5, %al
 
 function %splat_i8(i8) -> i8x16 {
 block0(v0: i8):
@@ -69,6 +170,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -79,6 +181,17 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pinsrb $0, %edi, %xmm0
+;   pxor %xmm6, %xmm6
+;   pshufb %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %splat_i16() -> i16x8 {
 block0:
@@ -87,6 +200,7 @@ block0:
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -98,6 +212,18 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0xffffffff, %esi
+;   pinsrw $0, %esi, %xmm4
+;   pinsrw $1, %esi, %xmm4
+;   pshufd $0, %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %splat_i32(i32) -> i32x4 {
 block0(v0: i32):
@@ -105,6 +231,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -114,6 +241,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pinsrd $0, %edi, %xmm3
+;   pshufd $0, %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %splat_f64(f64) -> f64x2 {
 block0(v0: f64):
@@ -121,6 +258,7 @@ block0(v0: f64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -132,6 +270,18 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   movdqa %xmm5, %xmm6
+;   movsd %xmm6, %xmm0
+;   movlhps %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %load32_zero_coalesced(i64) -> i32x4 {
 block0(v0: i64):
@@ -140,6 +290,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -147,6 +298,15 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movss (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %load32_zero_int(i32) -> i32x4 {
 block0(v0: i32):
@@ -154,6 +314,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -161,6 +322,15 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movd %edi, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %load32_zero_float(f32) -> f32x4 {
 block0(v0: f32):
@@ -168,10 +338,19 @@ block0(v0: f32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -8,6 +8,7 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,16 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pcmpeqd %xmm2, %xmm2
+;   pxor %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %vany_true_i32x4(i32x4) -> i8 {
 block0(v0: i32x4):
@@ -23,6 +34,7 @@ block0(v0: i32x4):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -31,6 +43,16 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ptest %xmm0, %xmm0
+;   setne %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %vall_true_i64x2(i64x2) -> i8 {
 block0(v0: i64x2):
@@ -38,6 +60,7 @@ block0(v0: i64x2):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -49,4 +72,17 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pxor %xmm2, %xmm2
+;   movdqa %xmm0, %xmm4
+;   pcmpeqq %xmm2, %xmm4
+;   ptest %xmm4, %xmm4
+;   sete %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -9,6 +9,7 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -19,6 +20,27 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm4
+;   movdqu 0x10(%rip), %xmm0
+;   movdqa %xmm4, %xmm5
+;   pmaddubsw %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
 
 function %fn2(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -28,6 +50,7 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -36,6 +59,29 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x14(%rip), %xmm2
+;   pmaddwd %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
+;   addb %al, (%rcx)
 
 function %fn3(i8x16) -> i16x8 {
 block0(v0: i8x16):
@@ -45,6 +91,7 @@ block0(v0: i8x16):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -53,6 +100,29 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x14(%rip), %xmm2
+;   pmaddubsw %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
+;   addl %eax, (%rcx)
 
 function %fn4(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -62,6 +132,7 @@ block0(v0: i16x8):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -74,4 +145,38 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x24(%rip), %xmm2
+;   pxor %xmm2, %xmm0
+;   movdqu 0x28(%rip), %xmm6
+;   pmaddwd %xmm6, %xmm0
+;   movdqu 0x2b(%rip), %xmm10
+;   paddd %xmm10, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb $0x80, (%rax)
+;   addb %al, -0x7fff8000(%rax)
+;   addb %al, -0x7fff8000(%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addl %eax, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rax)
 

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -12,6 +12,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -25,6 +26,21 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm3
+;   palignr $8, %xmm0, %xmm3
+;   pmovsxbw %xmm3, %xmm0
+;   movdqa %xmm1, %xmm7
+;   palignr $8, %xmm1, %xmm7
+;   pmovsxbw %xmm7, %xmm9
+;   pmullw %xmm9, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_swiden_hi_i16x8(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):
@@ -34,6 +50,7 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -47,6 +64,21 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   pmullw %xmm1, %xmm5
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm0, %xmm5
+;   pmulhw %xmm1, %xmm5
+;   movdqa %xmm6, %xmm0
+;   punpckhwd %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_swiden_hi_i32x4(i32x4, i32x4) -> i64x2 {
 block0(v0: i32x4, v1: i32x4):
@@ -56,6 +88,7 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -65,6 +98,17 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0xfa, %xmm0, %xmm0
+;   pshufd $0xfa, %xmm1, %xmm5
+;   pmuldq %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_swiden_low_i8x16(i8x16, i8x16) -> i16x8 {
 block0(v0: i8x16, v1: i8x16):
@@ -74,6 +118,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -83,6 +128,17 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovsxbw %xmm0, %xmm0
+;   pmovsxbw %xmm1, %xmm5
+;   pmullw %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_swiden_low_i16x8(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):
@@ -92,6 +148,7 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -105,6 +162,21 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   pmullw %xmm1, %xmm5
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm0, %xmm5
+;   pmulhw %xmm1, %xmm5
+;   movdqa %xmm6, %xmm0
+;   punpcklwd %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_swiden_low_i32x4(i32x4, i32x4) -> i64x2 {
 block0(v0: i32x4, v1: i32x4):
@@ -114,6 +186,7 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -123,6 +196,17 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0x50, %xmm0, %xmm0
+;   pshufd $0x50, %xmm1, %xmm5
+;   pmuldq %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_hi_i8x16(i8x16, i8x16) -> i16x8 {
 block0(v0: i8x16, v1: i8x16):
@@ -132,6 +216,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -145,6 +230,21 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm3
+;   palignr $8, %xmm0, %xmm3
+;   pmovzxbw %xmm3, %xmm0
+;   movdqa %xmm1, %xmm7
+;   palignr $8, %xmm1, %xmm7
+;   pmovzxbw %xmm7, %xmm9
+;   pmullw %xmm9, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_hi_i16x8(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):
@@ -154,6 +254,7 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -167,6 +268,21 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   pmullw %xmm1, %xmm5
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm0, %xmm5
+;   pmulhuw %xmm1, %xmm5
+;   movdqa %xmm6, %xmm0
+;   punpckhwd %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_hi_i32x4(i32x4, i32x4) -> i64x2 {
 block0(v0: i32x4, v1: i32x4):
@@ -176,6 +292,7 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -185,6 +302,17 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0xfa, %xmm0, %xmm0
+;   pshufd $0xfa, %xmm1, %xmm5
+;   pmuludq %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_low_i8x16(i8x16, i8x16) -> i16x8 {
 block0(v0: i8x16, v1: i8x16):
@@ -194,6 +322,7 @@ block0(v0: i8x16, v1: i8x16):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -203,6 +332,17 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovzxbw %xmm0, %xmm0
+;   pmovzxbw %xmm1, %xmm5
+;   pmullw %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_low_i16x8(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):
@@ -212,6 +352,7 @@ block0(v0: i16x8, v1: i16x8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -225,6 +366,21 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm5
+;   pmullw %xmm1, %xmm5
+;   movdqa %xmm5, %xmm6
+;   movdqa %xmm0, %xmm5
+;   pmulhuw %xmm1, %xmm5
+;   movdqa %xmm6, %xmm0
+;   punpcklwd %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %imul_uwiden_low_i32x4(i32x4, i32x4) -> i64x2 {
 block0(v0: i32x4, v1: i32x4):
@@ -234,6 +390,7 @@ block0(v0: i32x4, v1: i32x4):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -243,4 +400,15 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0x50, %xmm0, %xmm0
+;   pshufd $0x50, %xmm1, %xmm5
+;   pmuludq %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/smulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/smulhi.clif
@@ -7,6 +7,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   imulw %si
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -23,6 +35,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   imull %esi
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -39,6 +63,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,4 +73,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   imulq %rsi
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -7,6 +7,7 @@ block0(v0: i16x8, v1: i16x8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,4 +18,19 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x14(%rip), %xmm5
+;   pmulhrsw %xmm1, %xmm0
+;   pcmpeqw %xmm0, %xmm5
+;   pxor %xmm5, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, -0x7fff8000(%rax)
+;   addb %al, -0x7fff8000(%rax)
 

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -7,6 +7,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,6 +18,26 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpb $0, %sil
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpb $0xff, %sil
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cbtw
+;   idivb %sil ; trap: int_divz
+;   shrq $8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -24,6 +45,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -34,6 +56,26 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpw $0, %si
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpw $-1, %si
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cwtd
+;   idivw %si ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -41,6 +83,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -51,6 +94,26 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpl $0, %esi
+;   jne 0x14
+;   ud2 ; trap: int_divz
+;   cmpl $-1, %esi
+;   jne 0x27
+;   movl $0, %eax
+;   jmp 0x2a
+;   cltd
+;   idivl %esi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -58,6 +121,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -68,4 +132,24 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   xorl %edx, %edx
+;   cmpq $0, %rsi
+;   jne 0x15
+;   ud2 ; trap: int_divz
+;   cmpq $-1, %rsi
+;   jne 0x29
+;   movl $0, %eax
+;   jmp 0x2e
+;   cqto
+;   idivq %rsi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -13,6 +13,7 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -40,6 +41,35 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dl, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r10
+;   sarq %cl, %r10
+;   movq %rcx, %r11
+;   movl $0x40, %ecx
+;   movq %r11, %rax
+;   subq %rax, %rcx
+;   movq %rsi, %r9
+;   shlq %cl, %r9
+;   xorq %r11, %r11
+;   testq $0x7f, %rax
+;   cmoveq %r11, %r9
+;   orq %r9, %r8
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rax
+;   movq %r10, %rax
+;   cmoveq %r8, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i128_i64(i128, i64) -> i128 {
 block0(v0: i128, v1: i64):
@@ -47,6 +77,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -73,6 +104,34 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r11
+;   shrq %cl, %r11
+;   movq %rsi, %r9
+;   sarq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r8
+;   shlq %cl, %r8
+;   xorq %r10, %r10
+;   testq $0x7f, %rdi
+;   cmoveq %r10, %r8
+;   orq %r8, %r11
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i128_i32(i128, i32) -> i128 {
 block0(v0: i128, v1: i32):
@@ -80,6 +139,7 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -106,6 +166,34 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r11
+;   shrq %cl, %r11
+;   movq %rsi, %r9
+;   sarq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r8
+;   shlq %cl, %r8
+;   xorq %r10, %r10
+;   testq $0x7f, %rdi
+;   cmoveq %r10, %r8
+;   orq %r8, %r11
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i128_i16(i128, i16) -> i128 {
 block0(v0: i128, v1: i16):
@@ -113,6 +201,7 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -139,6 +228,34 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r11
+;   shrq %cl, %r11
+;   movq %rsi, %r9
+;   sarq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r8
+;   shlq %cl, %r8
+;   xorq %r10, %r10
+;   testq $0x7f, %rdi
+;   cmoveq %r10, %r8
+;   orq %r8, %r11
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -146,6 +263,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -172,6 +290,34 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r11
+;   shrq %cl, %r11
+;   movq %rsi, %r9
+;   sarq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r8
+;   shlq %cl, %r8
+;   xorq %r10, %r10
+;   testq $0x7f, %rdi
+;   cmoveq %r10, %r8
+;   orq %r8, %r11
+;   movq %rsi, %rdx
+;   sarq $0x3f, %rdx
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_i128(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -179,6 +325,7 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -188,6 +335,17 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_i128(i32, i128) -> i32 {
 block0(v0: i32, v1: i128):
@@ -195,6 +353,7 @@ block0(v0: i32, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -204,6 +363,17 @@ block0(v0: i32, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_i128(i16, i128) -> i16 {
 block0(v0: i16, v1: i128):
@@ -211,6 +381,7 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -221,6 +392,18 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   sarw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_i128(i8, i128) -> i8 {
 block0(v0: i8, v1: i128):
@@ -228,6 +411,7 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -238,6 +422,18 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   sarb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -245,6 +441,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -254,6 +451,17 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_i32(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):
@@ -261,6 +469,7 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -270,6 +479,17 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_i16(i64, i16) -> i64 {
 block0(v0: i64, v1: i16):
@@ -277,6 +497,7 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -286,6 +507,17 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_i8(i64, i8) -> i64 {
 block0(v0: i64, v1: i8):
@@ -293,6 +525,7 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -302,6 +535,17 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_i64(i32, i64) -> i32 {
 block0(v0: i32, v1: i64):
@@ -309,6 +553,7 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -318,6 +563,17 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -325,6 +581,7 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -334,6 +591,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_i16(i32, i16) -> i32 {
 block0(v0: i32, v1: i16):
@@ -341,6 +609,7 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -350,6 +619,17 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_i8(i32, i8) -> i32 {
 block0(v0: i32, v1: i8):
@@ -357,6 +637,7 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -366,6 +647,17 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   sarl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_i64(i16, i64) -> i16 {
 block0(v0: i16, v1: i64):
@@ -373,6 +665,7 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -383,6 +676,18 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   sarw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_i32(i16, i32) -> i16 {
 block0(v0: i16, v1: i32):
@@ -390,6 +695,7 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -400,6 +706,18 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   sarw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -407,6 +725,7 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -417,6 +736,18 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   sarw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_i8(i16, i8) -> i16 {
 block0(v0: i16, v1: i8):
@@ -424,6 +755,7 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -434,6 +766,18 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   sarw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_i64(i8, i64) -> i8 {
 block0(v0: i8, v1: i64):
@@ -441,6 +785,7 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -451,6 +796,18 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   sarb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_i32(i8, i32) -> i8 {
 block0(v0: i8, v1: i32):
@@ -458,6 +815,7 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -468,6 +826,18 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   sarb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_i16(i8, i16) -> i8 {
 block0(v0: i8, v1: i16):
@@ -475,6 +845,7 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -485,6 +856,18 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   sarb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -492,6 +875,7 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -502,6 +886,18 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   sarb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i64_const(i64) -> i64 {
 block0(v0: i64):
@@ -509,6 +905,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -517,6 +914,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   sarq $1, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i32_const(i32) -> i32 {
 block0(v0: i32):
@@ -524,6 +931,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -532,6 +940,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   sarl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i16_const(i16) -> i16 {
 block0(v0: i16):
@@ -539,6 +957,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -547,6 +966,16 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   sarw $1, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %sshr_i8_const(i8) -> i8 {
 block0(v0: i8):
@@ -554,6 +983,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -562,4 +992,14 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   sarb $1, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -7,6 +7,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   leaq 0x10(%rbp), %rsi
+;   movzbq (%rsi), %rax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function u0:1(i64 sarg(64), i64) -> i8 system_v {
 block0(v0: i64, v1: i64):
@@ -24,6 +35,7 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -34,6 +46,18 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   leaq 0x10(%rbp), %rcx
+;   movzbq (%rdi), %rax ; trap: heap_oob
+;   movzbq (%rcx), %r9 ; trap: heap_oob
+;   addl %r9d, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function u0:2(i64) -> i8 system_v {
 fn1 = colocated u0:0(i64 sarg(64)) -> i8 system_v
@@ -43,6 +67,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -59,6 +84,22 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rsi
+;   subq $0x40, %rsp
+;   leaq (%rsp), %rdi
+;   movl $0x40, %edx
+;   movabsq $0, %r11 ; reloc_external Abs8 %Memcpy 0
+;   callq *%r11
+;   callq 0x26 ; reloc_external CallPCRel4 u0:0 -4
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function u0:3(i64, i64) -> i8 system_v {
 fn1 = colocated u0:0(i64, i64 sarg(64)) -> i8 system_v
@@ -68,6 +109,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -89,6 +131,27 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r13, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdi, %r13
+;   subq $0x40, %rsp
+;   leaq (%rsp), %rdi
+;   movl $0x40, %edx
+;   movabsq $0, %rax ; reloc_external Abs8 %Memcpy 0
+;   callq *%rax
+;   movq %r13, %rdi
+;   callq 0x30 ; reloc_external CallPCRel4 u0:0 -4
+;   addq $0x40, %rsp
+;   movq (%rsp), %r13
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function u0:4(i64 sarg(128), i64 sarg(64)) -> i8 system_v {
 block0(v0: i64, v1: i64):
@@ -98,6 +161,7 @@ block0(v0: i64, v1: i64):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -109,6 +173,19 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   leaq 0x10(%rbp), %rsi
+;   leaq 0x90(%rbp), %rcx
+;   movzbq (%rsi), %rax ; trap: heap_oob
+;   movzbq (%rcx), %r9 ; trap: heap_oob
+;   addl %r9d, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function u0:5(i64, i64, i64) -> i8 system_v {
 fn1 = colocated u0:0(i64, i64 sarg(128), i64 sarg(64)) -> i8 system_v
@@ -118,6 +195,7 @@ block0(v0: i64, v1: i64, v2: i64):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -147,4 +225,33 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r12, (%rsp)
+;   movq %r14, 8(%rsp)
+; block0: ; offset 0x11
+;   movq %rdx, %r14
+;   movq %rdi, %r12
+;   subq $0xc0, %rsp
+;   leaq (%rsp), %rdi
+;   movl $0x80, %edx
+;   movabsq $0, %rax ; reloc_external Abs8 %Memcpy 0
+;   callq *%rax
+;   leaq 0x80(%rsp), %rdi
+;   movl $0x40, %edx
+;   movabsq $0, %r11 ; reloc_external Abs8 %Memcpy 0
+;   movq %r14, %rsi
+;   callq *%r11
+;   movq %r12, %rdi
+;   callq 0x58 ; reloc_external CallPCRel4 u0:0 -4
+;   addq $0xc0, %rsp
+;   movq (%rsp), %r12
+;   movq 8(%rsp), %r14
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -8,6 +8,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,7 +18,17 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0x2a, %edx
+;   movq %rdx, (%rdi) ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i64, i64) -> i64 {
     fn0 = %f2(i64 sret) -> i64
@@ -27,6 +38,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -37,6 +49,18 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rdi
+;   movabsq $0, %rdx ; reloc_external Abs8 %f2 0
+;   callq *%rdx
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64 sret) {
     fn0 = %f4(i64 sret)
@@ -46,6 +70,7 @@ block0(v0: i64):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
@@ -60,4 +85,20 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+;   movq %r15, (%rsp)
+; block0: ; offset 0xc
+;   movq %rdi, %r15
+;   movabsq $0, %rdx ; reloc_external Abs8 %f4 0
+;   callq *%rdx
+;   movq %r15, %rax
+;   movq (%rsp), %r15
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -9,6 +9,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,15 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rax ; reloc_external Abs8 %func0 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %symbol_value() -> i64 {
     gv0 = symbol %global0
@@ -25,6 +35,7 @@ block0:
     return v0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,4 +43,13 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rax ; reloc_external Abs8 %global0 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -16,6 +16,7 @@ block0(v0: i32, v1: r64, v2: i64):
     return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -35,4 +36,25 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   ret
 ; block1:
 ;   ud2 table_oob
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl 8(%rdx), %r11d
+;   cmpl %r11d, %edi
+;   jae 0x2b
+; block1: ; offset 0x11
+;   movl %edi, %ecx
+;   movq (%rdx), %rax
+;   movq %rax, %rdx
+;   addq %rcx, %rdx
+;   cmpl %r11d, %edi
+;   cmovaeq %rax, %rdx
+;   movq %rsi, (%rdx)
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2: ; offset 0x2b
+;   ud2 ; trap: table_oob
 

--- a/cranelift/filetests/filetests/isa/x64/tls_coff.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_coff.clif
@@ -11,6 +11,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -18,4 +19,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl (%rip), %eax ; reloc_external PCRel4 %CoffTlsIndex -4
+;   movq %gs:0x58, %rcx
+;   movq (%rcx, %rax, 8), %rax
+;   leaq (%rax), %rax ; reloc_external SecRel u1:0 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -10,6 +10,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,4 +18,14 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   leaq (%rip), %rdi ; reloc_external ElfX86_64TlsGd u1:0 -4
+;   callq 0x14 ; reloc_external CallPLTRel4 %ElfTlsGetAddr -4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -6,11 +6,17 @@ block0:
   trap user0
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ud2 user0
-
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   ud2 ; trap: user0
 
 function %trap_iadd_ifcout(i64, i64) {
 block0(v0: i64, v1: i64):
@@ -18,6 +24,7 @@ block0(v0: i64, v1: i64):
   return
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -27,4 +34,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rcx
+;   addq %rsi, %rcx
+;   jae 0x12
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %TruncF32 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -22,6 +33,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -30,4 +42,14 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movabsq $0, %rcx ; reloc_external Abs8 %TruncF64 0
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/trunc.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc.clif
@@ -7,6 +7,7 @@ block0(v0: f32):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundss $3, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(f64) -> f64 {
 block0(v0: f64):
@@ -21,6 +31,7 @@ block0(v0: f64):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundsd $3, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f32x4) -> f32x4 {
 block0(v0: f32x4):
@@ -35,6 +55,7 @@ block0(v0: f32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundps $3, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -49,6 +79,7 @@ block0(v0: f64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -56,4 +87,13 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   roundpd $3, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
@@ -8,6 +8,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,6 +18,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addl $0x7f, %eax
+;   jae 0x12
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f1(i32) -> i32 {
 block0(v0: i32):
@@ -25,6 +38,7 @@ block0(v0: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -34,6 +48,18 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addl $0x7f, %eax
+;   jae 0x12
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -41,6 +67,7 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -50,6 +77,18 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addl %esi, %eax
+;   jae 0x11
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64) -> i64 {
 block0(v0: i64):
@@ -58,6 +97,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -67,6 +107,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addq $0x7f, %rax
+;   jae 0x13
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64) -> i64 {
 block0(v0: i64):
@@ -75,6 +127,7 @@ block0(v0: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -84,6 +137,18 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addq $0x7f, %rax
+;   jae 0x13
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -91,6 +156,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -100,4 +166,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addq %rsi, %rax
+;   jae 0x12
+;   ud2 ; trap: user0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -7,6 +7,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -15,6 +16,16 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbl %dil, %eax
+;   divb %sil ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -22,6 +33,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -31,6 +43,17 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divw %si ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -38,6 +61,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -47,6 +71,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divl %esi ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -54,6 +89,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -63,4 +99,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divq %rsi ; trap: int_divz
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/udivrem.clif
+++ b/cranelift/filetests/filetests/isa/x64/udivrem.clif
@@ -10,6 +10,7 @@ block0(v0: i8, v1: i8):
   return v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -24,6 +25,22 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbl %dil, %eax
+;   divb %sil ; trap: int_divz
+;   movq %rax, %rcx
+;   movzbl %dil, %eax
+;   divb %sil ; trap: int_divz
+;   movq %rax, %rdx
+;   shrq $8, %rdx
+;   movq %rcx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %udivrem_i16(i16, i16) -> i16, i16 {
 block0(v0: i16, v1: i16):
@@ -32,6 +49,7 @@ block0(v0: i16, v1: i16):
   return v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -47,6 +65,23 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0, %edx
+;   movq %rdi, %rax
+;   divw %si ; trap: int_divz
+;   movq %rdi, %rcx
+;   movq %rax, %r8
+;   movl $0, %edx
+;   movq %rcx, %rax
+;   divw %si ; trap: int_divz
+;   movq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %udivrem_i32(i32, i32) -> i32, i32 {
 block0(v0: i32, v1: i32):
@@ -55,6 +90,7 @@ block0(v0: i32, v1: i32):
   return v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -70,6 +106,23 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0, %edx
+;   movq %rdi, %rax
+;   divl %esi ; trap: int_divz
+;   movq %rdi, %rcx
+;   movq %rax, %r8
+;   movl $0, %edx
+;   movq %rcx, %rax
+;   divl %esi ; trap: int_divz
+;   movq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %udivrem_i64(i64, i64) -> i64, i64 {
 block0(v0: i64, v1: i64):
@@ -78,6 +131,7 @@ block0(v0: i64, v1: i64):
   return v2, v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -93,4 +147,21 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl $0, %edx
+;   movq %rdi, %rax
+;   divq %rsi ; trap: int_divz
+;   movq %rdi, %rcx
+;   movq %rax, %r8
+;   movl $0, %edx
+;   movq %rcx, %rax
+;   divq %rsi ; trap: int_divz
+;   movq %r8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
@@ -8,6 +8,7 @@ block0(v0: i32, v1: i32):
     return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,4 +17,14 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   addl %esi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -8,6 +8,7 @@ block0(v1: i32, v2: i64):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -18,4 +19,16 @@ block0(v1: i32, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movl (%rsi), %edx
+;   cmpl %edi, %edx
+;   movq %rdi, %rax
+;   cmovael %edx, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/umulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/umulhi.clif
@@ -7,6 +7,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   mulw %si
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -23,6 +35,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -32,6 +45,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   mull %esi
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -39,6 +63,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -48,4 +73,15 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   mulq %rsi
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -7,6 +7,7 @@ block0(v0: i8, v1: i8):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -16,6 +17,17 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbl %dil, %eax
+;   divb %sil ; trap: int_divz
+;   shrq $8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -23,6 +35,7 @@ block0(v0: i16, v1: i16):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -33,6 +46,18 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divw %si ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -40,6 +65,7 @@ block0(v0: i32, v1: i32):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -50,6 +76,18 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divl %esi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -57,6 +95,7 @@ block0(v0: i64, v1: i64):
   return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -67,4 +106,16 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   movl $0, %edx
+;   divq %rsi ; trap: int_divz
+;   movq %rdx, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -12,6 +12,7 @@ block0(v0: i128, v1: i8):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -37,6 +38,33 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movzbq %dl, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r10
+;   shrq %cl, %r10
+;   movq %rcx, %r9
+;   movl $0x40, %ecx
+;   movq %r9, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r11
+;   shlq %cl, %r11
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r11
+;   orq %r8, %r11
+;   testq $0x40, %rdi
+;   movq %r10, %rax
+;   cmoveq %r11, %rax
+;   cmoveq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i128_i64(i128, i64) -> i128 {
 block0(v0: i128, v1: i64):
@@ -44,6 +72,7 @@ block0(v0: i128, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -68,6 +97,32 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r9
+;   shrq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r10
+;   orq %r8, %r10
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r10, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i128_i32(i128, i32) -> i128 {
 block0(v0: i128, v1: i32):
@@ -75,6 +130,7 @@ block0(v0: i128, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -99,6 +155,32 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r9
+;   shrq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r10
+;   orq %r8, %r10
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r10, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i128_i16(i128, i16) -> i128 {
 block0(v0: i128, v1: i16):
@@ -106,6 +188,7 @@ block0(v0: i128, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -130,6 +213,32 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r9
+;   shrq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r10
+;   orq %r8, %r10
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r10, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i128_i8(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):
@@ -137,6 +246,7 @@ block0(v0: i128, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -161,6 +271,32 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdx, %rcx
+;   movq %rdi, %r8
+;   shrq %cl, %r8
+;   movq %rsi, %r9
+;   shrq %cl, %r9
+;   movl $0x40, %ecx
+;   movq %rdx, %rdi
+;   subq %rdi, %rcx
+;   movq %rsi, %r10
+;   shlq %cl, %r10
+;   xorq %rdx, %rdx
+;   testq $0x7f, %rdi
+;   cmoveq %rdx, %r10
+;   orq %r8, %r10
+;   testq $0x40, %rdi
+;   movq %r9, %rax
+;   cmoveq %r10, %rax
+;   cmoveq %r9, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_i128(i64, i128) -> i64 {
 block0(v0: i64, v1: i128):
@@ -168,6 +304,7 @@ block0(v0: i64, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -177,6 +314,17 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_i128(i32, i64, i64) -> i32 {
 block0(v0: i32, v1: i64, v2: i64):
@@ -185,6 +333,7 @@ block0(v0: i32, v1: i64, v2: i64):
     return v4
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -194,6 +343,17 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_i128(i16, i128) -> i16 {
 block0(v0: i16, v1: i128):
@@ -201,6 +361,7 @@ block0(v0: i16, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -211,6 +372,18 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shrw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_i128(i8, i128) -> i8 {
 block0(v0: i8, v1: i128):
@@ -218,6 +391,7 @@ block0(v0: i8, v1: i128):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -228,6 +402,18 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shrb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -235,6 +421,7 @@ block0(v0: i64, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -244,6 +431,17 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_i32(i64, i32) -> i64 {
 block0(v0: i64, v1: i32):
@@ -251,6 +449,7 @@ block0(v0: i64, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -260,6 +459,17 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_i16(i64, i16) -> i64 {
 block0(v0: i64, v1: i16):
@@ -267,6 +477,7 @@ block0(v0: i64, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -276,6 +487,17 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_i8(i64, i8) -> i64 {
 block0(v0: i64, v1: i8):
@@ -283,6 +505,7 @@ block0(v0: i64, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -292,6 +515,17 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrq %cl, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_i64(i32, i64) -> i32 {
 block0(v0: i32, v1: i64):
@@ -299,6 +533,7 @@ block0(v0: i32, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -308,6 +543,17 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -315,6 +561,7 @@ block0(v0: i32, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -324,6 +571,17 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_i16(i32, i16) -> i32 {
 block0(v0: i32, v1: i16):
@@ -331,6 +589,7 @@ block0(v0: i32, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -340,6 +599,17 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_i8(i32, i8) -> i32 {
 block0(v0: i32, v1: i8):
@@ -347,6 +617,7 @@ block0(v0: i32, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -356,6 +627,17 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   movq %rdi, %rax
+;   shrl %cl, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_i64(i16, i64) -> i16 {
 block0(v0: i16, v1: i64):
@@ -363,6 +645,7 @@ block0(v0: i16, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -373,6 +656,18 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shrw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_i32(i16, i32) -> i16 {
 block0(v0: i16, v1: i32):
@@ -380,6 +675,7 @@ block0(v0: i16, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -390,6 +686,18 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shrw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):
@@ -397,6 +705,7 @@ block0(v0: i16, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -407,6 +716,18 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shrw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_i8(i16, i8) -> i16 {
 block0(v0: i16, v1: i8):
@@ -414,6 +735,7 @@ block0(v0: i16, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -424,6 +746,18 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $0xf, %rcx
+;   movq %rdi, %rax
+;   shrw %cl, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_i64(i8, i64) -> i8 {
 block0(v0: i8, v1: i64):
@@ -431,6 +765,7 @@ block0(v0: i8, v1: i64):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -441,6 +776,18 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shrb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_i32(i8, i32) -> i8 {
 block0(v0: i8, v1: i32):
@@ -448,6 +795,7 @@ block0(v0: i8, v1: i32):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -458,6 +806,18 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shrb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_i16(i8, i16) -> i8 {
 block0(v0: i8, v1: i16):
@@ -465,6 +825,7 @@ block0(v0: i8, v1: i16):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -475,6 +836,18 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shrb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -482,6 +855,7 @@ block0(v0: i8, v1: i8):
     return v2
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -492,6 +866,18 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rsi, %rcx
+;   andq $7, %rcx
+;   movq %rdi, %rax
+;   shrb %cl, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i64_const(i64) -> i64 {
 block0(v0: i64):
@@ -499,6 +885,7 @@ block0(v0: i64):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -507,6 +894,16 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrq $1, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i32_const(i32) -> i32 {
 block0(v0: i32):
@@ -514,6 +911,7 @@ block0(v0: i32):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -522,6 +920,16 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i16_const(i16) -> i16 {
 block0(v0: i16):
@@ -529,6 +937,7 @@ block0(v0: i16):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -537,6 +946,16 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrw $1, %ax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %ushr_i8_const(i8) -> i8 {
 block0(v0: i8):
@@ -544,6 +963,7 @@ block0(v0: i8):
     return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -552,4 +972,14 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movq %rdi, %rax
+;   shrb $1, %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -9,6 +9,7 @@ block0(v0: f64x2):
   return v3
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -24,4 +25,26 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   xorpd %xmm2, %xmm2
+;   movdqa %xmm0, %xmm6
+;   maxpd %xmm2, %xmm6
+;   movupd 0x28(%rip), %xmm7
+;   minpd %xmm7, %xmm6
+;   roundpd $3, %xmm6, %xmm0
+;   movupd 0x25(%rip), %xmm12
+;   addpd %xmm12, %xmm0
+;   shufps $0x88, %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %ah, %al
 

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
@@ -7,6 +7,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovmskb %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i8x16) -> i16 {
 block0(v0: i8x16):
@@ -21,6 +31,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovmskb %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i16x8) -> i8 {
 block0(v0: i16x8):
@@ -35,6 +55,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -45,6 +66,18 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   packsswb %xmm0, %xmm2
+;   pmovmskb %xmm2, %eax
+;   shrq $8, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i32x4) -> i8 {
 block0(v0: i32x4):
@@ -52,6 +85,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -59,6 +93,15 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movmskps %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i64x2) -> i8 {
 block0(v0: i64x2):
@@ -66,6 +109,7 @@ block0(v0: i64x2):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -73,4 +117,13 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movmskpd %xmm0, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -8,6 +8,7 @@ block0(v0: i64, v2: i8x16):
     return v6
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -17,4 +18,15 @@ block0(v0: i64, v2: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqu 0x50(%rdi), %xmm3
+;   palignr $8, %xmm3, %xmm3
+;   pmovzxbw %xmm3, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -7,6 +7,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -14,6 +15,15 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovsxbw %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f2(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -21,6 +31,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -28,6 +39,15 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovsxwd %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f3(i32x4) -> i64x2 {
 block0(v0: i32x4):
@@ -35,6 +55,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -42,6 +63,15 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovsxdq %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f4(i8x16) -> i16x8 {
 block0(v0: i8x16):
@@ -49,6 +79,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -58,6 +89,17 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   palignr $8, %xmm0, %xmm2
+;   pmovsxbw %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f5(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -65,6 +107,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -74,6 +117,17 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   palignr $8, %xmm0, %xmm2
+;   pmovsxwd %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f6(i32x4) -> i64x2 {
 block0(v0: i32x4):
@@ -81,6 +135,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -89,6 +144,16 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0xee, %xmm0, %xmm2
+;   pmovsxdq %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f7(i8x16) -> i16x8 {
 block0(v0: i8x16):
@@ -96,6 +161,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -103,6 +169,15 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovzxbw %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f8(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -110,6 +185,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -117,6 +193,15 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovzxwd %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f9(i32x4) -> i64x2 {
 block0(v0: i32x4):
@@ -124,6 +209,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -131,6 +217,15 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pmovzxdq %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f10(i8x16) -> i16x8 {
 block0(v0: i8x16):
@@ -138,6 +233,7 @@ block0(v0: i8x16):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -147,6 +243,17 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   palignr $8, %xmm0, %xmm2
+;   pmovzxbw %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f11(i16x8) -> i32x4 {
 block0(v0: i16x8):
@@ -154,6 +261,7 @@ block0(v0: i16x8):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -163,6 +271,17 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   palignr $8, %xmm0, %xmm2
+;   pmovzxwd %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 
 function %f12(i32x4) -> i64x2 {
 block0(v0: i32x4):
@@ -170,6 +289,7 @@ block0(v0: i32x4):
   return v1
 }
 
+; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
@@ -178,4 +298,14 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
+; 
+; Disassembled:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0: ; offset 0x4
+;   pshufd $0xee, %xmm0, %xmm2
+;   pmovzxdq %xmm2, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
 

--- a/cranelift/filetests/src/runone.rs
+++ b/cranelift/filetests/src/runone.rs
@@ -38,6 +38,7 @@ pub fn run(
     let options = ParseOptions {
         target,
         passes,
+        machine_code_cfg_info: true,
         ..ParseOptions::default()
     };
 

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -83,7 +83,7 @@ fn check_precise_output(
     let cs = isa
         .to_capstone()
         .map_err(|e| anyhow::format_err!("{}", e))?;
-    let buf = compiled_code.buffer.disassemble(Some(&params), &cs)?;
+    let buf = compiled_code.buffer.disassemble(Some(params), &cs)?;
 
     let actual: Vec<_> = buf.lines().collect();
 

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -62,7 +62,7 @@ impl SubTest for TestCompile {
             .map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?;
         let total_size = compiled_code.code_info().total_size;
 
-        let disasm = compiled_code.disasm.as_ref().unwrap();
+        let disasm = compiled_code.vcode.as_ref().unwrap();
 
         info!("Generated {} bytes of code:\n{}", total_size, disasm);
 
@@ -83,7 +83,7 @@ fn check_precise_output(
     let cs = isa
         .to_capstone()
         .map_err(|e| anyhow::format_err!("{}", e))?;
-    let buf = compiled_code.buffer.disassemble(Some(params), &cs)?;
+    let buf = compiled_code.disassemble(Some(params), &cs)?;
 
     let actual: Vec<_> = buf.lines().collect();
 

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -67,7 +67,7 @@ impl SubTest for TestCompile {
         info!("Generated {} bytes of code:\n{}", total_size, disasm);
 
         if self.precise_output {
-            check_precise_output(isa, params, &compiled_code, context)
+            check_precise_output(isa, &params, &compiled_code, context)
         } else {
             run_filecheck(&disasm, context)
         }
@@ -76,7 +76,7 @@ impl SubTest for TestCompile {
 
 fn check_precise_output(
     isa: &dyn isa::TargetIsa,
-    params: FunctionParameters,
+    params: &FunctionParameters,
     compiled_code: &CompiledCode,
     context: &Context,
 ) -> Result<()> {

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -5,6 +5,9 @@
 use crate::subtest::{run_filecheck, Context, SubTest};
 use anyhow::{bail, Result};
 use cranelift_codegen::ir;
+use cranelift_codegen::ir::function::FunctionParameters;
+use cranelift_codegen::isa;
+use cranelift_codegen::CompiledCode;
 use cranelift_reader::{TestCommand, TestOption};
 use log::info;
 use similar::TextDiff;
@@ -48,6 +51,7 @@ impl SubTest for TestCompile {
 
     fn run(&self, func: Cow<ir::Function>, context: &Context) -> Result<()> {
         let isa = context.isa.expect("compile needs an ISA");
+        let params = func.params.clone();
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         // With `MachBackend`s, we need to explicitly request dissassembly results.
@@ -63,15 +67,25 @@ impl SubTest for TestCompile {
         info!("Generated {} bytes of code:\n{}", total_size, disasm);
 
         if self.precise_output {
-            check_precise_output(&disasm, context)
+            check_precise_output(isa, params, &compiled_code, context)
         } else {
             run_filecheck(&disasm, context)
         }
     }
 }
 
-fn check_precise_output(text: &str, context: &Context) -> Result<()> {
-    let actual = text.lines().collect::<Vec<_>>();
+fn check_precise_output(
+    isa: &dyn isa::TargetIsa,
+    params: FunctionParameters,
+    compiled_code: &CompiledCode,
+    context: &Context,
+) -> Result<()> {
+    let cs = isa
+        .to_capstone()
+        .map_err(|e| anyhow::format_err!("{}", e))?;
+    let buf = compiled_code.buffer.disassemble(Some(&params), &cs)?;
+
+    let actual: Vec<_> = buf.lines().collect();
 
     // Use the comments after the function to build the test expectation.
     let expected = context

--- a/cranelift/filetests/src/test_wasm.rs
+++ b/cranelift/filetests/src/test_wasm.rs
@@ -61,7 +61,7 @@ pub fn run(path: &Path, wat: &str) -> Result<()> {
                 .compile(isa)
                 .map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?;
             writeln!(&mut actual, "function {}:", func.name).unwrap();
-            writeln!(&mut actual, "{}", code.disasm.as_ref().unwrap()).unwrap();
+            writeln!(&mut actual, "{}", code.vcode.as_ref().unwrap()).unwrap();
         } else if config.optimize {
             let mut ctx = cranelift_codegen::Context::for_function(func.clone());
             ctx.optimize(isa)

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -97,6 +97,8 @@ pub struct ParseOptions<'a> {
     pub default_calling_convention: CallConv,
     /// Default for unwind-info setting (enabled or disabled).
     pub unwind_info: bool,
+    /// Default for machine_code_cfg_info setting (enabled or disabled).
+    pub machine_code_cfg_info: bool,
 }
 
 impl Default for ParseOptions<'_> {
@@ -106,6 +108,7 @@ impl Default for ParseOptions<'_> {
             target: None,
             default_calling_convention: CallConv::Fast,
             unwind_info: false,
+            machine_code_cfg_info: false,
         }
     }
 }
@@ -1046,9 +1049,24 @@ impl<'a> Parser<'a> {
         let mut targets = Vec::new();
         let mut flag_builder = settings::builder();
 
-        let unwind_info = if options.unwind_info { "true" } else { "false" };
+        let bool_to_str = |val: bool| {
+            if val {
+                "true"
+            } else {
+                "false"
+            }
+        };
+
+        // default to enabling cfg info
         flag_builder
-            .set("unwind_info", unwind_info)
+            .set(
+                "machine_code_cfg_info",
+                bool_to_str(options.machine_code_cfg_info),
+            )
+            .expect("machine_code_cfg_info option should be present");
+
+        flag_builder
+            .set("unwind_info", bool_to_str(options.unwind_info))
             .expect("unwind_info option should be present");
 
         while let Some(Token::Identifier(command)) = self.token() {


### PR DESCRIPTION
Use `capstone` when checking precise-output test expectations. This lets us continue to rely on printing backend-specific pseudoinstructions in the VCode output for debuggign purposes (for instance `br_table` on x64), while also checking the final output of the machinst buffer in filetests.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
