### PR TITLE
wasmtime::component re-exports all Val variant types.

### DIFF
--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -21,7 +21,9 @@ pub use self::func::{
 pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
 pub use self::types::Type;
-pub use self::values::Val;
+pub use self::values::{
+    Enum, Flags, List, OptionVal, Record, ResultVal, Tuple, Union, Val, Variant,
+};
 pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 
 // These items are expected to be used by an eventual

--- a/crates/wasmtime/src/component/values.rs
+++ b/crates/wasmtime/src/component/values.rs
@@ -11,6 +11,7 @@ use std::ops::Deref;
 use wasmtime_component_util::{DiscriminantSize, FlagsSize};
 use wasmtime_environ::component::VariantInfo;
 
+/// Represents runtime list values
 #[derive(PartialEq, Eq, Clone)]
 pub struct List {
     ty: types::List,
@@ -57,6 +58,7 @@ impl fmt::Debug for List {
     }
 }
 
+/// Represents runtime record values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Record {
     ty: types::Record,
@@ -127,6 +129,7 @@ impl fmt::Debug for Record {
     }
 }
 
+/// Represents runtime tuple values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Tuple {
     ty: types::Tuple,
@@ -176,6 +179,7 @@ impl fmt::Debug for Tuple {
     }
 }
 
+/// Represents runtime variant values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Variant {
     ty: types::Variant,
@@ -246,6 +250,7 @@ impl fmt::Debug for Variant {
     }
 }
 
+/// Represents runtime enum values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Enum {
     ty: types::Enum,
@@ -284,6 +289,7 @@ impl fmt::Debug for Enum {
     }
 }
 
+/// Represents runtime union values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Union {
     ty: types::Union,
@@ -336,6 +342,7 @@ impl fmt::Debug for Union {
     }
 }
 
+/// Represents runtime option values
 #[derive(PartialEq, Eq, Clone)]
 pub struct OptionVal {
     ty: types::OptionType,
@@ -378,6 +385,7 @@ impl fmt::Debug for OptionVal {
     }
 }
 
+/// Represents runtime result values
 #[derive(PartialEq, Eq, Clone)]
 pub struct ResultVal {
     ty: types::ResultType,
@@ -425,6 +433,7 @@ impl fmt::Debug for ResultVal {
     }
 }
 
+/// Represents runtime flag values
 #[derive(PartialEq, Eq, Clone)]
 pub struct Flags {
     ty: types::Flags,


### PR DESCRIPTION
 Closes #5788
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
