### PR TITLE
Make sequence numbers local to instructions

### DIFF
--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -106,7 +106,7 @@ impl DominatorTree {
         let a = a.into();
         let b = b.into();
         self.rpo_cmp_block(layout.pp_block(a), layout.pp_block(b))
-            .then(layout.pp_cmp(a, b))
+            .then_with(|| layout.pp_cmp(a, b))
     }
 
     /// Returns `true` if `a` dominates `b`.
@@ -578,7 +578,7 @@ impl DominatorTreePreorder {
         let a = a.into();
         let b = b.into();
         self.pre_cmp_block(layout.pp_block(a), layout.pp_block(b))
-            .then(layout.pp_cmp(a, b))
+            .then_with(|| layout.pp_cmp(a, b))
     }
 }
 

--- a/cranelift/codegen/src/incremental_cache.rs
+++ b/cranelift/codegen/src/incremental_cache.rs
@@ -164,7 +164,15 @@ impl<'a> CacheKey<'a> {
         // Make sure the blocks and instructions are sequenced the same way as we might
         // have serialized them earlier. This is the symmetric of what's done in
         // `try_load`.
-        f.stencil.layout.full_renumber();
+        let mut block = f.stencil.layout.entry_block().expect("Missing entry block");
+        loop {
+            f.stencil.layout.full_block_renumber(block);
+            if let Some(next_block) = f.stencil.layout.next_block(block) {
+                block = next_block;
+            } else {
+                break;
+            }
+        }
         CacheKey {
             stencil: &f.stencil,
             parameters: CompileParameters::from_isa(isa),

--- a/cranelift/codegen/src/ir/layout.rs
+++ b/cranelift/codegen/src/ir/layout.rs
@@ -115,7 +115,7 @@ fn test_midpoint() {
 }
 
 impl Layout {
-    /// Compare the program points `a` and `b` relative to this program order.
+    /// Compare the program points `a` and `b` in the same block relative to this program order.
     ///
     /// Return `Less` if `a` appears in the program before `b`.
     ///
@@ -127,6 +127,9 @@ impl Layout {
         A: Into<ProgramPoint>,
         B: Into<ProgramPoint>,
     {
+        let a = a.into();
+        let b = b.into();
+        debug_assert_eq!(self.pp_block(a), self.pp_block(b));
         let a_seq = self.seq(a);
         let b_seq = self.seq(b);
         a_seq.cmp(&b_seq)
@@ -136,9 +139,9 @@ impl Layout {
 // Private methods for dealing with sequence numbers.
 impl Layout {
     /// Get the sequence number of a program point that must correspond to an entity in the layout.
-    fn seq<PP: Into<ProgramPoint>>(&self, pp: PP) -> SequenceNumber {
-        // When `PP = Inst` or `PP = Block`, we expect this dynamic type check to be optimized out.
-        match pp.into() {
+    #[inline]
+    fn seq(&self, pp: ProgramPoint) -> SequenceNumber {
+        match pp {
             ProgramPoint::Block(block) => self.blocks[block].seq,
             ProgramPoint::Inst(inst) => self.insts[inst].seq,
         }


### PR DESCRIPTION
This allows renumbering to be localized to a single block where previously it could affect the entire function. Also saves 32bit of overhead per block.

I originally set out to remove sequence numbers entirely to save 32bit of overhead for every instruction, but the dominator tree code uses sequence numbers to find the relative order of instructions within a block.

Builds on top of https://github.com/bytecodealliance/wasmtime/pull/6042. I split both of them to simplify bisection and help with reviewing.