### PR TITLE
Add filetest for unexpected `imm12_from_negated` aarch64 lowering

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.isle
+++ b/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.isle
@@ -1,0 +1,66 @@
+;; Test our lowerings that try to fit negated iconst values in immediates, like
+;; `x + -1 => sub x 0x1`. Currently, not working as expected for i32 and i16. 
+
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+;; Result uses immediate as expected
+function %c(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 -1
+    v3 = iadd v0, v1
+    return v3
+}
+
+; VCode:
+; block0:
+;   sub x0, x0, #1
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   sub x0, x0, #1
+;   ret
+
+;; 4294967295 is zero-extended i32 -1
+;; Result should use immediate but currently doesn't
+function %b(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 4294967295 
+    v3 = iadd v0, v1
+    return v3
+}
+
+; VCode:
+; block0:
+;   movn w2, #0
+;   add w0, w0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #-1
+;   add w0, w0, w2
+;   ret
+
+;; 65535 is zero-extended i16 -1
+;; Result should use immediate but currently doesn't
+function %a(i16) -> i16 {
+block0(v0: i16):
+    v1 = iconst.i16 65535
+    v3 = iadd v0, v1
+    return v3
+}
+
+; VCode:
+; block0:
+;   movz w2, #65535
+;   add w0, w0, w2
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w2, #0xffff
+;   add w0, w0, w2
+;   ret


### PR DESCRIPTION
Add a `precise-output` filetest for the unexpected behavior described in https://github.com/bytecodealliance/wasmtime/issues/5903 (immediates not being used for narrow widths). 