### PR TITLE
x64: Remove conditional `SseOpcode::uses_src1`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -331,6 +331,12 @@
                  (dst WritableGpr)
                  (dst_size OperandSize))
 
+       ;; XMM (scalar) unary op (from xmm to integer reg): pextr{w,b,d,q}
+       (XmmToGprImm (op SseOpcode)
+                    (src Xmm)
+                    (dst WritableGpr)
+                    (imm u8))
+
        ;; XMM (scalar) unary op (from integer to float reg): movd, movq,
        ;; cvtsi2s{s,d}
        (GprToXmm (op SseOpcode)
@@ -749,6 +755,7 @@
             Pextrb
             Pextrw
             Pextrd
+            Pextrq
             Pinsrb
             Pinsrw
             Pinsrd
@@ -3110,16 +3117,9 @@
       (xmm_rmr_imm_vex (AvxOpcode.Vinsertps) src1 src2 lane))
 
 ;; Helper for creating `pshufd` instructions.
-(decl x64_pshufd (XmmMem u8 OperandSize) Xmm)
-(rule (x64_pshufd src imm size)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pshufd)
-                                           dst
-                                           src
-                                           dst
-                                           imm
-                                           size))))
-        dst))
+(decl x64_pshufd (XmmMem u8) Xmm)
+(rule (x64_pshufd src imm)
+      (xmm_unary_rm_r_imm (SseOpcode.Pshufd) src imm))
 
 ;; Helper for creating `pshufb` instructions.
 (decl x64_pshufb (Xmm XmmMem) Xmm)
@@ -3314,46 +3314,37 @@
       (xmm_rmir_vex (AvxOpcode.Vpsrad) src1 src2))
 
 ;; Helper for creating `pextrb` instructions.
-(decl x64_pextrb (Type Xmm u8) Gpr)
-(rule (x64_pextrb ty src lane)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pextrb)
-                                           dst
-                                           src
-                                           dst
-                                           lane
-                                           (operand_size_of_type_32_64 (lane_type ty))))))
-        dst))
+(decl x64_pextrb (Xmm u8) Gpr)
+(rule (x64_pextrb src lane)
+      (xmm_to_gpr_imm (SseOpcode.Pextrb) src lane))
 
 ;; Helper for creating `pextrw` instructions.
-(decl x64_pextrw (Type Xmm u8) Gpr)
-(rule (x64_pextrw ty src lane)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pextrw)
-                                           dst
-                                           src
-                                           dst
-                                           lane
-                                           (operand_size_of_type_32_64 (lane_type ty))))))
-        dst))
+(decl x64_pextrw (Xmm u8) Gpr)
+(rule (x64_pextrw src lane)
+      (xmm_to_gpr_imm (SseOpcode.Pextrw) src lane))
 
 ;; Helper for creating `pextrd` instructions.
-(decl x64_pextrd (Type Xmm u8) Gpr)
-(rule (x64_pextrd ty src lane)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.XmmRmRImm (SseOpcode.Pextrd)
-                                           dst
-                                           src
-                                           dst
-                                           lane
-                                           (operand_size_of_type_32_64 (lane_type ty))))))
-        dst))
+(decl x64_pextrd (Xmm u8) Gpr)
+(rule (x64_pextrd src lane)
+      (xmm_to_gpr_imm (SseOpcode.Pextrd) src lane))
+
+;; Helper for creating `pextrq` instructions.
+(decl x64_pextrq (Xmm u8) Gpr)
+(rule (x64_pextrq src lane)
+      (xmm_to_gpr_imm (SseOpcode.Pextrq) src lane))
 
 ;; Helper for creating `MInst.XmmToGpr` instructions.
 (decl xmm_to_gpr (SseOpcode Xmm OperandSize) Gpr)
 (rule (xmm_to_gpr op src size)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.XmmToGpr op src dst size))))
