### PR TITLE
Restrict fcvt_to_uint and fcvt_to_sint to produce scalar integers

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3264,15 +3264,6 @@ pub(crate) fn define(
         );
     }
 
-    let IntTo = &TypeVar::new(
-        "IntTo",
-        "A larger integer type with the same number of lanes",
-        TypeSetBuilder::new()
-            .ints(Interval::All)
-            .simd_lanes(Interval::All)
-            .build(),
-    );
-
     let FloatTo = &TypeVar::new(
         "FloatTo",
         "A scalar or vector floating point number",
@@ -3390,18 +3381,24 @@ pub(crate) fn define(
         .operands_out(vec![x]),
     );
 
-    let FloatScalar = &TypeVar::new(
-        "FloatScalar",
-        "A scalar only floating point number",
-        TypeSetBuilder::new().floats(Interval::All).build(),
-    );
-    let x = &Operand::new("x", FloatScalar);
-    let a = &Operand::new("a", IntTo);
+    {
+        let FloatScalar = &TypeVar::new(
+            "FloatScalar",
+            "A scalar only floating point number",
+            TypeSetBuilder::new().floats(Interval::All).build(),
+        );
+        let IntTo = &TypeVar::new(
+            "IntTo",
+            "An scalar only integer type",
+            TypeSetBuilder::new().ints(Interval::All).build(),
+        );
+        let x = &Operand::new("x", FloatScalar);
+        let a = &Operand::new("a", IntTo);
 
-    ig.push(
-        Inst::new(
-            "fcvt_to_uint",
-            r#"
+        ig.push(
+            Inst::new(
+                "fcvt_to_uint",
+                r#"
         Converts floating point scalars to unsigned integer.
 
         Only operates on `x` if it is a scalar. If `x` is NaN or if
@@ -3409,18 +3406,18 @@ pub(crate) fn define(
         type, this instruction traps.
 
         "#,
-            &formats.unary,
-        )
-        .operands_in(vec![x])
-        .operands_out(vec![a])
-        .can_trap()
-        .side_effects_idempotent(),
-    );
+                &formats.unary,
+            )
+            .operands_in(vec![x])
+            .operands_out(vec![a])
+            .can_trap()
+            .side_effects_idempotent(),
+        );
 
-    ig.push(
-        Inst::new(
-            "fcvt_to_sint",
-            r#"
+        ig.push(
+            Inst::new(
+                "fcvt_to_sint",
+                r#"
         Converts floating point scalars to signed integer.
 
         Only operates on `x` if it is a scalar. If `x` is NaN or if
@@ -3428,12 +3425,22 @@ pub(crate) fn define(
         type, this instruction traps.
 
         "#,
-            &formats.unary,
-        )
-        .operands_in(vec![x])
-        .operands_out(vec![a])
-        .can_trap()
-        .side_effects_idempotent(),
+                &formats.unary,
+            )
+            .operands_in(vec![x])
+            .operands_out(vec![a])
+            .can_trap()
+            .side_effects_idempotent(),
+        );
+    }
+
+    let IntTo = &TypeVar::new(
+        "IntTo",
+        "A larger integer type with the same number of lanes",
+        TypeSetBuilder::new()
+            .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .build(),
     );
 
     let x = &Operand::new("x", Float);

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3381,24 +3381,23 @@ pub(crate) fn define(
         .operands_out(vec![x]),
     );
 
-    {
-        let FloatScalar = &TypeVar::new(
-            "FloatScalar",
-            "A scalar only floating point number",
-            TypeSetBuilder::new().floats(Interval::All).build(),
-        );
-        let IntTo = &TypeVar::new(
-            "IntTo",
-            "An scalar only integer type",
-            TypeSetBuilder::new().ints(Interval::All).build(),
-        );
-        let x = &Operand::new("x", FloatScalar);
-        let a = &Operand::new("a", IntTo);
+    let FloatScalar = &TypeVar::new(
+        "FloatScalar",
+        "A scalar only floating point number",
+        TypeSetBuilder::new().floats(Interval::All).build(),
+    );
+    let IntTo = &TypeVar::new(
+        "IntTo",
+        "An scalar only integer type",
+        TypeSetBuilder::new().ints(Interval::All).build(),
+    );
+    let x = &Operand::new("x", FloatScalar);
+    let a = &Operand::new("a", IntTo);
 
-        ig.push(
-            Inst::new(
-                "fcvt_to_uint",
-                r#"
+    ig.push(
+        Inst::new(
+            "fcvt_to_uint",
+            r#"
         Converts floating point scalars to unsigned integer.
 
         Only operates on `x` if it is a scalar. If `x` is NaN or if
@@ -3406,18 +3405,18 @@ pub(crate) fn define(
         type, this instruction traps.
 
         "#,
-                &formats.unary,
-            )
-            .operands_in(vec![x])
-            .operands_out(vec![a])
-            .can_trap()
-            .side_effects_idempotent(),
-        );
+            &formats.unary,
+        )
+        .operands_in(vec![x])
+        .operands_out(vec![a])
+        .can_trap()
+        .side_effects_idempotent(),
+    );
 
-        ig.push(
-            Inst::new(
-                "fcvt_to_sint",
-                r#"
+    ig.push(
+        Inst::new(
+            "fcvt_to_sint",
+            r#"
         Converts floating point scalars to signed integer.
 
         Only operates on `x` if it is a scalar. If `x` is NaN or if
@@ -3425,14 +3424,13 @@ pub(crate) fn define(
         type, this instruction traps.
 
         "#,
-                &formats.unary,
-            )
-            .operands_in(vec![x])
-            .operands_out(vec![a])
-            .can_trap()
-            .side_effects_idempotent(),
-        );
-    }
+            &formats.unary,
+        )
+        .operands_in(vec![x])
+        .operands_out(vec![a])
+        .can_trap()
+        .side_effects_idempotent(),
+    );
 
     let IntTo = &TypeVar::new(
         "IntTo",


### PR DESCRIPTION
The `fcvt_to_uint` and `fcvt_to_sint` operations both lack lowerings that would produce vectors on all backends. This PR tightens up the result type of both instructions to no longer permit vector results.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
