### PR TITLE
implement "part 1" of WIT Templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,8 +4171,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f887c3da527a51b321076ebe6a7513026a4757b6d4d144259946552d6fc728b3"
+source = "git+https://github.com/dicej/wasm-tools?branch=wit-templates#8095934efc132fbdc4db82b7f0882a78a97817a5"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,3 +261,6 @@ harness = false
 [[bench]]
 name = "wasi"
 harness = false
+
+[patch.crates-io]
+wit-parser = { git = "https://github.com/dicej/wasm-tools", branch = "wit-templates" }

--- a/crates/component-macro/tests/codegen/wildcards-mixed.wit
+++ b/crates/component-macro/tests/codegen/wildcards-mixed.wit
@@ -1,0 +1,12 @@
+default world wildcards-mixed {
+    import imports: interface {
+        *: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+        foo: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+        bar: func(v: u32) -> u32
+    }
+    export exports: interface {
+        *: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+        foo: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+        bar: func(v: u32) -> u32
+    }
+}

--- a/crates/component-macro/tests/codegen/wildcards.wit
+++ b/crates/component-macro/tests/codegen/wildcards.wit
@@ -1,0 +1,8 @@
+default world wildcards {
+    import imports: interface {
+        *: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+    }
+    export exports: interface {
+        *: func(s: string, v: u32, l: list<u8>) -> tuple<string, u32, list<u8>>
+    }
+}

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmtime_environ::component::{
-    ComponentTypes, GlobalInitializer, LoweredIndex, RuntimeAlwaysTrapIndex,
-    RuntimeTranscoderIndex, StaticModuleIndex, Translator,
+    ComponentTypes, Export, GlobalInitializer, LoweredIndex, RuntimeAlwaysTrapIndex,
+    RuntimeTranscoderIndex, StaticModuleIndex, Translator, TypeDef,
 };
 use wasmtime_environ::{EntityRef, FunctionLoc, ObjectKind, PrimaryMap, ScopeVec, SignatureIndex};
 use wasmtime_jit::{CodeMemory, CompiledModuleInfo};
@@ -526,5 +526,63 @@ impl Component {
     /// [`Module`]: crate::Module
     pub fn serialize(&self) -> Result<Vec<u8>> {
         Ok(self.code_object().code_memory().mmap().to_vec())
+    }
+
+    /// Get the names of all the functions exported from the specified instance.
+    //
+    // TODO: Eventually we'll want a public API for reflecting the entire
+    // component type, including the names and types of all its instances,
+    // imports, and exports.  This function is currently only intended for
+    // discovering wildcard imports.
+    pub fn function_import_names<'a>(
+        &'a self,
+        instance_name: &'a str,
+    ) -> impl Iterator<Item = &str> + 'a {
+        let env_component = self.env_component();
+
+        env_component
+            .imports
+            .values()
+            .filter_map(move |(import, names)| {
+                let (name, typedef) = &env_component.import_types[*import];
+                if let (TypeDef::ComponentInstance(_), true) = (typedef, instance_name == name) {
+                    Some(names.iter().map(String::as_str))
+                } else {
+                    None
+                }
+            })
+            .flatten()
+    }
+
+    /// Get the names of all the functions exported from the specified instance.
+    //
+    // TODO: Eventually we'll want a public API for reflecting the entire
+    // component type, including the names and types of all its instances,
+    // imports, and exports.  This function is currently only intended for
+    // discovering wildcard exports.
+    pub fn function_export_names<'a>(
+        &'a self,
+        instance_name: &'a str,
+    ) -> impl Iterator<Item = &str> + 'a {
+        let env_component = self.env_component();
+
+        env_component
+            .exports
+            .get(instance_name)
+            .and_then(|export| {
+                if let Export::Instance(map) = export {
+                    Some(map.iter().filter_map(|(n, e)| {
+                        if let Export::LiftedFunction { .. } = e {
+                            Some(n.as_str())
+                        } else {
+                            None
+                        }
+                    }))
+                } else {
+                    None
+                }
+            })
+            .into_iter()
+            .flatten()
     }
 }

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -672,6 +672,29 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
             })
     }
 
