### PR TITLE
x64: Fix the formatting for `andn`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -762,9 +762,9 @@ impl PrettyPrint for Inst {
                 format!(
                     "{} {}, {}, {}",
                     ljustify2(op.to_string(), String::new()),
-                    dst,
-                    src1,
                     src2,
+                    src1,
+                    dst,
                 )
             }
             Inst::UnaryRmR { src, dst, op, size } => {

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -11,11 +11,10 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andn    %eax, %esi, %edi
+;   andn    %edi, %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-
 
 function %reversed_operands(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
@@ -27,7 +26,7 @@ block0(v0: i8, v1: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   andn    %eax, %edi, %esi
+;   andn    %esi, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/wasm/i32-not-x64.wat
+++ b/cranelift/filetests/filetests/wasm/i32-not-x64.wat
@@ -40,7 +40,7 @@
 ;; block0:
 ;;   jmp     label1
 ;; block1:
-;;   andn    %eax, %esi, %edi
+;;   andn    %edi, %esi, %eax
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret


### PR DESCRIPTION
The formatting for the x64 `AluRmRVex` instructions followed intel syntax, while we emit at&t syntax for everything else. This PR fixes the argument order in the pretty-printer, and updates the test outputs.

This was identified in https://github.com/bytecodealliance/wasmtime/pull/5780#discussion_r1106570415
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
