### PR TITLE
test: add sample `poll_oneoff` WAT test

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -309,6 +309,17 @@ fn exit126_wasi_snapshot1() -> Result<()> {
     Ok(())
 }
 
+// Check that `poll_oneoff` with default parameters does not fail.
+#[test]
+fn poll_oneoff() -> Result<()> {
+    let wasm = build_wasm("tests/all/cli_tests/poll_oneoff.wat")?;
+    let output =
+        run_wasmtime_for_output(&[wasm.path().to_str().unwrap(), "--disable-cache"], None)?;
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+    assert_eq!(output.status.code().unwrap(), 0);
+    Ok(())
+}
+
 // Run a minimal command program.
 #[test]
 fn minimal_command() -> Result<()> {

--- a/tests/all/cli_tests/poll_oneoff.wat
+++ b/tests/all/cli_tests/poll_oneoff.wat
@@ -1,0 +1,34 @@
+;; When the main thread calls proc_exit, it should terminate
+;; a thread blocking in a WASI call. (poll_oneoff)
+;;
+;; linear memory usage:
+;;   0: wait
+;;   100: poll_oneoff subscription
+;;   200: poll_oneoff event
+;;   300: poll_oneoff return value
+
+(module
+  (func $proc_exit (import "wasi_snapshot_preview1" "proc_exit") (param i32))
+  (func $poll_oneoff (import "wasi_snapshot_preview1" "poll_oneoff") (param i32 i32 i32 i32) (result i32))
+  (func (export "_start")
+    ;; Set up subscription
+    i32.const 124 ;; 100 + offsetof(subscription, timeout)
+    i64.const 1_000_000 ;; 1ms
+    i64.store
+
+    ;; Wait for poll.
+    i32.const 100 ;; subscription
+    i32.const 200 ;; event (out)
+    i32.const 1   ;; nsubscriptions
+    i32.const 300 ;; retp (out)
+    call $poll_oneoff
+
+    ;; Check that one result is returned.
+    i32.const 1
+    i32.ne
+    if
+      unreachable
+    end
+  )
+  (memory (export "memory") 1 1)
+)


### PR DESCRIPTION
While debugging a [test] in the wasi-threads test suite, a use of `poll_oneoff` was failing in Wasmtime. Presumably the call works in other runtimes (i.e., WAMR) since it was upstreamed by a WAMR contributor. This tests checks that the use of `poll_oneoff` with some default (zero-filled?) parameters works in Wasmtime.

[test]: https://github.com/WebAssembly/wasi-threads/blob/main/test/testsuite/wasi_threads_exit_main_wasi.wat

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
