### PR TITLE
Initial implementation of wasi-http serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "wasmtime",
+ "wasmtime-wasi",
  "webpki-roots",
 ]
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -74,6 +74,10 @@ pub const SUPPORTED_WASI_MODULES: &[(&str, &str)] = &[
         "experimental-wasi-http",
         "enables support for the WASI HTTP APIs (experimental), see https://github.com/WebAssembly/wasi-http",
     ),
+    (
+        "experimental-wasi-http-server",
+        "enables support for the WASI HTTP APIs (experimental) for web serving, see https://github.com/WebAssembly/wasi-http",
+    ),
 ];
 
 fn init_file_per_thread_logger(prefix: &'static str) {
@@ -512,6 +516,7 @@ fn parse_wasi_modules(modules: &str) -> Result<WasiModules> {
                 "experimental-wasi-nn" => Ok(wasi_modules.wasi_nn = enable),
                 "experimental-wasi-threads" => Ok(wasi_modules.wasi_threads = enable),
                 "experimental-wasi-http" => Ok(wasi_modules.wasi_http = enable),
+                "experimental-wasi-http-server" => Ok(wasi_modules.wasi_http_server = enable),
                 "default" => bail!("'default' cannot be specified with other WASI modules"),
                 _ => bail!("unsupported WASI module '{}'", module),
             };
@@ -549,6 +554,9 @@ pub struct WasiModules {
 
     /// Enable the experimental wasi-http implementation
     pub wasi_http: bool,
+
+    /// Enable the experimental wasi-http-server implementation
+    pub wasi_http_server: bool,
 }
 
 impl Default for WasiModules {
@@ -559,6 +567,7 @@ impl Default for WasiModules {
             wasi_nn: false,
             wasi_threads: false,
             wasi_http: false,
+            wasi_http_server: false,
         }
     }
 }
@@ -572,6 +581,7 @@ impl WasiModules {
             wasi_crypto: false,
             wasi_threads: false,
             wasi_http: false,
+            wasi_http_server: false,
         }
     }
 }
@@ -734,6 +744,7 @@ mod test {
                 wasi_nn: false,
                 wasi_threads: false,
                 wasi_http: false,
+                wasi_http_server: false,
             }
         );
     }
@@ -748,7 +759,8 @@ mod test {
                 wasi_crypto: false,
                 wasi_nn: false,
                 wasi_threads: false,
-                wasi_http: false
+                wasi_http: false,
+                wasi_http_server: false,
             }
         );
     }
@@ -768,6 +780,7 @@ mod test {
                 wasi_nn: true,
                 wasi_threads: false,
                 wasi_http: false,
+                wasi_http_server: false,
             }
         );
     }
