### PR TITLE
Codegen fix `fcvt_from_sint.f32 ` with small types on riscv64.

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2122,6 +2122,13 @@
         (ones Reg (load_imm12 -1)))
   (value_reg (gen_select_reg (IntCC.Equal) zero input zero ones))))
 
+(decl normalize_fcvt_from_int (ValueRegs Type ExtendOp) ValueRegs)
+(rule 2 (normalize_fcvt_from_int r (fits_in_16 ty) op)
+  (extend r op ty $I64))
+(rule 1 (normalize_fcvt_from_int r _ _)
+  r)
+
+
 ;; Bitwise-or the two registers that make up the 128-bit value, then recurse as
 ;; though it was a 64-bit value.
 (rule

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1925,6 +1925,12 @@
 (rule (normalize_cmp_value $I64  r _) r)
 (rule (normalize_cmp_value $I128 r _) r)
 
+(decl normalize_fcvt_from_int (ValueRegs Type ExtendOp) ValueRegs)
+(rule 2 (normalize_fcvt_from_int r (fits_in_16 ty) op)
+  (extend r op ty $I64))
+(rule 1 (normalize_fcvt_from_int r _ _)
+  r)
+
 ;; Convert a truthy value, possibly of more than one register (an
 ;; I128), to one register. If narrower than 64 bits, must have already
 ;; been masked (e.g. by `normalize_cmp_value`).
@@ -2121,13 +2127,6 @@
         (zero Reg (zero_reg))
         (ones Reg (load_imm12 -1)))
   (value_reg (gen_select_reg (IntCC.Equal) zero input zero ones))))
