### PR TITLE
s390x: Fix integer overflow during negation

### DIFF
--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -628,21 +628,21 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     #[inline]
     fn i64_from_negated_value(&mut self, val: Value) -> Option<i64> {
         let constant = self.u64_from_signed_value(val)? as i64;
-        let imm = -constant;
+        let imm = constant.wrapping_neg();
         Some(imm)
     }
 
     #[inline]
     fn i32_from_negated_value(&mut self, val: Value) -> Option<i32> {
         let constant = self.u64_from_signed_value(val)? as i64;
-        let imm = i32::try_from(-constant).ok()?;
+        let imm = i32::try_from(constant.wrapping_neg()).ok()?;
         Some(imm)
     }
 
     #[inline]
     fn i16_from_negated_value(&mut self, val: Value) -> Option<i16> {
         let constant = self.u64_from_signed_value(val)? as i64;
-        let imm = i16::try_from(-constant).ok()?;
+        let imm = i16::try_from(constant.wrapping_neg()).ok()?;
         Some(imm)
     }
 


### PR DESCRIPTION
Use wrapping_neg in i{64,32,16}_from_negated_value to avoid Rust aborts due to integer overflow.  The resulting INT_MIN is already handled correctly in subsequent operations.

Fixes https://github.com/bytecodealliance/wasmtime/issues/5863.

CC @afonso360 @cfallin 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
