### PR TITLE
Codegen  fix atomic_cas with samll types on riscv64

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1511,7 +1511,7 @@ impl AtomicOP {
     }
 
     /// like extract but sign extend the value.
-    /// suitable for smax.
+    /// suitable for smax,etc.
     pub(crate) fn extract_sext(
         rd: WritableReg,
         offset: Reg,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1275,11 +1275,10 @@ impl MachInstEmit for Inst {
                     amo: AMO::SeqCst,
                 }
                 .emit(&[], sink, emit_info, state);
-                let origin_value = if ty.bits() < 32 {
-                    AtomicOP::extract(t0, offset, dst.to_reg(), ty)
+                if ty.bits() < 32 {
+                    AtomicOP::extract(dst, offset, dst.to_reg(), ty)
                         .iter()
                         .for_each(|i| i.emit(&[], sink, emit_info, state));
-                    t0.to_reg()
                 } else if ty.bits() == 32 {
                     Inst::Extend {
                         rd: t0,
@@ -1289,17 +1288,14 @@ impl MachInstEmit for Inst {
                         to_bits: 64,
                     }
                     .emit(&[], sink, emit_info, state);
-                    t0.to_reg()
-                } else {
-                    dst.to_reg()
-                };
+                }
                 Inst::CondBr {
                     taken: BranchTarget::Label(fail_label),
                     not_taken: BranchTarget::zero(),
                     kind: IntegerCompare {
                         kind: IntCC::NotEqual,
                         rs1: e,
-                        rs2: origin_value,
+                        rs2: dst.to_reg(),
                     },
                 }
                 .emit(&[], sink, emit_info, state);

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1281,7 +1281,7 @@ impl MachInstEmit for Inst {
                         .for_each(|i| i.emit(&[], sink, emit_info, state));
                 } else if ty.bits() == 32 {
                     Inst::Extend {
-                        rd: t0,
+                        rd: dst,
                         rn: dst.to_reg(),
                         signed: false,
                         from_bits: 32,

--- a/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target s390x
+target riscv64 has_a 
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/issue5901.clif
+++ b/cranelift/filetests/filetests/runtests/issue5901.clif
@@ -1,0 +1,18 @@
+test interpret
+test run
+target riscv64gc
+
+function %a(i8) -> i8 sext system_v {
+    ss2 = explicit_slot 2
+
+block0(v0: i8):
+    v2 = iconst.i16 0x00ff
+    v3 = stack_addr.i64 ss2
+    store v2, v3
+
+    v4 = stack_addr.i64 ss2+1
+    v5 = atomic_cas v4, v0, v0
+    return v5
+}
+
+; run: %a(0) == 0

--- a/cranelift/filetests/filetests/runtests/issue5901.clif
+++ b/cranelift/filetests/filetests/runtests/issue5901.clif
@@ -11,10 +11,10 @@ function %a(i8) -> i8 sext system_v {
 block0(v0: i8):
     v2 = iconst.i16 0x00ff
     v3 = stack_addr.i64 ss2
-    store v2, v3
+    store little v2, v3
 
     v4 = stack_addr.i64 ss2+1
-    v5 = atomic_cas v4, v0, v0
+    v5 = atomic_cas little v4, v0, v0
     return v5
 }
 

--- a/cranelift/filetests/filetests/runtests/issue5901.clif
+++ b/cranelift/filetests/filetests/runtests/issue5901.clif
@@ -1,6 +1,9 @@
 test interpret
 test run
-target riscv64gc
+target aarch64
+target s390x
+target x86_64
+target riscv64
 
 function %a(i8) -> i8 sext system_v {
     ss2 = explicit_slot 2


### PR DESCRIPTION
This   fix #5901.
When dealing with samll types,We should `extract` value to `dst` register instead of `t0` register.

