### PR TITLE
cranelift: Add big and little endian memory accesses to interpreter

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -101,12 +101,55 @@ impl DataValue {
         }
     }
 
-    /// Write a [DataValue] to a slice.
+    fn swap_bytes(self) -> Self {
+        match self {
+            DataValue::I8(i) => DataValue::I8(i.swap_bytes()),
+            DataValue::I16(i) => DataValue::I16(i.swap_bytes()),
+            DataValue::I32(i) => DataValue::I32(i.swap_bytes()),
+            DataValue::I64(i) => DataValue::I64(i.swap_bytes()),
+            DataValue::I128(i) => DataValue::I128(i.swap_bytes()),
+            DataValue::U8(i) => DataValue::U8(i.swap_bytes()),
+            DataValue::U16(i) => DataValue::U16(i.swap_bytes()),
+            DataValue::U32(i) => DataValue::U32(i.swap_bytes()),
+            DataValue::U64(i) => DataValue::U64(i.swap_bytes()),
+            DataValue::U128(i) => DataValue::U128(i.swap_bytes()),
+            DataValue::F32(f) => DataValue::F32(Ieee32::with_bits(f.bits().swap_bytes())),
+            DataValue::F64(f) => DataValue::F64(Ieee64::with_bits(f.bits().swap_bytes())),
+            DataValue::V128(mut v) => {
+                v.reverse();
+                DataValue::V128(v)
+            }
+            DataValue::V64(mut v) => {
+                v.reverse();
+                DataValue::V64(v)
+            }
+        }
+    }
+
+    /// Converts `self` to big endian from target's endianness.
+    pub fn to_be(self) -> Self {
+        if cfg!(target_endian = "big") {
+            self
+        } else {
+            self.swap_bytes()
+        }
+    }
+
+    /// Converts `self` to little endian from target's endianness.
+    pub fn to_le(self) -> Self {
+        if cfg!(target_endian = "little") {
+            self
+        } else {
+            self.swap_bytes()
+        }
+    }
+
+    /// Write a [DataValue] to a slice in native-endian byte order.
     ///
     /// # Panics:
     ///
     /// Panics if the slice does not have enough space to accommodate the [DataValue]
