### PR TITLE
Fix block label printing in precise-output tests

### DIFF
--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -356,16 +356,11 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
         let traps = self.buffer.traps();
 
         // Normalize the block starts to include an initial block of offset 0.
-        let block_starts = if let Some(start) = self.bb_starts.first() {
-            let mut starts = Vec::new();
-            if *start != 0 {
-                starts.push(0);
-            }
-            starts.extend_from_slice(&self.bb_starts);
-            starts
-        } else {
-            vec![0]
-        };
+        let mut block_starts = Vec::new();
+        if self.bb_starts.first().copied() != Some(0) {
+            block_starts.push(0);
+        }
+        block_starts.extend_from_slice(&self.bb_starts);
 
         // Iterate over block regions, to ensure that we always produce block labels
         let end = self.buffer.data().len();

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -354,49 +354,66 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
 
         let relocs = self.buffer.relocs();
         let traps = self.buffer.traps();
-        let labels = self.bb_starts.as_slice();
 
-        let insns = cs.disasm_all(self.buffer.data(), 0x0).map_err(map_caperr)?;
-        for i in insns.iter() {
-            if let Some((n, off)) = labels
-                .iter()
-                .copied()
-                .enumerate()
-                .find(|(_, val)| *val == i.address() as u32)
-            {
-                writeln!(buf, "block{}: ; offset 0x{:x}", n, off)?;
+        // Normalize the block starts to include an initial block of offset 0.
+        let block_starts = if let Some(start) = self.bb_starts.first() {
+            let mut starts = Vec::new();
+            if *start != 0 {
+                starts.push(0);
             }
+            starts.extend_from_slice(&self.bb_starts);
+            starts
+        } else {
+            vec![0]
+        };
 
-            write!(buf, "  ")?;
+        // Iterate over block regions, to ensure that we always produce block labels
+        let end = self.buffer.data().len();
+        for (n, start) in block_starts.iter().enumerate() {
+            let start = *start as usize;
+            let end = if let Some(next) = block_starts.get(n + 1) {
+                *next as usize
+            } else {
+                end
+            };
 
-            let op_str = i.op_str().unwrap_or("");
-            if let Some(s) = i.mnemonic() {
-                write!(buf, "{}", s)?;
-                if !op_str.is_empty() {
-                    write!(buf, " ")?;
+            writeln!(buf, "block{}: ; offset 0x{:x}", n, start)?;
+
+            let insns = cs
+                .disasm_all(&self.buffer.data()[start..end], start as u64)
+                .map_err(map_caperr)?;
+            for i in insns.iter() {
+                write!(buf, "  ")?;
+
+                let op_str = i.op_str().unwrap_or("");
+                if let Some(s) = i.mnemonic() {
+                    write!(buf, "{}", s)?;
+                    if !op_str.is_empty() {
+                        write!(buf, " ")?;
+                    }
                 }
+
+                write!(buf, "{}", op_str)?;
+
+                let end = i.address() + i.bytes().len() as u64;
+                let contains = |off| i.address() <= off && off < end;
+
+                if let Some(reloc) = relocs.iter().find(|reloc| contains(reloc.offset as u64)) {
+                    write!(
+                        buf,
+                        " ; reloc_external {} {} {}",
+                        reloc.kind,
+                        reloc.name.display(params),
+                        reloc.addend,
+                    )?;
+                }
+
+                if let Some(trap) = traps.iter().find(|trap| contains(trap.offset as u64)) {
+                    write!(buf, " ; trap: {}", trap.code)?;
+                }
+
+                writeln!(buf)?;
             }
-
-            write!(buf, "{}", op_str)?;
-
-            let end = i.address() + i.bytes().len() as u64;
-            let contains = |off| i.address() <= off && off < end;
-
-            if let Some(reloc) = relocs.iter().find(|reloc| contains(reloc.offset as u64)) {
-                write!(
-                    buf,
-                    " ; reloc_external {} {} {}",
-                    reloc.kind,
-                    reloc.name.display(params),
-                    reloc.addend,
-                )?;
-            }
-
-            if let Some(trap) = traps.iter().find(|trap| contains(trap.offset as u64)) {
-                write!(buf, " ; trap: {}", trap.code)?;
-            }
-
-            writeln!(buf)?;
         }
 
         return Ok(buf);

--- a/cranelift/filetests/filetests/egraph/multivalue.clif
+++ b/cranelift/filetests/filetests/egraph/multivalue.clif
@@ -26,9 +26,10 @@ function u0:359(i64) -> i8, i8 system_v {
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   callq 9 ; reloc_external CallPCRel4 u0:521 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/egraph/not_a_load.clif
+++ b/cranelift/filetests/filetests/egraph/not_a_load.clif
@@ -24,9 +24,10 @@ function u0:1302(i64) -> i64 system_v {
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rdi), %rax ; trap: heap_oob
 ;   movq %rax, %rcx
 ;   addq %rdi, %rcx

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
@@ -30,12 +30,13 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   mov x28, x2

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
@@ -232,12 +232,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -274,12 +275,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -316,12 +318,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -358,12 +361,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
@@ -24,12 +24,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -65,12 +66,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -106,12 +108,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -147,12 +150,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -188,12 +192,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -229,12 +234,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -270,12 +276,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -311,12 +318,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -352,12 +360,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -393,12 +402,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -434,12 +444,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -475,12 +486,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -516,12 +528,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -558,12 +571,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -600,12 +614,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -642,12 +657,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -684,12 +700,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -725,12 +742,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -766,12 +784,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -807,12 +826,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -848,12 +868,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -889,12 +910,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -930,12 +952,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -971,12 +994,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -1012,12 +1036,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -1054,12 +1079,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -1096,12 +1122,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -1139,12 +1166,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -1182,12 +1210,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -1224,12 +1253,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -1266,12 +1296,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -1308,12 +1339,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -1350,12 +1382,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -1392,12 +1425,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -1434,12 +1468,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -1477,12 +1512,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]
@@ -1520,12 +1556,13 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr x27, [x25]
@@ -1562,12 +1599,13 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxr w27, [x25]
@@ -1604,12 +1642,13 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25]
@@ -1646,12 +1685,13 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x26, x27, [sp, #-0x10]!
 ;   stp x24, x25, [sp, #-0x10]!
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25]

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -61,8 +61,9 @@ block5(v5: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   hint #0x22
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmp w0, #3
 ;   b.hs #0x30
 ;   csel x15, xzr, x0, hs
@@ -74,24 +75,24 @@ block5(v5: i32):
 ;   .byte 0x14, 0x00, 0x00, 0x00
 ;   .byte 0x20, 0x00, 0x00, 0x00
 ;   .byte 0x2c, 0x00, 0x00, 0x00
-; block1: ; offset 0x30
+; block2: ; offset 0x30
 ;   mov w5, #4
-; block2: ; offset 0x34
+; block3: ; offset 0x34
 ;   b #0x58
-; block3: ; offset 0x38
+; block4: ; offset 0x38
 ;   hint #0x24
 ;   mov w5, #1
-; block4: ; offset 0x40
+; block5: ; offset 0x40
 ;   b #0x58
-; block5: ; offset 0x44
+; block6: ; offset 0x44
 ;   hint #0x24
 ;   mov w5, #2
-; block6: ; offset 0x4c
+; block7: ; offset 0x4c
 ;   b #0x58
-; block7: ; offset 0x50
+; block8: ; offset 0x50
 ;   hint #0x24
 ;   mov w5, #3
-; block8: ; offset 0x58
+; block9: ; offset 0x58
 ;   add w0, w0, w5
 ;   ret
 
@@ -128,8 +129,9 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   hint #0x22
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ldr x5, [x0]
 ;   mov x8, x5
 ;   cmp w0, #1
@@ -141,10 +143,10 @@ block2:
 ;   add x6, x6, x7
 ;   br x6
 ;   .byte 0x0c, 0x00, 0x00, 0x00
-; block1: ; offset 0x30
+; block2: ; offset 0x30
 ;   mov x0, x8
 ;   ret
-; block2: ; offset 0x38
+; block3: ; offset 0x38
 ;   hint #0x24
 ;   mov x0, x8
 ;   add x0, x0, #0x2a
@@ -169,10 +171,11 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   hint #0x22
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldr x3, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0

--- a/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
@@ -18,9 +18,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   blr x1
 ;   ldp x29, x30, [sp], #0x10
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -21,10 +21,11 @@ block0(v0: i64):
 ;   autiasp ; ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   paciasp
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldr x3, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -21,9 +21,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldr x3, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -50,9 +51,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldr x3, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -92,9 +94,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldr x3, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -149,9 +152,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x8, x0
 ;   sub sp, sp, #0x10
 ;   mov w0, #0x2a
@@ -256,10 +260,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x30
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldr x9, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
@@ -351,10 +356,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x30
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldr x9, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
@@ -450,10 +456,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x30
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldr x9, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g0 0
@@ -538,9 +545,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x1, x0
 ;   mov x0, #0x2a
 ;   mov x2, #0x2a
@@ -591,9 +599,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x2, x0
 ;   mov x3, #0x2a
 ;   mov x0, #0x2a
@@ -644,9 +653,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x1, x0
 ;   mov x2, #0x2a
 ;   mov x0, #0x2a
@@ -673,9 +683,10 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldur x0, [x29, #0x10]
 ;   ldur x1, [x29, #0x18]
 ;   ldp x29, x30, [sp], #0x10
@@ -712,9 +723,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x6, x2
 ;   sub sp, sp, #0x10
 ;   stur x0, [sp]
@@ -749,9 +761,10 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldur x0, [x29, #0x10]
 ;   ldur x1, [x29, #0x18]
 ;   ldp x29, x30, [sp], #0x10
@@ -788,9 +801,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x6, x2
 ;   sub sp, sp, #0x10
 ;   stur x0, [sp]
@@ -873,9 +887,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x8, x0
 ;   ldr x3, #0x14
 ;   b #0x1c
@@ -907,10 +922,11 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x24, [sp, #-0x10]!
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x24, x8
 ;   ldr x4, #0x18
 ;   b #0x20

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -24,10 +24,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x1, sp
 ;   mov x2, #1
 ;   str x2, [x1]
@@ -58,10 +59,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x1, sp
 ;   mov x2, #1
 ;   str x2, [x1]
@@ -93,10 +95,11 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   dup v3.4s, w0
 ;   mov x3, sp
 ;   str q3, [x3]
@@ -127,10 +130,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x2, sp
 ;   ldr q0, [x2]
 ;   add sp, sp, #0x10
@@ -161,10 +165,11 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   dup v3.4s, w0
 ;   mov x3, sp
 ;   str q3, [x3]
@@ -193,10 +198,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x0, sp
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
@@ -18,10 +18,11 @@ block0:
 ;   autiasp ; ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   paciasp
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x0, x29
 ;   ldp x29, x30, [sp], #0x10
 ;   autiasp
@@ -43,10 +44,11 @@ block0:
 ;   autiasp ; ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   paciasp
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x0, sp
 ;   ldp x29, x30, [sp], #0x10
 ;   autiasp
@@ -70,10 +72,11 @@ block0:
 ;   autiasp ; ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   paciasp
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   ldur x30, [x29, #8]
 ;   xpaclri
 ;   mov x0, x30

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
@@ -17,9 +17,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x0, x29
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -39,9 +40,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   mov x0, sp
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -61,9 +63,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldur x0, [x29, #8]
 ;   ldp x29, x30, [sp], #0x10
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
@@ -26,10 +26,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x800
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x0, sp
 ;   add sp, sp, #0x800
 ;   ldp x29, x30, [sp], #0x10
@@ -57,6 +58,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov x16, #-0x1000
@@ -66,7 +68,7 @@ block0:
 ;   mov x16, #-0x3000
 ;   str wzr, [sp, x16, sxtx]
 ;   sub sp, sp, #3, lsl #12
-; block0: ; offset 0x24
+; block1: ; offset 0x24
 ;   mov x0, sp
 ;   add sp, sp, #3, lsl #12
 ;   ldp x29, x30, [sp], #0x10
@@ -99,6 +101,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov x16, #0
@@ -111,7 +114,7 @@ block0:
 ;   mov w16, #0x86a0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x30
+; block1: ; offset 0x30
 ;   mov x0, sp
 ;   mov w16, #0x86a0
 ;   movk w16, #1, lsl #16

--- a/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
@@ -18,9 +18,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-; block0: ; offset 0x8
+; block1: ; offset 0x8
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/prologue.clif
@@ -153,13 +153,14 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   stp d14, d15, [sp, #-0x10]!
 ;   stp d12, d13, [sp, #-0x10]!
 ;   stp d10, d11, [sp, #-0x10]!
 ;   stp d8, d9, [sp, #-0x10]!
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   fadd d23, d0, d0
 ;   fadd d24, d0, d0
 ;   fadd d25, d0, d0
@@ -323,11 +324,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x28, [sp, #-0x10]!
 ;   stp x21, x27, [sp, #-0x10]!
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   add x5, x0, x0
 ;   add x6, x0, x5
 ;   add x7, x0, x6

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -121,10 +121,11 @@ block3(v7: r64, v8: r64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x20
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   stur x0, [sp, #8]
 ;   stur x1, [sp, #0x10]
 ;   ldr x1, #0x1c
@@ -137,14 +138,14 @@ block3(v7: r64, v8: r64):
 ;   str x6, [x15]
 ;   uxtb w0, w0
 ;   cbz x0, #0x48
-; block1: ; offset 0x3c
+; block2: ; offset 0x3c
 ;   mov x0, x6
 ;   ldur x1, [sp, #0x10]
 ;   b #0x50
-; block2: ; offset 0x48
+; block3: ; offset 0x48
 ;   mov x1, x6
 ;   ldur x0, [sp, #0x10]
-; block3: ; offset 0x50
+; block4: ; offset 0x50
 ;   mov x2, sp
 ;   ldr x2, [x2]
 ;   add sp, sp, #0x20

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -64,12 +64,13 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   cmp sp, x0
 ;   b.hs #0x14
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   ldr x2, #0x1c
 ;   b #0x24
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
@@ -103,6 +104,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   ldur x16, [x0]
@@ -110,7 +112,7 @@ block0(v0: i64):
 ;   cmp sp, x16
 ;   b.hs #0x1c
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
-; block0: ; offset 0x1c
+; block1: ; offset 0x1c
 ;   ldr x2, #0x24
 ;   b #0x2c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
@@ -138,6 +140,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   add x16, x0, #0xb0
@@ -145,7 +148,7 @@ block0(v0: i64):
 ;   b.hs #0x18
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 ;   sub sp, sp, #0xb0
-; block0: ; offset 0x1c
+; block1: ; offset 0x1c
 ;   add sp, sp, #0xb0
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -177,6 +180,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   cmp sp, x0
@@ -191,7 +195,7 @@ block0(v0: i64):
 ;   mov w16, #0x1a80
 ;   movk w16, #6, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x38
+; block1: ; offset 0x38
 ;   mov w16, #0x1a80
 ;   movk w16, #6, lsl #16
 ;   add sp, sp, x16
@@ -223,6 +227,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   ldur x16, [x0]
@@ -232,7 +237,7 @@ block0(v0: i64):
 ;   b.hs #0x20
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 ;   sub sp, sp, #0x20
-; block0: ; offset 0x24
+; block1: ; offset 0x24
 ;   add sp, sp, #0x20
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -270,6 +275,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   ldur x16, [x0]
@@ -286,7 +292,7 @@ block0(v0: i64):
 ;   mov w16, #0x1a80
 ;   movk w16, #6, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x40
+; block1: ; offset 0x40
 ;   mov w16, #0x1a80
 ;   movk w16, #6, lsl #16
 ;   add sp, sp, x16
@@ -316,6 +322,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x1a80
@@ -326,7 +333,7 @@ block0(v0: i64):
 ;   b.hs #0x24
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: stk_ovf
 ;   sub sp, sp, #0x20
-; block0: ; offset 0x28
+; block1: ; offset 0x28
 ;   add sp, sp, #0x20
 ;   ldp x29, x30, [sp], #0x10
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -21,10 +21,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x0, sp
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10
@@ -54,12 +55,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x0, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
@@ -87,10 +89,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x1, sp
 ;   ldr x0, [x1]
 ;   add sp, sp, #0x10
@@ -122,12 +125,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x1, sp
 ;   ldr x0, [x1]
 ;   mov w16, #0x86b0
@@ -156,10 +160,11 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x2, sp
 ;   str x0, [x2]
 ;   add sp, sp, #0x10
@@ -191,12 +196,13 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x2, sp
 ;   str x0, [x2]
 ;   mov w16, #0x86b0
@@ -514,6 +520,7 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   stp x27, x28, [sp, #-0x10]!
@@ -522,7 +529,7 @@ block0(v0: i8):
 ;   stp x21, x22, [sp, #-0x10]!
 ;   stp x19, x20, [sp, #-0x10]!
 ;   sub sp, sp, #0x480
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   str x0, [sp, #0x3e8]
 ;   mov x6, #2
 ;   add x9, x6, #1
@@ -690,10 +697,11 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x3, sp
 ;   stp x0, x1, [x3]
 ;   add sp, sp, #0x10
@@ -721,10 +729,11 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x20
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   add x3, sp, #0x20
 ;   stp x0, x1, [x3]
 ;   add sp, sp, #0x20
@@ -756,12 +765,13 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x3, sp
 ;   stp x0, x1, [x3]
 ;   mov w16, #0x86b0
@@ -790,10 +800,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   mov x2, sp
 ;   ldp x0, x1, [x2]
 ;   add sp, sp, #0x10
@@ -821,10 +832,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   sub sp, sp, #0x20
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   add x2, sp, #0x20
 ;   ldp x0, x1, [x2]
 ;   add sp, sp, #0x20
@@ -856,12 +868,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mov x2, sp
 ;   ldp x0, x1, [x2]
 ;   mov w16, #0x86b0

--- a/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
@@ -32,6 +32,7 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ;   str x24, [sp, #-0x10]!
@@ -39,7 +40,7 @@ block0(v0: i32):
 ;   stp d12, d13, [sp, #-0x10]!
 ;   stp d10, d11, [sp, #-0x10]!
 ;   stp d8, d9, [sp, #-0x10]!
-; block0: ; offset 0x1c
+; block1: ; offset 0x1c
 ;   mov x24, x0
 ;   adrp x0, #0 ; reloc_external Aarch64TlsGdAdrPage21 u1:0 0
 ;   add x0, x0, #0 ; reloc_external Aarch64TlsGdAddLo12Nc u1:0 0

--- a/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
@@ -22,11 +22,12 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   jalr a1
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -24,11 +24,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   auipc a1, 0
 ;   ld a1, 0xc(a1)
 ;   j 0xc
@@ -63,11 +64,12 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   slli a0, a0, 0x20
 ;   srli a0, a0, 0x20
 ;   auipc a2, 0
@@ -120,11 +122,12 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   slli a0, a0, 0x20
 ;   srai a0, a0, 0x20
 ;   auipc a2, 0
@@ -192,11 +195,12 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori t3, a0, 0
 ;   addi sp, sp, -0x10
 ;   addi a0, zero, 0x2a
@@ -335,6 +339,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -343,7 +348,7 @@ block0:
 ;   fsd fs3, -0x10(sp)
 ;   fsd fs11, -0x18(sp)
 ;   addi sp, sp, -0x20
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   auipc a6, 0
 ;   ld a6, 0xc(a6)
 ;   j 0xc
@@ -445,11 +450,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a5, a0, 0
 ;   addi a0, zero, 0x2a
 ;   ori a1, a5, 0
@@ -510,11 +516,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a1, a0, 0
 ;   addi a2, zero, 0x2a
 ;   addi a0, zero, 0x2a
@@ -574,11 +581,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a1, a0, 0
 ;   addi a2, zero, 0x2a
 ;   addi a0, zero, 0x2a
@@ -612,11 +620,12 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a0, a7, 0
 ;   ld a1, 0x10(s0)
 ;   ld ra, 8(sp)
@@ -659,11 +668,12 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a7, a0, 0
 ;   ori a6, a2, 0
 ;   addi sp, sp, -0x10
@@ -705,11 +715,12 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a0, a7, 0
 ;   ld a1, 0x10(s0)
 ;   ld ra, 8(sp)
@@ -752,11 +763,12 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-; block0: ; offset 0x10
+; block1: ; offset 0x10
 ;   ori a7, a0, 0
 ;   ori a6, a2, 0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/prologue.clif
@@ -173,6 +173,7 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -189,7 +190,7 @@ block0(v0: f64):
 ;   fsd fs10, -0x50(sp)
 ;   fsd fs11, -0x58(sp)
 ;   addi sp, sp, -0x60
-; block0: ; offset 0x40
+; block1: ; offset 0x40
 ;   fadd.d ft3, fa0, fa0
 ;   fadd.d ft4, fa0, fa0
 ;   fadd.d ft5, fa0, fa0
@@ -377,6 +378,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -388,7 +390,7 @@ block0(v0: i64):
 ;   sd s9, -0x28(sp)
 ;   sd s10, -0x30(sp)
 ;   addi sp, sp, -0x30
-; block0: ; offset 0x2c
+; block1: ; offset 0x2c
 ;   add t3, a0, a0
 ;   add t4, a0, t3
 ;   add t0, a0, t4

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -132,13 +132,14 @@ block3(v7: r64, v8: r64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   sd s7, -8(sp)
 ;   addi sp, sp, -0x30
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   sd a0, 8(sp)
 ;   sd a1, 0x10(sp)
 ;   ori s7, a2, 0
@@ -153,14 +154,14 @@ block3(v7: r64, v8: r64):
 ;   sd t4, 0(a1)
 ;   andi a1, a0, 0xff
 ;   beqz a1, 0x10
-; block1: ; offset 0x50
+; block2: ; offset 0x50
 ;   ori a0, t4, 0
 ;   ld a1, 0x10(sp)
 ;   j 0xc
-; block2: ; offset 0x5c
+; block3: ; offset 0x5c
 ;   ori a1, t4, 0
 ;   ld a0, 0x10(sp)
-; block3: ; offset 0x64
+; block4: ; offset 0x64
 ;   mv a2, sp
 ;   ld a2, 0(a2)
 ;   ori a3, s7, 0

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -68,13 +68,14 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   bgeu sp, a0, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   auipc t2, 0
 ;   ld t2, 0xc(t2)
 ;   j 0xc
@@ -114,6 +115,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -122,7 +124,7 @@ block0(v0: i64):
 ;   ld t6, 4(t6)
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   auipc t2, 0
 ;   ld t2, 0xc(t2)
 ;   j 0xc
@@ -156,6 +158,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -164,7 +167,7 @@ block0(v0: i64):
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0xb0
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   addi sp, sp, 0xb0
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -199,6 +202,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -221,7 +225,7 @@ block0(v0: i64):
 ;   lui t6, 0xfff9e
 ;   addi t6, t6, 0x580
 ;   add sp, t6, sp
-; block0: ; offset 0x58
+; block1: ; offset 0x58
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
 ;   add sp, t6, sp
@@ -258,6 +262,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -268,7 +273,7 @@ block0(v0: i64):
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0x20
-; block0: ; offset 0x28
+; block1: ; offset 0x28
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -309,6 +314,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -333,7 +339,7 @@ block0(v0: i64):
 ;   lui t6, 0xfff9e
 ;   addi t6, t6, 0x580
 ;   add sp, t6, sp
-; block0: ; offset 0x60
+; block1: ; offset 0x60
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
 ;   add sp, t6, sp
@@ -368,6 +374,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -383,7 +390,7 @@ block0(v0: i64):
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0x20
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -26,12 +26,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x10
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mv a0, sp
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
@@ -66,6 +67,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -81,7 +83,7 @@ block0:
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   mv a0, sp
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
@@ -115,12 +117,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x10
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mv t1, sp
 ;   ld a0, 0(t1)
 ;   addi sp, sp, 0x10
@@ -157,6 +160,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -172,7 +176,7 @@ block0:
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   mv t1, sp
 ;   ld a0, 0(t1)
 ;   lui t6, 0x18
@@ -207,12 +211,13 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x10
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mv t2, sp
 ;   sd a0, 0(t2)
 ;   addi sp, sp, 0x10
@@ -249,6 +254,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -264,7 +270,7 @@ block0(v0: i64):
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   mv t2, sp
 ;   sd a0, 0(t2)
 ;   lui t6, 0x18
@@ -610,6 +616,7 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -626,7 +633,7 @@ block0(v0: i8):
 ;   sd s10, -0x50(sp)
 ;   sd s11, -0x58(sp)
 ;   addi sp, sp, -0x500
-; block0: ; offset 0x40
+; block1: ; offset 0x40
 ;   sd a0, 0x3e8(sp)
 ;   addi t3, zero, 2
 ;   addi t1, t3, 1
@@ -818,12 +825,13 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x10
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   ori a2, a0, 0
 ;   mv a0, sp
 ;   sd a2, 0(a0)
@@ -861,12 +869,13 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x20
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   ori a2, a0, 0
 ;   addi a0, sp, 0x20
 ;   sd a2, 0(a0)
@@ -907,6 +916,7 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -922,7 +932,7 @@ block0(v0: i128):
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   ori a2, a0, 0
 ;   mv a0, sp
 ;   sd a2, 0(a0)
@@ -960,12 +970,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x10
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   mv t2, sp
 ;   ld a0, 0(t2)
 ;   ld a1, 8(t2)
@@ -1001,12 +1012,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ;   addi sp, sp, -0x20
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   addi t2, sp, 0x20
 ;   ld a0, 0(t2)
 ;   ld a1, 8(t2)
@@ -1045,6 +1057,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
@@ -1060,7 +1073,7 @@ block0:
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
-; block0: ; offset 0x3c
+; block1: ; offset 0x3c
 ;   mv t2, sp
 ;   ld a0, 0(t2)
 ;   ld a1, 8(t2)

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -967,8 +967,9 @@ block0(v0: i128, v1: i128):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r10, %r2
 ;   vl %v1, 0(%r3)
 ;   vl %v3, 0(%r4)
@@ -1555,8 +1556,9 @@ block0(v0: i32, v1: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r7, %r3
 ;   lgfr %r3, %r2
 ;   iilf %r4, 0x7fffffff
@@ -1826,8 +1828,9 @@ block0(v0: i16, v1: i16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -1891,8 +1894,9 @@ block0(v0: i8, v1: i8):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -2089,8 +2093,9 @@ block0(v0: i16, v1: i16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -2123,8 +2128,9 @@ block0(v0: i8, v1: i8):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
@@ -70,8 +70,9 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r11, %r15, 0x58(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   sllk %r11, %r5, 3
 ;   nill %r5, 0xfffc
 ;   lrvr %r2, %r3
@@ -109,8 +110,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r10, %r15, 0x50(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r10, %r3
 ;   sllk %r3, %r5, 3
 ;   nill %r5, 0xfffc

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
@@ -89,8 +89,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r10, %r15, 0x50(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r10, %r3
 ;   sllk %r3, %r5, 3
 ;   nill %r5, 0xfffc

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -24,9 +24,10 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   bras %r1, 0x16
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00
@@ -57,9 +58,10 @@ block0(v0: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   llgfr %r2, %r2
 ;   bras %r1, 0x1a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -106,9 +108,10 @@ block0(v0: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   lgfr %r2, %r2
 ;   bras %r1, 0x1a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -153,9 +156,10 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   brasl %r14, 0xa ; reloc_external PLTRel32Dbl %g 2
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
@@ -180,9 +184,10 @@ block0(v0: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   llgfr %r2, %r2
 ;   bras %r1, 0x1a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
@@ -211,9 +216,10 @@ block0(v0: i64, v1: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
@@ -271,8 +277,9 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r6, %r15, 0x30(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lg %r12, 0xa0(%r15)
 ;   lg %r14, 0xa8(%r15)
 ;   llgc %r7, 0xb7(%r15)
@@ -378,9 +385,10 @@ block0:
 ;   trap
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   lghi %r2, 0
 ;   brasl %r14, 0xe ; reloc_external PLTRel32Dbl %g 2
 ;   .byte 0x00, 0x00 ; trap: user0

--- a/cranelift/filetests/filetests/isa/s390x/div-traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/div-traps.clif
@@ -92,8 +92,9 @@ block0(v0: i32, v1: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgfr %r5, %r2
 ;   lgr %r7, %r5
 ;   cite %r3, 0 ; trap: int_divz
@@ -379,8 +380,9 @@ block0(v0: i16, v1: i16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -446,8 +448,9 @@ block0(v0: i8, v1: i8):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -670,8 +673,9 @@ block0(v0: i16, v1: i16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5
@@ -706,8 +710,9 @@ block0(v0: i8, v1: i8):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r8, %r15, 0x40(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lgr %r4, %r3
 ;   lhi %r5, 0
 ;   lgr %r8, %r5

--- a/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
@@ -20,11 +20,12 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   lg %r2, 0(%r15)
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
@@ -47,11 +48,12 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   lgr %r2, %r15
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
@@ -74,11 +76,12 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   lg %r2, 0x110(%r15)
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
@@ -21,11 +21,12 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   lgr %r1, %r15
 ;   aghi %r15, -0xa0
 ;   stg %r1, 0(%r15)
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   lmg %r14, %r15, 0x110(%r15)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -54,8 +54,9 @@ block1:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   lghi %r4, 1
 ;   lgr %r14, %r4
 ;   lghi %r3, 2

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -126,9 +126,10 @@ block3(v7: r64, v8: r64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xb8
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   stg %r2, 0xa8(%r15)
 ;   stg %r3, 0xb0(%r15)
 ;   bras %r1, 0x22
@@ -144,14 +145,14 @@ block3(v7: r64, v8: r64):
 ;   lbr %r2, %r2
 ;   chi %r2, 0
 ;   jgnlh 0x58
-; block1: ; offset 0x48
+; block2: ; offset 0x48
 ;   lgr %r2, %r4
 ;   lg %r3, 0xb0(%r15)
 ;   jg 0x62
-; block2: ; offset 0x58
+; block3: ; offset 0x58
 ;   lgr %r3, %r4
 ;   lg %r2, 0xb0(%r15)
-; block3: ; offset 0x62
+; block4: ; offset 0x62
 ;   la %r4, 0xa0(%r15)
 ;   lg %r4, 0(%r4)
 ;   lmg %r14, %r15, 0x128(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
@@ -63,10 +63,11 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xe
+; block1: ; offset 0xe
 ;   bras %r1, 0x1a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00
@@ -102,12 +103,13 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0x1a
+; block1: ; offset 0x1a
 ;   bras %r1, 0x26
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00
@@ -133,10 +135,11 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   la %r1, 0xa8(%r2)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   aghi %r15, -0xa8
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   aghi %r15, 0xa8
 ;   br %r14
 
@@ -156,11 +159,12 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
 ;   lay %r1, 0x61a80(%r2)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   agfi %r15, -0x61a80
-; block0: ; offset 0x14
+; block1: ; offset 0x14
 ;   agfi %r15, 0x61a80
 ;   br %r14
 
@@ -181,12 +185,13 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
 ;   lgr %r1, %r2
 ;   algfi %r1, 0x3d0900
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   agfi %r15, -0x3d0900
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   agfi %r15, 0x3d0900
 ;   br %r14
 
@@ -211,12 +216,13 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   la %r1, 0x18(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   aghi %r15, -0x18
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   aghi %r15, 0x18
 ;   br %r14
 
@@ -242,13 +248,14 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   lay %r1, 0x61a80(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   agfi %r15, -0x61a80
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   agfi %r15, 0x61a80
 ;   br %r14
 
@@ -274,13 +281,14 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   algfi %r1, 0x3d0900
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   agfi %r15, -0x3d0900
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   agfi %r15, 0x3d0900
 ;   br %r14
 
@@ -303,12 +311,13 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   lgfi %r1, 0xf4240
 ;   lg %r1, 0(%r1, %r2)
 ;   la %r1, 0x18(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   aghi %r15, -0x18
-; block0: ; offset 0x18
+; block1: ; offset 0x18
 ;   aghi %r15, 0x18
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/stack.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack.clif
@@ -19,8 +19,9 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   aghi %r15, -8
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   la %r2, 0(%r15)
 ;   aghi %r15, 8
 ;   br %r14
@@ -42,8 +43,9 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   la %r2, 0(%r15)
 ;   agfi %r15, 0x186a8
 ;   br %r14
@@ -65,8 +67,9 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   aghi %r15, -8
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   la %r3, 0(%r15)
 ;   lg %r2, 0(%r3)
 ;   aghi %r15, 8
@@ -90,8 +93,9 @@ block0:
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   la %r3, 0(%r15)
 ;   lg %r2, 0(%r3)
 ;   agfi %r15, 0x186a8
@@ -114,8 +118,9 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   aghi %r15, -8
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   la %r4, 0(%r15)
 ;   stg %r2, 0(%r4)
 ;   aghi %r15, 8
@@ -139,8 +144,9 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8
-; block0: ; offset 0x6
+; block1: ; offset 0x6
 ;   la %r4, 0(%r15)
 ;   stg %r2, 0(%r4)
 ;   agfi %r15, 0x186a8

--- a/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
@@ -59,9 +59,10 @@ block0(v0: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   mvc 0xa0(0x40, %r15), 0(%r2)
 ;   la %r2, 0xa0(%r15)
 ;   brasl %r14, 0x14 ; reloc_external PLTRel32Dbl u0:0 2
@@ -88,9 +89,10 @@ block0(v0: i64, v1: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   mvc 0xa0(0x40, %r15), 0(%r3)
 ;   la %r3, 0xa0(%r15)
 ;   brasl %r14, 0x14 ; reloc_external PLTRel32Dbl u0:0 2
@@ -143,9 +145,10 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0x1e0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   mvc 0xa0(0x100, %r15), 0(%r3)
 ;   mvc 0x1a0(0x40, %r15), 0(%r4)
 ;   la %r3, 0xa0(%r15)
@@ -183,9 +186,10 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
 ;   aghi %r15, -0x4e0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   lgr %r7, %r2
 ;   lgr %r9, %r4
 ;   la %r2, 0xa0(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -26,9 +26,10 @@ block0(v0: i32):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r12, %r15, 0x60(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   larl %r12, 0xa ; reloc_external PCRel32Dbl %ElfGlobalOffsetTable 2
 ;   bras %r1, 0x1c
 ;   .byte 0x00, 0x00 ; reloc_external TlsGd64 u1:0 0

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -20,9 +20,10 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   bras %r1, 0x16
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
 ;   .byte 0x00, 0x00
@@ -80,6 +81,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
 ;   std %f8, 0xa0(%r15)
@@ -90,7 +92,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   std %f13, 0xc8(%r15)
 ;   std %f14, 0xd0(%r15)
 ;   std %f15, 0xd8(%r15)
-; block0: ; offset 0x2a
+; block1: ; offset 0x2a
 ;   vpdi %v24, %v24, %v24, 4
 ;   vpdi %v7, %v25, %v25, 4
 ;   verllg %v25, %v7, 0x20
@@ -168,6 +170,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
 ;   std %f8, 0xa0(%r15)
@@ -178,7 +181,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   std %f13, 0xc8(%r15)
 ;   std %f14, 0xd0(%r15)
 ;   std %f15, 0xd8(%r15)
-; block0: ; offset 0x2a
+; block1: ; offset 0x2a
 ;   vpdi %v24, %v24, %v24, 4
 ;   vpdi %v7, %v25, %v25, 4
 ;   verllg %v25, %v7, 0x20
@@ -228,9 +231,10 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   br %r14
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block0: ; offset 0xa
+; block1: ; offset 0xa
 ;   bras %r1, 0x16
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -18,9 +18,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rdi, %rsi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -44,9 +45,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x2a(%rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -70,9 +72,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x2a(%rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -97,9 +100,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x2a(%rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -124,9 +128,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x140(%rdi, %rsi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -151,9 +156,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq -1(%rdi, %rsi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -179,9 +185,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq -1(%rdi, %rsi, 8), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -209,9 +216,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl %esi, %ecx
 ;   movq -1(%rdi, %rcx, 8), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -242,9 +250,10 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %r8
 ;   addl %edx, %r8d
 ;   movq -1(%rdi, %r8, 4), %rax ; trap: heap_oob

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -18,9 +18,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andnl %edi, %esi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -43,9 +44,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andnl %esi, %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -18,9 +18,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addl %esi, %eax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -17,9 +17,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movd %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movd %edi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %xmm0, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -22,9 +22,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   movq %rdi, %rax
@@ -52,9 +53,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   movq %rdi, %rax
@@ -82,9 +84,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   movq %rdi, %rax
@@ -112,9 +115,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   movq %rdi, %rax
@@ -142,9 +146,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   movq %rdi, %rax
@@ -172,9 +177,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   movq %rdi, %rax
@@ -202,9 +208,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   movq %rdi, %rax
@@ -232,9 +239,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   movq %rdi, %rax
@@ -262,9 +270,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   movq %rdi, %rax
@@ -292,9 +301,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   movq %rdi, %rax
@@ -322,9 +332,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   movq %rdi, %rax
@@ -352,9 +363,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   movq %rdi, %rax
@@ -382,9 +394,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   movq %rdi, %rax
@@ -412,9 +425,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   movq %rdi, %rax
@@ -442,9 +456,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   movq %rdi, %rax
@@ -472,9 +487,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   movq %rdi, %rax
@@ -504,9 +520,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rdx
 ;   orq %rsi, %rdx
 ;   movq %rdx, %r8
@@ -537,9 +554,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   orq %rsi, %rax
 ;   movq %rax, %r8
@@ -569,9 +587,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   orq %rsi, %rax
 ;   movq %rax, %r8
@@ -601,9 +620,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   orq %rsi, %rax
 ;   movq %rax, %r8
@@ -633,9 +653,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   orq %rsi, %rax
 ;   movq %rax, %r8
@@ -665,9 +686,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   movq %rdi, %rdx
@@ -697,9 +719,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   movq %rdi, %rdx
@@ -729,9 +752,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   movq %rdi, %rdx
@@ -761,9 +785,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   movq %rdi, %rdx

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -33,17 +33,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   jne 0x16
-; block1: ; offset 0xc
+; block2: ; offset 0xc
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x16
+; block3: ; offset 0x16
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -81,17 +82,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   jne 0x16
-; block1: ; offset 0xc
+; block2: ; offset 0xc
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x16
+; block3: ; offset 0x16
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -129,17 +131,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   jne 0x16
-; block1: ; offset 0xc
+; block2: ; offset 0xc
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x16
+; block3: ; offset 0x16
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -178,18 +181,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
 ;   jp 0x1d
 ;   jne 0x1d
-; block1: ; offset 0x13
+; block2: ; offset 0x13
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x1d
+; block3: ; offset 0x1d
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -226,18 +230,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
 ;   jp 0x1a
 ;   jne 0x1a
-; block1: ; offset 0x13
+; block2: ; offset 0x13
 ;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x1a
+; block3: ; offset 0x1a
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -274,18 +279,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
 ;   jp 0x13
 ;   je 0x1a
-; block1: ; offset 0x13
+; block2: ; offset 0x13
 ;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x1a
+; block3: ; offset 0x1a
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -326,9 +332,10 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl $2, %edi
 ;   jae 0x34
 ;   movl %edi, %r9d
@@ -342,12 +349,12 @@ block2:
 ;   addb %al, (%rax)
 ;   adcb (%rax), %al
 ;   addb %al, (%rax)
-; block1: ; offset 0x34
+; block2: ; offset 0x34
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x3e
+; block3: ; offset 0x3e
 ;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -384,17 +391,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpq $0, %rdi
 ;   jge 0x18
-; block1: ; offset 0xe
+; block2: ; offset 0xe
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x18
+; block3: ; offset 0x18
 ;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -431,17 +439,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl $0, %edi
 ;   jge 0x17
-; block1: ; offset 0xd
+; block2: ; offset 0xd
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x17
+; block3: ; offset 0x17
 ;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -493,22 +502,23 @@ block202:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x42500000, %edx
 ;   movd %edx, %xmm6
 ;   ucomiss %xmm6, %xmm0
 ;   jp 0x1c
 ;   je 0x33
-; block1: ; offset 0x1c
+; block2: ; offset 0x1c
 ;   movl $0x42500000, %r11d
 ;   movd %r11d, %xmm10
 ;   ucomiss %xmm10, %xmm0
 ;   jp 0x33
-; block2: ; offset 0x31
+; block3: ; offset 0x31
 ;   ud2 ; trap: heap_oob
-; block3: ; offset 0x33
+; block4: ; offset 0x33
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -546,17 +556,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   jne 0x16
-; block1: ; offset 0xc
+; block2: ; offset 0xc
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x16
+; block3: ; offset 0x16
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -596,18 +607,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
 ;   jp 0x1d
 ;   jne 0x1d
-; block1: ; offset 0x13
+; block2: ; offset 0x13
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x1d
+; block3: ; offset 0x1d
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -646,17 +658,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   jne 0x16
-; block1: ; offset 0xc
+; block2: ; offset 0xc
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x16
+; block3: ; offset 0x16
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -696,18 +709,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
 ;   jp 0x1d
 ;   jne 0x1d
-; block1: ; offset 0x13
+; block2: ; offset 0x13
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x1d
+; block3: ; offset 0x1d
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/x64/bswap.clif
@@ -18,9 +18,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   bswapq %rax
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   bswapl %eax
 ;   movq %rbp, %rsp
@@ -70,9 +72,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   rolw $8, %ax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -24,9 +24,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rcx
 ;   subq $0x20, %rsp
 ;   callq *%rcx
@@ -64,9 +65,10 @@ block0(v0: i32, v1: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm6
 ;   subq $0x20, %rsp
 ;   movq %rdi, %rcx
@@ -124,6 +126,7 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0xb0, %rsp
@@ -139,7 +142,7 @@ block0(v0: i32):
 ;   movdqu %xmm13, 0x80(%rsp)
 ;   movdqu %xmm14, 0x90(%rsp)
 ;   movdqu %xmm15, 0xa0(%rsp)
-; block0: ; offset 0x61
+; block1: ; offset 0x61
 ;   callq *%rcx
 ;   movq (%rsp), %rsi
 ;   movq 8(%rsp), %rdi
@@ -228,9 +231,10 @@ block0(
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rcx, %rax
 ;   movq %rdx, %rcx
 ;   movq %rsi, %rdx
@@ -296,9 +300,10 @@ block0(v0: i64, v1:i64, v2:i64, v3:i64, v4:i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %r11
 ;   movq %rcx, %r9
 ;   movq %rsi, %rdx
@@ -347,9 +352,10 @@ block0(v0: i32, v1: f32, v2: i64, v3: f64, v4: i32, v5: i32, v6: i32, v7: f32, v
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %r9
 ;   movq %rdi, %rsi
 ;   movdqa %xmm1, %xmm12
@@ -388,9 +394,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   callq *%rdi
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -413,9 +420,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   callq *%rdi
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -446,9 +454,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $1, %esi
 ;   subq $0x10, %rsp
 ;   leaq (%rsp), %rdi
@@ -485,11 +494,12 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %rbx, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdi, %rbx
 ;   movl $1, %eax
 ;   callq *%rax
@@ -534,11 +544,12 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r13, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdi, %r13
 ;   movl $1, %eax
 ;   subq $0x10, %rsp
@@ -583,11 +594,12 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r13, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdi, %r13
 ;   movl $1, %eax
 ;   callq *%rax
@@ -629,11 +641,12 @@ block0(v0: f32, v1: i64, v2: i32, v3: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r12, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdx, %r12
 ;   movl $1, %r9d
 ;   callq *%r9

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -18,9 +18,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %CeilF32 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %CeilF64 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -17,9 +17,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundss $2, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundsd $2, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundps $2, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundpd $2, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -17,9 +17,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   lzcntq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   lzcntl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -26,9 +26,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rsi), %r9 ; trap: heap_oob
 ;   cmpq %r9, %rdi
 ;   sete %r10b
@@ -68,9 +69,10 @@ block0(v0: f64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsd (%rdi), %xmm9 ; trap: heap_oob
 ;   ucomisd %xmm9, %xmm0
 ;   setnp %dil

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -19,9 +19,10 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   testb %dil, %dil
 ;   movq %rdx, %rax
 ;   cmovnel %esi, %eax
@@ -58,17 +59,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   testb %dil, %dil
 ;   je 0x17
-; block1: ; offset 0xd
+; block2: ; offset 0xd
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x17
+; block3: ; offset 0x17
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -103,17 +105,18 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   testb %dil, %dil
 ;   je 0x17
-; block1: ; offset 0xd
+; block2: ; offset 0xd
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x17
+; block3: ; offset 0x17
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -152,18 +155,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl (%rdi), %edx ; trap: heap_oob
 ;   cmpl $1, %edx
 ;   jne 0x19
-; block1: ; offset 0xf
+; block2: ; offset 0xf
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x19
+; block3: ; offset 0x19
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -202,18 +206,19 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl (%rdi), %edx ; trap: heap_oob
 ;   cmpl $1, %edx
 ;   jne 0x19
-; block1: ; offset 0xf
+; block2: ; offset 0xf
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x19
+; block3: ; offset 0x19
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -237,9 +242,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrq $0x3f, %rax
 ;   movq %rbp, %rsp
@@ -264,9 +270,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
@@ -291,9 +298,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrq $0x3f, %rax
 ;   movq %rbp, %rsp
@@ -318,9 +326,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
@@ -346,9 +355,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   notq %rax
 ;   shrq $0x3f, %rax
@@ -375,9 +385,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   notq %rax
 ;   shrl $0x1f, %eax
@@ -404,9 +415,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   notq %rax
 ;   shrq $0x3f, %rax
@@ -433,9 +445,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   notq %rax
 ;   shrl $0x1f, %eax

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -17,9 +17,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   tzcntq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   tzcntl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -27,9 +27,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpb $0, %sil
@@ -66,9 +67,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpw $0, %si
@@ -105,9 +107,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpl $0, %esi
@@ -144,9 +147,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpq $0, %rsi

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -17,9 +17,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pextrb $1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pextrw $1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pextrd $1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: i64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pextrq $1, %xmm0, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -113,9 +117,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $1, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -137,9 +142,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0xee, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/fabs.clif
@@ -19,9 +19,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x7fffffff, %eax
 ;   movd %eax, %xmm4
 ;   andps %xmm4, %xmm0
@@ -47,9 +48,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x7fffffffffffffff, %rax
 ;   movq %rax, %xmm4
 ;   andpd %xmm4, %xmm0
@@ -75,9 +77,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm3, %xmm3
 ;   psrld $1, %xmm3
 ;   andps %xmm3, %xmm0
@@ -103,9 +106,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm3, %xmm3
 ;   psrlq $1, %xmm3
 ;   andpd %xmm3, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -20,9 +20,10 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rcx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -45,9 +46,10 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -70,9 +72,10 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %r8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -95,9 +98,10 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %r9, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -120,9 +124,10 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -145,9 +150,10 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %r9, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -181,9 +187,10 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x30(%rbp), %r8
 ;   movq 0x38(%rbp), %rax
 ;   movq %rbp, %rsp
@@ -209,9 +216,10 @@ block0(v0: i128, v1: i64, v2: i128, v3: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq 0x30(%rbp), %r8
 ;   movq 0x38(%rbp), %rax
 ;   movq 0x40(%rbp), %rdx
@@ -252,9 +260,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtsi2sdq %rcx, %xmm3
 ;   subq $0x30, %rsp
 ;   movq %rcx, 0x20(%rsp)
@@ -413,6 +422,7 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x100, %rsp
@@ -426,7 +436,7 @@ block0(v0: i64):
 ;   movdqu %xmm13, 0xd0(%rsp)
 ;   movdqu %xmm14, 0xe0(%rsp)
 ;   movdqu %xmm15, 0xf0(%rsp)
-; block0: ; offset 0x67
+; block1: ; offset 0x67
 ;   movsd (%rcx), %xmm0 ; trap: heap_oob
 ;   movsd 8(%rcx), %xmm10 ; trap: heap_oob
 ;   movdqu %xmm10, 0x50(%rsp)

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -23,9 +23,10 @@ block0(v0: f32, v1: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x80000000, %ecx
 ;   movd %ecx, %xmm7
 ;   movdqa %xmm0, %xmm10
@@ -59,9 +60,10 @@ block0(v0: f64, v1: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $9223372036854775808, %rcx
 ;   movq %rcx, %xmm7
 ;   movdqa %xmm0, %xmm10

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -18,9 +18,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   vcvtudq2ps %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -18,9 +18,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsbl %dil, %eax
 ;   cvtsi2ssl %eax, %xmm0
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movswl %di, %eax
 ;   cvtsi2ssl %eax, %xmm0
 ;   movq %rbp, %rsp
@@ -69,9 +71,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtsi2ssl %edi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -93,9 +96,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtsi2ssq %rdi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -118,9 +122,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsbl %dil, %eax
 ;   cvtsi2sdl %eax, %xmm0
 ;   movq %rbp, %rsp
@@ -144,9 +149,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movswl %di, %eax
 ;   cvtsi2sdl %eax, %xmm0
 ;   movq %rbp, %rsp
@@ -169,9 +175,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtsi2sdl %edi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -193,9 +200,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtsi2sdq %rdi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -217,9 +225,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvtdq2pd %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -256,9 +265,10 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dil, %r9
 ;   cvtsi2ssq %r9, %xmm0
 ;   movzwq %si, %r9
@@ -303,9 +313,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x14(%rip), %xmm2
 ;   unpcklps %xmm2, %xmm0
 ;   movdqu 0x19(%rip), %xmm6
@@ -353,9 +364,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm3
 ;   pslld $0x10, %xmm3
 ;   psrld $0x10, %xmm3
@@ -386,9 +398,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x4f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
@@ -426,9 +439,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x5f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
@@ -467,9 +481,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x41e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
@@ -507,9 +522,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x43e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
@@ -548,9 +564,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x4f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
@@ -591,9 +608,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x5f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
@@ -635,9 +653,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x41e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
@@ -678,9 +697,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x43e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
@@ -722,9 +742,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $1, %eax
 ;   jno 0x3f
@@ -760,9 +781,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $1, %rax
 ;   jno 0x41
@@ -798,9 +820,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $1, %eax
 ;   jno 0x48
@@ -836,9 +859,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $1, %rax
 ;   jno 0x4a
@@ -874,9 +898,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $1, %eax
 ;   jno 0x33
@@ -908,9 +933,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $1, %rax
 ;   jno 0x3b
@@ -942,9 +968,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $1, %eax
 ;   jno 0x35
@@ -976,9 +1003,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $1, %rax
 ;   jno 0x3d
@@ -1023,9 +1051,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pxor %xmm2, %xmm2
 ;   movdqa %xmm0, %xmm9
 ;   maxps %xmm2, %xmm9
@@ -1069,9 +1098,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   cmpeqps %xmm0, %xmm4
 ;   movdqa %xmm0, %xmm5

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -19,9 +19,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x7fffffffffffffff, %rax
 ;   movq %rax, %xmm4
 ;   andpd %xmm4, %xmm0
@@ -49,9 +50,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsd (%rdi), %xmm0 ; trap: heap_oob
 ;   movabsq $0x7fffffffffffffff, %rcx
 ;   movq %rcx, %xmm5

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -18,9 +18,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %FloorF32 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %FloorF64 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/floor.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor.clif
@@ -17,9 +17,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundss $1, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundsd $1, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundps $1, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundpd $1, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -18,9 +18,10 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %r8 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r8
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %r8 ; reloc_external Abs8 %FmaF64 0
 ;   callq *%r8
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/fma-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-inst.clif
@@ -17,9 +17,10 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   vfmadd213ss %xmm2, %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   vfmadd213sd %xmm2, %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fneg.clif
+++ b/cranelift/filetests/filetests/isa/x64/fneg.clif
@@ -19,9 +19,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x80000000, %eax
 ;   movd %eax, %xmm4
 ;   xorps %xmm4, %xmm0
@@ -47,9 +48,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $9223372036854775808, %rax
 ;   movq %rax, %xmm4
 ;   xorpd %xmm4, %xmm0
@@ -75,9 +77,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm3, %xmm3
 ;   pslld $0x1f, %xmm3
 ;   xorps %xmm3, %xmm0
@@ -103,9 +106,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm3, %xmm3
 ;   psllq $0x3f, %xmm3
 ;   xorpd %xmm3, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
@@ -18,9 +18,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rbp, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -42,9 +43,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsp, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -67,9 +69,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rbp, %rsi
 ;   movq 8(%rsi), %rax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -21,9 +21,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addq %rdx, %rax
 ;   movq %rsi, %rdx
@@ -51,9 +52,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   subq %rdx, %rax
 ;   movq %rsi, %rdx
@@ -81,9 +83,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   andq %rdx, %rax
 ;   movq %rsi, %rdx
@@ -111,9 +114,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   orq %rdx, %rax
 ;   movq %rsi, %rdx
@@ -141,9 +145,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorq %rdx, %rax
 ;   movq %rsi, %rdx
@@ -171,9 +176,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   notq %rax
 ;   movq %rsi, %rdx
@@ -210,9 +216,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rax
 ;   movq %rdi, %rdx
 ;   imulq %rcx, %rdx
@@ -247,9 +254,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rdx
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
@@ -273,9 +281,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rdx
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
@@ -424,6 +433,7 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x40, %rsp
@@ -432,7 +442,7 @@ block0(v0: i128, v1: i128):
 ;   movq %r13, 0x20(%rsp)
 ;   movq %r14, 0x28(%rsp)
 ;   movq %r15, 0x30(%rsp)
-; block0: ; offset 0x21
+; block1: ; offset 0x21
 ;   cmpq %rdx, %rdi
 ;   sete %r9b
 ;   cmpq %rcx, %rsi
@@ -575,21 +585,22 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpq $0, %rdi
 ;   sete %r9b
 ;   cmpq $0, %rsi
 ;   sete %sil
 ;   testb %r9b, %sil
 ;   jne 0x27
-; block1: ; offset 0x1d
+; block2: ; offset 0x1d
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x27
+; block3: ; offset 0x27
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -630,21 +641,22 @@ block2:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpq $0, %rdi
 ;   sete %r9b
 ;   cmpq $0, %rsi
 ;   sete %sil
 ;   testb %r9b, %sil
 ;   jne 0x27
-; block1: ; offset 0x1d
+; block2: ; offset 0x1d
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x27
+; block3: ; offset 0x27
 ;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -667,9 +679,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -694,9 +707,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rdx
 ;   sarq $0x3f, %rdx
 ;   movq %rdi, %rax
@@ -722,9 +736,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsbq %dil, %rax
 ;   movq %rax, %rdx
 ;   sarq $0x3f, %rdx
@@ -749,9 +764,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dil, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -774,9 +790,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -798,9 +815,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -823,9 +841,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dil, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -889,9 +908,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrq $1, %rax
 ;   movabsq $0x7777777777777777, %r8
@@ -1037,9 +1057,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0x5555555555555555, %rcx
 ;   movq %rsi, %rdx
 ;   andq %rcx, %rdx
@@ -1145,9 +1166,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, (%rdx) ; trap: heap_oob
 ;   movq %rsi, 8(%rdx) ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -1171,9 +1193,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rdi), %rax ; trap: heap_oob
 ;   movq 8(%rdi), %rdx ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -1227,14 +1250,15 @@ block2(v8: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorq %rax, %rax
 ;   xorq %r9, %r9
 ;   testb %dl, %dl
 ;   je 0x29
-; block1: ; offset 0x12
+; block2: ; offset 0x12
 ;   movl $1, %r8d
 ;   xorq %r10, %r10
 ;   addq %r8, %rax
@@ -1243,7 +1267,7 @@ block2(v8: i128):
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x29
+; block3: ; offset 0x29
 ;   movq %r9, %rdx
 ;   movl $2, %r9d
 ;   xorq %r11, %r11
@@ -1308,6 +1332,7 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x20, %rsp
@@ -1315,7 +1340,7 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq %r12, 8(%rsp)
 ;   movq %r14, 0x10(%rsp)
 ;   movq %r15, 0x18(%rsp)
-; block0: ; offset 0x1b
+; block1: ; offset 0x1b
 ;   movq %r8, %r14
 ;   movq %rcx, %rbx
 ;   movq %rdx, %rcx
@@ -1375,9 +1400,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, (%rdx)
 ;   movq %rsi, 8(%rdx)
 ;   movq %rdi, 0x10(%rdx)
@@ -1426,11 +1452,12 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r13, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %r8, %r13
 ;   subq $0x10, %rsp
 ;   leaq (%rsp), %r8
@@ -1478,9 +1505,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %r8
 ;   movq $18446744073709551615, %rcx
 ;   bsrq %rsi, %r9
@@ -1525,9 +1553,10 @@ block0(v0: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0x40, %ecx
 ;   bsfq %rdi, %rax
 ;   cmoveq %rcx, %rax
@@ -1561,9 +1590,10 @@ block0(v0: i8, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -1605,9 +1635,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -1663,9 +1694,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -1723,9 +1755,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -1805,9 +1838,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -1908,9 +1942,10 @@ block0(v0: i128, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8

--- a/cranelift/filetests/filetests/isa/x64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/iabs.clif
@@ -19,9 +19,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negb %al
 ;   cmovsl %edi, %eax
@@ -47,9 +48,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negw %ax
 ;   cmovsl %edi, %eax
@@ -75,9 +77,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negl %eax
 ;   cmovsl %edi, %eax
@@ -103,9 +106,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   negq %rax
 ;   cmovsq %rdi, %rax

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -35,9 +35,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %r9
 ;   addq 0x32(%rip), %r9
 ;   movq %r9, (%rsi) ; trap: heap_oob

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -28,10 +28,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x2000, %rsp
-; block0: ; offset 0xb
+; block1: ; offset 0xb
 ;   leaq (%rsp), %rax
 ;   addq $0x2000, %rsp
 ;   movq %rbp, %rsp
@@ -61,13 +62,14 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   movl %esp, -0x10000(%rsp)
 ;   movl %esp, -0x20000(%rsp)
 ;   movl %esp, -0x30000(%rsp)
 ;   subq $0x30000, %rsp
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   leaq (%rsp), %rax
 ;   addq $0x30000, %rsp
 ;   movq %rbp, %rsp
@@ -95,6 +97,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   movq %rsp, %r11
@@ -105,7 +108,7 @@ block0:
 ;   jne 0xe
 ;   addq $0x200000, %rsp
 ;   subq $0x200000, %rsp
-; block0: ; offset 0x2f
+; block1: ; offset 0x2f
 ;   leaq (%rsp), %rax
 ;   addq $0x200000, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -27,10 +27,11 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x800, %rsp
-; block0: ; offset 0xb
+; block1: ; offset 0xb
 ;   leaq (%rsp), %rax
 ;   addq $0x800, %rsp
 ;   movq %rbp, %rsp
@@ -60,13 +61,14 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   movl %esp, -0x1000(%rsp)
 ;   movl %esp, -0x2000(%rsp)
 ;   movl %esp, -0x3000(%rsp)
 ;   subq $0x3000, %rsp
-; block0: ; offset 0x20
+; block1: ; offset 0x20
 ;   leaq (%rsp), %rax
 ;   addq $0x3000, %rsp
 ;   movq %rbp, %rsp
@@ -94,6 +96,7 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   movq %rsp, %r11
@@ -104,7 +107,7 @@ block0:
 ;   jne 0xe
 ;   addq $0x19000, %rsp
 ;   subq $0x186a0, %rsp
-; block0: ; offset 0x2f
+; block1: ; offset 0x2f
 ;   leaq (%rsp), %rax
 ;   addq $0x186a0, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -41,9 +41,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dl, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -99,9 +100,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -157,9 +159,10 @@ block0(v0: i128, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -215,9 +218,10 @@ block0(v0: i128, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -273,9 +277,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
@@ -316,9 +321,10 @@ block0(v0: i64, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shlq %cl, %rax
@@ -344,9 +350,10 @@ block0(v0: i32, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shll %cl, %eax
@@ -373,9 +380,10 @@ block0(v0: i16, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -403,9 +411,10 @@ block0(v0: i8, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -432,9 +441,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shlq %cl, %rax
@@ -460,9 +470,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shlq %cl, %rax
@@ -488,9 +499,10 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shlq %cl, %rax
@@ -516,9 +528,10 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shlq %cl, %rax
@@ -544,9 +557,10 @@ block0(v0: i32, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shll %cl, %eax
@@ -572,9 +586,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shll %cl, %eax
@@ -600,9 +615,10 @@ block0(v0: i32, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shll %cl, %eax
@@ -628,9 +644,10 @@ block0(v0: i32, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shll %cl, %eax
@@ -657,9 +674,10 @@ block0(v0: i16, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -687,9 +705,10 @@ block0(v0: i16, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -717,9 +736,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -747,9 +767,10 @@ block0(v0: i16, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -777,9 +798,10 @@ block0(v0: i8, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -807,9 +829,10 @@ block0(v0: i8, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -837,9 +860,10 @@ block0(v0: i8, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -867,9 +891,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -895,9 +920,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shlq $1, %rax
 ;   movq %rbp, %rsp
@@ -921,9 +947,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shll $1, %eax
 ;   movq %rbp, %rsp
@@ -947,9 +974,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shlw $1, %ax
 ;   movq %rbp, %rsp
@@ -973,9 +1001,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shlb $1, %al
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf.clif
@@ -20,9 +20,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
@@ -20,9 +20,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/load-op-store.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op-store.clif
@@ -19,9 +19,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   addl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -45,9 +46,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   addl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -71,9 +73,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   subl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -97,9 +100,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -123,9 +127,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -149,9 +154,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   orl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -175,9 +181,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   orl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -201,9 +208,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -227,9 +235,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorl %esi, 0x20(%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -19,9 +19,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rax
 ;   addl (%rdi), %eax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -46,9 +47,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rax
 ;   addl (%rdi), %eax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -73,9 +75,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rax
 ;   addq (%rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -100,9 +103,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rax
 ;   addq (%rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -127,9 +131,10 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq (%rdi), %rax ; trap: heap_oob
 ;   addl %esi, %eax
 ;   movq %rbp, %rsp
@@ -159,9 +164,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rdi), %r8 ; trap: heap_oob
 ;   movq %r8, %r9
 ;   addq %rdi, %r9
@@ -193,11 +199,12 @@ block1:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movss (%rdi), %xmm0 ; trap: heap_oob
-; block1: ; offset 0x8
+; block2: ; offset 0x8
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -222,9 +229,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpq (%rdi), %rdi ; trap: heap_oob
 ;   sete %dl
 ;   movzbq %dl, %rax

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -22,9 +22,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -17,9 +17,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   packsswb %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   packssdw %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -73,9 +75,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   cmpeqpd %xmm0, %xmm4
 ;   movupd 0x1b(%rip), %xmm5
@@ -107,9 +110,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   packuswb %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -131,9 +135,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   packusdw %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -18,9 +18,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %NearestF32 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %NearestF64 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -17,9 +17,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundss $0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundsd $0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundps $0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundpd $0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -22,9 +22,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %r15, %rsi
 ;   addq $1, %rsi
 ;   movq %rsi, %r15
@@ -56,11 +57,12 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %rsi, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %r15, %rsi
 ;   addq $1, %rsi
 ;   movq %rsi, %r15

--- a/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
@@ -17,9 +17,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   popcntq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   popcntl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -36,9 +36,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rcx
 ;   shrq $1, %rdi
 ;   movq %rcx, %r8
@@ -99,9 +100,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq (%rdi), %rdx ; trap: heap_oob
 ;   movq %rdx, %rcx
 ;   shrq $1, %rcx
@@ -159,9 +161,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrl $1, %edi
 ;   movl $0x77777777, %edx
@@ -218,9 +221,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl (%rdi), %edx ; trap: heap_oob
 ;   movq %rdx, %rcx
 ;   shrl $1, %ecx

--- a/cranelift/filetests/filetests/isa/x64/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/probestack.clif
@@ -24,12 +24,13 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   movl $0x186a0, %eax
 ;   callq 0xe ; reloc_external CallPCRel4 %Probestack -4
 ;   subq $0x186a0, %rsp
-; block0: ; offset 0x15
+; block1: ; offset 0x15
 ;   leaq (%rsp), %rax
 ;   addq $0x186a0, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -19,9 +19,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   cbtw
 ;   idivb %sil ; trap: int_divz
@@ -47,9 +48,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   cwtd
 ;   idivw %si ; trap: int_divz
@@ -75,9 +77,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   cltd
 ;   idivl %esi ; trap: int_divz
@@ -103,9 +106,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   cqto
 ;   idivq %rsi ; trap: int_divz

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -25,9 +25,10 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl $0x2a, %edi
 ;   movq %rcx, %rax
 ;   cmoveq %rsi, %rax
@@ -61,9 +62,10 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm0, %xmm0
 ;   movq %rdi, %rax
 ;   cmovneq %rdx, %rax

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -21,9 +21,10 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpl %esi, %edi
 ;   movq %rcx, %rax
 ;   cmoveq %rdx, %rax
@@ -52,9 +53,10 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ucomiss %xmm0, %xmm1
 ;   movq %rdi, %rax
 ;   cmovneq %rsi, %rax

--- a/cranelift/filetests/filetests/isa/x64/sextend.clif
+++ b/cranelift/filetests/filetests/isa/x64/sextend.clif
@@ -17,9 +17,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movsbq %dil, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -22,9 +22,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   movdqu 0x10(%rip), %xmm0
 ;   movdqa %xmm5, %xmm6
@@ -65,9 +66,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm7
 ;   movdqu 0x30(%rip), %xmm0
 ;   movdqu 0x18(%rip), %xmm6
@@ -108,9 +110,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   movdqu 0x10(%rip), %xmm0
 ;   movdqa %xmm5, %xmm6

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -25,9 +25,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   pcmpeqb %xmm1, %xmm4
 ;   movdqa %xmm0, %xmm7
@@ -59,9 +60,10 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   cmpeqps %xmm1, %xmm0
 ;   movdqa %xmm3, %xmm6
 ;   pblendvb %xmm0, %xmm2, %xmm6
@@ -91,9 +93,10 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   pand %xmm2, %xmm4
 ;   movdqa %xmm2, %xmm0
@@ -125,9 +128,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   movdqu 0x20(%rip), %xmm0
 ;   movdqa %xmm5, %xmm6
@@ -173,9 +177,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   movdqu 0x20(%rip), %xmm0
 ;   movdqa %xmm5, %xmm6
@@ -218,9 +223,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm8
 ;   movdqu 0x1f(%rip), %xmm0
 ;   movdqa %xmm8, %xmm4

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -18,9 +18,10 @@ block0(v0: f32x4, v1: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andps %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -42,9 +43,10 @@ block0(v0: f64x2, v1: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   andpd %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -66,9 +68,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pand %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -90,9 +93,10 @@ block0(v0: f32x4, v1: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   orps %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -114,9 +118,10 @@ block0(v0: f64x2, v1: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   orpd %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -138,9 +143,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   por %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -162,9 +168,10 @@ block0(v0: f32x4, v1: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorps %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -186,9 +193,10 @@ block0(v0: f64x2, v1: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorpd %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -210,9 +218,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pxor %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -236,9 +245,10 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm2, %xmm4
 ;   pblendvb %xmm0, %xmm1, %xmm4
 ;   movdqa %xmm4, %xmm0
@@ -264,9 +274,10 @@ block0(v0: i32x4, v1: f32x4, v2: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm2, %xmm4
 ;   blendvps %xmm0, %xmm1, %xmm4
 ;   movdqa %xmm4, %xmm0
@@ -292,9 +303,10 @@ block0(v0: i64x2, v1: f64x2, v2: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm2, %xmm4
 ;   blendvpd %xmm0, %xmm1, %xmm4
 ;   movdqa %xmm4, %xmm0
@@ -327,9 +339,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0xb4(%rip), %xmm0
 ;   movq %rdi, %r10
 ;   andq $7, %r10
@@ -373,9 +386,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0xb4(%rip), %xmm0
 ;   movl $1, %r9d
 ;   andq $7, %r9
@@ -419,9 +433,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x33(%rip), %xmm8
 ;   movq %rdi, %r9
 ;   andq $7, %r9
@@ -468,9 +483,10 @@ block0(v0: i8x16, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $3, %r10d
 ;   andq $7, %r10
 ;   movdqa %xmm0, %xmm13
@@ -511,9 +527,10 @@ block0(v0: i64x2, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pextrq $0, %xmm0, %r8
 ;   pextrq $1, %xmm0, %r10
 ;   movq %rdi, %rcx

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -20,9 +20,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm1, %xmm0
 ;   pcmpeqd %xmm5, %xmm5
 ;   pxor %xmm5, %xmm0
@@ -49,9 +50,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmaxud %xmm1, %xmm0
 ;   pcmpeqd %xmm1, %xmm0
 ;   pcmpeqd %xmm7, %xmm7
@@ -78,9 +80,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm3
 ;   pmaxsw %xmm1, %xmm3
 ;   pcmpeqw %xmm3, %xmm0
@@ -106,9 +109,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm3
 ;   pmaxub %xmm1, %xmm3
 ;   pcmpeqb %xmm3, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -28,9 +28,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x64(%rip), %xmm0
 ;   movdqu 0x4c(%rip), %xmm4
 ;   movdqu 0x24(%rip), %xmm2
@@ -90,9 +91,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x24(%rip), %xmm0
 ;   movdqu 0xc(%rip), %xmm1
 ;   pshufb %xmm1, %xmm0
@@ -138,9 +140,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x34(%rip), %xmm0
 ;   movdqu 0x2c(%rip), %xmm2
 ;   movdqu 0x14(%rip), %xmm3
@@ -183,9 +186,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pinsrb $0, %edi, %xmm0
 ;   pxor %xmm6, %xmm6
 ;   pshufb %xmm6, %xmm0
@@ -214,9 +218,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0xffffffff, %esi
 ;   pinsrw $0, %esi, %xmm4
 ;   pinsrw $1, %esi, %xmm4
@@ -243,9 +248,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pinsrd $0, %edi, %xmm3
 ;   pshufd $0, %xmm3, %xmm0
 ;   movq %rbp, %rsp
@@ -272,9 +278,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   movdqa %xmm5, %xmm6
 ;   movsd %xmm6, %xmm0
@@ -300,9 +307,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movss (%rdi), %xmm0 ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -324,9 +332,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movd %edi, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -347,9 +356,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -19,9 +19,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pcmpeqd %xmm2, %xmm2
 ;   pxor %xmm2, %xmm0
 ;   movq %rbp, %rsp
@@ -45,9 +46,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ptest %xmm0, %xmm0
 ;   setne %al
 ;   movq %rbp, %rsp
@@ -74,9 +76,10 @@ block0(v0: i64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pxor %xmm2, %xmm2
 ;   movdqa %xmm0, %xmm4
 ;   pcmpeqq %xmm2, %xmm4

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -22,9 +22,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   movdqu 0x10(%rip), %xmm0
 ;   movdqa %xmm4, %xmm5
@@ -61,9 +62,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x14(%rip), %xmm2
 ;   pmaddwd %xmm2, %xmm0
 ;   movq %rbp, %rsp
@@ -102,9 +104,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x14(%rip), %xmm2
 ;   pmaddubsw %xmm2, %xmm0
 ;   movq %rbp, %rsp
@@ -147,9 +150,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x24(%rip), %xmm2
 ;   pxor %xmm2, %xmm0
 ;   movdqu 0x28(%rip), %xmm6

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -28,9 +28,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm3
 ;   palignr $8, %xmm0, %xmm3
 ;   pmovsxbw %xmm3, %xmm0
@@ -66,9 +67,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
 ;   movdqa %xmm5, %xmm6
@@ -100,9 +102,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0xfa, %xmm0, %xmm0
 ;   pshufd $0xfa, %xmm1, %xmm5
 ;   pmuldq %xmm5, %xmm0
@@ -130,9 +133,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovsxbw %xmm0, %xmm0
 ;   pmovsxbw %xmm1, %xmm5
 ;   pmullw %xmm5, %xmm0
@@ -164,9 +168,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
 ;   movdqa %xmm5, %xmm6
@@ -198,9 +203,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0x50, %xmm0, %xmm0
 ;   pshufd $0x50, %xmm1, %xmm5
 ;   pmuldq %xmm5, %xmm0
@@ -232,9 +238,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm3
 ;   palignr $8, %xmm0, %xmm3
 ;   pmovzxbw %xmm3, %xmm0
@@ -270,9 +277,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
 ;   movdqa %xmm5, %xmm6
@@ -304,9 +312,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0xfa, %xmm0, %xmm0
 ;   pshufd $0xfa, %xmm1, %xmm5
 ;   pmuludq %xmm5, %xmm0
@@ -334,9 +343,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovzxbw %xmm0, %xmm0
 ;   pmovzxbw %xmm1, %xmm5
 ;   pmullw %xmm5, %xmm0
@@ -368,9 +378,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
 ;   movdqa %xmm5, %xmm6
@@ -402,9 +413,10 @@ block0(v0: i32x4, v1: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0x50, %xmm0, %xmm0
 ;   pshufd $0x50, %xmm1, %xmm5
 ;   pmuludq %xmm5, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/smulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/smulhi.clif
@@ -19,9 +19,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   imulw %si
 ;   movq %rdx, %rax
@@ -47,9 +48,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   imull %esi
 ;   movq %rdx, %rax
@@ -75,9 +77,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   imulq %rsi
 ;   movq %rdx, %rax

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -20,9 +20,10 @@ block0(v0: i16x8, v1: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x14(%rip), %xmm5
 ;   pmulhrsw %xmm1, %xmm0
 ;   pcmpeqw %xmm0, %xmm5

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -20,9 +20,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpb $0, %sil
@@ -58,9 +59,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpw $0, %si
@@ -96,9 +98,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpl $0, %esi
@@ -134,9 +137,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   xorl %edx, %edx
 ;   cmpq $0, %rsi

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -43,9 +43,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dl, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -106,9 +107,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r11
 ;   shrq %cl, %r11
@@ -168,9 +170,10 @@ block0(v0: i128, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r11
 ;   shrq %cl, %r11
@@ -230,9 +233,10 @@ block0(v0: i128, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r11
 ;   shrq %cl, %r11
@@ -292,9 +296,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r11
 ;   shrq %cl, %r11
@@ -337,9 +342,10 @@ block0(v0: i64, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarq %cl, %rax
@@ -365,9 +371,10 @@ block0(v0: i32, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarl %cl, %eax
@@ -394,9 +401,10 @@ block0(v0: i16, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -424,9 +432,10 @@ block0(v0: i8, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -453,9 +462,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarq %cl, %rax
@@ -481,9 +491,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarq %cl, %rax
@@ -509,9 +520,10 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarq %cl, %rax
@@ -537,9 +549,10 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarq %cl, %rax
@@ -565,9 +578,10 @@ block0(v0: i32, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarl %cl, %eax
@@ -593,9 +607,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarl %cl, %eax
@@ -621,9 +636,10 @@ block0(v0: i32, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarl %cl, %eax
@@ -649,9 +665,10 @@ block0(v0: i32, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   sarl %cl, %eax
@@ -678,9 +695,10 @@ block0(v0: i16, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -708,9 +726,10 @@ block0(v0: i16, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -738,9 +757,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -768,9 +788,10 @@ block0(v0: i16, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -798,9 +819,10 @@ block0(v0: i8, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -828,9 +850,10 @@ block0(v0: i8, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -858,9 +881,10 @@ block0(v0: i8, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -888,9 +912,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -916,9 +941,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   sarq $1, %rax
 ;   movq %rbp, %rsp
@@ -942,9 +968,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   sarl $1, %eax
 ;   movq %rbp, %rsp
@@ -968,9 +995,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   sarw $1, %ax
 ;   movq %rbp, %rsp
@@ -994,9 +1022,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   sarb $1, %al
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -18,9 +18,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   leaq 0x10(%rbp), %rsi
 ;   movzbq (%rsi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
@@ -48,9 +49,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   leaq 0x10(%rbp), %rcx
 ;   movzbq (%rdi), %rax ; trap: heap_oob
 ;   movzbq (%rcx), %r9 ; trap: heap_oob
@@ -86,9 +88,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rsi
 ;   subq $0x40, %rsp
 ;   leaq (%rsp), %rdi
@@ -133,11 +136,12 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r13, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdi, %r13
 ;   subq $0x40, %rsp
 ;   leaq (%rsp), %rdi
@@ -175,9 +179,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   leaq 0x10(%rbp), %rsi
 ;   leaq 0x90(%rbp), %rcx
 ;   movzbq (%rsi), %rax ; trap: heap_oob
@@ -227,12 +232,13 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r12, (%rsp)
 ;   movq %r14, 8(%rsp)
-; block0: ; offset 0x11
+; block1: ; offset 0x11
 ;   movq %rdx, %r14
 ;   movq %rdi, %r12
 ;   subq $0xc0, %rsp

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -20,9 +20,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0x2a, %edx
 ;   movq %rdx, (%rdi) ; trap: heap_oob
@@ -51,9 +52,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rdi
 ;   movabsq $0, %rdx ; reloc_external Abs8 %f2 0
 ;   callq *%rdx
@@ -87,11 +89,12 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
 ;   movq %r15, (%rsp)
-; block0: ; offset 0xc
+; block1: ; offset 0xc
 ;   movq %rdi, %r15
 ;   movabsq $0, %rdx ; reloc_external Abs8 %f4 0
 ;   callq *%rdx

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -19,9 +19,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rax ; reloc_external Abs8 %func0 0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -45,9 +46,10 @@ block0:
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rax ; reloc_external Abs8 %global0 0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -38,13 +38,14 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   ud2 table_oob
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl 8(%rdx), %r11d
 ;   cmpl %r11d, %edi
 ;   jae 0x2b
-; block1: ; offset 0x11
+; block2: ; offset 0x11
 ;   movl %edi, %ecx
 ;   movq (%rdx), %rax
 ;   movq %rax, %rdx
@@ -55,6 +56,6 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block2: ; offset 0x2b
+; block3: ; offset 0x2b
 ;   ud2 ; trap: table_oob
 

--- a/cranelift/filetests/filetests/isa/x64/tls_coff.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_coff.clif
@@ -21,9 +21,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl (%rip), %eax ; reloc_external PCRel4 %CoffTlsIndex -4
 ;   movq %gs:0x58, %rcx
 ;   movq (%rcx, %rax, 8), %rax

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -20,9 +20,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   leaq (%rip), %rdi ; reloc_external ElfX86_64TlsGd u1:0 -4
 ;   callq 0x14 ; reloc_external CallPLTRel4 %ElfTlsGetAddr -4
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -13,9 +13,10 @@ block0:
 ;   ud2 user0
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   ud2 ; trap: user0
 
 function %trap_iadd_ifcout(i64, i64) {
@@ -36,9 +37,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rcx
 ;   addq %rsi, %rcx
 ;   jae 0x12

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -18,9 +18,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %TruncF32 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp
@@ -44,9 +45,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movabsq $0, %rcx ; reloc_external Abs8 %TruncF64 0
 ;   callq *%rcx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/trunc.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc.clif
@@ -17,9 +17,10 @@ block0(v0: f32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundss $3, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: f64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundsd $3, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: f32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundps $3, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -89,9 +92,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   roundpd $3, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
@@ -20,9 +20,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addl $0x7f, %eax
 ;   jae 0x12
@@ -50,9 +51,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addl $0x7f, %eax
 ;   jae 0x12
@@ -79,9 +81,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addl %esi, %eax
 ;   jae 0x11
@@ -109,9 +112,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addq $0x7f, %rax
 ;   jae 0x13
@@ -139,9 +143,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addq $0x7f, %rax
 ;   jae 0x13
@@ -168,9 +173,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addq %rsi, %rax
 ;   jae 0x12

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -18,9 +18,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbl %dil, %eax
 ;   divb %sil ; trap: int_divz
 ;   movq %rbp, %rsp
@@ -45,9 +46,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divw %si ; trap: int_divz
@@ -73,9 +75,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divl %esi ; trap: int_divz
@@ -101,9 +104,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divq %rsi ; trap: int_divz

--- a/cranelift/filetests/filetests/isa/x64/udivrem.clif
+++ b/cranelift/filetests/filetests/isa/x64/udivrem.clif
@@ -27,9 +27,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbl %dil, %eax
 ;   divb %sil ; trap: int_divz
 ;   movq %rax, %rcx
@@ -67,9 +68,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0, %edx
 ;   movq %rdi, %rax
 ;   divw %si ; trap: int_divz
@@ -108,9 +110,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0, %edx
 ;   movq %rdi, %rax
 ;   divl %esi ; trap: int_divz
@@ -149,9 +152,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl $0, %edx
 ;   movq %rdi, %rax
 ;   divq %rsi ; trap: int_divz

--- a/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
@@ -19,9 +19,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   addl %esi, %eax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -21,9 +21,10 @@ block0(v1: i32, v2: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movl (%rsi), %edx
 ;   cmpl %edi, %edx
 ;   movq %rdi, %rax

--- a/cranelift/filetests/filetests/isa/x64/umulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/umulhi.clif
@@ -19,9 +19,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   mulw %si
 ;   movq %rdx, %rax
@@ -47,9 +48,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   mull %esi
 ;   movq %rdx, %rax
@@ -75,9 +77,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   mulq %rsi
 ;   movq %rdx, %rax

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -19,9 +19,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbl %dil, %eax
 ;   divb %sil ; trap: int_divz
 ;   shrq $8, %rax
@@ -48,9 +49,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divw %si ; trap: int_divz
@@ -78,9 +80,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divl %esi ; trap: int_divz
@@ -108,9 +111,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   movl $0, %edx
 ;   divq %rsi ; trap: int_divz

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -40,9 +40,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movzbq %dl, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -99,9 +100,10 @@ block0(v0: i128, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -157,9 +159,10 @@ block0(v0: i128, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -215,9 +218,10 @@ block0(v0: i128, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -273,9 +277,10 @@ block0(v0: i128, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdi, %r8
 ;   shrq %cl, %r8
@@ -316,9 +321,10 @@ block0(v0: i64, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrq %cl, %rax
@@ -345,9 +351,10 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrl %cl, %eax
@@ -374,9 +381,10 @@ block0(v0: i16, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -404,9 +412,10 @@ block0(v0: i8, v1: i128):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -433,9 +442,10 @@ block0(v0: i64, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrq %cl, %rax
@@ -461,9 +471,10 @@ block0(v0: i64, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrq %cl, %rax
@@ -489,9 +500,10 @@ block0(v0: i64, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrq %cl, %rax
@@ -517,9 +529,10 @@ block0(v0: i64, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrq %cl, %rax
@@ -545,9 +558,10 @@ block0(v0: i32, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrl %cl, %eax
@@ -573,9 +587,10 @@ block0(v0: i32, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrl %cl, %eax
@@ -601,9 +616,10 @@ block0(v0: i32, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrl %cl, %eax
@@ -629,9 +645,10 @@ block0(v0: i32, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   movq %rdi, %rax
 ;   shrl %cl, %eax
@@ -658,9 +675,10 @@ block0(v0: i16, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -688,9 +706,10 @@ block0(v0: i16, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -718,9 +737,10 @@ block0(v0: i16, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -748,9 +768,10 @@ block0(v0: i16, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $0xf, %rcx
 ;   movq %rdi, %rax
@@ -778,9 +799,10 @@ block0(v0: i8, v1: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -808,9 +830,10 @@ block0(v0: i8, v1: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -838,9 +861,10 @@ block0(v0: i8, v1: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -868,9 +892,10 @@ block0(v0: i8, v1: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rsi, %rcx
 ;   andq $7, %rcx
 ;   movq %rdi, %rax
@@ -896,9 +921,10 @@ block0(v0: i64):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrq $1, %rax
 ;   movq %rbp, %rsp
@@ -922,9 +948,10 @@ block0(v0: i32):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrl $1, %eax
 ;   movq %rbp, %rsp
@@ -948,9 +975,10 @@ block0(v0: i16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrw $1, %ax
 ;   movq %rbp, %rsp
@@ -974,9 +1002,10 @@ block0(v0: i8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movq %rdi, %rax
 ;   shrb $1, %al
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -27,9 +27,10 @@ block0(v0: f64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   xorpd %xmm2, %xmm2
 ;   movdqa %xmm0, %xmm6
 ;   maxpd %xmm2, %xmm6

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
@@ -17,9 +17,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovmskb %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovmskb %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -68,9 +70,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm2
 ;   packsswb %xmm0, %xmm2
 ;   pmovmskb %xmm2, %eax
@@ -95,9 +98,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movmskps %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -119,9 +123,10 @@ block0(v0: i64x2):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movmskpd %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -20,9 +20,10 @@ block0(v0: i64, v2: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqu 0x50(%rdi), %xmm3
 ;   palignr $8, %xmm3, %xmm3
 ;   pmovzxbw %xmm3, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -17,9 +17,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovsxbw %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,9 +42,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovsxwd %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -65,9 +67,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovsxdq %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -91,9 +94,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm2
 ;   palignr $8, %xmm0, %xmm2
 ;   pmovsxbw %xmm2, %xmm0
@@ -119,9 +123,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm2
 ;   palignr $8, %xmm0, %xmm2
 ;   pmovsxwd %xmm2, %xmm0
@@ -146,9 +151,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0xee, %xmm0, %xmm2
 ;   pmovsxdq %xmm2, %xmm0
 ;   movq %rbp, %rsp
@@ -171,9 +177,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovzxbw %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -195,9 +202,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovzxwd %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -219,9 +227,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pmovzxdq %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -245,9 +254,10 @@ block0(v0: i8x16):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm2
 ;   palignr $8, %xmm0, %xmm2
 ;   pmovzxbw %xmm2, %xmm0
@@ -273,9 +283,10 @@ block0(v0: i16x8):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm2
 ;   palignr $8, %xmm0, %xmm2
 ;   pmovzxwd %xmm2, %xmm0
@@ -300,9 +311,10 @@ block0(v0: i32x4):
 ;   ret
 ; 
 ; Disassembled:
+; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block0: ; offset 0x4
+; block1: ; offset 0x4
 ;   pshufd $0xee, %xmm0, %xmm2
 ;   pmovzxdq %xmm2, %xmm0
 ;   movq %rbp, %rsp


### PR DESCRIPTION
As a follow-up to #5780, disassemble the regions identified by `bb_starts`, falling back on disassembling the whole buffer. This ensures that instructions like `br_table` that introduce a lot of constants don't throw off capstone for the remainder of the function.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
