### PR TITLE
fuzzgen: Generate random ISA flags

### DIFF
--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -6,7 +6,9 @@ use arbitrary::{Arbitrary, Unstructured};
 use cranelift::codegen::data_value::DataValue;
 use cranelift::codegen::ir::{types::*, UserExternalName, UserFuncName};
 use cranelift::codegen::ir::{Function, LibCall};
+use cranelift::codegen::isa::{self, Builder};
 use cranelift::codegen::Context;
+use cranelift::prelude::settings::SettingKind;
 use cranelift::prelude::*;
 use cranelift_arbitrary::CraneliftArbitrary;
 use cranelift_native::builder_with_options;
@@ -21,6 +23,15 @@ mod print;
 pub use print::PrintableTestCase;
 
 pub type TestCaseInput = Vec<DataValue>;
+
+pub enum IsaFlagGen {
+    /// When generating ISA flags, ensure that they are all supported by
+    /// the current host.
+    Host,
+    /// All flags available in cranelift are allowed to be generated.
+    /// We also allow generating all possible values for each enum flag.
+    All,
+}
 
 pub struct FuzzGen<'r, 'data>
 where
@@ -227,5 +238,57 @@ where
         builder.enable("machine_code_cfg_info")?;
 
         Ok(Flags::new(builder))
+    }
+
+    /// Generate a random set of ISA flags and apply them to a Builder.
+    ///
+    /// Based on `mode` we can either allow all flags, or just the subset that is
+    /// supported by the current host.
+    ///
+    /// In all cases only a subset of the allowed flags is applied to the builder.
+    pub fn set_isa_flags(&mut self, builder: &mut Builder, mode: IsaFlagGen) -> Result<()> {
+        // `max_isa` is the maximal set of flags that we can use.
+        let max_builder = match mode {
+            IsaFlagGen::All => {
+                let mut max_builder = isa::lookup(builder.triple().clone())?;
+
+                for flag in max_builder.iter() {
+                    match flag.kind {
+                        SettingKind::Bool => {
+                            max_builder.enable(flag.name)?;
+                        }
+                        SettingKind::Enum => {
+                            // Since these are enums there isn't a "max" value per se, pick one at random.
+                            let value = self.u.choose(flag.values.unwrap())?;
+                            max_builder.set(flag.name, value)?;
+                        }
+                        SettingKind::Preset => {
+                            // Presets are just special flags that combine other flags, we don't
+                            // want to enable them directly, just the underlying flags.
+                        }
+                        _ => todo!(),
+                    };
+                }
+                max_builder
+            }
+            // Use `cranelift-native` to do feature detection for us.
+            IsaFlagGen::Host => builder_with_options(true)
+                .expect("Unable to build a TargetIsa for the current host"),
+        };
+        // Cranelift has a somwhat weird API for this, but we need to build the final `TargetIsa` to be able
+        // to extract the values for the ISA flags. We need that to use the `string_value()` that formats
+        // the values so that we can pass it into the builder again.
+        let max_isa = max_builder.finish(Flags::new(settings::builder()))?;
+
+        // We give each of the flags a chance of being copied over. Otherwise we keep the default.
+        for value in max_isa.isa_flags().iter() {
+            let should_copy = bool::arbitrary(self.u)?;
+            if !should_copy {
+                continue;
+            }
+            builder.set(value.name, &value.value_string())?;
+        }
+
+        Ok(())
     }
 }

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -171,9 +171,10 @@ impl TestCase {
 
         // TestCase is meant to be consumed by a runner, so we make the assumption here that we're
         // generating a TargetIsa for the host.
-        let builder =
+        let mut builder =
             builder_with_options(true).expect("Unable to build a TargetIsa for the current host");
         let flags = gen.generate_flags(builder.triple().architecture)?;
+        gen.set_isa_flags(&mut builder, IsaFlagGen::Host)?;
         let isa = builder.finish(flags)?;
 
         // When generating functions, we allow each function to call any function that has

--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -48,13 +48,15 @@ impl FunctionWithIsa {
         // a supported one, so that the same fuzz input works across different build
         // configurations.
         let target = u.choose(isa::ALL_ARCHITECTURES)?;
-        let builder = isa::lookup_by_name(target).map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        let mut builder =
+            isa::lookup_by_name(target).map_err(|_| arbitrary::Error::IncorrectFormat)?;
         let architecture = builder.triple().architecture;
 
         let mut gen = FuzzGen::new(u);
         let flags = gen
             .generate_flags(architecture)
             .map_err(|_| arbitrary::Error::IncorrectFormat)?;
+        gen.set_isa_flags(&mut builder, IsaFlagGen::All)?;
         let isa = builder
             .finish(flags)
             .map_err(|_| arbitrary::Error::IncorrectFormat)?;


### PR DESCRIPTION
👋 Hey,

This PR allows fuzzgen to generate random ISA flags and run the tests with them. It has two modes, for `icache` since we are just compiling the code we enable all flags, but for `fuzzgen` we actually need to execute them, so we use `cranelift-native` and only allow flags available in the host.

So far this has found the following issues on `icache`, so we need to fix them before merging:
* #5857
  *  Here with `zbb` we generate an invalid lowering using integer instruction on float registers
* #5854
  * The issue here is that with `zbb` we accidentally lose a lowering for `ctz`
* #5979

I also don't have AVX-512 hardware, so It would be really nice if someone could run this on one of those fancy machines before merging, or we can also let OSS-Fuzz do it.

This has otherwise found nothing on AArch64 and RISC-V.

Fixes #5816