### PR TITLE
cranelift: rewrite `iabs(ineg(x))` and `iabs(iabs(x))`

### DIFF
--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -41,7 +41,7 @@
 
 ;; iabs(ineg(x)) == iabs(x).
 (rule (simplify (iabs ty (ineg ty x)))
-      (subsume (iabs ty x)))
+      (iabs ty x))
 
 ;; iabs(iabs(x)) == iabs(x).
 (rule (simplify (iabs ty inner @ (iabs ty x)))

--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -39,6 +39,14 @@
 (rule (simplify (imul ty (ineg ty x) (ineg ty y)))
       (subsume (imul ty x y)))
 
+;; iabs(ineg(x)) == iabs(x).
+(rule (simplify (iabs ty (ineg ty x)))
+      (subsume (iabs ty x)))
+
+;; iabs(iabs(x)) == x.
+(rule (simplify (iabs ty inner @ (iabs ty x)))
+      (subsume inner))
+
 ;; x-x == 0.
 (rule (simplify (isub (fits_in_64 (ty_int ty)) x x)) (subsume (iconst ty (imm64 0))))
 

--- a/cranelift/codegen/src/opts/algebraic.isle
+++ b/cranelift/codegen/src/opts/algebraic.isle
@@ -43,7 +43,7 @@
 (rule (simplify (iabs ty (ineg ty x)))
       (subsume (iabs ty x)))
 
-;; iabs(iabs(x)) == x.
+;; iabs(iabs(x)) == iabs(x).
 (rule (simplify (iabs ty inner @ (iabs ty x)))
       (subsume inner))
 

--- a/cranelift/filetests/filetests/egraph/algebraic.clif
+++ b/cranelift/filetests/filetests/egraph/algebraic.clif
@@ -242,6 +242,23 @@ block0(v0: i32, v1: i32):
     ; check: return v5
 }
 
+function %iabs_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = iabs v1
+    return v2
+    ; check: v3 = iabs v0
+    ; check: return v3
+}
+
+function %iabs_iabs(i32) -> i32 {
+block0(v0: i32):
+    v1 = iabs v0
+    v2 = iabs v1
+    return v2
+    ; check: return v1
+}
+
 function %isub_self(i32) -> i32 {
 block0(v0: i32):
     v1 = isub v0, v0


### PR DESCRIPTION
```
;; iabs(ineg(x)) == iabs(x).
;; iabs(iabs(x)) == x.
```