### PR TITLE
Add support for generating perf maps for simple perf profiling

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -80,6 +80,10 @@ enum wasmtime_profiling_strategy_enum { // ProfilingStrategy
   ///
   /// Note that this isn't always enabled at build time.
   WASMTIME_PROFILING_STRATEGY_VTUNE,
+  /// Linux's simple "perfmap" support in `perf` is enabled and when Wasmtime is
+  /// run under `perf` necessary calls will be made to profile generated JIT
+  /// code.
+  WASMTIME_PROFILING_STRATEGY_PERFMAP,
 };
 
 #define WASMTIME_CONFIG_PROP(ret, name, ty) \

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -36,6 +36,7 @@ pub enum wasmtime_profiling_strategy_t {
     WASMTIME_PROFILING_STRATEGY_NONE,
     WASMTIME_PROFILING_STRATEGY_JITDUMP,
     WASMTIME_PROFILING_STRATEGY_VTUNE,
+    WASMTIME_PROFILING_STRATEGY_PERFMAP,
 }
 
 #[no_mangle]
@@ -157,6 +158,7 @@ pub extern "C" fn wasmtime_config_profiler_set(
         WASMTIME_PROFILING_STRATEGY_NONE => ProfilingStrategy::None,
         WASMTIME_PROFILING_STRATEGY_JITDUMP => ProfilingStrategy::JitDump,
         WASMTIME_PROFILING_STRATEGY_VTUNE => ProfilingStrategy::VTune,
+        WASMTIME_PROFILING_STRATEGY_PERFMAP => ProfilingStrategy::PerfMap,
     });
 }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -68,24 +68,6 @@ pub const SUPPORTED_WASI_MODULES: &[(&str, &str)] = &[
     ),
 ];
 
