### PR TITLE
x64: Run more filetests with AVX support

### DIFF
--- a/cranelift/filetests/filetests/runtests/bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 
 function %bitcast_if32(i32) -> f32 {

--- a/cranelift/filetests/filetests/runtests/ceil.clif
+++ b/cranelift/filetests/filetests/runtests/ceil.clif
@@ -2,6 +2,8 @@ test interpret
 test run
 target x86_64
 target x86_64 has_sse41=false
+set enable_simd
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/conversion.clif
+++ b/cranelift/filetests/filetests/runtests/conversion.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 target riscv64
 
 function %fcvt_to_sint(f32) -> i32 {

--- a/cranelift/filetests/filetests/runtests/fabs.clif
+++ b/cranelift/filetests/filetests/runtests/fabs.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fadd.clif
+++ b/cranelift/filetests/filetests/runtests/fadd.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-eq.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ge.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-gt.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-le.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-lt.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ne.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-one.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ord.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uge.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ule.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ult.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uno.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fcopysign.clif
+++ b/cranelift/filetests/filetests/runtests/fcopysign.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fdemote.clif
+++ b/cranelift/filetests/filetests/runtests/fdemote.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target aarch64
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/fdiv.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/float-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitops.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 
 function %bnot_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/floor.clif
+++ b/cranelift/filetests/filetests/runtests/floor.clif
@@ -2,6 +2,8 @@ test interpret
 test run
 target x86_64
 target x86_64 has_sse41=false
+set enable_simd
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target riscv64
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug

--- a/cranelift/filetests/filetests/runtests/fmax.clif
+++ b/cranelift/filetests/filetests/runtests/fmax.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fmin-max-pseudo-vector.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-max-pseudo-vector.clif
@@ -2,6 +2,7 @@ test run
 set enable_simd
 target aarch64
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug
+target x86_64
 target x86_64 skylake
 
 function %fmin_pseudo_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target riscv64
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug

--- a/cranelift/filetests/filetests/runtests/fmin.clif
+++ b/cranelift/filetests/filetests/runtests/fmin.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fmul.clif
+++ b/cranelift/filetests/filetests/runtests/fmul.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fneg.clif
+++ b/cranelift/filetests/filetests/runtests/fneg.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/fpromote.clif
+++ b/cranelift/filetests/filetests/runtests/fpromote.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target s390x
 target aarch64
 target riscv64

--- a/cranelift/filetests/filetests/runtests/fsub.clif
+++ b/cranelift/filetests/filetests/runtests/fsub.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/nearest.clif
+++ b/cranelift/filetests/filetests/runtests/nearest.clif
@@ -2,6 +2,8 @@ test interpret
 test run
 target x86_64
 target x86_64 has_sse41=false
+set enable_simd
+target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/simd-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 
 function %bitcast_if32x4(i32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 set opt_level=speed_and_size
 set enable_simd
+target x86_64
 target x86_64 skylake
 
 function %mask_from_icmp(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -3,6 +3,7 @@ set enable_simd
 target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %bitselect_i32x4(i32x4, i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4, v2: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-conversion.clif
+++ b/cranelift/filetests/filetests/runtests/simd-conversion.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %fcvt_from_sint(i32x4) -> f32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 
 function %fcmp_eq_f32x4() -> i8 {

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-x86_64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-x86_64.clif
@@ -3,6 +3,7 @@
 ; simd-arithmetic-nondeterministic*.clif as well.
 test run
 set enable_simd
+target x86_64
 target x86_64 skylake
 
 function %fmax_f64x2(f64x2, f64x2) -> f64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %iabs_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_simd
 target x86_64
+target x86_64 has_avx
 target aarch64
 target s390x
 

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %simd_icmp_uge_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %simd_icmp_ugt_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %simd_icmp_ule_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %simd_icmp_ult_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-ishl.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ishl.clif
@@ -2,6 +2,7 @@ test run
 set enable_simd
 target aarch64
 target s390x
+target x86_64
 target x86_64 skylake
 
 

--- a/cranelift/filetests/filetests/runtests/simd-logical.clif
+++ b/cranelift/filetests/filetests/runtests/simd-logical.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %bnot() -> i32 {
 block0:

--- a/cranelift/filetests/filetests/runtests/simd-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/simd-min-max.clif
@@ -1,7 +1,9 @@
 test run
 test interpret
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 
 function %smin_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %saddsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %scalartovector_i32(i32) -> i32x4 {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %sqmulrs_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -2,6 +2,7 @@ test run
 set enable_simd
 target aarch64
 target s390x
+target x86_64
 target x86_64 skylake
 
 

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %ssubsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %swidenhigh_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %swidenlow_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %swizzle_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %uaddsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %usubsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %uwidenhigh_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %uwidenlow_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %vall_true_i8x16(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
@@ -1,8 +1,10 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 has_avx
 
 function %vany_true_i8x16(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vconst.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst.clif
@@ -3,6 +3,7 @@ target s390x
 target aarch64
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 
 function %vconst_zeroes() -> i8 {

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %vhighbits_i8x16(i8x16) -> i16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
+++ b/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 
 function %wpdps(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64
 
 

--- a/cranelift/filetests/filetests/runtests/sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/sqrt.clif
@@ -1,7 +1,9 @@
 test interpret
 test run
+set enable_simd
 target aarch64
 target x86_64
+target x86_64 has_avx
 target s390x
 target riscv64
 

--- a/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
+++ b/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
@@ -1,6 +1,8 @@
 test run
 set enable_llvm_abi_extensions
+set enable_simd
 target x86_64
+target x86_64 has_avx
 
 ; Regression test for unaligned loads to xmm registers when relying on automatic
 ; conversion to XmmMem arguments in ISLE.


### PR DESCRIPTION
This commit goes through the `runtests` folder of the `filetests` test suite and ensure that everything which uses simd or float-related instructions on x64 is executed with the baseline support for x86_64 in addition to adding in AVX support. Most of the instructions used have AVX equivalents so this should help test all of the equivalents in addition to the codegen filetests in the x64 folder.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
