### PR TITLE
Add `Clone for component::InstancePre`

### DIFF
--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -194,6 +194,7 @@ struct Instantiator<'a> {
     imports: &'a PrimaryMap<RuntimeImportIndex, RuntimeImport>,
 }
 
+#[derive(Clone)]
 pub enum RuntimeImport {
     Func(Arc<HostFunc>),
     Module(Module),
@@ -462,6 +463,17 @@ pub struct InstancePre<T> {
     component: Component,
     imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,
     _marker: marker::PhantomData<fn() -> T>,
+}
+
+// `InstancePre`'s clone does not require `T: Clone`
+impl<T> Clone for InstancePre<T> {
+    fn clone(&self) -> Self {
+        Self {
+            component: self.component.clone(),
+            imports: self.imports.clone(),
+            _marker: self._marker,
+        }
+    }
 }
 
 impl<T> InstancePre<T> {


### PR DESCRIPTION
This is present on `wasmtime::InstancePre` and should be available for components as well.

Closes #5965

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
