### PR TITLE
fuzzgen: Increase allowed stack space

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -81,7 +81,7 @@ impl Default for Config {
             switch_max_range_size: 2..=32,
             funcrefs_per_function: 0..=8,
             static_stack_slots_per_function: 0..=8,
-            static_stack_slot_size: 0..=128,
+            static_stack_slot_size: 0..=8192,
             // We need the mix of sizes that allows us to:
             //  * not generates any stack probes
             //  * generate unrolled stack probes


### PR DESCRIPTION
👋 Hey,

The motivation for this PR is the encoding error that @uweigand found in  #5786. He had previously run fuzzgen on s390x and that sort of error should have been found. But it wasn't because we never generate large offsets in our stack accesses.

This PR allows larger stack slots that let us explore these larger offsets and hopefully more errors like this.

I've picked `8192` somewhat arbitrarily, it's the next largest power of two after `4096` which i suspect might be the more troublesome value, although this probably depends on the ISA.

With `8192` we have a max stack usage per function of `8 * 8192 = 65536`. And with #5765 we generate at most 8 functions, so worst case `8 * 8 * 8192 = 524288` which still seems fairly reasonable.

Opening this as a draft because it has already found issues on the AArch64 backend! (#5824)