### PR TITLE
Restrict the types for isplit and iconcat to match backends

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3592,10 +3592,7 @@ pub(crate) fn define(
     let WideInt = &TypeVar::new(
         "WideInt",
         "An integer type with lanes from `i16` upwards",
-        TypeSetBuilder::new()
-            .ints(16..128)
-            .simd_lanes(Interval::All)
-            .build(),
+        TypeSetBuilder::new().ints(128..128).build(),
     );
 
     ig.push(
@@ -3617,6 +3614,12 @@ pub(crate) fn define(
             Operand::new("lo", &WideInt.half_width()).with_doc("The low bits of `x`"),
             Operand::new("hi", &WideInt.half_width()).with_doc("The high bits of `x`"),
         ]),
+    );
+
+    let NarrowInt = &TypeVar::new(
+        "NarrowInt",
+        "An integer type with lanes type to `i64`",
+        TypeSetBuilder::new().ints(64..64).build(),
     );
 
     ig.push(

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -3591,8 +3591,8 @@ pub(crate) fn define(
 
     let WideInt = &TypeVar::new(
         "WideInt",
-        "An integer type with lanes from `i16` upwards",
-        TypeSetBuilder::new().ints(128..128).build(),
+        "An integer type of width `i16` upwards",
+        TypeSetBuilder::new().ints(16..128).build(),
     );
 
     ig.push(
@@ -3618,8 +3618,8 @@ pub(crate) fn define(
 
     let NarrowInt = &TypeVar::new(
         "NarrowInt",
-        "An integer type with lanes type to `i64`",
-        TypeSetBuilder::new().ints(64..64).build(),
+        "An integer type of width up to `i64`",
+        TypeSetBuilder::new().ints(8..64).build(),
     );
 
     ig.push(

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -647,12 +647,8 @@ pub(crate) fn define(
 
     let NarrowInt = &TypeVar::new(
         "NarrowInt",
-        "An integer type with lanes type to `i64`",
-        TypeSetBuilder::new()
-            .ints(8..64)
-            .simd_lanes(Interval::All)
-            .dynamic_simd_lanes(Interval::All)
-            .build(),
+        "An integer type of width up to `i64`",
+        TypeSetBuilder::new().ints(8..64).build(),
     );
 
     let ScalarTruthy = &TypeVar::new(
@@ -3614,12 +3610,6 @@ pub(crate) fn define(
             Operand::new("lo", &WideInt.half_width()).with_doc("The low bits of `x`"),
             Operand::new("hi", &WideInt.half_width()).with_doc("The high bits of `x`"),
         ]),
-    );
-
-    let NarrowInt = &TypeVar::new(
-        "NarrowInt",
-        "An integer type of width up to `i64`",
-        TypeSetBuilder::new().ints(8..64).build(),
     );
 
     ig.push(

--- a/cranelift/filetests/filetests/parser/rewrite.clif
+++ b/cranelift/filetests/filetests/parser/rewrite.clif
@@ -5,13 +5,13 @@ test cat
 ; Defining numbers.
 function %defs() {
 block100(v20: i32):
-    v1000 = iconst.i32x8 5
+    v1000 = iconst.i32 5
     v9200 = f64const 0x4.0p0
     trap user4
 }
 ; sameln: function %defs() fast {
 ; nextln: block100(v20: i32):
-; nextln:     v1000 = iconst.i32x8 5
+; nextln:     v1000 = iconst.i32 5
 ; nextln:     v9200 = f64const 0x1.0000000000000p2
 ; nextln:     trap user4
 ; nextln: }

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -65,15 +65,13 @@ block0(v95: i32, v96: i32, v97: i8):
 ; nextln: }
 
 ; Lane indexes.
-function %lanes() {
-block0:
-    v0 = iconst.i32x4 2
+function %lanes(i32x4) {
+block0(v0: i32x4):
     v1 = extractlane v0, 3
     v2 = insertlane v0, v1, 1
 }
-; sameln: function %lanes() fast {
-; nextln: block0:
-; nextln:     v0 = iconst.i32x4 2
+; sameln: function %lanes(i32x4) fast {
+; nextln: block0(v0: i32x4):
 ; nextln:     v1 = extractlane v0, 3
 ; nextln:     v2 = insertlane v0, v1, 1
 ; nextln: }


### PR DESCRIPTION
All backends currently assume that `isplit` and `iconcat` only work for splitting `i128` values, or concatenating two `i64` values to make an `i128` value. The type constraints for both indicate that they can work over vectors as well as other bit-width integers. This PR resolves part of this discrepancy by removing vector support from both `isplit` and `iconcat`.
<!-- 

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
