### PR TITLE
fuzzgen: Initial SIMD support

### DIFF
--- a/cranelift/filetests/filetests/verifier/constant.clif
+++ b/cranelift/filetests/filetests/verifier/constant.clif
@@ -2,7 +2,7 @@ test verifier
 set enable_simd
 
 function %incorrect_constant_size() {
-const13 = [1 2 3 4 5]  ; this constant has 5 bytes
+const13 = 0x0102030405  ; this constant has 5 bytes
 block0:
     v0 = vconst.i32x4 const13 ; error: The instruction expects const13 to have a size of 16 bytes but it has 5
     return

--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -27,16 +27,16 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
     fn _type(&mut self, architecture: Architecture) -> Result<Type> {
         // TODO: It would be nice if we could get these directly from cranelift
         // TODO: RISCV does not support SIMD yet
-        let is_riscv = matches!(architecture, Architecture::Riscv64(_));
-        let choices = if is_riscv {
-            &[I8, I16, I32, I64, I128, F32, F64][..]
-        } else {
+        let supports_simd = !matches!(architecture, Architecture::Riscv64(_));
+        let choices = if supports_simd {
             &[
                 I8, I16, I32, I64, I128, // Scalar Integers
                 F32, F64, // Scalar Floats
                 I8X16, I16X8, I32X4, I64X2, // SIMD Integers
                 F32X4, F64X2, // SIMD Floats
             ][..]
+        } else {
+            &[I8, I16, I32, I64, I128, F32, F64][..]
         };
 
         Ok(*self.choose(choices)?)

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -313,13 +313,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
         }
     }
 
-    // RISC-V Does not support SIMD at all
-    let is_simd = args.iter().chain(rets).any(|t| t.is_vector());
-    let is_riscv = matches!(triple.architecture, Architecture::Riscv64(_));
-    if is_simd && is_riscv {
-        return false;
-    }
-
     match triple.architecture {
         Architecture::X86_64 => {
             exceptions!(
@@ -542,6 +535,12 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
         }
 
         Architecture::Riscv64(_) => {
+            // RISC-V Does not support SIMD at all
+            let is_simd = args.iter().chain(rets).any(|t| t.is_vector());
+            if is_simd {
+                return false;
+            }
+
             exceptions!(
                 // TODO
                 (Opcode::IaddCout),

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -256,7 +256,9 @@ where
     fn generate_func(&mut self, target_triple: Triple) -> Result<Function> {
         let max_params = self.u.int_in_range(self.config.signature_params.clone())?;
         let max_rets = self.u.int_in_range(self.config.signature_rets.clone())?;
-        let sig = self.u.signature(max_params, max_rets)?;
+        let sig = self
+            .u
+            .signature(target_triple.architecture, max_params, max_rets)?;
 
         // Function name must be in a different namespace than TESTFILE_NAMESPACE (0)
         let fname = UserFuncName::user(1, 0);
@@ -266,7 +268,9 @@ where
             .map(|i| {
                 let max_params = self.u.int_in_range(self.config.signature_params.clone())?;
                 let max_rets = self.u.int_in_range(self.config.signature_rets.clone())?;
-                let sig = self.u.signature(max_params, max_rets)?;
+                let sig = self
+                    .u
+                    .signature(target_triple.architecture, max_params, max_rets)?;
                 let name = UserExternalName {
                     namespace: 2,
                     index: i as u32,


### PR DESCRIPTION
👋 Hey,

This PR Introduces support for SIMD vectors on fuzzgen. This is mostly to test ABI since it doesn't enable a lot of instructions.

I'm also not planning on introducing pretty much any other SIMD opcodes with the current opcode list system. I think the next step really is to move away from the opcode list.

---

This also does some changes to the clif file format. The current format represents consts as:
```
const0 = [0x00 0x01 0x02]
```

However, when printing a function we print in the following format:
```
const0 = 0x000102
```

And the file does not parse anymore. I.e. we are printing invalid CLIF when constants are involved.

It was easier for me to change the parser, than the printer. However if people prefer the old format, it should also be a fairly easy change.

Another option would be to start accepting both formats, which should also be fairly easy.

If anyone has opinions about this, let me know!