### PR TITLE
cranelift-interpreter: Implement `call_indirect` and `return_call_indirect`

### DIFF
--- a/cranelift/filetests/filetests/runtests/call_indirect.clif
+++ b/cranelift/filetests/filetests/runtests/call_indirect.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
+target riscv64gc
 
 
 function %callee_indirect(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/call_indirect.clif
+++ b/cranelift/filetests/filetests/runtests/call_indirect.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target x86_64
 target aarch64

--- a/cranelift/filetests/filetests/runtests/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-indirect.clif
@@ -1,0 +1,76 @@
+test interpret
+;; test run
+;; target x86_64
+;; target aarch64
+;; target aarch64 sign_return_address
+;; target aarch64 has_pauth sign_return_address
+;; target s390x
+
+;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i64(i64) -> i64 tail {
+block0(v0: i64):
+    v1 = iadd_imm.i64 v0, 10
+    return v1
+}
+
+function %call_i64(i64) -> i64 tail {
+    fn0 = %callee_i64(i64) -> i64 tail
+    ; sig0 = (i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+; run: %call_i64(10) == 20
+
+;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %colocated_i64(i64) -> i64 tail {
+    fn0 = colocated %callee_i64(i64) -> i64 tail
+    ; sig0 = (i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+; run: %colocated_i64(10) == 20
+
+;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_f64(f64) -> f64 tail {
+block0(v0: f64):
+    v1 = f64const 0x10.0
+    v2 = fadd.f64 v0, v1
+    return v2
+}
+
+function %call_f64(f64) -> f64 tail {
+    fn0 = %callee_f64(f64) -> f64 tail
+    ; sig0 = (f64) -> f64 tail
+
+block0(v0: f64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+; run: %call_f64(0x10.0) == 0x20.0
+
+;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i8(i8) -> i8 tail {
+block0(v0: i8):
+    v1 = iconst.i8 0
+    v2 = icmp eq v0, v1
+    return v2
+}
+
+function %call_i8(i8) -> i8 tail {
+    fn0 = %callee_i8(i8) -> i8 tail
+    ; sig0 = (i8) -> i8 tail
+
+block0(v0: i8):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+; run: %call_i8(1) == 0
+; run: %call_i8(0) == 1

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -6,7 +6,7 @@ use crate::address::{Address, AddressFunctionEntry, AddressRegion, AddressSize};
 use crate::environment::{FuncIndex, FunctionStore};
 use crate::frame::Frame;
 use crate::instruction::DfgInstructionContext;
-use crate::state::{InterperterFunctionRef, MemoryError, State};
+use crate::state::{InterpreterFunctionRef, MemoryError, State};
 use crate::step::{step, ControlFlow, StepError};
 use crate::value::{Value, ValueError};
 use cranelift_codegen::data_value::DataValue;
@@ -384,7 +384,7 @@ impl<'a> State<'a, DataValue> for InterpreterState<'a> {
         Address::from_parts(size, AddressRegion::Function, entry as u64, index as u64)
     }
 
-    fn get_function_from_address(&self, address: Address) -> Option<InterperterFunctionRef<'a>> {
+    fn get_function_from_address(&self, address: Address) -> Option<InterpreterFunctionRef<'a>> {
         let index = address.offset as u32;
         if address.region != AddressRegion::Function {
             return None;
@@ -394,12 +394,12 @@ impl<'a> State<'a, DataValue> for InterpreterState<'a> {
             AddressFunctionEntry::UserFunction => self
                 .functions
                 .get_by_index(FuncIndex::from_u32(index))
-                .map(InterperterFunctionRef::from),
+                .map(InterpreterFunctionRef::from),
 
             AddressFunctionEntry::LibCall => LibCall::all_libcalls()
                 .get(index as usize)
                 .copied()
-                .map(InterperterFunctionRef::from),
+                .map(InterpreterFunctionRef::from),
         }
     }
 

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -2,17 +2,17 @@
 //!
 //! This module partially contains the logic for interpreting Cranelift IR.
 
-use crate::address::{Address, AddressRegion, AddressSize};
+use crate::address::{Address, AddressFunctionEntry, AddressRegion, AddressSize};
 use crate::environment::{FuncIndex, FunctionStore};
 use crate::frame::Frame;
 use crate::instruction::DfgInstructionContext;
-use crate::state::{MemoryError, State};
+use crate::state::{InterperterFunctionRef, MemoryError, State};
 use crate::step::{step, ControlFlow, StepError};
 use crate::value::{Value, ValueError};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{
-    ArgumentPurpose, Block, FuncRef, Function, GlobalValue, GlobalValueData, LibCall, StackSlot,
-    TrapCode, Type, Value as ValueRef,
+    ArgumentPurpose, Block, ExternalName, FuncRef, Function, GlobalValue, GlobalValueData, LibCall,
+    StackSlot, TrapCode, Type, Value as ValueRef,
 };
 use log::trace;
 use smallvec::SmallVec;
@@ -344,6 +344,63 @@ impl<'a> State<'a, DataValue> for InterpreterState<'a> {
         };
 
         Ok(v.write_to_slice(dst))
+    }
+
+    fn function_address(
+        &self,
+        size: AddressSize,
+        name: &ExternalName,
+    ) -> Result<Address, MemoryError> {
+        let curr_func = self.get_current_function();
+        let (entry, index) = match name {
+            ExternalName::User(username) => {
+                let ext_name = &curr_func.params.user_named_funcs()[*username];
+
+                // TODO: This is not optimal since we are looking up by string name
+                let index = self.functions.index_of(&ext_name.to_string()).unwrap();
+
+                (AddressFunctionEntry::UserFunction, index.as_u32())
+            }
+
+            ExternalName::TestCase(testname) => {
+                // TODO: This is not optimal since we are looking up by string name
+                let index = self.functions.index_of(&testname.to_string()).unwrap();
+
+                (AddressFunctionEntry::UserFunction, index.as_u32())
+            }
+            ExternalName::LibCall(libcall) => {
+                // We don't properly have a "libcall" store, but we can use `LibCall::all()`
+                // and index into that.
+                let index = LibCall::all_libcalls()
+                    .iter()
+                    .position(|lc| lc == libcall)
+                    .unwrap();
+
+                (AddressFunctionEntry::LibCall, index as u32)
+            }
+            _ => unimplemented!("function_address: {:?}", name),
+        };
+
+        Address::from_parts(size, AddressRegion::Function, entry as u64, index as u64)
+    }
+
+    fn get_function_from_address(&self, address: Address) -> Option<InterperterFunctionRef<'a>> {
+        let index = address.offset as u32;
+        if address.region != AddressRegion::Function {
+            return None;
+        }
+
+        match AddressFunctionEntry::from(address.entry) {
+            AddressFunctionEntry::UserFunction => self
+                .functions
+                .get_by_index(FuncIndex::from_u32(index))
+                .map(InterperterFunctionRef::from),
+
+            AddressFunctionEntry::LibCall => LibCall::all_libcalls()
+                .get(index as usize)
+                .copied()
+                .map(InterperterFunctionRef::from),
+        }
     }
 
     /// Non-Recursively resolves a global value until its address is found

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -75,7 +75,7 @@ pub trait State<'a, V> {
     ) -> Result<Address, MemoryError>;
 
     /// Retrieve a reference to a [Function] given its address.
-    fn get_function_from_address(&self, address: Address) -> Option<InterperterFunctionRef<'a>>;
+    fn get_function_from_address(&self, address: Address) -> Option<InterpreterFunctionRef<'a>>;
 
     /// Given a global value, compute the final value for that global value, applying all operations
     /// in intermediate global values.
@@ -90,30 +90,30 @@ pub trait State<'a, V> {
     fn set_pinned_reg(&mut self, v: V);
 }
 
-pub enum InterperterFunctionRef<'a> {
+pub enum InterpreterFunctionRef<'a> {
     Function(&'a Function),
     LibCall(LibCall),
 }
 
-impl<'a> InterperterFunctionRef<'a> {
+impl<'a> InterpreterFunctionRef<'a> {
     pub fn signature(&self) -> Signature {
         match self {
-            InterperterFunctionRef::Function(f) => f.stencil.signature.clone(),
+            InterpreterFunctionRef::Function(f) => f.stencil.signature.clone(),
             // CallConv here is sort of irrelevant, since we don't use it for anything
-            InterperterFunctionRef::LibCall(lc) => lc.signature(CallConv::SystemV),
+            InterpreterFunctionRef::LibCall(lc) => lc.signature(CallConv::SystemV),
         }
     }
 }
 
-impl<'a> From<&'a Function> for InterperterFunctionRef<'a> {
+impl<'a> From<&'a Function> for InterpreterFunctionRef<'a> {
     fn from(f: &'a Function) -> Self {
-        InterperterFunctionRef::Function(f)
+        InterpreterFunctionRef::Function(f)
     }
 }
 
-impl From<LibCall> for InterperterFunctionRef<'_> {
+impl From<LibCall> for InterpreterFunctionRef<'_> {
     fn from(lc: LibCall) -> Self {
-        InterperterFunctionRef::LibCall(lc)
+        InterpreterFunctionRef::LibCall(lc)
     }
 }
 
