### PR TITLE
Speed up index fetches on CI

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -44,6 +44,12 @@ runs:
         EOF
         fi
 
+        # Use a more efficient method for fetching the crates.io-index than
+        # the (currently) default git-based index.
+        cat >> "$GITHUB_ENV" <<EOF
+        CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+        EOF
+
     - name: Choose registry cache key
       shell: bash
       # Update the registry index cache at most once per day. actions/cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2023-03-30
+        toolchain: nightly-2023-03-20
     - run: cargo install cargo-fuzz --vers "^0.11"
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,7 +184,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2022-12-15
+        toolchain: nightly-2023-03-20
 
     # Build C API documentation
     - run: curl -L https://sourceforge.net/projects/doxygen/files/rel-1.9.3/doxygen-1.9.3.linux.bin.tar.gz/download | tar xzf -
@@ -336,7 +336,7 @@ jobs:
     # flags to rustc.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2022-12-15
+        toolchain: nightly-2023-03-30
     - run: cargo install cargo-fuzz --vers "^0.11"
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.


### PR DESCRIPTION
Use the `sparse` protocol from Rust 1.68.0 which should shave a minute or two off most steps on CI.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
