### PR TITLE
s390x: Fix implementation of {s,u}{min,max}

### DIFF
--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -239,9 +239,19 @@
 ;;;; Rules for `umax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Unsigned maximum of two scalar integers - expand to icmp + select.
-(rule 1 (lower (has_type (ty_int ty) (umax x y)))
-      (let ((cond ProducesBool (icmp_val $false (IntCC.UnsignedLessThan) x y)))
-        (select_bool_reg ty cond y x)))
+(rule 2 (lower (has_type (fits_in_64 ty) (umax x y)))
+      (let ((x_ext Reg (put_in_reg_zext32 x))
+            (y_ext Reg (put_in_reg_zext32 y))
+            (cond ProducesBool (bool (icmpu_reg (ty_ext32 ty) x_ext y_ext)
+                                     (intcc_as_cond (IntCC.UnsignedLessThan)))))
+        (select_bool_reg ty cond y_ext x_ext)))
+
+;; Unsigned maximum of two 128-bit integers - expand to icmp + select.
+(rule 1 (lower (has_type $I128 (umax x y)))
+      (let ((x_reg Reg (put_in_reg x))
+            (y_reg Reg (put_in_reg y))
+            (cond ProducesBool (vec_int128_ucmphi y_reg x_reg)))
+        (select_bool_reg $I128 cond y_reg x_reg)))
 
 ;; Unsigned maximum of two vector registers.
 (rule 0 (lower (has_type (ty_vec128 ty) (umax x y)))
@@ -251,9 +261,19 @@
 ;;;; Rules for `umin` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Unsigned minimum of two scalar integers - expand to icmp + select.
-(rule 1 (lower (has_type (ty_int ty) (umin x y)))
-      (let ((cond ProducesBool (icmp_val $false (IntCC.UnsignedGreaterThan) x y)))
-        (select_bool_reg ty cond y x)))
+(rule 2 (lower (has_type (fits_in_64 ty) (umin x y)))
+      (let ((x_ext Reg (put_in_reg_zext32 x))
+            (y_ext Reg (put_in_reg_zext32 y))
+            (cond ProducesBool (bool (icmpu_reg (ty_ext32 ty) x_ext y_ext)
+                                     (intcc_as_cond (IntCC.UnsignedGreaterThan)))))
+        (select_bool_reg ty cond y_ext x_ext)))
+
+;; Unsigned maximum of two 128-bit integers - expand to icmp + select.
+(rule 1 (lower (has_type $I128 (umin x y)))
+      (let ((x_reg Reg (put_in_reg x))
+            (y_reg Reg (put_in_reg y))
+            (cond ProducesBool (vec_int128_ucmphi x_reg y_reg)))
+        (select_bool_reg $I128 cond y_reg x_reg)))
 
 ;; Unsigned minimum of two vector registers.
 (rule 0 (lower (has_type (ty_vec128 ty) (umin x y)))
@@ -263,9 +283,19 @@
 ;;;; Rules for `smax` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Signed maximum of two scalar integers - expand to icmp + select.
-(rule 1 (lower (has_type (ty_int ty) (smax x y)))
-      (let ((cond ProducesBool (icmp_val $false (IntCC.SignedLessThan) x y)))
-        (select_bool_reg ty cond y x)))
+(rule 2 (lower (has_type (fits_in_64 ty) (smax x y)))
+      (let ((x_ext Reg (put_in_reg_sext32 x))
+            (y_ext Reg (put_in_reg_sext32 y))
+            (cond ProducesBool (bool (icmps_reg (ty_ext32 ty) x_ext y_ext)
+                                     (intcc_as_cond (IntCC.SignedLessThan)))))
+        (select_bool_reg ty cond y_ext x_ext)))
+
+;; Signed maximum of two 128-bit integers - expand to icmp + select.
+(rule 1 (lower (has_type $I128 (smax x y)))
+      (let ((x_reg Reg (put_in_reg x))
+            (y_reg Reg (put_in_reg y))
+            (cond ProducesBool (vec_int128_scmphi y_reg x_reg)))
+        (select_bool_reg $I128 cond y_reg x_reg)))
 
 ;; Signed maximum of two vector registers.
 (rule (lower (has_type (ty_vec128 ty) (smax x y)))
@@ -275,9 +305,19 @@
 ;;;; Rules for `smin` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Signed minimum of two scalar integers - expand to icmp + select.
-(rule 1 (lower (has_type (ty_int ty) (smin x y)))
-      (let ((cond ProducesBool (icmp_val $false (IntCC.SignedGreaterThan) x y)))
-        (select_bool_reg ty cond y x)))
+(rule 2 (lower (has_type (fits_in_64 ty) (smin x y)))
+      (let ((x_ext Reg (put_in_reg_sext32 x))
+            (y_ext Reg (put_in_reg_sext32 y))
+            (cond ProducesBool (bool (icmps_reg (ty_ext32 ty) x_ext y_ext)
+                                     (intcc_as_cond (IntCC.SignedGreaterThan)))))
+        (select_bool_reg ty cond y_ext x_ext)))
+
+;; Signed maximum of two 128-bit integers - expand to icmp + select.
+(rule 1 (lower (has_type $I128 (smin x y)))
+      (let ((x_reg Reg (put_in_reg x))
+            (y_reg Reg (put_in_reg y))
+            (cond ProducesBool (vec_int128_scmphi x_reg y_reg)))
+        (select_bool_reg $I128 cond y_reg x_reg)))
 
 ;; Signed minimum of two vector registers.
 (rule (lower (has_type (ty_vec128 ty) (smin x y)))

--- a/cranelift/filetests/filetests/isa/s390x/minmax.clif
+++ b/cranelift/filetests/filetests/isa/s390x/minmax.clif
@@ -72,17 +72,17 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   llhr %r5, %r2
-;   llhr %r4, %r3
-;   clr %r5, %r4
+;   llhr %r2, %r2
+;   llhr %r3, %r3
+;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   llhr %r5, %r2
-;   llhr %r4, %r3
-;   clr %r5, %r4
+;   llhr %r2, %r2
+;   llhr %r3, %r3
+;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 
@@ -94,17 +94,17 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   llcr %r5, %r2
-;   llcr %r4, %r3
-;   clr %r5, %r4
+;   llcr %r2, %r2
+;   llcr %r3, %r3
+;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   llcr %r5, %r2
-;   llcr %r4, %r3
-;   clr %r5, %r4
+;   llcr %r2, %r2
+;   llcr %r3, %r3
+;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 
@@ -179,17 +179,17 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   llhr %r5, %r2
-;   llhr %r4, %r3
-;   clr %r5, %r4
+;   llhr %r2, %r2
+;   llhr %r3, %r3
+;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   llhr %r5, %r2
-;   llhr %r4, %r3
-;   clr %r5, %r4
+;   llhr %r2, %r2
+;   llhr %r3, %r3
+;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 
@@ -201,17 +201,17 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   llcr %r5, %r2
-;   llcr %r4, %r3
-;   clr %r5, %r4
+;   llcr %r2, %r2
+;   llcr %r3, %r3
+;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   llcr %r5, %r2
-;   llcr %r4, %r3
-;   clr %r5, %r4
+;   llcr %r2, %r2
+;   llcr %r3, %r3
+;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 
@@ -286,17 +286,17 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   lhr %r5, %r2
-;   lhr %r4, %r3
-;   cr %r5, %r4
+;   lhr %r2, %r2
+;   lhr %r3, %r3
+;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lhr %r5, %r2
-;   lhr %r4, %r3
-;   cr %r5, %r4
+;   lhr %r2, %r2
+;   lhr %r3, %r3
+;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 
@@ -308,17 +308,17 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   lbr %r5, %r2
-;   lbr %r4, %r3
-;   cr %r5, %r4
+;   lbr %r2, %r2
+;   lbr %r3, %r3
+;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lbr %r5, %r2
-;   lbr %r4, %r3
-;   cr %r5, %r4
+;   lbr %r2, %r2
+;   lbr %r3, %r3
+;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
 
@@ -393,17 +393,17 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   lhr %r5, %r2
-;   lhr %r4, %r3
-;   cr %r5, %r4
+;   lhr %r2, %r2
+;   lhr %r3, %r3
+;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lhr %r5, %r2
-;   lhr %r4, %r3
-;   cr %r5, %r4
+;   lhr %r2, %r2
+;   lhr %r3, %r3
+;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 
@@ -415,17 +415,17 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   lbr %r5, %r2
-;   lbr %r4, %r3
-;   cr %r5, %r4
+;   lbr %r2, %r2
+;   lbr %r3, %r3
+;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lbr %r5, %r2
-;   lbr %r4, %r3
-;   cr %r5, %r4
+;   lbr %r2, %r2
+;   lbr %r3, %r3
+;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
 


### PR DESCRIPTION
When expanding a min/max operation to a pair of icmp + select, do not attempt to expand the input value operands twice, as this might fail with memory operands.

Fixes https://github.com/bytecodealliance/wasmtime/issues/5859.

CC @afonso360 @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
