### PR TITLE
Add a WASI test for a creating an absolute-path symlink.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
@@ -62,6 +62,11 @@ unsafe fn create_symlink_to_directory(dir_fd: wasi::Fd) {
         .expect("remove_directory on a directory should succeed");
 }
 
+unsafe fn create_symlink_to_root(dir_fd: wasi::Fd) {
+    // Create a symlink.
+    wasi::path_symlink("/", dir_fd, "symlink").expect_err("creating a symlink to an absolute path");
+}
+
 fn main() {
     let mut args = env::args();
     let prog = args.next().unwrap();
@@ -85,5 +90,6 @@ fn main() {
     unsafe {
         create_symlink_to_file(dir_fd);
         create_symlink_to_directory(dir_fd);
+        create_symlink_to_root(dir_fd);
     }
 }


### PR DESCRIPTION
Wasmtime disallows guests from using `path_symlink` to create absolute-path symlinks, as they could confuse other code into accessing resources on the host that the guest otherwise doesn't have access to.

This patch adds a test for this behavior.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
