### PR TITLE
clif: Remove the type variable from `swizzle`

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -367,6 +367,7 @@ fn define_simd_lane_access(
     );
     let x = &Operand::new("x", I8x16).with_doc("Vector to modify by re-arranging lanes");
     let y = &Operand::new("y", I8x16).with_doc("Mask for re-arranging lanes");
+    let a = &Operand::new("a", I8x16);
 
     ig.push(
         Inst::new(
@@ -388,6 +389,7 @@ fn define_simd_lane_access(
     let x = &Operand::new("x", TxN).with_doc("The vector to modify");
     let y = &Operand::new("y", &TxN.lane_of()).with_doc("New lane value");
     let Idx = &Operand::new("Idx", &imm.uimm8).with_doc("Lane index");
+    let a = &Operand::new("a", TxN);
 
     ig.push(
         Inst::new(

--- a/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
@@ -69,7 +69,7 @@ function %swizzle() -> i8x16 {
 block0:
     v0 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
     v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -3,7 +3,7 @@ target s390x
 
 function %swizzle(i8x16, i8x16) -> i8x16 wasmtime_system_v {
 block0(v0: i8x16, v1: i8x16):
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
@@ -3,7 +3,7 @@ target s390x
 
 function %swizzle(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -114,7 +114,7 @@ function %swizzle() -> i8x16 {
 block0:
     v0 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
     v1 = vconst.i8x16 [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15]
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 

--- a/cranelift/filetests/filetests/runtests/simd-lane-access.clif
+++ b/cranelift/filetests/filetests/runtests/simd-lane-access.clif
@@ -52,7 +52,7 @@ block0:
 
 function %swizzle(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 ; reverse the lanes, with over-large index 42 using lane 0

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -7,7 +7,7 @@ target x86_64 has_sse3 has_ssse3 has_sse41
 
 function %swizzle_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):
-    v2 = swizzle.i8x16 v0, v1
+    v2 = swizzle v0, v1
     return v2
 }
 ; run: %swizzle_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [0 9 15 1 6 13 7 11 10 8 100 12 4 2 3 5]) == [1 10 16 2 7 14 8 12 11 9 0 13 5 3 4 6]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1027,7 +1027,7 @@ where
                     new[i] = x[s[i] as usize];
                 } // else leave as 0
             }
-            assign(Value::vector(new, ctrl_ty)?)
+            assign(Value::vector(new, types::I8X16)?)
         }
         Opcode::Splat => {
             let mut new_vector = SimdVec::new();

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -1678,7 +1678,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         }
         Operator::I8x16Swizzle => {
             let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().swizzle(I8X16, a, b))
+            state.push1(builder.ins().swizzle(a, b))
         }
         Operator::I8x16Add | Operator::I16x8Add | Operator::I32x4Add | Operator::I64x2Add => {
             let (a, b) = pop2_with_bitcast(state, type_of(op), builder);


### PR DESCRIPTION
This instruction is only defined with i8x16 inputs and outputs so there's no need for a type variable, so shadow the otherwise-generic `a` result with a concrete i8x16 type.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