+        dst))
+
+;; Helper for creating `MInst.XmmToGpr` instructions.
+(decl xmm_to_gpr_imm (SseOpcode Xmm u8) Gpr)
+(rule (xmm_to_gpr_imm op src imm)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.XmmToGprImm op src dst imm))))
         dst))
 
 ;; Helper for creating `pmovmskb` instructions.

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -999,6 +999,7 @@ pub enum SseOpcode {
     Pextrb,
     Pextrw,
     Pextrd,
+    Pextrq,
     Pinsrb,
     Pinsrw,
     Pinsrd,
@@ -1237,6 +1238,7 @@ impl SseOpcode {
             | SseOpcode::Pcmpeqq
             | SseOpcode::Pextrb
             | SseOpcode::Pextrd
+            | SseOpcode::Pextrq
             | SseOpcode::Pinsrb
             | SseOpcode::Pinsrd
             | SseOpcode::Pmaxsb
@@ -1276,22 +1278,6 @@ impl SseOpcode {
         match self {
             SseOpcode::Movd => 4,
             _ => 8,
-        }
-    }
-
-    /// Does an XmmRmmRImm with this opcode use src1? FIXME: split
-    /// into separate instructions.
-    pub(crate) fn uses_src1(&self) -> bool {
-        match self {
-            SseOpcode::Pextrb => false,
-            SseOpcode::Pextrw => false,
-            SseOpcode::Pextrd => false,
-            SseOpcode::Pshufd => false,
-            SseOpcode::Roundss => false,
-            SseOpcode::Roundsd => false,
-            SseOpcode::Roundps => false,
-            SseOpcode::Roundpd => false,
-            _ => true,
         }
     }
 }
@@ -1393,6 +1379,7 @@ impl fmt::Debug for SseOpcode {
             SseOpcode::Pextrb => "pextrb",
             SseOpcode::Pextrw => "pextrw",
             SseOpcode::Pextrd => "pextrd",
+            SseOpcode::Pextrq => "pextrq",
             SseOpcode::Pinsrb => "pinsrb",
             SseOpcode::Pinsrw => "pinsrw",
             SseOpcode::Pinsrd => "pinsrd",

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -743,8 +743,8 @@
 ;; (TODO: when EVEX support is available, add an alternate lowering here).
 (rule (lower (has_type $I64X2 (sshr src amt)))
       (let ((src_ Xmm (put_in_xmm src))
-            (lo Gpr (x64_pextrd $I64 src_ 0))
-            (hi Gpr (x64_pextrd $I64 src_ 1))
+            (lo Gpr (x64_pextrq src_ 0))
+            (hi Gpr (x64_pextrq src_ 1))
             (amt_ Imm8Gpr (put_masked_in_imm8_gpr amt $I64))
             (shifted_lo Gpr (x64_sar $I64 lo amt_))
             (shifted_hi Gpr (x64_sar $I64 hi amt_)))
@@ -993,12 +993,8 @@
                                                x))
                              (swiden_high (and (value_type (multi_lane 32 4))
                                                y)))))
-      (let ((x2 Xmm (x64_pshufd x
-                            0xFA
-                            (OperandSize.Size32)))
-            (y2 Xmm (x64_pshufd y
-                            0xFA
-                            (OperandSize.Size32))))
+      (let ((x2 Xmm (x64_pshufd x 0xFA))
+            (y2 Xmm (x64_pshufd y 0xFA)))
         (x64_pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_s`.
@@ -1029,12 +1025,8 @@
                                               x))
                              (swiden_low (and (value_type (multi_lane 32 4))
                                               y)))))
-      (let ((x2 Xmm (x64_pshufd x
-                            0x50
-                            (OperandSize.Size32)))
-            (y2 Xmm (x64_pshufd y
-                            0x50
-                            (OperandSize.Size32))))
+      (let ((x2 Xmm (x64_pshufd x 0x50))
+            (y2 Xmm (x64_pshufd y 0x50)))
         (x64_pmuldq x2 y2)))
 
 ;; Special case for `i16x8.extmul_high_i8x16_u`.
@@ -1069,12 +1061,8 @@
                                                x))
                              (uwiden_high (and (value_type (multi_lane 32 4))
                                                y)))))
-      (let ((x2 Xmm (x64_pshufd x
-                            0xFA
-                            (OperandSize.Size32)))
-            (y2 Xmm (x64_pshufd y
-                            0xFA
-                            (OperandSize.Size32))))
+      (let ((x2 Xmm (x64_pshufd x 0xFA))
+            (y2 Xmm (x64_pshufd y 0xFA)))
         (x64_pmuludq x2 y2)))
 
 ;; Special case for `i16x8.extmul_low_i8x16_u`.
@@ -1105,12 +1093,8 @@
                                               x))
                              (uwiden_low (and (value_type (multi_lane 32 4))
                                               y)))))
-      (let ((x2 Xmm (x64_pshufd x
-                            0x50
-                            (OperandSize.Size32)))
-            (y2 Xmm (x64_pshufd y
-                            0x50
-                            (OperandSize.Size32))))
+      (let ((x2 Xmm (x64_pshufd x 0x50))
+            (y2 Xmm (x64_pshufd y 0x50)))
         (x64_pmuludq x2 y2)))
 
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3246,7 +3230,7 @@
         (x64_pmovsxwd (x64_palignr x x 8 (OperandSize.Size32)))))
 
 (rule (lower (has_type $I64X2 (swiden_high val @ (value_type $I32X4))))
-      (x64_pmovsxdq (x64_pshufd val 0xEE (OperandSize.Size32))))
+      (x64_pmovsxdq (x64_pshufd val 0xEE)))
 
 ;; Rules for `uwiden_low` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3270,7 +3254,7 @@
         (x64_pmovzxwd (x64_palignr x x 8 (OperandSize.Size32)))))
 
 (rule (lower (has_type $I64X2 (uwiden_high val @ (value_type $I32X4))))
-      (x64_pmovzxdq (x64_pshufd val 0xEE (OperandSize.Size32))))
+      (x64_pmovzxdq (x64_pshufd val 0xEE)))
 
 ;; Rules for `snarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3566,25 +3550,25 @@
 ;; Cases 2-4 for an F32X4
 (rule 1 (lower (has_type $F32 (extractlane val @ (value_type (ty_vec128 ty))
                                          (u8_from_uimm8 lane))))
-      (x64_pshufd val lane (OperandSize.Size32)))
+      (x64_pshufd val lane))
 
 ;; This is the only remaining case for F64X2
 (rule 1 (lower (has_type $F64 (extractlane val @ (value_type (ty_vec128 ty))
                                          (u8_from_uimm8 1))))
       ;; 0xee == 0b11_10_11_10
-      (x64_pshufd val 0xee (OperandSize.Size32)))
+      (x64_pshufd val 0xee))
 
 (rule 0 (lower (extractlane val @ (value_type ty @ (multi_lane 8 16)) (u8_from_uimm8 lane)))
-      (x64_pextrb ty val lane))
+      (x64_pextrb val lane))
 
 (rule 0 (lower (extractlane val @ (value_type ty @ (multi_lane 16 8)) (u8_from_uimm8 lane)))
-      (x64_pextrw ty val lane))
+      (x64_pextrw val lane))
 
 (rule 0 (lower (extractlane val @ (value_type ty @ (multi_lane 32 4)) (u8_from_uimm8 lane)))
-      (x64_pextrd ty val lane))
+      (x64_pextrd val lane))
 
 (rule 0 (lower (extractlane val @ (value_type ty @ (multi_lane 64 2)) (u8_from_uimm8 lane)))
-      (x64_pextrd ty val lane))
+      (x64_pextrq val lane))
 
 ;; Rules for `scalar_to_vector` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3622,7 +3606,7 @@
             (vec Xmm (vec_insert_lane $I16X8 (xmm_uninit_value) src 0))
             (vec Xmm (vec_insert_lane $I16X8 vec src 1)))
         ;; Shuffle the lowest two lanes to all other lanes.
