### PR TITLE
fuzzgen: Move `Arbitrary` structs into the fuzzers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,6 +3674,7 @@ dependencies = [
  "cranelift-filetests",
  "cranelift-fuzzgen",
  "cranelift-interpreter",
+ "cranelift-native",
  "cranelift-reader",
  "cranelift-wasm",
  "libfuzzer-sys",

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -18,16 +18,6 @@ mod cranelift_arbitrary;
 mod function_generator;
 mod passes;
 
-/// These libcalls need a interpreter implementation in `cranelift-fuzzgen.rs`
-const ALLOWED_LIBCALLS: &'static [LibCall] = &[
-    LibCall::CeilF32,
-    LibCall::CeilF64,
-    LibCall::FloorF32,
-    LibCall::FloorF64,
-    LibCall::TruncF32,
-    LibCall::TruncF64,
-];
-
 pub type TestCaseInput = Vec<DataValue>;
 
 /// Print only non default flags.
@@ -152,6 +142,7 @@ where
         name: UserFuncName,
         target_triple: Triple,
         usercalls: Vec<(UserExternalName, Signature)>,
+        libcalls: Vec<LibCall>,
     ) -> Result<Function> {
         let sig = self.generate_signature(target_triple.architecture)?;
 
@@ -162,7 +153,7 @@ where
             name,
             sig,
             usercalls,
-            ALLOWED_LIBCALLS.to_vec(),
+            libcalls,
         )
         .generate()?;
 

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -10,29 +10,17 @@ use cranelift::codegen::Context;
 use cranelift::prelude::*;
 use cranelift_arbitrary::CraneliftArbitrary;
 use cranelift_native::builder_with_options;
-use std::fmt;
 use target_lexicon::{Architecture, Triple};
 
 mod config;
 mod cranelift_arbitrary;
 mod function_generator;
 mod passes;
+mod print;
+
+pub use print::PrintableTestCase;
 
 pub type TestCaseInput = Vec<DataValue>;
-
-/// Print only non default flags.
-pub fn write_non_default_flags(f: &mut fmt::Formatter<'_>, flags: &settings::Flags) -> fmt::Result {
-    let default_flags = settings::Flags::new(settings::builder());
-    for (default, flag) in default_flags.iter().zip(flags.iter()) {
-        assert_eq!(default.name, flag.name);
-
-        if default.value_string() != flag.value_string() {
-            writeln!(f, "set {}={}", flag.name, flag.value_string())?;
-        }
-    }
-
-    Ok(())
-}
 
 pub struct FuzzGen<'r, 'data>
 where

