### PR TITLE
Allow to disable clocks in WasiCtx

### DIFF
--- a/crates/wasi-common/cap-std-sync/src/clocks.rs
+++ b/crates/wasi-common/cap-std-sync/src/clocks.rs
@@ -35,13 +35,7 @@ impl WasiMonotonicClock for MonotonicClock {
 }
 
 pub fn clocks_ctx() -> WasiClocks {
-    let system = Box::new(SystemClock::new(ambient_authority()));
-    let monotonic = cap_std::time::MonotonicClock::new(ambient_authority());
-    let creation_time = monotonic.now();
-    let monotonic = Box::new(MonotonicClock(monotonic));
-    WasiClocks {
-        system,
-        monotonic,
-        creation_time,
-    }
+    WasiClocks::new()
+        .with_system(SystemClock::new(ambient_authority()))
+        .with_monotonic(MonotonicClock::new(ambient_authority()))
 }

--- a/crates/wasi-common/src/clocks.rs
+++ b/crates/wasi-common/src/clocks.rs
@@ -1,3 +1,4 @@
+use crate::{Error, ErrorExt};
 use cap_std::time::{Duration, Instant, SystemTime};
 
 pub enum SystemTimeSpec {
@@ -15,8 +16,52 @@ pub trait WasiMonotonicClock: Send + Sync {
     fn now(&self, precision: Duration) -> Instant;
 }
 
-pub struct WasiClocks {
-    pub system: Box<dyn WasiSystemClock>,
-    pub monotonic: Box<dyn WasiMonotonicClock>,
+pub struct WasiMonotonicOffsetClock {
     pub creation_time: cap_std::time::Instant,
+    pub abs_clock: Box<dyn WasiMonotonicClock>,
+}
+
+impl WasiMonotonicOffsetClock {
+    pub fn new(clock: impl 'static + WasiMonotonicClock) -> Self {
+        Self {
+            creation_time: clock.now(clock.resolution()),
+            abs_clock: Box::new(clock),
+        }
+    }
+}
+
+pub struct WasiClocks {
+    pub system: Option<Box<dyn WasiSystemClock>>,
+    pub monotonic: Option<WasiMonotonicOffsetClock>,
+}
+
+impl WasiClocks {
+    pub fn new() -> Self {
+        Self {
+            system: None,
+            monotonic: None,
+        }
+    }
+
+    pub fn with_system(mut self, clock: impl 'static + WasiSystemClock) -> Self {
+        self.system = Some(Box::new(clock));
+        self
+    }
+
+    pub fn with_monotonic(mut self, clock: impl 'static + WasiMonotonicClock) -> Self {
+        self.monotonic = Some(WasiMonotonicOffsetClock::new(clock));
+        self
+    }
+
+    pub fn system(&self) -> Result<&dyn WasiSystemClock, Error> {
+        self.system
+            .as_deref()
+            .ok_or_else(|| Error::badf().context("system clock is not supported"))
+    }
+
+    pub fn monotonic(&self) -> Result<&WasiMonotonicOffsetClock, Error> {
+        self.monotonic
+            .as_ref()
+            .ok_or_else(|| Error::badf().context("monotonic clock is not supported"))
+    }
 }

--- a/crates/wasi-common/tokio/tests/poll_oneoff.rs
+++ b/crates/wasi-common/tokio/tests/poll_oneoff.rs
@@ -38,14 +38,14 @@ async fn empty_file_readable() -> Result<(), Error> {
     let mut poll = Poll::new();
     poll.subscribe_read(&mut *f, Userdata::from(123));
     // Timeout bounds time in poll_oneoff
+    let monotonic = &*clocks.monotonic()?.abs_clock;
     poll.subscribe_monotonic_clock(
-        &*clocks.monotonic,
-        clocks
-            .monotonic
-            .now(clocks.monotonic.resolution())
+        monotonic,
+        monotonic
+            .now(monotonic.resolution())
             .checked_add(TIMEOUT)
             .unwrap(),
-        clocks.monotonic.resolution(),
+        monotonic.resolution(),
         Userdata::from(0),
     );
     poll_oneoff(&mut poll).await?;
@@ -81,14 +81,14 @@ async fn empty_file_writable() -> Result<(), Error> {
     let mut poll = Poll::new();
     poll.subscribe_write(&mut *writable_f, Userdata::from(123));
     // Timeout bounds time in poll_oneoff
+    let monotonic = &*clocks.monotonic()?.abs_clock;
     poll.subscribe_monotonic_clock(
-        &*clocks.monotonic,
-        clocks
-            .monotonic
-            .now(clocks.monotonic.resolution())
+        monotonic,
+        monotonic
+            .now(monotonic.resolution())
             .checked_add(TIMEOUT)
             .unwrap(),
-        clocks.monotonic.resolution(),
+        monotonic.resolution(),
         Userdata::from(0),
     );
     poll_oneoff(&mut poll).await?;
@@ -110,9 +110,9 @@ async fn empty_file_writable() -> Result<(), Error> {
 async fn stdio_readable() -> Result<(), Error> {
     let clocks = clocks_ctx();
 
-    let deadline = clocks
-        .monotonic
-        .now(clocks.monotonic.resolution())
+    let monotonic = &*clocks.monotonic()?.abs_clock;
+    let deadline = monotonic
+        .now(monotonic.resolution())
         .checked_add(TIMEOUT)
         .unwrap();
 
@@ -133,10 +133,11 @@ async fn stdio_readable() -> Result<(), Error> {
             poll.subscribe_write(&mut **file, Userdata::from(*ix));
         }
         // Timeout bounds time in poll_oneoff
+        let monotonic = &*clocks.monotonic()?.abs_clock;
         poll.subscribe_monotonic_clock(
-            &*clocks.monotonic,
+            monotonic,
             deadline,
-            clocks.monotonic.resolution(),
+            monotonic.resolution(),
             Userdata::from(999),
         );
         poll_oneoff(&mut poll).await?;


### PR DESCRIPTION
Takes the approach described in #6004, but also creates a wrapper for the monotonic time that encapsulates the `creation_time` field as well, since they logically belong and are always used together.

This makes it easier to configure `WasiCtx` with custom clocks as well as disable them for security or determinism reasons.

Closes #6004.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