-        (x64_pshufd vec 0 (OperandSize.Size32))))
+        (x64_pshufd vec 0)))
 
 (rule 1 (lower (has_type (multi_lane 32 4) (splat src @ (value_type (ty_scalar_float _)))))
       (lower_splat_32x4 $F32X4 src))
@@ -3635,7 +3619,7 @@
       (let ((src RegMem src)
             (vec Xmm (vec_insert_lane ty (xmm_uninit_value) src 0)))
         ;; Shuffle the lowest lane to all other lanes.
-        (x64_pshufd vec 0 (OperandSize.Size32))))
+        (x64_pshufd vec 0)))
 
 (rule 1 (lower (has_type (multi_lane 64 2) (splat src @ (value_type (ty_scalar_float _)))))
       (lower_splat_64x2 $F64X2 src))

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -86,7 +86,7 @@ block0(v0: i64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pextrd.w $1, %xmm0, %rax
+;   pextrq  $1, %xmm0, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -753,8 +753,8 @@ block0(v0: i64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pextrd.w $0, %xmm0, %rdx
-;   pextrd.w $1, %xmm0, %r9
+;   pextrq  $0, %xmm0, %rdx
+;   pextrq  $1, %xmm0, %r9
 ;   sarq    $36, %rdx, %rdx
 ;   sarq    $36, %r9, %r9
 ;   uninit  %xmm0
@@ -789,8 +789,8 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pextrd.w $0, %xmm0, %r8
-;   pextrd.w $1, %xmm0, %r10
+;   pextrq  $0, %xmm0, %r8
+;   pextrq  $1, %xmm0, %r10
 ;   movq    %rdi, %rcx
 ;   sarq    %cl, %r8, %r8
 ;   sarq    %cl, %r10, %r10


### PR DESCRIPTION
This is a follow-up to comments in #5795 to remove some cruft in the x64 instruction model to ensure that the shape of an `Inst` reflects what's going to happen in regalloc and encoding. This accessor was used to handle `round*`, `pextr*`, and `pshufb` instructions. The `round*` ones had already moved to the appropriate `XmmUnary*` variant and `pshufb` was additionally moved over to that variant as well.

The `pextr*` instructions got a new `Inst` variant and additionally had their constructors slightly modified to no longer require the type as input. The encoding for these instructions now automatically handles the various type-related operands through a new `SseOpcode::Pextrq` operand to represent 64-bit movements.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
