### PR TITLE
cranelift: Mark fpromote and fdemote as operating on float scalars

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3320,13 +3320,16 @@ pub(crate) fn define(
         );
     }
 
-    let FloatTo = &TypeVar::new(
-        "FloatTo",
-        "A scalar or vector floating point number",
-        TypeSetBuilder::new()
-            .floats(Interval::All)
-            .simd_lanes(Interval::All)
-            .build(),
+    let FloatScalar = &TypeVar::new(
+        "FloatScalar",
+        "A scalar only floating point number",
+        TypeSetBuilder::new().floats(Interval::All).build(),
+    );
+
+    let FloatScalarTo = &TypeVar::new(
+        "FloatScalarTo",
+        "A scalar only floating point number",
+        TypeSetBuilder::new().floats(Interval::All).build(),
     );
 
     ig.push(
@@ -3346,8 +3349,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![Operand::new("a", FloatTo)]),
+        .operands_in(vec![Operand::new("x", FloatScalar)])
+        .operands_out(vec![Operand::new("a", FloatScalarTo)]),
     );
 
     ig.push(
@@ -3367,8 +3370,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![Operand::new("a", FloatTo)]),
+        .operands_in(vec![Operand::new("x", FloatScalar)])
+        .operands_out(vec![Operand::new("a", FloatScalarTo)]),
     );
 
     let F64x2 = &TypeVar::new(
@@ -3431,11 +3434,6 @@ pub(crate) fn define(
         .operands_out(vec![Operand::new("x", F64x2)]),
     );
 
-    let FloatScalar = &TypeVar::new(
-        "FloatScalar",
-        "A scalar only floating point number",
-        TypeSetBuilder::new().floats(Interval::All).build(),
-    );
     let IntTo = &TypeVar::new(
         "IntTo",
         "An scalar only integer type",
@@ -3535,6 +3533,15 @@ pub(crate) fn define(
         "A scalar or vector integer type",
         TypeSetBuilder::new()
             .ints(Interval::All)
+            .simd_lanes(Interval::All)
+            .build(),
+    );
+
+    let FloatTo = &TypeVar::new(
+        "FloatTo",
+        "A scalar or vector floating point number",
+        TypeSetBuilder::new()
+            .floats(Interval::All)
             .simd_lanes(Interval::All)
             .build(),
     );


### PR DESCRIPTION
Mark `fpromote` and `fdemote` as not operating on scalars. This enforces the existing behavior in the backends, as no backend currently supports either of these instructions with vector arguments. Tightening up the argument/result types in the instruction definitions will help with landing #5947, and opting more instructions into fuzzing automatically.
<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
