### PR TITLE
cranelift-interpreter: Add trap on misaligned memory accesses

### DIFF
--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -142,6 +142,10 @@ pub enum MemoryError {
     OutOfBoundsLoad { addr: Address, load_size: usize },
     #[error("Store of {store_size} bytes is larger than available size at address {addr:?}")]
     OutOfBoundsStore { addr: Address, store_size: usize },
+    #[error("Load of {load_size} bytes is misaligned at address {addr:?}")]
+    MisalignedLoad { addr: Address, load_size: usize },
+    #[error("Store of {store_size} bytes is misaligned at address {addr:?}")]
+    MisalignedStore { addr: Address, store_size: usize },
 }
 
 /// This dummy state allows interpretation over an immutable mapping of values in a single frame.

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -173,6 +173,8 @@ where
         MemoryError::InvalidEntry { .. } => TrapCode::HeapOutOfBounds,
         MemoryError::OutOfBoundsStore { .. } => TrapCode::HeapOutOfBounds,
         MemoryError::OutOfBoundsLoad { .. } => TrapCode::HeapOutOfBounds,
+        MemoryError::MisalignedLoad { .. } => TrapCode::HeapMisaligned,
+        MemoryError::MisalignedStore { .. } => TrapCode::HeapMisaligned,
     };
 
     // Assigns or traps depending on the value of the result
@@ -522,7 +524,7 @@ where
             let load_ty = inst_context.controlling_type().unwrap();
             let slot = inst.stack_slot().unwrap();
             let offset = sum(imm(), args()?)? as u64;
-            let mem_flags = MemFlags::trusted();
+            let mem_flags = MemFlags::new();
             assign_or_memtrap({
                 state
                     .stack_address(AddressSize::_64, slot, offset)
@@ -533,7 +535,7 @@ where
             let arg = arg(0)?;
             let slot = inst.stack_slot().unwrap();
             let offset = sum(imm(), args_range(1..)?)? as u64;
-            let mem_flags = MemFlags::trusted();
+            let mem_flags = MemFlags::new();
             continue_or_memtrap({
                 state
                     .stack_address(AddressSize::_64, slot, offset)


### PR DESCRIPTION
This PR adds trap generation on misaligned memory accesses when the `aligned` memory flag is set, as proposed over at #5899.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
