### PR TITLE
Reuse the DominatorTree postorder travesal in BlockLoweringOrder

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -140,7 +140,7 @@ impl Context {
 
         self.optimize(isa)?;
 
-        isa.compile_function(&self.func, self.want_disasm)
+        isa.compile_function(&self.func, &self.domtree, self.want_disasm)
     }
 
     /// Optimize the function, performing all compilation steps up to

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -43,6 +43,7 @@
 //! The configured target ISA trait object is a `Box<TargetIsa>` which can be used for multiple
 //! concurrent function compilations.
 
+use crate::dominator_tree::DominatorTree;
 pub use crate::isa::call_conv::CallConv;
 
 use crate::flowgraph;
@@ -252,6 +253,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     fn compile_function(
         &self,
         func: &Function,
+        domtree: &DominatorTree,
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil>;
 

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -1,5 +1,6 @@
 //! risc-v 64-bit Instruction Set Architecture.
 
+use crate::dominator_tree::DominatorTree;
 use crate::ir;
 use crate::ir::condcodes::IntCC;
 use crate::ir::Function;
@@ -56,11 +57,12 @@ impl Riscv64Backend {
     fn compile_vcode(
         &self,
         func: &Function,
+        domtree: &DominatorTree,
     ) -> CodegenResult<(VCode<inst::Inst>, regalloc2::Output)> {
         let emit_info = EmitInfo::new(self.flags.clone(), self.isa_flags.clone());
         let sigs = SigSet::new::<abi::Riscv64MachineDeps>(func, &self.flags)?;
         let abi = abi::Riscv64Callee::new(func, self, &self.isa_flags, &sigs)?;
-        compile::compile::<Riscv64Backend>(func, self, abi, emit_info, sigs)
+        compile::compile::<Riscv64Backend>(func, domtree, self, abi, emit_info, sigs)
     }
 }
 
@@ -68,9 +70,10 @@ impl TargetIsa for Riscv64Backend {
     fn compile_function(
         &self,
         func: &Function,
+        domtree: &DominatorTree,
         want_disasm: bool,
     ) -> CodegenResult<CompiledCodeStencil> {
-        let (vcode, regalloc_result) = self.compile_vcode(func)?;
+        let (vcode, regalloc_result) = self.compile_vcode(func, domtree)?;
 
         let want_disasm = want_disasm || log::log_enabled!(log::Level::Debug);
         let emit_result = vcode.emit(
@@ -216,6 +219,8 @@ pub fn isa_builder(triple: Triple) -> IsaBuilder {
 mod test {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
+    use crate::dominator_tree::DominatorTree;
+    use crate::flowgraph::ControlFlowGraph;
     use crate::ir::types::*;
     use crate::ir::{AbiParam, Function, InstBuilder, Signature, UserFuncName};
     use crate::isa::CallConv;
@@ -250,7 +255,9 @@ mod test {
             shared_flags,
             isa_flags,
         );
-        let buffer = backend.compile_function(&mut func, true).unwrap();
+        let cfg = ControlFlowGraph::with_function(&func);
+        let domtree = DominatorTree::with_function(&func, &cfg);
+        let buffer = backend.compile_function(&mut func, &domtree, true).unwrap();
         let code = buffer.buffer.data();
 
         // To update this comment, write the golden bytes to a file, and run the following command

--- a/cranelift/codegen/src/loop_analysis.rs
+++ b/cranelift/codegen/src/loop_analysis.rs
@@ -417,25 +417,23 @@ mod tests {
         }
 
         let mut loop_analysis = LoopAnalysis::new();
-        let mut cfg = ControlFlowGraph::new();
-        let mut domtree = DominatorTree::new();
-        cfg.compute(&func);
-        domtree.compute(&func, &cfg);
+        let cfg = ControlFlowGraph::with_function(&func);
+        let domtree = DominatorTree::with_function(&func, &cfg);
         loop_analysis.compute(&func, &cfg, &domtree);
 
         let loops = loop_analysis.loops().collect::<Vec<Loop>>();
         assert_eq!(loops.len(), 3);
         assert_eq!(loop_analysis.loop_header(loops[0]), block0);
-        assert_eq!(loop_analysis.loop_header(loops[1]), block1);
-        assert_eq!(loop_analysis.loop_header(loops[2]), block3);
+        assert_eq!(loop_analysis.loop_header(loops[1]), block3);
+        assert_eq!(loop_analysis.loop_header(loops[2]), block1);
         assert_eq!(loop_analysis.loop_parent(loops[1]), Some(loops[0]));
         assert_eq!(loop_analysis.loop_parent(loops[2]), Some(loops[0]));
         assert_eq!(loop_analysis.loop_parent(loops[0]), None);
         assert_eq!(loop_analysis.is_in_loop(block0, loops[0]), true);
-        assert_eq!(loop_analysis.is_in_loop(block1, loops[1]), true);
-        assert_eq!(loop_analysis.is_in_loop(block2, loops[1]), true);
-        assert_eq!(loop_analysis.is_in_loop(block3, loops[2]), true);
-        assert_eq!(loop_analysis.is_in_loop(block4, loops[2]), true);
+        assert_eq!(loop_analysis.is_in_loop(block1, loops[2]), true);
+        assert_eq!(loop_analysis.is_in_loop(block2, loops[2]), true);
+        assert_eq!(loop_analysis.is_in_loop(block3, loops[1]), true);
+        assert_eq!(loop_analysis.is_in_loop(block4, loops[1]), true);
         assert_eq!(loop_analysis.is_in_loop(block5, loops[0]), true);
         assert_eq!(loop_analysis.loop_level(block0).level(), 1);
         assert_eq!(loop_analysis.loop_level(block1).level(), 2);

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -34,27 +34,18 @@
 //!            +--------------+
 //!               /           \
 //!     +--------------+     +--------------+
-//!     | (edge 0->1)  |     |(edge 0->2)   |
+//!     | (edge 0->1)  |     | (edge 0->2)  |
 //!     | CLIF block 1 |     | CLIF block 2 |
+//!     | (edge 1->3)  |     | (edge 2->3)  |
 //!     +--------------+     +--------------+
-//!              \                /
-//!          +-----------+ +-----------+
-//!          |(edge 1->3)| |(edge 2->3)|
-//!          +-----------+ +-----------+
-//!                   \      /
+//!                \           /
+//!                 \         /
 //!                +------------+
 //!                |CLIF block 3|
 //!                +------------+
 //! ```
 //!
-//! (note that the edges into CLIF blocks 1 and 2 could be merged with those
-//! blocks' original bodies, but the out-edges could not because for simplicity
-//! in the successor-function definition, we only ever merge an edge onto one
-//! side of an original CLIF block.)
-//!
-//! Each `LoweredBlock` names just an original CLIF block, an original CLIF
-//! block prepended or appended with an edge block (never both, though), or just
-//! an edge block.
+//! Each `LoweredBlock` names just an original CLIF block, or just an edge block.
 //!
 //! To compute this lowering, we do a DFS over the CLIF-plus-edge-block graph
 //! (never actually materialized, just defined by a "successors" function), and
@@ -69,10 +60,11 @@
 //! branch editing that in practice elides empty blocks and simplifies some of
 //! the other redundancies that this scheme produces.
 
+use crate::dominator_tree::DominatorTree;
 use crate::entity::SecondaryMap;
 use crate::fx::{FxHashMap, FxHashSet};
 use crate::inst_predicates::visit_block_succs;
-use crate::ir::{Block, Function, Inst, Opcode};
+use crate::ir::{Block, Function, Inst};
 use crate::{machinst::*, trace};
 
 use smallvec::SmallVec;
@@ -84,21 +76,11 @@ pub struct BlockLoweringOrder {
     /// (i) a CLIF block, and (ii) inserted crit-edge blocks before or after;
     /// see [LoweredBlock] for details.
     lowered_order: Vec<LoweredBlock>,
-    /// Successors for all lowered blocks, in one serialized vector. Indexed by
-    /// the ranges in `lowered_succ_ranges`.
-    #[allow(dead_code)]
-    lowered_succs: Vec<(Inst, LoweredBlock)>,
-    /// BlockIndex values for successors for all lowered blocks, in the same
-    /// order as `lowered_succs`.
-    lowered_succ_indices: Vec<(Inst, BlockIndex)>,
-    /// Ranges in `lowered_succs` giving the successor lists for each lowered
+    /// BlockIndex values for successors for all lowered blocks, indexing `lowered_order`.
+    lowered_succ_indices: Vec<BlockIndex>,
+    /// Ranges in `lowered_succ_indices` giving the successor lists for each lowered
     /// block. Indexed by lowering-order index (`BlockIndex`).
-    lowered_succ_ranges: Vec<(usize, usize)>,
-    /// Mapping from CLIF BB to BlockIndex (index in lowered order). Note that
-    /// some CLIF BBs may not be lowered; in particular, we skip unreachable
-    /// blocks.
-    #[allow(dead_code)]
-    orig_map: SecondaryMap<Block, Option<BlockIndex>>,
+    lowered_succ_ranges: Vec<(Option<Inst>, std::ops::Range<usize>)>,
     /// Cold blocks. These blocks are not reordered in the
     /// `lowered_order` above; the lowered order must respect RPO
     /// (uses after defs) in order for lowering to be
@@ -110,390 +92,186 @@ pub struct BlockLoweringOrder {
     indirect_branch_targets: FxHashSet<BlockIndex>,
 }
 
-/// The origin of a block in the lowered block-order: either an original CLIF
-/// block, or an inserted edge-block, or a combination of the two if an edge is
-/// non-critical.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum LoweredBlock {
-    /// Block in original CLIF, with no merged edge-blocks.
+    /// Block in original CLIF.
     Orig {
         /// Original CLIF block.
         block: Block,
     },
-    /// Block in the original CLIF, plus edge-block to one succ (which is the
-    /// one successor of the original block).
-    OrigAndEdge {
-        /// The original CLIF block contained in this lowered block.
-        block: Block,
-        /// The edge (jump) instruction transitioning from this block
-        /// to the next, i.e., corresponding to the included edge-block. This
-        /// will be an instruction in `block`.
-        edge_inst: Inst,
-        /// The successor index in this edge, to distinguish multiple
-        /// edges between the same block pair.
-        succ_idx: usize,
-        /// The successor CLIF block.
-        succ: Block,
-    },
-    /// Block in the original CLIF, preceded by edge-block from one pred (which
-    /// is the one pred of the original block).
-    EdgeAndOrig {
-        /// The previous CLIF block, i.e., the edge block's predecessor.
+
+    /// Critical edge between two CLIF blocks.
+    CriticalEdge {
+        /// The predecessor block.
         pred: Block,
-        /// The edge (jump) instruction corresponding to the included
-        /// edge-block. This will be an instruction in `pred`.
-        edge_inst: Inst,
-        /// The successor index in this edge, to distinguish multiple
-        /// edges between the same block pair.
-        succ_idx: usize,
-        /// The original CLIF block included in this lowered block.
-        block: Block,
-    },
-    /// Split critical edge between two CLIF blocks. This lowered block does not
-    /// correspond to any original CLIF blocks; it only serves as an insertion
-    /// point for work to happen on the transition from `pred` to `succ`.
-    Edge {
-        /// The predecessor CLIF block.
-        pred: Block,
-        /// The edge (jump) instruction corresponding to this edge's transition.
-        /// This will be an instruction in `pred`.
-        edge_inst: Inst,
-        /// The successor index in this edge, to distinguish multiple
-        /// edges between the same block pair.
-        succ_idx: usize,
-        /// The successor CLIF block.
+
+        /// The successor block.
         succ: Block,
+
+        /// The branch index
+        branch_idx: u32,
     },
 }
 
 impl LoweredBlock {
-    /// The associated original (CLIF) block included in this lowered block, if
-    /// any.
-    pub fn orig_block(self) -> Option<Block> {
+    /// Unwrap an `Orig` block.
+    pub fn orig_block(&self) -> Option<Block> {
         match self {
-            LoweredBlock::Orig { block, .. }
-            | LoweredBlock::OrigAndEdge { block, .. }
-            | LoweredBlock::EdgeAndOrig { block, .. } => Some(block),
-            LoweredBlock::Edge { .. } => None,
+            &LoweredBlock::Orig { block } => Some(block),
+            &LoweredBlock::CriticalEdge { .. } => None,
         }
     }
 
-    /// The associated in-edge, if any.
+    /// The associated in-edge predecessor, if this is a critical edge.
     #[cfg(test)]
-    pub fn in_edge(self) -> Option<(Block, Inst, Block)> {
+    pub fn in_edge(&self) -> Option<Block> {
         match self {
-            LoweredBlock::EdgeAndOrig {
-                pred,
-                edge_inst,
-                block,
-                ..
-            } => Some((pred, edge_inst, block)),
-            _ => None,
+            &LoweredBlock::CriticalEdge { pred, .. } => Some(pred),
+            &LoweredBlock::Orig { .. } => None,
         }
     }
 
-    /// the associated out-edge, if any. Also includes edge-only blocks.
+    /// The associated out-edge successor, if this is a critical edge.
     #[cfg(test)]
-    pub fn out_edge(self) -> Option<(Block, Inst, Block)> {
+    pub fn out_edge(&self) -> Option<Block> {
         match self {
-            LoweredBlock::OrigAndEdge {
-                block,
-                edge_inst,
-                succ,
-                ..
-            } => Some((block, edge_inst, succ)),
-            LoweredBlock::Edge {
-                pred,
-                edge_inst,
-                succ,
-                ..
-            } => Some((pred, edge_inst, succ)),
-            _ => None,
+            &LoweredBlock::CriticalEdge { succ, .. } => Some(succ),
+            &LoweredBlock::Orig { .. } => None,
         }
     }
 }
 
 impl BlockLoweringOrder {
     /// Compute and return a lowered block order for `f`.
-    pub fn new(f: &Function) -> BlockLoweringOrder {
+    pub fn new(f: &Function, domtree: &DominatorTree) -> BlockLoweringOrder {
         trace!("BlockLoweringOrder: function body {:?}", f);
-
-        // Make sure that we have an entry block, and the entry block is
-        // not marked as cold. (The verifier ensures this as well, but
-        // the user may not have run the verifier, and this property is
-        // critical to avoid a miscompile, so we assert it here too.)
-        let entry = f.layout.entry_block().expect("Must have entry block");
-        assert!(!f.layout.is_cold(entry));
 
         // Step 1: compute the in-edge and out-edge count of every block.
         let mut block_in_count = SecondaryMap::with_default(0);
         let mut block_out_count = SecondaryMap::with_default(0);
 
-        // Cache the block successors to avoid re-examining branches below.
-        let mut block_succs: SmallVec<[(Inst, usize, Block); 128]> = SmallVec::new();
-        let mut block_succ_range = SecondaryMap::with_default((0, 0));
+        // Block successors are stored as `LoweredBlocks` to simplify the construction of
+        // `lowered_succs` in the final result. Initially, all entries are `Orig` values, and are
+        // updated to be `CriticalEdge` when those cases are identified in step 2 below.
+        let mut block_succs: SmallVec<[LoweredBlock; 128]> = SmallVec::new();
+        let mut block_succ_range = SecondaryMap::with_default(0..0);
+
         let mut indirect_branch_target_clif_blocks = FxHashSet::default();
 
         for block in f.layout.blocks() {
-            let block_succ_start = block_succs.len();
-            let mut succ_idx = 0;
-            visit_block_succs(f, block, |inst, succ, from_table| {
+            let start = block_succs.len();
+            visit_block_succs(f, block, |_, succ, from_table| {
                 block_out_count[block] += 1;
                 block_in_count[succ] += 1;
-                block_succs.push((inst, succ_idx, succ));
-                succ_idx += 1;
+                block_succs.push(LoweredBlock::Orig { block: succ });
 
                 if from_table {
                     indirect_branch_target_clif_blocks.insert(succ);
                 }
             });
-            let block_succ_end = block_succs.len();
-            block_succ_range[block] = (block_succ_start, block_succ_end);
-
-            if let Some(inst) = f.layout.last_inst(block) {
-                if f.dfg.insts[inst].opcode() == Opcode::Return {
-                    // Implicit output edge for any return.
-                    block_out_count[block] += 1;
-                }
-            }
-        }
-        // Implicit input edge for entry block.
-        block_in_count[entry] += 1;
-
-        // All blocks ending in conditional branches or br_tables must
-        // have edge-moves inserted at the top of successor blocks,
-        // not at the end of themselves. This is because the moves
-        // would have to be inserted prior to the branch's register
-        // use; but RA2's model is that the moves happen *on* the
-        // edge, after every def/use in the block. RA2 will check for
-        // "branch register use safety" and panic if such a problem
-        // occurs. To avoid this, we force the below algorithm to
-        // never merge the edge block onto the end of a block that
-        // ends in a conditional branch. We do this by "faking" more
-        // than one successor, even if there is only one.
-        //
-        // (One might ask, isn't that always the case already? It
-        // could not be, in cases of br_table with no table and just a
-        // default label, for example.)
-        for block in f.layout.blocks() {
-            if let Some(inst) = f.layout.last_inst(block) {
-                // If the block has a branch with any "fixed args"
-                // (not blockparam args) ...
-                if f.dfg.insts[inst].opcode().is_branch() && f.dfg.inst_fixed_args(inst).len() > 0 {
-                    // ... then force a minimum successor count of
-                    // two, so the below algorithm cannot put
-                    // edge-moves on the end of the block.
-                    block_out_count[block] = std::cmp::max(2, block_out_count[block]);
-                }
-            }
+            let end = block_succs.len();
+            block_succ_range[block] = start..end;
         }
 
-        // Here we define the implicit CLIF-plus-edges graph. There are
-        // conceptually two such graphs: the original, with every edge explicit,
-        // and the merged one, with blocks (represented by `LoweredBlock`
-        // values) that contain original CLIF blocks, edges, or both. This
-        // function returns a lowered block's successors as per the latter, with
-        // consideration to edge-block merging.
-        //
-        // Note that there is a property of the block-merging rules below
-        // that is very important to ensure we don't miss any lowered blocks:
-        // any block in the implicit CLIF-plus-edges graph will *only* be
-        // included in one block in the merged graph.
-        //
-        // This, combined with the property that every edge block is reachable
-        // only from one predecessor (and hence cannot be reached by a DFS
-        // backedge), means that it is sufficient in our DFS below to track
-        // visited-bits per original CLIF block only, not per edge. This greatly
-        // simplifies the data structures (no need to keep a sparse hash-set of
-        // (block, block) tuples).
-        let compute_lowered_succs = |ret: &mut Vec<(Inst, LoweredBlock)>, block: LoweredBlock| {
-            let start_idx = ret.len();
-            match block {
-                LoweredBlock::Orig { block } | LoweredBlock::EdgeAndOrig { block, .. } => {
-                    // At an orig block; successors are always edge blocks,
-                    // possibly with orig blocks following.
-                    let range = block_succ_range[block];
-                    for &(edge_inst, succ_idx, succ) in &block_succs[range.0..range.1] {
-                        if block_in_count[succ] == 1 {
-                            ret.push((
-                                edge_inst,
-                                LoweredBlock::EdgeAndOrig {
-                                    pred: block,
-                                    edge_inst,
-                                    succ_idx,
-                                    block: succ,
-                                },
-                            ));
-                        } else {
-                            ret.push((
-                                edge_inst,
-                                LoweredBlock::Edge {
-                                    pred: block,
-                                    edge_inst,
-                                    succ_idx,
-                                    succ,
-                                },
-                            ));
-                        }
-                    }
-                }
-                LoweredBlock::Edge {
-                    succ, edge_inst, ..
-                }
-                | LoweredBlock::OrigAndEdge {
-                    succ, edge_inst, ..
-                } => {
-                    // At an edge block; successors are always orig blocks,
-                    // possibly with edge blocks following.
-                    if block_out_count[succ] == 1 {
-                        let range = block_succ_range[succ];
-                        // check if the one succ is a real CFG edge (vs.
-                        // implicit return succ).
-                        if range.1 - range.0 > 0 {
-                            debug_assert!(range.1 - range.0 == 1);
-                            let (succ_edge_inst, succ_succ_idx, succ_succ) = block_succs[range.0];
-                            ret.push((
-                                edge_inst,
-                                LoweredBlock::OrigAndEdge {
-                                    block: succ,
-                                    edge_inst: succ_edge_inst,
-                                    succ_idx: succ_succ_idx,
-                                    succ: succ_succ,
-                                },
-                            ));
-                        } else {
-                            ret.push((edge_inst, LoweredBlock::Orig { block: succ }));
-                        }
-                    } else {
-                        ret.push((edge_inst, LoweredBlock::Orig { block: succ }));
-                    }
-                }
-            }
-            let end_idx = ret.len();
-            (start_idx, end_idx)
-        };
+        // Step 2: walk the postorder from the domtree in reverse to produce our desired node
+        // lowering order, identifying critical edges to split along the way.
 
-        // Build the explicit LoweredBlock-to-LoweredBlock successors list.
-        let mut lowered_succs = vec![];
-        let mut lowered_succ_indices = vec![];
-
-        // Step 2: Compute RPO traversal of the implicit CLIF-plus-edge-block graph. Use an
-        // explicit stack so we don't overflow the real stack with a deep DFS.
-        #[derive(Debug)]
-        struct StackEntry {
-            this: LoweredBlock,
-            succs: (usize, usize), // range in lowered_succs
-            cur_succ: usize,       // index in lowered_succs
-        }
-
-        let mut stack: SmallVec<[StackEntry; 16]> = SmallVec::new();
-        let mut visited = FxHashSet::default();
-        let mut postorder = vec![];
-
-        // Add the entry block.
-        //
-        // FIXME(cfallin): we might be able to use OrigAndEdge. Find a
-        // way to not special-case the entry block here.
-        let block = LoweredBlock::Orig { block: entry };
-        visited.insert(block);
-        let range = compute_lowered_succs(&mut lowered_succs, block);
-        lowered_succ_indices.resize(lowered_succs.len(), 0);
-        stack.push(StackEntry {
-            this: block,
-            succs: range,
-            cur_succ: range.1,
-        });
-
-        while !stack.is_empty() {
-            let stack_entry = stack.last_mut().unwrap();
-            let range = stack_entry.succs;
-            if stack_entry.cur_succ == range.0 {
-                postorder.push((stack_entry.this, range));
-                stack.pop();
-            } else {
-                // Heuristic: chase the children in reverse. This puts the first
-                // successor block first in RPO, all other things being equal,
-                // which tends to prioritize loop backedges over out-edges,
-                // putting the edge-block closer to the loop body and minimizing
-                // live-ranges in linear instruction space.
-                let next = lowered_succs[stack_entry.cur_succ - 1].1;
-                stack_entry.cur_succ -= 1;
-                if visited.contains(&next) {
-                    continue;
-                }
-                visited.insert(next);
-                let range = compute_lowered_succs(&mut lowered_succs, next);
-                lowered_succ_indices.resize(lowered_succs.len(), 0);
-                stack.push(StackEntry {
-                    this: next,
-                    succs: range,
-                    cur_succ: range.1,
-                });
-            }
-        }
-
-        postorder.reverse();
-        let rpo = postorder;
-
-        // Step 3: now that we have RPO, build the BlockIndex/BB fwd/rev maps.
-        let mut lowered_order = vec![];
-        let mut cold_blocks = FxHashSet::default();
-        let mut lowered_succ_ranges = vec![];
         let mut lb_to_bindex = FxHashMap::default();
+        let mut lowered_order = Vec::new();
+
+        for &block in domtree.cfg_postorder().iter().rev() {
+            let lb = LoweredBlock::Orig { block };
+            let bindex = BlockIndex::new(lowered_order.len());
+            lb_to_bindex.insert(lb.clone(), bindex);
+            lowered_order.push(lb);
+
+            if block_out_count[block] > 1 {
+                let range = block_succ_range[block].clone();
+                for (ix, lb) in block_succs[range].iter_mut().enumerate() {
+                    let succ = lb.orig_block().unwrap();
+                    if block_in_count[succ] > 1 {
+                        // Mutate the successor to be a critical edge, as `block` has multiple
+                        // edges leaving it, and `succ` has multiple edges entering it.
+                        *lb = LoweredBlock::CriticalEdge {
+                            pred: block,
+                            succ,
+                            branch_idx: ix as u32,
+                        };
+                        let bindex = BlockIndex::new(lowered_order.len());
+                        lb_to_bindex.insert(*lb, bindex);
+                        lowered_order.push(*lb);
+                    }
+                }
+            }
+        }
+
+        // Step 3: build the successor tables given the lowering order. We can't perform this step
+        // during the creation of `lowering_order`, as we need `lb_to_bindex` to be fully populated
+        // first.
+        let mut lowered_succ_indices = Vec::new();
+        let mut cold_blocks = FxHashSet::default();
         let mut indirect_branch_targets = FxHashSet::default();
-        for (block, succ_range) in rpo.into_iter() {
-            let index = BlockIndex::new(lowered_order.len());
-            lb_to_bindex.insert(block, index);
-            lowered_order.push(block);
-            lowered_succ_ranges.push(succ_range);
+        let lowered_succ_ranges =
+            Vec::from_iter(lowered_order.iter().enumerate().map(|(ix, lb)| {
+                let bindex = BlockIndex::new(ix);
+                let start = lowered_succ_indices.len();
+                let opt_inst = match lb {
+                    // Block successors are pulled directly over, as they'll have been mutated when
+                    // determining the block order already.
+                    &LoweredBlock::Orig { block } => {
+                        let range = block_succ_range[block].clone();
+                        lowered_succ_indices
+                            .extend(block_succs[range].iter().map(|lb| lb_to_bindex[lb]));
 
-            match block {
-                LoweredBlock::Orig { block }
-                | LoweredBlock::OrigAndEdge { block, .. }
-                | LoweredBlock::EdgeAndOrig { block, .. } => {
-                    if f.layout.is_cold(block) {
-                        cold_blocks.insert(index);
+                        if f.layout.is_cold(block) {
+                            cold_blocks.insert(bindex);
+                        }
+
+                        if indirect_branch_target_clif_blocks.contains(&block) {
+                            indirect_branch_targets.insert(bindex);
+                        }
+
+                        let last = f.layout.last_inst(block).unwrap();
+                        let opcode = f.dfg.insts[last].opcode();
+
+                        assert!(opcode.is_terminator());
+
+                        opcode.is_branch().then_some(last)
                     }
 
-                    if indirect_branch_target_clif_blocks.contains(&block) {
-                        indirect_branch_targets.insert(index);
-                    }
-                }
-                LoweredBlock::Edge { pred, succ, .. } => {
-                    if f.layout.is_cold(pred) || f.layout.is_cold(succ) {
-                        cold_blocks.insert(index);
-                    }
+                    // Critical edges won't have successor information in block_succ_range, but
+                    // they only have a single known successor to record anyway.
+                    &LoweredBlock::CriticalEdge { succ, .. } => {
+                        let succ_index = lb_to_bindex[&LoweredBlock::Orig { block: succ }];
+                        lowered_succ_indices.push(succ_index);
 
-                    if indirect_branch_target_clif_blocks.contains(&succ) {
-                        indirect_branch_targets.insert(index);
+                        // Edges inherit indirect branch and cold block metadata from their
+                        // successor.
+
+                        if f.layout.is_cold(succ) {
+                            cold_blocks.insert(bindex);
+                        }
+
+                        if indirect_branch_target_clif_blocks.contains(&succ) {
+                            indirect_branch_targets.insert(bindex);
+                        }
+
+                        None
                     }
-                }
-            }
-        }
-
-        let lowered_succ_indices = lowered_succs
-            .iter()
-            .map(|&(inst, succ)| (inst, lb_to_bindex.get(&succ).cloned().unwrap()))
-            .collect();
-
-        let mut orig_map = SecondaryMap::with_default(None);
-        for (i, lb) in lowered_order.iter().enumerate() {
-            let i = BlockIndex::new(i);
-            if let Some(b) = lb.orig_block() {
-                orig_map[b] = Some(i);
-            }
-        }
+                };
+                let end = lowered_succ_indices.len();
+                (opt_inst, start..end)
+            }));
 
         let result = BlockLoweringOrder {
             lowered_order,
-            lowered_succs,
             lowered_succ_indices,
             lowered_succ_ranges,
-            orig_map,
             cold_blocks,
             indirect_branch_targets,
         };
-        trace!("BlockLoweringOrder: {:?}", result);
+
+        trace!("BlockLoweringOrder: {:#?}", result);
         result
     }
 
@@ -503,9 +281,9 @@ impl BlockLoweringOrder {
     }
 
     /// Get the successor indices for a lowered block.
-    pub fn succ_indices(&self, block: BlockIndex) -> &[(Inst, BlockIndex)] {
-        let range = self.lowered_succ_ranges[block.index()];
-        &self.lowered_succ_indices[range.0..range.1]
+    pub fn succ_indices(&self, block: BlockIndex) -> (Option<Inst>, &[BlockIndex]) {
+        let (opt_inst, range) = &self.lowered_succ_ranges[block.index()];
+        (opt_inst.clone(), &self.lowered_succ_indices[range.clone()])
     }
 
     /// Determine whether the given lowered-block index is cold.
@@ -524,12 +302,13 @@ impl BlockLoweringOrder {
 mod test {
     use super::*;
     use crate::cursor::{Cursor, FuncCursor};
+    use crate::flowgraph::ControlFlowGraph;
     use crate::ir::types::*;
     use crate::ir::UserFuncName;
     use crate::ir::{AbiParam, Function, InstBuilder, Signature};
     use crate::isa::CallConv;
 
-    fn build_test_func(n_blocks: usize, edges: &[(usize, usize)]) -> Function {
+    fn build_test_func(n_blocks: usize, edges: &[(usize, usize)]) -> BlockLoweringOrder {
         assert!(n_blocks > 0);
 
         let name = UserFuncName::testcase("test0");
@@ -568,42 +347,20 @@ mod test {
             }
         }
 
-        func
+        let mut cfg = ControlFlowGraph::new();
+        cfg.compute(&func);
+        let dom_tree = DominatorTree::with_function(&func, &cfg);
+
+        BlockLoweringOrder::new(&func, &dom_tree)
     }
 
     #[test]
     fn test_blockorder_diamond() {
-        let func = build_test_func(4, &[(0, 1), (0, 2), (1, 3), (2, 3)]);
-        let order = BlockLoweringOrder::new(&func);
+        let order = build_test_func(4, &[(0, 1), (0, 2), (1, 3), (2, 3)]);
 
-        assert_eq!(order.lowered_order.len(), 6);
-
-        assert!(order.lowered_order[0].orig_block().unwrap().as_u32() == 0);
-        assert!(order.lowered_order[0].in_edge().is_none());
-        assert!(order.lowered_order[0].out_edge().is_none());
-
-        assert!(order.lowered_order[1].orig_block().unwrap().as_u32() == 1);
-        assert!(order.lowered_order[1].in_edge().unwrap().0.as_u32() == 0);
-        assert!(order.lowered_order[1].in_edge().unwrap().2.as_u32() == 1);
-
-        assert!(order.lowered_order[2].orig_block().is_none());
-        assert!(order.lowered_order[2].in_edge().is_none());
-        assert!(order.lowered_order[2].out_edge().unwrap().0.as_u32() == 1);
-        assert!(order.lowered_order[2].out_edge().unwrap().2.as_u32() == 3);
-
-        assert!(order.lowered_order[3].orig_block().unwrap().as_u32() == 2);
-        assert!(order.lowered_order[3].in_edge().unwrap().0.as_u32() == 0);
-        assert!(order.lowered_order[3].in_edge().unwrap().2.as_u32() == 2);
-        assert!(order.lowered_order[3].out_edge().is_none());
-
-        assert!(order.lowered_order[4].orig_block().is_none());
-        assert!(order.lowered_order[4].in_edge().is_none());
-        assert!(order.lowered_order[4].out_edge().unwrap().0.as_u32() == 2);
-        assert!(order.lowered_order[4].out_edge().unwrap().2.as_u32() == 3);
-
-        assert!(order.lowered_order[5].orig_block().unwrap().as_u32() == 3);
-        assert!(order.lowered_order[5].in_edge().is_none());
-        assert!(order.lowered_order[5].out_edge().is_none());
+        // This test case doesn't need to introduce any critical edges, as all regalloc allocations
+        // can sit on either the entry or exit of blocks 1 and 2.
+        assert_eq!(order.lowered_order.len(), 4);
     }
 
     #[test]
@@ -618,9 +375,9 @@ mod test {
         //       | /\ |
         //       5    6
         //
-        // (3 -> 5, 3 -> 6, 4 -> 6 are critical edges and must be split)
+        // (3 -> 5, and 3 -> 6 are critical edges and must be split)
         //
-        let func = build_test_func(
+        let order = build_test_func(
             7,
             &[
                 (0, 1),
@@ -633,72 +390,53 @@ mod test {
                 (4, 6),
             ],
         );
-        let order = BlockLoweringOrder::new(&func);
 
-        assert_eq!(order.lowered_order.len(), 11);
+        assert_eq!(order.lowered_order.len(), 9);
         println!("ordered = {:?}", order.lowered_order);
 
         // block 0
-        assert!(order.lowered_order[0].orig_block().unwrap().as_u32() == 0);
+        assert_eq!(order.lowered_order[0].orig_block().unwrap().as_u32(), 0);
         assert!(order.lowered_order[0].in_edge().is_none());
         assert!(order.lowered_order[0].out_edge().is_none());
 
-        // edge 0->1 + block 1
-        assert!(order.lowered_order[1].orig_block().unwrap().as_u32() == 1);
-        assert!(order.lowered_order[1].in_edge().unwrap().0.as_u32() == 0);
-        assert!(order.lowered_order[1].in_edge().unwrap().2.as_u32() == 1);
+        // block 2
+        assert_eq!(order.lowered_order[1].orig_block().unwrap().as_u32(), 2);
+        assert!(order.lowered_order[1].in_edge().is_none());
         assert!(order.lowered_order[1].out_edge().is_none());
 
-        // edge 1->3 + block 3
-        assert!(order.lowered_order[2].orig_block().unwrap().as_u32() == 3);
-        assert!(order.lowered_order[2].in_edge().unwrap().0.as_u32() == 1);
-        assert!(order.lowered_order[2].in_edge().unwrap().2.as_u32() == 3);
+        // block 1
+        assert_eq!(order.lowered_order[2].orig_block().unwrap().as_u32(), 1);
+        assert!(order.lowered_order[2].in_edge().is_none());
         assert!(order.lowered_order[2].out_edge().is_none());
 
-        // edge 3->5
-        assert!(order.lowered_order[3].orig_block().is_none());
+        // block 4
+        assert_eq!(order.lowered_order[3].orig_block().unwrap().as_u32(), 4);
         assert!(order.lowered_order[3].in_edge().is_none());
-        assert!(order.lowered_order[3].out_edge().unwrap().0.as_u32() == 3);
-        assert!(order.lowered_order[3].out_edge().unwrap().2.as_u32() == 5);
+        assert!(order.lowered_order[3].out_edge().is_none());
 
-        // edge 3->6
-        assert!(order.lowered_order[4].orig_block().is_none());
+        // block 3
+        assert_eq!(order.lowered_order[4].orig_block().unwrap().as_u32(), 3);
         assert!(order.lowered_order[4].in_edge().is_none());
-        assert!(order.lowered_order[4].out_edge().unwrap().0.as_u32() == 3);
-        assert!(order.lowered_order[4].out_edge().unwrap().2.as_u32() == 6);
+        assert!(order.lowered_order[4].out_edge().is_none());
 
-        // edge 1->4 + block 4
-        assert!(order.lowered_order[5].orig_block().unwrap().as_u32() == 4);
-        assert!(order.lowered_order[5].in_edge().unwrap().0.as_u32() == 1);
-        assert!(order.lowered_order[5].in_edge().unwrap().2.as_u32() == 4);
-        assert!(order.lowered_order[5].out_edge().is_none());
+        // critical edge 3 -> 5
+        assert!(order.lowered_order[5].orig_block().is_none());
+        assert_eq!(order.lowered_order[5].in_edge().unwrap().as_u32(), 3);
+        assert_eq!(order.lowered_order[5].out_edge().unwrap().as_u32(), 5);
 
-        // edge 4->6
+        // critical edge 3 -> 6
         assert!(order.lowered_order[6].orig_block().is_none());
-        assert!(order.lowered_order[6].in_edge().is_none());
-        assert!(order.lowered_order[6].out_edge().unwrap().0.as_u32() == 4);
-        assert!(order.lowered_order[6].out_edge().unwrap().2.as_u32() == 6);
+        assert_eq!(order.lowered_order[6].in_edge().unwrap().as_u32(), 3);
+        assert_eq!(order.lowered_order[6].out_edge().unwrap().as_u32(), 6);
 
         // block 6
-        assert!(order.lowered_order[7].orig_block().unwrap().as_u32() == 6);
+        assert_eq!(order.lowered_order[7].orig_block().unwrap().as_u32(), 6);
         assert!(order.lowered_order[7].in_edge().is_none());
         assert!(order.lowered_order[7].out_edge().is_none());
 
-        // edge 0->2 + block 2
-        assert!(order.lowered_order[8].orig_block().unwrap().as_u32() == 2);
-        assert!(order.lowered_order[8].in_edge().unwrap().0.as_u32() == 0);
-        assert!(order.lowered_order[8].in_edge().unwrap().2.as_u32() == 2);
-        assert!(order.lowered_order[8].out_edge().is_none());
-
-        // edge 2->5
-        assert!(order.lowered_order[9].orig_block().is_none());
-        assert!(order.lowered_order[9].in_edge().is_none());
-        assert!(order.lowered_order[9].out_edge().unwrap().0.as_u32() == 2);
-        assert!(order.lowered_order[9].out_edge().unwrap().2.as_u32() == 5);
-
         // block 5
-        assert!(order.lowered_order[10].orig_block().unwrap().as_u32() == 5);
-        assert!(order.lowered_order[10].in_edge().is_none());
-        assert!(order.lowered_order[10].out_edge().is_none());
+        assert_eq!(order.lowered_order[8].orig_block().unwrap().as_u32(), 5);
+        assert!(order.lowered_order[8].in_edge().is_none());
+        assert!(order.lowered_order[8].out_edge().is_none());
     }
 }

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -108,8 +108,10 @@ pub enum LoweredBlock {
         /// The successor block.
         succ: Block,
 
-        /// The branch index
-        branch_idx: u32,
+        /// The index of this branch in the successor edges from `pred`, following the same
+        /// indexing order as `inst_predicates::visit_block_succs`. This is used to distinguish
+        /// multiple edges between the same CLIF blocks.
+        succ_idx: u32,
     },
 }
 
@@ -197,7 +199,7 @@ impl BlockLoweringOrder {
 
             if block_out_count[block] > 1 {
                 let range = block_succ_range[block].clone();
-                for (ix, lb) in block_succs[range].iter_mut().enumerate() {
+                for (succ_ix, lb) in block_succs[range].iter_mut().enumerate() {
                     let succ = lb.orig_block().unwrap();
                     if block_in_count[succ] > 1 {
                         // Mutate the successor to be a critical edge, as `block` has multiple
@@ -205,7 +207,7 @@ impl BlockLoweringOrder {
                         *lb = LoweredBlock::CriticalEdge {
                             pred: block,
                             succ,
-                            branch_idx: ix as u32,
+                            succ_idx: succ_ix as u32,
                         };
                         let bindex = BlockIndex::new(lowered_order.len());
                         lb_to_bindex.insert(*lb, bindex);

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -1,5 +1,6 @@
 //! Compilation backend pipeline: optimized IR to VCode / binemit.
 
+use crate::dominator_tree::DominatorTree;
 use crate::ir::Function;
 use crate::isa::TargetIsa;
 use crate::machinst::*;
@@ -12,6 +13,7 @@ use regalloc2::RegallocOptions;
 /// for binary emission.
 pub fn compile<B: LowerBackend + TargetIsa>(
     f: &Function,
+    domtree: &DominatorTree,
     b: &B,
     abi: Callee<<<B as LowerBackend>::MInst as MachInst>::ABIMachineSpec>,
     emit_info: <B::MInst as MachInstEmit>::Info,
@@ -20,7 +22,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
     let machine_env = b.machine_env();
 
     // Compute lowered block order.
-    let block_order = BlockLoweringOrder::new(f);
+    let block_order = BlockLoweringOrder::new(f, domtree);
 
     // Build the lowering context.
     let lower = crate::machinst::Lower::new(f, machine_env, abi, emit_info, block_order, sigs)?;

--- a/cranelift/filetests/filetests/domtree/loops.clif
+++ b/cranelift/filetests/filetests/domtree/loops.clif
@@ -44,21 +44,21 @@ function %test(i32) {
 ;
 ; check: cfg_postorder:
 ; sameln: block6
-; sameln: block5
-; sameln: block4
 ; sameln: block3
-; sameln: block1
+; sameln: block4
+; sameln: block5
 ; sameln: block2
+; sameln: block1
 ; sameln: block0
 
 ; check: domtree_preorder {
-; nextln: block0: block2 block1 block3 block4 block5
-; nextln: block2:
+; nextln: block0: block1 block2 block5 block4 block3
 ; nextln: block1:
-; nextln: block3:
-; nextln: block4:
+; nextln: block2:
 ; nextln: block5: block6
 ; nextln: block6:
+; nextln: block4:
+; nextln: block3:
 ; nextln: }
 
 function %loop2(i32) system_v {
@@ -84,26 +84,26 @@ function %loop2(i32) system_v {
         return
 }
 ; check: cfg_postorder:
+; sameln: block9
 ; sameln: block7
 ; sameln: block6
-; sameln: block9
-; sameln: block5
 ; sameln: block8
-; sameln: block4
 ; sameln: block3
-; sameln: block1
+; sameln: block4
+; sameln: block5
 ; sameln: block2
+; sameln: block1
 ; sameln: block0
 
 ; check: domtree_preorder {
-; nextln: block0: block2 block1 block3 block4 block5
-; nextln: block2:
+; nextln: block0: block1 block2 block5 block4 block3
 ; nextln: block1:
-; nextln: block3:
+; nextln: block2:
+; nextln: block5: block9
+; nextln: block9:
 ; nextln: block4: block8
 ; nextln: block8: block6
 ; nextln: block6: block7
 ; nextln: block7:
-; nextln: block5: block9
-; nextln: block9:
+; nextln: block3:
 ; nextln: }

--- a/cranelift/filetests/filetests/domtree/loops2.clif
+++ b/cranelift/filetests/filetests/domtree/loops2.clif
@@ -30,18 +30,18 @@ function %loop1(i32) {
 }
 
 ; check: domtree_preorder {
-; nextln: block0: block10 block1 block6
-; nextln: block10: block2 block3 block9
-; nextln: block2: block5 block4 block7 block8
-; nextln: block5: block12
-; nextln: block12:
+; nextln: block0: block1 block10 block6
+; nextln: block1:
+; nextln: block10: block3 block2 block9
+; nextln: block3:
+; nextln: block2: block4 block5 block7 block8
 ; nextln: block4: block11
 ; nextln: block11:
+; nextln: block5: block12
+; nextln: block12:
 ; nextln: block7:
 ; nextln: block8:
-; nextln: block3:
 ; nextln: block9:
-; nextln: block1:
 ; nextln: block6:
 ; nextln: }
 
@@ -63,19 +63,19 @@ function %loop2(i32) system_v {
 }
 ; check: cfg_postorder:
 ; sameln: block6
-; sameln: block5
-; sameln: block4
 ; sameln: block3
-; sameln: block1
+; sameln: block4
+; sameln: block5
 ; sameln: block2
+; sameln: block1
 ; sameln: block0
 
 ; check: domtree_preorder {
-; nextln: block0: block2 block1 block3 block4 block5
-; nextln: block2:
+; nextln: block0: block1 block2 block5 block4 block3
 ; nextln: block1:
-; nextln: block3:
-; nextln: block4:
+; nextln: block2:
 ; nextln: block5: block6
 ; nextln: block6:
+; nextln: block4:
+; nextln: block3:
 ; nextln: }

--- a/cranelift/filetests/filetests/domtree/tall-tree.clif
+++ b/cranelift/filetests/filetests/domtree/tall-tree.clif
@@ -32,18 +32,18 @@ function %test(i32) {
 }
 
 ; check: domtree_preorder {
-; nextln: block0: block12 block1
-; nextln: block12: block2 block3 block5
-; nextln: block2:
-; nextln: block3:
-; nextln: block5:
+; nextln: block0: block1 block12
 ; nextln: block1: block4
-; nextln: block4: block7 block6 block10
-; nextln: block7:
-; nextln: block6: block13 block8 block11
+; nextln: block4: block6 block7 block10
+; nextln: block6: block8 block13 block11
+; nextln: block8:
 ; nextln: block13: block9
 ; nextln: block9:
-; nextln: block8:
 ; nextln: block11:
+; nextln: block7:
 ; nextln: block10:
+; nextln: block12: block3 block2 block5
+; nextln: block3:
+; nextln: block2:
+; nextln: block5:
 ; nextln: }

--- a/cranelift/filetests/filetests/domtree/wide-tree.clif
+++ b/cranelift/filetests/filetests/domtree/wide-tree.clif
@@ -43,22 +43,22 @@ function %test(i32) {
 
 ; check: domtree_preorder {
 ; nextln: block0: block1 block13
-; nextln: block1: block20 block2 block7
-; nextln: block20: block3 block21
-; nextln: block3:
-; nextln: block21: block22 block4
-; nextln: block22: block5 block6
-; nextln: block5:
-; nextln: block6:
-; nextln: block4:
+; nextln: block1: block2 block20 block7
 ; nextln: block2:
-; nextln: block7: block8 block23 block12
-; nextln: block8:
-; nextln: block23: block24 block9
-; nextln: block24: block10 block11
-; nextln: block10:
-; nextln: block11:
+; nextln: block20: block21 block3
+; nextln: block21: block4 block22
+; nextln: block4:
+; nextln: block22: block6 block5
+; nextln: block6:
+; nextln: block5:
+; nextln: block3:
+; nextln: block7: block23 block8 block12
+; nextln: block23: block9 block24
 ; nextln: block9:
+; nextln: block24: block11 block10
+; nextln: block11:
+; nextln: block10:
+; nextln: block8:
 ; nextln: block12:
 ; nextln: block13:
 ; nextln: }

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -32,31 +32,23 @@ block5(v5: i32):
 ; block0:
 ;   emit_island 44
 ;   subs wzr, w0, #3
-;   b.hs label1 ; csel x15, xzr, x0, hs ; csdb ; adr x14, pc+16 ; ldrsw x15, [x14, x15, uxtw #2] ; add x14, x14, x15 ; br x14 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(5)), Label(MachLabel(7))]
+;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(2)), Label(MachLabel(1))]
 ; block1:
-;   movz w5, #4
-;   b label2
+;   bti j
+;   movz w5, #3
+;   b label5
 ; block2:
-;   b label9
+;   bti j
+;   movz w5, #2
+;   b label5
 ; block3:
 ;   bti j
 ;   movz w5, #1
-;   b label4
+;   b label5
 ; block4:
-;   b label9
+;   movz w5, #4
+;   b label5
 ; block5:
-;   bti j
-;   movz w5, #2
-;   b label6
-; block6:
-;   b label9
-; block7:
-;   bti j
-;   movz w5, #3
-;   b label8
-; block8:
-;   b label9
-; block9:
 ;   add w0, w0, w5
 ;   ret
 ; 
@@ -65,34 +57,31 @@ block5(v5: i32):
 ;   hint #0x22
 ; block1: ; offset 0x4
 ;   cmp w0, #3
-;   b.hs #0x30
-;   csel x15, xzr, x0, hs
+;   b.hs #0x54
+;   csel x11, xzr, x0, hs
 ;   csdb
-;   adr x14, #0x24
-;   ldrsw x15, [x14, w15, uxtw #2]
-;   add x14, x14, x15
-;   br x14
-;   .byte 0x14, 0x00, 0x00, 0x00
-;   .byte 0x20, 0x00, 0x00, 0x00
-;   .byte 0x2c, 0x00, 0x00, 0x00
+;   adr x10, #0x24
+;   ldrsw x11, [x10, w11, uxtw #2]
+;   add x10, x10, x11
+;   br x10
+;   .byte 0x24, 0x00, 0x00, 0x00
+;   .byte 0x18, 0x00, 0x00, 0x00
+;   .byte 0x0c, 0x00, 0x00, 0x00
 ; block2: ; offset 0x30
-;   mov w5, #4
-; block3: ; offset 0x34
-;   b #0x58
-; block4: ; offset 0x38
-;   hint #0x24
-;   mov w5, #1
-; block5: ; offset 0x40
-;   b #0x58
-; block6: ; offset 0x44
-;   hint #0x24
-;   mov w5, #2
-; block7: ; offset 0x4c
-;   b #0x58
-; block8: ; offset 0x50
 ;   hint #0x24
 ;   mov w5, #3
-; block9: ; offset 0x58
+;   b #0x58
+; block3: ; offset 0x3c
+;   hint #0x24
+;   mov w5, #2
+;   b #0x58
+; block4: ; offset 0x48
+;   hint #0x24
+;   mov w5, #1
+;   b #0x58
+; block5: ; offset 0x54
+;   mov w5, #4
+; block6: ; offset 0x58
 ;   add w0, w0, w5
 ;   ret
 
@@ -118,14 +107,14 @@ block2:
 ;   mov x8, x5
 ;   emit_island 36
 ;   subs wzr, w0, #1
-;   b.hs label1 ; csel x7, xzr, x0, hs ; csdb ; adr x6, pc+16 ; ldrsw x7, [x6, x7, uxtw #2] ; add x6, x6, x7 ; br x6 ; jt_entries [Label(MachLabel(2))]
+;   b.hs label2 ; csel x7, xzr, x0, hs ; csdb ; adr x6, pc+16 ; ldrsw x7, [x6, x7, uxtw #2] ; add x6, x6, x7 ; br x6 ; jt_entries [Label(MachLabel(1))]
 ; block1:
-;   mov x0, x8
-;   ret
-; block2:
 ;   bti j
 ;   mov x0, x8
 ;   add x0, x0, #42
+;   ret
+; block2:
+;   mov x0, x8
 ;   ret
 ; 
 ; Disassembled:
@@ -135,21 +124,21 @@ block2:
 ;   ldr x5, [x0]
 ;   mov x8, x5
 ;   cmp w0, #1
-;   b.hs #0x30
+;   b.hs #0x40
 ;   csel x7, xzr, x0, hs
 ;   csdb
 ;   adr x6, #0x2c
 ;   ldrsw x7, [x6, w7, uxtw #2]
 ;   add x6, x6, x7
 ;   br x6
-;   .byte 0x0c, 0x00, 0x00, 0x00
+;   .byte 0x04, 0x00, 0x00, 0x00
 ; block2: ; offset 0x30
-;   mov x0, x8
-;   ret
-; block3: ; offset 0x38
 ;   hint #0x24
 ;   mov x0, x8
 ;   add x0, x0, #0x2a
+;   ret
+; block3: ; offset 0x40
+;   mov x0, x8
 ;   ret
 
 function %f3(i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -270,23 +270,23 @@ block2:
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x1
-;   b.eq label1 ; b label2
+;   b.eq label2 ; b label1
 ; block1:
-;   movz x0, #1
+;   movz x0, #2
 ;   ret
 ; block2:
-;   movz x0, #2
+;   movz x0, #1
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x1
-;   b.ne #0x10
+;   b.eq #0x10
 ; block1: ; offset 0x8
-;   mov x0, #1
+;   mov x0, #2
 ;   ret
 ; block2: ; offset 0x10
-;   mov x0, #2
+;   mov x0, #1
 ;   ret
 
 function %f(i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
@@ -31,59 +31,48 @@ block5(v5: i32):
 ; block0:
 ;   emit_island 44
 ;   subs wzr, w0, #3
-;   b.hs label1 ; csel x15, xzr, x0, hs ; csdb ; adr x14, pc+16 ; ldrsw x15, [x14, x15, uxtw #2] ; add x14, x14, x15 ; br x14 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(5)), Label(MachLabel(7))]
+;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(2)), Label(MachLabel(1))]
 ; block1:
-;   movz w5, #4
-;   b label2
+;   movz w5, #3
+;   b label5
 ; block2:
-;   b label9
+;   movz w5, #2
+;   b label5
 ; block3:
 ;   movz w5, #1
-;   b label4
+;   b label5
 ; block4:
-;   b label9
+;   movz w5, #4
+;   b label5
 ; block5:
-;   movz w5, #2
-;   b label6
-; block6:
-;   b label9
-; block7:
-;   movz w5, #3
-;   b label8
-; block8:
-;   b label9
-; block9:
 ;   add w0, w0, w5
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #3
-;   b.hs #0x2c
-;   csel x15, xzr, x0, hs
+;   b.hs #0x44
+;   csel x11, xzr, x0, hs
 ;   csdb
-;   adr x14, #0x20
-;   ldrsw x15, [x14, w15, uxtw #2]
-;   add x14, x14, x15
-;   br x14
-;   .byte 0x14, 0x00, 0x00, 0x00
+;   adr x10, #0x20
+;   ldrsw x11, [x10, w11, uxtw #2]
+;   add x10, x10, x11
+;   br x10
 ;   .byte 0x1c, 0x00, 0x00, 0x00
-;   .byte 0x24, 0x00, 0x00, 0x00
+;   .byte 0x14, 0x00, 0x00, 0x00
+;   .byte 0x0c, 0x00, 0x00, 0x00
 ; block1: ; offset 0x2c
-;   mov w5, #4
-; block2: ; offset 0x30
-;   b #0x48
-; block3: ; offset 0x34
-;   mov w5, #1
-; block4: ; offset 0x38
-;   b #0x48
-; block5: ; offset 0x3c
-;   mov w5, #2
-; block6: ; offset 0x40
-;   b #0x48
-; block7: ; offset 0x44
 ;   mov w5, #3
-; block8: ; offset 0x48
+;   b #0x48
+; block2: ; offset 0x34
+;   mov w5, #2
+;   b #0x48
+; block3: ; offset 0x3c
+;   mov w5, #1
+;   b #0x48
+; block4: ; offset 0x44
+;   mov w5, #4
+; block5: ; offset 0x48
 ;   add w0, w0, w5
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -94,28 +94,24 @@ block3(v7: r64, v8: r64):
 ; block0:
 ;   str x0, [sp, #8]
 ;   str x1, [sp, #16]
-;   load_ext_name x1, TestCase(%f)+0
-;   blr x1
-;   mov x15, sp
-;   ldr x6, [sp, #8]
-;   str x6, [x15]
-;   uxtb w0, w0
-;   cbnz x0, label1 ; b label3
+;   load_ext_name x12, TestCase(%f)+0
+;   blr x12
+;   mov x11, sp
+;   ldr x2, [sp, #8]
+;   str x2, [x11]
+;   uxtb w12, w0
+;   cbnz x12, label2 ; b label1
 ; block1:
-;   b label2
-; block2:
-;   mov x0, x6
-;   ldr x1, [sp, #16]
-;   b label5
-; block3:
-;   b label4
-; block4:
-;   mov x1, x6
+;   mov x1, x2
 ;   ldr x0, [sp, #16]
-;   b label5
-; block5:
-;   mov x2, sp
-;   ldr x2, [x2]
+;   b label3
+; block2:
+;   mov x0, x2
+;   ldr x1, [sp, #16]
+;   b label3
+; block3:
+;   mov x15, sp
+;   ldr x2, [x15]
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -128,26 +124,26 @@ block3(v7: r64, v8: r64):
 ; block1: ; offset 0xc
 ;   stur x0, [sp, #8]
 ;   stur x1, [sp, #0x10]
-;   ldr x1, #0x1c
+;   ldr x12, #0x1c
 ;   b #0x24
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x1
-;   mov x15, sp
-;   ldur x6, [sp, #8]
-;   str x6, [x15]
-;   uxtb w0, w0
-;   cbz x0, #0x48
+;   blr x12
+;   mov x11, sp
+;   ldur x2, [sp, #8]
+;   str x2, [x11]
+;   uxtb w12, w0
+;   cbnz x12, #0x48
 ; block2: ; offset 0x3c
-;   mov x0, x6
-;   ldur x1, [sp, #0x10]
+;   mov x1, x2
+;   ldur x0, [sp, #0x10]
 ;   b #0x50
 ; block3: ; offset 0x48
-;   mov x1, x6
-;   ldur x0, [sp, #0x10]
+;   mov x0, x2
+;   ldur x1, [sp, #0x10]
 ; block4: ; offset 0x50
-;   mov x2, sp
-;   ldr x2, [x2]
+;   mov x15, sp
+;   ldr x2, [x15]
 ;   add sp, sp, #0x20
 ;   ldp x29, x30, [sp], #0x10
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -45,14 +45,14 @@
 ;;   ldr x8, [x2, #8]
 ;;   sub x8, x8, #4
 ;;   subs xzr, x7, x8
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   str w1, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   str w1, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;;   ldr x8, [x1, #8]
 ;;   sub x8, x8, #4
 ;;   subs xzr, x7, x8
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   ldr w0, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   ldr w0, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,15 +46,15 @@
 ;;   movn x8, #4099
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x2]
-;;   add x12, x12, #4096
-;;   str w1, [x12, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x2]
+;;   add x11, x11, #4096
+;;   str w1, [x11, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   movn x8, #4099
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x1]
-;;   add x11, x12, #4096
-;;   ldr w0, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x1]
+;;   add x10, x11, #4096
+;;   ldr w0, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -47,16 +47,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x2, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x2]
-;;   movz x15, #65535, LSL #16
-;;   add x14, x15, x14
-;;   str w1, [x14, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x2]
+;;   movz x14, #65535, LSL #16
+;;   add x13, x14, x13
+;;   str w1, [x13, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x1, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x1]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x14
-;;   ldr w0, [x13, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x1]
+;;   movz x12, #65535, LSL #16
+;;   add x12, x12, x13
+;;   ldr w0, [x12, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   mov w6, w0
 ;;   ldr x7, [x2, #8]
 ;;   subs xzr, x6, x7
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   strb w1, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   strb w1, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -59,12 +59,12 @@
 ;;   mov w6, w0
 ;;   ldr x7, [x1, #8]
 ;;   subs xzr, x6, x7
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldrb w0, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldrb w0, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,15 +46,15 @@
 ;;   movn x8, #4096
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x2]
-;;   add x12, x12, #4096
-;;   strb w1, [x12, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x2]
+;;   add x11, x11, #4096
+;;   strb w1, [x11, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   movn x8, #4096
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x1]
-;;   add x11, x12, #4096
-;;   ldrb w0, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x1]
+;;   add x10, x11, #4096
+;;   ldrb w0, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -47,16 +47,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x2, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x2]
-;;   movz x15, #65535, LSL #16
-;;   add x14, x15, x14
-;;   strb w1, [x14, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x2]
+;;   movz x14, #65535, LSL #16
+;;   add x13, x14, x13
+;;   strb w1, [x13, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x1, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x1]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x14
-;;   ldrb w0, [x13, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x1]
+;;   movz x12, #65535, LSL #16
+;;   add x12, x12, x13
+;;   ldrb w0, [x12, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -45,14 +45,14 @@
 ;;   ldr x8, [x2, #8]
 ;;   sub x8, x8, #4
 ;;   subs xzr, x7, x8
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   str w1, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   str w1, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;;   ldr x8, [x1, #8]
 ;;   sub x8, x8, #4
 ;;   subs xzr, x7, x8
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   ldr w0, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   ldr w0, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,15 +46,15 @@
 ;;   movn x8, #4099
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x2]
-;;   add x12, x12, #4096
-;;   str w1, [x12, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x2]
+;;   add x11, x11, #4096
+;;   str w1, [x11, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   movn x8, #4099
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x1]
-;;   add x11, x12, #4096
-;;   ldr w0, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x1]
+;;   add x10, x11, #4096
+;;   ldr w0, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -47,16 +47,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x2, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x2]
-;;   movz x15, #65535, LSL #16
-;;   add x14, x15, x14
-;;   str w1, [x14, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x2]
+;;   movz x14, #65535, LSL #16
+;;   add x13, x14, x13
+;;   str w1, [x13, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x1, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x1]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x14
-;;   ldr w0, [x13, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x1]
+;;   movz x12, #65535, LSL #16
+;;   add x12, x12, x13
+;;   ldr w0, [x12, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   mov w6, w0
 ;;   ldr x7, [x2, #8]
 ;;   subs xzr, x6, x7
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   strb w1, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   strb w1, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -59,12 +59,12 @@
 ;;   mov w6, w0
 ;;   ldr x7, [x1, #8]
 ;;   subs xzr, x6, x7
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldrb w0, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldrb w0, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,15 +46,15 @@
 ;;   movn x8, #4096
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x2]
-;;   add x12, x12, #4096
-;;   strb w1, [x12, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x2]
+;;   add x11, x11, #4096
+;;   strb w1, [x11, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   movn x8, #4096
 ;;   add x10, x10, x8
 ;;   subs xzr, x9, x10
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x12, [x1]
-;;   add x11, x12, #4096
-;;   ldrb w0, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x11, [x1]
+;;   add x10, x11, #4096
+;;   ldrb w0, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -47,16 +47,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x2, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x2]
-;;   movz x15, #65535, LSL #16
-;;   add x14, x15, x14
-;;   strb w1, [x14, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x2]
+;;   movz x14, #65535, LSL #16
+;;   add x13, x14, x13
+;;   strb w1, [x13, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x12, [x1, #8]
 ;;   subs xzr, x11, x12
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x14, [x1]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x14
-;;   ldrb w0, [x13, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x13, [x1]
+;;   movz x12, #65535, LSL #16
+;;   add x12, x12, x13
+;;   ldrb w0, [x12, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   ldr x6, [x2, #8]
 ;;   sub x6, x6, #4
 ;;   subs xzr, x0, x6
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   str w1, [x9, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   str w1, [x8, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -59,12 +59,12 @@
 ;;   ldr x6, [x1, #8]
 ;;   sub x6, x6, #4
 ;;   subs xzr, x0, x6
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldr w0, [x9, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldr w0, [x8, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,15 +45,15 @@
 ;;   movn x7, #4099
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x12, x0, #4096
-;;   str w1, [x12, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x11, x0, #4096
+;;   str w1, [x11, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   movn x7, #4099
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x0, #4096
-;;   ldr w0, [x10, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x0, #4096
+;;   ldr w0, [x9, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -46,16 +46,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x2, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x14, x14, x0
-;;   str w1, [x14, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x2]
+;;   movz x13, #65535, LSL #16
+;;   add x13, x13, x0
+;;   str w1, [x13, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x1, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x0
-;;   ldr w0, [x12, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x1]
+;;   movz x11, #65535, LSL #16
+;;   add x11, x11, x0
+;;   ldr w0, [x11, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -43,26 +43,26 @@
 ;; block0:
 ;;   ldr x5, [x2, #8]
 ;;   subs xzr, x0, x5
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   strb w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   strb w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   ldr x5, [x1, #8]
 ;;   subs xzr, x0, x5
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldrb w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldrb w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,15 +45,15 @@
 ;;   movn x7, #4096
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x12, x0, #4096
-;;   strb w1, [x12, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x11, x0, #4096
+;;   strb w1, [x11, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   movn x7, #4096
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x0, #4096
-;;   ldrb w0, [x10, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x0, #4096
+;;   ldrb w0, [x9, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -46,16 +46,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x2, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x14, x14, x0
-;;   strb w1, [x14, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x2]
+;;   movz x13, #65535, LSL #16
+;;   add x13, x13, x0
+;;   strb w1, [x13, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x1, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x0
-;;   ldrb w0, [x12, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x1]
+;;   movz x11, #65535, LSL #16
+;;   add x11, x11, x0
+;;   ldrb w0, [x11, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   ldr x6, [x2, #8]
 ;;   sub x6, x6, #4
 ;;   subs xzr, x0, x6
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   str w1, [x9, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   str w1, [x8, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -59,12 +59,12 @@
 ;;   ldr x6, [x1, #8]
 ;;   sub x6, x6, #4
 ;;   subs xzr, x0, x6
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldr w0, [x9, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldr w0, [x8, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,15 +45,15 @@
 ;;   movn x7, #4099
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x12, x0, #4096
-;;   str w1, [x12, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x11, x0, #4096
+;;   str w1, [x11, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   movn x7, #4099
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x0, #4096
-;;   ldr w0, [x10, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x0, #4096
+;;   ldr w0, [x9, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -46,16 +46,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x2, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x14, x14, x0
-;;   str w1, [x14, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x2]
+;;   movz x13, #65535, LSL #16
+;;   add x13, x13, x0
+;;   str w1, [x13, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x1, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x0
-;;   ldr w0, [x12, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x1]
+;;   movz x11, #65535, LSL #16
+;;   add x11, x11, x0
+;;   ldr w0, [x11, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -43,26 +43,26 @@
 ;; block0:
 ;;   ldr x5, [x2, #8]
 ;;   subs xzr, x0, x5
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   strb w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   strb w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   ldr x5, [x1, #8]
 ;;   subs xzr, x0, x5
-;;   b.hs label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldrb w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hs label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldrb w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,15 +45,15 @@
 ;;   movn x7, #4096
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x12, x0, #4096
-;;   strb w1, [x12, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x11, x0, #4096
+;;   strb w1, [x11, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   movn x7, #4096
 ;;   add x9, x8, x7
 ;;   subs xzr, x0, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x0, #4096
-;;   ldrb w0, [x10, x11]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x0, #4096
+;;   ldrb w0, [x9, x10]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -46,16 +46,16 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x2, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x14, x14, x0
-;;   strb w1, [x14, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x2]
+;;   movz x13, #65535, LSL #16
+;;   add x13, x13, x0
+;;   strb w1, [x13, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   b.lo 8 ; udf
 ;;   ldr x11, [x1, #8]
 ;;   subs xzr, x10, x11
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x0
-;;   ldrb w0, [x12, x13]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x12, [x1]
+;;   movz x11, #65535, LSL #16
+;;   add x11, x11, x0
+;;   ldrb w0, [x11, x12]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   mov w6, w0
 ;;   orr x7, xzr, #268435452
 ;;   subs xzr, x6, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   str w1, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   str w1, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   mov w6, w0
 ;;   orr x7, xzr, #268435452
 ;;   subs xzr, x6, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldr w0, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldr w0, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -43,15 +43,15 @@
 ;;   movz w9, #61436
 ;;   movk w9, w9, #4095, LSL #16
 ;;   subs xzr, x8, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x11, x11, #4096
-;;   str w1, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x10, x10, #4096
+;;   str w1, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -60,13 +60,13 @@
 ;;   movz w9, #61436
 ;;   movk w9, w9, #4095, LSL #16
 ;;   subs xzr, x8, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x11, #4096
-;;   ldr w0, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x10, #4096
+;;   ldr w0, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   mov w6, w0
 ;;   orr x7, xzr, #268435455
 ;;   subs xzr, x6, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x2]
-;;   strb w1, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x2]
+;;   strb w1, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   mov w6, w0
 ;;   orr x7, xzr, #268435455
 ;;   subs xzr, x6, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x9, [x1]
-;;   ldrb w0, [x9, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x8, [x1]
+;;   ldrb w0, [x8, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -43,15 +43,15 @@
 ;;   movz w9, #61439
 ;;   movk w9, w9, #4095, LSL #16
 ;;   subs xzr, x8, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x2]
-;;   add x11, x11, #4096
-;;   strb w1, [x11, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x2]
+;;   add x10, x10, #4096
+;;   strb w1, [x10, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -60,13 +60,13 @@
 ;;   movz w9, #61439
 ;;   movk w9, w9, #4095, LSL #16
 ;;   subs xzr, x8, x9
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x11, [x1]
-;;   add x10, x11, #4096
-;;   ldrb w0, [x10, w0, UXTW]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x10, [x1]
+;;   add x9, x10, #4096
+;;   ldrb w0, [x9, w0, UXTW]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -41,26 +41,26 @@
 ;; block0:
 ;;   orr x5, xzr, #268435452
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   str w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   str w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   orr x5, xzr, #268435452
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldr w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldr w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,15 +42,15 @@
 ;;   movz w7, #61436
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   str w1, [x11, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   add x10, x0, #4096
+;;   str w1, [x10, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   movz w7, #61436
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldr w0, [x9, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   add x8, x0, #4096
+;;   ldr w0, [x8, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -41,26 +41,26 @@
 ;; block0:
 ;;   orr x5, xzr, #268435455
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   strb w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   strb w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   orr x5, xzr, #268435455
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldrb w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldrb w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,15 +42,15 @@
 ;;   movz w7, #61439
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   strb w1, [x11, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   add x10, x0, #4096
+;;   strb w1, [x10, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   movz w7, #61439
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldrb w0, [x9, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   add x8, x0, #4096
+;;   ldrb w0, [x8, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -41,26 +41,26 @@
 ;; block0:
 ;;   orr x5, xzr, #268435452
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   str w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   str w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   orr x5, xzr, #268435452
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldr w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldr w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,15 +42,15 @@
 ;;   movz w7, #61436
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   str w1, [x11, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   add x10, x0, #4096
+;;   str w1, [x10, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   movz w7, #61436
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldr w0, [x9, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   add x8, x0, #4096
+;;   ldr w0, [x8, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -41,26 +41,26 @@
 ;; block0:
 ;;   orr x5, xzr, #268435455
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x2]
-;;   strb w1, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x2]
+;;   strb w1, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   orr x5, xzr, #268435455
 ;;   subs xzr, x0, x5
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x8, [x1]
-;;   ldrb w0, [x8, x0]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x7, [x1]
+;;   ldrb w0, [x7, x0]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,15 +42,15 @@
 ;;   movz w7, #61439
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   strb w1, [x11, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x2]
+;;   add x10, x0, #4096
+;;   strb w1, [x10, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   movz w7, #61439
 ;;   movk w7, w7, #4095, LSL #16
 ;;   subs xzr, x0, x7
-;;   b.hi label1 ; b label2
-;; block2:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldrb w0, [x9, x10]
-;;   b label3
-;; block3:
-;;   ret
+;;   b.hi label3 ; b label1
 ;; block1:
+;;   ldr x9, [x1]
+;;   add x8, x0, #4096
+;;   ldrb w0, [x8, x9]
+;;   b label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf #0xc11f

--- a/cranelift/filetests/filetests/isa/riscv64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/br_table.clif
@@ -29,67 +29,61 @@ block5(v5: i32):
 
 ; VCode:
 ; block0:
-;   br_table a0,[MachLabel(1),MachLabel(3),MachLabel(5),MachLabel(6),MachLabel(8)]##tmp1=t3,tmp2=t4
+;   br_table a0,[MachLabel(6),MachLabel(5),MachLabel(1),MachLabel(2),MachLabel(3)]##tmp1=a5,tmp2=a6
 ; block1:
-;   li a1,4
-;   j label2
-; block2:
-;   j label10
-; block3:
-;   li a1,1
 ;   j label4
+; block2:
+;   j label4
+; block3:
+;   li a2,3
+;   j label7
 ; block4:
-;   j label10
+;   li a2,2
+;   j label7
 ; block5:
+;   li a2,1
 ;   j label7
 ; block6:
+;   li a2,4
 ;   j label7
 ; block7:
-;   li a1,2
-;   j label10
-; block8:
-;   li a1,3
-;   j label9
-; block9:
-;   j label10
-; block10:
-;   addw a0,a0,a1
+;   addw a0,a0,a2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t6, a0, 0x20
 ;   srli t6, t6, 0x20
-;   addi t4, zero, 4
-;   bltu t6, t4, 0xc
-;   auipc t4, 0
-;   jalr zero, t4, 0x38
-;   auipc t3, 0
-;   slli t4, t6, 3
-;   add t3, t3, t4
-;   jalr zero, t3, 0x10
-;   auipc t4, 0
-;   jalr zero, t4, 0x28
-;   auipc t4, 0
-;   jalr zero, t4, 0x28
-;   auipc t4, 0
-;   jalr zero, t4, 0x20
-;   auipc t4, 0
-;   jalr zero, t4, 0x20
+;   addi a6, zero, 4
+;   bltu t6, a6, 0xc
+;   auipc a6, 0
+;   jalr zero, a6, 0x54
+;   auipc a5, 0
+;   slli a6, t6, 3
+;   add a5, a5, a6
+;   jalr zero, a5, 0x10
+;   auipc a6, 0
+;   jalr zero, a6, 0x34
+;   auipc a6, 0
+;   jalr zero, a6, 0x24
+;   auipc a6, 0
+;   jalr zero, a6, 0x1c
+;   auipc a6, 0
+;   jalr zero, a6, 0xc
 ; block1: ; offset 0x48
-;   addi a1, zero, 4
+;   j 0xc
 ; block2: ; offset 0x4c
+;   addi a2, zero, 3
 ;   j 0x18
-; block3: ; offset 0x50
-;   addi a1, zero, 1
-; block4: ; offset 0x54
+; block3: ; offset 0x54
+;   addi a2, zero, 2
 ;   j 0x10
-; block5: ; offset 0x58
-;   addi a1, zero, 2
+; block4: ; offset 0x5c
+;   addi a2, zero, 1
 ;   j 8
-; block6: ; offset 0x60
-;   addi a1, zero, 3
-; block7: ; offset 0x64
-;   addw a0, a0, a1
+; block5: ; offset 0x64
+;   addi a2, zero, 4
+; block6: ; offset 0x68
+;   addw a0, a0, a2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condbr.clif
@@ -246,12 +246,12 @@ block2:
 ; VCode:
 ; block0:
 ;   eq a2,a0,a1##ty=i64
-;   bne a2,zero,taken(label1),not_taken(label2)
+;   bne a2,zero,taken(label2),not_taken(label1)
 ; block1:
-;   li a0,1
+;   li a0,2
 ;   ret
 ; block2:
-;   li a0,2
+;   li a0,1
 ;   ret
 ; 
 ; Disassembled:
@@ -260,12 +260,12 @@ block2:
 ;   addi a2, zero, 1
 ;   j 8
 ;   mv a2, zero
-;   beqz a2, 0xc
+;   bnez a2, 0xc
 ; block1: ; offset 0x14
-;   addi a0, zero, 1
+;   addi a0, zero, 2
 ;   ret
 ; block2: ; offset 0x1c
-;   addi a0, zero, 2
+;   addi a0, zero, 1
 ;   ret
 
 function %f(i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -94,38 +94,34 @@ block3(v7: r64, v8: r64):
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   sd s7,-8(sp)
+;   sd s3,-8(sp)
 ;   add sp,-48
 ; block0:
 ;   sd a0,8(nominal_sp)
 ;   sd a1,16(nominal_sp)
-;   mv s7,a2
-;   load_sym a1,%f+0
-;   callind a1
-;   load_addr a1,nsp+0
-;   ld t4,8(nominal_sp)
-;   sd t4,0(a1)
-;   andi a1,a0,255
-;   bne a1,zero,taken(label1),not_taken(label3)
+;   mv s3,a2
+;   load_sym t0,%f+0
+;   callind t0
+;   load_addr t4,nsp+0
+;   ld a5,8(nominal_sp)
+;   sd a5,0(t4)
+;   andi t0,a0,255
+;   bne t0,zero,taken(label2),not_taken(label1)
 ; block1:
-;   j label2
-; block2:
-;   mv a0,t4
-;   ld a1,16(nominal_sp)
-;   j label5
-; block3:
-;   j label4
-; block4:
-;   mv a1,t4
+;   mv a1,a5
 ;   ld a0,16(nominal_sp)
-;   j label5
-; block5:
+;   j label3
+; block2:
+;   mv a0,a5
+;   ld a1,16(nominal_sp)
+;   j label3
+; block3:
 ;   load_addr a2,nsp+0
 ;   ld a2,0(a2)
-;   mv a3,s7
-;   sd a2,0(a3)
+;   mv t3,s3
+;   sd a2,0(t3)
 ;   add sp,+48
-;   ld s7,-8(sp)
+;   ld s3,-8(sp)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -137,37 +133,37 @@ block3(v7: r64, v8: r64):
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-;   sd s7, -8(sp)
+;   sd s3, -8(sp)
 ;   addi sp, sp, -0x30
 ; block1: ; offset 0x18
 ;   sd a0, 8(sp)
 ;   sd a1, 0x10(sp)
-;   ori s7, a2, 0
-;   auipc a1, 0
-;   ld a1, 0xc(a1)
+;   ori s3, a2, 0
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   jalr a1
-;   mv a1, sp
-;   ld t4, 8(sp)
-;   sd t4, 0(a1)
-;   andi a1, a0, 0xff
-;   beqz a1, 0x10
+;   jalr t0
+;   mv t4, sp
+;   ld a5, 8(sp)
+;   sd a5, 0(t4)
+;   andi t0, a0, 0xff
+;   bnez t0, 0x10
 ; block2: ; offset 0x50
-;   ori a0, t4, 0
-;   ld a1, 0x10(sp)
+;   ori a1, a5, 0
+;   ld a0, 0x10(sp)
 ;   j 0xc
 ; block3: ; offset 0x5c
-;   ori a1, t4, 0
-;   ld a0, 0x10(sp)
+;   ori a0, a5, 0
+;   ld a1, 0x10(sp)
 ; block4: ; offset 0x64
 ;   mv a2, sp
 ;   ld a2, 0(a2)
-;   ori a3, s7, 0
-;   sd a2, 0(a3)
+;   ori t3, s3, 0
+;   sd a2, 0(t3)
 ;   addi sp, sp, 0x30
-;   ld s7, -8(sp)
+;   ld s3, -8(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/traps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/traps.clif
@@ -27,10 +27,10 @@ block0(v0: i64):
 ; block0:
 ;   li t2,42
 ;   eq a1,a0,t2##ty=i64
-;   bne a1,zero,taken(label1),not_taken(label2)
-; block2:
-;   ret
+;   bne a1,zero,taken(label2),not_taken(label1)
 ; block1:
+;   ret
+; block2:
 ;   udf##trap_code=user0
 ; 
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -46,15 +46,15 @@
 ;;   ld a7,8(a2)
 ;;   addi a7,a7,-4
 ;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,t3
-;;   sw a1,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a2)
+;;   add t3,t4,t3
+;;   sw a1,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   ld a7,8(a1)
 ;;   addi a7,a7,-4
 ;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,t3
-;;   lw a0,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a1)
+;;   add t3,t4,t3
+;;   lw a0,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,17 +48,17 @@
 ;;   addi t0,t0,4092
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   sw a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   sw a1,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -70,15 +70,15 @@
 ;;   addi t0,t0,4092
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   lw a0,0(a1)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   lw a0,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -49,17 +49,17 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a2)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a2,0(a2)
-;;   add a2,a2,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a2,a0
-;;   sw a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a2,a0,t2
+;;   sw a1,0(a2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -72,15 +72,15 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a1)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a1,0(a1)
-;;   add a1,a1,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a1,a0
-;;   lw a0,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a1,a0,t2
+;;   lw a0,0(a1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -45,15 +45,15 @@
 ;;   srli a7,a5,32
 ;;   ld a6,8(a2)
 ;;   uge a6,a7,a6##ty=i64
-;;   bne a6,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t3,0(a2)
-;;   add t3,t3,a7
-;;   sb a1,0(t3)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add a7,t3,a7
+;;   sb a1,0(a7)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   srli a7,a5,32
 ;;   ld a6,8(a1)
 ;;   uge a6,a7,a6##ty=i64
-;;   bne a6,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t3,0(a1)
-;;   add t3,t3,a7
-;;   lbu a0,0(t3)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add a7,t3,a7
+;;   lbu a0,0(a7)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,17 +48,17 @@
 ;;   addi t0,t0,4095
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   sb a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   sb a1,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -70,15 +70,15 @@
 ;;   addi t0,t0,4095
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   lbu a0,0(a1)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   lbu a0,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -49,17 +49,17 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a2)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a2,0(a2)
-;;   add a2,a2,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a2,a0
-;;   sb a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a2,a0,t2
+;;   sb a1,0(a2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -72,15 +72,15 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a1)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a1,0(a1)
-;;   add a1,a1,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a1,a0
-;;   lbu a0,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a1,a0,t2
+;;   lbu a0,0(a1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -46,15 +46,15 @@
 ;;   ld a7,8(a2)
 ;;   addi a7,a7,-4
 ;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,t3
-;;   sw a1,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a2)
+;;   add t3,t4,t3
+;;   sw a1,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -64,13 +64,13 @@
 ;;   ld a7,8(a1)
 ;;   addi a7,a7,-4
 ;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,t3
-;;   lw a0,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a1)
+;;   add t3,t4,t3
+;;   lw a0,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,17 +48,17 @@
 ;;   addi t0,t0,4092
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   sw a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   sw a1,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -70,15 +70,15 @@
 ;;   addi t0,t0,4092
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   lw a0,0(a1)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   lw a0,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -49,17 +49,17 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a2)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a2,0(a2)
-;;   add a2,a2,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a2,a0
-;;   sw a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a2,a0,t2
+;;   sw a1,0(a2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -72,15 +72,15 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a1)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a1,0(a1)
-;;   add a1,a1,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a1,a0
-;;   lw a0,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a1,a0,t2
+;;   lw a0,0(a1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -45,15 +45,15 @@
 ;;   srli a7,a5,32
 ;;   ld a6,8(a2)
 ;;   uge a6,a7,a6##ty=i64
-;;   bne a6,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t3,0(a2)
-;;   add t3,t3,a7
-;;   sb a1,0(t3)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add a7,t3,a7
+;;   sb a1,0(a7)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   srli a7,a5,32
 ;;   ld a6,8(a1)
 ;;   uge a6,a7,a6##ty=i64
-;;   bne a6,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t3,0(a1)
-;;   add t3,t3,a7
-;;   lbu a0,0(t3)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add a7,t3,a7
+;;   lbu a0,0(a7)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,17 +48,17 @@
 ;;   addi t0,t0,4095
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   sb a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   sb a1,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -70,15 +70,15 @@
 ;;   addi t0,t0,4095
 ;;   add a0,t1,t0
 ;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   lbu a0,0(a1)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add t2,a0,t2
+;;   lui t1,1
+;;   add a0,t2,t1
+;;   lbu a0,0(a0)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -49,17 +49,17 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a2)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a2,0(a2)
-;;   add a2,a2,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a2,a0
-;;   sb a1,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a2)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a2,a0,t2
+;;   sb a1,0(a2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -72,15 +72,15 @@
 ;;   trap_if a0,heap_oob
 ;;   ld a0,8(a1)
 ;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a1,0(a1)
-;;   add a1,a1,t2
-;;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
-;;   add a2,a1,a0
-;;   lbu a0,0(a2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a0,0(a1)
+;;   add a0,a0,t2
+;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
+;;   add a1,a0,t2
+;;   lbu a0,0(a1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,15 +44,15 @@
 ;;   ld a5,8(a2)
 ;;   addi a5,a5,-4
 ;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sw a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sw a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,13 +60,13 @@
 ;;   ld a5,8(a1)
 ;;   addi a5,a5,-4
 ;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lw a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lw a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,17 +46,17 @@
 ;;   addi t3,t3,4092
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sw a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a2)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sw a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -66,15 +66,15 @@
 ;;   addi t3,t3,4092
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lw a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a1)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lw a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -47,17 +47,17 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a2)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a2)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   sw a1,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   sw a1,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -68,15 +68,15 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a1)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a1)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   lw a0,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   lw a0,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -43,28 +43,28 @@
 ;; block0:
 ;;   ld a4,8(a2)
 ;;   uge a4,a0,a4##ty=i64
-;;   bne a4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a6,0(a2)
-;;   add a6,a6,a0
-;;   sb a1,0(a6)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sb a1,0(a5)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   ld a4,8(a1)
 ;;   uge a4,a0,a4##ty=i64
-;;   bne a4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a6,0(a1)
-;;   add a6,a6,a0
-;;   lbu a0,0(a6)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lbu a0,0(a5)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,17 +46,17 @@
 ;;   addi t3,t3,4095
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sb a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a2)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sb a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -66,15 +66,15 @@
 ;;   addi t3,t3,4095
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lbu a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a1)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lbu a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -47,17 +47,17 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a2)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a2)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   sb a1,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   sb a1,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -68,15 +68,15 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a1)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a1)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   lbu a0,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   lbu a0,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -44,15 +44,15 @@
 ;;   ld a5,8(a2)
 ;;   addi a5,a5,-4
 ;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sw a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sw a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,13 +60,13 @@
 ;;   ld a5,8(a1)
 ;;   addi a5,a5,-4
 ;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lw a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lw a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,17 +46,17 @@
 ;;   addi t3,t3,4092
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sw a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a2)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sw a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -66,15 +66,15 @@
 ;;   addi t3,t3,4092
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lw a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a1)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lw a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -47,17 +47,17 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a2)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a2)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   sw a1,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   sw a1,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -68,15 +68,15 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a1)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a1)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   lw a0,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   lw a0,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -43,28 +43,28 @@
 ;; block0:
 ;;   ld a4,8(a2)
 ;;   uge a4,a0,a4##ty=i64
-;;   bne a4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a6,0(a2)
-;;   add a6,a6,a0
-;;   sb a1,0(a6)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sb a1,0(a5)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
 ;; block0:
 ;;   ld a4,8(a1)
 ;;   uge a4,a0,a4##ty=i64
-;;   bne a4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a6,0(a1)
-;;   add a6,a6,a0
-;;   lbu a0,0(a6)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lbu a0,0(a5)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,17 +46,17 @@
 ;;   addi t3,t3,4095
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sb a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a2)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sb a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -66,15 +66,15 @@
 ;;   addi t3,t3,4095
 ;;   add t1,t4,t3
 ;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lbu a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t0,0(a1)
+;;   add t0,t0,a0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lbu a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -47,17 +47,17 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a2)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a2)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   sb a1,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   sb a1,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -68,15 +68,15 @@
 ;;   trap_if t1,heap_oob
 ;;   ld t0,8(a1)
 ;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t2,0(a1)
-;;   add t2,t2,a0
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0000
-;;   add a0,t2,t1
-;;   lbu a0,0(a0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t0,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t1,t1,a0
+;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
+;;   add t2,t1,t0
+;;   lbu a0,0(t2)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,15 +44,15 @@
 ;;   lui a6,65536
 ;;   addi a6,a6,4092
 ;;   ugt t4,t3,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,t3
-;;   sw a1,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a2)
+;;   add t3,t4,t3
+;;   sw a1,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   lui a6,65536
 ;;   addi a6,a6,4092
 ;;   ugt t4,t3,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,t3
-;;   lw a0,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a1)
+;;   add t3,t4,t3
+;;   lw a0,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,17 +44,17 @@
 ;;   lui t3,65535
 ;;   addi t3,t3,4092
 ;;   ugt t1,t0,t3##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,t0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sw a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t0,t1,t0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sw a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -64,15 +64,15 @@
 ;;   lui t3,65535
 ;;   addi t3,t3,4092
 ;;   ugt t1,t0,t3##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,t0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lw a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t0,t1,t0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lw a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -44,15 +44,15 @@
 ;;   lui a6,65536
 ;;   addi a6,a6,4095
 ;;   ugt t4,t3,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,t3
-;;   sb a1,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a2)
+;;   add t3,t4,t3
+;;   sb a1,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -62,13 +62,13 @@
 ;;   lui a6,65536
 ;;   addi a6,a6,4095
 ;;   ugt t4,t3,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,t3
-;;   lbu a0,0(t4)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t4,0(a1)
+;;   add t3,t4,t3
+;;   lbu a0,0(t3)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,17 +44,17 @@
 ;;   lui t3,65535
 ;;   addi t3,t3,4095
 ;;   ugt t1,t0,t3##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a2)
-;;   add t1,t1,t0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   sb a1,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a2)
+;;   add t0,t1,t0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   sb a1,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -64,15 +64,15 @@
 ;;   lui t3,65535
 ;;   addi t3,t3,4095
 ;;   ugt t1,t0,t3##ty=i64
-;;   bne t1,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t1,0(a1)
-;;   add t1,t1,t0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   lbu a0,0(t2)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t1,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t1,0(a1)
+;;   add t0,t1,t0
+;;   lui t4,1
+;;   add t1,t0,t4
+;;   lbu a0,0(t1)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,15 +42,15 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4092
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sw a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sw a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4092
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lw a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lw a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,17 +42,17 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4092
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   sw a1,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   sw a1,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,15 +60,15 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4092
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   lw a0,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   lw a0,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -42,15 +42,15 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4095
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sb a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sb a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4095
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lbu a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lbu a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,17 +42,17 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4095
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   sb a1,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   sb a1,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,15 +60,15 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4095
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   lbu a0,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   lbu a0,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -42,15 +42,15 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4092
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sw a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sw a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4092
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lw a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lw a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,17 +42,17 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4092
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   sw a1,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   sw a1,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,15 +60,15 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4092
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   lw a0,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   lw a0,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -42,15 +42,15 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4095
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a2)
-;;   add a7,a7,a0
-;;   sb a1,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a2)
+;;   add a6,a6,a0
+;;   sb a1,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -58,13 +58,13 @@
 ;;   lui a4,65536
 ;;   addi a4,a4,4095
 ;;   ugt a7,a0,a4##ty=i64
-;;   bne a7,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld a7,0(a1)
-;;   add a7,a7,a0
-;;   lbu a0,0(a7)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld a6,0(a1)
+;;   add a6,a6,a0
+;;   lbu a0,0(a6)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,17 +42,17 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4095
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a2)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   sb a1,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a2)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   sb a1,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob
 ;;
 ;; function u0:1:
@@ -60,15 +60,15 @@
 ;;   lui a6,65535
 ;;   addi a6,a6,4095
 ;;   ugt t4,a0,a6##ty=i64
-;;   bne t4,zero,taken(label1),not_taken(label2)
-;; block2:
-;;   ld t4,0(a1)
-;;   add t4,t4,a0
-;;   lui t3,1
-;;   add t0,t4,t3
-;;   lbu a0,0(t0)
-;;   j label3
-;; block3:
-;;   ret
+;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
+;;   ld t3,0(a1)
+;;   add t3,t3,a0
+;;   lui a7,1
+;;   add t4,t3,a7
+;;   lbu a0,0(t4)
+;;   j label2
+;; block2:
+;;   ret
+;; block3:
 ;;   udf##trap_code=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/condbr.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condbr.clif
@@ -38,23 +38,23 @@ block2:
 ; VCode:
 ; block0:
 ;   clgr %r2, %r3
-;   jge label1 ; jg label2
+;   jge label2 ; jg label1
 ; block1:
-;   lghi %r2, 1
+;   lghi %r2, 2
 ;   br %r14
 ; block2:
-;   lghi %r2, 2
+;   lghi %r2, 1
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
-;   jgne 0x10
+;   jge 0x10
 ; block1: ; offset 0xa
-;   lghi %r2, 1
+;   lghi %r2, 2
 ;   br %r14
 ; block2: ; offset 0x10
-;   lghi %r2, 2
+;   lghi %r2, 1
 ;   br %r14
 
 function %f(i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/s390x/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/s390x/jumptable.clif
@@ -30,30 +30,22 @@ block5(v5: i32):
 ; block0:
 ;   llgfr %r3, %r2
 ;   clgfi %r3, 3
-;   jghe label1
+;   jghe label4
 ;   sllg %r3, %r3, 2
-;   larl %r1, 14 ; agf %r1, 0(%r1, %r3) ; br %r1 ; jt_entries label3 label5 label7
+;   larl %r1, 14 ; agf %r1, 0(%r1, %r3) ; br %r1 ; jt_entries label3 label2 label1
 ; block1:
-;   lhi %r5, 4
-;   jg label2
+;   lhi %r5, 3
+;   jg label5
 ; block2:
-;   jg label9
+;   lhi %r5, 2
+;   jg label5
 ; block3:
 ;   lhi %r5, 1
-;   jg label4
+;   jg label5
 ; block4:
-;   jg label9
+;   lhi %r5, 4
+;   jg label5
 ; block5:
-;   lhi %r5, 2
-;   jg label6
-; block6:
-;   jg label9
-; block7:
-;   lhi %r5, 3
-;   jg label8
-; block8:
-;   jg label9
-; block9:
 ;   ar %r2, %r5
 ;   br %r14
 ; 
@@ -61,32 +53,29 @@ block5(v5: i32):
 ; block0: ; offset 0x0
 ;   llgfr %r3, %r2
 ;   clgfi %r3, 3
-;   jghe 0x30
+;   jghe 0x4e
 ;   sllg %r3, %r3, 2
 ;   larl %r1, 0x24
 ;   agf %r1, 0(%r3, %r1)
 ;   br %r1
 ;   .byte 0x00, 0x00
-;   .byte 0x00, 0x16
-;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x20
 ;   .byte 0x00, 0x00
-;   .byte 0x00, 0x2a
+;   .byte 0x00, 0x16
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x0c
 ; block1: ; offset 0x30
-;   lhi %r5, 4
-; block2: ; offset 0x34
-;   jg 0x52
-; block3: ; offset 0x3a
-;   lhi %r5, 1
-; block4: ; offset 0x3e
-;   jg 0x52
-; block5: ; offset 0x44
-;   lhi %r5, 2
-; block6: ; offset 0x48
-;   jg 0x52
-; block7: ; offset 0x4e
 ;   lhi %r5, 3
-; block8: ; offset 0x52
+;   jg 0x52
+; block2: ; offset 0x3a
+;   lhi %r5, 2
+;   jg 0x52
+; block3: ; offset 0x44
+;   lhi %r5, 1
+;   jg 0x52
+; block4: ; offset 0x4e
+;   lhi %r5, 4
+; block5: ; offset 0x52
 ;   ar %r2, %r5
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -106,20 +106,16 @@ block3(v7: r64, v8: r64):
 ;   stg %r4, 0(%r5)
 ;   lbr %r2, %r2
 ;   chi %r2, 0
-;   jglh label1 ; jg label3
+;   jglh label2 ; jg label1
 ; block1:
-;   jg label2
+;   lgr %r3, %r4
+;   lg %r2, 176(%r15)
+;   jg label3
 ; block2:
 ;   lgr %r2, %r4
 ;   lg %r3, 176(%r15)
-;   jg label5
+;   jg label3
 ; block3:
-;   jg label4
-; block4:
-;   lgr %r3, %r4
-;   lg %r2, 176(%r15)
-;   jg label5
-; block5:
 ;   la %r4, 160(%r15)
 ;   lg %r4, 0(%r4)
 ;   lmg %r14, %r15, 296(%r15)
@@ -144,14 +140,14 @@ block3(v7: r64, v8: r64):
 ;   stg %r4, 0(%r5)
 ;   lbr %r2, %r2
 ;   chi %r2, 0
-;   jgnlh 0x58
+;   jglh 0x58
 ; block2: ; offset 0x48
-;   lgr %r2, %r4
-;   lg %r3, 0xb0(%r15)
-;   jg 0x62
-; block3: ; offset 0x58
 ;   lgr %r3, %r4
 ;   lg %r2, 0xb0(%r15)
+;   jg 0x62
+; block3: ; offset 0x58
+;   lgr %r2, %r4
+;   lg %r3, 0xb0(%r15)
 ; block4: ; offset 0x62
 ;   la %r4, 0xa0(%r15)
 ;   lg %r4, 0(%r4)

--- a/cranelift/filetests/filetests/isa/s390x/traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/traps.clif
@@ -42,10 +42,10 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   clgfi %r2, 42
-;   jge label1 ; jg label2
-; block1:
-;   br %r14
+;   jge label2 ; jg label1
 ; block2:
+;   br %r14
+; block1:
 ;   trap
 ; 
 ; Disassembled:
@@ -68,10 +68,10 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   clgfi %r2, 42
-;   jge label1 ; jg label2
-; block2:
-;   br %r14
+;   jge label2 ; jg label1
 ; block1:
+;   br %r14
+; block2:
 ;   trap
 ; 
 ; Disassembled:
@@ -94,10 +94,10 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   clgfi %r2, 42
-;   jge label1 ; jg label2
-; block2:
-;   br %r14
+;   jge label2 ; jg label1
 ; block1:
+;   br %r14
+; block2:
 ;   trap
 ; 
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -47,14 +47,14 @@
 ;;   lghi %r2, -4
 ;;   ag %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r4, 0(%r4)
 ;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,12 +65,12 @@
 ;;   lghi %r2, -4
 ;;   ag %r2, 8(%r3)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r4, 0(%r3)
-;;   lrv %r2, 0(%r5,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r3, 0(%r3)
+;;   lrv %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,15 +48,15 @@
 ;;   lghi %r2, -4100
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r4, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
 ;;   lghi %r5, 4096
 ;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -69,13 +69,13 @@
 ;;   lgr %r5, %r4
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r3, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r3, 0(%r5)
 ;;   lghi %r4, 4096
 ;;   lrv %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -62,16 +62,16 @@
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r5, 65535
-;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   llilh %r2, 65535
+;;   strv %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -85,13 +85,13 @@
 ;;   jle 6 ; trap
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r4)
-;;   llilh %r2, 65535
-;;   lrv %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r3, 0(%r4)
+;;   llilh %r5, 65535
+;;   lrv %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -48,14 +48,14 @@
 ;;   lgr %r2, %r5
 ;;   lg %r5, 8(%r2)
 ;;   clgr %r4, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r2)
-;;   stc %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r2, 0(%r2)
+;;   stc %r3, 0(%r4,%r2)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,12 +65,12 @@
 ;;   llgfr %r4, %r2
 ;;   lg %r5, 8(%r3)
 ;;   clgr %r4, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r3, 0(%r3)
-;;   llc %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r2, 0(%r3)
+;;   llc %r2, 0(%r4,%r2)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,15 +48,15 @@
 ;;   lghi %r2, -4097
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r4, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
 ;;   lghi %r5, 4096
 ;;   stc %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -69,13 +69,13 @@
 ;;   lgr %r5, %r4
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r3, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r3, 0(%r5)
 ;;   lghi %r4, 4096
 ;;   llc %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -62,16 +62,16 @@
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r5, 65535
-;;   stc %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   llilh %r2, 65535
+;;   stc %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -85,13 +85,13 @@
 ;;   jle 6 ; trap
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r4)
-;;   llilh %r2, 65535
-;;   llc %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r3, 0(%r4)
+;;   llilh %r5, 65535
+;;   llc %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -47,14 +47,14 @@
 ;;   lghi %r2, -4
 ;;   ag %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r4, 0(%r4)
 ;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,12 +65,12 @@
 ;;   lghi %r2, -4
 ;;   ag %r2, 8(%r3)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r4, 0(%r3)
-;;   lrv %r2, 0(%r5,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r3, 0(%r3)
+;;   lrv %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,15 +48,15 @@
 ;;   lghi %r2, -4100
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r4, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
 ;;   lghi %r5, 4096
 ;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -69,13 +69,13 @@
 ;;   lgr %r5, %r4
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r3, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r3, 0(%r5)
 ;;   lghi %r4, 4096
 ;;   lrv %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -62,16 +62,16 @@
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r5, 65535
-;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   llilh %r2, 65535
+;;   strv %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -85,13 +85,13 @@
 ;;   jle 6 ; trap
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r4)
-;;   llilh %r2, 65535
-;;   lrv %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r3, 0(%r4)
+;;   llilh %r5, 65535
+;;   lrv %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -48,14 +48,14 @@
 ;;   lgr %r2, %r5
 ;;   lg %r5, 8(%r2)
 ;;   clgr %r4, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r2)
-;;   stc %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r2, 0(%r2)
+;;   stc %r3, 0(%r4,%r2)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,12 +65,12 @@
 ;;   llgfr %r4, %r2
 ;;   lg %r5, 8(%r3)
 ;;   clgr %r4, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r3, 0(%r3)
-;;   llc %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r2, 0(%r3)
+;;   llc %r2, 0(%r4,%r2)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,15 +48,15 @@
 ;;   lghi %r2, -4097
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r4, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
 ;;   lghi %r5, 4096
 ;;   stc %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -69,13 +69,13 @@
 ;;   lgr %r5, %r4
 ;;   ag %r2, 8(%r5)
 ;;   clgr %r3, %r2
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r3, 0(%r5)
 ;;   lghi %r4, 4096
 ;;   llc %r2, 0(%r4,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -62,16 +62,16 @@
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r5, 65535
-;;   stc %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
+;;   llilh %r2, 65535
+;;   stc %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -85,13 +85,13 @@
 ;;   jle 6 ; trap
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r4)
-;;   llilh %r2, 65535
-;;   llc %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r3, 0(%r4)
+;;   llilh %r5, 65535
+;;   llc %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -46,14 +46,14 @@
 ;;   lghi %r5, -4
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r4, 0(%r4)
 ;;   strv %r3, 0(%r2,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -63,12 +63,12 @@
 ;;   lghi %r4, -4
 ;;   ag %r4, 8(%r3)
 ;;   clgr %r2, %r4
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r3, 0(%r3)
 ;;   lrv %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,16 +46,16 @@
 ;;   lghi %r5, -4100
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   strv %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   lghi %r5, -4100
 ;;   ag %r5, 8(%r3)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r3)
-;;   lghi %r3, 4096
-;;   lrv %r2, 0(%r3,%r4)
-;;   jg label3
-;; block3:
+;;   lghi %r2, 4096
+;;   lrv %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jle 6 ; trap
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
-;;   llilh %r2, 65535
-;;   strv %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
+;;   llilh %r4, 65535
+;;   strv %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -73,14 +73,14 @@
 ;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   llilh %r4, 65535
-;;   lrv %r2, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r2
+;;   ag %r4, 0(%r3)
+;;   llilh %r3, 65535
+;;   lrv %r2, 0(%r3,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -45,14 +45,14 @@
 ;; block0:
 ;;   lg %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r4, 0(%r4)
-;;   stc %r3, 0(%r2,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r4)
+;;   stc %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;; block0:
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r2, %r4
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r3, 0(%r3)
-;;   llc %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r3)
+;;   llc %r2, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,16 +46,16 @@
 ;;   lghi %r5, -4097
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   stc %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   lghi %r5, -4097
 ;;   ag %r5, 8(%r3)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r3)
-;;   lghi %r3, 4096
-;;   llc %r2, 0(%r3,%r4)
-;;   jg label3
-;; block3:
+;;   lghi %r2, 4096
+;;   llc %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jle 6 ; trap
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
-;;   llilh %r2, 65535
-;;   stc %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
+;;   llilh %r4, 65535
+;;   stc %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -73,14 +73,14 @@
 ;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   llilh %r4, 65535
-;;   llc %r2, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r2
+;;   ag %r4, 0(%r3)
+;;   llilh %r3, 65535
+;;   llc %r2, 0(%r3,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -46,14 +46,14 @@
 ;;   lghi %r5, -4
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r4, 0(%r4)
 ;;   strv %r3, 0(%r2,%r4)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -63,12 +63,12 @@
 ;;   lghi %r4, -4
 ;;   ag %r4, 8(%r3)
 ;;   clgr %r2, %r4
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lg %r3, 0(%r3)
 ;;   lrv %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,16 +46,16 @@
 ;;   lghi %r5, -4100
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   strv %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   lghi %r5, -4100
 ;;   ag %r5, 8(%r3)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r3)
-;;   lghi %r3, 4096
-;;   lrv %r2, 0(%r3,%r4)
-;;   jg label3
-;; block3:
+;;   lghi %r2, 4096
+;;   lrv %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jle 6 ; trap
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
-;;   llilh %r2, 65535
-;;   strv %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
+;;   llilh %r4, 65535
+;;   strv %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -73,14 +73,14 @@
 ;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   llilh %r4, 65535
-;;   lrv %r2, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r2
+;;   ag %r4, 0(%r3)
+;;   llilh %r3, 65535
+;;   lrv %r2, 0(%r3,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -45,14 +45,14 @@
 ;; block0:
 ;;   lg %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r4, 0(%r4)
-;;   stc %r3, 0(%r2,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r4)
+;;   stc %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;; block0:
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r2, %r4
-;;   jghe label1 ; jg label2
-;; block2:
-;;   lg %r3, 0(%r3)
-;;   llc %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jghe label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r3)
+;;   llc %r2, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,16 +46,16 @@
 ;;   lghi %r5, -4097
 ;;   ag %r5, 8(%r4)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   stc %r3, 0(%r4,%r5)
-;;   jg label3
-;; block3:
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;;   lghi %r5, -4097
 ;;   ag %r5, 8(%r3)
 ;;   clgr %r2, %r5
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r3)
-;;   lghi %r3, 4096
-;;   llc %r2, 0(%r3,%r4)
-;;   jg label3
-;; block3:
+;;   lghi %r2, 4096
+;;   llc %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jle 6 ; trap
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
-;;   jgh label1 ; jg label2
-;; block2:
+;;   jgh label3 ; jg label1
+;; block1:
 ;;   lgr %r5, %r2
 ;;   ag %r5, 0(%r4)
-;;   llilh %r2, 65535
-;;   stc %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
+;;   llilh %r4, 65535
+;;   stc %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
-;; block1:
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -73,14 +73,14 @@
 ;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   llilh %r4, 65535
-;;   llc %r2, 0(%r4,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r2
+;;   ag %r4, 0(%r3)
+;;   llilh %r3, 65535
+;;   llc %r2, 0(%r3,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
 ;;   clgfi %r4, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r2, 0(%r5)
-;;   strv %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r5)
+;;   strv %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
 ;;   clgfi %r3, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r2, 0(%r4)
-;;   lrv %r2, 0(%r3,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r4)
+;;   lrv %r2, 0(%r3,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,15 +44,15 @@
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
 ;;   clgfi %r4, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r4, 0(%r5)
-;;   lghi %r5, 4096
-;;   strv %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r4, 0(%r5)
+;;   lghi %r2, 4096
+;;   strv %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -62,13 +62,14 @@
 ;;   lgr %r5, %r3
 ;;   llgfr %r3, %r2
 ;;   clgfi %r3, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r5)
-;;   lghi %r2, 4096
-;;   lrv %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r5
+;;   ag %r3, 0(%r4)
+;;   lghi %r5, 4096
+;;   lrv %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -44,14 +44,14 @@
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
 ;;   clgfi %r4, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r2, 0(%r5)
-;;   stc %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r5)
+;;   stc %r3, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -61,12 +61,12 @@
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
 ;;   clgfi %r3, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r2, 0(%r4)
-;;   llc %r2, 0(%r3,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r5, 0(%r4)
+;;   llc %r2, 0(%r3,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,15 +44,15 @@
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
 ;;   clgfi %r4, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r4, 0(%r5)
-;;   lghi %r5, 4096
-;;   stc %r3, 0(%r5,%r4)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   ag %r4, 0(%r5)
+;;   lghi %r2, 4096
+;;   stc %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -62,13 +62,14 @@
 ;;   lgr %r5, %r3
 ;;   llgfr %r3, %r2
 ;;   clgfi %r3, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r3, 0(%r5)
-;;   lghi %r2, 4096
-;;   llc %r2, 0(%r2,%r3)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r4, %r5
+;;   ag %r3, 0(%r4)
+;;   lghi %r5, 4096
+;;   llc %r2, 0(%r5,%r3)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r4)
-;;   strv %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r4)
+;;   strv %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r3)
-;;   lrv %r2, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r3)
+;;   lrv %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,15 +42,16 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r4)
-;;   lghi %r4, 4096
-;;   strv %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   lghi %r2, 4096
+;;   strv %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -58,13 +59,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r3)
-;;   lghi %r5, 4096
-;;   lrv %r2, 0(%r5,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   lghi %r4, 4096
+;;   lrv %r2, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r4)
-;;   stc %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r4)
+;;   stc %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r3)
-;;   llc %r2, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r3)
+;;   llc %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,15 +42,16 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r4)
-;;   lghi %r4, 4096
-;;   stc %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   lghi %r2, 4096
+;;   stc %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -58,13 +59,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r3)
-;;   lghi %r5, 4096
-;;   llc %r2, 0(%r5,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   lghi %r4, 4096
+;;   llc %r2, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r4)
-;;   strv %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r4)
+;;   strv %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435452
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r3)
-;;   lrv %r2, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r3)
+;;   lrv %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,15 +42,16 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r4)
-;;   lghi %r4, 4096
-;;   strv %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   lghi %r2, 4096
+;;   strv %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -58,13 +59,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431356
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r3)
-;;   lghi %r5, 4096
-;;   lrv %r2, 0(%r5,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   lghi %r4, 4096
+;;   lrv %r2, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -42,14 +42,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r4)
-;;   stc %r3, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r4)
+;;   stc %r3, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -57,12 +57,12 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268435455
-;;   jgh label1 ; jg label2
-;; block2:
-;;   lg %r5, 0(%r3)
-;;   llc %r2, 0(%r2,%r5)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lg %r4, 0(%r3)
+;;   llc %r2, 0(%r2,%r4)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,15 +42,16 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r4)
-;;   lghi %r4, 4096
-;;   stc %r3, 0(%r4,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   lghi %r2, 4096
+;;   stc %r3, 0(%r2,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap
 ;;
 ;; function u0:1:
@@ -58,13 +59,14 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   clgfi %r2, 268431359
-;;   jgh label1 ; jg label2
-;; block2:
-;;   ag %r2, 0(%r3)
-;;   lghi %r5, 4096
-;;   llc %r2, 0(%r5,%r2)
-;;   jg label3
-;; block3:
-;;   br %r14
+;;   jgh label3 ; jg label1
 ;; block1:
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   lghi %r4, 4096
+;;   llc %r2, 0(%r4,%r5)
+;;   jg label2
+;; block2:
+;;   br %r14
+;; block3:
 ;;   trap

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -20,14 +20,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -38,14 +38,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl %esi, %edi
-;   jne 0x16
+;   je 0x16
 ; block2: ; offset 0xc
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x16
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -69,14 +69,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -87,14 +87,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl %esi, %edi
-;   jne 0x16
+;   je 0x16
 ; block2: ; offset 0xc
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x16
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -118,14 +118,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -136,14 +136,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl %esi, %edi
-;   jne 0x16
+;   je 0x16
 ; block2: ; offset 0xc
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x16
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -167,15 +167,15 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   jp      label2
-;   jnz     label2; j label1
+;   jp      label1
+;   jnz     label1; j label2
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -186,15 +186,15 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
-;   jp 0x1d
-;   jne 0x1d
+;   jp 0x13
+;   je 0x1d
 ; block2: ; offset 0x13
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x1d
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -216,15 +216,15 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   jp      label2
-;   jnz     label2; j label1
+;   jp      label1
+;   jnz     label1; j label2
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $1, %eax
+;   xorl    %eax, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -235,15 +235,15 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
-;   jp 0x1a
-;   jne 0x1a
+;   jp 0x13
+;   je 0x1d
 ; block2: ; offset 0x13
-;   xorl %eax, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x1a
-;   movl $1, %eax
+; block3: ; offset 0x1d
+;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -265,15 +265,15 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   jp      label1
-;   jnz     label1; j label2
+;   jp      label2
+;   jnz     label2; j label1
 ; block1:
-;   xorl    %eax, %eax, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $1, %eax
+;   xorl    %eax, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -284,15 +284,15 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
-;   jp 0x13
-;   je 0x1a
+;   jp 0x1d
+;   jne 0x1d
 ; block2: ; offset 0x13
-;   xorl %eax, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x1a
-;   movl $1, %eax
+; block3: ; offset 0x1d
+;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -317,16 +317,16 @@ block2:
 ;   cmpl    $2, %edi
 ;   br_table %rdi, %r8, %r9
 ; block1:
-;   jmp     label3
+;   jmp     label4
 ; block2:
-;   jmp     label3
+;   jmp     label4
 ; block3:
-;   movl    $1, %eax
+;   xorl    %eax, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block4:
-;   xorl    %eax, %eax, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -337,7 +337,7 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl $2, %edi
-;   jae 0x34
+;   jae 0x40
 ;   movl %edi, %r9d
 ;   movl $0, %r8d
 ;   cmovaeq %r8, %r9
@@ -345,17 +345,17 @@ block2:
 ;   movslq (%r8, %r9, 4), %r9
 ;   addq %r9, %r8
 ;   jmpq *%r8
-;   orb %al, (%rax)
-;   addb %al, (%rax)
-;   adcb (%rax), %al
+;   adcb $0, %al
 ;   addb %al, (%rax)
 ; block2: ; offset 0x34
-;   movl $1, %eax
+;   jmp 0x40
+; block3: ; offset 0x39
+;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x3e
-;   xorl %eax, %eax
+; block4: ; offset 0x40
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -378,14 +378,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpq    $0, %rdi
-;   jl      label1; j label2
+;   jl      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   xorl    %eax, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   xorl    %eax, %eax, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -396,14 +396,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpq $0, %rdi
-;   jge 0x18
+;   jl 0x15
 ; block2: ; offset 0xe
-;   movl $1, %eax
+;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x18
-;   xorl %eax, %eax
+; block3: ; offset 0x15
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -426,14 +426,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    $0, %edi
-;   jl      label1; j label2
+;   jl      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   xorl    %eax, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   xorl    %eax, %eax, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -444,14 +444,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl $0, %edi
-;   jge 0x17
+;   jl 0x14
 ; block2: ; offset 0xd
-;   movl $1, %eax
+;   xorl %eax, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x17
-;   xorl %eax, %eax
+; block3: ; offset 0x14
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -491,11 +491,11 @@ block202:
 ;   movl    $1112539136, %r11d
 ;   movd    %r11d, %xmm10
 ;   ucomiss %xmm10, %xmm0
-;   jnp     label3; j label4
+;   jnp     label4; j label3
 ; block3:
-;   ud2 heap_oob
-; block4:
 ;   jmp     label5
+; block4:
+;   ud2 heap_oob
 ; block5:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -543,14 +543,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -561,14 +561,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl %esi, %edi
-;   jne 0x16
+;   je 0x16
 ; block2: ; offset 0xc
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x16
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -593,15 +593,15 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   jp      label2
-;   jnz     label2; j label1
+;   jp      label1
+;   jnz     label1; j label2
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -612,15 +612,15 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
-;   jp 0x1d
-;   jne 0x1d
+;   jp 0x13
+;   je 0x1d
 ; block2: ; offset 0x13
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x1d
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -645,14 +645,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    %esi, %edi
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -663,14 +663,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl %esi, %edi
-;   jne 0x16
+;   je 0x16
 ; block2: ; offset 0xc
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x16
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -695,15 +695,15 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   jp      label2
-;   jnz     label2; j label1
+;   jp      label1
+;   jnz     label1; j label2
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -714,15 +714,15 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
-;   jp 0x1d
-;   jne 0x1d
+;   jp 0x13
+;   je 0x1d
 ; block2: ; offset 0x13
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x1d
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -757,32 +757,26 @@ block5(v5: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   cmpl    $4, %edi
-;   br_table %rdi, %rcx, %rdx
+;   br_table %rdi, %rsi, %rax
 ; block1:
-;   movl    $4, %edx
-;   jmp     label2
-; block2:
-;   jmp     label10
-; block3:
-;   movl    $1, %edx
 ;   jmp     label4
+; block2:
+;   jmp     label4
+; block3:
+;   movl    $3, %r9d
+;   jmp     label7
 ; block4:
-;   jmp     label10
+;   movl    $2, %r9d
+;   jmp     label7
 ; block5:
+;   movl    $1, %r9d
 ;   jmp     label7
 ; block6:
+;   movl    $4, %r9d
 ;   jmp     label7
 ; block7:
-;   movl    $2, %edx
-;   jmp     label10
-; block8:
-;   movl    $3, %edx
-;   jmp     label9
-; block9:
-;   jmp     label10
-; block10:
 ;   movq    %rdi, %rax
-;   addl    %eax, %edx, %eax
+;   addl    %eax, %r9d, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -793,37 +787,36 @@ block5(v5: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   cmpl $4, %edi
-;   jae 0x39
-;   movl %edi, %edx
-;   movl $0, %ecx
-;   cmovaeq %rcx, %rdx
-;   leaq 0xa(%rip), %rcx
-;   movslq (%rcx, %rdx, 4), %rdx
-;   addq %rdx, %rcx
-;   jmpq *%rcx
-;   sbbb (%rax), %al
+;   jae 0x5f
+;   movl %edi, %eax
+;   movl $0, %esi
+;   cmovaeq %rsi, %rax
+;   leaq 0xa(%rip), %rsi
+;   movslq (%rsi, %rax, 4), %rax
+;   addq %rax, %rsi
+;   jmpq *%rsi
+;   subl (%rax), %eax
 ;   addb %al, (%rax)
-;   andb $0, %al
+;   andb %al, (%rax)
 ;   addb %al, (%rax)
-;   andb $0, %al
+;   andb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb %al, %cs:(%rax)
 ; block2: ; offset 0x39
-;   movl $4, %edx
+;   jmp 0x49
 ; block3: ; offset 0x3e
-;   jmp 0x5c
-; block4: ; offset 0x43
-;   movl $1, %edx
-; block5: ; offset 0x48
-;   jmp 0x5c
-; block6: ; offset 0x4d
-;   movl $2, %edx
-;   jmp 0x5c
-; block7: ; offset 0x57
-;   movl $3, %edx
-; block8: ; offset 0x5c
+;   movl $3, %r9d
+;   jmp 0x65
+; block4: ; offset 0x49
+;   movl $2, %r9d
+;   jmp 0x65
+; block5: ; offset 0x54
+;   movl $1, %r9d
+;   jmp 0x65
+; block6: ; offset 0x5f
+;   movl $4, %r9d
+; block7: ; offset 0x65
 ;   movq %rdi, %rax
-;   addl %edx, %eax
+;   addl %r9d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -46,14 +46,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   testb   %dil, %dil
-;   jnz     label1; j label2
+;   jnz     label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -64,14 +64,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   testb %dil, %dil
-;   je 0x17
+;   jne 0x17
 ; block2: ; offset 0xd
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x17
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -92,14 +92,14 @@ block2:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   testb   %dil, %dil
-;   jnz     label1; j label2
+;   jnz     label2; j label1
 ; block1:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -110,14 +110,14 @@ block2:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   testb %dil, %dil
-;   je 0x17
+;   jne 0x17
 ; block2: ; offset 0xd
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x17
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -142,7 +142,7 @@ block2:
 ; block0:
 ;   movl    0(%rdi), %edx
 ;   cmpl    $1, %edx
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
 ;   movl    $1, %eax
 ;   movq    %rbp, %rsp
@@ -161,7 +161,7 @@ block2:
 ; block1: ; offset 0x4
 ;   movl (%rdi), %edx ; trap: heap_oob
 ;   cmpl $1, %edx
-;   jne 0x19
+;   je 0x19
 ; block2: ; offset 0xf
 ;   movl $1, %eax
 ;   movq %rbp, %rsp
@@ -193,7 +193,7 @@ block2:
 ; block0:
 ;   movl    0(%rdi), %edx
 ;   cmpl    $1, %edx
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
 ;   movl    $1, %eax
 ;   movq    %rbp, %rsp
@@ -212,7 +212,7 @@ block2:
 ; block1: ; offset 0x4
 ;   movl (%rdi), %edx ; trap: heap_oob
 ;   cmpl $1, %edx
-;   jne 0x19
+;   je 0x19
 ; block2: ; offset 0xf
 ;   movl $1, %eax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -572,14 +572,14 @@ block2:
 ;   cmpq    $0, %rsi
 ;   setz    %sil
 ;   testb   %r9b, %sil
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -594,14 +594,14 @@ block2:
 ;   cmpq $0, %rsi
 ;   sete %sil
 ;   testb %r9b, %sil
-;   jne 0x27
+;   je 0x27
 ; block2: ; offset 0x1d
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x27
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -628,14 +628,14 @@ block2:
 ;   cmpq    $0, %rsi
 ;   setz    %sil
 ;   testb   %r9b, %sil
-;   jz      label1; j label2
+;   jz      label2; j label1
 ; block1:
-;   movl    $1, %eax
+;   movl    $2, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
 ; block2:
-;   movl    $2, %eax
+;   movl    $1, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -650,14 +650,14 @@ block2:
 ;   cmpq $0, %rsi
 ;   sete %sil
 ;   testb %r9b, %sil
-;   jne 0x27
+;   je 0x27
 ; block2: ; offset 0x1d
-;   movl $1, %eax
+;   movl $2, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block3: ; offset 0x27
-;   movl $2, %eax
+;   movl $1, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1229,9 +1229,9 @@ block2(v8: i128):
 ;   xorq    %rax, %rax, %rax
 ;   xorq    %r9, %r9, %r9
 ;   testb   %dl, %dl
-;   jnz     label1; j label2
+;   jnz     label2; j label1
 ; block1:
-;   movl    $1, %r8d
+;   movl    $2, %r8d
 ;   xorq    %r10, %r10, %r10
 ;   addq    %rax, %r8, %rax
 ;   movq    %r9, %rdx
@@ -1241,7 +1241,7 @@ block2(v8: i128):
 ;   ret
 ; block2:
 ;   movq    %r9, %rdx
-;   movl    $2, %r9d
+;   movl    $1, %r9d
 ;   xorq    %r11, %r11, %r11
 ;   addq    %rax, %r9, %rax
 ;   adcq    %rdx, %r11, %rdx
@@ -1257,9 +1257,9 @@ block2(v8: i128):
 ;   xorq %rax, %rax
 ;   xorq %r9, %r9
 ;   testb %dl, %dl
-;   je 0x29
+;   jne 0x29
 ; block2: ; offset 0x12
-;   movl $1, %r8d
+;   movl $2, %r8d
 ;   xorq %r10, %r10
 ;   addq %r8, %rax
 ;   movq %r9, %rdx
@@ -1269,7 +1269,7 @@ block2(v8: i128):
 ;   retq
 ; block3: ; offset 0x29
 ;   movq %r9, %rdx
-;   movl $2, %r9d
+;   movl $1, %r9d
 ;   xorq %r11, %r11
 ;   addq %r9, %rax
 ;   adcq %r11, %rdx

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -22,8 +22,8 @@ block0(v0: i32, v1: r64, v2: i64):
 ; block0:
 ;   movl    8(%rdx), %r11d
 ;   cmpl    %r11d, %edi
-;   jnb     label1; j label2
-; block2:
+;   jnb     label2; j label1
+; block1:
 ;   movl    %edi, %ecx
 ;   movq    0(%rdx), %rax
 ;   movq    %rax, %rdx
@@ -34,7 +34,7 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; block1:
+; block2:
 ;   ud2 table_oob
 ; 
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movl    %esi, 0(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movl    0(%rsi,%r10,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movl    0(%rdi,%r10,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movl    %esi, 4096(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movl    4096(%rsi,%r10,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movl    4096(%rdi,%r10,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %rdi
+;;   addq    %rdi, const(0), %rdi
+;;   movl    %esi, 0(%rdi,%r11,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movl    %esi, 0(%rax,%r11,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -76,15 +76,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   addq    %rsi, const(0), %rsi
+;;   movl    0(%rsi,%r11,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movl    0(%rdi,%r11,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -48,16 +48,16 @@
 ;;   movl    %edi, %r9d
 ;;   movq    8(%rdx), %r10
 ;;   cmpq    %r10, %r9
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movb    %sil, 0(%r11,%r9,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rdi
-;;   movb    %sil, 0(%rdi,%r9,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movl    %edi, %r9d
 ;;   movq    8(%rsi), %r10
 ;;   cmpq    %r10, %r9
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movzbq  0(%r11,%r9,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movzbq  0(%rsi,%r9,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movb    %sil, 4096(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movzbq  4096(%rsi,%r10,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movzbq  4096(%rdi,%r10,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %rdi
+;;   addq    %rdi, const(0), %rdi
+;;   movb    %sil, 0(%rdi,%r11,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movb    %sil, 0(%rax,%r11,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -76,15 +76,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   addq    %rsi, const(0), %rsi
+;;   movzbq  0(%rsi,%r11,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movzbq  0(%rdi,%r11,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movl    %esi, 0(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movl    0(%rsi,%r10,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movl    0(%rdi,%r10,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movl    %esi, 4096(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movl    4096(%rsi,%r10,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movl    4096(%rdi,%r10,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %rdi
+;;   addq    %rdi, const(0), %rdi
+;;   movl    %esi, 0(%rdi,%r11,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movl    %esi, 0(%rax,%r11,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -76,15 +76,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   addq    %rsi, const(0), %rsi
+;;   movl    0(%rsi,%r11,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movl    0(%rdi,%r11,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -48,16 +48,16 @@
 ;;   movl    %edi, %r9d
 ;;   movq    8(%rdx), %r10
 ;;   cmpq    %r10, %r9
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movb    %sil, 0(%r11,%r9,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rdi
-;;   movb    %sil, 0(%rdi,%r9,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movl    %edi, %r9d
 ;;   movq    8(%rsi), %r10
 ;;   cmpq    %r10, %r9
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movzbq  0(%r11,%r9,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movzbq  0(%rsi,%r9,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -49,16 +49,16 @@
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rdi
 ;;   movb    %sil, 4096(%rdi,%r10,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -71,14 +71,14 @@
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   movzbq  4096(%rsi,%r10,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   movzbq  4096(%rdi,%r10,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -51,17 +51,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %rdi
+;;   addq    %rdi, const(0), %rdi
+;;   movb    %sil, 0(%rdi,%r11,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movb    %sil, 0(%rax,%r11,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -76,15 +76,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %rax
 ;;   cmpq    %rax, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %rsi
+;;   addq    %rsi, const(0), %rsi
+;;   movzbq  0(%rsi,%r11,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movzbq  0(%rdi,%r11,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 0(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movl    %esi, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movl    0(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movl    0(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4100, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 4096(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movl    %esi, 4096(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4100, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movl    4096(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movl    4096(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -50,17 +50,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rax
 ;;   addq    %rax, const(0), %rax
 ;;   movl    %esi, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -74,15 +74,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   addq    %r11, const(0), %r11
+;;   movl    0(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movl    0(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -47,16 +47,16 @@
 ;; block0:
 ;;   movq    8(%rdx), %r8
 ;;   cmpq    %r8, %rdi
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movb    %sil, 0(%r10,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movb    %sil, 0(%r11,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;; block0:
 ;;   movq    8(%rsi), %r8
 ;;   cmpq    %r8, %rdi
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movzbq  0(%r10,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movzbq  0(%r11,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4097, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movb    %sil, 4096(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movb    %sil, 4096(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4097, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movzbq  4096(%r11,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movzbq  4096(%rsi,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -50,17 +50,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rax
 ;;   addq    %rax, const(0), %rax
 ;;   movb    %sil, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -74,15 +74,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   addq    %r11, const(0), %r11
+;;   movzbq  0(%r11,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movzbq  0(%rsi,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 0(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movl    %esi, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movl    0(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movl    0(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4100, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 4096(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movl    %esi, 4096(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4100, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movl    4096(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movl    4096(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -50,17 +50,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rax
 ;;   addq    %rax, const(0), %rax
 ;;   movl    %esi, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -74,15 +74,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   addq    %r11, const(0), %r11
+;;   movl    0(%r11,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movl    0(%rsi,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -47,16 +47,16 @@
 ;; block0:
 ;;   movq    8(%rdx), %r8
 ;;   cmpq    %r8, %rdi
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movb    %sil, 0(%r10,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movb    %sil, 0(%r11,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -67,14 +67,14 @@
 ;; block0:
 ;;   movq    8(%rsi), %r8
 ;;   cmpq    %r8, %rdi
-;;   jnb     label1; j label2
+;;   jnb     label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movzbq  0(%r10,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movzbq  0(%r11,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,16 +48,16 @@
 ;;   movabsq $-4097, %r9
 ;;   addq    %r9, 8(%rdx), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r11
+;;   movb    %sil, 4096(%r11,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %rax
-;;   movb    %sil, 4096(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -69,14 +69,14 @@
 ;;   movabsq $-4097, %r9
 ;;   addq    %r9, 8(%rsi), %r9
 ;;   cmpq    %r9, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   movzbq  4096(%r11,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   movzbq  4096(%rsi,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -50,17 +50,17 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
-;; block2:
+;;   jnbe    label3; j label1
+;; block1:
 ;;   movq    0(%rdx), %rax
 ;;   addq    %rax, const(0), %rax
 ;;   movb    %sil, 0(%rax,%rdi,1)
-;;   jmp     label3
-;; block3:
+;;   jmp     label2
+;; block2:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -74,15 +74,15 @@
 ;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r11
+;;   addq    %r11, const(0), %r11
+;;   movzbq  0(%r11,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movzbq  0(%rsi,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -45,16 +45,16 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268435452, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movl    %esi, 0(%r10,%r8,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movl    %esi, 0(%r11,%r8,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268435452, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movl    0(%r10,%r8,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movl    0(%r11,%r8,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,16 +45,16 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268431356, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movl    %esi, 4096(%r10,%r8,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movl    %esi, 4096(%r11,%r8,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268431356, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movl    4096(%r10,%r8,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movl    4096(%r11,%r8,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -45,16 +45,16 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268435455, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movb    %sil, 0(%r10,%r8,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movb    %sil, 0(%r11,%r8,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268435455, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movzbq  0(%r10,%r8,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movzbq  0(%r11,%r8,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,16 +45,16 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268431359, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r10
+;;   movb    %sil, 4096(%r10,%r8,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r11
-;;   movb    %sil, 4096(%r11,%r8,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -65,14 +65,14 @@
 ;; block0:
 ;;   movl    %edi, %r8d
 ;;   cmpq    $268431359, %r8
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r10
+;;   movzbq  4096(%r10,%r8,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r11
-;;   movzbq  4096(%r11,%r8,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435452, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movl    %esi, 0(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movl    %esi, 0(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435452, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movl    0(%r9,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movl    0(%r10,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431356, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movl    %esi, 4096(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movl    %esi, 4096(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431356, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movl    4096(%r9,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movl    4096(%r10,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435455, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movb    %sil, 0(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movb    %sil, 0(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435455, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movzbq  0(%r9,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movzbq  0(%r10,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431359, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movb    %sil, 4096(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movb    %sil, 4096(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431359, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movzbq  4096(%r9,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movzbq  4096(%r10,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435452, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movl    %esi, 0(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movl    %esi, 0(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435452, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movl    0(%r9,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movl    0(%r10,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431356, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movl    %esi, 4096(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movl    %esi, 4096(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431356, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movl    4096(%r9,%rdi,1), %eax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movl    4096(%r10,%rdi,1), %eax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435455, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movb    %sil, 0(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movb    %sil, 0(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268435455, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movzbq  0(%r9,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movzbq  0(%r10,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,16 +44,16 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431359, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rdx), %r9
+;;   movb    %sil, 4096(%r9,%rdi,1)
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rdx), %r10
-;;   movb    %sil, 4096(%r10,%rdi,1)
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob
 ;;
 ;; function u0:1:
@@ -63,14 +63,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   cmpq    $268431359, %rdi
-;;   jnbe    label1; j label2
+;;   jnbe    label3; j label1
+;; block1:
+;;   movq    0(%rsi), %r9
+;;   movzbq  4096(%r9,%rdi,1), %rax
+;;   jmp     label2
 ;; block2:
-;;   movq    0(%rsi), %r10
-;;   movzbq  4096(%r10,%rdi,1), %rax
-;;   jmp     label3
-;; block3:
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
-;; block1:
+;; block3:
 ;;   ud2 heap_oob


### PR DESCRIPTION
Rework `BlockLoweringOrder` construction to use the postorder traversal created by the `DominatorTree`. Additionally, construct fewer critical edge splits by identifying edges up-front that will need splitting, and otherwise allowing regalloc2 to place moves on either the entry or exit edges of a block. Identifying critical edges up-front often yields fewer critical edge splits than the previous algorithm, leading to lowering orders with fewer blocks overall. This change leads to small but measurable improvements in sightglass benchmarks for compilation on both `bz2` and `spidermonkey` wasm.

The meat of this change is in the first commit, which both changes the block lowering order implementation and propagates a heuristic from the old implementation's postorder construction to the DominatorTree's implementation. This heuristic (reversing the children before pushing them on the work stack) is responsible for much of the test change fallout in this PR, but is important in that without it the new lowering order sees significantly more cache misses on the bz2 benchmark.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
