### PR TITLE
Bump cargo-vet to 0.4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     if: needs.determine.outputs.audit
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.3.1
+      CARGO_VET_VERSION: 0.4.0
     steps:
     - uses: actions/checkout@v3
       with:

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1594,4 +1594,3 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 version = "0.6.4"
 notes = "The Bytecode Alliance is the author of this crate."
-

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -119,10 +119,6 @@ version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "2.34.0"
-criteria = "safe-to-run"
-
-[[exemptions.clap]]
 version = "3.2.8"
 criteria = "safe-to-deploy"
 
@@ -185,14 +181,6 @@ criteria = "safe-to-deploy"
 [[exemptions.crypto-mac]]
 version = "0.11.1"
 criteria = "safe-to-deploy"
-
-[[exemptions.csv]]
-version = "1.1.6"
-criteria = "safe-to-run"
-
-[[exemptions.csv-core]]
-version = "0.1.10"
-criteria = "safe-to-run"
 
 [[exemptions.ctr]]
 version = "0.8.0"
@@ -377,10 +365,6 @@ criteria = "safe-to-deploy"
 [[exemptions.itertools]]
 version = "0.10.3"
 criteria = "safe-to-deploy"
-
-[[exemptions.itoa]]
-version = "0.4.8"
-criteria = "safe-to-run"
 
 [[exemptions.itoa]]
 version = "1.0.1"
@@ -827,10 +811,6 @@ version = "0.1.17"
 criteria = "safe-to-deploy"
 
 [[exemptions.textwrap]]
-version = "0.11.0"
-criteria = "safe-to-run"
-
-[[exemptions.textwrap]]
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
@@ -997,4 +977,3 @@ criteria = "safe-to-deploy"
 [[exemptions.zstd-sys]]
 version = "2.0.1+zstd.1.5.2"
 criteria = "safe-to-deploy"
