### PR TITLE
Ensure the sequence number doesn't leak out of Layout

### DIFF
--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -103,7 +103,7 @@ impl<'a> Arbitrary<'a> for FunctionWithIsa {
 fuzz_target!(|func: FunctionWithIsa| {
     let FunctionWithIsa { mut func, isa } = func;
 
-    let cache_key_hash = icache::compute_cache_key(&*isa, &mut func);
+    let cache_key_hash = icache::compute_cache_key(&*isa, &func);
 
     let mut context = Context::for_function(func.clone());
     let prev_stencil = match context.compile_stencil(&*isa) {
@@ -187,7 +187,7 @@ fuzz_target!(|func: FunctionWithIsa| {
         false
     };
 
-    let new_cache_key_hash = icache::compute_cache_key(&*isa, &mut func);
+    let new_cache_key_hash = icache::compute_cache_key(&*isa, &func);
 
     if expect_cache_hit {
         assert!(cache_key_hash == new_cache_key_hash);


### PR DESCRIPTION
Previously it could affect the PartialEq and Hash impls. Ignoring the sequence number in PartialEq and Hash allows us to not renumber all blocks in the incremental cache.

Follow up to https://github.com/bytecodealliance/wasmtime/pull/6043