### PR TITLE
Remove reference to `store` in `Linker::instantiate_pre` docs

### DIFF
--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -1125,13 +1125,6 @@ impl<T> Linker<T> {
     /// Returns an error which may be downcast to an [`UnknownImportError`] if
     /// the module has any unresolvable imports.
     ///
-    /// # Panics
-    ///
-    /// This method will panic if any item defined in this linker used by
-    /// `module` is not owned by `store`. Additionally this will panic if the
-    /// [`Engine`] that the `store` belongs to is different than this
-    /// [`Linker`].
-    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
The `store` param was removed in #5683

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
