### PR TITLE
Fix handling of jumps in bugpoint

### DIFF
--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -709,20 +709,24 @@ impl Mutator for MergeBlocks {
 
         let pred = cfg.pred_iter(block).next().unwrap();
 
-        // If the branch instruction that lead us to this block is preceded by another branch
-        // instruction, then we have a conditional jump sequence that we should not break by
-        // replacing the second instruction by more of them.
-        if let Some(pred_pred_inst) = func.layout.prev_inst(pred.inst) {
-            if func.dfg.insts[pred_pred_inst].opcode().is_branch() {
-                return Some((
-                    func,
-                    format!("did nothing for {}", block),
-                    ProgressStatus::Skip,
-                ));
-            }
+        // If the branch instruction that lead us to this block wasn't an unconditional jump, then
+        // we have a conditional jump sequence that we should not break.
+        let branch_dests = func.dfg.insts[pred.inst].branch_destination();
+        if branch_dests.len() != 1 {
+            return Some((
+                func,
+                format!("did nothing for {}", block),
+                ProgressStatus::Skip,
+            ));
         }
 
-        assert!(func.dfg.block_params(block).len() == func.dfg.inst_variable_args(pred.inst).len());
+        let branch_args = Vec::from_iter(
+            branch_dests[0]
+                .args_slice(&func.dfg.value_lists)
+                .iter()
+                .copied(),
+        );
+        assert_eq!(func.dfg.block_params(block).len(), branch_args.len());
 
         // If there were any block parameters in block, then the last instruction in pred will
         // fill these parameters. Make the block params aliases of the terminator arguments.
@@ -732,7 +736,7 @@ impl Mutator for MergeBlocks {
             .as_slice(&func.dfg.value_lists)
             .iter()
             .cloned()
-            .zip(func.dfg.inst_variable_args(pred.inst).iter().cloned())
+            .zip(branch_args)
             .collect::<Vec<_>>()
         {
             if block_param != arg {


### PR DESCRIPTION
Fixes #5792.

The introduction of `brif` didn't take into account the branch mutation behavior in bugpoint, which led to a crash when trying to reduce a fuzz bug. This PR fixes the bug by handling block terminators that branch to a single destination as before.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