@@ -784,6 +797,45 @@ mod test {
                 wasi_nn: false,
                 wasi_threads: false,
                 wasi_http: false,
+                wasi_http_server: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_client() {
+        let options =
+            CommonOptions::try_parse_from(vec!["foo", "--wasi-modules=experimental-wasi-http"])
+                .unwrap();
+        assert_eq!(
+            options.wasi_modules.unwrap(),
+            WasiModules {
+                wasi_common: true,
+                wasi_crypto: false,
+                wasi_nn: false,
+                wasi_threads: false,
+                wasi_http: true,
+                wasi_http_server: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_server() {
+        let options = CommonOptions::try_parse_from(vec![
+            "foo",
+            "--wasi-modules=experimental-wasi-http-server",
+        ])
+        .unwrap();
+        assert_eq!(
+            options.wasi_modules.unwrap(),
+            WasiModules {
+                wasi_common: true,
+                wasi_crypto: false,
+                wasi_nn: false,
+                wasi_threads: false,
+                wasi_http: false,
+                wasi_http_server: true,
             }
         );
     }

--- a/crates/test-programs/tests/wasi-http.rs
+++ b/crates/test-programs/tests/wasi-http.rs
@@ -73,7 +73,7 @@ pub fn run(name: &str) -> anyhow::Result<()> {
     }
 
     wasmtime_wasi::sync::add_to_linker(&mut linker, |cx: &mut Ctx| &mut cx.wasi)?;
-    wasmtime_wasi_http::add_to_linker(&mut linker, |cx: &mut Ctx| &mut cx.http)?;
+    wasmtime_wasi_http::add_to_linker(&mut linker, |cx: &mut Ctx| &mut cx.http, false)?;
 
     // Create our wasi context.
     let builder = WasiCtxBuilder::new().inherit_stdio().arg(name)?;

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -16,7 +16,8 @@ http = { version = "0.2.9" }
 http-body = "1.0.0-rc.2"
 http-body-util = "0.1.0-rc.2"
 thiserror = { workspace = true }
-wasmtime = { workspace = true, features = ['component-model'] }
+wasmtime = { workspace = true, features = ['component-model', 'async'] }
+wasmtime-wasi = { workspace = true, features = [ 'tokio' ] }
 
 # The `ring` crate, used to implement TLS, does not build on riscv64 or s390x
 [target.'cfg(not(any(target_arch = "riscv64", target_arch = "s390x")))'.dependencies]

--- a/crates/wasi-http/src/http_server.rs
+++ b/crates/wasi-http/src/http_server.rs
@@ -1,0 +1,128 @@
+use crate::types::Method;
+use crate::WasiHttp;
+use http::{Request, Response, StatusCode};
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use tokio::net::TcpListener;
+use tokio::runtime::Runtime;
+use wasmtime::{AsContext, AsContextMut, Store};
+
+use crate::r#struct::ActiveRequest;
+
+struct HttpHandler<'a, T> {
+    pub linker: Option<&'a wasmtime::Linker<T>>,
+    pub store: Option<&'a mut wasmtime::Store<T>>,
+    pub get_cx: Box<dyn Fn(&mut T) -> &mut WasiHttp>,
+}
+
+impl<T> hyper::service::Service<Request<Incoming>> for HttpHandler<'_, T> {
+    type Response = Response<Full<Bytes>>;
+    type Error = hyper::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn call(&mut self, req: Request<Incoming>) -> Self::Future {
+        let mut wasi_http = (self.get_cx)(self.store.as_mut().unwrap().data_mut());
+        let ptr = wasi_http.request_id_base;
+        wasi_http.request_id_base += 1;
+
+        let mut request = ActiveRequest::new(ptr);
+        request.method = Method::new(req.method());
+        request.scheme = match req.uri().scheme() {
+            Some(s) => Some(s.into()),
+            None => None,
+        };
+        request.authority = match req.uri().authority() {
+            Some(s) => s.to_string(),
+            None => "".to_string(),
+        };
+        request.path = req.uri().path().to_string();
+
+        for (name, value) in req.headers().iter() {
+            let val = value.to_str().unwrap().to_string();
+            let key = name.to_string();
+            match request.headers.get_mut(&key) {
+                Some(vec) => vec.push(val),
+                None => {
+                    let mut vec = std::vec::Vec::new();
+                    vec.push(val);
+                    request.headers.insert(key.to_string(), vec);
+                }
+            }
+        }
+
+        wasi_http.requests.insert(ptr, request);
+        let outparam_id = wasi_http.outparams_id_base;
+        wasi_http.outparams_id_base += 1;
+
+        let http = self
+            .linker
+            .as_ref()
+            .unwrap()
+            .get(&mut *self.store.as_mut().unwrap(), "", "HTTP#handle")
+            .unwrap();
+        let func = http.into_func().unwrap();
+        let typed = func
+            .typed::<(u32, u32), ()>(self.store.as_mut().unwrap().as_context())
+            .unwrap();
+        typed
+            .call(
+                self.store.as_mut().unwrap().as_context_mut(),
+                (ptr, outparam_id),
+            )
+            .unwrap();
+
+        wasi_http = (self.get_cx)(self.store.as_mut().unwrap().data_mut());
+        let response_id = wasi_http
+            .response_outparams
+            .get(&outparam_id)
+            .unwrap()
+            .unwrap();
+        let response = wasi_http.responses.get(&response_id).unwrap();
+        let body = Full::<Bytes>::new(wasi_http.streams.entry(response.body).or_default().into());
+        let code = StatusCode::from_u16(response.status).unwrap();
+        let res = Ok(Response::builder().status(code).body(body).unwrap());
+        Box::pin(async { res })
+    }
+}
+
+// adapted from https://docs.rs/hyper/1.0.0-rc.3/hyper/server/conn/index.html
+pub async fn async_http_server<T>(
+    linker: &mut wasmtime::Linker<T>,
+    store: &mut Store<T>,
+    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
+) {
+    let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
+
+    let tcp_listener = TcpListener::bind(addr).await.unwrap();
+    loop {
+        let server: HttpHandler<T> = HttpHandler {
+            linker: Some(linker),
+            store: Some(store),
+            get_cx: Box::new(get_cx),
+        };
+
+        let (tcp_stream, _) = tcp_listener.accept().await.unwrap();
+        if let Err(http_err) = http1::Builder::new()
+            .keep_alive(true)
+            .serve_connection(tcp_stream, server)
+            .await
+        {
+            eprintln!("Error while serving HTTP connection: {}", http_err);
+        }
+    }
+}
+
+pub fn spawn_http_server<T>(
+    linker: &mut wasmtime::Linker<T>,
+    wasi_http: &mut Store<T>,
+    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
+) {
+    let rt = Runtime::new().unwrap();
+    let _enter = rt.enter();
+
+    rt.block_on(async_http_server(linker, wasi_http, get_cx))
+}

--- a/crates/wasi-http/src/http_server.rs
+++ b/crates/wasi-http/src/http_server.rs
@@ -6,6 +6,7 @@ use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::pin::Pin;
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
@@ -13,21 +14,37 @@ use wasmtime::{AsContext, AsContextMut, Store};
 
 use crate::r#struct::ActiveRequest;
 
-struct HttpHandler<'a, T> {
-    pub linker: Option<&'a wasmtime::Linker<T>>,
-    pub store: Option<&'a mut wasmtime::Store<T>>,
-    pub get_cx: Box<dyn Fn(&mut T) -> &mut WasiHttp>,
+struct Host {
+    wasi_http: WasiHttp,
+    wasi: wasmtime_wasi::WasiCtx,
 }
 
-impl<T> hyper::service::Service<Request<Incoming>> for HttpHandler<'_, T> {
+impl Host {
+    pub fn new() -> Self {
+        Self {
+            wasi_http: WasiHttp::new(),
+            wasi: wasmtime_wasi::WasiCtxBuilder::new()
+                .stdin(Box::new(wasmtime_wasi::stdio::stdin()))
+                .build(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct HttpHandler<'a> {
+    engine: &'a wasmtime::Engine,
+    module: &'a PathBuf,
+}
+
+impl hyper::service::Service<Request<Incoming>> for HttpHandler<'_> {
     type Response = Response<Full<Bytes>>;
     type Error = hyper::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn call(&mut self, req: Request<Incoming>) -> Self::Future {
-        let mut wasi_http = (self.get_cx)(self.store.as_mut().unwrap().data_mut());
-        let ptr = wasi_http.request_id_base;
-        wasi_http.request_id_base += 1;
+        let mut host = Host::new();
+        let ptr = host.wasi_http.request_id_base;
+        host.wasi_http.request_id_base += 1;
 
         let mut request = ActiveRequest::new(ptr);
         request.method = Method::new(req.method());
@@ -54,57 +71,60 @@ impl<T> hyper::service::Service<Request<Incoming>> for HttpHandler<'_, T> {
             }
         }
 
-        wasi_http.requests.insert(ptr, request);
-        let outparam_id = wasi_http.outparams_id_base;
-        wasi_http.outparams_id_base += 1;
+        host.wasi_http.requests.insert(ptr, request);
+        let outparam_id = host.wasi_http.outparams_id_base;
+        host.wasi_http.outparams_id_base += 1;
 
-        let http = self
-            .linker
-            .as_ref()
-            .unwrap()
-            .get(&mut *self.store.as_mut().unwrap(), "", "HTTP#handle")
-            .unwrap();
-        let func = http.into_func().unwrap();
-        let typed = func
-            .typed::<(u32, u32), ()>(self.store.as_mut().unwrap().as_context())
-            .unwrap();
-        typed
-            .call(
-                self.store.as_mut().unwrap().as_context_mut(),
-                (ptr, outparam_id),
-            )
-            .unwrap();
+        let mut linker = wasmtime::Linker::new(self.engine);
+        let mut store = Store::new(self.engine, host);
+        let path = self.module.clone();
 
-        wasi_http = (self.get_cx)(self.store.as_mut().unwrap().data_mut());
-        let response_id = wasi_http
-            .response_outparams
-            .get(&outparam_id)
-            .unwrap()
-            .unwrap();
-        let response = wasi_http.responses.get(&response_id).unwrap();
-        let body = Full::<Bytes>::new(wasi_http.streams.entry(response.body).or_default().into());
-        let code = StatusCode::from_u16(response.status).unwrap();
-        let res = Ok(Response::builder().status(code).body(body).unwrap());
-        Box::pin(async { res })
+        Box::pin(async move {
+            wasmtime_wasi::tokio::add_to_linker(&mut linker, |h: &mut Host| &mut h.wasi).unwrap();
+            crate::add_to_linker(&mut linker, |h: &mut Host| &mut h.wasi_http, true).unwrap();
+
+            let module = wasmtime::Module::from_file(&store.engine(), path).unwrap();
+            let instance = linker.instantiate_async(&mut store, &module).await.unwrap();
+            let func = instance.get_func(&mut store, "HTTP#handle").unwrap();
+            let typed = func.typed::<(u32, u32), ()>(store.as_context()).unwrap();
+            typed
+                .call_async(store.as_context_mut(), (ptr, outparam_id))
+                .await
+                .unwrap();
+
+            let host = store.data_mut();
+            let response_id = host
+                .wasi_http
+                .response_outparams
+                .get(&outparam_id)
+                .unwrap()
+                .unwrap();
+            let response = host.wasi_http.responses.get(&response_id).unwrap();
+            let body = Full::<Bytes>::new(
+                host.wasi_http
+                    .streams
+                    .entry(response.body)
+                    .or_default()
+                    .into(),
+            );
+            let code = StatusCode::from_u16(response.status).unwrap();
+            let res = Ok(Response::builder().status(code).body(body).unwrap());
+            res
+        })
     }
 }
 
 // adapted from https://docs.rs/hyper/1.0.0-rc.3/hyper/server/conn/index.html
-pub async fn async_http_server<T>(
-    linker: &mut wasmtime::Linker<T>,
-    store: &mut Store<T>,
-    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
-) {
+pub async fn async_http_server(engine: &wasmtime::Engine, module: &PathBuf) {
     let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
 
     let tcp_listener = TcpListener::bind(addr).await.unwrap();
-    loop {
-        let server: HttpHandler<T> = HttpHandler {
-            linker: Some(linker),
-            store: Some(store),
-            get_cx: Box::new(get_cx),
-        };
+    let server: HttpHandler = HttpHandler {
+        engine: engine,
+        module: module,
+    };
 
+    loop {
         let (tcp_stream, _) = tcp_listener.accept().await.unwrap();
         if let Err(http_err) = http1::Builder::new()
             .keep_alive(true)
@@ -116,13 +136,15 @@ pub async fn async_http_server<T>(
     }
 }
 
-pub fn spawn_http_server<T>(
-    linker: &mut wasmtime::Linker<T>,
-    wasi_http: &mut Store<T>,
-    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
-) {
-    let rt = Runtime::new().unwrap();
-    let _enter = rt.enter();
+pub fn spawn_http_server(engine: &wasmtime::Engine, module: &PathBuf) {
+    let (handle, _runtime) = match tokio::runtime::Handle::try_current() {
+        Ok(h) => (h, None),
+        Err(_) => {
+            let rt = Runtime::new().unwrap();
+            let _enter = rt.enter();
+            (rt.handle().clone(), Some(rt))
+        }
+    };
 
-    rt.block_on(async_http_server(linker, wasi_http, get_cx))
+    handle.block_on(async_http_server(engine, module))
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -1,10 +1,14 @@
 use crate::component_impl::add_component_to_linker;
+use crate::http_server::async_http_server;
+use crate::http_server::spawn_http_server;
 pub use crate::r#struct::WasiHttp;
+use wasmtime::Store;
 
 wasmtime::component::bindgen!({ path: "wasi-http/wit", world: "proxy"});
 
 pub mod component_impl;
 pub mod http_impl;
+pub mod http_server;
 pub mod streams_impl;
 pub mod r#struct;
 pub mod types_impl;
@@ -24,4 +28,20 @@ pub fn add_to_linker<T>(
     get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
 ) -> anyhow::Result<()> {
     add_component_to_linker(linker, get_cx)
+}
+
+pub fn run_http<T>(
+    linker: &mut wasmtime::Linker<T>,
+    wasi_http: &mut Store<T>,
+    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
+) {
+    spawn_http_server(linker, wasi_http, get_cx);
+}
+
+pub async fn async_run_http<T>(
+    linker: &mut wasmtime::Linker<T>,
+    wasi_http: &mut Store<T>,
+    get_cx: impl Fn(&mut T) -> &mut WasiHttp + Send + Sync + Copy + 'static,
+) {
+    async_http_server(linker, wasi_http, get_cx).await
 }

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -8,6 +8,50 @@ pub struct Stream {
     pub data: BytesMut,
 }
 
+impl crate::types::Method {
+    pub fn new(m: &hyper::Method) -> Self {
+        match m {
+            &hyper::Method::GET => Method::Get,
+            &hyper::Method::PUT => Method::Put,
+            &hyper::Method::POST => Method::Post,
+            &hyper::Method::DELETE => Method::Delete,
+            &hyper::Method::OPTIONS => Method::Options,
+            &hyper::Method::HEAD => Method::Head,
+            &hyper::Method::CONNECT => Method::Connect,
+            &hyper::Method::TRACE => Method::Trace,
+            &hyper::Method::PATCH => Method::Patch,
+            _ => panic!("unknown method!"),
+        }
+    }
+}
+
+impl From<&http::uri::Scheme> for crate::types::Scheme {
+    fn from(s: &http::uri::Scheme) -> crate::types::Scheme {
+        match s.as_str() {
+            "http" => crate::types::Scheme::Http,
+            "https" => crate::types::Scheme::Https,
+            _ => panic!("unsupported scheme!"),
+        }
+    }
+}
+
+impl From<crate::types::Method> for u32 {
+    fn from(e: crate::types::Method) -> u32 {
+        match e {
+            Method::Get => 0,
+            Method::Head => 1,
+            Method::Post => 2,
+            Method::Put => 3,
+            Method::Delete => 4,
+            Method::Connect => 5,
+            Method::Options => 6,
+            Method::Trace => 7,
+            Method::Patch => 8,
+            _ => panic!("unknown method"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct WasiHttp {
     pub request_id_base: u32,
@@ -15,17 +59,19 @@ pub struct WasiHttp {
     pub fields_id_base: u32,
     pub streams_id_base: u32,
     pub future_id_base: u32,
+    pub outparams_id_base: u32,
+
     pub requests: HashMap<u32, ActiveRequest>,
     pub responses: HashMap<u32, ActiveResponse>,
     pub fields: HashMap<u32, HashMap<String, Vec<Vec<u8>>>>,
     pub streams: HashMap<u32, Stream>,
     pub futures: HashMap<u32, ActiveFuture>,
+    pub response_outparams: HashMap<u32, Option<u32>>,
 }
 
 #[derive(Clone)]
 pub struct ActiveRequest {
     pub id: u32,
-    pub active_request: bool,
     pub method: Method,
     pub scheme: Option<Scheme>,
     pub path_with_query: String,
@@ -37,7 +83,6 @@ pub struct ActiveRequest {
 #[derive(Clone)]
 pub struct ActiveResponse {
     pub id: u32,
-    pub active_response: bool,
     pub status: u16,
     pub body: u32,
     pub response_headers: HashMap<String, Vec<Vec<u8>>>,
@@ -55,7 +100,6 @@ impl ActiveRequest {
     pub fn new(id: u32) -> Self {
         Self {
             id,
-            active_request: false,
             method: Method::Get,
             scheme: Some(Scheme::Http),
             path_with_query: "".to_string(),
@@ -70,7 +114,6 @@ impl ActiveResponse {
     pub fn new(id: u32) -> Self {
         Self {
             id,
-            active_response: false,
             status: 0,
             body: 0,
             response_headers: HashMap::new(),
@@ -106,6 +149,12 @@ impl From<Bytes> for Stream {
     }
 }
 
+impl From<&mut Stream> for bytes::Bytes {
+    fn from(stream: &mut Stream) -> Self {
+        stream.data.clone().into()
+    }
+}
+
 impl WasiHttp {
     pub fn new() -> Self {
         Self {
@@ -114,11 +163,14 @@ impl WasiHttp {
             fields_id_base: 1,
             streams_id_base: 1,
             future_id_base: 1,
+            outparams_id_base: 1,
+
             requests: HashMap::new(),
             responses: HashMap::new(),
             fields: HashMap::new(),
             streams: HashMap::new(),
             futures: HashMap::new(),
+            response_outparams: HashMap::new(),
         }
     }
 }

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -8,7 +8,7 @@ pub struct Stream {
     pub data: BytesMut,
 }
 
-impl crate::types::Method {
+impl crate::wasi::http::types::Method {
     pub fn new(m: &hyper::Method) -> Self {
         match m {
             &hyper::Method::GET => Method::Get,
@@ -25,18 +25,18 @@ impl crate::types::Method {
     }
 }
 
-impl From<&http::uri::Scheme> for crate::types::Scheme {
-    fn from(s: &http::uri::Scheme) -> crate::types::Scheme {
+impl From<&http::uri::Scheme> for crate::wasi::http::types::Scheme {
+    fn from(s: &http::uri::Scheme) -> crate::wasi::http::types::Scheme {
         match s.as_str() {
-            "http" => crate::types::Scheme::Http,
-            "https" => crate::types::Scheme::Https,
+            "http" => crate::wasi::http::types::Scheme::Http,
+            "https" => crate::wasi::http::types::Scheme::Https,
             _ => panic!("unsupported scheme!"),
         }
     }
 }
 
-impl From<crate::types::Method> for u32 {
-    fn from(e: crate::types::Method) -> u32 {
+impl From<crate::wasi::http::types::Method> for u32 {
+    fn from(e: crate::wasi::http::types::Method) -> u32 {
         match e {
             Method::Get => 0,
             Method::Head => 1,

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -151,7 +151,7 @@ impl Host for WasiHttp {
             .requests
             .get(&request)
             .ok_or_else(|| anyhow!("unknown request: {request}"))?;
-        Ok(r.path.clone())
+        Ok(Some(r.path_with_query.clone()))
     }
     fn incoming_request_scheme(
         &mut self,
@@ -171,7 +171,7 @@ impl Host for WasiHttp {
             .requests
             .get(&request)
             .ok_or_else(|| anyhow!("unknown request: {request}"))?;
-        Ok(r.authority.clone())
+        Ok(Some(r.authority.clone()))
     }
     fn incoming_request_headers(&mut self, request: IncomingRequest) -> wasmtime::Result<Headers> {
         let r = self
@@ -193,13 +193,6 @@ impl Host for WasiHttp {
             .get(&request)
             .ok_or_else(|| anyhow!("unknown request: {request}"))?;
         Ok(Ok(r.body))
-    }
-    fn incoming_request_query(&mut self, request: IncomingRequest) -> wasmtime::Result<String> {
-        let r = self
-            .requests
-            .get(&request)
-            .ok_or_else(|| anyhow!("unknown request: {request}"))?;
-        Ok(r.query.clone())
     }
     fn new_outgoing_request(
         &mut self,

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -35,7 +35,7 @@ use wasmtime_wasi_crypto::WasiCryptoCtx;
 use wasmtime_wasi_threads::WasiThreadsCtx;
 
 #[cfg(feature = "wasi-http")]
-use wasmtime_wasi_http::WasiHttp;
+use wasmtime_wasi_http::{run_http, WasiHttp};
 
 fn parse_module(s: &OsStr) -> anyhow::Result<PathBuf> {
     // Do not accept wasmtime subcommand names as the module name
@@ -370,6 +370,17 @@ impl RunCommand {
                 // code.
                 return Err(maybe_exit_on_error(e));
             }
+        }
+
+        if self
+            .common
+            .wasi_modules
+            .unwrap_or(WasiModules::default())
+            .wasi_http_server
+        {
+            run_http(&mut linker, &mut store, |host| {
+                host.wasi_http.as_mut().unwrap()
+            });
         }
 
         Ok(())

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -372,7 +372,10 @@ impl RunCommand {
             .unwrap_or(WasiModules::default())
             .wasi_http_server
         {
+            #[cfg(feature = "wasi-http")]
             run_http(&engine, &self.module);
+            #[cfg(not(feature = "wasi-http"))]
+            panic!("Requesting HTTP server, but wasi-http feature is not enabled.");
         } else {
             // Load the main wasm module.
             match self


### PR DESCRIPTION
This builds on top of #5929 to add an implementation of http serving.

~A `server.c` example is also added.~

This is a basic implementation, but ready for feedback/review.

Known limitations:
* Single-threaded for now. It can only handle one request at a time
* Server is only on `localhost:8080` and is not currently configurable
* Memory state is not preserved between calls to the server.
* The `main` method of your HTTP serving WASM must exit before the server starts (no infinite loops)


There are some interesting questions about what we actually want `wasi-http` serving to mean revealed by this implementation. 

Specifically, three interesting questions come to mind.
* How do we want to configure the server that is started (listening host/port), currently there are no flags to `wasmtime` that are  specific to a module. I think using an `http_config.toml` file similar to what the cache settings does makes the most sense, but interested in other's thoughts.
* What is the relationship between serving and the `main`/`_start` method in the WASM module. If you request an HTTP server, should the main run? Should the server run in parallel to the main? Currently it does run the main, but it expects it to exit before the server starts up.
* Currently there's no memory persistence between calls to the request handler, static variables are re-initialized with each call. I _believe_ that this is because the `main` has exited and so the memory is recreated fresh each time. What do we expect the memory lifespan inside the module to be.

It's quite possible that some of these questions are better asked in the wasi-http spec repo rather than this implementation, happy to take the discussion there. It's related to the discussion about requests here: https://github.com/WebAssembly/wasi-http/issues/24


cc @pchickey 