### PR TITLE
Fix a panic due to a race in unpark and park

### DIFF
--- a/crates/runtime/src/parking_spot.rs
+++ b/crates/runtime/src/parking_spot.rs
@@ -119,7 +119,7 @@ impl ParkingSpot {
                 // agents as returned from the `unpark` return value.
                 //
                 // Note that this may actually prevent other threads from
-                // getting unaprked. For example:
+                // getting unparked. For example:
                 //
                 // * Thread A parks with a timeout
                 // * Thread B parks with no timeout


### PR DESCRIPTION
This commit fixes a panic in the `ParkingSpot` implementation where an
`unpark` signal may not get acknowledged when a waiter times out,
causing the waiter to remove itself from the internal map but panic
thinking that it missed an unpark signal.

The fix in this commit is to consume unpark signals when a timeout
happens. This can lead to another possible race I've detailed in the
comments which I believe is allowed by the specification of park/unpark
in wasm.