### PR TITLE
Initial designation of code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,42 @@
+# In this project, we use CODEOWNERS to identify people who are likely to know
+# who should review a pull request.
+#
+# People listed in this file are committing to respond in a timely fashion to
+# PRs in the selected areas. However, that response doesn't have to be a full
+# code review; it could also take any of these forms:
+#
+# - "I intend to review this but I can't yet. Please leave me a message if I
+#   haven't responded by (a specific date in the near future)."
+#
+# - "I think (a specific other contributor) should review this." (Note that the
+#   best reviewer for a PR may not necessarily be listed in this file.)
+#
+# People must only be added to this file if they've agreed to provide one of
+# the above responses in a reasonable amount of time for every PR to which
+# they're assigned.
+#
+# We only ask for this commitment from people who are employed full-time to
+# work on this project. We gratefully welcome reviews from other contributors,
+# but we don't believe it's fair to ask volunteers to respond quickly.
+
+# TODO: use GitHub teams instead of individual usernames
+
+# If none of the later patterns match, assign to anyone:
+* @alexcrichton @cfallin @elliottt @fitzgen @jameysharp @pchickey
+
+# Some parts of the project require more specialized knowledge. In those areas
+# we designate smaller groups who are more likely to be aware of who's working
+# in specific areas.
+
+# Wasmtime
+/crates/   @alexcrichton @fitzgen @jameysharp @pchickey
+/examples/ @alexcrichton @fitzgen @jameysharp @pchickey
+/src/      @alexcrichton @fitzgen @jameysharp @pchickey
+/tests/    @alexcrichton @fitzgen @jameysharp @pchickey
+
+# Cranelift/Winch compilers
+/cranelift/ @cfallin @elliottt @fitzgen @jameysharp
+/winch/     @cfallin @elliottt @fitzgen @jameysharp
+
+# Fuzz testing
+/fuzz/ @alexcrichton @elliottt @fitzgen @jameysharp


### PR DESCRIPTION
We want to make sure every contributor gets some kind of meaningful response in a timely fashion. To that end, this PR configures GitHub to auto-assign somebody to every newly-opened PR.

People must only be added to this file if they've agreed to this obligation. The details of what's expected are listed in the file. I'll only merge this if it's signed off by everyone listed in this initial version.

I've requested review from everyone; please either approve or request to be removed. Or suggest changes, of course; I'd particularly like to know if my description of the expectations aren't clear or don't seem right, or if we should slice up the repository differently.

I considered using the bytecodealliance/cranelift-core and wasmtime-core teams for this, but they have too many people and I wanted to make sure I was getting opt-in from everyone. Eventually I think we should create a few new teams specifically for this purpose, but that requires bytecodealliance org admin rights as far as I can tell, and I wanted to get the general shape of this sorted out before dealing with that.

I'd like to ask some more people to join some of these lists, but for example @itsrainy is out this week so I couldn't check with them.