### PR TITLE
cranelift: Merge `bitcasts` into `loads`

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -103,12 +103,17 @@ impl MemFlags {
     /// caller since it is not explicitly encoded in CLIF IR -- this allows a
     /// front end to create IR without having to know the target endianness.
     pub fn endianness(self, native_endianness: Endianness) -> Endianness {
+        self.get_endianness().unwrap_or(native_endianness)
+    }
+
+    /// Get endianness of the memory access if any.
+    pub fn get_endianness(&self) -> Option<Endianness> {
         if self.read(FlagBit::LittleEndian) {
-            Endianness::Little
+            Some(Endianness::Little)
         } else if self.read(FlagBit::BigEndian) {
-            Endianness::Big
+            Some(Endianness::Big)
         } else {
-            native_endianness
+            None
         }
     }
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -656,6 +656,11 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn mem_flags_endianness_eq(&mut self, lhs: MemFlags, rhs: MemFlags) -> bool {
+            lhs.get_endianness() == rhs.get_endianness()
+        }
+
+        #[inline]
         fn intcc_unsigned(&mut self, x: &IntCC) -> IntCC {
             x.unsigned()
         }

--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -537,3 +537,25 @@
 ;; both of them since they cancel out.
 (rule (simplify (fmul ty (fneg ty x) (fneg ty y)))
       (fmul ty x y))
+
+
+;; Wasmtime generates a lot of load+bitcast's. This is because in Wasm
+;; SIMD loads are always v128.load, without type information. This means
+;; that the translation to CLIF first loads into a `i8x16` and then each
+;; op bitcasts the vector as needed.
+;;
+;; This bitcasting prevents the x64 backend from merging the load into the
+;; op, so try to change the type of the load into the bitcast type.
+(rule (simplify (bitcast cty cflags (load lty lflags addr offset)))
+      ;; Two preconditions for this rule:
+      ;; 1. The types must have the same size. (this is enforced by the verifier)
+      ;; 2. The endiannes on both memflags must match
+      (if-let $true (mem_flags_endianness_eq cflags lflags))
+      (load cty lflags addr offset))
+
+;; TODO: We could also do this for `store`. It doesen't seem to be generated in clif_opt.isle.
+
+;; This is a more general case where we do a double bitcast.
+(rule (simplify (bitcast ty lflags (bitcast _ rflags x)))
+      (if-let $true (mem_flags_endianness_eq lflags rflags))
+      (bitcast ty lflags x))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -228,6 +228,13 @@
 (decl pure mem_flags_trusted () MemFlags)
 (extern constructor mem_flags_trusted mem_flags_trusted)
 
+;; Checks if the `endianness` flag on both memflags is equal.
+;;
+;; If the `endianness` flag is not set, then we only consider
+;; them equal if both are not set.
+(decl pure mem_flags_endianness_eq (MemFlags MemFlags) bool)
+(extern constructor mem_flags_endianness_eq mem_flags_endianness_eq)
+
 ;;;; Helpers for Working with Flags ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Reverse an IntCC flag.

--- a/cranelift/filetests/filetests/egraph/bitcast.clif
+++ b/cranelift/filetests/filetests/egraph/bitcast.clif
@@ -1,0 +1,66 @@
+test optimize
+set opt_level=speed
+set use_egraphs=true
+target x86_64
+
+function %bitcast_to_bitcast(i8x16) -> i64x2 {
+block0(v0: i8x16):
+    v1 = bitcast.i32x4 little v0
+    v2 = bitcast.i64x2 little v1
+    return v2
+}
+
+; check: block0(v0: i8x16):
+; check:    v3 = bitcast.i64x2 little v0
+; check:    return v3
+
+
+;; If the bitcasts have different memory flags, we can't optimize.
+function %bitcast_different_memflags(i8x16) -> i64x2 {
+block0(v0: i8x16):
+    v1 = bitcast.i32x4 little v0
+    v2 = bitcast.i64x2 big v1
+    return v2
+}
+
+; check: block0(v0: i8x16):
+; check:    v1 = bitcast.i32x4 little v0
+; check:    v2 = bitcast.i64x2 big v1
+; check:    return v2
+
+
+function %load_bitcast(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i8x16 little v0
+    v2 = bitcast.i64x2 little v1
+    return v2
+}
+
+; check: block0(v0: i64):
+; check:    v3 = load.i64x2 little v0
+; check:    return v3
+
+
+function %load_bitcast_aligned(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i8x16 little aligned v0
+    v2 = bitcast.i64x2 little v1
+    return v2
+}
+
+; check: block0(v0: i64):
+; check:    v3 = load.i64x2 little aligned v0
+; check:    return v3
+
+
+function %load_bitcast_different_flags(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i8x16 little aligned v0
+    v2 = bitcast.i64x2 big v1
+    return v2
+}
+
+; check: block0(v0: i64):
+; check:    v1 = load.i8x16 little aligned v0
+; check:    v2 = bitcast.i64x2 big v1
+; check:    return v2


### PR DESCRIPTION
👋 Hey,

I was looking at some wasmtime generated CLIF, and noticed that wasmtime emits a `bitcast` after SIMD loads. That's okay, but it prevents the loads being merged into some ops. So I decided to have a go at trying to remove these.

The rule works, which is nice, but It [doesn't seem to delete the previous load](https://github.com/bytecodealliance/wasmtime/actions/runs/4331044775/jobs/7562649279#step:15:913), which I assume is some sort of correctness rule embedded in the mid end? This optimization looks correct to me, but I might be wrong!


--- 

For this example CLIF:
```
function %b() -> i32x4 {
    ss0 = explicit_slot 16

block0:
    v0 = stack_addr.i64 ss0
    v1 = load.i8x16 little notrap aligned v0
    v2 = bitcast.i32x4 little v1
    v3 = iabs v2
    return v3
}
```

We now merge the load into the iabs:
```
 10:   66 0f 38 1e 00          pabsd   (%rax), %xmm0
```

Where we used to do a `load` + `pabsd`:
```
   c:   f3 0f 6f 10             movdqu  (%rax), %xmm2
  10:   66 0f 38 1e c2          pabsd   %xmm2, %xmm0
```

In practice this doesn't help Wasmtime that much for SSE ops, since they require the loads to be aligned, but it should for VEX/EVEX ops.