### PR TITLE
cranelift-jit: Implement RISC-V Call relocation

### DIFF
--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -810,3 +810,52 @@ block0:
 ;   addi a1, zero, 1
 ;   ret
 
+
+
+function %call_colocated(i16) -> i16 {
+    sig0 = () system_v
+    fn0 = colocated u0:0 sig0
+
+block0(v0: i16):
+    call fn0()
+    return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s3,-8(sp)
+;   add sp,-16
+; block0:
+;   mv s3,a0
+;   call userextname0
+;   mv a0,s3
+;   add sp,+16
+;   ld s3,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   sd s3, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   ori s3, a0, 0
+;   auipc ra, 0 ; reloc_external RiscvCall u0:0 0
+;   jalr ra
+;   ori a0, s3, 0
+;   addi sp, sp, 0x10
+;   ld s3, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/call.clif
+++ b/cranelift/filetests/filetests/runtests/call.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
+target riscv64
 
 
 function %callee_i64(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/call_libcall.clif
+++ b/cranelift/filetests/filetests/runtests/call_libcall.clif
@@ -2,6 +2,7 @@ test run
 target x86_64
 ; AArch64 Does not have these libcalls
 target s390x
+target riscv64
 
 
 function %libcall_ceilf32(f32) -> f32 {


### PR DESCRIPTION
👋 Hey,

This PR implements handling for the R_RISCV_CALL relocation in the JIT.

I'm going to let the fuzzer run overnight on this.

Fixes #5832

Edit: Fuzzer ran overnight and didn't find anything related to calls.