### PR TITLE
components: Fix bindgen! with renamed interfaces

### DIFF
--- a/crates/component-macro/tests/codegen/rename.wit
+++ b/crates/component-macro/tests/codegen/rename.wit
@@ -1,0 +1,14 @@
+interface red {
+  use self.green.{thing}
+
+  foo: func() -> thing
+}
+
+interface green {
+  type thing = s32
+}
+
+default world neptune {
+  import blue: self.red
+  import orange: self.green
+}

--- a/crates/wit-bindgen/src/rust.rs
+++ b/crates/wit-bindgen/src/rust.rs
@@ -15,7 +15,7 @@ pub trait RustGenerator<'a> {
 
     fn push_str(&mut self, s: &str);
     fn info(&self, ty: TypeId) -> TypeInfo;
-    fn current_interface(&self) -> Option<InterfaceId>;
+    fn path_to_interface(&self, interface: InterfaceId) -> Option<String>;
 
     fn print_ty(&mut self, ty: &Type, mode: TypeMode) {
         match ty {
@@ -64,19 +64,9 @@ pub trait RustGenerator<'a> {
                 self.result_name(id)
             };
             if let TypeOwner::Interface(id) = ty.owner {
-                if let Some(name) = &self.resolve().interfaces[id].name {
-                    match self.current_interface() {
-                        Some(cur) if cur == id => {}
-                        Some(_other) => {
-                            self.push_str("super::");
-                            self.push_str(&name.to_snake_case());
-                            self.push_str("::");
-                        }
-                        None => {
-                            self.push_str(&name.to_snake_case());
-                            self.push_str("::");
-                        }
-                    }
+                if let Some(path) = self.path_to_interface(id) {
+                    self.push_str(&path);
+                    self.push_str("::");
                 }
             }
             self.push_str(&name);


### PR DESCRIPTION
This follows the same strategy pioneered by the `wit-bindgen` guest Rust bindgen which keeps track of the latest name of an interface for how to refer to an interface.

Closes #5961

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