-

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -7,30 +7,9 @@ criteria = "safe-to-deploy"
 delta = "1.0.57 -> 1.0.61"
 
 [[audits.mozilla.audits.anyhow]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "1.0.58 -> 1.0.57"
-notes = "No functional differences, just CI config and docs."
-
-[[audits.mozilla.audits.anyhow]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.61 -> 1.0.62"
-
-[[audits.mozilla.audits.arbitrary]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "1.1.0 -> 1.1.1"
-
-[[audits.mozilla.audits.arbitrary]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "1.1.1 -> 1.1.3"
-
-[[audits.mozilla.audits.async-trait]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.1.56 -> 0.1.57"
 
 [[audits.mozilla.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"
@@ -44,102 +23,22 @@ criteria = "safe-to-deploy"
 version = "0.5.2"
 notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
 
-[[audits.mozilla.audits.bit-set]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.2 -> 0.5.3"
-
 [[audits.mozilla.audits.bit-vec]]
 who = "Aria Beingessner <a.beingessner@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.6.3"
 notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
 
-[[audits.mozilla.audits.bumpalo]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-run"
-delta = "3.9.1 -> 3.10.0"
-notes = """
-Some nontrivial functional changes but certainly meets the no-malware bar of
-safe-to-run. If we needed safe-to-deploy for this in m-c I'd ask Nick to re-
-certify this version, but we don't, so this is fine for now.
-"""
-
-[[audits.mozilla.audits.bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.1.0 -> 1.2.1"
-
-[[audits.mozilla.audits.clap_lex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.0 -> 0.2.2"
-
-[[audits.mozilla.audits.clap_lex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.2 -> 0.2.4"
-
-[[audits.mozilla.audits.cpufeatures]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.2 -> 0.2.4"
-
-[[audits.mozilla.audits.crossbeam-channel]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.4 -> 0.5.6"
-
-[[audits.mozilla.audits.crossbeam-deque]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.8.1 -> 0.8.2"
-
-[[audits.mozilla.audits.crossbeam-epoch]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.9.8 -> 0.9.10"
-
-[[audits.mozilla.audits.crossbeam-utils]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.8.8 -> 0.8.11"
-
 [[audits.mozilla.audits.crypto-common]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.1.6"
-
-[[audits.mozilla.audits.derive_arbitrary]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "1.1.0 -> 1.1.1"
-
-[[audits.mozilla.audits.derive_arbitrary]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "1.1.1 -> 1.1.3"
-
-[[audits.mozilla.audits.either]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.6.1 -> 1.7.0"
-
-[[audits.mozilla.audits.either]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 1.8.0"
 
 [[audits.mozilla.audits.encoding_rs]]
 who = "Henri Sivonen <hsivonen@hsivonen.fi>"
 criteria = "safe-to-deploy"
 version = "0.8.31"
 notes = "I, Henri Sivonen, wrote encoding_rs for Gecko and have reviewed contributions by others. There are two caveats to the certification: 1) The crate does things that are documented to be UB but that do not appear to actually be UB due to integer types differing from the general rule; https://github.com/hsivonen/encoding_rs/issues/79 . 2) It would be prudent to re-review the code that reinterprets buffers of integers as SIMD vectors; see https://github.com/hsivonen/encoding_rs/issues/87 ."
-
-[[audits.mozilla.audits.fastrand]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.7.0 -> 1.8.0"
 
 [[audits.mozilla.audits.flagset]]
 who = "Ryan Hunt <rhunt@eqrion.net>"
@@ -158,16 +57,6 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.2.1"
 notes = "Straightforward crate with no unsafe code, does what it says on the tin."
-
-[[audits.mozilla.audits.generic-array]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.14.5 -> 0.14.6"
-
-[[audits.mozilla.audits.getrandom]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.6 -> 0.2.7"
 
 [[audits.mozilla.audits.half]]
 who = "John M. Schanck <jschanck@mozilla.com>"
@@ -190,30 +79,10 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.19 -> 0.2.6"
 
-[[audits.mozilla.audits.indexmap]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.8.2 -> 1.9.1"
-
-[[audits.mozilla.audits.itoa]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.2 -> 1.0.3"
-
-[[audits.mozilla.audits.libc]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.126 -> 0.2.132"
-
 [[audits.mozilla.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 version = "0.4.17"
-
-[[audits.mozilla.audits.memmap2]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.5.4 -> 0.5.7"
 
 [[audits.mozilla.audits.memoffset]]
 who = "Gabriele Svelto <gsvelto@mozilla.com>"
@@ -263,21 +132,6 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "1.13.1 -> 1.16.0"
 
-[[audits.mozilla.audits.os_str_bytes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "6.1.0 -> 6.3.0"
-
-[[audits.mozilla.audits.paste]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.7 -> 1.0.8"
-
-[[audits.mozilla.audits.proc-macro2]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.39 -> 1.0.43"
-
 [[audits.mozilla.audits.quote]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -293,81 +147,6 @@ read, is generally straightforward. I have audited the the quote macros, ident
 formatter, and runtime logic.
 """
 
-[[audits.mozilla.audits.quote]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.18 -> 1.0.21"
-
-[[audits.mozilla.audits.redox_syscall]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.2.13 -> 0.2.16"
-
-[[audits.mozilla.audits.regex]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.5.6 -> 1.6.0"
-
-[[audits.mozilla.audits.regex-syntax]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "0.6.26 -> 0.6.27"
-
-[[audits.mozilla.audits.ryu]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.10 -> 1.0.11"
-
-[[audits.mozilla.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.137 -> 1.0.143"
-
-[[audits.mozilla.audits.serde]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.mozilla.audits.serde_cbor]]
-who = "R. Martinho Fernandes <bugs@rmf.io>"
-criteria = "safe-to-deploy"
-version = "0.11.1"
-
-[[audits.mozilla.audits.serde_cbor]]
-who = "John M. Schanck <jschanck@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.11.1 -> 0.11.2"
-
-[[audits.mozilla.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.137 -> 1.0.143"
-
-[[audits.mozilla.audits.serde_derive]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.143 -> 1.0.144"
-
-[[audits.mozilla.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.81 -> 1.0.83"
-
-[[audits.mozilla.audits.serde_json]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.83 -> 1.0.85"
-
-[[audits.mozilla.audits.smallvec]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.8.0 -> 1.9.0"
-
-[[audits.mozilla.audits.syn]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.96 -> 1.0.99"
-
 [[audits.mozilla.audits.synstructure]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -377,31 +156,6 @@ I am the primary author of the `synstructure` crate, and its current
 maintainer. The one use of `unsafe` is unnecessary, but documented and
 harmless. It will be removed in the next version.
 """
-
-[[audits.mozilla.audits.thiserror]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.31 -> 1.0.32"
-
-[[audits.mozilla.audits.thiserror-impl]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-deploy"
-delta = "1.0.31 -> 1.0.32"
-
-[[audits.mozilla.audits.tracing]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.35 -> 0.1.36"
-
-[[audits.mozilla.audits.tracing-attributes]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.21 -> 0.1.22"
-
-[[audits.mozilla.audits.tracing-core]]
-who = "Mike Hommey <mh+mozilla@glandium.org>"
-criteria = "safe-to-run"
-delta = "0.1.27 -> 0.1.29"
 
 [[audits.mozilla.audits.unicode-normalization]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -413,53 +167,3 @@ notes = "I am the author of most of these changes upstream, and prepared the rel
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.1.20 -> 0.1.21"
-
-[[audits.mozilla.audits.wasm-encoder]]
-who = "Ryan Hunt <rhunt@eqrion.net>"
-criteria = "safe-to-deploy"
-version = "0.7.0"
-notes = "Maintained by the Bytecode Alliance, with contributions from Mozilla. This has no unsafe code and uses no ambient capabilities."
-
-[[audits.mozilla.audits.wasm-encoder]]
-who = "Ryan Hunt <rhunt@eqrion.net>"
-criteria = "safe-to-deploy"
-delta = "0.7.0 -> 0.14.0"
-notes = "wasm-encoder has no unsafe code and uses no ambient capabilities."
-
-[[audits.mozilla.audits.wasm-encoder]]
-who = "Yury Delendik <ydelendik@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.14.0 -> 0.15.0"
-
-[[audits.mozilla.audits.wasm-smith]]
-who = "Ryan Hunt <rhunt@eqrion.net>"
-criteria = "safe-to-deploy"
-version = "0.11.2"
-notes = "Maintained by the Bytecode Alliance, with contributions from Mozilla. I've vetted the one instance of unsafe code."
-
-[[audits.mozilla.audits.wasm-smith]]
-who = "Yury Delendik <ydelendik@mozilla.com>"
-criteria = "safe-to-run"
-delta = "0.11.2 -> 0.11.3"
-
-[[audits.mozilla.audits.wasmparser]]
-who = "Ryan Hunt <rhunt@eqrion.net>"
-criteria = "safe-to-deploy"
-version = "0.87.0"
-notes = "Maintained by the Bytecode Alliance, with contributions from Mozilla. I've vetted the one instance of unsafe code."
-
-[[audits.mozilla.audits.wasmparser]]
-who = "Yury Delendik <ydelendik@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.87.0 -> 0.88.0"
-
-[[audits.mozilla.audits.wast]]
-who = "Ryan Hunt <rhunt@eqrion.net>"
-criteria = "safe-to-deploy"
-version = "44.0.0"
-
-[[audits.mozilla.audits.wast]]
-who = "Yury Delendik <ydelendik@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "44.0.0 -> 45.0.0"
-


### PR DESCRIPTION
This PR bumps cargo-vet to the new release and runs the newly-available `cargo vet prune`, which shrinks imports and exemptions to the minimal set.