### PR TITLE
cranelift: Translate `stack_*` accesses as unaligned

### DIFF
--- a/cranelift/codegen/src/legalizer/mod.rs
+++ b/cranelift/codegen/src/legalizer/mod.rs
@@ -82,8 +82,10 @@ pub fn simple_legalize(func: &mut ir::Function, cfg: &mut ControlFlowGraph, isa:
 
                     let addr = pos.ins().stack_addr(addr_ty, stack_slot, offset);
 
-                    // Stack slots are required to be accessible and aligned.
-                    let mflags = MemFlags::trusted();
+                    // Stack slots are required to be accessible.
+                    // We can't currently ensure that they are aligned.
+                    let mut mflags = MemFlags::new();
+                    mflags.set_notrap();
                     pos.func.dfg.replace(inst).load(ty, mflags, addr, 0);
                 }
                 InstructionData::StackStore {
@@ -99,10 +101,10 @@ pub fn simple_legalize(func: &mut ir::Function, cfg: &mut ControlFlowGraph, isa:
 
                     let addr = pos.ins().stack_addr(addr_ty, stack_slot, offset);
 
+                    // Stack slots are required to be accessible.
+                    // We can't currently ensure that they are aligned.
                     let mut mflags = MemFlags::new();
-                    // Stack slots are required to be accessible and aligned.
                     mflags.set_notrap();
-                    mflags.set_aligned();
                     pos.func.dfg.replace(inst).store(mflags, arg, addr, 0);
                 }
                 InstructionData::DynamicStackLoad {

--- a/cranelift/filetests/filetests/egraph/misc.clif
+++ b/cranelift/filetests/filetests/egraph/misc.clif
@@ -16,6 +16,6 @@ block0(v0: i64):
 ; nextln:    ss0 = explicit_slot 8
 ; check:  block0(v0: i64):
 ; nextln:     v2 = stack_addr.i64 ss0
-; nextln:     store notrap aligned v0, v2
+; nextln:     store notrap v0, v2
 ; nextln:     return v0
 ; nextln: }

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -100,3 +100,19 @@ block0(v0: f64x2):
     return v4
 }
 ; run: %extractlane_f64x2_through_stack([0x1.0 0x2.0]) == 0x1.0
+
+
+function %unaligned_extractlane() -> f64 {
+    ss0 = explicit_slot 24
+
+block0:
+    v0 = iconst.i64 0
+    stack_store.i64 v0, ss0+0
+    stack_store.i64 v0, ss0+8
+    stack_store.i64 v0, ss0+16
+
+    v1 = stack_load.f64x2 ss0+1
+    v2 = extractlane v1, 1
+    return v2
+}
+; run: %unaligned_extractlane() == 0.0


### PR DESCRIPTION
👋 Hey,

We can't currently ensure that these will be aligned, so we shouldn't mark them as such. Once we have alignment specifiers it would be neat to check those and optimize these legalizations if possible.

See also the discussion on #5922 we may want to eventually make `stack_{load,store}` accept `MemFlags` directly, or remove the instructions entirely.

Fixes #5922