-fn pick_profiling_strategy(perfmap: bool, jitdump: bool, vtune: bool) -> Result<ProfilingStrategy> {
-    Ok(if (perfmap as u8) + (jitdump as u8) + (vtune as u8) > 1 {
-        println!(
-            "Can't enable two or more of --jitdump, --vtune and --perfmap at the same time.
-Profiling not enabled."
-        );
-        ProfilingStrategy::None
-    } else if perfmap {
-        ProfilingStrategy::PerfMap
-    } else if jitdump {
-        ProfilingStrategy::JitDump
-    } else if vtune {
-        ProfilingStrategy::VTune
-    } else {
-        ProfilingStrategy::None
-    })
-}
-
 fn init_file_per_thread_logger(prefix: &'static str) {
     file_per_thread_logger::initialize(prefix);
 
@@ -148,18 +130,11 @@ pub struct CommonOptions {
     #[clap(long, value_name = "MODULE,MODULE,...", parse(try_from_str = parse_wasi_modules))]
     pub wasi_modules: Option<WasiModules>,
 
+    /// Profiling strategy (valid options are: perfmap, jitdump, vtune)
+    #[clap(long)]
+    pub profile: Option<ProfilingStrategy>,
+
     /// Generate jitdump file (supported on --features=profiling build)
-    #[clap(long, conflicts_with_all = &["vtune", "perfmap"])]
-    pub jitdump: bool,
-
-    /// Generate perf mapping file
-    #[clap(long, conflicts_with_all = &["vtune", "jitdump"])]
-    pub perfmap: bool,
-
-    /// Generate vtune runtime information (supported on --features=vtune build)
-    #[clap(long, conflicts_with_all = &["jitdump", "perfmap"])]
-    pub vtune: bool,
-
     /// Run optimization passes on translated functions, on by default
     #[clap(short = 'O', long)]
     pub optimize: bool,
@@ -293,11 +268,7 @@ impl CommonOptions {
             .cranelift_debug_verifier(self.enable_cranelift_debug_verifier)
             .debug_info(self.debug_info)
             .cranelift_opt_level(self.opt_level())
-            .profiler(pick_profiling_strategy(
-                self.perfmap,
-                self.jitdump,
-                self.vtune,
-            )?)
+            .profiler(self.profile.unwrap_or(ProfilingStrategy::None))
             .cranelift_nan_canonicalization(self.enable_cranelift_nan_canonicalization);
 
         self.enable_wasm_features(&mut config);

--- a/crates/jit-debug/src/perf_jitdump.rs
+++ b/crates/jit-debug/src/perf_jitdump.rs
@@ -4,7 +4,7 @@
 //!
 //! Usage Example:
 //!     Record
-//!         sudo perf record -k 1 -e instructions:u target/debug/wasmtime -g --jitdump test.wasm
+//!         sudo perf record -k 1 -e instructions:u target/debug/wasmtime -g --profile=jitdump test.wasm
 //!     Combine
 //!         sudo perf inject -v -j -i perf.data -o perf.jit.data
 //!     Report

--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -12,6 +12,16 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        #[path = "profiling/perfmap_linux.rs"]
+        mod perfmap;
+    } else {
+        #[path = "profiling/perfmap_disabled.rs"]
+        mod perfmap;
+    }
+}
+
+cfg_if::cfg_if! {
     // Note: VTune support is disabled on windows mingw because the ittapi crate doesn't compile
     // there; see also https://github.com/bytecodealliance/wasmtime/pull/4003 for rationale.
     if #[cfg(all(feature = "vtune", target_arch = "x86_64", not(all(target_os = "windows", target_env = "gnu"))))] {
@@ -24,6 +34,7 @@ cfg_if::cfg_if! {
 }
 
 pub use jitdump::JitDumpAgent;
+pub use perfmap::PerfMapAgent;
 pub use vtune::VTuneAgent;
 
 /// Common interface for profiling tools.

--- a/crates/jit/src/profiling/jitdump_disabled.rs
+++ b/crates/jit/src/profiling/jitdump_disabled.rs
@@ -8,6 +8,7 @@ pub struct JitDumpAgent {
 }
 
 impl JitDumpAgent {
+    /// Intialize a dummy JitDumpAgent that will fail upon instantiation.
     pub fn new() -> Result<Self> {
         if cfg!(feature = "jitdump") {
             bail!("jitdump is not supported on this platform");

--- a/crates/jit/src/profiling/jitdump_linux.rs
+++ b/crates/jit/src/profiling/jitdump_linux.rs
@@ -4,7 +4,7 @@
 //!
 //! Usage Example:
 //!     Record
-//!         sudo perf record -k 1 -e instructions:u target/debug/wasmtime -g --jitdump test.wasm
+//!         sudo perf record -k 1 -e instructions:u target/debug/wasmtime -g --profile=jitdump test.wasm
 //!     Combine
 //!         sudo perf inject -v -j -i perf.data -o perf.jit.data
 //!     Report

--- a/crates/jit/src/profiling/perfmap_disabled.rs
+++ b/crates/jit/src/profiling/perfmap_disabled.rs
@@ -8,6 +8,7 @@ pub struct PerfMapAgent {
 }
 
 impl PerfMapAgent {
+    /// Intialize a dummy PerfMapAgent that will fail upon instantiation.
     pub fn new() -> Result<Self> {
         bail!("perfmap support not supported on this platform");
     }

--- a/crates/jit/src/profiling/perfmap_disabled.rs
+++ b/crates/jit/src/profiling/perfmap_disabled.rs
@@ -3,21 +3,17 @@ use anyhow::{bail, Result};
 
 /// Interface for driving the creation of jitdump files
 #[derive(Debug)]
-pub struct JitDumpAgent {
+pub struct PerfMapAgent {
     _private: (),
 }
 
-impl JitDumpAgent {
+impl PerfMapAgent {
     pub fn new() -> Result<Self> {
-        if cfg!(feature = "jitdump") {
-            bail!("jitdump is not supported on this platform");
-        } else {
-            bail!("jitdump support disabled at compile time");
-        }
+        bail!("perfmap support not supported on this platform");
     }
 }
 
-impl ProfilingAgent for JitDumpAgent {
+impl ProfilingAgent for PerfMapAgent {
     fn module_load(&self, _module: &CompiledModule, _dbg_image: Option<&[u8]>) {}
     fn load_single_trampoline(
         &self,

--- a/crates/jit/src/profiling/perfmap_linux.rs
+++ b/crates/jit/src/profiling/perfmap_linux.rs
@@ -1,0 +1,63 @@
+use crate::{CompiledModule, ProfilingAgent};
+use anyhow::Result;
+use std::io::Write as _;
+use std::process;
+use std::{fs::File, sync::Mutex};
+use wasmtime_environ::EntityRef as _;
+
+/// Process-wide perf map file. Perf only reads a unique file per process.
+static PERFMAP_FILE: Mutex<Option<File>> = Mutex::new(None);
+
+/// Interface for driving the creation of jitdump files
+pub struct PerfMapAgent;
+
+impl PerfMapAgent {
+    /// Intialize a JitDumpAgent and write out the header.
+    pub fn new() -> Result<Self> {
+        let mut file = PERFMAP_FILE.lock().unwrap();
+        if file.is_none() {
+            let filename = format!("/tmp/perf-{}.map", process::id());
+            *file = Some(File::create(filename)?);
+        }
+        Ok(PerfMapAgent)
+    }
+
+    fn make_line(name: &str, addr: *const u8, len: usize) -> String {
+        format!("{:#x} {len} {name}\n", addr as usize)
+    }
+}
+
+impl ProfilingAgent for PerfMapAgent {
+    /// Sent when a method is compiled and loaded into memory by the VM.
+    fn module_load(&self, module: &CompiledModule, _dbg_image: Option<&[u8]>) {
+        let mut file = PERFMAP_FILE.lock().unwrap();
+        let file = file.as_mut().unwrap();
+
+        for (idx, func) in module.finished_functions() {
+            let addr = func.as_ptr();
+            let len = func.len();
+            let name = super::debug_name(module, idx);
+            let _ = file.write_all(Self::make_line(&name, addr, len).as_bytes());
+        }
+
+        // Note: these are the trampolines into exported functions.
+        for (idx, func, len) in module.trampolines() {
+            let (addr, len) = (func as usize as *const u8, len);
+            let name = format!("wasm::trampoline[{}]", idx.index());
+            let _ = file.write_all(Self::make_line(&name, addr, len).as_bytes());
+        }
+    }
+
+    fn load_single_trampoline(
+        &self,
+        name: &str,
+        addr: *const u8,
+        size: usize,
+        _pid: u32,
+        _tid: u32,
+    ) {
+        let mut file = PERFMAP_FILE.lock().unwrap();
+        let file = file.as_mut().unwrap();
+        let _ = file.write_all(Self::make_line(name, addr, size).as_bytes());
+    }
+}

--- a/crates/jit/src/profiling/perfmap_linux.rs
+++ b/crates/jit/src/profiling/perfmap_linux.rs
@@ -23,7 +23,7 @@ impl PerfMapAgent {
     }
 
     fn make_line(name: &str, addr: *const u8, len: usize) -> String {
-        format!("{:#x} {len} {name}\n", addr as usize)
+        format!("{:x} {len:x} {name}\n", addr as usize)
     }
 }
 

--- a/crates/jit/src/profiling/vtune.rs
+++ b/crates/jit/src/profiling/vtune.rs
@@ -1,11 +1,11 @@
 //! Adds support for profiling JIT-ed code using VTune. By default, VTune
 //! support is built in to Wasmtime (configure with the `vtune` feature flag).
-//! To enable it at runtime, use the `--vtune` CLI flag.
+//! To enable it at runtime, use the `--profile=vtune` CLI flag.
 //!
 //! ### Profile
 //!
 //! ```ignore
-//! vtune -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --vtune test.wasm
+//! vtune -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --profile=vtune test.wasm
 //! ```
 //!
 //! Note: `vtune` is a command-line tool for VTune which must [be

--- a/crates/jit/src/profiling/vtune_disabled.rs
+++ b/crates/jit/src/profiling/vtune_disabled.rs
@@ -8,7 +8,7 @@ pub struct VTuneAgent {
 }
 
 impl VTuneAgent {
-    /// Intialize a VTuneAgent and write out the header
+    /// Intialize a dummy VTuneAgent that will fail upon instantiation.
     pub fn new() -> Result<Self> {
         if cfg!(feature = "vtune") {
             bail!("VTune is not supported on this platform.");

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "cache")]
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::Arc;
 use target_lexicon::Architecture;
 use wasmparser::WasmFeatures;
@@ -1742,6 +1743,20 @@ pub enum ProfilingStrategy {
 
     /// Collect profiling info using the "ittapi", used with `VTune` on Linux.
     VTune,
+}
+
+impl FromStr for ProfilingStrategy {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(Self::None),
+            "perfmap" => Ok(Self::PerfMap),
+            "jitdump" => Ok(Self::JitDump),
+            "vtune" => Ok(Self::VTune),
+            _ => anyhow::bail!("unknown value for profiling strategy"),
+        }
+    }
 }
 
 /// Select how wasm backtrace detailed information is handled.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1728,7 +1728,7 @@ pub enum OptLevel {
 }
 
 /// Select which profiling technique to support.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ProfilingStrategy {
     /// No profiler support.
     None,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -12,7 +12,7 @@ use wasmparser::WasmFeatures;
 #[cfg(feature = "cache")]
 use wasmtime_cache::CacheConfig;
 use wasmtime_environ::Tunables;
-use wasmtime_jit::{JitDumpAgent, NullProfilerAgent, ProfilingAgent, VTuneAgent};
+use wasmtime_jit::{JitDumpAgent, NullProfilerAgent, PerfMapAgent, ProfilingAgent, VTuneAgent};
 use wasmtime_runtime::{InstanceAllocator, OnDemandInstanceAllocator, RuntimeMemoryCreator};
 
 pub use wasmtime_environ::CacheStore;
@@ -1536,6 +1536,7 @@ impl Config {
 
     pub(crate) fn build_profiler(&self) -> Result<Box<dyn ProfilingAgent>> {
         Ok(match self.profiling_strategy {
+            ProfilingStrategy::PerfMap => Box::new(PerfMapAgent::new()?) as Box<dyn ProfilingAgent>,
             ProfilingStrategy::JitDump => Box::new(JitDumpAgent::new()?) as Box<dyn ProfilingAgent>,
             ProfilingStrategy::VTune => Box::new(VTuneAgent::new()?) as Box<dyn ProfilingAgent>,
             ProfilingStrategy::None => Box::new(NullProfilerAgent),
@@ -1731,6 +1732,9 @@ pub enum OptLevel {
 pub enum ProfilingStrategy {
     /// No profiler support.
     None,
+
+    /// Collect function name information as the "perf map" file format, used with `perf` on Linux.
+    PerfMap,
 
     /// Collect profiling info for "jitdump" file format, used with `perf` on
     /// Linux.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -222,7 +222,6 @@ impl Config {
     #[cfg(compiler)]
     #[cfg_attr(nightlydoc, doc(cfg(feature = "cranelift")))] // see build.rs
     pub fn target(&mut self, target: &str) -> Result<&mut Self> {
-        use std::str::FromStr;
         self.compiler_config.target =
             Some(target_lexicon::Triple::from_str(target).map_err(|e| anyhow::anyhow!(e))?);
 

--- a/docs/examples-profiling-perf.md
+++ b/docs/examples-profiling-perf.md
@@ -6,6 +6,59 @@ an extremely powerful profiler with lots of documentation on the web, but for
 the rest of this section we'll assume you're running on Linux and already have
 `perf` installed.
 
+There are two profiling agents for `perf`:
+
+- a very simple one that will map code regions to symbol names: `perfmap`.
+- a more detailed one that can provide additional information and mappings between the source
+  language statements and generated JIT code: `jitdump`.
+
+## Profiling with `perfmap`
+
+Simple profiling support with `perf` generates a "perf map" file that the `perf` CLI will
+automatically look for, when running into unresolved symbols. This requires runtime support from
+Wasmtime itself, so you will need to manually change a few things to enable profiling support in
+your application. Enabling runtime support depends on how you're using Wasmtime:
+
+* **Rust API** - you'll want to call the [`Config::profiler`] method with
+  `ProfilingStrategy::PerfMap` to enable profiling of your wasm modules.
+
+* **C API** - you'll want to call the `wasmtime_config_profiler_set` API with a
+  `WASMTIME_PROFILING_STRATEGY_PERFMAP` value.
+
+* **Command Line** - you'll want to pass the `--perfmap` flag on the command
+  line.
+
+Once perfmap support is enabled, you'll use `perf record` like usual to record
+your application's performance.
+
+For example if you're using the CLI, you'll execute:
+
+```sh
+$ perf record -k mono wasmtime --perfmap foo.wasm
+```
+
+This will create a `perf.data` file as per usual, but it will *also* create a
+`/tmp/perf-XXXX.map` file. This extra `.map` file is the perf map file which is
+specified by `perf` and Wasmtime generates at runtime.
+
+After that you can explore the `perf.data` profile as you usually would, for example with:
+
+```sh
+$ perf report --input perf.data
+```
+
+You should be able to see time spent in wasm functions, generate flamegraphs based on that, etc..
+You should also see entries for wasm functions show up as one function and the name of each
+function matches the debug name section in the wasm file.
+
+Note that support for perfmap is still relatively new in Wasmtime, so if you
+have any problems, please don't hesitate to [file an issue]!
+
+[file an issue]: https://github.com/bytecodealliance/wasmtime/issues/new
+
+
+## Profiling with `jitdump`
+
 Profiling support with `perf` uses the "jitdump" support in the `perf` CLI. This
 requires runtime support from Wasmtime itself, so you will need to manually
 change a few things to enable profiling support in your application. First

--- a/docs/examples-profiling-perf.md
+++ b/docs/examples-profiling-perf.md
@@ -25,7 +25,7 @@ your application. Enabling runtime support depends on how you're using Wasmtime:
 * **C API** - you'll want to call the `wasmtime_config_profiler_set` API with a
   `WASMTIME_PROFILING_STRATEGY_PERFMAP` value.
 
-* **Command Line** - you'll want to pass the `--perfmap` flag on the command
+* **Command Line** - you'll want to pass the `--profile=perfmap` flag on the command
   line.
 
 Once perfmap support is enabled, you'll use `perf record` like usual to record
@@ -34,7 +34,7 @@ your application's performance.
 For example if you're using the CLI, you'll execute:
 
 ```sh
-$ perf record -k mono wasmtime --perfmap foo.wasm
+$ perf record -k mono wasmtime --profile=perfmap foo.wasm
 ```
 
 This will create a `perf.data` file as per usual, but it will *also* create a
@@ -72,7 +72,7 @@ depends on how you're using Wasmtime:
 * **C API** - you'll want to call the `wasmtime_config_profiler_set` API with a
   `WASMTIME_PROFILING_STRATEGY_JITDUMP` value.
 
-* **Command Line** - you'll want to pass the `--jitdump` flag on the command
+* **Command Line** - you'll want to pass the `--profile=jitdump` flag on the command
   line.
 
 Once jitdump support is enabled, you'll use `perf record` like usual to record
@@ -82,7 +82,7 @@ your application's performance. You'll need to also be sure to pass the
 For example if you're using the CLI, you'll execute:
 
 ```sh
-$ perf record -k mono wasmtime --jitdump foo.wasm
+$ perf record -k mono wasmtime --profile=jitdump foo.wasm
 ```
 
 This will create a `perf.data` file as per usual, but it will *also* create a
@@ -163,7 +163,7 @@ To collect perf information for this wasm module we'll execute:
 
 ```sh
 $ rustc --target wasm32-wasi fib.rs -O
-$ perf record -k mono wasmtime --jitdump fib.wasm
+$ perf record -k mono wasmtime --profile=jitdump fib.wasm
 fib(42) = 267914296
 [ perf record: Woken up 1 times to write data ]
 [ perf record: Captured and wrote 0.147 MB perf.data (3435 samples) ]

--- a/docs/examples-profiling-vtune.md
+++ b/docs/examples-profiling-vtune.md
@@ -39,7 +39,7 @@ runtime--enable runtime support based on how you use Wasmtime:
 * **C API** - call the `wasmtime_config_profiler_set` API with a
   `WASMTIME_PROFILING_STRATEGY_VTUNE` value.
 
-* **Command Line** - pass the `--vtune` flag on the command line.
+* **Command Line** - pass the `--profile=vtune` flag on the command line.
 
 
 ### Profiling Wasmtime itself
@@ -58,11 +58,11 @@ With VTune [properly installed][download], if you are using the CLI execute:
 
 ```sh
 $ cargo build
-$ vtune -run-pass-thru=--no-altstack -collect hotspots target/debug/wasmtime --vtune foo.wasm
+$ vtune -run-pass-thru=--no-altstack -collect hotspots target/debug/wasmtime --profile=vtune foo.wasm
 ```
 
 This command tells the VTune collector (`vtune`) to collect hot spot
-profiling data as Wasmtime is executing `foo.wasm`. The `--vtune` flag enables
+profiling data as Wasmtime is executing `foo.wasm`. The `--profile=vtune` flag enables
 VTune support in Wasmtime so that the collector is also alerted to JIT events
 that take place during runtime. The first time this is run, the result of the
 command is a results diretory `r000hs/` which contains profiling data for
@@ -96,13 +96,13 @@ $ rustc --target wasm32-wasi fib.rs -C opt-level=z -C lto=yes
 ```
 
 Then we execute the Wasmtime runtime (built with the `vtune` feature and
-executed with the `--vtune` flag to enable reporting) inside the VTune CLI
+executed with the `--profile=vtune` flag to enable reporting) inside the VTune CLI
 application, `vtune`, which must already be installed and available on the
 path. To collect hot spot profiling information, we execute:
 
 ```sh
 $ rustc --target wasm32-wasi fib.rs -C opt-level=z -C lto=yes
-$ vtune -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --vtune fib.wasm
+$ vtune -run-pass-thru=--no-altstack -v -collect hotspots target/debug/wasmtime --profile=vtune fib.wasm
 fib(45) = 1134903170
 amplxe: Collection stopped.
 amplxe: Using result path /home/jlb6740/wasmtime/r000hs
@@ -141,7 +141,7 @@ like:
 - Open VTune Profiler
 - "Configure Analysis" with
   - "Application" set to `/path/to/wasmtime` (e.g., `target/debug/wasmtime`)
-  - "Application parameters" set to `--vtune /path/to/module.wasm`
+  - "Application parameters" set to `--profile=vtune /path/to/module.wasm`
   - "Working directory" set as appropriate
   - Enable "Hardware Event-Based Sampling," which may require some system
     configuration, e.g. `sysctl -w kernel.perf_event_paranoid=0`


### PR DESCRIPTION
This adds support for a simpler way to profile with `perf`, using perf maps files. While `jitdump` support is pretty effective and complete when you have access to DWARF metadata, the `perf-inject` step may take lots of time, and it is not optimized at all when modules contain lots of functions. (In our embedding, I've stopped `perf-inject` after it ran for 5 hours and didn't complete, while creating 175K `.so` objects.) Simplistic support for perf maps enable basic profiling: caller/callee trees, top/bottom time analysis, flamegraphs etc., and works very nicely when the wasm modules have many functions.

I've also tweaked the documentation and tried to make the feature available in the C API too.

I haven't put this behind a feature toggle because this profiling agent does very little, so it's always compiled _when running Linux_. For consistency I could add one, if you prefer.