-    pub fn write_to_slice(&self, dst: &mut [u8]) {
+    pub fn write_to_slice_ne(&self, dst: &mut [u8]) {
         match self {
             DataValue::I8(i) => dst[..1].copy_from_slice(&i.to_ne_bytes()[..]),
             DataValue::I16(i) => dst[..2].copy_from_slice(&i.to_ne_bytes()[..]),
@@ -121,12 +164,30 @@ impl DataValue {
         };
     }
 
-    /// Read a [DataValue] from a slice using a given [Type].
+    /// Write a [DataValue] to a slice in big-endian byte order.
     ///
     /// # Panics:
     ///
     /// Panics if the slice does not have enough space to accommodate the [DataValue]
-    pub fn read_from_slice(src: &[u8], ty: Type) -> Self {
+    pub fn write_to_slice_be(&self, dst: &mut [u8]) {
+        self.clone().to_be().write_to_slice_ne(dst);
+    }
+
+    /// Write a [DataValue] to a slice in little-endian byte order.
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn write_to_slice_le(&self, dst: &mut [u8]) {
+        self.clone().to_le().write_to_slice_ne(dst);
+    }
+
+    /// Read a [DataValue] from a slice using a given [Type] with native-endian byte order.
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn read_from_slice_ne(src: &[u8], ty: Type) -> Self {
         match ty {
             types::I8 => DataValue::I8(i8::from_ne_bytes(src[..1].try_into().unwrap())),
             types::I16 => DataValue::I16(i16::from_ne_bytes(src[..2].try_into().unwrap())),
@@ -152,15 +213,33 @@ impl DataValue {
         }
     }
 
-    /// Write a [DataValue] to a memory location.
-    pub unsafe fn write_value_to(&self, p: *mut u128) {
-        let size = self.ty().bytes() as usize;
-        self.write_to_slice(std::slice::from_raw_parts_mut(p as *mut u8, size));
+    /// Read a [DataValue] from a slice using a given [Type] in big-endian byte order.
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn read_from_slice_be(src: &[u8], ty: Type) -> Self {
+        DataValue::read_from_slice_ne(src, ty).to_be()
     }
 
-    /// Read a [DataValue] from a memory location using a given [Type].
+    /// Read a [DataValue] from a slice using a given [Type] in little-endian byte order.
+    ///
+    /// # Panics:
+    ///
+    /// Panics if the slice does not have enough space to accommodate the [DataValue]
+    pub fn read_from_slice_le(src: &[u8], ty: Type) -> Self {
+        DataValue::read_from_slice_ne(src, ty).to_le()
+    }
+
+    /// Write a [DataValue] to a memory location in native-endian byte order.
+    pub unsafe fn write_value_to(&self, p: *mut u128) {
+        let size = self.ty().bytes() as usize;
+        self.write_to_slice_ne(std::slice::from_raw_parts_mut(p as *mut u8, size));
+    }
+
+    /// Read a [DataValue] from a memory location using a given [Type] in native-endian byte order.
     pub unsafe fn read_value_from(p: *const u128, ty: Type) -> Self {
-        DataValue::read_from_slice(
+        DataValue::read_from_slice_ne(
             std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
             ty,
         )

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -403,7 +403,9 @@ impl InstructionData {
             &InstructionData::Load { flags, .. }
             | &InstructionData::LoadNoOffset { flags, .. }
             | &InstructionData::Store { flags, .. }
-            | &InstructionData::StoreNoOffset { flags, .. } => Some(flags),
+            | &InstructionData::StoreNoOffset { flags, .. }
+            | &InstructionData::AtomicCas { flags, .. }
+            | &InstructionData::AtomicRmw { flags, .. } => Some(flags),
             _ => None,
         }
     }

--- a/cranelift/filetests/filetests/runtests/atomic-cas-subword-big.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-subword-big.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/atomic-cas-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-subword-little.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target s390x
 target aarch64

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target s390x
 target s390x has_mie2
@@ -431,10 +432,10 @@ block0(v0: i32, v1: i64, v2: i16):
     v6 = load.i32 big v3
     return v6
 }
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0x1111) == 0x11115678
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 0, 0xffff) == 0xffff5678
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0x1111) == 0x12341111
-; run: %atomic_rmw_xchg_little_i16(0x12345678, 2, 0xffff) == 0x1234ffff
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0x1111) == 0x11115678
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 0, 0xffff) == 0xffff5678
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0x1111) == 0x12341111
+; run: %atomic_rmw_xchg_big_i16(0x12345678, 2, 0xffff) == 0x1234ffff
 
 
 function %atomic_rmw_xchg_big_i8(i32, i64, i8) -> i32 {

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -1,3 +1,4 @@
+test interpret
 test run
 target s390x
 target s390x has_mie2

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -123,7 +123,7 @@ impl fmt::Debug for TestCase {
             let returns = &self.func.signature.returns;
             let placeholder_output = returns
                 .iter()
-                .map(|param| DataValue::read_from_slice(&[0; 16][..], param.value_type))
+                .map(|param| DataValue::read_from_slice_ne(&[0; 16][..], param.value_type))
                 .map(|val| format!("{}", val))
                 .collect::<Vec<_>>()
                 .join(", ");

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -4,7 +4,8 @@ use crate::address::{Address, AddressSize};
 use crate::interpreter::LibCallHandler;
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::ir::{
-    ExternalName, FuncRef, Function, GlobalValue, LibCall, Signature, StackSlot, Type, Value,
+    ExternalName, FuncRef, Function, GlobalValue, LibCall, MemFlags, Signature, StackSlot, Type,
+    Value,
 };
 use cranelift_codegen::isa::CallConv;
 use cranelift_entity::PrimaryMap;
@@ -62,10 +63,20 @@ pub trait State<'a, V> {
     ) -> Result<Address, MemoryError>;
     /// Retrieve a value `V` from memory at the given `address`, checking if it belongs either to the
     /// stack or to one of the heaps; the number of bytes loaded corresponds to the specified [Type].
-    fn checked_load(&self, address: Address, ty: Type) -> Result<V, MemoryError>;
+    fn checked_load(
+        &self,
+        address: Address,
+        ty: Type,
+        mem_flags: MemFlags,
+    ) -> Result<V, MemoryError>;
     /// Store a value `V` into memory at the given `address`, checking if it belongs either to the
     /// stack or to one of the heaps; the number of bytes stored corresponds to the specified [Type].
-    fn checked_store(&mut self, address: Address, v: V) -> Result<(), MemoryError>;
+    fn checked_store(
+        &mut self,
+        address: Address,
+        v: V,
+        mem_flags: MemFlags,
+    ) -> Result<(), MemoryError>;
 
     /// Compute the address of a function given its name.
     fn function_address(
@@ -182,11 +193,21 @@ where
         unimplemented!()
     }
 
-    fn checked_load(&self, _addr: Address, _ty: Type) -> Result<V, MemoryError> {
+    fn checked_load(
+        &self,
+        _addr: Address,
+        _ty: Type,
+        _mem_flags: MemFlags,
+    ) -> Result<V, MemoryError> {
         unimplemented!()
     }
 
-    fn checked_store(&mut self, _addr: Address, _v: V) -> Result<(), MemoryError> {
+    fn checked_store(
+        &mut self,
+        _addr: Address,
+        _v: V,
+        _mem_flags: MemFlags,
+    ) -> Result<(), MemoryError> {
         unimplemented!()
     }
 


### PR DESCRIPTION
This PR aims to add specific big-endian and little-endian memory accesses to the interpreter when performing a load or store operation, as discussed over at #5881.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
