### PR TITLE
Codegen fix  atomic_rmw_loop missing move result to `dst` register On riscv64.

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1558,6 +1558,17 @@ impl MachInstEmit for Inst {
                     }
                 };
 
+                // store to dst.
+                {
+                    Inst::AluRRR {
+                        alu_op: AluOPRRR::Srl,
+                        rd: dst,
+                        rs1: store_value,
+                        rs2: offset,
+                    }
+                    .emit(&[], sink, emit_info, state);
+                }
+
                 Inst::Atomic {
                     op: AtomicOP::store_op(ty),
                     rd: t0,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1408,7 +1408,7 @@ impl MachInstEmit for Inst {
                     | crate::ir::AtomicRmwOp::And
                     | crate::ir::AtomicRmwOp::Or
                     | crate::ir::AtomicRmwOp::Xor => {
-                        AtomicOP::extract(t0, offset, dst.to_reg(), ty)
+                        AtomicOP::extract(dst, offset, dst.to_reg(), ty)
                             .iter()
                             .for_each(|i| i.emit(&[], sink, emit_info, state));
                         Inst::AluRRR {
@@ -1421,7 +1421,7 @@ impl MachInstEmit for Inst {
                                 _ => unreachable!(),
                             },
                             rd: t0,
-                            rs1: t0.to_reg(),
+                            rs1: dst.to_reg(),
                             rs2: x,
                         }
                         .emit(&[], sink, emit_info, state);
@@ -1445,19 +1445,16 @@ impl MachInstEmit for Inst {
                         spilltmp_reg2()
                     }
                     crate::ir::AtomicRmwOp::Nand => {
-                        let x2 = if ty.bits() < 32 {
-                            AtomicOP::extract(t0, offset, dst.to_reg(), ty)
+                        if ty.bits() < 32 {
+                            AtomicOP::extract(dst, offset, dst.to_reg(), ty)
                                 .iter()
                                 .for_each(|i| i.emit(&[], sink, emit_info, state));
-                            t0.to_reg()
-                        } else {
-                            dst.to_reg()
-                        };
+                        }
                         Inst::AluRRR {
                             alu_op: AluOPRRR::And,
                             rd: t0,
                             rs1: x,
-                            rs2: x2,
+                            rs2: dst.to_reg(),
                         }
                         .emit(&[], sink, emit_info, state);
                         Inst::construct_bit_not(t0, t0.to_reg()).emit(&[], sink, emit_info, state);
@@ -1489,12 +1486,13 @@ impl MachInstEmit for Inst {
                     | crate::ir::AtomicRmwOp::Umax
                     | crate::ir::AtomicRmwOp::Smin
                     | crate::ir::AtomicRmwOp::Smax => {
+                        let label_select_dst = sink.get_label();
                         let label_select_done = sink.get_label();
                         if op == crate::ir::AtomicRmwOp::Umin || op == crate::ir::AtomicRmwOp::Umax
                         {
-                            AtomicOP::extract(t0, offset, dst.to_reg(), ty)
+                            AtomicOP::extract(dst, offset, dst.to_reg(), ty)
                         } else {
-                            AtomicOP::extract_sext(t0, offset, dst.to_reg(), ty)
+                            AtomicOP::extract_sext(dst, offset, dst.to_reg(), ty)
                         }
                         .iter()
                         .for_each(|i| i.emit(&[], sink, emit_info, state));
@@ -1506,9 +1504,9 @@ impl MachInstEmit for Inst {
                                 crate::ir::AtomicRmwOp::Smax => IntCC::SignedGreaterThan,
                                 _ => unreachable!(),
                             },
-                            ValueRegs::one(t0.to_reg()),
+                            ValueRegs::one(dst.to_reg()),
                             ValueRegs::one(x),
-                            BranchTarget::Label(label_select_done),
+                            BranchTarget::Label(label_select_dst),
                             BranchTarget::zero(),
                             ty,
                         )
@@ -1516,6 +1514,12 @@ impl MachInstEmit for Inst {
                         .for_each(|i| i.emit(&[], sink, emit_info, state));
                         // here we select x.
                         Inst::gen_move(t0, x, I64).emit(&[], sink, emit_info, state);
+                        Inst::Jal {
+                            dest: BranchTarget::Label(label_select_done),
+                        }
+                        .emit(&[], sink, emit_info, state);
+                        sink.bind_label(label_select_dst);
+                        Inst::gen_move(t0, dst.to_reg(), I64).emit(&[], sink, emit_info, state);
                         sink.bind_label(label_select_done);
                         Inst::Atomic {
                             op: AtomicOP::load_op(ty),
@@ -1537,6 +1541,9 @@ impl MachInstEmit for Inst {
                         spilltmp_reg2()
                     }
                     crate::ir::AtomicRmwOp::Xchg => {
+                        AtomicOP::extract(dst, offset, dst.to_reg(), ty)
+                            .iter()
+                            .for_each(|i| i.emit(&[], sink, emit_info, state));
                         Inst::Atomic {
                             op: AtomicOP::load_op(ty),
                             rd: writable_spilltmp_reg2(),
@@ -1557,17 +1564,6 @@ impl MachInstEmit for Inst {
                         spilltmp_reg2()
                     }
                 };
-
-                // store to dst.
-                {
-                    Inst::AluRRR {
-                        alu_op: AluOPRRR::Srl,
-                        rd: dst,
-                        rs1: store_value,
-                        rs2: offset,
-                    }
-                    .emit(&[], sink, emit_info, state);
-                }
 
                 Inst::Atomic {
                     op: AtomicOP::store_op(ty),

--- a/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
@@ -122,9 +122,8 @@ block0(v0: i64, v1: i64):
 ;   lr.d.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1
-;   srl a0, a1, zero
 ;   sc.d.aqrl a1, a1, (a3)
-;   bnez a1, -0x14
+;   bnez a1, -0x10
 ;   ret
 
 function %atomic_rmw_nand_i32(i64, i32) {
@@ -147,9 +146,8 @@ block0(v0: i64, v1: i32):
 ;   lr.w.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1
-;   srl a0, a1, zero
 ;   sc.w.aqrl a1, a1, (a3)
-;   bnez a1, -0x14
+;   bnez a1, -0x10
 ;   ret
 
 function %atomic_rmw_or_i64(i64, i64) {

--- a/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
@@ -122,8 +122,9 @@ block0(v0: i64, v1: i64):
 ;   lr.d.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1
+;   srl a0, a1, zero
 ;   sc.d.aqrl a1, a1, (a3)
-;   bnez a1, -0x10
+;   bnez a1, -0x14
 ;   ret
 
 function %atomic_rmw_nand_i32(i64, i32) {
@@ -146,8 +147,9 @@ block0(v0: i64, v1: i32):
 ;   lr.w.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1
+;   srl a0, a1, zero
 ;   sc.w.aqrl a1, a1, (a3)
-;   bnez a1, -0x10
+;   bnez a1, -0x14
 ;   ret
 
 function %atomic_rmw_or_i64(i64, i64) {

--- a/cranelift/filetests/filetests/runtests/issue5884.clif
+++ b/cranelift/filetests/filetests/runtests/issue5884.clif
@@ -1,4 +1,3 @@
-
 test run
 target aarch64
 target x86_64
@@ -10,11 +9,12 @@ function %a(i64, i16) -> i16 {
     ss0 = explicit_slot 8
 
 block0(v0: i64, v1: i16):
-    stack_store.i64 v0, ss0
+    v2 = stack_addr.i64 ss0+0
+    store little v0, v2
 
-    v2 = stack_addr.i64 ss0+6
-    v3 = atomic_rmw.i16 or v2, v1
-    return v3
+    v3 = stack_addr.i64 ss0+6
+    v4 = atomic_rmw.i16 little or v3, v1
+    return v4
 }
 
 ; run: %a(8608481011852310776, 0) == 30583

--- a/cranelift/filetests/filetests/runtests/issue5884.clif
+++ b/cranelift/filetests/filetests/runtests/issue5884.clif
@@ -1,7 +1,10 @@
 
 test run
-target riscv64
+target aarch64
 target x86_64
+target riscv64
+target s390x
+
 
 function %a(i64, i16) -> i16 {
     ss0 = explicit_slot 8

--- a/cranelift/filetests/filetests/runtests/issue5884.clif
+++ b/cranelift/filetests/filetests/runtests/issue5884.clif
@@ -1,0 +1,17 @@
+
+test run
+target riscv64
+target x86_64
+
+function %a(i64, i16) -> i16 {
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i16):
+    stack_store.i64 v0, ss0
+
+    v2 = stack_addr.i64 ss0+6
+    v3 = atomic_rmw.i16 or v2, v1
+    return v3
+}
+
+; run: %a(8608481011852310776, 0) == 30583


### PR DESCRIPTION
This will fix https://github.com/bytecodealliance/wasmtime/issues/5884.
I forget move   the result to `dst` register.