### PR TITLE
Have StoreContext::data return &'a T

### DIFF
--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -980,7 +980,7 @@ impl<'a, T> StoreContext<'a, T> {
     /// Access the underlying data owned by this `Store`.
     ///
     /// Same as [`Store::data`].
-    pub fn data(&self) -> &T {
+    pub fn data(&self) -> &'a T {
         self.0.data()
     }
 

--- a/crates/wasmtime/src/store/context.rs
+++ b/crates/wasmtime/src/store/context.rs
@@ -161,6 +161,13 @@ impl<T> AsContextMut for StoreContextMut<'_, T> {
     }
 }
 
+impl<'a, T> From<StoreContextMut<'a, T>> for StoreContext<'a, T> {
+    #[inline]
+    fn from(store: StoreContextMut<'a, T>) -> StoreContext<'a, T> {
+        StoreContext(store.0)
+    }
+}
+
 // Implementations for internal consumers, but these aren't public types so
 // they're not publicly accessible for crate consumers.
 impl<T> AsContext for &'_ StoreInner<T> {


### PR DESCRIPTION
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->

I ran into a case where because `Memory::data_and_store_mut` returns a `&'a mut T`, I was expecting `StoreContext::data` to return a `&'a T`, but that wasn't the case despite it being perfectly sound for it to do so. (was trying to make a `data_and_store(impl Into<StoreContext<'a, T>>) -> (&'a [u8], &'a T)` convenience function in my project but it failed to compile for the aforementioned reason)

Also added a `StoreContext: From<StoreContextMut>` impl, which would probably be useful for something in context/data/memory juggling even if I can't think of what specifically off the top of my head.