--- a/cranelift/fuzzgen/src/print.rs
+++ b/cranelift/fuzzgen/src/print.rs
@@ -1,0 +1,130 @@
+use cranelift::codegen::data_value::DataValue;
+use cranelift::codegen::ir::Function;
+use cranelift::prelude::settings;
+use cranelift::prelude::*;
+use std::fmt;
+
+use crate::TestCaseInput;
+
+#[derive(Debug)]
+enum TestCaseKind {
+    Compile,
+    Run,
+}
+
+/// Provides a way to format a `TestCase` in the .clif format.
+pub struct PrintableTestCase<'a> {
+    kind: TestCaseKind,
+    isa: &'a isa::OwnedTargetIsa,
+    functions: &'a [Function],
+    // Only applicable for run test cases
+    inputs: &'a [TestCaseInput],
+}
+
+impl<'a> PrintableTestCase<'a> {
+    /// Emits a `test compile` test case.
+    pub fn compile(isa: &'a isa::OwnedTargetIsa, functions: &'a [Function]) -> Self {
+        Self {
+            kind: TestCaseKind::Compile,
+            isa,
+            functions,
+            inputs: &[],
+        }
+    }
+
+    /// Emits a `test run` test case. These also include a `test interpret`.
+    ///
+    /// By convention the first function in `functions` will be considered the main function.
+    pub fn run(
+        isa: &'a isa::OwnedTargetIsa,
+        functions: &'a [Function],
+        inputs: &'a [TestCaseInput],
+    ) -> Self {
+        Self {
+            kind: TestCaseKind::Run,
+            isa,
+            functions,
+            inputs,
+        }
+    }
+
+    /// Returns the main function of this test case.
+    pub fn main(&self) -> &Function {
+        &self.functions[0]
+    }
+}
+
+impl<'a> fmt::Debug for PrintableTestCase<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            TestCaseKind::Compile => {
+                writeln!(f, ";; Compile test case\n")?;
+                writeln!(f, "test compile")?;
+            }
+            TestCaseKind::Run => {
+                writeln!(f, ";; Run test case\n")?;
+                writeln!(f, "test interpret")?;
+                writeln!(f, "test run")?;
+            }
+        };
+
+        write_non_default_flags(f, self.isa.flags())?;
+
+        writeln!(f, "target {}\n", self.isa.triple().architecture)?;
+
+        // Print the functions backwards, so that the main function is printed last
+        // and near the test inputs for run test cases.
+        for func in self.functions.iter().rev() {
+            writeln!(f, "{}\n", func)?;
+        }
+
+        if !self.inputs.is_empty() {
+            writeln!(f, "; Note: the results in the below test cases are simply a placeholder and probably will be wrong\n")?;
+        }
+
+        for input in self.inputs.iter() {
+            // TODO: We don't know the expected outputs, maybe we can run the interpreter
+            // here to figure them out? Should work, however we need to be careful to catch
+            // panics in case its the interpreter that is failing.
+            // For now create a placeholder output consisting of the zero value for the type
+            let returns = &self.main().signature.returns;
+            let placeholder_output = returns
+                .iter()
+                .map(|param| DataValue::read_from_slice_ne(&[0; 16][..], param.value_type))
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            // If we have no output, we don't need the == condition
+            let test_condition = match returns.len() {
+                0 => String::new(),
+                1 => format!(" == {}", placeholder_output),
+                _ => format!(" == [{}]", placeholder_output),
+            };
+
+            let args = input
+                .iter()
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            writeln!(f, "; run: {}({}){}", self.main().name, args, test_condition)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Print only non default flags.
+fn write_non_default_flags(f: &mut fmt::Formatter<'_>, flags: &settings::Flags) -> fmt::Result {
+    let default_flags = settings::Flags::new(settings::builder());
+    for (default, flag) in default_flags.iter().zip(flags.iter()) {
+        assert_eq!(default.name, flag.name);
+
+        if default.value_string() != flag.value_string() {
+            writeln!(f, "set {}={}", flag.name, flag.value_string())?;
+        }
+    }
+
+    Ok(())
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ cranelift-wasm = { workspace = true }
 cranelift-filetests = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-fuzzgen = { workspace = true }
+cranelift-native = { workspace = true }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 target-lexicon = { workspace = true }
 smallvec = { workspace = true }

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -229,7 +229,12 @@ impl TestCase {
                 })
                 .collect();
 
-            let func = gen.generate_func(fname, isa.triple().clone(), usercalls)?;
+            let func = gen.generate_func(
+                fname,
+                isa.triple().clone(),
+                usercalls,
+                ALLOWED_LIBCALLS.to_vec(),
+            )?;
             functions.push(func);
         }
         // Now reverse the functions so that the main function is at the start.
@@ -269,6 +274,16 @@ fn run_in_host(trampoline: &Trampoline, args: &[DataValue]) -> RunResult {
     let res = trampoline.call(args);
     RunResult::Success(res)
 }