@@ -198,7 +198,7 @@ where
         unimplemented!()
     }
 
-    fn get_function_from_address(&self, _address: Address) -> Option<InterperterFunctionRef<'a>> {
+    fn get_function_from_address(&self, _address: Address) -> Option<InterpreterFunctionRef<'a>> {
         unimplemented!()
     }
 

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -3,7 +3,10 @@
 use crate::address::{Address, AddressSize};
 use crate::interpreter::LibCallHandler;
 use cranelift_codegen::data_value::DataValue;
-use cranelift_codegen::ir::{FuncRef, Function, GlobalValue, StackSlot, Type, Value};
+use cranelift_codegen::ir::{
+    ExternalName, FuncRef, Function, GlobalValue, LibCall, Signature, StackSlot, Type, Value,
+};
+use cranelift_codegen::isa::CallConv;
 use cranelift_entity::PrimaryMap;
 use smallvec::SmallVec;
 use thiserror::Error;
@@ -64,6 +67,16 @@ pub trait State<'a, V> {
     /// stack or to one of the heaps; the number of bytes stored corresponds to the specified [Type].
     fn checked_store(&mut self, address: Address, v: V) -> Result<(), MemoryError>;
 
+    /// Compute the address of a function given its name.
+    fn function_address(
+        &self,
+        size: AddressSize,
+        name: &ExternalName,
+    ) -> Result<Address, MemoryError>;
+
+    /// Retrieve a reference to a [Function] given its address.
+    fn get_function_from_address(&self, address: Address) -> Option<InterperterFunctionRef<'a>>;
+
     /// Given a global value, compute the final value for that global value, applying all operations
     /// in intermediate global values.
     fn resolve_global_value(&self, gv: GlobalValue) -> Result<V, MemoryError>;
