### PR TITLE
cranelift-wasm: Add a bounds-checking optimization for dynamic memories and guard pages

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -41,14 +41,13 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w7, w0
-;;   ldr x8, [x2, #8]
-;;   sub x8, x8, #4
-;;   subs xzr, x7, x8
+;;   mov w6, w0
+;;   ldr x7, [x2, #8]
+;;   subs xzr, x6, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x9, [x2]
-;;   str w1, [x9, w0, UXTW]
+;;   ldr x8, [x2]
+;;   str w1, [x8, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -57,14 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w7, w0
-;;   ldr x8, [x1, #8]
-;;   sub x8, x8, #4
-;;   subs xzr, x7, x8
+;;   mov w6, w0
+;;   ldr x7, [x1, #8]
+;;   subs xzr, x6, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x9, [x1]
-;;   ldr w0, [x9, w0, UXTW]
+;;   ldr x8, [x1]
+;;   ldr w0, [x8, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,16 +41,14 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w9, w0
-;;   ldr x10, [x2, #8]
-;;   movn x8, #4099
-;;   add x10, x10, x8
-;;   subs xzr, x9, x10
+;;   mov w7, w0
+;;   ldr x8, [x2, #8]
+;;   subs xzr, x7, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x11, [x2]
-;;   add x11, x11, #4096
-;;   str w1, [x11, w0, UXTW]
+;;   ldr x9, [x2]
+;;   add x9, x9, #4096
+;;   str w1, [x9, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -59,16 +57,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w9, w0
-;;   ldr x10, [x1, #8]
-;;   movn x8, #4099
-;;   add x10, x10, x8
-;;   subs xzr, x9, x10
+;;   mov w7, w0
+;;   ldr x8, [x1, #8]
+;;   subs xzr, x7, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x11, [x1]
-;;   add x10, x11, #4096
-;;   ldr w0, [x10, w0, UXTW]
+;;   ldr x9, [x1]
+;;   add x8, x9, #4096
+;;   ldr w0, [x8, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,18 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w10, w0
-;;   movn w9, #65531
-;;   adds x11, x10, x9
-;;   b.lo 8 ; udf
-;;   ldr x12, [x2, #8]
-;;   subs xzr, x11, x12
+;;   mov w8, w0
+;;   ldr x9, [x2, #8]
+;;   subs xzr, x8, x9
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x13, x14, x13
-;;   str w1, [x13, w0, UXTW]
+;;   ldr x10, [x2]
+;;   movz x11, #65535, LSL #16
+;;   add x10, x11, x10
+;;   str w1, [x10, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -61,18 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w10, w0
-;;   movn w9, #65531
-;;   adds x11, x10, x9
-;;   b.lo 8 ; udf
-;;   ldr x12, [x1, #8]
-;;   subs xzr, x11, x12
+;;   mov w8, w0
+;;   ldr x9, [x1, #8]
+;;   subs xzr, x8, x9
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x13
-;;   ldr w0, [x12, w0, UXTW]
+;;   ldr x10, [x1]
+;;   movz x9, #65535, LSL #16
+;;   add x9, x9, x10
+;;   ldr w0, [x9, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,16 +41,14 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w9, w0
-;;   ldr x10, [x2, #8]
-;;   movn x8, #4096
-;;   add x10, x10, x8
-;;   subs xzr, x9, x10
+;;   mov w7, w0
+;;   ldr x8, [x2, #8]
+;;   subs xzr, x7, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x11, [x2]
-;;   add x11, x11, #4096
-;;   strb w1, [x11, w0, UXTW]
+;;   ldr x9, [x2]
+;;   add x9, x9, #4096
+;;   strb w1, [x9, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -59,16 +57,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w9, w0
-;;   ldr x10, [x1, #8]
-;;   movn x8, #4096
-;;   add x10, x10, x8
-;;   subs xzr, x9, x10
+;;   mov w7, w0
+;;   ldr x8, [x1, #8]
+;;   subs xzr, x7, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x11, [x1]
-;;   add x10, x11, #4096
-;;   ldrb w0, [x10, w0, UXTW]
+;;   ldr x9, [x1]
+;;   add x8, x9, #4096
+;;   ldrb w0, [x8, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,18 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w10, w0
-;;   movn w9, #65534
-;;   adds x11, x10, x9
-;;   b.lo 8 ; udf
-;;   ldr x12, [x2, #8]
-;;   subs xzr, x11, x12
+;;   mov w8, w0
+;;   ldr x9, [x2, #8]
+;;   subs xzr, x8, x9
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x13, [x2]
-;;   movz x14, #65535, LSL #16
-;;   add x13, x14, x13
-;;   strb w1, [x13, w0, UXTW]
+;;   ldr x10, [x2]
+;;   movz x11, #65535, LSL #16
+;;   add x10, x11, x10
+;;   strb w1, [x10, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -61,18 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w10, w0
-;;   movn w9, #65534
-;;   adds x11, x10, x9
-;;   b.lo 8 ; udf
-;;   ldr x12, [x1, #8]
-;;   subs xzr, x11, x12
+;;   mov w8, w0
+;;   ldr x9, [x1, #8]
+;;   subs xzr, x8, x9
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x13, [x1]
-;;   movz x12, #65535, LSL #16
-;;   add x12, x12, x13
-;;   ldrb w0, [x12, w0, UXTW]
+;;   ldr x10, [x1]
+;;   movz x9, #65535, LSL #16
+;;   add x9, x9, x10
+;;   ldrb w0, [x9, w0, UXTW]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,32 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w10, w0
-;;   ldr x11, [x2, #8]
-;;   sub x11, x11, #4
-;;   ldr x12, [x2]
-;;   add x12, x12, x0, UXTW
-;;   movz x9, #0
-;;   subs xzr, x10, x11
-;;   csel x12, x9, x12, hi
+;;   mov w9, w0
+;;   ldr x10, [x2, #8]
+;;   ldr x11, [x2]
+;;   add x11, x11, x0, UXTW
+;;   movz x8, #0
+;;   subs xzr, x9, x10
+;;   csel x11, x8, x11, hi
 ;;   csdb
-;;   str w1, [x12]
+;;   str w1, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w10, w0
-;;   ldr x11, [x1, #8]
-;;   sub x11, x11, #4
-;;   ldr x12, [x1]
-;;   add x12, x12, x0, UXTW
-;;   movz x9, #0
-;;   subs xzr, x10, x11
-;;   csel x12, x9, x12, hi
+;;   mov w9, w0
+;;   ldr x10, [x1, #8]
+;;   ldr x11, [x1]
+;;   add x11, x11, x0, UXTW
+;;   movz x8, #0
+;;   subs xzr, x9, x10
+;;   csel x11, x8, x11, hi
 ;;   csdb
-;;   ldr w0, [x12]
+;;   ldr w0, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,36 +41,32 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w12, w0
-;;   ldr x13, [x2, #8]
-;;   movn x11, #4099
-;;   add x13, x13, x11
-;;   ldr x14, [x2]
-;;   add x14, x14, x0, UXTW
-;;   add x14, x14, #4096
-;;   movz x11, #0
-;;   subs xzr, x12, x13
-;;   csel x14, x11, x14, hi
+;;   mov w10, w0
+;;   ldr x11, [x2, #8]
+;;   ldr x12, [x2]
+;;   add x12, x12, x0, UXTW
+;;   add x12, x12, #4096
+;;   movz x9, #0
+;;   subs xzr, x10, x11
+;;   csel x12, x9, x12, hi
 ;;   csdb
-;;   str w1, [x14]
+;;   str w1, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w12, w0
-;;   ldr x13, [x1, #8]
-;;   movn x11, #4099
-;;   add x13, x13, x11
-;;   ldr x14, [x1]
-;;   add x14, x14, x0, UXTW
-;;   add x14, x14, #4096
-;;   movz x11, #0
-;;   subs xzr, x12, x13
-;;   csel x14, x11, x14, hi
+;;   mov w10, w0
+;;   ldr x11, [x1, #8]
+;;   ldr x12, [x1]
+;;   add x12, x12, x0, UXTW
+;;   add x12, x12, #4096
+;;   movz x9, #0
+;;   subs xzr, x10, x11
+;;   csel x12, x9, x12, hi
 ;;   csdb
-;;   ldr w0, [x14]
+;;   ldr w0, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w13, w0
-;;   movn w12, #65531
-;;   adds x14, x13, x12
-;;   b.lo 8 ; udf
-;;   ldr x15, [x2, #8]
-;;   ldr x2, [x2]
-;;   add x0, x2, x0, UXTW
-;;   movz x13, #65535, LSL #16
-;;   add x0, x0, x13
-;;   movz x13, #0
-;;   subs xzr, x14, x15
-;;   csel x0, x13, x0, hi
+;;   mov w11, w0
+;;   ldr x12, [x2, #8]
+;;   ldr x13, [x2]
+;;   add x13, x13, x0, UXTW
+;;   movz x10, #65535, LSL #16
+;;   add x13, x13, x10
+;;   movz x10, #0
+;;   subs xzr, x11, x12
+;;   csel x13, x10, x13, hi
 ;;   csdb
-;;   str w1, [x0]
+;;   str w1, [x13]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w13, w0
-;;   movn w12, #65531
-;;   adds x14, x13, x12
-;;   b.lo 8 ; udf
-;;   ldr x15, [x1, #8]
-;;   ldr x1, [x1]
-;;   add x0, x1, x0, UXTW
-;;   movz x13, #65535, LSL #16
-;;   add x0, x0, x13
-;;   movz x13, #0
-;;   subs xzr, x14, x15
-;;   csel x0, x13, x0, hi
+;;   mov w11, w0
+;;   ldr x12, [x1, #8]
+;;   ldr x13, [x1]
+;;   add x13, x13, x0, UXTW
+;;   movz x10, #65535, LSL #16
+;;   add x13, x13, x10
+;;   movz x10, #0
+;;   subs xzr, x11, x12
+;;   csel x13, x10, x13, hi
 ;;   csdb
-;;   ldr w0, [x0]
+;;   ldr w0, [x13]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,36 +41,32 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w12, w0
-;;   ldr x13, [x2, #8]
-;;   movn x11, #4096
-;;   add x13, x13, x11
-;;   ldr x14, [x2]
-;;   add x14, x14, x0, UXTW
-;;   add x14, x14, #4096
-;;   movz x11, #0
-;;   subs xzr, x12, x13
-;;   csel x14, x11, x14, hi
+;;   mov w10, w0
+;;   ldr x11, [x2, #8]
+;;   ldr x12, [x2]
+;;   add x12, x12, x0, UXTW
+;;   add x12, x12, #4096
+;;   movz x9, #0
+;;   subs xzr, x10, x11
+;;   csel x12, x9, x12, hi
 ;;   csdb
-;;   strb w1, [x14]
+;;   strb w1, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w12, w0
-;;   ldr x13, [x1, #8]
-;;   movn x11, #4096
-;;   add x13, x13, x11
-;;   ldr x14, [x1]
-;;   add x14, x14, x0, UXTW
-;;   add x14, x14, #4096
-;;   movz x11, #0
-;;   subs xzr, x12, x13
-;;   csel x14, x11, x14, hi
+;;   mov w10, w0
+;;   ldr x11, [x1, #8]
+;;   ldr x12, [x1]
+;;   add x12, x12, x0, UXTW
+;;   add x12, x12, #4096
+;;   movz x9, #0
+;;   subs xzr, x10, x11
+;;   csel x12, x9, x12, hi
 ;;   csdb
-;;   ldrb w0, [x14]
+;;   ldrb w0, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mov w13, w0
-;;   movn w12, #65534
-;;   adds x14, x13, x12
-;;   b.lo 8 ; udf
-;;   ldr x15, [x2, #8]
-;;   ldr x2, [x2]
-;;   add x0, x2, x0, UXTW
-;;   movz x13, #65535, LSL #16
-;;   add x0, x0, x13
-;;   movz x13, #0
-;;   subs xzr, x14, x15
-;;   csel x0, x13, x0, hi
+;;   mov w11, w0
+;;   ldr x12, [x2, #8]
+;;   ldr x13, [x2]
+;;   add x13, x13, x0, UXTW
+;;   movz x10, #65535, LSL #16
+;;   add x13, x13, x10
+;;   movz x10, #0
+;;   subs xzr, x11, x12
+;;   csel x13, x10, x13, hi
 ;;   csdb
-;;   strb w1, [x0]
+;;   strb w1, [x13]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mov w13, w0
-;;   movn w12, #65534
-;;   adds x14, x13, x12
-;;   b.lo 8 ; udf
-;;   ldr x15, [x1, #8]
-;;   ldr x1, [x1]
-;;   add x0, x1, x0, UXTW
-;;   movz x13, #65535, LSL #16
-;;   add x0, x0, x13
-;;   movz x13, #0
-;;   subs xzr, x14, x15
-;;   csel x0, x13, x0, hi
+;;   mov w11, w0
+;;   ldr x12, [x1, #8]
+;;   ldr x13, [x1]
+;;   add x13, x13, x0, UXTW
+;;   movz x10, #65535, LSL #16
+;;   add x13, x13, x10
+;;   movz x10, #0
+;;   subs xzr, x11, x12
+;;   csel x13, x10, x13, hi
 ;;   csdb
-;;   ldrb w0, [x0]
+;;   ldrb w0, [x13]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -41,13 +41,12 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x6, [x2, #8]
-;;   sub x6, x6, #4
-;;   subs xzr, x0, x6
+;;   ldr x5, [x2, #8]
+;;   subs xzr, x0, x5
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x8, [x2]
-;;   str w1, [x8, x0]
+;;   ldr x7, [x2]
+;;   str w1, [x7, x0]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -56,13 +55,12 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x6, [x1, #8]
-;;   sub x6, x6, #4
-;;   subs xzr, x0, x6
+;;   ldr x5, [x1, #8]
+;;   subs xzr, x0, x5
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x8, [x1]
-;;   ldr w0, [x8, x0]
+;;   ldr x7, [x1]
+;;   ldr w0, [x7, x0]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,15 +41,13 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x8, [x2, #8]
-;;   movn x7, #4099
-;;   add x9, x8, x7
-;;   subs xzr, x0, x9
+;;   ldr x6, [x2, #8]
+;;   subs xzr, x0, x6
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   str w1, [x11, x10]
+;;   ldr x8, [x2]
+;;   add x9, x0, #4096
+;;   str w1, [x9, x8]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -58,15 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x8, [x1, #8]
-;;   movn x7, #4099
-;;   add x9, x8, x7
-;;   subs xzr, x0, x9
+;;   ldr x6, [x1, #8]
+;;   subs xzr, x0, x6
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldr w0, [x9, x10]
+;;   ldr x8, [x1]
+;;   add x7, x0, #4096
+;;   ldr w0, [x7, x8]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,17 +41,14 @@
 
 ;; function u0:0:
 ;; block0:
-;;   movn w8, #65531
-;;   adds x10, x0, x8
-;;   b.lo 8 ; udf
-;;   ldr x11, [x2, #8]
-;;   subs xzr, x10, x11
+;;   ldr x7, [x2, #8]
+;;   subs xzr, x0, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x12, [x2]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x0
-;;   str w1, [x13, x12]
+;;   ldr x9, [x2]
+;;   movz x10, #65535, LSL #16
+;;   add x10, x10, x0
+;;   str w1, [x10, x9]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -60,17 +57,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   movn w8, #65531
-;;   adds x10, x0, x8
-;;   b.lo 8 ; udf
-;;   ldr x11, [x1, #8]
-;;   subs xzr, x10, x11
+;;   ldr x7, [x1, #8]
+;;   subs xzr, x0, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x12, [x1]
-;;   movz x11, #65535, LSL #16
-;;   add x11, x11, x0
-;;   ldr w0, [x11, x12]
+;;   ldr x9, [x1]
+;;   movz x8, #65535, LSL #16
+;;   add x8, x8, x0
+;;   ldr w0, [x8, x9]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,15 +41,13 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x8, [x2, #8]
-;;   movn x7, #4096
-;;   add x9, x8, x7
-;;   subs xzr, x0, x9
+;;   ldr x6, [x2, #8]
+;;   subs xzr, x0, x6
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x10, [x2]
-;;   add x11, x0, #4096
-;;   strb w1, [x11, x10]
+;;   ldr x8, [x2]
+;;   add x9, x0, #4096
+;;   strb w1, [x9, x8]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -58,15 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x8, [x1, #8]
-;;   movn x7, #4096
-;;   add x9, x8, x7
-;;   subs xzr, x0, x9
+;;   ldr x6, [x1, #8]
+;;   subs xzr, x0, x6
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x10, [x1]
-;;   add x9, x0, #4096
-;;   ldrb w0, [x9, x10]
+;;   ldr x8, [x1]
+;;   add x7, x0, #4096
+;;   ldrb w0, [x7, x8]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,17 +41,14 @@
 
 ;; function u0:0:
 ;; block0:
-;;   movn w8, #65534
-;;   adds x10, x0, x8
-;;   b.lo 8 ; udf
-;;   ldr x11, [x2, #8]
-;;   subs xzr, x10, x11
+;;   ldr x7, [x2, #8]
+;;   subs xzr, x0, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x12, [x2]
-;;   movz x13, #65535, LSL #16
-;;   add x13, x13, x0
-;;   strb w1, [x13, x12]
+;;   ldr x9, [x2]
+;;   movz x10, #65535, LSL #16
+;;   add x10, x10, x0
+;;   strb w1, [x10, x9]
 ;;   b label2
 ;; block2:
 ;;   ret
@@ -60,17 +57,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   movn w8, #65534
-;;   adds x10, x0, x8
-;;   b.lo 8 ; udf
-;;   ldr x11, [x1, #8]
-;;   subs xzr, x10, x11
+;;   ldr x7, [x1, #8]
+;;   subs xzr, x0, x7
 ;;   b.hi label3 ; b label1
 ;; block1:
-;;   ldr x12, [x1]
-;;   movz x11, #65535, LSL #16
-;;   add x11, x11, x0
-;;   ldrb w0, [x11, x12]
+;;   ldr x9, [x1]
+;;   movz x8, #65535, LSL #16
+;;   add x8, x8, x0
+;;   ldrb w0, [x8, x9]
 ;;   b label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,30 +41,28 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x9, [x2, #8]
-;;   sub x9, x9, #4
-;;   ldr x10, [x2]
-;;   add x10, x10, x0
-;;   movz x8, #0
-;;   subs xzr, x0, x9
-;;   csel x11, x8, x10, hi
+;;   ldr x8, [x2, #8]
+;;   ldr x9, [x2]
+;;   add x9, x9, x0
+;;   movz x7, #0
+;;   subs xzr, x0, x8
+;;   csel x10, x7, x9, hi
 ;;   csdb
-;;   str w1, [x11]
+;;   str w1, [x10]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x9, [x1, #8]
-;;   sub x9, x9, #4
-;;   ldr x10, [x1]
-;;   add x10, x10, x0
-;;   movz x8, #0
-;;   subs xzr, x0, x9
-;;   csel x11, x8, x10, hi
+;;   ldr x8, [x1, #8]
+;;   ldr x9, [x1]
+;;   add x9, x9, x0
+;;   movz x7, #0
+;;   subs xzr, x0, x8
+;;   csel x10, x7, x9, hi
 ;;   csdb
-;;   ldr w0, [x11]
+;;   ldr w0, [x10]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,34 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x11, [x2, #8]
-;;   movn x10, #4099
-;;   add x12, x11, x10
-;;   ldr x11, [x2]
-;;   add x11, x11, x0
-;;   add x11, x11, #4096
-;;   movz x10, #0
-;;   subs xzr, x0, x12
-;;   csel x13, x10, x11, hi
+;;   ldr x9, [x2, #8]
+;;   ldr x10, [x2]
+;;   add x10, x10, x0
+;;   add x10, x10, #4096
+;;   movz x8, #0
+;;   subs xzr, x0, x9
+;;   csel x11, x8, x10, hi
 ;;   csdb
-;;   str w1, [x13]
+;;   str w1, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x11, [x1, #8]
-;;   movn x10, #4099
-;;   add x12, x11, x10
-;;   ldr x11, [x1]
-;;   add x11, x11, x0
-;;   add x11, x11, #4096
-;;   movz x10, #0
-;;   subs xzr, x0, x12
-;;   csel x13, x10, x11, hi
+;;   ldr x9, [x1, #8]
+;;   ldr x10, [x1]
+;;   add x10, x10, x0
+;;   add x10, x10, #4096
+;;   movz x8, #0
+;;   subs xzr, x0, x9
+;;   csel x11, x8, x10, hi
 ;;   csdb
-;;   ldr w0, [x13]
+;;   ldr w0, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,38 +41,32 @@
 
 ;; function u0:0:
 ;; block0:
-;;   movn w11, #65531
-;;   adds x13, x0, x11
-;;   b.lo 8 ; udf
-;;   ldr x14, [x2, #8]
-;;   ldr x15, [x2]
-;;   add x15, x15, x0
-;;   movz x12, #65535, LSL #16
-;;   add x15, x15, x12
-;;   movz x12, #0
-;;   subs xzr, x13, x14
-;;   csel x15, x12, x15, hi
+;;   ldr x10, [x2, #8]
+;;   ldr x11, [x2]
+;;   add x11, x11, x0
+;;   movz x9, #65535, LSL #16
+;;   add x11, x11, x9
+;;   movz x9, #0
+;;   subs xzr, x0, x10
+;;   csel x12, x9, x11, hi
 ;;   csdb
-;;   str w1, [x15]
+;;   str w1, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   movn w11, #65531
-;;   adds x13, x0, x11
-;;   b.lo 8 ; udf
-;;   ldr x14, [x1, #8]
-;;   ldr x15, [x1]
-;;   add x15, x15, x0
-;;   movz x12, #65535, LSL #16
-;;   add x15, x15, x12
-;;   movz x12, #0
-;;   subs xzr, x13, x14
-;;   csel x15, x12, x15, hi
+;;   ldr x10, [x1, #8]
+;;   ldr x11, [x1]
+;;   add x11, x11, x0
+;;   movz x9, #65535, LSL #16
+;;   add x11, x11, x9
+;;   movz x9, #0
+;;   subs xzr, x0, x10
+;;   csel x12, x9, x11, hi
 ;;   csdb
-;;   ldr w0, [x15]
+;;   ldr w0, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,34 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ldr x11, [x2, #8]
-;;   movn x10, #4096
-;;   add x12, x11, x10
-;;   ldr x11, [x2]
-;;   add x11, x11, x0
-;;   add x11, x11, #4096
-;;   movz x10, #0
-;;   subs xzr, x0, x12
-;;   csel x13, x10, x11, hi
+;;   ldr x9, [x2, #8]
+;;   ldr x10, [x2]
+;;   add x10, x10, x0
+;;   add x10, x10, #4096
+;;   movz x8, #0
+;;   subs xzr, x0, x9
+;;   csel x11, x8, x10, hi
 ;;   csdb
-;;   strb w1, [x13]
+;;   strb w1, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ldr x11, [x1, #8]
-;;   movn x10, #4096
-;;   add x12, x11, x10
-;;   ldr x11, [x1]
-;;   add x11, x11, x0
-;;   add x11, x11, #4096
-;;   movz x10, #0
-;;   subs xzr, x0, x12
-;;   csel x13, x10, x11, hi
+;;   ldr x9, [x1, #8]
+;;   ldr x10, [x1]
+;;   add x10, x10, x0
+;;   add x10, x10, #4096
+;;   movz x8, #0
+;;   subs xzr, x0, x9
+;;   csel x11, x8, x10, hi
 ;;   csdb
-;;   ldrb w0, [x13]
+;;   ldrb w0, [x11]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,38 +41,32 @@
 
 ;; function u0:0:
 ;; block0:
-;;   movn w11, #65534
-;;   adds x13, x0, x11
-;;   b.lo 8 ; udf
-;;   ldr x14, [x2, #8]
-;;   ldr x15, [x2]
-;;   add x15, x15, x0
-;;   movz x12, #65535, LSL #16
-;;   add x15, x15, x12
-;;   movz x12, #0
-;;   subs xzr, x13, x14
-;;   csel x15, x12, x15, hi
+;;   ldr x10, [x2, #8]
+;;   ldr x11, [x2]
+;;   add x11, x11, x0
+;;   movz x9, #65535, LSL #16
+;;   add x11, x11, x9
+;;   movz x9, #0
+;;   subs xzr, x0, x10
+;;   csel x12, x9, x11, hi
 ;;   csdb
-;;   strb w1, [x15]
+;;   strb w1, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   movn w11, #65534
-;;   adds x13, x0, x11
-;;   b.lo 8 ; udf
-;;   ldr x14, [x1, #8]
-;;   ldr x15, [x1]
-;;   add x15, x15, x0
-;;   movz x12, #65535, LSL #16
-;;   add x15, x15, x12
-;;   movz x12, #0
-;;   subs xzr, x13, x14
-;;   csel x15, x12, x15, hi
+;;   ldr x10, [x1, #8]
+;;   ldr x11, [x1]
+;;   add x11, x11, x0
+;;   movz x9, #65535, LSL #16
+;;   add x11, x11, x9
+;;   movz x9, #0
+;;   subs xzr, x0, x10
+;;   csel x12, x9, x11, hi
 ;;   csdb
-;;   ldrb w0, [x15]
+;;   ldrb w0, [x12]
 ;;   b label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -41,16 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a6,a0,32
-;;   srli t3,a6,32
-;;   ld a7,8(a2)
-;;   addi a7,a7,-4
-;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label3),not_taken(label1)
+;;   slli a5,a0,32
+;;   srli a7,a5,32
+;;   ld a6,8(a2)
+;;   ugt a6,a7,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t4,0(a2)
-;;   add t3,t4,t3
-;;   sw a1,0(t3)
+;;   ld t3,0(a2)
+;;   add a7,t3,a7
+;;   sw a1,0(a7)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -59,16 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a6,a0,32
-;;   srli t3,a6,32
-;;   ld a7,8(a1)
-;;   addi a7,a7,-4
-;;   ugt a7,t3,a7##ty=i64
-;;   bne a7,zero,taken(label3),not_taken(label1)
+;;   slli a5,a0,32
+;;   srli a7,a5,32
+;;   ld a6,8(a1)
+;;   ugt a6,a7,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t4,0(a1)
-;;   add t3,t4,t3
-;;   lw a0,0(t3)
+;;   ld t3,0(a1)
+;;   add a7,t3,a7
+;;   lw a0,0(a7)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,20 +41,17 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   ld t1,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
-;;   add a0,t1,t0
-;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a2)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a2)
-;;   add t2,a0,t2
-;;   lui t1,1
-;;   add a0,t2,t1
-;;   sw a1,0(a0)
+;;   ld t0,0(a2)
+;;   add t4,t0,t4
+;;   lui t3,1
+;;   add t0,t4,t3
+;;   sw a1,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -63,20 +60,17 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   ld t1,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
-;;   add a0,t1,t0
-;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a1)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a1)
-;;   add t2,a0,t2
-;;   lui t1,1
-;;   add a0,t2,t1
-;;   lw a0,0(a0)
+;;   ld t0,0(a1)
+;;   add t4,t0,t4
+;;   lui t3,1
+;;   add t0,t4,t3
+;;   lw a0,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,21 +41,17 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0004
-;;   add t1,t2,t4
-;;   ult a0,t1,t2##ty=i64
-;;   trap_if a0,heap_oob
-;;   ld a0,8(a2)
-;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a2)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
-;;   add a2,a0,t2
-;;   sw a1,0(a2)
+;;   ld t0,0(a2)
+;;   add t4,t0,t4
+;;   auipc t3,0; ld t3,12(t3); j 12; .8byte 0xffff0000
+;;   add t0,t4,t3
+;;   sw a1,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -64,21 +60,17 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0004
-;;   add t1,t2,t4
-;;   ult a0,t1,t2##ty=i64
-;;   trap_if a0,heap_oob
-;;   ld a0,8(a1)
-;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a1)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
-;;   add a1,a0,t2
-;;   lw a0,0(a1)
+;;   ld t0,0(a1)
+;;   add t4,t0,t4
+;;   auipc t3,0; ld t3,12(t3); j 12; .8byte 0xffff0000
+;;   add t0,t4,t3
+;;   lw a0,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,20 +41,17 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   ld t1,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
-;;   add a0,t1,t0
-;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a2)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a2)
-;;   add t2,a0,t2
-;;   lui t1,1
-;;   add a0,t2,t1
-;;   sb a1,0(a0)
+;;   ld t0,0(a2)
+;;   add t4,t0,t4
+;;   lui t3,1
+;;   add t0,t4,t3
+;;   sb a1,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -63,20 +60,17 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   ld t1,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
-;;   add a0,t1,t0
-;;   ugt t1,t2,a0##ty=i64
-;;   bne t1,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a1)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a1)
-;;   add t2,a0,t2
-;;   lui t1,1
-;;   add a0,t2,t1
-;;   lbu a0,0(a0)
+;;   ld t0,0(a1)
+;;   add t4,t0,t4
+;;   lui t3,1
+;;   add t0,t4,t3
+;;   lbu a0,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,21 +41,17 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0001
-;;   add t1,t2,t4
-;;   ult a0,t1,t2##ty=i64
-;;   trap_if a0,heap_oob
-;;   ld a0,8(a2)
-;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a2)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a2)
-;;   add a0,a0,t2
-;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
-;;   add a2,a0,t2
-;;   sb a1,0(a2)
+;;   ld t0,0(a2)
+;;   add t4,t0,t4
+;;   auipc t3,0; ld t3,12(t3); j 12; .8byte 0xffff0000
+;;   add t0,t4,t3
+;;   sb a1,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -64,21 +60,17 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t0,a0,32
-;;   srli t2,t0,32
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0001
-;;   add t1,t2,t4
-;;   ult a0,t1,t2##ty=i64
-;;   trap_if a0,heap_oob
-;;   ld a0,8(a1)
-;;   ugt a0,t1,a0##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a1)
+;;   ugt t3,t4,t3##ty=i64
+;;   bne t3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a1)
-;;   add a0,a0,t2
-;;   auipc t2,0; ld t2,12(t2); j 12; .8byte 0xffff0000
-;;   add a1,a0,t2
-;;   lbu a0,0(a1)
+;;   ld t0,0(a1)
+;;   add t4,t0,t4
+;;   auipc t3,0; ld t3,12(t3); j 12; .8byte 0xffff0000
+;;   add t0,t4,t3
+;;   lbu a0,0(t0)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,32 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t3,a0,32
-;;   srli t0,t3,32
-;;   ld t4,8(a2)
-;;   addi t4,t4,-4
-;;   ld t1,0(a2)
-;;   add t1,t1,t0
-;;   ugt t3,t0,t4##ty=i64
-;;   li t0,0
-;;   selectif_spectre_guard t4,t0,t1##test=t3
-;;   sw a1,0(t4)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a2)
+;;   ld t0,0(a2)
+;;   add t0,t0,t4
+;;   ugt a7,t4,t3##ty=i64
+;;   li t4,0
+;;   selectif_spectre_guard t3,t4,t0##test=a7
+;;   sw a1,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t3,a0,32
-;;   srli t0,t3,32
-;;   ld t4,8(a1)
-;;   addi t4,t4,-4
-;;   ld t1,0(a1)
-;;   add t1,t1,t0
-;;   ugt t3,t0,t4##ty=i64
-;;   li t0,0
-;;   selectif_spectre_guard t4,t0,t1##test=t3
-;;   lw a0,0(t4)
+;;   slli a7,a0,32
+;;   srli t4,a7,32
+;;   ld t3,8(a1)
+;;   ld t0,0(a1)
+;;   add t0,t0,t4
+;;   ugt a7,t4,t3##ty=i64
+;;   li t4,0
+;;   selectif_spectre_guard t3,t4,t0##test=a7
+;;   lw a0,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a3,t2,32
-;;   ld a0,8(a2)
-;;   lui t2,1048575
-;;   addi t2,t2,4092
-;;   add a4,a0,t2
-;;   ld a0,0(a2)
-;;   add a0,a0,a3
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   ugt t2,a3,a4##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a0,a3,a2##test=t2
-;;   sw a1,0(a0)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a2)
+;;   ld t2,0(a2)
+;;   add t2,t2,t1
+;;   lui t4,1
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   sw a1,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a2,t2,32
-;;   ld a0,8(a1)
-;;   lui t2,1048575
-;;   addi t2,t2,4092
-;;   add a3,a0,t2
-;;   ld a0,0(a1)
-;;   add a0,a0,a2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   ugt t2,a2,a3##ty=i64
-;;   li a2,0
-;;   selectif_spectre_guard a0,a2,a1##test=t2
-;;   lw a0,0(a0)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a1)
+;;   ld t2,0(a1)
+;;   add t2,t2,t1
+;;   lui t4,1
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   lw a0,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,42 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a3,t2,32
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0004
-;;   add a0,a3,t1
-;;   ult a4,a0,a3##ty=i64
-;;   trap_if a4,heap_oob
-;;   ld a4,8(a2)
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   auipc a3,0; ld a3,12(a3); j 12; .8byte 0xffff0000
-;;   add a2,a2,a3
-;;   ugt a0,a0,a4##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a4,a3,a2##test=a0
-;;   sw a1,0(a4)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a2)
+;;   ld t2,0(a2)
+;;   add t2,t2,t1
+;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0000
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   sw a1,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a2,t2,32
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0004
-;;   add a0,a2,t1
-;;   ult a3,a0,a2##ty=i64
-;;   trap_if a3,heap_oob
-;;   ld a3,8(a1)
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   auipc a2,0; ld a2,12(a2); j 12; .8byte 0xffff0000
-;;   add a2,a1,a2
-;;   ugt a0,a0,a3##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a1,a3,a2##test=a0
-;;   lw a0,0(a1)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a1)
+;;   ld t2,0(a1)
+;;   add t2,t2,t1
+;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0000
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   lw a0,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a3,t2,32
-;;   ld a0,8(a2)
-;;   lui t2,1048575
-;;   addi t2,t2,4095
-;;   add a4,a0,t2
-;;   ld a0,0(a2)
-;;   add a0,a0,a3
-;;   lui t2,1
-;;   add a2,a0,t2
-;;   ugt t2,a3,a4##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a0,a3,a2##test=t2
-;;   sb a1,0(a0)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a2)
+;;   ld t2,0(a2)
+;;   add t2,t2,t1
+;;   lui t4,1
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   sb a1,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a2,t2,32
-;;   ld a0,8(a1)
-;;   lui t2,1048575
-;;   addi t2,t2,4095
-;;   add a3,a0,t2
-;;   ld a0,0(a1)
-;;   add a0,a0,a2
-;;   lui t2,1
-;;   add a1,a0,t2
-;;   ugt t2,a2,a3##ty=i64
-;;   li a2,0
-;;   selectif_spectre_guard a0,a2,a1##test=t2
-;;   lbu a0,0(a0)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a1)
+;;   ld t2,0(a1)
+;;   add t2,t2,t1
+;;   lui t4,1
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   lbu a0,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,42 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a3,t2,32
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0001
-;;   add a0,a3,t1
-;;   ult a4,a0,a3##ty=i64
-;;   trap_if a4,heap_oob
-;;   ld a4,8(a2)
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   auipc a3,0; ld a3,12(a3); j 12; .8byte 0xffff0000
-;;   add a2,a2,a3
-;;   ugt a0,a0,a4##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a4,a3,a2##test=a0
-;;   sb a1,0(a4)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a2)
+;;   ld t2,0(a2)
+;;   add t2,t2,t1
+;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0000
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   sb a1,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli t2,a0,32
-;;   srli a2,t2,32
-;;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xffff0001
-;;   add a0,a2,t1
-;;   ult a3,a0,a2##ty=i64
-;;   trap_if a3,heap_oob
-;;   ld a3,8(a1)
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   auipc a2,0; ld a2,12(a2); j 12; .8byte 0xffff0000
-;;   add a2,a1,a2
-;;   ugt a0,a0,a3##ty=i64
-;;   li a3,0
-;;   selectif_spectre_guard a1,a3,a2##test=a0
-;;   lbu a0,0(a1)
+;;   slli t4,a0,32
+;;   srli t1,t4,32
+;;   ld t0,8(a1)
+;;   ld t2,0(a1)
+;;   add t2,t2,t1
+;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0000
+;;   add t2,t2,t4
+;;   ugt t4,t1,t0##ty=i64
+;;   li t1,0
+;;   selectif_spectre_guard t0,t1,t2##test=t4
+;;   lbu a0,0(t0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -41,14 +41,13 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a5,8(a2)
-;;   addi a5,a5,-4
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a2)
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a6,0(a2)
-;;   add a6,a6,a0
-;;   sw a1,0(a6)
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sw a1,0(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,14 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a5,8(a1)
-;;   addi a5,a5,-4
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a1)
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a6,0(a1)
-;;   add a6,a6,a0
-;;   lw a0,0(a6)
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lw a0,0(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,18 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld t4,8(a2)
-;;   lui t3,1048575
-;;   addi t3,t3,4092
-;;   add t1,t4,t3
-;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a2)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t0,0(a2)
-;;   add t0,t0,a0
-;;   lui t4,1
-;;   add t1,t0,t4
-;;   sw a1,0(t1)
+;;   ld a7,0(a2)
+;;   add a7,a7,a0
+;;   lui a6,1
+;;   add t3,a7,a6
+;;   sw a1,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -61,18 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld t4,8(a1)
-;;   lui t3,1048575
-;;   addi t3,t3,4092
-;;   add t1,t4,t3
-;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a1)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t0,0(a1)
-;;   add t0,t0,a0
-;;   lui t4,1
-;;   add t1,t0,t4
-;;   lw a0,0(t1)
+;;   ld a7,0(a1)
+;;   add a7,a7,a0
+;;   lui a6,1
+;;   add t3,a7,a6
+;;   lw a0,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,19 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0004
-;;   add t4,a0,a7
-;;   ult t1,t4,a0##ty=i64
-;;   trap_if t1,heap_oob
-;;   ld t0,8(a2)
-;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a2)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
-;;   add t2,t1,t0
-;;   sw a1,0(t2)
+;;   ld a7,0(a2)
+;;   add a7,a7,a0
+;;   auipc a6,0; ld a6,12(a6); j 12; .8byte 0xffff0000
+;;   add t3,a7,a6
+;;   sw a1,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -62,19 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0004
-;;   add t4,a0,a7
-;;   ult t1,t4,a0##ty=i64
-;;   trap_if t1,heap_oob
-;;   ld t0,8(a1)
-;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a1)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
-;;   add t2,t1,t0
-;;   lw a0,0(t2)
+;;   ld a7,0(a1)
+;;   add a7,a7,a0
+;;   auipc a6,0; ld a6,12(a6); j 12; .8byte 0xffff0000
+;;   add t3,a7,a6
+;;   lw a0,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,18 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld t4,8(a2)
-;;   lui t3,1048575
-;;   addi t3,t3,4095
-;;   add t1,t4,t3
-;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a2)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t0,0(a2)
-;;   add t0,t0,a0
-;;   lui t4,1
-;;   add t1,t0,t4
-;;   sb a1,0(t1)
+;;   ld a7,0(a2)
+;;   add a7,a7,a0
+;;   lui a6,1
+;;   add t3,a7,a6
+;;   sb a1,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -61,18 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld t4,8(a1)
-;;   lui t3,1048575
-;;   addi t3,t3,4095
-;;   add t1,t4,t3
-;;   ugt t4,a0,t1##ty=i64
-;;   bne t4,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a1)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t0,0(a1)
-;;   add t0,t0,a0
-;;   lui t4,1
-;;   add t1,t0,t4
-;;   lbu a0,0(t1)
+;;   ld a7,0(a1)
+;;   add a7,a7,a0
+;;   lui a6,1
+;;   add t3,a7,a6
+;;   lbu a0,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,19 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0001
-;;   add t4,a0,a7
-;;   ult t1,t4,a0##ty=i64
-;;   trap_if t1,heap_oob
-;;   ld t0,8(a2)
-;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a2)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
-;;   add t2,t1,t0
-;;   sb a1,0(t2)
+;;   ld a7,0(a2)
+;;   add a7,a7,a0
+;;   auipc a6,0; ld a6,12(a6); j 12; .8byte 0xffff0000
+;;   add t3,a7,a6
+;;   sb a1,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -62,19 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0001
-;;   add t4,a0,a7
-;;   ult t1,t4,a0##ty=i64
-;;   trap_if t1,heap_oob
-;;   ld t0,8(a1)
-;;   ugt t0,t4,t0##ty=i64
-;;   bne t0,zero,taken(label3),not_taken(label1)
+;;   ld a6,8(a1)
+;;   ugt a6,a0,a6##ty=i64
+;;   bne a6,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xffff0000
-;;   add t2,t1,t0
-;;   lbu a0,0(t2)
+;;   ld a7,0(a1)
+;;   add a7,a7,a0
+;;   auipc a6,0; ld a6,12(a6); j 12; .8byte 0xffff0000
+;;   add t3,a7,a6
+;;   lbu a0,0(t3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,28 +41,26 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a7,8(a2)
-;;   addi a7,a7,-4
-;;   ld t3,0(a2)
-;;   add t3,t3,a0
-;;   ugt a6,a0,a7##ty=i64
-;;   li t4,0
-;;   selectif_spectre_guard a7,t4,t3##test=a6
-;;   sw a1,0(a7)
+;;   ld a6,8(a2)
+;;   ld a7,0(a2)
+;;   add a7,a7,a0
+;;   ugt a5,a0,a6##ty=i64
+;;   li t3,0
+;;   selectif_spectre_guard a6,t3,a7##test=a5
+;;   sw a1,0(a6)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a7,8(a1)
-;;   addi a7,a7,-4
-;;   ld t3,0(a1)
-;;   add t3,t3,a0
-;;   ugt a6,a0,a7##ty=i64
-;;   li t4,0
-;;   selectif_spectre_guard a7,t4,t3##test=a6
-;;   lw a0,0(a7)
+;;   ld a6,8(a1)
+;;   ld a7,0(a1)
+;;   add a7,a7,a0
+;;   ugt a5,a0,a6##ty=i64
+;;   li t3,0
+;;   selectif_spectre_guard a6,t3,a7##test=a5
+;;   lw a0,0(a6)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,36 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld t1,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
-;;   add a3,t1,t0
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   ugt t0,a0,a3##ty=i64
-;;   li a0,0
-;;   selectif_spectre_guard t1,a0,t2##test=t0
-;;   sw a1,0(t1)
+;;   ld t3,8(a2)
+;;   ld t4,0(a2)
+;;   add t4,t4,a0
+;;   lui a7,1
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   sw a1,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld t1,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
-;;   add a2,t1,t0
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   ugt t0,a0,a2##ty=i64
-;;   li a0,0
-;;   selectif_spectre_guard t1,a0,t2##test=t0
-;;   lw a0,0(t1)
+;;   ld t3,8(a1)
+;;   ld t4,0(a1)
+;;   add t4,t4,a0
+;;   lui a7,1
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   lw a0,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,38 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0004
-;;   add t1,a0,t4
-;;   ult a3,t1,a0##ty=i64
-;;   trap_if a3,heap_oob
-;;   ld t2,8(a2)
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   auipc a2,0; ld a2,12(a2); j 12; .8byte 0xffff0000
-;;   add a0,a0,a2
-;;   ugt t1,t1,t2##ty=i64
-;;   li a2,0
-;;   selectif_spectre_guard t2,a2,a0##test=t1
-;;   sw a1,0(t2)
+;;   ld t3,8(a2)
+;;   ld t4,0(a2)
+;;   add t4,t4,a0
+;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0000
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   sw a1,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0004
-;;   add t1,a0,t4
-;;   ult a2,t1,a0##ty=i64
-;;   trap_if a2,heap_oob
-;;   ld t2,8(a1)
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   auipc a1,0; ld a1,12(a1); j 12; .8byte 0xffff0000
-;;   add a0,a0,a1
-;;   ugt t1,t1,t2##ty=i64
-;;   li a1,0
-;;   selectif_spectre_guard t2,a1,a0##test=t1
-;;   lw a0,0(t2)
+;;   ld t3,8(a1)
+;;   ld t4,0(a1)
+;;   add t4,t4,a0
+;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0000
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   lw a0,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,36 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld t1,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
-;;   add a3,t1,t0
-;;   ld t1,0(a2)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   ugt t0,a0,a3##ty=i64
-;;   li a0,0
-;;   selectif_spectre_guard t1,a0,t2##test=t0
-;;   sb a1,0(t1)
+;;   ld t3,8(a2)
+;;   ld t4,0(a2)
+;;   add t4,t4,a0
+;;   lui a7,1
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   sb a1,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld t1,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
-;;   add a2,t1,t0
-;;   ld t1,0(a1)
-;;   add t1,t1,a0
-;;   lui t0,1
-;;   add t2,t1,t0
-;;   ugt t0,a0,a2##ty=i64
-;;   li a0,0
-;;   selectif_spectre_guard t1,a0,t2##test=t0
-;;   lbu a0,0(t1)
+;;   ld t3,8(a1)
+;;   ld t4,0(a1)
+;;   add t4,t4,a0
+;;   lui a7,1
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   lbu a0,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,38 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0001
-;;   add t1,a0,t4
-;;   ult a3,t1,a0##ty=i64
-;;   trap_if a3,heap_oob
-;;   ld t2,8(a2)
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   auipc a2,0; ld a2,12(a2); j 12; .8byte 0xffff0000
-;;   add a0,a0,a2
-;;   ugt t1,t1,t2##ty=i64
-;;   li a2,0
-;;   selectif_spectre_guard t2,a2,a0##test=t1
-;;   sb a1,0(t2)
+;;   ld t3,8(a2)
+;;   ld t4,0(a2)
+;;   add t4,t4,a0
+;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0000
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   sb a1,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0xffff0001
-;;   add t1,a0,t4
-;;   ult a2,t1,a0##ty=i64
-;;   trap_if a2,heap_oob
-;;   ld t2,8(a1)
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   auipc a1,0; ld a1,12(a1); j 12; .8byte 0xffff0000
-;;   add a0,a0,a1
-;;   ugt t1,t1,t2##ty=i64
-;;   li a1,0
-;;   selectif_spectre_guard t2,a1,a0##test=t1
-;;   lbu a0,0(t2)
+;;   ld t3,8(a1)
+;;   ld t4,0(a1)
+;;   add t4,t4,a0
+;;   auipc a7,0; ld a7,12(a7); j 12; .8byte 0xffff0000
+;;   add t4,t4,a7
+;;   ugt a7,a0,t3##ty=i64
+;;   li t0,0
+;;   selectif_spectre_guard t3,t0,t4##test=a7
+;;   lbu a0,0(t3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -43,14 +43,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r5, %r2
-;;   lghi %r2, -4
-;;   ag %r2, 8(%r4)
-;;   clgr %r5, %r2
+;;   lgr %r5, %r4
+;;   llgfr %r4, %r2
+;;   lgr %r2, %r5
+;;   lg %r5, 8(%r2)
+;;   clgr %r4, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lg %r4, 0(%r4)
-;;   strv %r3, 0(%r5,%r4)
+;;   lg %r2, 0(%r2)
+;;   strv %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -61,14 +62,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r5, %r2
-;;   lghi %r2, -4
-;;   ag %r2, 8(%r3)
-;;   clgr %r5, %r2
+;;   llgfr %r4, %r2
+;;   lg %r5, 8(%r3)
+;;   clgr %r4, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lg %r3, 0(%r3)
-;;   lrv %r2, 0(%r5,%r3)
+;;   lg %r2, 0(%r3)
+;;   lrv %r2, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,8 +45,7 @@
 ;; block0:
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lghi %r2, -4100
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r5)
 ;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -65,15 +64,13 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   lghi %r2, -4100
-;;   lgr %r5, %r4
-;;   ag %r2, 8(%r5)
-;;   clgr %r3, %r2
+;;   lg %r5, 8(%r4)
+;;   clgr %r3, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   ag %r3, 0(%r5)
-;;   lghi %r4, 4096
-;;   lrv %r2, 0(%r4,%r3)
+;;   ag %r3, 0(%r4)
+;;   lghi %r2, 4096
+;;   lrv %r2, 0(%r2,%r3)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,35 +41,19 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
-;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
-;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
-;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
-;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r7, %r4
+;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lgr %r5, %r2
-;;   llilf %r2, 4294901764
-;;   algfr %r2, %r5
-;;   jle 6 ; trap
-;;   lgr %r5, %r7
-;;   lg %r7, 8(%r5)
-;;   clgr %r2, %r7
+;;   lg %r2, 8(%r5)
+;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r2, 65535
-;;   strv %r3, 0(%r2,%r4)
+;;   llilh %r5, 65535
+;;   strv %r3, 0(%r5,%r4)
 ;;   jg label2
 ;; block2:
-;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;; block3:
 ;;   trap
@@ -80,16 +64,13 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   llilf %r5, 4294901764
-;;   algfr %r5, %r2
-;;   jle 6 ; trap
-;;   lg %r2, 8(%r4)
-;;   clgr %r5, %r2
+;;   lg %r5, 8(%r4)
+;;   clgr %r3, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r3, 0(%r4)
-;;   llilh %r5, 65535
-;;   lrv %r2, 0(%r5,%r3)
+;;   llilh %r2, 65535
+;;   lrv %r2, 0(%r2,%r3)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,8 +45,7 @@
 ;; block0:
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lghi %r2, -4097
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r5)
 ;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -65,15 +64,13 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   lghi %r2, -4097
-;;   lgr %r5, %r4
-;;   ag %r2, 8(%r5)
-;;   clgr %r3, %r2
+;;   lg %r5, 8(%r4)
+;;   clgr %r3, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   ag %r3, 0(%r5)
-;;   lghi %r4, 4096
-;;   llc %r2, 0(%r4,%r3)
+;;   ag %r3, 0(%r4)
+;;   lghi %r2, 4096
+;;   llc %r2, 0(%r2,%r3)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,35 +41,19 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
-;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
-;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
-;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
-;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r7, %r4
+;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lgr %r5, %r2
-;;   llilf %r2, 4294901761
-;;   algfr %r2, %r5
-;;   jle 6 ; trap
-;;   lgr %r5, %r7
-;;   lg %r7, 8(%r5)
-;;   clgr %r2, %r7
+;;   lg %r2, 8(%r5)
+;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r4, 0(%r5)
-;;   llilh %r2, 65535
-;;   stc %r3, 0(%r2,%r4)
+;;   llilh %r5, 65535
+;;   stc %r3, 0(%r5,%r4)
 ;;   jg label2
 ;; block2:
-;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;; block3:
 ;;   trap
@@ -80,16 +64,13 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   llilf %r5, 4294901761
-;;   algfr %r5, %r2
-;;   jle 6 ; trap
-;;   lg %r2, 8(%r4)
-;;   clgr %r5, %r2
+;;   lg %r5, 8(%r4)
+;;   clgr %r3, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r3, 0(%r4)
-;;   llilh %r5, 65535
-;;   llc %r2, 0(%r5,%r3)
+;;   llilh %r2, 65535
+;;   llc %r2, 0(%r2,%r3)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,48 +41,36 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
-;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
-;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
+;;   stmg %r14, %r15, 112(%r15)
 ;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r7, %r4
-;;   llgfr %r4, %r2
-;;   lghi %r5, -4
-;;   lgr %r9, %r7
-;;   ag %r5, 8(%r9)
-;;   lgr %r2, %r4
-;;   ag %r2, 0(%r9)
-;;   lghi %r14, 0
-;;   clgr %r4, %r5
-;;   locgrh %r2, %r14
-;;   strv %r3, 0(%r2)
+;;   llgfr %r2, %r2
+;;   lg %r14, 8(%r4)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   lghi %r4, 0
+;;   clgr %r2, %r14
+;;   locgrh %r5, %r4
+;;   strv %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
-;;   lmg %r7, %r15, 56(%r15)
+;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r3
-;;   llgfr %r3, %r2
-;;   lghi %r4, -4
-;;   ag %r4, 8(%r5)
-;;   lgr %r2, %r3
-;;   ag %r2, 0(%r5)
-;;   lghi %r5, 0
-;;   clgr %r3, %r4
-;;   locgrh %r2, %r5
-;;   lrv %r2, 0(%r2)
+;;   llgfr %r2, %r2
+;;   lg %r4, 8(%r3)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   lghi %r3, 0
+;;   clgr %r2, %r4
+;;   locgrh %r5, %r3
+;;   lrv %r2, 0(%r5)
 ;;   jg label1
 ;; block1:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -54,16 +54,15 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r2, %r2
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r4)
-;;   lgr %r7, %r2
-;;   ag %r7, 0(%r4)
-;;   aghik %r4, %r7, 4096
-;;   lghi %r6, 0
-;;   clgr %r2, %r5
-;;   locgrh %r4, %r6
-;;   strv %r3, 0(%r4)
+;;   llgfr %r6, %r2
+;;   lg %r5, 8(%r4)
+;;   lgr %r2, %r6
+;;   ag %r2, 0(%r4)
+;;   aghi %r2, 4096
+;;   lghi %r4, 0
+;;   clgr %r6, %r5
+;;   locgrh %r2, %r4
+;;   strv %r3, 0(%r2)
 ;;   jg label1
 ;; block1:
 ;;   lmg %r6, %r15, 48(%r15)
@@ -73,16 +72,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r4, %r2
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r3)
-;;   lgr %r2, %r4
+;;   llgfr %r5, %r2
+;;   lg %r4, 8(%r3)
+;;   lgr %r2, %r5
 ;;   ag %r2, 0(%r3)
-;;   aghik %r3, %r2, 4096
-;;   lghi %r2, 0
-;;   clgr %r4, %r5
-;;   locgrh %r3, %r2
-;;   lrv %r2, 0(%r3)
+;;   aghi %r2, 4096
+;;   lghi %r3, 0
+;;   clgr %r5, %r4
+;;   locgrh %r2, %r3
+;;   lrv %r2, 0(%r2)
 ;;   jg label1
 ;; block1:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,7 +41,9 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r9, %r15, 72(%r15)
+;;   stmg %r7, %r15, 56(%r15)
+;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
+;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
 ;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
 ;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
 ;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
@@ -51,41 +53,33 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   llgfr %r4, %r2
-;;   llilf %r9, 4294901764
-;;   algfr %r9, %r2
-;;   jle 6 ; trap
-;;   lgr %r2, %r5
-;;   lg %r5, 8(%r2)
-;;   ag %r4, 0(%r2)
-;;   llilh %r2, 65535
-;;   agr %r4, %r2
-;;   lghi %r2, 0
-;;   clgr %r9, %r5
-;;   locgrh %r4, %r2
-;;   strv %r3, 0(%r4)
+;;   llgfr %r7, %r2
+;;   lg %r5, 8(%r4)
+;;   lgr %r2, %r7
+;;   ag %r2, 0(%r4)
+;;   llilh %r4, 65535
+;;   agr %r2, %r4
+;;   lghi %r4, 0
+;;   clgr %r7, %r5
+;;   locgrh %r2, %r4
+;;   strv %r3, 0(%r2)
 ;;   jg label1
 ;; block1:
-;;   lmg %r9, %r15, 72(%r15)
+;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   llgfr %r3, %r2
-;;   llilf %r5, 4294901764
-;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   llgfr %r4, %r2
+;;   lg %r5, 8(%r3)
 ;;   lgr %r2, %r4
-;;   lg %r4, 8(%r2)
-;;   ag %r3, 0(%r2)
-;;   llilh %r2, 65535
-;;   agr %r3, %r2
+;;   ag %r2, 0(%r3)
+;;   llilh %r3, 65535
+;;   agrk %r3, %r2, %r3
 ;;   lghi %r2, 0
-;;   clgr %r5, %r4
+;;   clgr %r4, %r5
 ;;   locgrh %r3, %r2
 ;;   lrv %r2, 0(%r3)
 ;;   jg label1

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -54,16 +54,15 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r2, %r2
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r4)
-;;   lgr %r7, %r2
-;;   ag %r7, 0(%r4)
-;;   aghik %r4, %r7, 4096
-;;   lghi %r6, 0
-;;   clgr %r2, %r5
-;;   locgrh %r4, %r6
-;;   stc %r3, 0(%r4)
+;;   llgfr %r6, %r2
+;;   lg %r5, 8(%r4)
+;;   lgr %r2, %r6
+;;   ag %r2, 0(%r4)
+;;   aghi %r2, 4096
+;;   lghi %r4, 0
+;;   clgr %r6, %r5
+;;   locgrh %r2, %r4
+;;   stc %r3, 0(%r2)
 ;;   jg label1
 ;; block1:
 ;;   lmg %r6, %r15, 48(%r15)
@@ -73,16 +72,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r4, %r2
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r3)
-;;   lgr %r2, %r4
+;;   llgfr %r5, %r2
+;;   lg %r4, 8(%r3)
+;;   lgr %r2, %r5
 ;;   ag %r2, 0(%r3)
-;;   aghik %r3, %r2, 4096
-;;   lghi %r2, 0
-;;   clgr %r4, %r5
-;;   locgrh %r3, %r2
-;;   llc %r2, 0(%r3)
+;;   aghi %r2, 4096
+;;   lghi %r3, 0
+;;   clgr %r5, %r4
+;;   locgrh %r2, %r3
+;;   llc %r2, 0(%r2)
 ;;   jg label1
 ;; block1:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,7 +41,9 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r9, %r15, 72(%r15)
+;;   stmg %r7, %r15, 56(%r15)
+;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
+;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
 ;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
 ;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
 ;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
@@ -51,41 +53,33 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   llgfr %r4, %r2
-;;   llilf %r9, 4294901761
-;;   algfr %r9, %r2
-;;   jle 6 ; trap
-;;   lgr %r2, %r5
-;;   lg %r5, 8(%r2)
-;;   ag %r4, 0(%r2)
-;;   llilh %r2, 65535
-;;   agr %r4, %r2
-;;   lghi %r2, 0
-;;   clgr %r9, %r5
-;;   locgrh %r4, %r2
-;;   stc %r3, 0(%r4)
+;;   llgfr %r7, %r2
+;;   lg %r5, 8(%r4)
+;;   lgr %r2, %r7
+;;   ag %r2, 0(%r4)
+;;   llilh %r4, 65535
+;;   agr %r2, %r4
+;;   lghi %r4, 0
+;;   clgr %r7, %r5
+;;   locgrh %r2, %r4
+;;   stc %r3, 0(%r2)
 ;;   jg label1
 ;; block1:
-;;   lmg %r9, %r15, 72(%r15)
+;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   llgfr %r3, %r2
-;;   llilf %r5, 4294901761
-;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   llgfr %r4, %r2
+;;   lg %r5, 8(%r3)
 ;;   lgr %r2, %r4
-;;   lg %r4, 8(%r2)
-;;   ag %r3, 0(%r2)
-;;   llilh %r2, 65535
-;;   agr %r3, %r2
+;;   ag %r2, 0(%r3)
+;;   llilh %r3, 65535
+;;   agrk %r3, %r2, %r3
 ;;   lghi %r2, 0
-;;   clgr %r5, %r4
+;;   clgr %r4, %r5
 ;;   locgrh %r3, %r2
 ;;   llc %r2, 0(%r3)
 ;;   jg label1

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -43,13 +43,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lg %r4, 0(%r4)
-;;   strv %r3, 0(%r2,%r4)
+;;   lg %r5, 0(%r4)
+;;   strv %r3, 0(%r2,%r5)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -60,13 +59,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r4, -4
-;;   ag %r4, 8(%r3)
+;;   lg %r4, 8(%r3)
 ;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lg %r3, 0(%r3)
-;;   lrv %r2, 0(%r2,%r3)
+;;   lg %r5, 0(%r3)
+;;   lrv %r2, 0(%r2,%r5)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -43,15 +43,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   lghi %r4, 4096
-;;   strv %r3, 0(%r4,%r5)
+;;   strv %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -62,15 +60,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r3)
-;;   clgr %r2, %r5
+;;   lg %r4, 8(%r3)
+;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   lghi %r2, 4096
-;;   lrv %r2, 0(%r2,%r4)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   lrv %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,25 +41,17 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r14, %r15, 112(%r15)
-;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
-;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r2
-;;   algfi %r5, 4294901764
-;;   jle 6 ; trap
-;;   lg %r14, 8(%r4)
-;;   clgr %r5, %r14
+;;   lg %r5, 8(%r4)
+;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
-;;   strv %r3, 0(%r4,%r5)
+;;   strv %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
-;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
 ;; block3:
 ;;   trap
@@ -68,17 +60,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r2
-;;   algfi %r5, 4294901764
-;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
-;;   clgr %r5, %r4
+;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   llilh %r3, 65535
-;;   lrv %r2, 0(%r3,%r4)
+;;   ag %r2, 0(%r3)
+;;   llilh %r5, 65535
+;;   lrv %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -43,15 +43,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   lghi %r4, 4096
-;;   stc %r3, 0(%r4,%r5)
+;;   stc %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -62,15 +60,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r3)
-;;   clgr %r2, %r5
+;;   lg %r4, 8(%r3)
+;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   lghi %r2, 4096
-;;   llc %r2, 0(%r2,%r4)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   llc %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,25 +41,17 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r14, %r15, 112(%r15)
-;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
-;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r2
-;;   algfi %r5, 4294901761
-;;   jle 6 ; trap
-;;   lg %r14, 8(%r4)
-;;   clgr %r5, %r14
+;;   lg %r5, 8(%r4)
+;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
-;;   stc %r3, 0(%r4,%r5)
+;;   stc %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
-;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
 ;; block3:
 ;;   trap
@@ -68,17 +60,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r2
-;;   algfi %r5, 4294901761
-;;   jle 6 ; trap
 ;;   lg %r4, 8(%r3)
-;;   clgr %r5, %r4
+;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   llilh %r3, 65535
-;;   llc %r2, 0(%r3,%r4)
+;;   ag %r2, 0(%r3)
+;;   llilh %r5, 65535
+;;   llc %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,46 +41,36 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
+;;   stmg %r12, %r15, 96(%r15)
 ;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
 ;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
 ;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   lghi %r4, -4
-;;   lgr %r7, %r5
-;;   ag %r4, 8(%r7)
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r7)
-;;   lghi %r13, 0
-;;   clgr %r2, %r4
-;;   locgrh %r5, %r13
-;;   strv %r3, 0(%r5)
+;;   lg %r5, 8(%r4)
+;;   lgr %r13, %r2
+;;   ag %r13, 0(%r4)
+;;   lghi %r12, 0
+;;   clgr %r2, %r5
+;;   locgrh %r13, %r12
+;;   strv %r3, 0(%r13)
 ;;   jg label1
 ;; block1:
-;;   lmg %r7, %r15, 56(%r15)
+;;   lmg %r12, %r15, 96(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   lghi %r3, -4
-;;   ag %r3, 8(%r4)
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
-;;   lghi %r4, 0
-;;   clgr %r2, %r3
-;;   locgrh %r5, %r4
-;;   lrv %r2, 0(%r5)
+;;   lg %r5, 8(%r3)
+;;   lgr %r4, %r2
+;;   ag %r4, 0(%r3)
+;;   lghi %r3, 0
+;;   clgr %r2, %r5
+;;   locgrh %r4, %r3
+;;   lrv %r2, 0(%r4)
 ;;   jg label1
 ;; block1:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,49 +41,41 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r6, %r15, 48(%r15)
-;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
-;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
+;;   stmg %r13, %r15, 104(%r15)
 ;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
 ;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   lghi %r4, -4100
-;;   ag %r4, 8(%r5)
-;;   lgr %r6, %r2
-;;   ag %r6, 0(%r5)
-;;   aghik %r5, %r6, 4096
-;;   lghi %r14, 0
-;;   clgr %r2, %r4
-;;   locgrh %r5, %r14
+;;   lg %r14, 8(%r4)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   aghi %r5, 4096
+;;   lghi %r13, 0
+;;   clgr %r2, %r14
+;;   locgrh %r5, %r13
 ;;   strv %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
-;;   lmg %r6, %r15, 48(%r15)
+;;   lmg %r13, %r15, 104(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
+;;   stmg %r14, %r15, 112(%r15)
+;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
+;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   lghi %r3, -4100
-;;   lgr %r5, %r4
-;;   ag %r3, 8(%r5)
+;;   lg %r14, 8(%r3)
 ;;   lgr %r4, %r2
-;;   ag %r4, 0(%r5)
-;;   aghi %r4, 4096
-;;   lghi %r5, 0
-;;   clgr %r2, %r3
-;;   locgrh %r4, %r5
-;;   lrv %r2, 0(%r4)
+;;   ag %r4, 0(%r3)
+;;   aghik %r5, %r4, 4096
+;;   lghi %r4, 0
+;;   clgr %r2, %r14
+;;   locgrh %r5, %r4
+;;   lrv %r2, 0(%r5)
 ;;   jg label1
 ;; block1:
+;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,7 +41,8 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
+;;   stmg %r6, %r15, 48(%r15)
+;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
 ;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
 ;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
 ;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
@@ -53,37 +54,45 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r7, %r2
-;;   algfi %r7, 4294901764
-;;   jle 6 ; trap
-;;   lg %r5, 8(%r4)
-;;   ag %r2, 0(%r4)
+;;   lg %r6, 8(%r4)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
 ;;   llilh %r4, 65535
-;;   agrk %r4, %r2, %r4
-;;   lghi %r2, 0
-;;   clgr %r7, %r5
-;;   locgrh %r4, %r2
-;;   strv %r3, 0(%r4)
+;;   agr %r5, %r4
+;;   lghi %r14, 0
+;;   clgr %r2, %r6
+;;   locgrh %r5, %r14
+;;   strv %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
-;;   lmg %r7, %r15, 56(%r15)
+;;   lmg %r6, %r15, 48(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
+;;   stmg %r6, %r15, 48(%r15)
+;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
+;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
+;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
+;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
+;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
+;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
+;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
+;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
+;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
+;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
+;;   lg %r6, 8(%r3)
 ;;   lgr %r4, %r2
-;;   algfi %r4, 4294901764
-;;   jle 6 ; trap
-;;   lg %r5, 8(%r3)
-;;   ag %r2, 0(%r3)
+;;   ag %r4, 0(%r3)
 ;;   llilh %r3, 65535
-;;   agr %r2, %r3
-;;   lghi %r3, 0
-;;   clgr %r4, %r5
-;;   locgrh %r2, %r3
-;;   lrv %r2, 0(%r2)
+;;   agr %r4, %r3
+;;   lghi %r5, 0
+;;   clgr %r2, %r6
+;;   locgrh %r4, %r5
+;;   lrv %r2, 0(%r4)
 ;;   jg label1
 ;; block1:
+;;   lmg %r6, %r15, 48(%r15)
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,49 +41,41 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r6, %r15, 48(%r15)
-;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
-;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
-;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
-;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
-;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
-;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
-;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
+;;   stmg %r13, %r15, 104(%r15)
 ;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
 ;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   lghi %r4, -4097
-;;   ag %r4, 8(%r5)
-;;   lgr %r6, %r2
-;;   ag %r6, 0(%r5)
-;;   aghik %r5, %r6, 4096
-;;   lghi %r14, 0
-;;   clgr %r2, %r4
-;;   locgrh %r5, %r14
+;;   lg %r14, 8(%r4)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   aghi %r5, 4096
+;;   lghi %r13, 0
+;;   clgr %r2, %r14
+;;   locgrh %r5, %r13
 ;;   stc %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
-;;   lmg %r6, %r15, 48(%r15)
+;;   lmg %r13, %r15, 104(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
+;;   stmg %r14, %r15, 112(%r15)
+;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
+;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   lghi %r3, -4097
-;;   lgr %r5, %r4
-;;   ag %r3, 8(%r5)
+;;   lg %r14, 8(%r3)
 ;;   lgr %r4, %r2
-;;   ag %r4, 0(%r5)
-;;   aghi %r4, 4096
-;;   lghi %r5, 0
-;;   clgr %r2, %r3
-;;   locgrh %r4, %r5
-;;   llc %r2, 0(%r4)
+;;   ag %r4, 0(%r3)
+;;   aghik %r5, %r4, 4096
+;;   lghi %r4, 0
+;;   clgr %r2, %r14
+;;   locgrh %r5, %r4
+;;   llc %r2, 0(%r5)
 ;;   jg label1
 ;; block1:
+;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,7 +41,8 @@
 
 ;; function u0:0:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
-;;   stmg %r7, %r15, 56(%r15)
+;;   stmg %r6, %r15, 48(%r15)
+;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
 ;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
 ;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
 ;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
@@ -53,37 +54,45 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r7, %r2
-;;   algfi %r7, 4294901761
-;;   jle 6 ; trap
-;;   lg %r5, 8(%r4)
-;;   ag %r2, 0(%r4)
+;;   lg %r6, 8(%r4)
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
 ;;   llilh %r4, 65535
-;;   agrk %r4, %r2, %r4
-;;   lghi %r2, 0
-;;   clgr %r7, %r5
-;;   locgrh %r4, %r2
-;;   stc %r3, 0(%r4)
+;;   agr %r5, %r4
+;;   lghi %r14, 0
+;;   clgr %r2, %r6
+;;   locgrh %r5, %r14
+;;   stc %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
-;;   lmg %r7, %r15, 56(%r15)
+;;   lmg %r6, %r15, 48(%r15)
 ;;   br %r14
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
+;;   stmg %r6, %r15, 48(%r15)
+;;   unwind SaveReg { clobber_offset: 48, reg: p6i }
+;;   unwind SaveReg { clobber_offset: 56, reg: p7i }
+;;   unwind SaveReg { clobber_offset: 64, reg: p8i }
+;;   unwind SaveReg { clobber_offset: 72, reg: p9i }
+;;   unwind SaveReg { clobber_offset: 80, reg: p10i }
+;;   unwind SaveReg { clobber_offset: 88, reg: p11i }
+;;   unwind SaveReg { clobber_offset: 96, reg: p12i }
+;;   unwind SaveReg { clobber_offset: 104, reg: p13i }
+;;   unwind SaveReg { clobber_offset: 112, reg: p14i }
+;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
+;;   lg %r6, 8(%r3)
 ;;   lgr %r4, %r2
-;;   algfi %r4, 4294901761
-;;   jle 6 ; trap
-;;   lg %r5, 8(%r3)
-;;   ag %r2, 0(%r3)
+;;   ag %r4, 0(%r3)
 ;;   llilh %r3, 65535
-;;   agr %r2, %r3
-;;   lghi %r3, 0
-;;   clgr %r4, %r5
-;;   locgrh %r2, %r3
-;;   llc %r2, 0(%r2)
+;;   agr %r4, %r3
+;;   lghi %r5, 0
+;;   clgr %r2, %r6
+;;   locgrh %r4, %r5
+;;   llc %r2, 0(%r4)
 ;;   jg label1
 ;; block1:
+;;   lmg %r6, %r15, 48(%r15)
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4, %r11
-;;   addq    %r11, 8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rdi
-;;   movl    %esi, 0(%rdi,%r10,1)
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 0(%r11,%r9,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -67,14 +66,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4, %r11
-;;   addq    %r11, 8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %rsi
-;;   movl    0(%rsi,%r10,1), %eax
+;;   movq    0(%rsi), %r11
+;;   movl    0(%r11,%r9,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4100, %r11
-;;   addq    %r11, 8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rdi
-;;   movl    %esi, 4096(%rdi,%r10,1)
+;;   movq    0(%rdx), %r11
+;;   movl    %esi, 4096(%r11,%r9,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -67,14 +66,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4100, %r11
-;;   addq    %r11, 8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %rsi
-;;   movl    4096(%rsi,%r10,1), %eax
+;;   movq    0(%rsi), %r11
+;;   movl    4096(%r11,%r9,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -46,16 +46,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r8d
-;;   movq    %r8, %r11
-;;   addq    %r11, const(0), %r11
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %rdi
-;;   cmpq    %rdi, %r11
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
 ;;   addq    %r8, 0(%rdx), %r8
-;;   movl    $-65536, %eax
-;;   movl    %esi, 0(%r8,%rax,1)
+;;   movl    $-65536, %edi
+;;   movl    %esi, 0(%r8,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -71,16 +68,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r8d
-;;   movq    %r8, %r11
-;;   addq    %r11, const(0), %r11
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rdi
-;;   cmpq    %rdi, %r11
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
 ;;   addq    %r8, 0(%rsi), %r8
-;;   movl    $-65536, %edi
-;;   movl    0(%r8,%rdi,1), %eax
+;;   movl    $-65536, %r11d
+;;   movl    0(%r8,%r11,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4097, %r11
-;;   addq    %r11, 8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rdi
-;;   movb    %sil, 4096(%rdi,%r10,1)
+;;   movq    0(%rdx), %r11
+;;   movb    %sil, 4096(%r11,%r9,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -67,14 +66,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movabsq $-4097, %r11
-;;   addq    %r11, 8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r9d
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r9
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %rsi
-;;   movzbq  4096(%rsi,%r10,1), %rax
+;;   movq    0(%rsi), %r11
+;;   movzbq  4096(%r11,%r9,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -46,16 +46,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r8d
-;;   movq    %r8, %r11
-;;   addq    %r11, const(0), %r11
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %rdi
-;;   cmpq    %rdi, %r11
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
 ;;   addq    %r8, 0(%rdx), %r8
-;;   movl    $-65536, %eax
-;;   movb    %sil, 0(%r8,%rax,1)
+;;   movl    $-65536, %edi
+;;   movb    %sil, 0(%r8,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -71,16 +68,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r8d
-;;   movq    %r8, %r11
-;;   addq    %r11, const(0), %r11
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rdi
-;;   cmpq    %rdi, %r11
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
 ;;   addq    %r8, 0(%rsi), %r8
-;;   movl    $-65536, %edi
-;;   movzbq  0(%r8,%rdi,1), %rax
+;;   movl    $-65536, %r11d
+;;   movzbq  0(%r8,%r11,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -45,15 +45,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %edi
-;;   movabsq $-4, %rax
-;;   addq    %rax, 8(%rdx), %rax
-;;   movq    %rdi, %r11
-;;   addq    %r11, 0(%rdx), %r11
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r11, %r11
-;;   movl    %esi, 0(%r11)
+;;   movl    %edi, %r11d
+;;   movq    8(%rdx), %rdi
+;;   movq    %r11, %r10
+;;   addq    %r10, 0(%rdx), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rdi, %r11
+;;   cmovnbeq %rax, %r10, %r10
+;;   movl    %esi, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,17 +65,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rsi, %rax
-;;   movl    %edi, %esi
-;;   movabsq $-4, %rdi
-;;   movq    %rax, %rcx
-;;   addq    %rdi, 8(%rcx), %rdi
-;;   movq    %rsi, %r11
-;;   addq    %r11, 0(%rcx), %r11
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %rdi, %rsi
-;;   cmovnbeq %rax, %r11, %r11
-;;   movl    0(%r11), %eax
+;;   movl    %edi, %r11d
+;;   movq    8(%rsi), %rdi
+;;   movq    %r11, %r10
+;;   addq    %r10, 0(%rsi), %r10
+;;   xorq    %rsi, %rsi, %rsi
+;;   cmpq    %rdi, %r11
+;;   cmovnbeq %rsi, %r10, %r10
+;;   movl    0(%r10), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,14 +46,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %edi
-;;   movabsq $-4100, %rax
-;;   addq    %rax, 8(%rdx), %rax
+;;   movq    8(%rdx), %rax
 ;;   movq    0(%rdx), %rcx
-;;   lea     4096(%rcx,%rdi,1), %rcx
-;;   xorq    %rdx, %rdx, %rdx
+;;   lea     4096(%rcx,%rdi,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rdx, %rcx, %rcx
-;;   movl    %esi, 0(%rcx)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movl    %esi, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +65,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %edi
-;;   movabsq $-4100, %rax
-;;   addq    %rax, 8(%rsi), %rax
-;;   movq    0(%rsi), %rcx
-;;   lea     4096(%rcx,%rdi,1), %rsi
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rsi, %rsi
-;;   movl    0(%rsi), %eax
+;;   movl    %edi, %ecx
+;;   movq    8(%rsi), %rdi
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rcx,1), %r11
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rdi, %rcx
+;;   cmovnbeq %rax, %r11, %r11
+;;   movl    0(%r11), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,18 +45,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rax
-;;   addq    %rax, const(0), %rax
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %rcx
-;;   addq    %r11, 0(%rdx), %r11
+;;   movl    %edi, %edi
+;;   movq    8(%rdx), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
 ;;   movl    $-65536, %edx
-;;   lea     0(%r11,%rdx,1), %rdx
-;;   xorq    %r8, %r8, %r8
-;;   cmpq    %rcx, %rax
-;;   cmovnbeq %r8, %rdx, %rdx
-;;   movl    %esi, 0(%rdx)
+;;   lea     0(%rcx,%rdx,1), %rcx
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rdx, %rcx, %rcx
+;;   movl    %esi, 0(%rcx)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,18 +67,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rax
-;;   addq    %rax, const(0), %rax
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rcx
-;;   addq    %r11, 0(%rsi), %r11
-;;   movl    $-65536, %edx
-;;   lea     0(%r11,%rdx,1), %rdx
-;;   xorq    %r8, %r8, %r8
-;;   cmpq    %rcx, %rax
-;;   cmovnbeq %r8, %rdx, %rdx
-;;   movl    0(%rdx), %eax
+;;   movl    %edi, %edi
+;;   movq    8(%rsi), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rsi), %rcx
+;;   movl    $-65536, %esi
+;;   lea     0(%rcx,%rsi,1), %rsi
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %rsi, %rsi
+;;   movl    0(%rsi), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -46,14 +46,13 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %edi
-;;   movabsq $-4097, %rax
-;;   addq    %rax, 8(%rdx), %rax
+;;   movq    8(%rdx), %rax
 ;;   movq    0(%rdx), %rcx
-;;   lea     4096(%rcx,%rdi,1), %rcx
-;;   xorq    %rdx, %rdx, %rdx
+;;   lea     4096(%rcx,%rdi,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rdx, %rcx, %rcx
-;;   movb    %sil, 0(%rcx)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movb    %sil, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +65,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %edi
-;;   movabsq $-4097, %rax
-;;   addq    %rax, 8(%rsi), %rax
-;;   movq    0(%rsi), %rcx
-;;   lea     4096(%rcx,%rdi,1), %rsi
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rsi, %rsi
-;;   movzbq  0(%rsi), %rax
+;;   movl    %edi, %ecx
+;;   movq    8(%rsi), %rdi
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rcx,1), %r11
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rdi, %rcx
+;;   cmovnbeq %rax, %r11, %r11
+;;   movzbq  0(%r11), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,18 +45,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rax
-;;   addq    %rax, const(0), %rax
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %rcx
-;;   addq    %r11, 0(%rdx), %r11
+;;   movl    %edi, %edi
+;;   movq    8(%rdx), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
 ;;   movl    $-65536, %edx
-;;   lea     0(%r11,%rdx,1), %rdx
-;;   xorq    %r8, %r8, %r8
-;;   cmpq    %rcx, %rax
-;;   cmovnbeq %r8, %rdx, %rdx
-;;   movb    %sil, 0(%rdx)
+;;   lea     0(%rcx,%rdx,1), %rcx
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rdx, %rcx, %rcx
+;;   movb    %sil, 0(%rcx)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,18 +67,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rax
-;;   addq    %rax, const(0), %rax
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rcx
-;;   addq    %r11, 0(%rsi), %r11
-;;   movl    $-65536, %edx
-;;   lea     0(%r11,%rdx,1), %rdx
-;;   xorq    %r8, %r8, %r8
-;;   cmpq    %rcx, %rax
-;;   cmovnbeq %r8, %rdx, %rdx
-;;   movzbq  0(%rdx), %rax
+;;   movl    %edi, %edi
+;;   movq    8(%rsi), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rsi), %rcx
+;;   movl    $-65536, %esi
+;;   lea     0(%rcx,%rsi,1), %rsi
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %rsi, %rsi
+;;   movzbq  0(%rsi), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -45,13 +45,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r9
-;;   addq    %r9, 8(%rdx), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rdx), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r11
-;;   movl    %esi, 0(%r11,%rdi,1)
+;;   movq    0(%rdx), %r10
+;;   movl    %esi, 0(%r10,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -66,13 +65,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r9
-;;   addq    %r9, 8(%rsi), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rsi), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   movl    0(%r11,%rdi,1), %eax
+;;   movq    0(%rsi), %r10
+;;   movl    0(%r10,%rdi,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,13 +45,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r9
-;;   addq    %r9, 8(%rdx), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rdx), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r11
-;;   movl    %esi, 4096(%r11,%rdi,1)
+;;   movq    0(%rdx), %r10
+;;   movl    %esi, 4096(%r10,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -66,13 +65,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r9
-;;   addq    %r9, 8(%rsi), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rsi), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   movl    4096(%r11,%rdi,1), %eax
+;;   movq    0(%rsi), %r10
+;;   movl    4096(%r10,%rdi,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -45,16 +45,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r10
-;;   addq    %r10, const(0), %r10
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movq    8(%rdx), %r9
+;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   addq    %rdi, 0(%rdx), %rdi
-;;   movl    $-65536, %eax
-;;   movl    %esi, 0(%rdi,%rax,1)
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edi
+;;   movl    %esi, 0(%r11,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -69,16 +67,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r10
-;;   addq    %r10, const(0), %r10
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movq    8(%rsi), %r9
+;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   addq    %rdi, 0(%rsi), %rdi
-;;   movl    $-65536, %esi
-;;   movl    0(%rdi,%rsi,1), %eax
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %r10d
+;;   movl    0(%r11,%r10,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,13 +45,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r9
-;;   addq    %r9, 8(%rdx), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rdx), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r11
-;;   movb    %sil, 4096(%r11,%rdi,1)
+;;   movq    0(%rdx), %r10
+;;   movb    %sil, 4096(%r10,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -66,13 +65,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r9
-;;   addq    %r9, 8(%rsi), %r9
-;;   cmpq    %r9, %rdi
+;;   movq    8(%rsi), %r8
+;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   movzbq  4096(%r11,%rdi,1), %rax
+;;   movq    0(%rsi), %r10
+;;   movzbq  4096(%r10,%rdi,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -45,16 +45,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r10
-;;   addq    %r10, const(0), %r10
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movq    8(%rdx), %r9
+;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   addq    %rdi, 0(%rdx), %rdi
-;;   movl    $-65536, %eax
-;;   movb    %sil, 0(%rdi,%rax,1)
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edi
+;;   movb    %sil, 0(%r11,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -69,16 +67,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r10
-;;   addq    %r10, const(0), %r10
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movq    8(%rsi), %r9
+;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   addq    %rdi, 0(%rsi), %rdi
-;;   movl    $-65536, %esi
-;;   movzbq  0(%rdi,%rsi,1), %rax
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %r10d
+;;   movzbq  0(%r11,%r10,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r11
-;;   addq    %r11, 8(%rdx), %r11
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r10, %r10
-;;   movl    %esi, 0(%r10)
+;;   movq    8(%rdx), %r10
+;;   movq    %rdi, %r9
+;;   addq    %r9, 0(%rdx), %r9
+;;   xorq    %r11, %r11, %r11
+;;   cmpq    %r10, %rdi
+;;   cmovnbeq %r11, %r9, %r9
+;;   movl    %esi, 0(%r9)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -65,14 +64,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r11
-;;   addq    %r11, 8(%rsi), %r11
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rsi), %r10
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r10, %r10
-;;   movl    0(%r10), %eax
+;;   movq    8(%rsi), %r10
+;;   movq    %rdi, %r9
+;;   addq    %r9, 0(%rsi), %r9
+;;   xorq    %r11, %r11, %r11
+;;   cmpq    %r10, %rdi
+;;   cmovnbeq %r11, %r9, %r9
+;;   movl    0(%r9), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %rax
-;;   addq    %rax, 8(%rdx), %rax
-;;   movq    0(%rdx), %rcx
-;;   lea     4096(%rcx,%rdi,1), %r11
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r11, %r11
-;;   movl    %esi, 0(%r11)
+;;   movq    8(%rdx), %r11
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %r11, %rdi
+;;   cmovnbeq %rax, %r10, %r10
+;;   movl    %esi, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -65,14 +64,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %rcx
-;;   addq    %rcx, 8(%rsi), %rcx
+;;   movq    8(%rsi), %r11
 ;;   movq    0(%rsi), %rsi
-;;   lea     4096(%rsi,%rdi,1), %r11
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %rcx, %rdi
-;;   cmovnbeq %rax, %r11, %r11
-;;   movl    0(%r11), %eax
+;;   lea     4096(%rsi,%rdi,1), %r10
+;;   xorq    %rsi, %rsi, %rsi
+;;   cmpq    %r11, %rdi
+;;   cmovnbeq %rsi, %r10, %r10
+;;   movl    0(%r10), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,18 +45,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, const(0), %r8
-;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   movq    %rdi, %rcx
 ;;   addq    %rcx, 0(%rdx), %rcx
-;;   movl    $-65536, %edi
-;;   lea     0(%rcx,%rdi,1), %rcx
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %r8
-;;   cmovnbeq %rdi, %rcx, %rcx
-;;   movl    %esi, 0(%rcx)
+;;   movl    $-65536, %r11d
+;;   lea     0(%rcx,%r11,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movl    %esi, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,18 +66,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, 0(%rsi), %rcx
-;;   movl    $-65536, %edi
-;;   lea     0(%rcx,%rdi,1), %rcx
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %rdx
-;;   cmovnbeq %rdi, %rcx, %rcx
-;;   movl    0(%rcx), %eax
+;;   movq    8(%rsi), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, 0(%rsi), %rax
+;;   movl    $-65536, %r11d
+;;   lea     0(%rax,%r11,1), %r11
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rcx, %rdi
+;;   cmovnbeq %rax, %r11, %r11
+;;   movl    0(%r11), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -45,14 +45,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %rax
-;;   addq    %rax, 8(%rdx), %rax
-;;   movq    0(%rdx), %rcx
-;;   lea     4096(%rcx,%rdi,1), %r11
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r11, %r11
-;;   movb    %sil, 0(%r11)
+;;   movq    8(%rdx), %r11
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %r11, %rdi
+;;   cmovnbeq %rax, %r10, %r10
+;;   movb    %sil, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -65,14 +64,13 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %rcx
-;;   addq    %rcx, 8(%rsi), %rcx
+;;   movq    8(%rsi), %r11
 ;;   movq    0(%rsi), %rsi
-;;   lea     4096(%rsi,%rdi,1), %r11
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %rcx, %rdi
-;;   cmovnbeq %rax, %r11, %r11
-;;   movzbq  0(%r11), %rax
+;;   lea     4096(%rsi,%rdi,1), %r10
+;;   xorq    %rsi, %rsi, %rsi
+;;   cmpq    %r11, %rdi
+;;   cmovnbeq %rsi, %r10, %r10
+;;   movzbq  0(%r10), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,18 +45,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, const(0), %r8
-;;   jnb ; ud2 heap_oob ;
 ;;   movq    8(%rdx), %rax
 ;;   movq    %rdi, %rcx
 ;;   addq    %rcx, 0(%rdx), %rcx
-;;   movl    $-65536, %edi
-;;   lea     0(%rcx,%rdi,1), %rcx
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %r8
-;;   cmovnbeq %rdi, %rcx, %rcx
-;;   movb    %sil, 0(%rcx)
+;;   movl    $-65536, %r11d
+;;   lea     0(%rcx,%r11,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movb    %sil, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,18 +66,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   jnb ; ud2 heap_oob ;
-;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, 0(%rsi), %rcx
-;;   movl    $-65536, %edi
-;;   lea     0(%rcx,%rdi,1), %rcx
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %rdx
-;;   cmovnbeq %rdi, %rcx, %rcx
-;;   movzbq  0(%rcx), %rax
+;;   movq    8(%rsi), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, 0(%rsi), %rax
+;;   movl    $-65536, %r11d
+;;   lea     0(%rax,%r11,1), %r11
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rcx, %rdi
+;;   cmovnbeq %rax, %r11, %r11
+;;   movzbq  0(%r11), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/wasm/duplicate-loads-dynamic-memory-egraph.wat
+++ b/cranelift/filetests/filetests/wasm/duplicate-loads-dynamic-memory-egraph.wat
@@ -49,21 +49,19 @@
 ;;     gv2 = load.i64 notrap aligned gv0
 ;;
 ;;                                 block0(v0: i32, v1: i64):
+;; @0057                               v5 = load.i64 notrap aligned v1+8
+;; @0057                               v6 = load.i64 notrap aligned v1
 ;; @0057                               v4 = uextend.i64 v0
-;; @0057                               v5 = iconst.i64 4
-;; @0057                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 4
-;; @0057                               v7 = load.i64 notrap aligned v1+8
-;; @0057                               v8 = load.i64 notrap aligned v1
-;; @0057                               v11 = icmp ugt v6, v7
-;; @0057                               v10 = iconst.i64 0
-;; @0057                               v9 = iadd v8, v4
-;; @0057                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;; @0057                               v13 = load.i32 little heap v12
-;;                                     v2 -> v13
+;; @0057                               v9 = icmp ugt v4, v5
+;; @0057                               v8 = iconst.i64 0
+;; @0057                               v7 = iadd v6, v4
+;; @0057                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0057                               v11 = load.i32 little heap v10
+;;                                     v2 -> v11
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v13, v13
+;; @005f                               return v11, v11
 ;; }
 ;;
 ;; function u0:1(i32, i64 vmctx) -> i32, i32 fast {
@@ -72,21 +70,19 @@
 ;;     gv2 = load.i64 notrap aligned gv0
 ;;
 ;;                                 block0(v0: i32, v1: i64):
+;; @0064                               v5 = load.i64 notrap aligned v1+8
+;; @0064                               v6 = load.i64 notrap aligned v1
 ;; @0064                               v4 = uextend.i64 v0
-;; @0064                               v5 = iconst.i64 1238
-;; @0064                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 1238
-;; @0064                               v7 = load.i64 notrap aligned v1+8
-;; @0064                               v8 = load.i64 notrap aligned v1
-;; @0064                               v12 = icmp ugt v6, v7
-;; @0064                               v11 = iconst.i64 0
-;; @0064                               v9 = iadd v8, v4
-;;                                     v26 = iconst.i64 1234
-;; @0064                               v10 = iadd v9, v26  ; v26 = 1234
-;; @0064                               v13 = select_spectre_guard v12, v11, v10  ; v11 = 0
-;; @0064                               v14 = load.i32 little heap v13
-;;                                     v2 -> v14
+;; @0064                               v10 = icmp ugt v4, v5
+;; @0064                               v9 = iconst.i64 0
+;; @0064                               v7 = iadd v6, v4
+;;                                     v22 = iconst.i64 1234
+;; @0064                               v8 = iadd v7, v22  ; v22 = 1234
+;; @0064                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
+;; @0064                               v12 = load.i32 little heap v11
+;;                                     v2 -> v12
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v14, v14
+;; @006e                               return v12, v12
 ;; }

--- a/cranelift/filetests/filetests/wasm/duplicate-loads-dynamic-memory.wat
+++ b/cranelift/filetests/filetests/wasm/duplicate-loads-dynamic-memory.wat
@@ -50,31 +50,27 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0057                               v4 = uextend.i64 v0
-;;                                     v14 -> v4
-;; @0057                               v5 = iconst.i64 4
-;;                                     v15 -> v5
-;; @0057                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 4
-;;                                     v16 -> v6
-;; @0057                               v7 = load.i64 notrap aligned v1+8
-;;                                     v17 -> v7
-;; @0057                               v8 = load.i64 notrap aligned v1
-;;                                     v18 -> v8
-;; @0057                               v9 = iadd v8, v4
-;;                                     v19 -> v9
-;; @0057                               v10 = iconst.i64 0
-;;                                     v20 -> v10
-;; @0057                               v11 = icmp ugt v6, v7
-;;                                     v21 -> v11
-;; @0057                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;;                                     v22 -> v12
-;; @0057                               v13 = load.i32 little heap v12
-;;                                     v2 -> v13
-;;                                     v23 -> v13
-;;                                     v3 -> v23
+;;                                     v12 -> v4
+;; @0057                               v5 = load.i64 notrap aligned v1+8
+;;                                     v13 -> v5
+;; @0057                               v6 = load.i64 notrap aligned v1
+;;                                     v14 -> v6
+;; @0057                               v7 = iadd v6, v4
+;;                                     v15 -> v7
+;; @0057                               v8 = iconst.i64 0
+;;                                     v16 -> v8
+;; @0057                               v9 = icmp ugt v4, v5
+;;                                     v17 -> v9
+;; @0057                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;;                                     v18 -> v10
+;; @0057                               v11 = load.i32 little heap v10
+;;                                     v2 -> v11
+;;                                     v19 -> v11
+;;                                     v3 -> v19
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
-;; @005f                               return v13, v13
+;; @005f                               return v11, v11
 ;; }
 ;;
 ;; function u0:1(i32, i64 vmctx) -> i32, i32 fast {
@@ -84,33 +80,29 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0064                               v4 = uextend.i64 v0
-;;                                     v15 -> v4
-;; @0064                               v5 = iconst.i64 1238
-;;                                     v16 -> v5
-;; @0064                               v6 = uadd_overflow_trap v4, v5, heap_oob  ; v5 = 1238
-;;                                     v17 -> v6
-;; @0064                               v7 = load.i64 notrap aligned v1+8
-;;                                     v18 -> v7
-;; @0064                               v8 = load.i64 notrap aligned v1
-;;                                     v19 -> v8
-;; @0064                               v9 = iadd v8, v4
-;;                                     v20 -> v9
-;;                                     v26 = iconst.i64 1234
-;;                                     v27 -> v26
-;; @0064                               v10 = iadd v9, v26  ; v26 = 1234
-;;                                     v21 -> v10
-;; @0064                               v11 = iconst.i64 0
-;;                                     v22 -> v11
-;; @0064                               v12 = icmp ugt v6, v7
-;;                                     v23 -> v12
-;; @0064                               v13 = select_spectre_guard v12, v11, v10  ; v11 = 0
-;;                                     v24 -> v13
-;; @0064                               v14 = load.i32 little heap v13
-;;                                     v2 -> v14
-;;                                     v25 -> v14
-;;                                     v3 -> v25
+;;                                     v13 -> v4
+;; @0064                               v5 = load.i64 notrap aligned v1+8
+;;                                     v14 -> v5
+;; @0064                               v6 = load.i64 notrap aligned v1
+;;                                     v15 -> v6
+;; @0064                               v7 = iadd v6, v4
+;;                                     v16 -> v7
+;;                                     v22 = iconst.i64 1234
+;;                                     v23 -> v22
+;; @0064                               v8 = iadd v7, v22  ; v22 = 1234
+;;                                     v17 -> v8
+;; @0064                               v9 = iconst.i64 0
+;;                                     v18 -> v9
+;; @0064                               v10 = icmp ugt v4, v5
+;;                                     v19 -> v10
+;; @0064                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
+;;                                     v20 -> v11
+;; @0064                               v12 = load.i32 little heap v11
+;;                                     v2 -> v12
+;;                                     v21 -> v12
+;;                                     v3 -> v21
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:
-;; @006e                               return v14, v14
+;; @006e                               return v12, v12
 ;; }

--- a/cranelift/filetests/filetests/wasm/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/cranelift/filetests/filetests/wasm/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -1,0 +1,154 @@
+;;! target = "x86_64"
+;;!
+;;! optimize = true
+;;!
+;;! settings = [
+;;!   "enable_heap_access_spectre_mitigation=false",
+;;!   "opt_level=speed_and_size",
+;;!   "use_egraphs=true"
+;;! ]
+;;!
+;;! [globals.vmctx]
+;;! type = "i64"
+;;! vmctx = true
+;;!
+;;! [globals.heap_base]
+;;! type = "i64"
+;;! load = { base = "vmctx", offset = 0 }
+;;!
+;;! [globals.heap_bound]
+;;! type = "i64"
+;;! load = { base = "vmctx", offset = 8 }
+;;!
+;;! [[heaps]]
+;;! base = "heap_base"
+;;! min_size = 0
+;;! offset_guard_size = 0x0000ffff
+;;! index_type = "i32"
+;;! style = { kind = "dynamic", bound = "heap_bound" }
+
+(module
+  (memory (export "memory") 0)
+
+  (func (export "loads") (param i32) (result i32 i32 i32)
+    ;; Within the guard region.
+    local.get 0
+    i32.load offset=0
+    ;; Also within the guard region, bounds check should GVN with previous.
+    local.get 0
+    i32.load offset=4
+    ;; Outside the guard region, needs additional bounds checks.
+    local.get 0
+    i32.load offset=0x000fffff
+  )
+
+  ;; Same as above, but for stores.
+  (func (export "stores") (param i32 i32 i32 i32)
+    local.get 0
+    local.get 1
+    i32.store offset=0
+    local.get 0
+    local.get 2
+    i32.store offset=4
+    local.get 0
+    local.get 3
+    i32.store offset=0x000fffff
+  )
+)
+
+;; function u0:0(i32, i64 vmctx) -> i32, i32, i32 fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned gv0+8
+;;     gv2 = load.i64 notrap aligned gv0
+;;
+;;                                 block0(v0: i32, v1: i64):
+;; @0047                               v6 = load.i64 notrap aligned v1+8
+;; @0047                               v5 = uextend.i64 v0
+;; @0047                               v7 = icmp ugt v5, v6
+;; @0047                               brif v7, block2, block3
+;;
+;;                                 block2 cold:
+;; @0047                               trap heap_oob
+;;
+;;                                 block3:
+;; @0047                               v8 = load.i64 notrap aligned v1
+;; @0047                               v9 = iadd v8, v5
+;; @0047                               v10 = load.i32 little heap v9
+;;                                     v2 -> v10
+;; @004c                               brif.i8 v7, block4, block5
+;;
+;;                                 block4 cold:
+;; @004c                               trap heap_oob
+;;
+;;                                 block5:
+;;                                     v27 = iconst.i64 4
+;; @004c                               v16 = iadd.i64 v9, v27  ; v27 = 4
+;; @004c                               v17 = load.i32 little heap v16
+;;                                     v3 -> v17
+;; @0051                               v19 = iconst.i64 0x0010_0003
+;; @0051                               v20 = uadd_overflow_trap.i64 v5, v19, heap_oob  ; v19 = 0x0010_0003
+;; @0051                               v22 = icmp ugt v20, v6
+;; @0051                               brif v22, block6, block7
+;;
+;;                                 block6 cold:
+;; @0051                               trap heap_oob
+;;
+;;                                 block7:
+;; @0051                               v23 = load.i64 notrap aligned v1
+;; @0051                               v24 = iadd v23, v5
+;;                                     v28 = iconst.i64 0x000f_ffff
+;; @0051                               v25 = iadd v24, v28  ; v28 = 0x000f_ffff
+;; @0051                               v26 = load.i32 little heap v25
+;;                                     v4 -> v26
+;; @0056                               jump block1
+;;
+;;                                 block1:
+;; @0056                               return v10, v17, v26
+;; }
+;;
+;; function u0:1(i32, i32, i32, i32, i64 vmctx) fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned gv0+8
+;;     gv2 = load.i64 notrap aligned gv0
+;;
+;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i64):
+;; @005d                               v6 = load.i64 notrap aligned v4+8
+;; @005d                               v5 = uextend.i64 v0
+;; @005d                               v7 = icmp ugt v5, v6
+;; @005d                               brif v7, block2, block3
+;;
+;;                                 block2 cold:
+;; @005d                               trap heap_oob
+;;
+;;                                 block3:
+;; @005d                               v8 = load.i64 notrap aligned v4
+;; @005d                               v9 = iadd v8, v5
+;; @005d                               store.i32 little heap v1, v9
+;; @0064                               brif.i8 v7, block4, block5
+;;
+;;                                 block4 cold:
+;; @0064                               trap heap_oob
+;;
+;;                                 block5:
+;;                                     v24 = iconst.i64 4
+;; @0064                               v15 = iadd.i64 v9, v24  ; v24 = 4
+;; @0064                               store.i32 little heap v2, v15
+;; @006b                               v17 = iconst.i64 0x0010_0003
+;; @006b                               v18 = uadd_overflow_trap.i64 v5, v17, heap_oob  ; v17 = 0x0010_0003
+;; @006b                               v20 = icmp ugt v18, v6
+;; @006b                               brif v20, block6, block7
+;;
+;;                                 block6 cold:
+;; @006b                               trap heap_oob
+;;
+;;                                 block7:
+;; @006b                               v21 = load.i64 notrap aligned v4
+;; @006b                               v22 = iadd v21, v5
+;;                                     v25 = iconst.i64 0x000f_ffff
+;; @006b                               v23 = iadd v22, v25  ; v25 = 0x000f_ffff
+;; @006b                               store.i32 little heap v3, v23
+;; @0070                               jump block1
+;;
+;;                                 block1:
+;; @0070                               return
+;; }

--- a/cranelift/filetests/filetests/wasm/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/cranelift/filetests/filetests/wasm/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -1,0 +1,122 @@
+;;! target = "x86_64"
+;;!
+;;! optimize = true
+;;!
+;;! settings = [
+;;!   "enable_heap_access_spectre_mitigation=true",
+;;!   "opt_level=speed_and_size",
+;;!   "use_egraphs=true"
+;;! ]
+;;!
+;;! [globals.vmctx]
+;;! type = "i64"
+;;! vmctx = true
+;;!
+;;! [globals.heap_base]
+;;! type = "i64"
+;;! load = { base = "vmctx", offset = 0 }
+;;!
+;;! [globals.heap_bound]
+;;! type = "i64"
+;;! load = { base = "vmctx", offset = 8 }
+;;!
+;;! [[heaps]]
+;;! base = "heap_base"
+;;! min_size = 0
+;;! offset_guard_size = 0x0000ffff
+;;! index_type = "i32"
+;;! style = { kind = "dynamic", bound = "heap_bound" }
+
+(module
+  (memory (export "memory") 0)
+
+  (func (export "loads") (param i32) (result i32 i32 i32)
+    ;; Within the guard region.
+    local.get 0
+    i32.load offset=0
+    ;; Also within the guard region, bounds check should GVN with previous.
+    local.get 0
+    i32.load offset=4
+    ;; Outside the guard region, needs additional bounds checks.
+    local.get 0
+    i32.load offset=0x000fffff
+  )
+
+  ;; Same as above, but for stores.
+  (func (export "stores") (param i32 i32 i32 i32)
+    local.get 0
+    local.get 1
+    i32.store offset=0
+    local.get 0
+    local.get 2
+    i32.store offset=4
+    local.get 0
+    local.get 3
+    i32.store offset=0x000fffff
+  )
+)
+
+;; function u0:0(i32, i64 vmctx) -> i32, i32, i32 fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned gv0+8
+;;     gv2 = load.i64 notrap aligned gv0
+;;
+;;                                 block0(v0: i32, v1: i64):
+;; @0047                               v6 = load.i64 notrap aligned v1+8
+;; @0047                               v7 = load.i64 notrap aligned v1
+;; @0047                               v5 = uextend.i64 v0
+;; @0047                               v10 = icmp ugt v5, v6
+;; @0047                               v9 = iconst.i64 0
+;; @0047                               v8 = iadd v7, v5
+;; @0047                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
+;; @0047                               v12 = load.i32 little heap v11
+;;                                     v2 -> v12
+;;                                     v33 = iconst.i64 4
+;; @004c                               v17 = iadd v8, v33  ; v33 = 4
+;; @004c                               v20 = select_spectre_guard v10, v9, v17  ; v9 = 0
+;; @004c                               v21 = load.i32 little heap v20
+;;                                     v3 -> v21
+;; @0051                               v23 = iconst.i64 0x0010_0003
+;; @0051                               v24 = uadd_overflow_trap v5, v23, heap_oob  ; v23 = 0x0010_0003
+;; @0051                               v30 = icmp ugt v24, v6
+;;                                     v34 = iconst.i64 0x000f_ffff
+;; @0051                               v28 = iadd v8, v34  ; v34 = 0x000f_ffff
+;; @0051                               v31 = select_spectre_guard v30, v9, v28  ; v9 = 0
+;; @0051                               v32 = load.i32 little heap v31
+;;                                     v4 -> v32
+;; @0056                               jump block1
+;;
+;;                                 block1:
+;; @0056                               return v12, v21, v32
+;; }
+;;
+;; function u0:1(i32, i32, i32, i32, i64 vmctx) fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned gv0+8
+;;     gv2 = load.i64 notrap aligned gv0
+;;
+;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i64):
+;; @005d                               v6 = load.i64 notrap aligned v4+8
+;; @005d                               v7 = load.i64 notrap aligned v4
+;; @005d                               v5 = uextend.i64 v0
+;; @005d                               v10 = icmp ugt v5, v6
+;; @005d                               v9 = iconst.i64 0
+;; @005d                               v8 = iadd v7, v5
+;; @005d                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
+;; @005d                               store little heap v1, v11
+;;                                     v30 = iconst.i64 4
+;; @0064                               v16 = iadd v8, v30  ; v30 = 4
+;; @0064                               v19 = select_spectre_guard v10, v9, v16  ; v9 = 0
+;; @0064                               store little heap v2, v19
+;; @006b                               v21 = iconst.i64 0x0010_0003
+;; @006b                               v22 = uadd_overflow_trap v5, v21, heap_oob  ; v21 = 0x0010_0003
+;; @006b                               v28 = icmp ugt v22, v6
+;;                                     v31 = iconst.i64 0x000f_ffff
+;; @006b                               v26 = iadd v8, v31  ; v31 = 0x000f_ffff
+;; @006b                               v29 = select_spectre_guard v28, v9, v26  ; v9 = 0
+;; @006b                               store little heap v3, v29
+;; @0070                               jump block1
+;;
+;;                                 block1:
+;; @0070                               return
+;; }

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -47,12 +47,11 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               store little heap v1, v8
+;; @0040                               v5 = icmp ugt v3, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv2
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               store little heap v1, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -67,13 +66,12 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
 ;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd_imm v4, -4
-;; @0048                               v6 = icmp ugt v3, v5
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv2
-;; @0048                               v8 = iadd v7, v3
-;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v5 = icmp ugt v3, v4
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv2
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = load.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4100
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iadd_imm v8, 4096
-;; @0040                               store little heap v1, v9
+;; @0040                               v5 = icmp ugt v3, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv2
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iadd_imm v7, 4096
+;; @0040                               store little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -68,14 +67,13 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4100
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iadd_imm v8, 4096
-;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv2
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iadd_imm v7, 4096
+;; @0049                               v9 = load.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -46,15 +46,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = iconst.i64 0xffff_0004
-;; @0040                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = global_value.i64 gv1
-;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv2
-;; @0040                               v9 = iadd v8, v3
-;; @0040                               v10 = iadd_imm v9, 0xffff_0000
-;; @0040                               store little heap v1, v10
+;; @0040                               v4 = global_value.i64 gv1
+;; @0040                               v5 = icmp ugt v3, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv2
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iadd_imm v7, 0xffff_0000
+;; @0040                               store little heap v1, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -68,16 +66,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @004c                               v3 = uextend.i64 v0
-;; @004c                               v4 = iconst.i64 0xffff_0004
-;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = global_value.i64 gv1
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv2
-;; @004c                               v9 = iadd v8, v3
-;; @004c                               v10 = iadd_imm v9, 0xffff_0000
-;; @004c                               v11 = load.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = global_value.i64 gv1
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv2
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iadd_imm v7, 0xffff_0000
+;; @004c                               v9 = load.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4097
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iadd_imm v8, 4096
-;; @0040                               istore8 little heap v1, v9
+;; @0040                               v5 = icmp ugt v3, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv2
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iadd_imm v7, 4096
+;; @0040                               istore8 little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -68,14 +67,13 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4097
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iadd_imm v8, 4096
-;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v5 = icmp ugt v3, v4
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv2
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iadd_imm v7, 4096
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -46,15 +46,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = iconst.i64 0xffff_0001
-;; @0040                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = global_value.i64 gv1
-;; @0040                               v7 = icmp ugt v5, v6
-;; @0040                               trapnz v7, heap_oob
-;; @0040                               v8 = global_value.i64 gv2
-;; @0040                               v9 = iadd v8, v3
-;; @0040                               v10 = iadd_imm v9, 0xffff_0000
-;; @0040                               istore8 little heap v1, v10
+;; @0040                               v4 = global_value.i64 gv1
+;; @0040                               v5 = icmp ugt v3, v4
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv2
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iadd_imm v7, 0xffff_0000
+;; @0040                               istore8 little heap v1, v8
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -68,16 +66,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @004c                               v3 = uextend.i64 v0
-;; @004c                               v4 = iconst.i64 0xffff_0001
-;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = global_value.i64 gv1
-;; @004c                               v7 = icmp ugt v5, v6
-;; @004c                               trapnz v7, heap_oob
-;; @004c                               v8 = global_value.i64 gv2
-;; @004c                               v9 = iadd v8, v3
-;; @004c                               v10 = iadd_imm v9, 0xffff_0000
-;; @004c                               v11 = uload8.i32 little heap v10
-;; @0053                               jump block1(v11)
+;; @004c                               v4 = global_value.i64 gv1
+;; @004c                               v5 = icmp ugt v3, v4
+;; @004c                               trapnz v5, heap_oob
+;; @004c                               v6 = global_value.i64 gv2
+;; @004c                               v7 = iadd v6, v3
+;; @004c                               v8 = iadd_imm v7, 0xffff_0000
+;; @004c                               v9 = uload8.i32 little heap v8
+;; @0053                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -47,13 +47,12 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v3
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = icmp ugt v3, v5
-;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0040                               store little heap v1, v10
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v3
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = icmp ugt v3, v4
+;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0040                               store little heap v1, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -68,14 +67,13 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
 ;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd_imm v4, -4
-;; @0048                               v6 = global_value.i64 gv2
-;; @0048                               v7 = iadd v6, v3
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = icmp ugt v3, v5
-;; @0048                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v5 = global_value.i64 gv2
+;; @0048                               v6 = iadd v5, v3
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = icmp ugt v3, v4
+;; @0048                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -47,14 +47,13 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4100
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v3
-;; @0040                               v8 = iadd_imm v7, 4096
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = icmp ugt v3, v5
-;; @0040                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0040                               store little heap v1, v11
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v3
+;; @0040                               v7 = iadd_imm v6, 4096
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = icmp ugt v3, v4
+;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0040                               store little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -69,15 +68,14 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4100
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v3
-;; @0049                               v8 = iadd_imm v7, 4096
-;; @0049                               v9 = iconst.i64 0
-;; @0049                               v10 = icmp ugt v3, v5
-;; @0049                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v5 = global_value.i64 gv2
+;; @0049                               v6 = iadd v5, v3
+;; @0049                               v7 = iadd_imm v6, 4096
+;; @0049                               v8 = iconst.i64 0
+;; @0049                               v9 = icmp ugt v3, v4
+;; @0049                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -46,16 +46,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = iconst.i64 0xffff_0004
-;; @0040                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
-;; @0040                               v6 = global_value.i64 gv1
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iadd_imm v8, 0xffff_0000
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = icmp ugt v5, v6
-;; @0040                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;; @0040                               store little heap v1, v12
+;; @0040                               v4 = global_value.i64 gv1
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v3
+;; @0040                               v7 = iadd_imm v6, 0xffff_0000
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = icmp ugt v3, v4
+;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0040                               store little heap v1, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -69,17 +67,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @004c                               v3 = uextend.i64 v0
-;; @004c                               v4 = iconst.i64 0xffff_0004
-;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0004
-;; @004c                               v6 = global_value.i64 gv1
-;; @004c                               v7 = global_value.i64 gv2
-;; @004c                               v8 = iadd v7, v3
-;; @004c                               v9 = iadd_imm v8, 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = icmp ugt v5, v6
-;; @004c                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;; @004c                               v13 = load.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = global_value.i64 gv1
+;; @004c                               v5 = global_value.i64 gv2
+;; @004c                               v6 = iadd v5, v3
+;; @004c                               v7 = iadd_imm v6, 0xffff_0000
+;; @004c                               v8 = iconst.i64 0
+;; @004c                               v9 = icmp ugt v3, v4
+;; @004c                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @004c                               v11 = load.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -47,14 +47,13 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4097
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v3
-;; @0040                               v8 = iadd_imm v7, 4096
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = icmp ugt v3, v5
-;; @0040                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0040                               istore8 little heap v1, v11
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v3
+;; @0040                               v7 = iadd_imm v6, 4096
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = icmp ugt v3, v4
+;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -69,15 +68,14 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4097
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v3
-;; @0049                               v8 = iadd_imm v7, 4096
-;; @0049                               v9 = iconst.i64 0
-;; @0049                               v10 = icmp ugt v3, v5
-;; @0049                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v5 = global_value.i64 gv2
+;; @0049                               v6 = iadd v5, v3
+;; @0049                               v7 = iadd_imm v6, 4096
+;; @0049                               v8 = iconst.i64 0
+;; @0049                               v9 = icmp ugt v3, v4
+;; @0049                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -46,16 +46,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = iconst.i64 0xffff_0001
-;; @0040                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
-;; @0040                               v6 = global_value.i64 gv1
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iadd_imm v8, 0xffff_0000
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = icmp ugt v5, v6
-;; @0040                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v1, v12
+;; @0040                               v4 = global_value.i64 gv1
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v3
+;; @0040                               v7 = iadd_imm v6, 0xffff_0000
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = icmp ugt v3, v4
+;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v1, v10
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -69,17 +67,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @004c                               v3 = uextend.i64 v0
-;; @004c                               v4 = iconst.i64 0xffff_0001
-;; @004c                               v5 = uadd_overflow_trap v3, v4, heap_oob  ; v4 = 0xffff_0001
-;; @004c                               v6 = global_value.i64 gv1
-;; @004c                               v7 = global_value.i64 gv2
-;; @004c                               v8 = iadd v7, v3
-;; @004c                               v9 = iadd_imm v8, 0xffff_0000
-;; @004c                               v10 = iconst.i64 0
-;; @004c                               v11 = icmp ugt v5, v6
-;; @004c                               v12 = select_spectre_guard v11, v10, v9  ; v10 = 0
-;; @004c                               v13 = uload8.i32 little heap v12
-;; @0053                               jump block1(v13)
+;; @004c                               v4 = global_value.i64 gv1
+;; @004c                               v5 = global_value.i64 gv2
+;; @004c                               v6 = iadd v5, v3
+;; @004c                               v7 = iadd_imm v6, 0xffff_0000
+;; @004c                               v8 = iconst.i64 0
+;; @004c                               v9 = icmp ugt v3, v4
+;; @004c                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
+;; @004c                               v11 = uload8.i32 little heap v10
+;; @0053                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -46,12 +46,11 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               store little heap v1, v7
+;; @0040                               v4 = icmp ugt v0, v3
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               store little heap v1, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -65,13 +64,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0048                               v3 = global_value.i64 gv1
-;; @0048                               v4 = iadd_imm v3, -4
-;; @0048                               v5 = icmp ugt v0, v4
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv2
-;; @0048                               v7 = iadd v6, v0
-;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v4 = icmp ugt v0, v3
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = global_value.i64 gv2
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = load.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,13 +46,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4100
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iadd_imm v7, 4096
-;; @0040                               store little heap v1, v8
+;; @0040                               v4 = icmp ugt v0, v3
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iadd_imm v6, 4096
+;; @0040                               store little heap v1, v7
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -66,14 +65,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4100
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iadd_imm v7, 4096
-;; @0049                               v9 = load.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @0049                               v4 = icmp ugt v0, v3
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv2
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iadd_imm v6, 4096
+;; @0049                               v8 = load.i32 little heap v7
+;; @004d                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -45,15 +45,13 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = iconst.i64 0xffff_0004
-;; @0040                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0004
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v0
-;; @0040                               v9 = iadd_imm v8, 0xffff_0000
-;; @0040                               store little heap v1, v9
+;; @0040                               v3 = global_value.i64 gv1
+;; @0040                               v4 = icmp ugt v0, v3
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iadd_imm v6, 0xffff_0000
+;; @0040                               store little heap v1, v7
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -66,16 +64,14 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = iconst.i64 0xffff_0004
-;; @004c                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0004
-;; @004c                               v5 = global_value.i64 gv1
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv2
-;; @004c                               v8 = iadd v7, v0
-;; @004c                               v9 = iadd_imm v8, 0xffff_0000
-;; @004c                               v10 = load.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @004c                               v3 = global_value.i64 gv1
+;; @004c                               v4 = icmp ugt v0, v3
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = global_value.i64 gv2
+;; @004c                               v6 = iadd v5, v0
+;; @004c                               v7 = iadd_imm v6, 0xffff_0000
+;; @004c                               v8 = load.i32 little heap v7
+;; @0053                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,13 +46,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4097
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iadd_imm v7, 4096
-;; @0040                               istore8 little heap v1, v8
+;; @0040                               v4 = icmp ugt v0, v3
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iadd_imm v6, 4096
+;; @0040                               istore8 little heap v1, v7
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -66,14 +65,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4097
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iadd_imm v7, 4096
-;; @0049                               v9 = uload8.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @0049                               v4 = icmp ugt v0, v3
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv2
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iadd_imm v6, 4096
+;; @0049                               v8 = uload8.i32 little heap v7
+;; @004d                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -45,15 +45,13 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = iconst.i64 0xffff_0001
-;; @0040                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0001
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = icmp ugt v4, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v0
-;; @0040                               v9 = iadd_imm v8, 0xffff_0000
-;; @0040                               istore8 little heap v1, v9
+;; @0040                               v3 = global_value.i64 gv1
+;; @0040                               v4 = icmp ugt v0, v3
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv2
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iadd_imm v6, 0xffff_0000
+;; @0040                               istore8 little heap v1, v7
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -66,16 +64,14 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = iconst.i64 0xffff_0001
-;; @004c                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0001
-;; @004c                               v5 = global_value.i64 gv1
-;; @004c                               v6 = icmp ugt v4, v5
-;; @004c                               trapnz v6, heap_oob
-;; @004c                               v7 = global_value.i64 gv2
-;; @004c                               v8 = iadd v7, v0
-;; @004c                               v9 = iadd_imm v8, 0xffff_0000
-;; @004c                               v10 = uload8.i32 little heap v9
-;; @0053                               jump block1(v10)
+;; @004c                               v3 = global_value.i64 gv1
+;; @004c                               v4 = icmp ugt v0, v3
+;; @004c                               trapnz v4, heap_oob
+;; @004c                               v5 = global_value.i64 gv2
+;; @004c                               v6 = iadd v5, v0
+;; @004c                               v7 = iadd_imm v6, 0xffff_0000
+;; @004c                               v8 = uload8.i32 little heap v7
+;; @0053                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -46,13 +46,12 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4
-;; @0040                               v5 = global_value.i64 gv2
-;; @0040                               v6 = iadd v5, v0
-;; @0040                               v7 = iconst.i64 0
-;; @0040                               v8 = icmp ugt v0, v4
-;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
-;; @0040                               store little heap v1, v9
+;; @0040                               v4 = global_value.i64 gv2
+;; @0040                               v5 = iadd v4, v0
+;; @0040                               v6 = iconst.i64 0
+;; @0040                               v7 = icmp ugt v0, v3
+;; @0040                               v8 = select_spectre_guard v7, v6, v5  ; v6 = 0
+;; @0040                               store little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -66,14 +65,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0048                               v3 = global_value.i64 gv1
-;; @0048                               v4 = iadd_imm v3, -4
-;; @0048                               v5 = global_value.i64 gv2
-;; @0048                               v6 = iadd v5, v0
-;; @0048                               v7 = iconst.i64 0
-;; @0048                               v8 = icmp ugt v0, v4
-;; @0048                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
-;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = global_value.i64 gv2
+;; @0048                               v5 = iadd v4, v0
+;; @0048                               v6 = iconst.i64 0
+;; @0048                               v7 = icmp ugt v0, v3
+;; @0048                               v8 = select_spectre_guard v7, v6, v5  ; v6 = 0
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,14 +46,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4100
-;; @0040                               v5 = global_value.i64 gv2
-;; @0040                               v6 = iadd v5, v0
-;; @0040                               v7 = iadd_imm v6, 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = icmp ugt v0, v4
-;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0040                               store little heap v1, v10
+;; @0040                               v4 = global_value.i64 gv2
+;; @0040                               v5 = iadd v4, v0
+;; @0040                               v6 = iadd_imm v5, 4096
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = icmp ugt v0, v3
+;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0040                               store little heap v1, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -67,15 +66,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4100
-;; @0049                               v5 = global_value.i64 gv2
-;; @0049                               v6 = iadd v5, v0
-;; @0049                               v7 = iadd_imm v6, 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = icmp ugt v0, v4
-;; @0049                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = global_value.i64 gv2
+;; @0049                               v5 = iadd v4, v0
+;; @0049                               v6 = iadd_imm v5, 4096
+;; @0049                               v7 = iconst.i64 0
+;; @0049                               v8 = icmp ugt v0, v3
+;; @0049                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0049                               v10 = load.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,16 +45,14 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = iconst.i64 0xffff_0004
-;; @0040                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0004
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iadd_imm v7, 0xffff_0000
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = icmp ugt v4, v5
-;; @0040                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0040                               store little heap v1, v11
+;; @0040                               v3 = global_value.i64 gv1
+;; @0040                               v4 = global_value.i64 gv2
+;; @0040                               v5 = iadd v4, v0
+;; @0040                               v6 = iadd_imm v5, 0xffff_0000
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = icmp ugt v0, v3
+;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0040                               store little heap v1, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -67,17 +65,15 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = iconst.i64 0xffff_0004
-;; @004c                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0004
-;; @004c                               v5 = global_value.i64 gv1
-;; @004c                               v6 = global_value.i64 gv2
-;; @004c                               v7 = iadd v6, v0
-;; @004c                               v8 = iadd_imm v7, 0xffff_0000
-;; @004c                               v9 = iconst.i64 0
-;; @004c                               v10 = icmp ugt v4, v5
-;; @004c                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @004c                               v12 = load.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v3 = global_value.i64 gv1
+;; @004c                               v4 = global_value.i64 gv2
+;; @004c                               v5 = iadd v4, v0
+;; @004c                               v6 = iadd_imm v5, 0xffff_0000
+;; @004c                               v7 = iconst.i64 0
+;; @004c                               v8 = icmp ugt v0, v3
+;; @004c                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @004c                               v10 = load.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -46,14 +46,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4097
-;; @0040                               v5 = global_value.i64 gv2
-;; @0040                               v6 = iadd v5, v0
-;; @0040                               v7 = iadd_imm v6, 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = icmp ugt v0, v4
-;; @0040                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0040                               istore8 little heap v1, v10
+;; @0040                               v4 = global_value.i64 gv2
+;; @0040                               v5 = iadd v4, v0
+;; @0040                               v6 = iadd_imm v5, 4096
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = icmp ugt v0, v3
+;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0040                               istore8 little heap v1, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -67,15 +66,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4097
-;; @0049                               v5 = global_value.i64 gv2
-;; @0049                               v6 = iadd v5, v0
-;; @0049                               v7 = iadd_imm v6, 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = icmp ugt v0, v4
-;; @0049                               v10 = select_spectre_guard v9, v8, v7  ; v8 = 0
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = global_value.i64 gv2
+;; @0049                               v5 = iadd v4, v0
+;; @0049                               v6 = iadd_imm v5, 4096
+;; @0049                               v7 = iconst.i64 0
+;; @0049                               v8 = icmp ugt v0, v3
+;; @0049                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0049                               v10 = uload8.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,16 +45,14 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = iconst.i64 0xffff_0001
-;; @0040                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0001
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iadd_imm v7, 0xffff_0000
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = icmp ugt v4, v5
-;; @0040                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @0040                               istore8 little heap v1, v11
+;; @0040                               v3 = global_value.i64 gv1
+;; @0040                               v4 = global_value.i64 gv2
+;; @0040                               v5 = iadd v4, v0
+;; @0040                               v6 = iadd_imm v5, 0xffff_0000
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = icmp ugt v0, v3
+;; @0040                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @0040                               istore8 little heap v1, v9
 ;; @0047                               jump block1
 ;;
 ;;                                 block1:
@@ -67,17 +65,15 @@
 ;;     gv2 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @004c                               v3 = iconst.i64 0xffff_0001
-;; @004c                               v4 = uadd_overflow_trap v0, v3, heap_oob  ; v3 = 0xffff_0001
-;; @004c                               v5 = global_value.i64 gv1
-;; @004c                               v6 = global_value.i64 gv2
-;; @004c                               v7 = iadd v6, v0
-;; @004c                               v8 = iadd_imm v7, 0xffff_0000
-;; @004c                               v9 = iconst.i64 0
-;; @004c                               v10 = icmp ugt v4, v5
-;; @004c                               v11 = select_spectre_guard v10, v9, v8  ; v9 = 0
-;; @004c                               v12 = uload8.i32 little heap v11
-;; @0053                               jump block1(v12)
+;; @004c                               v3 = global_value.i64 gv1
+;; @004c                               v4 = global_value.i64 gv2
+;; @004c                               v5 = iadd v4, v0
+;; @004c                               v6 = iadd_imm v5, 0xffff_0000
+;; @004c                               v7 = iconst.i64 0
+;; @004c                               v8 = icmp ugt v0, v3
+;; @004c                               v9 = select_spectre_guard v8, v7, v6  ; v7 = 0
+;; @004c                               v10 = uload8.i32 little heap v9
+;; @0053                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @0053                               return v2

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -815,7 +815,7 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
             // the process to continue, because we never perform a
             // mmap that would leave an open space for someone
             // else to come in and map something.
-            slot.instantiate(initial_size as usize, image, &plan.style)?;
+            slot.instantiate(initial_size as usize, image, &plan)?;
 
             memories.push(Memory::new_static(plan, memory, slot, unsafe {
                 &mut *req.store.get().unwrap()

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -241,7 +241,7 @@ impl MmapMemory {
                     minimum,
                     alloc_bytes + extra_to_reserve_on_growth,
                 );
-                slot.instantiate(minimum, Some(image), &plan.style)?;
+                slot.instantiate(minimum, Some(image), &plan)?;
                 // On drop, we will unmap our mmap'd range that this slot was
                 // mapped on top of, so there is no need for the slot to wipe
                 // it with an anonymous mapping first.


### PR DESCRIPTION
This is a new special case for when we know that there are enough guard pages to cover the memory access's offset and access size.

The precise should-we-trap condition is

    index + offset + access_size > bound

However, if we instead check only the partial condition

    index > bound

then the most out of bounds that the access can be, while that partial check still succeeds, is `offset + access_size`.

However, when we have a guard region that is at least as large as `offset + access_size`, we can rely on the virtual memory subsystem handling these out-of-bounds errors at runtime. Therefore, the partial `index > bound` check is sufficient for this heap configuration.

Additionally, this has the advantage that a series of Wasm loads that use the same dynamic index operand but different static offset immediates -- which is a common code pattern when accessing multiple fields in the same struct that is in linear memory -- will all emit the same `index > bound` check, which we can GVN.

Partially.

The bounds check comparison is GVN'd but we still branch on values we should know will always be true if we get this far in the code. This is actual `br_if`s in the non-Spectre code and `select_spectre_guard`s that we should know will always go a certain way if we have Spectre mitigations enabled. See the second commit for examples.

Improving the non-Spectre case is pretty straightforward: walk the dominator tree and remember which values we've already branched on at this point, and therefore we can simplify any further conditional branches on those same values into direct jumps.

Improving the Spectre case requires something that is morally the same, but has a couple snags:

* We don't have actual `br_if`s to determine whether the bounds checking condition succeeded or not. We need to instead reason about dominating `select_spectre_guard; {load, store}` instruction pairs.

* We have to be SUPER careful about reasoning "through" `select_spectre_guard`s.  Our general rule is never to do that, since it could break the speculative execution sandboxing that the instruction is designed for.

This pull request leaves implementing these new optimization passes for follow ups.