### PR TITLE
riscv64: Move `is_null`/`is_invalid` to ISLE

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -205,11 +205,6 @@
       (x ValueRegs)
       (y ValueRegs))
 
-    (ReferenceCheck
-      (rd WritableReg)
-      (op ReferenceCheckOP)
-      (x Reg))
-
     (BrTable
       (index Reg)
       (tmp1 WritableReg)
@@ -368,11 +363,6 @@
   (Umax)
   (Smin)
   (Umin)
-))
-
-(type ReferenceCheckOP (enum
-  (IsNull)
-  (IsInvalid)
 ))
 
 (type AtomicOP (enum
@@ -877,6 +867,17 @@
 (decl select_addi (Type) AluOPRRI)
 (rule 1 (select_addi (fits_in_32 ty)) (AluOPRRI.Addiw))
 (rule (select_addi (fits_in_64 ty)) (AluOPRRI.Addi))
+
+
+;; Helper for emiting the `sltiu` instruction
+(decl sltiu (Reg Imm12) Reg)
+(rule (sltiu r imm)
+  (alu_rr_imm12 (AluOPRRI.SltiU) r imm))
+
+;; Helper for emiting the `seqz` mnemonic
+(decl seqz (Reg) Reg)
+(rule (seqz r)
+  (sltiu r (imm12_const 1)))
 
 
 (decl bnot_128 (ValueRegs) ValueRegs)
@@ -1699,14 +1700,6 @@
 (decl gen_moves (ValueRegs Type Type) ValueRegs)
 (extern constructor gen_moves gen_moves)
 
-;;
-(decl gen_reference_check (ReferenceCheckOP Reg) Reg)
-(rule
-  (gen_reference_check op r)
-  (let
-    ((tmp WritableReg (temp_writable_reg $I64))
-      (_ Unit (emit (MInst.ReferenceCheck tmp op r))))
-    tmp))
 
 ;;
 (decl gen_select (Type Reg ValueRegs ValueRegs) ValueRegs)

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1639,23 +1639,6 @@ impl IntSelectOP {
     }
 }
 
-impl ReferenceCheckOP {
-    pub(crate) fn op_name(self) -> &'static str {
-        match self {
-            ReferenceCheckOP::IsNull => "is_null",
-            ReferenceCheckOP::IsInvalid => "is_invalid",
-        }
-    }
-    #[inline]
-    pub(crate) fn from_ir_op(op: crate::ir::Opcode) -> Self {
-        match op {
-            crate::ir::Opcode::IsInvalid => Self::IsInvalid,
-            crate::ir::Opcode::IsNull => Self::IsNull,
-            _ => unreachable!(),
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 pub enum CsrAddress {
     Fcsr = 0x3,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -680,57 +680,6 @@ impl MachInstEmit for Inst {
                         .for_each(|inst| inst.emit(&[], sink, emit_info, state));
                 }
             }
-
-            &Inst::ReferenceCheck { rd, op, x } => {
-                let x = allocs.next(x);
-                let rd = allocs.next_writable(rd);
-                let mut insts = SmallInstVec::new();
-                match op {
-                    ReferenceCheckOP::IsNull => {
-                        insts.push(Inst::CondBr {
-                            taken: BranchTarget::ResolvedOffset(Inst::INSTRUCTION_SIZE * 3),
-                            not_taken: BranchTarget::zero(),
-                            kind: IntegerCompare {
-                                kind: IntCC::Equal,
-                                rs1: zero_reg(),
-                                rs2: x,
-                            },
-                        });
-                        // here is false
-                        insts.push(Inst::load_imm12(rd, Imm12::FALSE));
-                        insts.push(Inst::Jal {
-                            dest: BranchTarget::ResolvedOffset(Inst::INSTRUCTION_SIZE * 2),
-                        });
-                        // here is true
-                        insts.push(Inst::load_imm12(rd, Imm12::TRUE));
-                    }
-
-                    ReferenceCheckOP::IsInvalid => {
-                        // todo:: right now just check if it is null
-                        // null is a valid reference??????
-                        insts.push(Inst::CondBr {
-                            taken: BranchTarget::ResolvedOffset(Inst::INSTRUCTION_SIZE * 3),
-                            not_taken: BranchTarget::zero(),
-                            kind: IntegerCompare {
-                                kind: IntCC::Equal,
-                                rs1: zero_reg(),
-                                rs2: x,
-                            },
-                        });
-                        // here is false
-                        insts.push(Inst::load_imm12(rd, Imm12::FALSE));
-                        insts.push(Inst::Jal {
-                            dest: BranchTarget::ResolvedOffset(Inst::INSTRUCTION_SIZE * 2),
-                        });
-                        // here is true
-                        insts.push(Inst::load_imm12(rd, Imm12::TRUE));
-                    }
-                }
-
-                insts
-                    .into_iter()
-                    .for_each(|i| i.emit(&[], sink, emit_info, state));
-            }
             &Inst::Args { .. } => {
                 // Nothing: this is a pseudoinstruction that serves
                 // only to constrain registers at a certain point.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -612,13 +612,17 @@
   (gen_stack_addr ss offset))
 
 ;;;;;  Rules for `is_null`;;;;;;;;;
+
+;; Null references are represented by the constant value `0`.
 (rule (lower (is_null v))
   (seqz v))
 
 ;;;;;  Rules for `is_invalid`;;;;;;;;;
-;; TODO: Is `is_invalid` the same as `is_null`?
+
+;; Invalid references are represented by the constant value `-1`.
 (rule (lower (is_invalid v))
-  (seqz v))
+  (let ((v Reg (alu_rr_imm12 (AluOPRRI.Addi) v (imm12_const 1))))
+    (seqz v)))
 
 ;;;;;  Rules for `select`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -612,14 +612,13 @@
   (gen_stack_addr ss offset))
 
 ;;;;;  Rules for `is_null`;;;;;;;;;
-(rule
-  (lower (is_null v))
-  (gen_reference_check (ReferenceCheckOP.IsNull) v))
+(rule (lower (is_null v))
+  (seqz v))
 
 ;;;;;  Rules for `is_invalid`;;;;;;;;;
-(rule
-  (lower (is_invalid v))
-  (gen_reference_check (ReferenceCheckOP.IsInvalid) v))
+;; TODO: Is `is_invalid` the same as `is_null`?
+(rule (lower (is_invalid v))
+  (seqz v))
 
 ;;;;;  Rules for `select`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -621,8 +621,7 @@
 
 ;; Invalid references are represented by the constant value `-1`.
 (rule (lower (is_invalid v))
-  (let ((v Reg (alu_rr_imm12 (AluOPRRI.Addi) v (imm12_const 1))))
-    (seqz v)))
+  (seqz (alu_rr_imm12 (AluOPRRI.Addi) v (imm12_const 1))))
 
 ;;;;;  Rules for `select`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -452,7 +452,7 @@ fn construct_dest<F: std::ops::FnMut(Type) -> WritableReg>(
     mut alloc: F,
     ty: Type,
 ) -> WritableValueRegs {
-    if ty.is_int() {
+    if ty.is_int() || ty.is_ref() {
         if ty.bits() == 128 {
             WritableValueRegs::two(alloc(I64), alloc(I64))
         } else {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2025,7 +2025,7 @@
 
 ;; Rules for `is_invalid` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Null references are represented by the constant value `-1`.
+;; Invalid references are represented by the constant value `-1`.
 (rule (lower (is_invalid src @ (value_type $R64)))
       (with_flags
        (x64_cmp_imm (OperandSize.Size64) 0xffffffff src)  ;; simm32 0xffff_ffff is sign-extended to -1.

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -39,12 +39,14 @@ block0(v0: r64):
 
 ; VCode:
 ; block0:
-;   seqz a0,a0
+;   addi t2,a0,1
+;   seqz a0,t2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   seqz a0, a0
+;   addi t2, a0, 1
+;   seqz a0, t2
 ;   ret
 
 function %f3() -> r64 {

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -23,15 +23,12 @@ block0(v0: r64):
 
 ; VCode:
 ; block0:
-;   is_null a0,a0
+;   seqz a0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   beq zero, a0, 0xc
-;   mv a0, zero
-;   j 8
-;   addi a0, zero, 1
+;   seqz a0, a0
 ;   ret
 
 function %f2(r64) -> i8 {
@@ -42,15 +39,12 @@ block0(v0: r64):
 
 ; VCode:
 ; block0:
-;   is_invalid a0,a0
+;   seqz a0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   beq zero, a0, 0xc
-;   mv a0, zero
-;   j 8
-;   addi a0, zero, 1
+;   seqz a0, a0
 ;   ret
 
 function %f3() -> r64 {

--- a/cranelift/filetests/filetests/runtests/bitcast-ref64.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast-ref64.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target x86_64
 target s390x
+target riscv64gc
 ; the interpreter does not support bitcasting to/from references
 
 function %bitcast_ir64(i64) -> i8 {

--- a/cranelift/filetests/filetests/runtests/ref64-invalid-null.clif
+++ b/cranelift/filetests/filetests/runtests/ref64-invalid-null.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target s390x
+target riscv64gc
 
 function %is_null_true_r64() -> i8 {
 block0:


### PR DESCRIPTION
👋 Hey,

Small PR moving `is_null`/`is_invalid` to ISLE. It also removes a few branches from the generated code.

It also fixes `is_invalid` which was slightly broken.