@@ -75,6 +88,33 @@ pub trait State<'a, V> {
     fn get_pinned_reg(&self) -> V;
     /// Sets a value for the pinned reg
     fn set_pinned_reg(&mut self, v: V);
+}
+
+pub enum InterperterFunctionRef<'a> {
+    Function(&'a Function),
+    LibCall(LibCall),
+}
+
+impl<'a> InterperterFunctionRef<'a> {
+    pub fn signature(&self) -> Signature {
+        match self {
+            InterperterFunctionRef::Function(f) => f.stencil.signature.clone(),
+            // CallConv here is sort of irrelevant, since we don't use it for anything
+            InterperterFunctionRef::LibCall(lc) => lc.signature(CallConv::SystemV),
+        }
+    }
+}
+
+impl<'a> From<&'a Function> for InterperterFunctionRef<'a> {
+    fn from(f: &'a Function) -> Self {
+        InterperterFunctionRef::Function(f)
+    }
+}
+
+impl From<LibCall> for InterperterFunctionRef<'_> {
+    fn from(lc: LibCall) -> Self {
+        InterperterFunctionRef::LibCall(lc)
+    }
 }
 
 #[derive(Error, Debug)]
@@ -147,6 +187,18 @@ where
     }
 
     fn checked_store(&mut self, _addr: Address, _v: V) -> Result<(), MemoryError> {
+        unimplemented!()
+    }
+
+    fn function_address(
+        &self,
+        _size: AddressSize,
+        _name: &ExternalName,
+    ) -> Result<Address, MemoryError> {
+        unimplemented!()
+    }
+
+    fn get_function_from_address(&self, _address: Address) -> Option<InterperterFunctionRef<'a>> {
         unimplemented!()
     }
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -2,7 +2,7 @@
 //! [InstructionContext]; the interpretation is generic over [Value]s.
 use crate::address::{Address, AddressSize};
 use crate::instruction::InstructionContext;
-use crate::state::{InterperterFunctionRef, MemoryError, State};
+use crate::state::{InterpreterFunctionRef, MemoryError, State};
 use crate::value::{Value, ValueConversionKind, ValueError, ValueResult};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
