### PR TITLE
Fix function call on component instance

### DIFF
--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -135,7 +135,7 @@ pub(crate) use self::store::ComponentStoreData;
 ///
 ///     // Here our `greet` function doesn't take any parameters for the component,
 ///     // but in the Wasmtime embedding API the first argument is always a `Store`.
-///     bindings.greet(&mut store)?;
+///     bindings.call_greet(&mut store)?;
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
The exported function in the instance is not called directly by its name, but by `call_<the-name>`.

I guess that in the example with the interface further down, the code also needs a change. But I didn't dare to change anything there, as I haven't tried it out myself. 

I haven't opened a separate issue as it was a quick fix.