### PR TITLE
Update PR tests slightly and when what runs where

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -439,7 +439,7 @@ jobs:
     - run: |
         sudo apt-get update && sudo apt-get install -y gdb lldb llvm
         cargo test test_debug_dwarf -- --ignored --test-threads 1
-      if: matrix.os == 'ubuntu-latest' && matrix.target == ''
+      if: matrix.os == 'ubuntu-latest' && matrix.target == ''&& needs.determine.outputs.run-full
       env:
         RUST_BACKTRACE: 1
 

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -36,7 +36,8 @@ const array = [
   {
     "os": "ubuntu-latest",
     "name": "Test Linux x86_64",
-    "filter": "linux-x64"
+    "filter": "linux-x64",
+    "isa": "x64"
   },
   {
     "os": "macos-latest",


### PR DESCRIPTION
* Don't run the LLDB tests on PRs
* Add a filter for `x64` directory changes to always run the linux x86_64 builder