### PR TITLE
Fix github-release action when the dev tag is missing

### DIFF
--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -57,13 +57,11 @@ async function runOnce() {
         console.log("ERROR: ", JSON.stringify(e.data, null, 2));
         core.info(`creating dev tag`);
         try {
-          await octokit.git.createTag({
+          await octokit.rest.git.createRef({
             owner,
             repo,
-            tag: 'dev',
-            message: 'dev release',
-            object: sha,
-            type: 'commit',
+            ref: 'refs/tags/dev',
+            sha,
           });
         } catch (e) {
           // we might race with others, so assume someone else has created the


### PR DESCRIPTION
There was a missing rest field access. In addition createTag doesn't actually create a tag, it creates a tag object. A tag object is an object which references a commit or other kind of object and has various kinds of metadata. You need to store it in a reference stored in refs/tags/ to actually show as tag in the git ui. The code to update the tag however creates a lightweight tag (which is a file in refs/tags/ which directly references a commit rather than a tag object) as such do the same when creating the initial dev tag by using createRef with a commit id as object sha.

See also https://git-scm.com/book/en/v2/Git-Internals-Git-References for the difference between a lightweight tag and an annotated tag.