### PR TITLE
cranelift: simplify `ineg(ineg(x))` to `x`

### DIFF
--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -32,6 +32,9 @@
                       x))
       (ineg ty x))
 
+;; ineg(ineg(x)) == x.
+(rule (simplify (ineg ty (ineg ty x))) (subsume x))
+
 ;; x*1 == 1*x == x.
 (rule (simplify (imul ty
                       x

--- a/cranelift/filetests/filetests/egraph/algebraic.clif
+++ b/cranelift/filetests/filetests/egraph/algebraic.clif
@@ -224,6 +224,14 @@ block0(v0: i8):
     ; check: return v5
 }
 
+function %double_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = ineg v1
+    return v2
+    ; check: return v0
+}
+
 function %or_and_y_with_not_y_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):
     v2 = band v0, v1


### PR DESCRIPTION
`algrebraic.isle` rewrites `0-x` to `isub x`, but misses an opportunity to further simplify