+
+/// These libcalls need a interpreter implementation in `build_interpreter`
+const ALLOWED_LIBCALLS: &'static [LibCall] = &[
+    LibCall::CeilF32,
+    LibCall::CeilF64,
+    LibCall::FloorF32,
+    LibCall::FloorF64,
+    LibCall::TruncF32,
+    LibCall::TruncF64,
+];
 
 fn build_interpreter(testcase: &TestCase) -> Interpreter {
     let mut env = FunctionStore::default();

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -1,13 +1,22 @@
 #![no_main]
 
+use cranelift_codegen::ir::Function;
+use cranelift_codegen::ir::Signature;
+use cranelift_codegen::ir::UserExternalName;
+use cranelift_codegen::ir::UserFuncName;
+use libfuzzer_sys::arbitrary;
+use libfuzzer_sys::arbitrary::Arbitrary;
+use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{LibCall, TrapCode};
+use cranelift_codegen::isa;
 use cranelift_filetests::function_runner::{TestFileCompiler, Trampoline};
 use cranelift_fuzzgen::*;
 use cranelift_interpreter::environment::FuncIndex;
@@ -17,6 +26,7 @@ use cranelift_interpreter::interpreter::{
 };
 use cranelift_interpreter::step::ControlFlow;
 use cranelift_interpreter::step::CraneliftTrap;
+use cranelift_native::builder_with_options;
 use smallvec::smallvec;
 
 const INTERPRETER_FUEL: u64 = 4096;
@@ -117,6 +127,127 @@ impl PartialEq for RunResult {
         } else {
             false
         }
+    }
+}
+
+pub struct TestCase {
+    /// TargetIsa to use when compiling this test case
+    pub isa: isa::OwnedTargetIsa,
+    /// Functions under test
+    /// By convention the first function is the main function.
+    pub functions: Vec<Function>,
+    /// Generate multiple test inputs for each test case.
+    /// This allows us to get more coverage per compilation, which may be somewhat expensive.
+    pub inputs: Vec<TestCaseInput>,
+}
+
+impl fmt::Debug for TestCase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, ";; Fuzzgen test case\n")?;
+        writeln!(f, "test interpret")?;
+        writeln!(f, "test run")?;
+
+        write_non_default_flags(f, self.isa.flags())?;
+
+        writeln!(f, "target {}\n", self.isa.triple().architecture)?;
+
+        // Print the functions backwards, so that the main function is printed last
+        // and near the test inputs.
+        for func in self.functions.iter().rev() {
+            writeln!(f, "{}\n", func)?;
+        }
+
+        writeln!(f, "; Note: the results in the below test cases are simply a placeholder and probably will be wrong\n")?;
+
+        for input in self.inputs.iter() {
+            // TODO: We don't know the expected outputs, maybe we can run the interpreter
+            // here to figure them out? Should work, however we need to be careful to catch
+            // panics in case its the interpreter that is failing.
+            // For now create a placeholder output consisting of the zero value for the type
+            let returns = &self.main().signature.returns;
+            let placeholder_output = returns
+                .iter()
+                .map(|param| DataValue::read_from_slice_ne(&[0; 16][..], param.value_type))
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            // If we have no output, we don't need the == condition
+            let test_condition = match returns.len() {
+                0 => String::new(),
+                1 => format!(" == {}", placeholder_output),
+                _ => format!(" == [{}]", placeholder_output),
+            };
+
+            let args = input
+                .iter()
+                .map(|val| format!("{}", val))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            writeln!(f, "; run: {}({}){}", self.main().name, args, test_condition)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Arbitrary<'a> for TestCase {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Self::generate(u).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+impl TestCase {
+    pub fn generate(u: &mut Unstructured) -> anyhow::Result<Self> {
+        let mut gen = FuzzGen::new(u);
+
+        // TestCase is meant to be consumed by a runner, so we make the assumption here that we're
+        // generating a TargetIsa for the host.
+        let builder =
+            builder_with_options(true).expect("Unable to build a TargetIsa for the current host");
+        let flags = gen.generate_flags(builder.triple().architecture)?;
+        let isa = builder.finish(flags)?;
+
+        // When generating functions, we allow each function to call any function that has
+        // already been generated. This guarantees that we never have loops in the call graph.
+        // We generate these backwards, and then reverse them so that the main function is at
+        // the start.
+        let func_count = gen.u.int_in_range(gen.config.testcase_funcs.clone())?;
+        let mut functions: Vec<Function> = Vec::with_capacity(func_count);
+        for i in (0..func_count).rev() {
+            // Function name must be in a different namespace than TESTFILE_NAMESPACE (0)
+            let fname = UserFuncName::user(1, i as u32);
+
+            let usercalls: Vec<(UserExternalName, Signature)> = functions
+                .iter()
+                .map(|f| {
+                    (
+                        f.name.get_user().unwrap().clone(),
+                        f.stencil.signature.clone(),
+                    )
+                })
+                .collect();
+
+            let func = gen.generate_func(fname, isa.triple().clone(), usercalls)?;
+            functions.push(func);
+        }
+        // Now reverse the functions so that the main function is at the start.
+        functions.reverse();
+
+        let main = &functions[0];
+        let inputs = gen.generate_test_inputs(&main.signature)?;
+
+        Ok(TestCase {
+            isa,
+            functions,
+            inputs,
+        })
+    }
+
+    /// Returns the main function of this test case.
+    pub fn main(&self) -> &Function {
+        &self.functions[0]
     }
 }
 


### PR DESCRIPTION
👋 Hey,

This PR is built on top of  #5765, sorry about chaining these PR's so much, but doing it on top of main would cause conflicts with the two other PR's.

This PR does some cleanup around fuzzgen that @jameysharp sugested in https://github.com/bytecodealliance/wasmtime/pull/5764#issuecomment-1431781405.

Namely:
* It moves the `Arbitrary` structs from fuzzgen into the individual fuzzers.
  * This also allows us to keep `ALLOWED_LIBCALLS` near the interpreter implementation, which need to be updated together.
* It centralizes the testcase printing infrastructure in a helper struct provided by fuzzgen.
