### PR TITLE
fuzzgen: Disable unaligned atomics for RISCV

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1460,14 +1460,14 @@ where
         is_atomic: bool,
     ) -> Result<(Value, MemFlags, Offset32)> {
         // Should we generate an aligned address
-        let supports_unaligned_atomics = !matches!(
+        // Some backends have issues with unaligned atomics.
+        // AArch64: https://github.com/bytecodealliance/wasmtime/issues/5483
+        // RISCV: https://github.com/bytecodealliance/wasmtime/issues/5882
+        let requires_aligned_atomics = matches!(
             self.target_triple.architecture,
             Architecture::Aarch64(_) | Architecture::Riscv64(_)
         );
-        let aligned = if is_atomic && !supports_unaligned_atomics {
-            // Some backends have issues with unaligned atomics.
-            // AArch64: https://github.com/bytecodealliance/wasmtime/issues/5483
-            // RISCV: https://github.com/bytecodealliance/wasmtime/issues/5882
+        let aligned = if is_atomic && requires_aligned_atomics {
             true
         } else {
             bool::arbitrary(self.u)?

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -617,6 +617,8 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 // TODO
                 (Opcode::BxorNot, &[F32, F32]),
                 (Opcode::BxorNot, &[F64, F64]),
+                // https://github.com/bytecodealliance/wasmtime/issues/5884
+                (Opcode::AtomicRmw),
             )
         }
 
@@ -1458,10 +1460,14 @@ where
         is_atomic: bool,
     ) -> Result<(Value, MemFlags, Offset32)> {
         // Should we generate an aligned address
-        let is_aarch64 = matches!(self.target_triple.architecture, Architecture::Aarch64(_));
-        let aligned = if is_atomic && is_aarch64 {
-            // AArch64 has issues with unaligned atomics.
-            // https://github.com/bytecodealliance/wasmtime/issues/5483
+        let supports_unaligned_atomics = !matches!(
+            self.target_triple.architecture,
+            Architecture::Aarch64(_) | Architecture::Riscv64(_)
+        );
+        let aligned = if is_atomic && !supports_unaligned_atomics {
+            // Some backends have issues with unaligned atomics.
+            // AArch64: https://github.com/bytecodealliance/wasmtime/issues/5483
+            // RISCV: https://github.com/bytecodealliance/wasmtime/issues/5882
             true
         } else {
             bool::arbitrary(self.u)?


### PR DESCRIPTION
👋 Hey,

Fuzzgen found some issues on RISCV with unaligned `atomic_rmw`'s (#5882). Lets disable them for now.

Edit: And it turns out its not sufficient to just align addresses, the instruction is actually broken (#5884).