### PR TITLE
Fix incorrect shadowing of `world` option in component bindgen macro options.

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -53,7 +53,6 @@ impl Parse for Config {
             let content;
             syn::braced!(content in input);
             let fields = Punctuated::<Opt, Token![,]>::parse_terminated(&content)?;
-            let mut world = None;
             for field in fields.into_pairs() {
                 match field.into_value() {
                     Opt::Path(s) => {


### PR DESCRIPTION
This prevents the `world` option from ever being treated as present (other than verifying there are no duplicate `world` options).