-
-(decl normalize_fcvt_from_int (ValueRegs Type ExtendOp) ValueRegs)
-(rule 2 (normalize_fcvt_from_int r (fits_in_16 ty) op)
-  (extend r op ty $I64))
-(rule 1 (normalize_fcvt_from_int r _ _)
-  r)
-
 
 ;; Bitwise-or the two registers that make up the 128-bit value, then recurse as
 ;; though it was a 64-bit value.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -802,12 +802,12 @@
 ;;;;;  Rules for `fcvt_from_sint`;;;;;;;;;
 (rule
   (lower (has_type to (fcvt_from_sint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $true to) to (normalize_cmp_value from v (ExtendOp.Signed))))
+  (fpu_rr (int_convert_2_float_op from $true to) to (normalize_fcvt_from_int v from (ExtendOp.Signed))))
 
 ;;;;;  Rules for `fcvt_from_uint`;;;;;;;;;
 (rule
   (lower (has_type to (fcvt_from_uint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_cmp_value from v (ExtendOp.Zero))))
+  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_fcvt_from_int v from  (ExtendOp.Zero))))
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -807,7 +807,7 @@
 ;;;;;  Rules for `fcvt_from_uint`;;;;;;;;;
 (rule
   (lower (has_type to (fcvt_from_uint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_fcvt_from_int v from  (ExtendOp.Zero))))
+  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_fcvt_from_int v from (ExtendOp.Zero))))
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -802,12 +802,12 @@
 ;;;;;  Rules for `fcvt_from_sint`;;;;;;;;;
 (rule
   (lower (has_type to (fcvt_from_sint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $true to) to v))
+  (fpu_rr (int_convert_2_float_op from $true to) to (normalize_cmp_value from v (ExtendOp.Signed))))
 
 ;;;;;  Rules for `fcvt_from_uint`;;;;;;;;;
 (rule
   (lower (has_type to (fcvt_from_uint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $false to) to v))
+  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_cmp_value from v (ExtendOp.Zero))))
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
 (rule

--- a/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
@@ -10,12 +10,14 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   fcvt.s.lu fa0,a0
+;   andi t2,a0,255
+;   fcvt.s.lu fa0,t2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.s.lu fa0, a0
+;   andi t2, a0, 0xff
+;   fcvt.s.lu fa0, t2
 ;   ret
 
 function u0:0(i8) -> f64 {
@@ -26,12 +28,14 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   fcvt.d.lu fa0,a0
+;   andi t2,a0,255
+;   fcvt.d.lu fa0,t2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.d.lu fa0, a0
+;   andi t2, a0, 0xff
+;   fcvt.d.lu fa0, t2
 ;   ret
 
 function u0:0(i16) -> f32 {
@@ -42,12 +46,16 @@ block0(v0: i16):
 
 ; VCode:
 ; block0:
-;   fcvt.s.lu fa0,a0
+;   slli t2,a0,48
+;   srli a1,t2,48
+;   fcvt.s.lu fa0,a1
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.s.lu fa0, a0
+;   slli t2, a0, 0x30
+;   srli a1, t2, 0x30
+;   fcvt.s.lu fa0, a1
 ;   ret
 
 function u0:0(i16) -> f64 {
@@ -58,12 +66,16 @@ block0(v0: i16):
 
 ; VCode:
 ; block0:
-;   fcvt.d.lu fa0,a0
+;   slli t2,a0,48
+;   srli a1,t2,48
+;   fcvt.d.lu fa0,a1
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.d.lu fa0, a0
+;   slli t2, a0, 0x30
+;   srli a1, t2, 0x30
+;   fcvt.d.lu fa0, a1
 ;   ret
 
 function u0:0(f32) -> i8 {

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -1026,16 +1026,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   slli t2,a0,32
-;   srli a1,t2,32
-;   fcvt.s.wu fa0,a1
+;   fcvt.s.wu fa0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   slli t2, a0, 0x20
-;   srli a1, t2, 0x20
-;   fcvt.s.wu fa0, a1
+;   fcvt.s.wu fa0, a0
 ;   ret
 
 function %f42(i32) -> f32 {
@@ -1046,14 +1042,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   sext.w t2,a0
-;   fcvt.s.w fa0,t2
+;   fcvt.s.w fa0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   sext.w t2, a0
-;   fcvt.s.w fa0, t2
+;   fcvt.s.w fa0, a0
 ;   ret
 
 function %f43(i64) -> f32 {
@@ -1096,16 +1090,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   slli t2,a0,32
-;   srli a1,t2,32
-;   fcvt.d.wu fa0,a1
+;   fcvt.d.wu fa0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   slli t2, a0, 0x20
-;   srli a1, t2, 0x20
-;   fcvt.d.wu fa0, a1
+;   fcvt.d.wu fa0, a0
 ;   ret
 
 function %f46(i32) -> f64 {
@@ -1116,14 +1106,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   sext.w t2,a0
-;   fcvt.d.w fa0,t2
+;   fcvt.d.w fa0,a0
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   sext.w t2, a0
-;   .byte 0x53, 0xf5, 0x03, 0xd2
+;   .byte 0x53, 0x75, 0x05, 0xd2
 ;   ret
 
 function %f47(i64) -> f64 {

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -1026,12 +1026,16 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   fcvt.s.wu fa0,a0
+;   slli t2,a0,32
+;   srli a1,t2,32
+;   fcvt.s.wu fa0,a1
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.s.wu fa0, a0
+;   slli t2, a0, 0x20
+;   srli a1, t2, 0x20
+;   fcvt.s.wu fa0, a1
 ;   ret
 
 function %f42(i32) -> f32 {
@@ -1042,12 +1046,14 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   fcvt.s.w fa0,a0
+;   sext.w t2,a0
+;   fcvt.s.w fa0,t2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.s.w fa0, a0
+;   sext.w t2, a0
+;   fcvt.s.w fa0, t2
 ;   ret
 
 function %f43(i64) -> f32 {
@@ -1090,12 +1096,16 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   fcvt.d.wu fa0,a0
+;   slli t2,a0,32
+;   srli a1,t2,32
+;   fcvt.d.wu fa0,a1
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   fcvt.d.wu fa0, a0
+;   slli t2, a0, 0x20
+;   srli a1, t2, 0x20
+;   fcvt.d.wu fa0, a1
 ;   ret
 
 function %f46(i32) -> f64 {
@@ -1106,12 +1116,14 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   fcvt.d.w fa0,a0
+;   sext.w t2,a0
+;   fcvt.d.w fa0,t2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   .byte 0x53, 0x75, 0x05, 0xd2
+;   sext.w t2, a0
+;   .byte 0x53, 0xf5, 0x03, 0xd2
 ;   ret
 
 function %f47(i64) -> f64 {

--- a/cranelift/filetests/filetests/runtests/issue5952.clif
+++ b/cranelift/filetests/filetests/runtests/issue5952.clif
@@ -1,0 +1,14 @@
+test interpret
+test run
+target aarch64
+target x86_64
+target s390x
+target riscv64
+
+function %a(i16 uext) -> f32 {
+block0(v0: i16):
+    v1 = fcvt_from_sint.f32 v0
+    return v1
+}
+
+; run: %a(-12800) == -0x1.900000p13


### PR DESCRIPTION
This will fix #5952.