+    /// Returns an iterator of all of the exported functions that this instance
+    /// contains.
+    //
+    // See FIXME in above `modules` method, which also applies here.
+    pub fn funcs(&mut self) -> impl Iterator<Item = (&'a str, Func)> + '_ {
+        self.exports
+            .iter()
+            .filter_map(|(name, export)| match export {
+                Export::LiftedFunction { ty, func, options } => Some((
+                    name.as_str(),
+                    Func::from_lifted_func(
+                        self.store,
+                        self.instance,
+                        self.data,
+                        *ty,
+                        func,
+                        options,
+                    ),
+                )),
+                _ => None,
+            })
+    }
+
     fn as_mut(&mut self) -> ExportInstance<'a, '_> {
         ExportInstance {
             exports: self.exports,

--- a/crates/wit-bindgen/src/types.rs
+++ b/crates/wit-bindgen/src/types.rs
@@ -54,6 +54,9 @@ impl Types {
                     for (_, f) in iface.functions.iter() {
                         self.type_info_func(resolve, f, import);
                     }
+                    if let Some(f) = &iface.wildcard {
+                        self.type_info_func(resolve, f, import);
+                    }
                 }
                 WorldItem::Type(id) => {
                     self.type_id_info(resolve, *id);

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1,5 +1,6 @@
-use super::engine;
+use super::{async_engine, engine};
 use anyhow::Result;
+use std::collections::HashSet;
 use wasmtime::{
     component::{Component, Linker},
     Store,
@@ -111,5 +112,179 @@ mod one_import {
         one_import.call_bar(&mut store)?;
         assert!(store.data().hit);
         Ok(())
+    }
+}
+
+mod wildcards {
+    use super::*;
+
+    const COMPONENT: &str = r#"
+        (component
+            (import "imports" (instance $i
+                (export "a" (func (result u32)))
+                (export "b" (func (result u32)))
+                (export "c" (func (result u32)))
+            ))
+            (core module $m
+                (import "" "a" (func (result i32)))
+                (import "" "b" (func (result i32)))
+                (import "" "c" (func (result i32)))
+                (export "x" (func 0))
+                (export "y" (func 1))
+                (export "z" (func 2))
+            )
+            (core func $a (canon lower (func $i "a")))
+            (core func $b (canon lower (func $i "b")))
+            (core func $c (canon lower (func $i "c")))
+            (core instance $j (instantiate $m
+                (with "" (instance
+                    (export "a" (func $a))
+                    (export "b" (func $b))
+                    (export "c" (func $c))
+                ))
+            ))
+            (func $x (result u32) (canon lift (core func $j "x")))
+            (func $y (result u32) (canon lift (core func $j "y")))
+            (func $z (export "z") (result u32) (canon lift (core func $j "z")))
+            (instance $k
+               (export "x" (func $x))
+               (export "y" (func $y))
+               (export "z" (func $z))
+            )
+            (export "exports" (instance $k))
+        )
+    "#;
+
+    mod sync {
+        use super::*;
+
+        wasmtime::component::bindgen!({
+            inline: "
+                default world wildcards {
+                    import imports: interface {
+                        *: func() -> u32
+                    }
+                    export exports: interface {
+                        *: func() -> u32
+                    }
+                }
+            "
+        });
+
+        #[test]
+        fn run() -> Result<()> {
+            let engine = engine();
+
+            let component = Component::new(&engine, COMPONENT)?;
+
+            assert_eq!(
+                ["a", "b", "c"].into_iter().collect::<HashSet<_>>(),
+                component.function_import_names("imports").collect()
+            );
+
+            assert_eq!(
+                ["x", "y", "z"].into_iter().collect::<HashSet<_>>(),
+                component.function_export_names("exports").collect()
+            );
+
+            #[derive(Default)]
+            struct Host;
+
+            impl imports::Host for Host {}
+
+            struct Match(u32);
+
+            impl imports::WildcardMatch<Host> for Match {
+                fn call(&self, _host: &mut Host, _name: &str) -> Result<u32> {
+                    Ok(self.0)
+                }
+            }
+
+            let mut linker = Linker::new(&engine);
+            Wildcards::add_to_linker(
+                &mut linker,
+                WildcardMatches {
+                    imports: vec![("a", Match(42)), ("b", Match(43)), ("c", Match(44))],
+                },
+                |f: &mut Host| f,
+            )?;
+            let mut store = Store::new(&engine, Host::default());
+            let (wildcards, _) = Wildcards::instantiate(&mut store, &component, &linker)?;
+            for (name, value) in [("x", 42), ("y", 43), ("z", 44)] {
+                assert_eq!(
+                    value,
+                    wildcards
+                        .exports
+                        .get_wildcard_match(name)
+                        .unwrap()
+                        .call(&mut store)?
+                );
+            }
+            Ok(())
+        }
+    }
+
+    mod async_ {
+        use super::*;
+
+        wasmtime::component::bindgen!({
+            inline: "
+                default world wildcards {
+                    import imports: interface {
+                        *: func() -> u32
+                    }
+                    export exports: interface {
+                        *: func() -> u32
+                    }
+                }
+            ",
+            async: true
+        });
+
+        #[tokio::test]
+        async fn run() -> Result<()> {
+            let engine = async_engine();
+
+            let component = Component::new(&engine, COMPONENT)?;
+
+            #[derive(Default)]
+            struct Host;
+
+            impl imports::Host for Host {}
+
+            #[derive(Clone)]
+            struct Match(u32);
+
+            #[async_trait::async_trait]
+            impl imports::WildcardMatch<Host> for Match {
+                async fn call(&self, _host: &mut Host, _name: &str) -> Result<u32> {
+                    Ok(self.0)
+                }
+            }
+
+            let mut linker = Linker::new(&engine);
+            Wildcards::add_to_linker(
+                &mut linker,
+                WildcardMatches {
+                    imports: vec![("a", Match(42)), ("b", Match(43)), ("c", Match(44))],
+                },
+                |f: &mut Host| f,
+            )?;
+            let mut store = Store::new(&engine, Host::default());
+            let (wildcards, _) =
+                Wildcards::instantiate_async(&mut store, &component, &linker).await?;
+            for (name, value) in [("x", 42), ("y", 43), ("z", 44)] {
+                assert_eq!(
+                    value,
+                    wildcards
+                        .exports
+                        .get_wildcard_match(name)
+                        .unwrap()
+                        .call(&mut store)
+                        .await?
+                );
+            }
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Per WebAssembly/component-model#172, this implements "part 1" of WIT templates, allowing WIT files to define interfaces which contain a single wildcard function, which worlds may import or export.

I've taken a "minimalist" approach to this, such that the host binding generator just skips wildcards entirely, leaving it to the host to use dynamic APIs to reflect on the component and do the necessary func_wrap (for imports) and typed_func (for exports) calls directly.

This adds two new functions to the public API:

- `Component::names`: provides an iterator over the names of the functions imported by the specified instance.
- `ExportInstance::funcs`: provides an iterator over the names of the functions exported by this instance.

In both cases, I'm open to alternative API designs for getting that information.

Note that I've added a temporary dependency override to Cargo.toml, pointing to our fork of wasm-tools, which includes the necessary wit-parser changes. We're still iterating on that and will PR those changes separately. We also have a fork of wit-bindgen with a new "wildcards" test to verify everything works end-to-end: https://github.com/bytecodealliance/wit-bindgen/compare/main...dicej:wit-templates. I'll PR that last once everything else is stable.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
