### PR TITLE
x64: Add `shuffle` cases for `punpck{h,l}bw`

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3510,6 +3510,21 @@
 
 ;; Rules for `shuffle` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+;; Special case for the `punpckhbw` instruction which interleaves the upper
+;; lanes of the two input registers.
+(rule 5 (lower (shuffle a b (vec_mask_from_immediate mask)))
+      (if-let $true (vec_mask_is mask 8 24 9 25 10 26 11 27 12 28 13 29 14 30 15 31))
+      (x64_punpckhbw a b))
+
+;; Special case for the `punpcklbw` instruction which interleaves the upper
+;; lanes of the two input registers.
+(rule 4 (lower (shuffle a b (vec_mask_from_immediate mask)))
+      (if-let $true (vec_mask_is mask 0 16 1 17 2 18 3 19 4 20 5 21 6 22 7 23))
+      (x64_punpcklbw a b))
+
+(decl pure vec_mask_is (VecMask u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8) bool)
+(extern constructor vec_mask_is vec_mask_is)
+
 ;; If `lhs` and `rhs` are the same we can use a single PSHUFB to shuffle the XMM
 ;; register. We statically build `constructed_mask` to zero out any unknown lane
 ;; indices (may not be completely necessary: verification could fail incorrect

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3512,23 +3512,13 @@
 
 ;; Special case for the `punpckhbw` instruction which interleaves the upper
 ;; lanes of the two input registers.
-(rule 5 (lower (shuffle a b (vec_mask_from_immediate mask)))
-      (if-let $true (vec_mask_is mask 0x1f0f_1e0e_1d0d_1c0c_1b0b_1a0a_1909_1808))
+(rule 4 (lower (shuffle a b (u128_from_immediate 0x1f0f_1e0e_1d0d_1c0c_1b0b_1a0a_1909_1808)))
       (x64_punpckhbw a b))
 
 ;; Special case for the `punpcklbw` instruction which interleaves the lower
 ;; lanes of the two input registers.
-(rule 4 (lower (shuffle a b (vec_mask_from_immediate mask)))
-      (if-let $true (vec_mask_is mask 0x1707_1606_1505_1404_1303_1202_1101_1000))
+(rule 4 (lower (shuffle a b (u128_from_immediate 0x1707_1606_1505_1404_1303_1202_1101_1000)))
       (x64_punpcklbw a b))
-
-;; Tests whether the `VecMask` provided is equal to the u128 literal provided.
-;;
-;; Note that the u128 is equated in its little-endian representation so the
-;; most significant bytes left correspond to the last entries in the `VecMask`,
-;; and least significant bytes correspond to the first entries in `VecMask`.
-(decl pure vec_mask_is (VecMask u128) bool)
-(extern constructor vec_mask_is vec_mask_is)
 
 ;; If `lhs` and `rhs` are the same we can use a single PSHUFB to shuffle the XMM
 ;; register. We statically build `constructed_mask` to zero out any unknown lane

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3513,16 +3513,21 @@
 ;; Special case for the `punpckhbw` instruction which interleaves the upper
 ;; lanes of the two input registers.
 (rule 5 (lower (shuffle a b (vec_mask_from_immediate mask)))
-      (if-let $true (vec_mask_is mask 8 24 9 25 10 26 11 27 12 28 13 29 14 30 15 31))
+      (if-let $true (vec_mask_is mask 0x1f0f_1e0e_1d0d_1c0c_1b0b_1a0a_1909_1808))
       (x64_punpckhbw a b))
 
-;; Special case for the `punpcklbw` instruction which interleaves the upper
+;; Special case for the `punpcklbw` instruction which interleaves the lower
 ;; lanes of the two input registers.
 (rule 4 (lower (shuffle a b (vec_mask_from_immediate mask)))
-      (if-let $true (vec_mask_is mask 0 16 1 17 2 18 3 19 4 20 5 21 6 22 7 23))
+      (if-let $true (vec_mask_is mask 0x1707_1606_1505_1404_1303_1202_1101_1000))
       (x64_punpcklbw a b))
 
-(decl pure vec_mask_is (VecMask u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8 u8) bool)
+;; Tests whether the `VecMask` provided is equal to the u128 literal provided.
+;;
+;; Note that the u128 is equated in its little-endian representation so the
+;; most significant bytes left correspond to the last entries in the `VecMask`,
+;; and least significant bytes correspond to the first entries in `VecMask`.
+(decl pure vec_mask_is (VecMask u128) bool)
 (extern constructor vec_mask_is vec_mask_is)
 
 ;; If `lhs` and `rhs` are the same we can use a single PSHUFB to shuffle the XMM

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -999,10 +999,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             },
         }
     }
-
-    fn vec_mask_is(&mut self, mask: &VecMask, val: u128) -> bool {
-        &mask[..] == val.to_le_bytes()
-    }
 }
 
 impl IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -1000,30 +1000,8 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         }
     }
 
-    fn vec_mask_is(
-        &mut self,
-        mask: &VecMask,
-        a1: u8,
-        a2: u8,
-        a3: u8,
-        a4: u8,
-        a5: u8,
-        a6: u8,
-        a7: u8,
-        a8: u8,
-        a9: u8,
-        a10: u8,
-        a11: u8,
-        a12: u8,
-        a13: u8,
-        a14: u8,
-        a15: u8,
-        a16: u8,
-    ) -> bool {
-        let mask: &[u8] = mask;
-        mask == [
-            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16,
-        ]
+    fn vec_mask_is(&mut self, mask: &VecMask, val: u128) -> bool {
+        &mask[..] == val.to_le_bytes()
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -999,6 +999,32 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             },
         }
     }
+
+    fn vec_mask_is(
+        &mut self,
+        mask: &VecMask,
+        a1: u8,
+        a2: u8,
+        a3: u8,
+        a4: u8,
+        a5: u8,
+        a6: u8,
+        a7: u8,
+        a8: u8,
+        a9: u8,
+        a10: u8,
+        a11: u8,
+        a12: u8,
+        a13: u8,
+        a14: u8,
+        a15: u8,
+        a16: u8,
+    ) -> bool {
+        let mask: &[u8] = mask;
+        mask == [
+            a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16,
+        ]
+    }
 }
 
 impl IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -1,0 +1,54 @@
+test compile precise-output
+set enable_simd
+target x86_64
+
+function %punpcklbw(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = shuffle v0, v1, 0x17071606150514041303120211011000
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   punpcklbw %xmm0, %xmm1, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   punpcklbw %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %punpckhbw(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = shuffle v0, v1, 0x1f0f1e0e1d0d1c0c1b0b1a0a19091808
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   punpckhbw %xmm0, %xmm1, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   punpckhbw %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
I noticed this difference between LLVM and Cranelift for something I was looking at recently, and while it's probably not all that common I figured I'd add it here since it should be somewhat useful nevertheless.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
