### PR TITLE
craneleft: cancel `ineg` when args to `imul`

### DIFF
--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -35,6 +35,14 @@
 ;; ineg(ineg(x)) == x.
 (rule (simplify (ineg ty (ineg ty x))) (subsume x))
 
+;; ineg(x) * ineg(y) == x*y.
+(rule (simplify (imul ty (ineg ty x) (ineg ty y)))
+      (subsume (imul ty x y)))
+
+;; iabs(x) * iabs(y) == x*y.
+(rule (simplify (imul ty (iabs ty x) (iabs ty y)))
+      (subsume (imul ty x y)))
+
 ;; x-x == 0.
 (rule (simplify (isub (fits_in_64 (ty_int ty)) x x)) (subsume (iconst ty (imm64 0))))
 

--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -39,10 +39,6 @@
 (rule (simplify (imul ty (ineg ty x) (ineg ty y)))
       (subsume (imul ty x y)))
 
-;; iabs(x) * iabs(y) == x*y.
-(rule (simplify (imul ty (iabs ty x) (iabs ty y)))
-      (subsume (imul ty x y)))
-
 ;; x-x == 0.
 (rule (simplify (isub (fits_in_64 (ty_int ty)) x x)) (subsume (iconst ty (imm64 0))))
 

--- a/cranelift/filetests/filetests/egraph/algebraic.clif
+++ b/cranelift/filetests/filetests/egraph/algebraic.clif
@@ -232,6 +232,26 @@ block0(v0: i32):
     ; check: return v0
 }
 
+function %imul_ineg_cancel(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = ineg v0
+    v3 = ineg v1
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v1
+    ; check: return v5
+}
+
+function %imul_iabs_cancel(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iabs v0
+    v3 = iabs v1
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v1
+    ; check: return v5
+}
+
 function %isub_self(i32) -> i32 {
 block0(v0: i32):
     v1 = isub v0, v0

--- a/cranelift/filetests/filetests/egraph/algebraic.clif
+++ b/cranelift/filetests/filetests/egraph/algebraic.clif
@@ -242,16 +242,6 @@ block0(v0: i32, v1: i32):
     ; check: return v5
 }
 
-function %imul_iabs_cancel(i32, i32) -> i32 {
-block0(v0: i32, v1: i32):
-    v2 = iabs v0
-    v3 = iabs v1
-    v4 = imul v2, v3
-    return v4
-    ; check: v5 = imul v0, v1
-    ; check: return v5
-}
-
 function %isub_self(i32) -> i32 {
 block0(v0: i32):
     v1 = isub v0, v0


### PR DESCRIPTION
```
;; ineg(x) * ineg(y) == x*y.
```