### PR TITLE
support worlds which import and/or export "wildcard" interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,9 +4142,8 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84965789410bf21087f5a352703142f77b9b4d1478764c3f33a1ea8c7101f40"
+version = "0.6.2"
+source = "git+https://github.com/fermyon/wasm-tools?branch=wit-templates#2496c371d2c4be0f4428c8ef19458ffbd6490152"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ wasmprinter = "0.2.50"
 wasm-encoder = "0.23.0"
 wasm-smith = "0.12.1"
 wasm-mutate = "0.2.17"
-wit-parser = "0.6.1"
+wit-parser = "0.6.2"
 windows-sys = "0.45.0"
 env_logger = "0.9"
 rustix = "0.36.7"
@@ -253,3 +253,6 @@ harness = false
 [[bench]]
 name = "wasi"
 harness = false
+
+[patch.crates-io]
+wit-parser = { git = "https://github.com/fermyon/wasm-tools", branch = "wit-templates" }

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::mem;
+use std::ops::Deref;
 use std::path::Path;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -526,5 +527,22 @@ impl Component {
     /// [`Module`]: crate::Module
     pub fn serialize(&self) -> Result<Vec<u8>> {
         Ok(self.code_object().code_memory().mmap().to_vec())
+    }
+
+    /// Get the names of all the imports from the specified instance.
+    pub fn names<'a>(&'a self, instance_name: &'a str) -> impl Iterator<Item = &str> + 'a {
+        let env_component = self.env_component();
+
+        env_component
+            .imports
+            .values()
+            .filter_map(move |(import, names)| {
+                if instance_name == &env_component.import_types[*import].0 {
+                    Some(names.iter().map(Deref::deref))
+                } else {
+                    None
+                }
+            })
+            .flatten()
     }
 }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1,5 +1,5 @@
 use super::engine;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use wasmtime::{
     component::{Component, Linker},
     Store,
@@ -105,11 +105,96 @@ mod one_import {
         }
 
         let mut linker = Linker::new(&engine);
-        foo::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        foo::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
         let mut store = Store::new(&engine, MyImports::default());
         let (one_import, _) = OneImport::instantiate(&mut store, &component, &linker)?;
         one_import.call_bar(&mut store)?;
         assert!(store.data().hit);
+        Ok(())
+    }
+}
+
+mod wildcards {
+    use super::*;
+
+    wasmtime::component::bindgen!({
+        inline: "
+            default world wildcards {
+                import imports: interface {
+                    *: func() -> u32
+                }
+                export exports: interface {
+                    *: func() -> u32
+                }
+            }
+        ",
+    });
+
+    #[test]
+    fn run() -> Result<()> {
+        let engine = engine();
+
+        let component = Component::new(
+            &engine,
+            r#"
+                (component
+                    (import "imports" (instance $i
+                        (export "a" (func (result u32)))
+                        (export "b" (func (result u32)))
+                        (export "c" (func (result u32)))
+                    ))
+                    (core module $m
+                        (import "" "a" (func (result i32)))
+                        (import "" "b" (func (result i32)))
+                        (import "" "c" (func (result i32)))
+                        (export "x" (func 0))
+                        (export "y" (func 1))
+                        (export "z" (func 2))
+                    )
+                    (core func $a (canon lower (func $i "a")))
+                    (core func $b (canon lower (func $i "b")))
+                    (core func $c (canon lower (func $i "c")))
+                    (core instance $j (instantiate $m
+                        (with "" (instance
+                            (export "a" (func $a))
+                            (export "b" (func $b))
+                            (export "c" (func $c))
+                        ))
+                    ))
+                    (func $x (result u32) (canon lift (core func $j "x")))
+                    (func $y (result u32) (canon lift (core func $j "y")))
+                    (func $z (export "z") (result u32) (canon lift (core func $j "z")))
+                    (instance $k
+                       (export "x" (func $x))
+                       (export "y" (func $y))
+                       (export "z" (func $z))
+                    )
+                    (export "exports" (instance $k))
+                )
+            "#,
+        )?;
+
+        #[derive(Default)]
+        struct MyImports;
+
+        impl imports::Host for MyImports {
+            fn call(&mut self, name: &str) -> Result<u32> {
+                Ok(match name {
+                    "a" => 42,
+                    "b" => 43,
+                    "c" => 44,
+                    _ => bail!("unexpected function name: \"{name}\""),
+                })
+            }
+        }
+
+        let mut linker = Linker::new(&engine);
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
+        let mut store = Store::new(&engine, MyImports::default());
+        let (wildcards, _) = Wildcards::instantiate(&mut store, &component, &linker)?;
+        assert_eq!(42, wildcards.exports.call("x", &mut store)?);
+        assert_eq!(43, wildcards.exports.call("y", &mut store)?);
+        assert_eq!(44, wildcards.exports.call("z", &mut store)?);
         Ok(())
     }
 }

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -73,7 +73,7 @@ mod empty_error {
         }
 
         let mut linker = Linker::new(&engine);
