### PR TITLE
cranelift: Add narrower and wider constraints to the instruction DSL

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -483,8 +483,6 @@ fn is_ctrl_typevar_candidate(
         }
 
         let typ = result.type_var().unwrap();
-        let free_typevar = typ.free_typevar();
-
         if let Some(tv) = typ.free_typevar() {
             if &tv != ctrl_typevar {
                 return Err("type variable in output not derived from ctrl_typevar".into());

--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -485,19 +485,15 @@ fn is_ctrl_typevar_candidate(
         let typ = result.type_var().unwrap();
         let free_typevar = typ.free_typevar();
 
-        if let Some(tv) = free_typevar {
+        if let Some(tv) = typ.free_typevar() {
+            if &tv != ctrl_typevar {
+                return Err("type variable in output not derived from ctrl_typevar".into());
+            }
+
             // Variables derived from the control variable are ok, but we remember if they refine
             // the control variable, as that still requires another type to instantiate.
-            if &tv == ctrl_typevar {
-                refines_output = typ.refines_parent();
-                continue;
-            }
-        } else {
-            // Non-polymorphic is OK.
-            continue;
+            refines_output = typ.refines_parent();
         }
-
-        return Err("type variable in output not derived from ctrl_typevar".into());
     }
 
     Ok((refines_output, other_typevars))

--- a/cranelift/codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift/codegen/meta/src/cdsl/typevar.rs
@@ -220,7 +220,7 @@ impl TypeVar {
                     (!ts.ints.is_empty() || !ts.floats.is_empty())
                         && ts.refs.is_empty()
                         && ts.dynamic_lanes.is_empty(),
-                    "The `narrower` constraint only applies to scalar ints"
+                    "The `narrower` constraint only applies to scalar ints or floats"
                 );
             }
             DerivedFunc::Wider => {
@@ -233,7 +233,7 @@ impl TypeVar {
                     (!ts.ints.is_empty() || !ts.floats.is_empty())
                         && ts.refs.is_empty()
                         && ts.dynamic_lanes.is_empty(),
-                    "The `wider` constraint only applies to scalar ints"
+                    "The `wider` constraint only applies to scalar ints or floats"
                 );
             }
             DerivedFunc::LaneOf | DerivedFunc::AsBool | DerivedFunc::DynamicToVector => {

--- a/cranelift/codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift/codegen/meta/src/cdsl/typevar.rs
@@ -124,14 +124,6 @@ impl TypeVar {
         &self.type_set
     }
 
-    /// Returns true if this type variable refines but doesn't fully determine its value from the
-    /// parent type variable.
-    pub fn refines_parent(&self) -> bool {
-        self.base
-            .as_ref()
-            .map_or(false, |base| !base.derived_func.is_singleton())
-    }
-
     /// If the associated typeset has a single type return it. Otherwise return None.
     pub fn singleton_type(&self) -> Option<ValueType> {
         let type_set = self.get_typeset();
@@ -362,21 +354,6 @@ impl DerivedFunc {
             DerivedFunc::DynamicToVector => "dynamic_to_vector",
             DerivedFunc::Narrower => "narrower",
             DerivedFunc::Wider => "wider",
-        }
-    }
-
-    /// Returns `true` when this derived function will fully determine a resulting type, and
-    /// `false` if it determines a set of types.
-    pub fn is_singleton(self) -> bool {
-        match self {
-            DerivedFunc::LaneOf
-            | DerivedFunc::AsBool
-            | DerivedFunc::HalfWidth
-            | DerivedFunc::DoubleWidth
-            | DerivedFunc::SplitLanes
-            | DerivedFunc::MergeLanes
-            | DerivedFunc::DynamicToVector => true,
-            DerivedFunc::Narrower | DerivedFunc::Wider => false,
         }
     }
 }

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3064,12 +3064,6 @@ pub(crate) fn define(
         TypeSetBuilder::new().ints(Interval::All).build(),
     );
 
-    let IntTo = &TypeVar::new(
-        "IntTo",
-        "A smaller integer type",
-        TypeSetBuilder::new().ints(Interval::All).build(),
-    );
-
     ig.push(
         Inst::new(
             "ireduce",
@@ -3081,8 +3075,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", IntTo)]),
+        .operands_in(vec![Operand::new("x", &Int.wider())])
+        .operands_out(vec![Operand::new("a", Int)]),
     );
 
     let I16or32or64xN = &TypeVar::new(
@@ -3272,17 +3266,10 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("a", I16x8)]),
     );
 
-    {
-        let IntTo = &TypeVar::new(
-            "IntTo",
-            "A larger integer type with the same number of lanes",
-            TypeSetBuilder::new().ints(Interval::All).build(),
-        );
-
-        ig.push(
-            Inst::new(
-                "uextend",
-                r#"
+    ig.push(
+        Inst::new(
+            "uextend",
+            r#"
         Convert `x` to a larger integer type by zero-extending.
 
         Each lane in `x` is converted to a larger integer type by adding
@@ -3293,16 +3280,16 @@ pub(crate) fn define(
         and each lane must not have fewer bits that the input lanes. If the
         input and output types are the same, this is a no-op.
         "#,
-                &formats.unary,
-            )
-            .operands_in(vec![Operand::new("x", Int)])
-            .operands_out(vec![Operand::new("a", IntTo)]),
-        );
+            &formats.unary,
+        )
+        .operands_in(vec![Operand::new("x", &Int.narrower())])
+        .operands_out(vec![Operand::new("a", Int)]),
+    );
 
-        ig.push(
-            Inst::new(
-                "sextend",
-                r#"
+    ig.push(
+        Inst::new(
+            "sextend",
+            r#"
         Convert `x` to a larger integer type by sign-extending.
 
         Each lane in `x` is converted to a larger integer type by replicating
@@ -3313,21 +3300,14 @@ pub(crate) fn define(
         and each lane must not have fewer bits that the input lanes. If the
         input and output types are the same, this is a no-op.
         "#,
-                &formats.unary,
-            )
-            .operands_in(vec![Operand::new("x", Int)])
-            .operands_out(vec![Operand::new("a", IntTo)]),
-        );
-    }
+            &formats.unary,
+        )
+        .operands_in(vec![Operand::new("x", &Int.narrower())])
+        .operands_out(vec![Operand::new("a", Int)]),
+    );
 
     let FloatScalar = &TypeVar::new(
         "FloatScalar",
-        "A scalar only floating point number",
-        TypeSetBuilder::new().floats(Interval::All).build(),
-    );
-
-    let FloatScalarTo = &TypeVar::new(
-        "FloatScalarTo",
         "A scalar only floating point number",
         TypeSetBuilder::new().floats(Interval::All).build(),
     );
@@ -3349,8 +3329,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", FloatScalar)])
-        .operands_out(vec![Operand::new("a", FloatScalarTo)]),
+        .operands_in(vec![Operand::new("x", &FloatScalar.narrower())])
+        .operands_out(vec![Operand::new("a", FloatScalar)]),
     );
 
     ig.push(
@@ -3370,8 +3350,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", FloatScalar)])
-        .operands_out(vec![Operand::new("a", FloatScalarTo)]),
+        .operands_in(vec![Operand::new("x", &FloatScalar.wider())])
+        .operands_out(vec![Operand::new("a", FloatScalar)]),
     );
 
     let F64x2 = &TypeVar::new(

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3075,7 +3075,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &Int.wider())])
+        .operands_in(vec![Operand::new("x", &Int.wider())
+            .with_doc("A scalar integer type, wider than the controlling type")])
         .operands_out(vec![Operand::new("a", Int)]),
     );
 
