### PR TITLE
wasi-threads: build the crate in the CLI application by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ default = [
   "wasmtime/parallel-compilation",
   "vtune",
   "wasi-nn",
+  "wasi-threads",
   "pooling-allocator",
 ]
 jitdump = ["wasmtime/jitdump"]


### PR DESCRIPTION
This change adds the `wasmtime-wasi-threads` crate as a default crate for the CLI application. This is no change for embedders of Wasmtime: they would still have to include `wasmtime-wasi-threads` manually. Enabling the crate by default in the CLI application has several benefits, e.g., that it is simpler to experiment with and that it will be part of more test runs (and thus bugs can be discovered more quickly). Users will still have to add
`--wasi-modules=experimental-wasi-threads` to enable wasi-threads on the command line.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