-        imports::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
 
         let mut store = Store::new(&engine, MyImports::default());
         let (results, _) = ResultPlayground::instantiate(&mut store, &component, &linker)?;
@@ -184,7 +184,7 @@ mod string_error {
         }
 
         let mut linker = Linker::new(&engine);
-        imports::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
 
         let mut store = Store::new(&engine, MyImports::default());
         let (results, _) = ResultPlayground::instantiate(&mut store, &component, &linker)?;
@@ -326,7 +326,7 @@ mod enum_error {
         }
 
         let mut linker = Linker::new(&engine);
-        imports::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
 
         let mut store = Store::new(&engine, MyImports::default());
         let (results, _) = ResultPlayground::instantiate(&mut store, &component, &linker)?;
@@ -456,7 +456,7 @@ mod record_error {
         }
 
         let mut linker = Linker::new(&engine);
-        imports::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
 
         let mut store = Store::new(&engine, MyImports::default());
         let (results, _) = ResultPlayground::instantiate(&mut store, &component, &linker)?;
@@ -592,7 +592,7 @@ mod variant_error {
         }
 
         let mut linker = Linker::new(&engine);
-        imports::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        imports::add_to_linker(&mut linker, &component, |f: &mut MyImports| f)?;
 
         let mut store = Store::new(&engine, MyImports::default());
         let (results, _) = ResultPlayground::instantiate(&mut store, &component, &linker)?;


### PR DESCRIPTION
Per https://github.com/WebAssembly/component-model/issues/172, this implements "part 1" of WIT templates, allowing WIT files to define interfaces which contain a single wildcard function, which worlds may import or export.

I've chosen to implement the bindings for host-implemented functions in such a way that the host may delay import resolution until the latest possible moment, i.e. when the guest is actually calling the function.  This allows for fully dynamic resolution (e.g. using the function name as a key to be looked up in a remote key-value store) when desired.  This does come at a small performance cost compared to doing resolution at e.g. link time instead.

In cases where the host wants to do resolution earlier (e.g. at deploy or instantiation time), that's certainly possible, e.g.:

```rust
let component = Component::new(&engine, wasm)?;
let funcs = component
    .names("imports")
    .map(|name| Ok((name.to_owned(), my_resolver(name)?)))
    .collect::<Result<HashMap<_, _>>>()?;

struct MyImports<F> {
   funcs: HashMap<String, F>
}

impl <F: Fn() -> Result<u32>> imports::Host for MyImports<F> {
    fn call(&mut self, name: &str) -> Result<u32> {
        (self.funcs.get(name).unwrap())()
    }
}

let mut store = Store::new(&engine, MyImports { funcs });
...
```

If we feel that early resolution is the more common case, we could consider adding a configuration option to the binding generator which indicates whether early or late resolution is desired, allowing the generator to optimize (ergonmically and performance-wise) accordingly.

Note that the generated `add_to_linker` functions now take a `&Component` parameter as well as a `&mut Linker`.  This allows those functions to inspect the component in order to determine how many `func_wrap{_async}` calls to make, and with what names.  I'm open to alternatives to this if there's a better way.

Finally, I've added a temporary dependency override to Cargo.toml, pointing to our fork of `wasm-tools`, which includes the necessary `wit-parser` changes.  We're still iterating on that and will PR those changes separately.  We also have a fork of `wit-bindgen` with a new "wildcards" test to verify everything works end-to-end: https://github.com/bytecodealliance/wit-bindgen/compare/main...dicej:wit-templates. I'll PR that last once everything else is stable.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
