### PR TITLE
Only emit ISLE/egraph terms for single-value insts

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -1405,7 +1405,9 @@ fn gen_common_isle(
         IsleTarget::Opt => "Value",
     };
     for inst in instructions {
-        if isle_target == IsleTarget::Opt && inst.format.has_value_list {
+        if isle_target == IsleTarget::Opt
+            && (inst.format.has_value_list || inst.value_results.len() != 1)
+        {
             continue;
         }
 


### PR DESCRIPTION
For instructions with no results (such as branches and stores) or instructions with multiple results (such as add with carry), we have assertions checking that an optimization rule doesn't try to match on or construct such instructions.

When we generate terms for matching or constructing instructions, the terms for these instructions are guaranteed to panic if they're ever used. So let's just not generate them.

In the future we may wish to generate terms with different types for these instructions, to make them usable in ISLE rules for optimization that fall outside our current egraph constraints.