### PR TITLE
s390x: Improved TrapIf implementation

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7027,22 +7027,22 @@ fn test_s390x_binemit() {
         "br %r14",
     ));
 
-    insns.push((Inst::Debugtrap, "0001", "debugtrap"));
+    insns.push((Inst::Debugtrap, "0001", ".word 0x0001 # debugtrap"));
 
     insns.push((
         Inst::Trap {
             trap_code: TrapCode::StackOverflow,
         },
         "0000",
-        "trap",
+        ".word 0x0000 # trap=stk_ovf",
     ));
     insns.push((
         Inst::TrapIf {
             cond: Cond::from_mask(1),
             trap_code: TrapCode::StackOverflow,
         },
-        "A7E400030000",
-        "jno 6 ; trap",
+        "C01400000001",
+        "jgo .+2 # trap=stk_ovf",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -3185,11 +3185,13 @@ impl Inst {
                 let cond = cond.pretty_print_default();
                 format!("jg{} {}", cond, target)
             }
-            &Inst::Debugtrap => "debugtrap".to_string(),
-            &Inst::Trap { .. } => "trap".to_string(),
-            &Inst::TrapIf { cond, .. } => {
-                let cond = cond.invert().pretty_print_default();
-                format!("j{} 6 ; trap", cond)
+            &Inst::Debugtrap => ".word 0x0001 # debugtrap".to_string(),
+            &Inst::Trap { trap_code } => {
+                format!(".word 0x0000 # trap={}", trap_code)
+            }
+            &Inst::TrapIf { cond, trap_code } => {
+                let cond = cond.pretty_print_default();
+                format!("jg{} .+2 # trap={}", cond, trap_code)
             }
             &Inst::JTSequence { ridx, ref targets } => {
                 let ridx = pretty_print_reg(ridx, allocs);

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -382,7 +382,7 @@ block0:
 ; block0:
 ;   lghi %r2, 0
 ;   brasl %r14, %g
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
@@ -10,13 +10,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 256 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -24,20 +24,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   ic %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -51,13 +48,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 128 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -129 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -65,21 +62,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   ic %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   .byte 0xc3, 0x01
 ;   .byte 0x00, 0x00
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -93,13 +87,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 65536 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -107,20 +101,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   be 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -134,13 +125,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 32768 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -32769 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -148,21 +139,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   bc 0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   bpp 0, -0x31dc, 0x100
 ;   lpr %r0, %r0
 ;   .byte 0x08, 0x03
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -176,13 +164,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 4294967300 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -190,20 +178,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   cvb %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vclgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -217,13 +202,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 2147483600 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -2147484000 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -231,21 +216,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   cvb %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   .byte 0xcf, 0x00
 ;   .byte 0x00, 0x01
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   vcgd %v20, %v0, 2, 8, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
@@ -259,13 +241,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 18446744000000000000 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -274,20 +256,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   sl %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -302,13 +281,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 9223372000000000000 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -9223373000000000000 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -317,21 +296,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   sl %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   edmk 1(1), 0x700(%r14)
 ;   lpr %r0, %r0
 ;   .byte 0x08, 0x03
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -346,13 +322,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 256 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -360,24 +336,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r7, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -391,13 +364,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 128 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -129 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -405,23 +378,20 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r6, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   larl %r6, 0x40000028
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -435,13 +405,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 65536 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -449,24 +419,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -480,13 +447,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 32768 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -32769 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -494,23 +461,20 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   larl %r14, 0x400028
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -524,13 +488,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 4294967296 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -538,24 +502,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   la %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -569,13 +530,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 2147483648 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -2147483649 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -583,16 +544,14 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   la %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   .byte 0xc1, 0xe0
 ;   .byte 0x00, 0x00
@@ -600,8 +559,7 @@ block0(v0: f64):
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -615,13 +573,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 18446744073709552000 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -629,24 +587,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   ic %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -660,13 +615,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 9223372036854776000 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -9223372036854778000 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -674,16 +629,14 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   ic %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   .byte 0xc3, 0xe0
 ;   .byte 0x00, 0x00
@@ -691,8 +644,7 @@ block0(v0: f64):
 ;   .byte 0x00, 0x01
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -683,13 +683,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 256 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -698,20 +698,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   ic %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -726,13 +723,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 128 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -129 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -741,21 +738,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   ic %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   .byte 0xc3, 0x01
 ;   .byte 0x00, 0x00
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -770,13 +764,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 65536 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -785,20 +779,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   be 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -813,13 +804,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 32768 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -32769 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -828,21 +819,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   bc 0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   bpp 0, -0x31dc, 0x100
 ;   lpr %r0, %r0
 ;   .byte 0x08, 0x03
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -857,13 +845,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 4294967300 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -872,20 +860,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   cvb %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -900,13 +885,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 2147483600 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -2147484000 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -915,21 +900,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   cvb %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   .byte 0xcf, 0x00
 ;   .byte 0x00, 0x01
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -944,13 +926,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 18446744000000000000 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -1 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -959,20 +941,17 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   sl %r8, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   icm %r8, 0, 0
 ;   vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -987,13 +966,13 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   cebr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 8 ; data.f32 9223372000000000000 ; le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 8 ; data.f32 -9223373000000000000 ; vlef %v16, 0(%r1), 0
 ;   wfcsb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -1002,21 +981,18 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x12
 ;   sl %r0, 0
 ;   le %f4, 0(%r1)
 ;   cebr %f0, %f4
-;   jnhe 0x20
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x1c ; trap: int_ovf
 ;   bras %r1, 0x28
 ;   edmk 1(1), 0x700(%r14)
 ;   lpr %r0, %r0
 ;   .byte 0x08, 0x03
 ;   wfcsb %f0, %v16
-;   jnle 0x3a
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x36 ; trap: int_ovf
 ;   wldeb %v20, %f0
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
@@ -1031,13 +1007,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 256 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1045,24 +1021,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r7, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1076,13 +1049,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 128 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -129 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1090,23 +1063,20 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r6, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   larl %r6, 0x40000028
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1120,13 +1090,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 65536 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1134,24 +1104,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1165,13 +1132,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 32768 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -32769 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1179,23 +1146,20 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   sth %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   larl %r14, 0x400028
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1209,13 +1173,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 4294967296 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1223,24 +1187,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   la %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1254,13 +1215,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 2147483648 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -2147483649 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1268,16 +1229,14 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   la %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   .byte 0xc1, 0xe0
 ;   .byte 0x00, 0x00
@@ -1285,8 +1244,7 @@ block0(v0: f64):
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1300,13 +1258,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 18446744073709552000 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -1 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1314,24 +1272,21 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   ic %r15, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   icm %r15, 0, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1345,13 +1300,13 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   cdbr %f0, %f0
-;   jno 6 ; trap
+;   jgo .+2 # trap=bad_toint
 ;   bras %r1, 12 ; data.f64 9223372036854776000 ; ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 6 ; trap
+;   jghe .+2 # trap=int_ovf
 ;   bras %r1, 12 ; data.f64 -9223372036854778000 ; vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 6 ; trap
+;   jgle .+2 # trap=int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
@@ -1359,16 +1314,14 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
-;   jno 0xa
-;   .byte 0x00, 0x00 ; trap: bad_toint
+;   jgo 6 ; trap: bad_toint
 ;   bras %r1, 0x16
 ;   ic %r14, 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   ld %f4, 0(%r1)
 ;   cdbr %f0, %f4
-;   jnhe 0x24
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jghe 0x20 ; trap: int_ovf
 ;   bras %r1, 0x30
 ;   .byte 0xc3, 0xe0
 ;   .byte 0x00, 0x00
@@ -1376,8 +1329,7 @@ block0(v0: f64):
 ;   .byte 0x00, 0x01
 ;   vleg %v16, 0(%r1), 0
 ;   wfcdb %f0, %v16
-;   jnle 0x42
-;   .byte 0x00, 0x00 ; trap: int_ovf
+;   jgle 0x3e ; trap: int_ovf
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/traps.clif
@@ -12,7 +12,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -25,7 +25,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -46,7 +46,7 @@ block0(v0: i64):
 ; block2:
 ;   br %r14
 ; block1:
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -72,7 +72,7 @@ block0(v0: i64):
 ; block1:
 ;   br %r14
 ; block2:
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -98,7 +98,7 @@ block0(v0: i64):
 ; block1:
 ;   br %r14
 ; block2:
-;   trap
+;   .word 0x0000 # trap=user0
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -117,7 +117,7 @@ block0:
 
 ; VCode:
 ; block0:
-;   debugtrap
+;   .word 0x0001 # debugtrap
 ;   br %r14
 ; 
 ; Disassembled:

--- a/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
@@ -11,14 +11,13 @@ block0(v0: i32):
 ; VCode:
 ; block0:
 ;   alfi %r2, 127
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alfi %r2, 0x7f
-;   jle 0xc
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 8 ; trap: user0
 ;   br %r14
 
 function %f1(i32) -> i32 {
@@ -31,14 +30,13 @@ block0(v0: i32):
 ; VCode:
 ; block0:
 ;   alfi %r2, 127
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alfi %r2, 0x7f
-;   jle 0xc
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 8 ; trap: user0
 ;   br %r14
 
 function %f2(i32, i32) -> i32 {
@@ -50,14 +48,13 @@ block0(v0: i32, v1: i32):
 ; VCode:
 ; block0:
 ;   alr %r2, %r3
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alr %r2, %r3
-;   jle 8
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 4 ; trap: user0
 ;   br %r14
 
 function %f3(i64) -> i64 {
@@ -70,14 +67,13 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   algfi %r2, 127
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfi %r2, 0x7f
-;   jle 0xc
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 8 ; trap: user0
 ;   br %r14
 
 function %f3(i64) -> i64 {
@@ -90,14 +86,13 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   algfi %r2, 127
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfi %r2, 0x7f
-;   jle 0xc
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 8 ; trap: user0
 ;   br %r14
 
 function %f4(i64, i64) -> i64 {
@@ -109,14 +104,13 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ; block0:
 ;   algr %r2, %r3
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algr %r2, %r3
-;   jle 0xa
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 6 ; trap: user0
 ;   br %r14
 
 function %f5(i64, i32) -> i64 {
@@ -129,13 +123,12 @@ block0(v0: i64, v1: i32):
 ; VCode:
 ; block0:
 ;   algfr %r2, %r3
-;   jle 6 ; trap
+;   jgnle .+2 # trap=user0
 ;   br %r14
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfr %r2, %r3
-;   jle 0xa
-;   .byte 0x00, 0x00 ; trap: user0
+;   jgnle 6 ; trap: user0
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -55,7 +55,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -73,4 +73,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -57,7 +57,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -78,4 +78,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -58,7 +58,7 @@
 ;;   lgr %r5, %r2
 ;;   llilf %r2, 4294901764
 ;;   algfr %r2, %r5
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
@@ -72,7 +72,7 @@
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -82,7 +82,7 @@
 ;;   llgfr %r3, %r2
 ;;   llilf %r5, 4294901764
 ;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
 ;;   jgh label3 ; jg label1
@@ -94,4 +94,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -73,4 +73,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -57,7 +57,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -78,4 +78,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -58,7 +58,7 @@
 ;;   lgr %r5, %r2
 ;;   llilf %r2, 4294901761
 ;;   algfr %r2, %r5
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r5, %r7
 ;;   lg %r7, 8(%r5)
 ;;   clgr %r2, %r7
@@ -72,7 +72,7 @@
 ;;   lmg %r7, %r15, 56(%r15)
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -82,7 +82,7 @@
 ;;   llgfr %r3, %r2
 ;;   llilf %r5, 4294901761
 ;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r2, 8(%r4)
 ;;   clgr %r5, %r2
 ;;   jgh label3 ; jg label1
@@ -94,4 +94,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -55,7 +55,7 @@
 ;;   llgfr %r4, %r2
 ;;   llilf %r9, 4294901764
 ;;   algfr %r9, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r2, %r5
 ;;   lg %r5, 8(%r2)
 ;;   ag %r4, 0(%r2)
@@ -78,7 +78,7 @@
 ;;   llgfr %r3, %r2
 ;;   llilf %r5, 4294901764
 ;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r2, %r4
 ;;   lg %r4, 8(%r2)
 ;;   ag %r3, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -55,7 +55,7 @@
 ;;   llgfr %r4, %r2
 ;;   llilf %r9, 4294901761
 ;;   algfr %r9, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r2, %r5
 ;;   lg %r5, 8(%r2)
 ;;   ag %r4, 0(%r2)
@@ -78,7 +78,7 @@
 ;;   llgfr %r3, %r2
 ;;   llilf %r5, 4294901761
 ;;   algfr %r5, %r2
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lgr %r2, %r4
 ;;   lg %r4, 8(%r2)
 ;;   ag %r3, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -73,4 +73,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -73,4 +73,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -54,7 +54,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -71,4 +71,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -48,7 +48,7 @@
 ;; block0:
 ;;   lgr %r5, %r2
 ;;   algfi %r5, 4294901764
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
 ;;   jgh label3 ; jg label1
@@ -62,7 +62,7 @@
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -70,7 +70,7 @@
 ;; block0:
 ;;   lgr %r5, %r2
 ;;   algfi %r5, 4294901764
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
 ;;   jgh label3 ; jg label1
@@ -83,4 +83,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -53,7 +53,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -56,7 +56,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -75,4 +75,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -48,7 +48,7 @@
 ;; block0:
 ;;   lgr %r5, %r2
 ;;   algfi %r5, 4294901761
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r14, 8(%r4)
 ;;   clgr %r5, %r14
 ;;   jgh label3 ; jg label1
@@ -62,7 +62,7 @@
 ;;   lmg %r14, %r15, 112(%r15)
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -70,7 +70,7 @@
 ;; block0:
 ;;   lgr %r5, %r2
 ;;   algfi %r5, 4294901761
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r4, 8(%r3)
 ;;   clgr %r5, %r4
 ;;   jgh label3 ; jg label1
@@ -83,4 +83,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -55,7 +55,7 @@
 ;; block0:
 ;;   lgr %r7, %r2
 ;;   algfi %r7, 4294901764
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r5, 8(%r4)
 ;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
@@ -75,7 +75,7 @@
 ;; block0:
 ;;   lgr %r4, %r2
 ;;   algfi %r4, 4294901764
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r5, 8(%r3)
 ;;   ag %r2, 0(%r3)
 ;;   llilh %r3, 65535

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -55,7 +55,7 @@
 ;; block0:
 ;;   lgr %r7, %r2
 ;;   algfi %r7, 4294901761
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r5, 8(%r4)
 ;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
@@ -75,7 +75,7 @@
 ;; block0:
 ;;   lgr %r4, %r2
 ;;   algfi %r4, 4294901761
-;;   jle 6 ; trap
+;;   jgnle .+2 # trap=heap_oob
 ;;   lg %r5, 8(%r3)
 ;;   ag %r2, 0(%r3)
 ;;   llilh %r3, 65535

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -53,7 +53,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -54,7 +54,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -71,4 +71,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -54,7 +54,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -71,4 +71,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -53,7 +53,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -54,7 +54,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -71,4 +71,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -54,7 +54,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -71,4 +71,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -53,7 +53,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -72,4 +72,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -53,7 +53,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -72,4 +72,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -50,7 +50,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -65,4 +65,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -50,7 +50,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -65,4 +65,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -50,7 +50,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -65,4 +65,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -50,7 +50,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -65,4 +65,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -52,7 +52,7 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
@@ -69,4 +69,4 @@
 ;; block2:
 ;;   br %r14
 ;; block3:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,10 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob
 ;;
 ;; function u0:1:
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   trap
+;;   .word 0x0000 # trap=heap_oob


### PR DESCRIPTION
Following up on the discussion in
https://github.com/bytecodealliance/wasmtime/pull/6011 this adds an improved implementation of TrapIf for s390x using a single conditional branch instruction.

If the trap conditions is true, we branch into the middle of the branch instruction - those middle two bytes are zero, which matches the encoding of the trap instruction.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