@@ -277,7 +277,7 @@ where
     };
 
     // Calls a function reference with the given arguments.
-    let call_func = |func_ref: InterperterFunctionRef<'a>,
+    let call_func = |func_ref: InterpreterFunctionRef<'a>,
                      args: SmallVec<[V; 1]>,
                      make_ctrl_flow: fn(&'a Function, SmallVec<[V; 1]>) -> ControlFlow<'a, V>|
      -> Result<ControlFlow<'a, V>, StepError> {
@@ -293,8 +293,8 @@ where
         }
 
         Ok(match func_ref {
-            InterperterFunctionRef::Function(func) => make_ctrl_flow(func, args),
-            InterperterFunctionRef::LibCall(libcall) => {
+            InterpreterFunctionRef::Function(func) => make_ctrl_flow(func, args),
+            InterpreterFunctionRef::LibCall(libcall) => {
                 debug_assert!(
                     !matches!(
                         inst.opcode(),
@@ -394,9 +394,9 @@ where
                     let function = state
                         .get_function(func_ref)
                         .ok_or(StepError::UnknownFunction(func_ref))?;
-                    InterperterFunctionRef::Function(function)
+                    InterpreterFunctionRef::Function(function)
                 }
-                ExternalName::LibCall(libcall) => InterperterFunctionRef::LibCall(libcall),
+                ExternalName::LibCall(libcall) => InterpreterFunctionRef::LibCall(libcall),
                 ExternalName::KnownSymbol(_) => unimplemented!(),
             };
 

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -2,7 +2,7 @@
 //! [InstructionContext]; the interpretation is generic over [Value]s.
 use crate::address::{Address, AddressSize};
 use crate::instruction::InstructionContext;
-use crate::state::{MemoryError, State};
+use crate::state::{InterperterFunctionRef, MemoryError, State};
 use crate::value::{Value, ValueConversionKind, ValueError, ValueResult};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
@@ -276,35 +276,12 @@ where
         }
     };
 
-    // Perform a call operation.
-    //
-    // The returned `ControlFlow` variant is determined by the given function
-    // argument, which should make either a `ControlFlow::Call` or a
-    // `ControlFlow::ReturnCall`.
-    let do_call = |make_ctrl_flow: fn(&'a Function, SmallVec<[V; 1]>) -> ControlFlow<'a, V>|
+    // Calls a function reference with the given arguments.
+    let call_func = |func_ref: InterperterFunctionRef<'a>,
+                     args: SmallVec<[V; 1]>,
+                     make_ctrl_flow: fn(&'a Function, SmallVec<[V; 1]>) -> ControlFlow<'a, V>|
      -> Result<ControlFlow<'a, V>, StepError> {
-        let func_ref = if let InstructionData::Call { func_ref, .. } = inst {
-            func_ref
-        } else {
-            unreachable!()
-        };
-
-        let curr_func = state.get_current_function();
-        let ext_data = curr_func
-            .dfg
-            .ext_funcs
-            .get(func_ref)
-            .ok_or(StepError::UnknownFunction(func_ref))?;
-
-        let signature = if let Some(sig) = curr_func.dfg.signatures.get(ext_data.signature) {
-            sig
-        } else {
-            return Ok(ControlFlow::Trap(CraneliftTrap::User(
-                TrapCode::BadSignature,
-            )));
-        };
-
-        let args = args()?;
+        let signature = func_ref.signature();
 
         // Check the types of the arguments. This is usually done by the verifier, but nothing
         // guarantees that the user has ran that.
@@ -315,17 +292,16 @@ where
             )));
         }
 
