### PR TITLE
Run labeler triage once an hour

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,11 +4,11 @@ on:
   issues:
     types: ["labeled"]
   schedule:
-    # Run pull request triage every 5 minutes. Ideally, this would be on
+    # Run pull request triage once an hour. Ideally, this would be on
     # "labeled" types of pull request events, but that doesn't work if the pull
     # request is from another fork. For example, see
     # https://github.com/actions/labeler/issues/12
-    - cron: '*/5 * * * *'
+    - cron: '42 * * * *'
 
 concurrency:
   group: issue-triage


### PR DESCRIPTION
Instead of every 5 minutes since this seems to eat through the rate limits pretty quickly if it ends up running.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