@@ -3282,7 +3283,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &Int.narrower())])
+        .operands_in(vec![Operand::new("x", &Int.narrower()).with_doc(
+            "A scalar integer type, narrower than the controlling type",
+        )])
         .operands_out(vec![Operand::new("a", Int)]),
     );
 
@@ -3302,7 +3305,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &Int.narrower())])
+        .operands_in(vec![Operand::new("x", &Int.narrower()).with_doc(
+            "A scalar integer type, narrower than the controlling type",
+        )])
         .operands_out(vec![Operand::new("a", Int)]),
     );
 
@@ -3329,7 +3334,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &FloatScalar.narrower())])
+        .operands_in(vec![Operand::new("x", &FloatScalar.narrower()).with_doc(
+            "A scalar only floating point number, narrower than the controlling type",
+        )])
         .operands_out(vec![Operand::new("a", FloatScalar)]),
     );
 
@@ -3350,7 +3357,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &FloatScalar.wider())])
+        .operands_in(vec![Operand::new("x", &FloatScalar.wider()).with_doc(
+            "A scalar only floating point number, wider than the controlling type",
+        )])
         .operands_out(vec![Operand::new("a", FloatScalar)]),
     );
 

--- a/cranelift/codegen/src/bitset.rs
+++ b/cranelift/codegen/src/bitset.rs
@@ -11,7 +11,7 @@ use core::mem::size_of;
 use core::ops::{Add, BitOr, Shl, Sub};
 
 /// A small bitset built on a single primitive integer type
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BitSet<T>(pub T);
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -799,7 +799,7 @@ impl OperandConstraint {
                 if ctrl_type.is_int() {
                     // The upper bound should include all types wider than `ctrl_type`, so we use
                     // `2^8` as the upper bound to define the closed range `[ctrl_type, I128]`.
-                    tys.ints = BitSet::from_range(ctrl_type_bits as u8, BitSet8::bits() as u8);
+                    tys.ints = BitSet::from_range(ctrl_type_bits as u8, 8);
                 } else if ctrl_type.is_float() {
                     // The upper bound should include all float types wider than `ctrl_type`, so we
                     // use `2^7` as the upper bound to define the closed range `[ctrl_type, F64]`.

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -575,12 +575,9 @@ impl OpcodeConstraints {
     /// `ctrl_type`.
     pub fn result_type(self, n: usize, ctrl_type: Type) -> Type {
         debug_assert!(n < self.num_fixed_results(), "Invalid result index");
-        if let ResolvedConstraint::Bound(t) =
-            OPERAND_CONSTRAINTS[self.constraint_offset() + n].resolve(ctrl_type)
-        {
-            t
-        } else {
-            panic!("Result constraints can't be free");
+        match OPERAND_CONSTRAINTS[self.constraint_offset() + n].resolve(ctrl_type) {
+            ResolvedConstraint::Bound(t) => t,
+            ResolvedConstraint::Free(ts) => panic!("Result constraints can't be free: {:?}", ts),
         }
     }
 
@@ -614,7 +611,7 @@ type BitSet8 = BitSet<u8>;
 type BitSet16 = BitSet<u16>;
 
 /// A value type set describes the permitted set of types for a type variable.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ValueTypeSet {
     /// Allowed lane sizes
     pub lanes: BitSet16,
@@ -703,6 +700,12 @@ enum OperandConstraint {
 
     /// This operands is `ctrlType.dynamic_to_vector()`.
     DynamicToVector,
+
+    /// This operand is `ctrlType.narrower()`.
+    Narrower,
+
+    /// This operand is `ctrlType.wider()`.
+    Wider,
 }
 
 impl OperandConstraint {
@@ -766,6 +769,47 @@ impl OperandConstraint {
                     .dynamic_to_vector()
                     .expect("invalid type for dynamic_to_vector"),
             ),
+            Narrower => {
+                let ctrl_type_bits = ctrl_type.log2_lane_bits();
+                let mut tys = ValueTypeSet::default();
+
+                // We're testing scalar values, only.
+                tys.lanes = BitSet::from_range(0, 1);
+
+                if ctrl_type.is_int() {
+                    // The upper bound in from_range is exclusive, so add one here get the closed
+                    // interval of [I8, ctrl_type].
+                    tys.ints = BitSet::from_range(3, ctrl_type_bits as u8 + 1);
+                } else if ctrl_type.is_float() {
+                    // The upper bound in from_range is exclusive, so add one here get the closed
+                    // interval of [F32, ctrl_type].
+                    tys.floats = BitSet::from_range(5, ctrl_type_bits as u8 + 1);
+                } else {
+                    panic!("The Narrower constraint only operates on floats or ints");
+                }
+                ResolvedConstraint::Free(tys)
+            }
+            Wider => {
+                let ctrl_type_bits = ctrl_type.log2_lane_bits();
+                let mut tys = ValueTypeSet::default();
+
+                // We're testing scalar values, only.
+                tys.lanes = BitSet::from_range(0, 1);
+
+                if ctrl_type.is_int() {
+                    // The upper bound should include all types wider than `ctrl_type`, so we use
+                    // `2^8` as the upper bound to define the closed range `[ctrl_type, I128]`.
+                    tys.ints = BitSet::from_range(ctrl_type_bits as u8, BitSet8::bits() as u8);
+                } else if ctrl_type.is_float() {
+                    // The upper bound should include all float types wider than `ctrl_type`, so we
+                    // use `2^7` as the upper bound to define the closed range `[ctrl_type, F64]`.
+                    tys.floats = BitSet::from_range(ctrl_type_bits as u8, 7);
+                } else {
+                    panic!("The Wider constraint only operates on floats or ints");
+                }
+
+                ResolvedConstraint::Free(tys)
+            }
         }
     }
 }

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1191,7 +1191,7 @@ impl<'a> Verifier<'a> {
         let _ = self.typecheck_fixed_args(inst, ctrl_type, errors);
         let _ = self.typecheck_variable_args(inst, errors);
         let _ = self.typecheck_return(inst, errors);
-        let _ = self.typecheck_special(inst, ctrl_type, errors);
+        let _ = self.typecheck_special(inst, errors);
 
         Ok(())
     }
@@ -1478,12 +1478,7 @@ impl<'a> Verifier<'a> {
 
     // Check special-purpose type constraints that can't be expressed in the normal opcode
     // constraints.
-    fn typecheck_special(
-        &self,
-        inst: Inst,
-        ctrl_type: Type,
-        errors: &mut VerifierErrors,
-    ) -> VerifierStepResult<()> {
+    fn typecheck_special(&self, inst: Inst, errors: &mut VerifierErrors) -> VerifierStepResult<()> {
         match self.func.dfg.insts[inst] {
             ir::InstructionData::TableAddr { table, arg, .. } => {
                 let index_type = self.func.dfg.value_type(arg);

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1499,16 +1499,6 @@ impl<'a> Verifier<'a> {
                                 ),
                             ));
                         }
-                        if arg_type.lane_bits() >= ctrl_type.lane_bits() {
-                            return errors.nonfatal((
-                                inst,
-                                self.context(inst),
-                                format!(
-                                    "input {} must be smaller than output {}",
-                                    arg_type, ctrl_type,
-                                ),
-                            ));
-                        }
                     }
                     Opcode::Ireduce | Opcode::Fdemote => {
                         if arg_type.lane_count() != ctrl_type.lane_count() {
@@ -1517,16 +1507,6 @@ impl<'a> Verifier<'a> {
                                 self.context(inst),
                                 format!(
                                     "input {} and output {} must have same number of lanes",
-                                    arg_type, ctrl_type,
-                                ),
-                            ));
-                        }
-                        if arg_type.lane_bits() <= ctrl_type.lane_bits() {
-                            return errors.nonfatal((
-                                inst,
-                                self.context(inst),
-                                format!(
-                                    "input {} must be larger than output {}",
                                     arg_type, ctrl_type,
                                 ),
                             ));

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1485,36 +1485,6 @@ impl<'a> Verifier<'a> {
         errors: &mut VerifierErrors,
     ) -> VerifierStepResult<()> {
         match self.func.dfg.insts[inst] {
-            ir::InstructionData::Unary { opcode, arg } => {
-                let arg_type = self.func.dfg.value_type(arg);
-                match opcode {
-                    Opcode::Uextend | Opcode::Sextend | Opcode::Fpromote => {
-                        if arg_type.lane_count() != ctrl_type.lane_count() {
-                            return errors.nonfatal((
-                                inst,
-                                self.context(inst),
-                                format!(
-                                    "input {} and output {} must have same number of lanes",
-                                    arg_type, ctrl_type,
-                                ),
-                            ));
-                        }
-                    }
-                    Opcode::Ireduce | Opcode::Fdemote => {
-                        if arg_type.lane_count() != ctrl_type.lane_count() {
-                            return errors.nonfatal((
-                                inst,
-                                self.context(inst),
-                                format!(
-                                    "input {} and output {} must have same number of lanes",
-                                    arg_type, ctrl_type,
-                                ),
-                            ));
-                        }
-                    }
-                    _ => {}
-                }
-            }
             ir::InstructionData::TableAddr { table, arg, .. } => {
                 let index_type = self.func.dfg.value_type(arg);
                 let table_index_type = self.func.tables[table].index_type;

--- a/cranelift/filetests/filetests/verifier/type_check.clif
+++ b/cranelift/filetests/filetests/verifier/type_check.clif
@@ -113,14 +113,28 @@ block2(v3: f32, v4: i8):
 function %bad_extend() {
 block0:
     v0 = iconst.i32 10
-    v1 = uextend.i16 v0 ; error: input i32 must be smaller than output i16
+    v1 = uextend.i16 v0 ; error: arg 0 (v0) with type i32 failed to satisfy type set
     return
 }
 
 function %bad_reduce() {
 block0:
     v0 = iconst.i32 10
-    v1 = ireduce.i64 v0 ; error: input i32 must be larger than output i64
+    v1 = ireduce.i64 v0 ; error: arg 0 (v0) with type i32 failed to satisfy type set
+    return
+}
+
+function %bad_fdemote() {
+block0:
+    v0 = f32const 0xf.f
+    v1 = fdemote.f64 v0 ; error: arg 0 (v0) with type f32 failed to satisfy type set
+    return
+}
+
+function %bad_fpromote() {
+block0:
+    v0 = f64const 0xf.f
+    v1 = fpromote.f32 v0 ; error: arg 0 (v0) with type f64 failed to satisfy type set
     return
 }
 


### PR DESCRIPTION
In service of merging #5947, add the `narrower` and `wider` constraints to the `TypeVar` type in the instruction DSL.

These two new constraints capture the situation where an instruction requires that its output be either narrower or wider than one of its input arguments. Instructions that fit one of these two patterns include: `uextend`, `sextend`, `ireduce`, `fpromote`, and `fdemote`. Previously these constraints were validated by special case typechecking behavior in the verifier, and with their addition those special cases can now be removed.

The benefit to #5947 is that the constraints are now available to the `function_generator` module when determining which arguments to select for random instruction instantiations. This gets us a bit closer to being able to use the generated opcode list as the source of truth for how we generate arbitrary instructions.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
