### PR TITLE
Cranelift: aarch64: fix undefined dest reg in f32x4.splat case.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -416,21 +416,29 @@ impl Inst {
                 size
             }]
         } else if let Some(imm) = widen_32_bit_pattern(pattern, lane_size) {
-            let tmp = alloc_tmp(types::I64X2);
-            let mut insts = smallvec![Inst::VecDupImm {
-                rd: tmp,
-                imm,
-                invert: false,
-                size: VectorSize::Size64x2,
-            }];
+            let mut insts = smallvec![];
 
             // TODO: Implement support for 64-bit scalar MOVI; we zero-extend the
             // lower 64 bits instead.
             if !size.is_128bits() {
+                let tmp = alloc_tmp(types::I64X2);
+                insts.push(Inst::VecDupImm {
+                    rd: tmp,
+                    imm,
+                    invert: false,
+                    size: VectorSize::Size64x2,
+                });
                 insts.push(Inst::FpuExtend {
                     rd,
                     rn: tmp.to_reg(),
                     size: ScalarSize::Size64,
+                });
+            } else {
+                insts.push(Inst::VecDupImm {
+                    rd,
+                    imm,
+                    invert: false,
+                    size: VectorSize::Size64x2,
                 });
             }
 

--- a/cranelift/filetests/filetests/isa/aarch64/issue-5985.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/issue-5985.clif
@@ -1,0 +1,20 @@
+test compile precise-output
+target aarch64
+
+function %a() -> f32x4 system_v {
+block0:
+    v16 = f32const 0x1.fffe00p-126
+    v25 = splat.f32x4 v16
+    return v25
+}
+
+; VCode:
+; block0:
+;   movi v0.2d, #72056494543077120
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   movi v0.2d, #0xffff0000ffff00
+;   ret
+


### PR DESCRIPTION
One of the cases for a splat operation, as updated in #5370, wrote to a temp reg but then only conditionally transformed the temp into the final destination register. In another codepath, `rd` was left undefined. This causes a panic later when regalloc2 verifies SSA properties of its input (here, value not def'd before use).

Fixes #5985.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