-        Ok(match ext_data.name {
-            // These functions should be registered in the regular function store
-            ExternalName::User(_) | ExternalName::TestCase(_) => {
-                let function = state
-                    .get_function(func_ref)
-                    .ok_or(StepError::UnknownFunction(func_ref))?;
-
-                make_ctrl_flow(function, args)
-            }
-            ExternalName::LibCall(libcall) => {
-                debug_assert_ne!(inst.opcode(), Opcode::ReturnCall, "Cannot tail call to libcalls");
+        Ok(match func_ref {
+            InterperterFunctionRef::Function(func) => make_ctrl_flow(func, args),
+            InterperterFunctionRef::LibCall(libcall) => {
+                debug_assert!(
+                    !matches!(
+                        inst.opcode(),
+                        Opcode::ReturnCall | Opcode::ReturnCallIndirect,
+                    ),
+                    "Cannot tail call to libcalls"
+                );
                 let libcall_handler = state.get_libcall_handler();
 
                 // We don't transfer control to a libcall, we just execute it and return the results
@@ -342,7 +318,6 @@ where
                     ControlFlow::Trap(CraneliftTrap::User(TrapCode::BadSignature))
                 }
             }
-            ExternalName::KnownSymbol(_) => unimplemented!(),
         })
     };
 
@@ -398,11 +373,83 @@ where
         Opcode::Trapnz => trap_when(arg(0)?.into_bool()?, CraneliftTrap::User(trap_code())),
         Opcode::ResumableTrapnz => trap_when(arg(0)?.into_bool()?, CraneliftTrap::Resumable),
         Opcode::Return => ControlFlow::Return(args()?),
-        Opcode::Call => do_call(ControlFlow::Call)?,
-        Opcode::CallIndirect => unimplemented!("CallIndirect"),
-        Opcode::ReturnCall => do_call(ControlFlow::ReturnCall)?,
-        Opcode::ReturnCallIndirect => unimplemented!("ReturnCallIndirect"),
-        Opcode::FuncAddr => unimplemented!("FuncAddr"),
+        Opcode::Call | Opcode::ReturnCall => {
+            let func_ref = if let InstructionData::Call { func_ref, .. } = inst {
+                func_ref
+            } else {
+                unreachable!()
+            };
+
+            let curr_func = state.get_current_function();
+            let ext_data = curr_func
+                .dfg
+                .ext_funcs
+                .get(func_ref)
+                .ok_or(StepError::UnknownFunction(func_ref))?;
+
+            let args = args()?;
+            let func = match ext_data.name {
+                // These functions should be registered in the regular function store
+                ExternalName::User(_) | ExternalName::TestCase(_) => {
+                    let function = state
+                        .get_function(func_ref)
+                        .ok_or(StepError::UnknownFunction(func_ref))?;
+                    InterperterFunctionRef::Function(function)
+                }
+                ExternalName::LibCall(libcall) => InterperterFunctionRef::LibCall(libcall),
+                ExternalName::KnownSymbol(_) => unimplemented!(),
+            };
+
+            let make_control_flow = match inst.opcode() {
+                Opcode::Call => ControlFlow::Call,
+                Opcode::ReturnCall => ControlFlow::ReturnCall,
+                _ => unreachable!(),
+            };
+
+            call_func(func, args, make_control_flow)?
+        }
+        Opcode::CallIndirect | Opcode::ReturnCallIndirect => {
+            let args = args()?;
+            let addr_dv = DataValue::U64(arg(0)?.into_int()? as u64);
+            let addr = Address::try_from(addr_dv.clone()).map_err(StepError::MemoryError)?;
+
+            let func = state
+                .get_function_from_address(addr)
+                .ok_or_else(|| StepError::MemoryError(MemoryError::InvalidAddress(addr_dv)))?;
+
+            let call_args: SmallVec<[V; 1]> = SmallVec::from(&args[1..]);
+
+            let make_control_flow = match inst.opcode() {
+                Opcode::CallIndirect => ControlFlow::Call,
+                Opcode::ReturnCallIndirect => ControlFlow::ReturnCall,
+                _ => unreachable!(),
+            };
+
+            call_func(func, call_args, make_control_flow)?
+        }
+        Opcode::FuncAddr => {
+            let func_ref = if let InstructionData::FuncAddr { func_ref, .. } = inst {
+                func_ref
+            } else {
+                unreachable!()
+            };
+
+            let ext_data = state
+                .get_current_function()
+                .dfg
+                .ext_funcs
+                .get(func_ref)
+                .ok_or(StepError::UnknownFunction(func_ref))?;
+
+            let addr_ty = inst_context.controlling_type().unwrap();
+            assign_or_memtrap({
+                AddressSize::try_from(addr_ty).and_then(|addr_size| {
+                    let addr = state.function_address(addr_size, &ext_data.name)?;
+                    let dv = DataValue::try_from(addr)?;
+                    Ok(dv.into())
+                })
+            })
+        }
         Opcode::Load
         | Opcode::Uload8
         | Opcode::Sload8


### PR DESCRIPTION
👋 Hey,

This PR implements `call_indirect` and `return_call_indirect` in the interpreter.

I'm not too happy with how this turned out, I think there is a way of making the function references and the address round tripping a bit cleaner but I'm not seeing how right now.