### PR TITLE
Rename `as_bool` to `as_truthy`, and fix TypeSet::as_bool

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift/codegen/meta/src/cdsl/typevar.rs
@@ -228,7 +228,7 @@ impl TypeVar {
                     "The `wider` constraint only applies to scalar ints or floats"
                 );
             }
-            DerivedFunc::LaneOf | DerivedFunc::AsBool | DerivedFunc::DynamicToVector => {
+            DerivedFunc::LaneOf | DerivedFunc::AsTruthy | DerivedFunc::DynamicToVector => {
                 /* no particular assertions */
             }
         }
@@ -249,8 +249,8 @@ impl TypeVar {
     pub fn lane_of(&self) -> TypeVar {
         self.derived(DerivedFunc::LaneOf)
     }
-    pub fn as_bool(&self) -> TypeVar {
-        self.derived(DerivedFunc::AsBool)
+    pub fn as_truthy(&self) -> TypeVar {
+        self.derived(DerivedFunc::AsTruthy)
     }
     pub fn half_width(&self) -> TypeVar {
         self.derived(DerivedFunc::HalfWidth)
@@ -332,7 +332,7 @@ impl ops::Deref for TypeVar {
 #[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub(crate) enum DerivedFunc {
     LaneOf,
-    AsBool,
+    AsTruthy,
     HalfWidth,
     DoubleWidth,
     SplitLanes,
@@ -346,7 +346,7 @@ impl DerivedFunc {
     pub fn name(self) -> &'static str {
         match self {
             DerivedFunc::LaneOf => "lane_of",
-            DerivedFunc::AsBool => "as_bool",
+            DerivedFunc::AsTruthy => "as_truthy",
             DerivedFunc::HalfWidth => "half_width",
             DerivedFunc::DoubleWidth => "double_width",
             DerivedFunc::SplitLanes => "split_lanes",
@@ -425,7 +425,7 @@ impl TypeSet {
     fn image(&self, derived_func: DerivedFunc) -> TypeSet {
         match derived_func {
             DerivedFunc::LaneOf => self.lane_of(),
-            DerivedFunc::AsBool => self.as_bool(),
+            DerivedFunc::AsTruthy => self.as_truthy(),
             DerivedFunc::HalfWidth => self.half_width(),
             DerivedFunc::DoubleWidth => self.double_width(),
             DerivedFunc::SplitLanes => self.half_width().double_vector(),
@@ -443,10 +443,19 @@ impl TypeSet {
         copy
     }
 
-    /// Return a TypeSet describing the image of self across as_bool.
-    fn as_bool(&self) -> TypeSet {
+    /// Return a TypeSet describing the image of self across as_truthy.
+    fn as_truthy(&self) -> TypeSet {
         let mut copy = self.clone();
-        copy.ints = NumSet::new();
+
+        // If this type set represents a scalar, `as_truthy` produces an I8, otherwise it returns a
+        // vector of the same number of lanes, whose elements are integers of the same width. For
+        // example, F32X4 gets turned into I32X4, while I32 gets turned into I8.
+        if self.lanes.len() == 1 && self.lanes.contains(&1) {
+            copy.ints = NumSet::from([8]);
+        } else {
+            copy.ints.extend(&self.floats)
+        }
+
         copy.floats = NumSet::new();
         copy.refs = NumSet::new();
         copy
@@ -814,7 +823,7 @@ fn test_typevar_builder_inverted_bounds_panic() {
 }
 
 #[test]
-fn test_as_bool() {
+fn test_as_truthy() {
     let a = TypeSetBuilder::new()
         .simd_lanes(2..8)
         .ints(8..8)
@@ -824,6 +833,14 @@ fn test_as_bool() {
         a.lane_of(),
         TypeSetBuilder::new().ints(8..8).floats(32..32).build()
     );
+
+    let mut a_as_truthy = TypeSetBuilder::new().simd_lanes(2..8).build();
+    a_as_truthy.ints = num_set![8, 32];
+    assert_eq!(a.as_truthy(), a_as_truthy);
+
+    let a = TypeSetBuilder::new().ints(8..32).floats(32..64).build();
+    let a_as_truthy = TypeSetBuilder::new().ints(8..8).build();
+    assert_eq!(a.as_truthy(), a_as_truthy);
 }
 
 #[test]

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -669,7 +669,7 @@ fn gen_opcodes(all_inst: &AllInstructions, fmt: &mut Formatter) {
 /// Each operand constraint is represented as a string, one of:
 /// - `Concrete(vt)`, where `vt` is a value type name.
 /// - `Free(idx)` where `idx` is an index into `type_sets`.
-/// - `Same`, `Lane`, `AsBool` for controlling typevar-derived constraints.
+/// - `Same`, `Lane`, `AsTruthy` for controlling typevar-derived constraints.
 fn get_constraint<'entries, 'table>(
     operand: &'entries Operand,
     ctrl_typevar: Option<&TypeVar>,
@@ -778,7 +778,7 @@ fn gen_type_constraints(all_inst: &AllInstructions, fmt: &mut Formatter) {
     // constraint is represented as a string, one of:
     // - `Concrete(vt)`, where `vt` is a value type name.
     // - `Free(idx)` where `idx` is an index into `type_sets`.
-    // - `Same`, `Lane`, `AsBool` for controlling typevar-derived constraints.
+    // - `Same`, `Lane`, `AsTruthy` for controlling typevar-derived constraints.
     let mut operand_seqs = UniqueSeqTable::new();
 
     // Preload table with constraints for typical binops.

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1627,7 +1627,7 @@ pub(crate) fn define(
             Operand::new("x", Int),
             Operand::new("y", Int),
         ])
-        .operands_out(vec![Operand::new("a", &Int.as_bool())]),
+        .operands_out(vec![Operand::new("a", &Int.as_truthy())]),
     );
 
     ig.push(
@@ -2684,7 +2684,7 @@ pub(crate) fn define(
             Operand::new("x", Float),
             Operand::new("y", Float),
         ])
-        .operands_out(vec![Operand::new("a", &Float.as_bool())]),
+        .operands_out(vec![Operand::new("a", &Float.as_truthy())]),
     );
 
     ig.push(

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -683,8 +683,8 @@ enum OperandConstraint {
     /// This operand is `ctrlType.lane_of()`.
     LaneOf,
 
-    /// This operand is `ctrlType.as_bool()`.
-    AsBool,
+    /// This operand is `ctrlType.as_truthy()`.
+    AsTruthy,
 
     /// This operand is `ctrlType.half_width()`.
     HalfWidth,
@@ -719,7 +719,7 @@ impl OperandConstraint {
             Free(vts) => ResolvedConstraint::Free(TYPE_SETS[vts as usize]),
             Same => Bound(ctrl_type),
             LaneOf => Bound(ctrl_type.lane_of()),
-            AsBool => Bound(ctrl_type.as_bool()),
+            AsTruthy => Bound(ctrl_type.as_truthy()),
             HalfWidth => Bound(ctrl_type.half_width().expect("invalid type for half_width")),
             DoubleWidth => Bound(
                 ctrl_type

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -133,28 +133,27 @@ impl Type {
     ///
     /// Lane types are treated as vectors with one lane, so they are converted to the multi-bit
     /// boolean types.
-    pub fn as_bool_pedantic(self) -> Self {
+    pub fn as_truthy_pedantic(self) -> Self {
         // Replace the low 4 bits with the boolean version, preserve the high 4 bits.
         self.replace_lanes(match self.lane_type() {
             I8 => I8,
             I16 => I16,
             I32 | F32 => I32,
             I64 | F64 => I64,
-            R32 | R64 => panic!("Reference types should not convert to bool"),
+            R32 | R64 => panic!("Reference types are not truthy"),
             I128 => I128,
             _ => I8,
         })
     }
 
-    /// Get a type with the same number of lanes as this type, but with the lanes replaced by
-    /// booleans of the same size.
-    ///
-    /// Scalar types are all converted to `b1` which is usually what you want.
-    pub fn as_bool(self) -> Self {
+    /// Get the type of a comparison result for the given type. For vectors this will be a vector
+    /// with the same number of lanes and integer elements, and for scalar types this will be `i8`,
+    /// which is the result type of comparisons.
+    pub fn as_truthy(self) -> Self {
         if !self.is_vector() {
             I8
         } else {
-            self.as_bool_pedantic()
+            self.as_truthy_pedantic()
         }
     }
 
@@ -604,11 +603,11 @@ mod tests {
     }
 
     #[test]
-    fn as_bool() {
-        assert_eq!(I32X4.as_bool(), I32X4);
-        assert_eq!(I32.as_bool(), I8);
-        assert_eq!(I32X4.as_bool_pedantic(), I32X4);
-        assert_eq!(I32.as_bool_pedantic(), I32);
+    fn as_truthy() {
+        assert_eq!(I32X4.as_truthy(), I32X4);
+        assert_eq!(I32.as_truthy(), I8);
+        assert_eq!(I32X4.as_truthy_pedantic(), I32X4);
+        assert_eq!(I32.as_truthy_pedantic(), I32);
     }
 
     #[test]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -865,7 +865,7 @@ where
                         V::bool(
                             fcmp(inst.fp_cond_code().unwrap(), &x, &y).unwrap(),
                             ctrl_ty.is_vector(),
-                            ctrl_ty.lane_type().as_bool(),
+                            ctrl_ty.lane_type().as_truthy(),
                         )
                     })
                     .collect::<ValueResult<SimdVec<V>>>()?),
@@ -985,7 +985,7 @@ where
         }
         Opcode::Bmask => assign({
             let bool = arg(0)?;
-            let bool_ty = ctrl_ty.as_bool_pedantic();
+            let bool_ty = ctrl_ty.as_truthy_pedantic();
             let lanes = extractlanes(&bool, bool_ty)?
                 .into_iter()
                 .map(|lane| lane.convert(ValueConversionKind::Mask(ctrl_ty.lane_type())))
@@ -1467,7 +1467,7 @@ where
         )?)
     };
 
-    let dst_ty = ctrl_ty.as_bool();
+    let dst_ty = ctrl_ty.as_truthy();
     let left = extractlanes(left, ctrl_ty)?;
     let right = extractlanes(right, ctrl_ty)?;
 


### PR DESCRIPTION
Rename the `as_bool` functions in cranelift-codegen-meta to `as_truthy` to better describe their behavior. Additionally, fix the implementation of `TypeSet::as_truthy` to match the behavior of `Type::as_truthy`, as it was returning an empty `TypeSet` when it should have been mirroring the behavior.

This bug was introduced in #5031 when we removed booleans from cranelift.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
