### PR TITLE
Fix naming of the source tarball

### DIFF
--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -4,8 +4,8 @@ set -ex
 
 # Determine the name of the tarball
 tag=dev
-if [[ $GITHUB_REF == refs/tags/v* ]]; then
-  tag=${GITHUB_REF#refs/tags/}
+if [[ $GITHUB_REF == refs/heads/release-* ]]; then
+  tag=v${GITHUB_REF:19}
 fi
 pkgname=wasmtime-$tag-src
 


### PR DESCRIPTION
This refactoring from #5766 accidentally broke the tag name calculation for the `build-src-tarball.sh` script so this fixes it by copying over the same logic from `build-tarballs.sh`.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
