### PR TITLE
fuzzgen: Allow inline stackprobes for riscv64

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -321,6 +321,7 @@ where
         let supports_inline_probestack = match target_arch {
             Architecture::X86_64 => true,
             Architecture::Aarch64(_) => true,
+            Architecture::Riscv64(_) => true,
             _ => false,
         };
 


### PR DESCRIPTION
👋 Hey,

The RISC-V backend has had support for inline stack probing for a while, but we never fuzzed it via fuzzgen. This PR changes that.

I've been running this for a couple of hours on a RISC-V machine and it hasn't panicked yet. I've also ran the `icache` fuzzer on my faster desktop computer for the past hour.