### PR TITLE
ci: unpin the wasi-nn tasks from an older Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -466,14 +466,17 @@ jobs:
     needs: determine
     if: needs.determine.outputs.run-full
     name: Test wasi-nn module
-    runs-on: ubuntu-20.04 # TODO: remove pin when fixed (#5408)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
       - uses: ./.github/actions/install-rust
       - run: rustup target add wasm32-wasi
-      - uses: abrown/install-openvino-action@v3
+      - uses: abrown/install-openvino-action@50a2ab733ef4b504dd7de3ac45c36eae7f9bc228
+        with:
+          version: 2022.3.0
+          apt: true
       - run: ./ci/run-wasi-nn-example.sh
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,19 +1953,20 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openvino"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7336c11cad0eb45f65436cdbf073c697397a1bfe53836cef997129d69443c77"
+checksum = "cbc731d9a7805dd533b69de3ee33062d5ea1dfa9fca1c19f8fd165b62e2cdde7"
 dependencies = [
+ "openvino-finder",
  "openvino-sys",
  "thiserror",
 ]
 
 [[package]]
 name = "openvino-finder"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650edf39ea54dfbe18f0ad513858ff0bed3f6a308b677e0d5f71b330f476ccf"
+checksum = "d8bbd80eea06c2b9ec3dce85900ff3ae596c01105b759b38a005af69bbeb4d07"
 dependencies = [
  "cfg-if",
  "log",
@@ -1973,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d003d61f18f7bf6dd965b4e913cbd3e7cda6a3c179115c8ee59e5c29b390f45"
+checksum = "318ed662bdf05a3f86486408159e806d53363171621a8000b81366fab5158713"
 dependencies = [
  "libloading",
  "once_cell",

--- a/ci/run-wasi-nn-example.sh
+++ b/ci/run-wasi-nn-example.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# The following script demonstrates how to execute a machine learning inference using the wasi-nn module optionally
-# compiled into Wasmtime. Calling it will download the necessary model and tensor files stored separately in $FIXTURE
-# into $TMP_DIR (optionally pass a directory with existing files as the first argument to re-try the script). Then,
-# it will compile the example code in crates/wasi-nn/tests/example into a Wasm file that is subsequently
-# executed with the Wasmtime CLI.
+# The following script demonstrates how to execute a machine learning inference using the wasi-nn
+# module optionally compiled into Wasmtime. Calling it will download the necessary model and tensor
+# files stored separately in $FIXTURE into $TMP_DIR (optionally pass a directory with existing files
+# as the first argument to re-try the script). Then, it will compile the example code in
+# crates/wasi-nn/tests/example into a Wasm file that is subsequently executed with the Wasmtime CLI.
 set -e
 WASMTIME_DIR=$(dirname "$0" | xargs dirname)
 FIXTURE=https://github.com/intel/openvino-rs/raw/main/crates/openvino/tests/fixtures/mobilenet
@@ -18,12 +18,8 @@ else
     REMOVE_TMP_DIR=0
 fi
 
-# Inform the environment of OpenVINO library locations. Then we use OPENVINO_INSTALL_DIR below to avoid building all of
-# OpenVINO from source (quite slow).
-source /opt/intel/openvino_2022/setupvars.sh
-
 # Build Wasmtime with wasi-nn enabled; we attempt this first to avoid extra work if the build fails.
-OPENVINO_INSTALL_DIR=/opt/intel/openvino_2022 cargo build -p wasmtime-cli --features wasi-nn
+cargo build -p wasmtime-cli --features wasi-nn
 
 # Download all necessary test fixtures to the temporary directory.
 wget --no-clobber $FIXTURE/mobilenet.bin --output-document=$TMP_DIR/model.bin

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true }
 wiggle = { workspace = true }
 
 # These dependencies are necessary for the wasi-nn implementation:
-openvino = { version = "0.4.2", features = ["runtime-linking"] }
+openvino = { version = "0.5.0", features = ["runtime-linking"] }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/crates/wasi-nn/src/openvino.rs
+++ b/crates/wasi-nn/src/openvino.rs
@@ -119,7 +119,7 @@ impl BackendExecutionContext for OpenvinoExecutionContext {
 
     fn get_output(&mut self, index: u32, destination: &mut [u8]) -> Result<u32, BackendError> {
         let output_name = self.0.get_output_name(index as usize)?;
-        let mut blob = self.1.get_blob(&output_name)?;
+        let blob = self.1.get_blob(&output_name)?;
         let blob_size = blob.byte_len()?;
         if blob_size > destination.len() {
             return Err(BackendError::NotEnoughMemory(blob_size));

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -596,6 +596,11 @@ notes = """
 I am the author of most of these changes.
 """
 
+[[audits.openvino]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.5.0"
+
 [[audits.openvino-finder]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -604,6 +609,11 @@ notes = """
 Only updates to Cargo file for versioning.
 """
 
+[[audits.openvino-finder]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.5.0"
+
 [[audits.openvino-sys]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -611,6 +621,11 @@ delta = "0.4.1 -> 0.4.2"
 notes = """
 Only updates to tests to use new rust functions for mut pointers.
 """
+
+[[audits.openvino-sys]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.5.0"
 
 [[audits.peeking_take_while]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"


### PR DESCRIPTION
Previously, OpenVINO's lack of APT packages for Ubuntu 22.04 (`jammy`) prevented us from upgrading the GitHub runner to use `ubuntu-latest`. I updated the `install-openvino-action` to substitute in the `focal` packages in this case (this is what the OpenVINO team considers the fix) so this pin should no longer be necessary. Fixes #5408.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
