### PR TITLE
Restrict uextend and sextend to scalar integers

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3213,21 +3213,20 @@ pub(crate) fn define(
         .operands_out(vec![a]),
     );
 
-    let IntTo = &TypeVar::new(
-        "IntTo",
-        "A larger integer type with the same number of lanes",
-        TypeSetBuilder::new()
-            .ints(Interval::All)
-            .simd_lanes(Interval::All)
-            .build(),
-    );
-    let x = &Operand::new("x", Int);
-    let a = &Operand::new("a", IntTo);
+    {
+        let IntTo = &TypeVar::new(
+            "IntTo",
+            "A larger integer type with the same number of lanes",
+            TypeSetBuilder::new().ints(Interval::All).build(),
+        );
 
-    ig.push(
-        Inst::new(
-            "uextend",
-            r#"
+        let x = &Operand::new("x", Int);
+        let a = &Operand::new("a", IntTo);
+
+        ig.push(
+            Inst::new(
+                "uextend",
+                r#"
         Convert `x` to a larger integer type by zero-extending.
 
         Each lane in `x` is converted to a larger integer type by adding
@@ -3238,16 +3237,16 @@ pub(crate) fn define(
         and each lane must not have fewer bits that the input lanes. If the
         input and output types are the same, this is a no-op.
         "#,
-            &formats.unary,
-        )
-        .operands_in(vec![x])
-        .operands_out(vec![a]),
-    );
+                &formats.unary,
+            )
+            .operands_in(vec![x])
+            .operands_out(vec![a]),
+        );
 
-    ig.push(
-        Inst::new(
-            "sextend",
-            r#"
+        ig.push(
+            Inst::new(
+                "sextend",
+                r#"
         Convert `x` to a larger integer type by sign-extending.
 
         Each lane in `x` is converted to a larger integer type by replicating
@@ -3258,10 +3257,20 @@ pub(crate) fn define(
         and each lane must not have fewer bits that the input lanes. If the
         input and output types are the same, this is a no-op.
         "#,
-            &formats.unary,
-        )
-        .operands_in(vec![x])
-        .operands_out(vec![a]),
+                &formats.unary,
+            )
+            .operands_in(vec![x])
+            .operands_out(vec![a]),
+        );
+    }
+
+    let IntTo = &TypeVar::new(
+        "IntTo",
+        "A larger integer type with the same number of lanes",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .build(),
     );
 
     let FloatTo = &TypeVar::new(
@@ -3272,6 +3281,7 @@ pub(crate) fn define(
             .simd_lanes(Interval::All)
             .build(),
     );
+
     let x = &Operand::new("x", Float);
     let a = &Operand::new("a", FloatTo);
 

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -931,14 +931,14 @@
       (put_in_reg_zext64 x))
 
 ;; 128-bit target types.
-(rule (lower (has_type (vr128_ty ty) (uextend x @ (value_type $I8))))
-      (vec_insert_lane $I8X16 (vec_imm ty 0) x 15 (zero_reg)))
-(rule (lower (has_type (vr128_ty ty) (uextend x @ (value_type $I16))))
-      (vec_insert_lane $I16X8 (vec_imm ty 0) x 7 (zero_reg)))
-(rule (lower (has_type (vr128_ty ty) (uextend x @ (value_type $I32))))
-      (vec_insert_lane $I32X4 (vec_imm ty 0) x 3 (zero_reg)))
-(rule (lower (has_type (vr128_ty ty) (uextend x @ (value_type $I64))))
-      (vec_insert_lane $I64X2 (vec_imm ty 0) x 1 (zero_reg)))
+(rule (lower (has_type $I128 (uextend x @ (value_type $I8))))
+      (vec_insert_lane $I8X16 (vec_imm $I128 0) x 15 (zero_reg)))
+(rule (lower (has_type $I128 (uextend x @ (value_type $I16))))
+      (vec_insert_lane $I16X8 (vec_imm $I128 0) x 7 (zero_reg)))
+(rule (lower (has_type $I128 (uextend x @ (value_type $I32))))
+      (vec_insert_lane $I32X4 (vec_imm $I128 0) x 3 (zero_reg)))
+(rule (lower (has_type $I128 (uextend x @ (value_type $I64))))
+      (vec_insert_lane $I64X2 (vec_imm $I128 0) x 1 (zero_reg)))
 
 
 ;;;; Rules for `sextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -952,9 +952,9 @@
       (put_in_reg_sext64 x))
 
 ;; 128-bit target types.
-(rule (lower (has_type (vr128_ty ty) (sextend x)))
+(rule (lower (has_type $I128 (sextend x)))
       (let ((x_ext Reg (put_in_reg_sext64 x)))
-        (mov_to_vec128 ty (ashr_imm $I64 x_ext 63) x_ext)))
+        (mov_to_vec128 $I128 (ashr_imm $I64 x_ext 63) x_ext)))
 
 
 ;;;; Rules for `snarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The `uextend` and `sextend` operations had types in the instruction dsl that suggested they could produce vectors from scalars, while no backends could support this behavior. This PR tightens the result type constraints for both instructions to only produce scalar integers, and further restricts the types matched in the s390x backend to avoid any ambiguity.

cc @uweigand

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
