### PR TITLE
Test all backends when a runtest is modified

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -97,6 +97,13 @@ function myFilter(item) {
   if (item.filter && commits.includes(`prtest:${item.filter}`)) {
     return true;
   }
+
+  // If any runtest was modified, re-run the whole test suite as those can
+  // target any backend.
+  if (names.includes(`cranelift/filetests/filetests/runtests`)) {
+    return true;
+  }
+
   return false;
 }
 

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -6,8 +6,6 @@ set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target riscv64
 
-; add a comment for testing
-
 
 function %smulhi_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -6,6 +6,8 @@ set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target riscv64
 
+; add a comment for testing
+
 
 function %smulhi_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):


### PR DESCRIPTION
As any backend can be affected by modifying runtests, test all backends when one of them is modified.

I tested this by making a change to a runtest file and reverting it, to verify that all backends were tested when that file was changed.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
