### PR TITLE
Audit `object` crate update to 0.30.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,9 +1891,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.30.1"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ windows-sys = "0.45.0"
 env_logger = "0.9"
 rustix = "0.36.7"
 log = { version = "0.4.8", default-features = false }
-object = { version = "0.30.1", default-features = false, features = ['read_core', 'elf', 'std'] }
+object = { version = "0.30.3", default-features = false, features = ['read_core', 'elf', 'std'] }
 gimli = { version = "0.27.0", default-features = false, features = ['read', 'std'] }
 clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
 hashbrown = "0.13"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -517,6 +517,15 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "0.29.0 -> 0.30.1"
 
+[[audits.object]]
+who = "Jamey Sharp <jsharp@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.30.1 -> 0.30.3"
+notes = """
+No unsafe blocks or I/O in the diff. The only changes clearly implement what
+the changelog says is new in these versions.
+"""
+
 [[audits.once_cell]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This audit is needed for #5619. I'm going ahead and updating Cargo.toml and Cargo.lock at the same time because no source code changes are required for this update.