### PR TITLE
Handle failures in the `determine` step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -679,6 +679,7 @@ jobs:
       - bench
       - meta_deterministic_check
       - verify-publish
+      - determine
     if: always()
     steps:
     - name: Dump needs context


### PR DESCRIPTION
I saw some PRs fail this step earlier today due to rate limits but it ended up not failing the entire PR's CI due to it not being listed in the final set of dependencies, so add it there.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
