### PR TITLE
cranelift: Add atomic_rmw to interpreter (#5817)

### DIFF
--- a/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target s390x
 target s390x has_mie2
@@ -116,11 +117,11 @@ block0(v0: i32, v1: i32):
     return v4
 }
 
-; run: %atomic_rmw_and_i64(0, 0) == 0
-; run: %atomic_rmw_and_i64(1, 0) == 0
-; run: %atomic_rmw_and_i64(0, 1) == 0
-; run: %atomic_rmw_and_i64(1, 1) == 1
-; run: %atomic_rmw_and_i64(0xF1FFFEFE, 0xCEFFEFEF) == 0xC0FFEEEE
+; run: %atomic_rmw_and_i32(0, 0) == 0
+; run: %atomic_rmw_and_i32(1, 0) == 0
+; run: %atomic_rmw_and_i32(0, 1) == 0
+; run: %atomic_rmw_and_i32(1, 1) == 1
+; run: %atomic_rmw_and_i32(0xF1FFFEFE, 0xCEFFEFEF) == 0xC0FFEEEE
 
 
 


### PR DESCRIPTION
This PR adds the `atomic_rmw` implementation to the interpreter in accordance with issue #5817 and ensures that the relevant filetest passes.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ x] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ x] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ x] This PR contains test cases, if meaningful.
- [x ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
