### PR TITLE
riscv64: Add instruction helpers

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -875,6 +875,17 @@
   (rv_sltiu rs1 (imm12_const 1)))
 
 
+;; RV64I Base Integer Instruction Set
+;; Unlike RV32I instructions these are only present in the 64bit ISA
+
+;; Helper for emitting the `addw` ("Add Word") instruction.
+;; rd ← sext32(rs1) + sext32(rs2)
+(decl rv_addw (Reg Reg) Reg)
+(rule (rv_addw rs1 rs2)
+  (alu_rrr (AluOPRRR.Addw) rs1 rs2))
+
+
+
 
 ;; for load immediate
 (decl imm (Type u64) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -965,6 +965,11 @@
 (rule (rv_divu rs1 rs2)
   (alu_rrr (AluOPRRR.DivU) rs1 rs2))
 
+;; Helper for emitting the `rem` instruction.
+;; rd ← rs1 mod rs2
+(decl rv_rem (Reg Reg) Reg)
+(rule (rv_rem rs1 rs2)
+  (alu_rrr (AluOPRRR.Rem) rs1 rs2))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1050,6 +1050,11 @@
 (rule (rv_fmul $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulS) $F32 rs1 rs2))
 (rule (rv_fmul $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fdiv` instruction.
+(decl rv_fdiv (Type Reg Reg) Reg)
+(rule (rv_fdiv $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivS) $F32 rs1 rs2))
+(rule (rv_fdiv $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivD) $F64 rs1 rs2))
+
 
 
 
@@ -1874,18 +1879,6 @@
   (gen_atomic_store p ty src)
   (side_effect (SideEffectNoResult.Inst (MInst.AtomicStore src ty p)))
 )
-
-
-;; float arithmatic op
-(decl f_arithmatic_op (Type Opcode) FpuOPRRR)
-
-(rule
-  (f_arithmatic_op $F32 (Opcode.Fdiv))
-  (FpuOPRRR.FdivS))
-
-(rule
-  (f_arithmatic_op $F64 (Opcode.Fdiv))
-  (FpuOPRRR.FdivD))
 
 
 (decl move_f_to_x (Reg Type) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1071,6 +1071,12 @@
 (rule (rv_fsgnj $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjS) $F32 rs1 rs2))
 (rule (rv_fsgnj $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fsgnjn` ("Floating Point Sign Injection Negated") instruction.
+;; This implements the `neg` operation
+(decl rv_fsgnjn (Type Reg Reg) Reg)
+(rule (rv_fsgnjn $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnS) $F32 rs1 rs2))
+(rule (rv_fsgnjn $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnD) $F64 rs1 rs2))
+
 
 
 
@@ -1901,11 +1907,6 @@
 
 (decl move_x_to_f (Reg Type) Reg)
 (extern constructor move_x_to_f move_x_to_f)
-
-;;float copy neg sign bit op.
-(decl f_copy_neg_sign_op (Type) FpuOPRRR)
-(rule (f_copy_neg_sign_op $F32) (FpuOPRRR.FsgnjnS))
-(rule (f_copy_neg_sign_op $F64) (FpuOPRRR.FsgnjnD))
 
 (decl fabs_copy_sign (Type) FpuOPRRR)
 (rule (fabs_copy_sign $F32) (FpuOPRRR.FsgnjxS))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -971,6 +971,12 @@
 (rule (rv_rem rs1 rs2)
   (alu_rrr (AluOPRRR.Rem) rs1 rs2))
 
+;; Helper for emitting the `remu` ("Remainder Unsigned") instruction.
+;; rd ← rs1 mod rs2
+(decl rv_remu (Reg Reg) Reg)
+(rule (rv_remu rs1 rs2)
+  (alu_rrr (AluOPRRR.RemU) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1209,6 +1209,11 @@
 (rule (rv_ror rs1 rs2)
   (alu_rrr (AluOPRRR.Ror) rs1 rs2))
 
+;; Helper for emitting the `rorw` ("Rotate Right Word") instruction.
+(decl rv_rorw (Reg Reg) Reg)
+(rule (rv_rorw rs1 rs2)
+  (alu_rrr (AluOPRRR.Rorw) rs1 rs2))
+
 
 
 
@@ -1693,7 +1698,7 @@
 (rule 1
   (lower_rotr $I32 rs amount)
   (if-let $true (has_zbb))
-  (alu_rrr (AluOPRRR.Rorw) rs amount))
+  (rv_rorw rs amount))
 
 (rule
   (lower_rotr $I32 rs amount)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -902,6 +902,11 @@
 (rule (rv_slliw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Slliw) rs1 imm))
 
+;; Helper for emitting the `srlw` ("Shift Right Logical Word") instruction.
+;; rd ← sext32(uext32(rs1) >> rs2)
+(decl rv_srlw (Reg Reg) Reg)
+(rule (rv_srlw rs1 rs2)
+  (alu_rrr (AluOPRRR.Srlw) rs1 rs2))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -896,6 +896,12 @@
 (rule (rv_addw rs1 rs2)
   (alu_rrr (AluOPRRR.Addw) rs1 rs2))
 
+;; Helper for emitting the `addiw` ("Add Word Immediate") instruction.
+;; rd ← sext32(rs1) + imm
+(decl rv_addiw (Reg Imm12) Reg)
+(rule (rv_addiw rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Addiw) rs1 imm))
+
 ;; Helper for emitting the `subw` ("Subtract Word") instruction.
 ;; rd ← sext32(rs1) - sext32(rs2)
 (decl rv_subw (Reg Reg) Reg)
@@ -1336,7 +1342,7 @@
 ;; `addiw val 0`. Also known as a `sext.w`
 (rule 1 (extend val (ExtendOp.Signed) $I32 $I64)
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rr_imm12 (AluOPRRI.Addiw) val (imm12_const 0))))
+    (rv_addiw val (imm12_const 0))))
 
 
 ;; No point in trying to use `packh` here to zero extend 8 bit values

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1104,6 +1104,11 @@
 (rule (rv_flt $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FltS) $I64 rs1 rs2))
 (rule (rv_flt $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FltD) $I64 rs1 rs2))
 
+;; Helper for emitting the `fle` ("Float Less Than or Equal") instruction.
+(decl rv_fle (Type Reg Reg) Reg)
+(rule (rv_fle $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FleS) $I64 rs1 rs2))
+(rule (rv_fle $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FleD) $I64 rs1 rs2))
+
 ;; `Zba` Extension Instructions
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
@@ -2487,15 +2492,11 @@
 (decl is_not_nan (Type Reg) Reg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
-(decl fle (Type Reg Reg) Reg)
-(rule (fle $F32 a b) (fpu_rrr (FpuOPRRR.FleS) $I64 a b))
-(rule (fle $F64 a b) (fpu_rrr (FpuOPRRR.FleD) $I64 a b))
-
 (decl fgt (Type Reg Reg) Reg)
 (rule (fgt ty a b) (rv_flt ty b a))
 
 (decl fge (Type Reg Reg) Reg)
-(rule (fge ty a b) (fle ty b a))
+(rule (fge ty a b) (rv_fle ty b a))
 
 (decl ordered (Type Reg Reg) Reg)
 (rule (ordered ty a b) (rv_and (is_not_nan ty a) (is_not_nan ty b)))
@@ -2584,7 +2585,7 @@
 ;; a <= b
 (rule
   (emit_fcmp (FloatCC.LessThanOrEqual) ty a b)
-  (cmp_result (fle ty a b)))
+  (cmp_result (rv_fle ty a b)))
 
 ;; a > b
 (rule
@@ -2612,7 +2613,7 @@
 ;; == !(ordered a b && a <= b)
 (rule
   (emit_fcmp (FloatCC.UnorderedOrGreaterThan) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (fle ty a b))))
+  (cmp_result_invert (rv_and (ordered ty a b) (rv_fle ty a b))))
 
 ;; !(ordered a b) || a >= b
 ;; == !(ordered a b && a < b)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1184,6 +1184,11 @@
 (rule (rv_sextb rs1)
   (alu_rr_imm12 (AluOPRRI.Sextb) rs1 (imm12_const 0)))
 
+;; Helper for emitting the `sext.h` instruction.
+(decl rv_sexth (Reg) Reg)
+(rule (rv_sexth rs1)
+  (alu_rr_imm12 (AluOPRRI.Sexth) rs1 (imm12_const 0)))
+
 
 
 
@@ -1536,7 +1541,7 @@
 (rule 1 (extend val (ExtendOp.Signed) $I16 (fits_in_64 _))
   (if-let $true (has_zbb))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rr_imm12 (AluOPRRI.Sexth) val (imm12_const 0))))
+    (rv_sexth val)))
 
 ;; If we have the `zbb` extension we can use the dedicated `zext.h` instruction.
 (rule 2 (extend val (ExtendOp.Zero) $I16 (fits_in_64 _))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -979,6 +979,13 @@
 
 
 
+;; RV64M Extension
+
+;; Helper for emitting the `mulw` ("Multiply Word") instruction.
+;; rd ← uext32(rs1) × uext32(rs2)
+(decl rv_mulw (Reg Reg) Reg)
+(rule (rv_mulw rs1 rs2)
+  (alu_rrr (AluOPRRR.Mulw) rs1 rs2))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1066,17 +1066,25 @@
 (rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
 
 ;; Helper for emitting the `fsgnj` ("Floating Point Sign Injection") instruction.
+;; The output of this instruction is `rs1` with the sign bit from `rs2`
 ;; This implements the `copysign` operation
 (decl rv_fsgnj (Type Reg Reg) Reg)
 (rule (rv_fsgnj $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjS) $F32 rs1 rs2))
 (rule (rv_fsgnj $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fsgnjn` ("Floating Point Sign Injection Negated") instruction.
-;; This implements the `neg` operation
+;; The output of this instruction is `rs1` with the negated sign bit from `rs2`
+;; When `rs1 == rs2` this implements the `neg` operation
 (decl rv_fsgnjn (Type Reg Reg) Reg)
 (rule (rv_fsgnjn $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnS) $F32 rs1 rs2))
 (rule (rv_fsgnjn $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fsgnjx` ("Floating Point Sign Injection Exclusive") instruction.
+;; The output of this instruction is `rs1` with the XOR of the sign bits from `rs1` and `rs2`.
+;; When `rs1 == rs2` this implements `fabs`
+(decl rv_fsgnjx (Type Reg Reg) Reg)
+(rule (rv_fsgnjx $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxS) $F32 rs1 rs2))
+(rule (rv_fsgnjx $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxD) $F64 rs1 rs2))
 
 
 
@@ -1908,10 +1916,6 @@
 (decl move_x_to_f (Reg Type) Reg)
 (extern constructor move_x_to_f move_x_to_f)
 
-(decl fabs_copy_sign (Type) FpuOPRRR)
-(rule (fabs_copy_sign $F32) (FpuOPRRR.FsgnjxS))
-(rule (fabs_copy_sign $F64) (FpuOPRRR.FsgnjxD))
-
 (decl gen_stack_addr (StackSlot Offset32) Reg )
 (extern constructor gen_stack_addr gen_stack_addr)
 
@@ -2085,11 +2089,6 @@
       (high Reg (rv_sub high_tmp borrow)))
     (value_regs low high)))
 
-
-(decl gen_fabs (Reg Type) Reg)
-(rule
-  (gen_fabs x ty)
-  (fpu_rrr (fabs_copy_sign ty) ty x x))
 
 ;;; Returns the sum in the first register, and the overflow test in the second.
 (decl lower_uadd_overflow (Reg Reg Type) ValueRegs)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1060,6 +1060,11 @@
 (rule (rv_fsqrt $F32 rs1) (fpu_rr (FpuOPRR.FsqrtS) $F32 rs1))
 (rule (rv_fsqrt $F64 rs1) (fpu_rr (FpuOPRR.FsqrtD) $F64 rs1))
 
+;; Helper for emitting the `fmadd` instruction.
+(decl rv_fmadd (Type Reg Reg Reg) Reg)
+(rule (rv_fmadd $F32 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddS) $F32 rs1 rs2 rs3))
+(rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1095,6 +1095,14 @@
 (rule (rv_fsgnjx $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxD) $F64 rs1 rs2))
 
 
+;; `Zba` Extension Instructions
+
+;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
+;; rd ← uext32(rs1) + uext32(rs2)
+(decl rv_adduw (Reg Reg) Reg)
+(rule (rv_adduw rs1 rs2)
+  (alu_rrr (AluOPRRR.Adduw) rs1 rs2))
+
 
 ;; for load immediate
 (decl imm (Type u64) Reg)
@@ -1453,7 +1461,7 @@
 (rule 2 (extend val (ExtendOp.Zero) $I32 $I64)
   (if-let $true (has_zba))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rrr (AluOPRRR.Adduw) val (zero_reg))))
+    (rv_adduw val (zero_reg))))
 
 ;;; Signed rules extending to I128
 ;; Extend the bottom part, and extract the sign bit from the bottom as the top

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -999,6 +999,12 @@
 (rule (rv_divuw rs1 rs2)
   (alu_rrr (AluOPRRR.Divuw) rs1 rs2))
 
+;; Helper for emitting the `remw` ("Remainder Word") instruction.
+;; rd ← sext32(rs1) mod sext32(rs2)
+(decl rv_remw (Reg Reg) Reg)
+(rule (rv_remw rs1 rs2)
+  (alu_rrr (AluOPRRR.Remw) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1069,6 +1069,10 @@
 (decl rv_fcvtds (Reg) Reg)
 (rule (rv_fcvtds rs1) (fpu_rr (FpuOPRR.FcvtDS) $F32 rs1))
 
+;; Helper for emitting the `fcvt.s.d` ("Float Convert Single to Double") instruction.
+(decl rv_fcvtsd (Reg) Reg)
+(rule (rv_fcvtsd rs1) (fpu_rr (FpuOPRR.FcvtSD) $F64 rs1))
+
 ;; Helper for emitting the `fsgnj` ("Floating Point Sign Injection") instruction.
 ;; The output of this instruction is `rs1` with the sign bit from `rs2`
 ;; This implements the `copysign` operation

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1179,6 +1179,11 @@
 (rule (rv_max rs1 rs2)
   (alu_rrr (AluOPRRR.Max) rs1 rs2))
 
+;; Helper for emitting the `sext.b` instruction.
+(decl rv_sextb (Reg) Reg)
+(rule (rv_sextb rs1)
+  (alu_rr_imm12 (AluOPRRI.Sextb) rs1 (imm12_const 0)))
+
 
 
 
@@ -1525,7 +1530,7 @@
 (rule 1 (extend val (ExtendOp.Signed) $I8 (fits_in_64 _))
   (if-let $true (has_zbb))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rr_imm12 (AluOPRRI.Sextb) val (imm12_const 0))))
+    (rv_sextb val)))
 
 ;; If we have the `zbb` extension we can use the dedicated `sext.h` instruction.
 (rule 1 (extend val (ExtendOp.Signed) $I16 (fits_in_64 _))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1055,6 +1055,11 @@
 (rule (rv_fdiv $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivS) $F32 rs1 rs2))
 (rule (rv_fdiv $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fsqrt` instruction.
+(decl rv_fsqrt (Type Reg) Reg)
+(rule (rv_fsqrt $F32 rs1) (fpu_rr (FpuOPRR.FsqrtS) $F32 rs1))
+(rule (rv_fsqrt $F64 rs1) (fpu_rr (FpuOPRR.FsqrtD) $F64 rs1))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1241,7 +1241,10 @@
 (rule (rv_pack rs1 rs2)
   (alu_rrr (AluOPRRR.Pack) rs1 rs2))
 
-
+;; Helper for emitting the `packw` ("Pack low 16-bits of registers") instruction.
+(decl rv_packw (Reg Reg) Reg)
+(rule (rv_packw rs1 rs2)
+  (alu_rrr (AluOPRRR.Packw) rs1 rs2))
 
 
 
@@ -1553,7 +1556,7 @@
 (rule 1 (extend val (ExtendOp.Zero) $I16 (fits_in_64 _))
   (if-let $true (has_zbkb))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rrr (AluOPRRR.Packw) val (zero_reg))))
+    (rv_packw val (zero_reg))))
 
 ;; If we have the `zbkb` extension `pack` can be used to zero extend 32 bit registers
 (rule 1 (extend val (ExtendOp.Zero) $I32 $I64)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1094,6 +1094,10 @@
 (rule (rv_fsgnjx $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxS) $F32 rs1 rs2))
 (rule (rv_fsgnjx $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxD) $F64 rs1 rs2))
 
+;; Helper for emitting the `feq` ("Float Equal") instruction.
+(decl rv_feq (Type Reg Reg) Reg)
+(rule (rv_feq $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqS) $I64 rs1 rs2))
+(rule (rv_feq $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqD) $I64 rs1 rs2))
 
 ;; `Zba` Extension Instructions
 
@@ -2476,11 +2480,7 @@
 (rule (not x) (rv_xori x (imm_from_bits 1)))
 
 (decl is_not_nan (Type Reg) Reg)
-(rule (is_not_nan ty a) (feq ty a a))
-
-(decl feq (Type Reg Reg) Reg)
-(rule (feq $F32 a b) (fpu_rrr (FpuOPRRR.FeqS) $I64 a b))
-(rule (feq $F64 a b) (fpu_rrr (FpuOPRRR.FeqD) $I64 a b))
+(rule (is_not_nan ty a) (rv_feq ty a a))
 
 (decl flt (Type Reg Reg) Reg)
 (rule (flt $F32 a b) (fpu_rrr (FpuOPRRR.FltS) $I64 a b))
@@ -2557,13 +2557,13 @@
 ;; a == b
 (rule
   (emit_fcmp (FloatCC.Equal) ty a b)
-  (cmp_result (feq ty a b)))
+  (cmp_result (rv_feq ty a b)))
 
 ;; a != b
 ;; == !(a == b)
 (rule
   (emit_fcmp (FloatCC.NotEqual) ty a b)
-  (cmp_result_invert (feq ty a b)))
+  (cmp_result_invert (rv_feq ty a b)))
 
 ;; a < b || a > b
 (rule
@@ -2573,7 +2573,7 @@
 ;; !(ordered a b) || a == b
 (rule
   (emit_fcmp (FloatCC.UnorderedOrEqual) ty a b)
-  (cmp_result (rv_or (not (ordered ty a b)) (feq ty a b))))
+  (cmp_result (rv_or (not (ordered ty a b)) (rv_feq ty a b))))
 
 ;; a < b
 (rule

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1219,6 +1219,14 @@
 (rule (rv_rev8 rs1)
   (alu_rr_funct12 (AluOPRRI.Rev8) rs1))
 
+;; Helper for emitting the `brev8` ("Bit Reverse Inside Bytes") instruction.
+;; TODO: This instruction is mentioned in some older versions of the
+;; spec, but has since disappeared, we should follow up on this.
+;; It probably was renamed to `rev.b` which seems to be the closest match.
+(decl rv_brev8 (Reg) Reg)
+(rule (rv_brev8 rs1)
+  (alu_rr_funct12 (AluOPRRI.Brev8) rs1))
+
 
 
 
@@ -2370,7 +2378,7 @@
 (rule 1
   (gen_brev8 rs _)
   (if-let $true (has_zbkb))
-  (alu_rr_funct12 (AluOPRRI.Brev8) rs))
+  (rv_brev8 rs))
 (rule
   (gen_brev8 rs ty)
   (if-let $false (has_zbkb))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1065,6 +1065,11 @@
 (rule (rv_fmadd $F32 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddS) $F32 rs1 rs2 rs3))
 (rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
 
+;; Helper for emitting the `fsgnj` ("Floating Point Sign Injection") instruction.
+;; This implements the `copysign` operation
+(decl rv_fsgnj (Type Reg Reg) Reg)
+(rule (rv_fsgnj $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjS) $F32 rs1 rs2))
+(rule (rv_fsgnj $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjD) $F64 rs1 rs2))
 
 
 
@@ -1896,12 +1901,6 @@
 
 (decl move_x_to_f (Reg Type) Reg)
 (extern constructor move_x_to_f move_x_to_f)
-
-
-;;float copy sign bit op.
-(decl f_copysign_op (Type) FpuOPRRR)
-(rule (f_copysign_op $F32) (FpuOPRRR.FsgnjS))
-(rule (f_copysign_op $F64) (FpuOPRRR.FsgnjD))
 
 ;;float copy neg sign bit op.
 (decl f_copy_neg_sign_op (Type) FpuOPRRR)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1189,6 +1189,11 @@
 (rule (rv_sexth rs1)
   (alu_rr_imm12 (AluOPRRI.Sexth) rs1 (imm12_const 0)))
 
+;; Helper for emitting the `zext.h` instruction.
+(decl rv_zexth (Reg) Reg)
+(rule (rv_zexth rs1)
+  (alu_rr_imm12 (AluOPRRI.Zexth) rs1 (imm12_const 0)))
+
 
 
 
@@ -1547,7 +1552,7 @@
 (rule 2 (extend val (ExtendOp.Zero) $I16 (fits_in_64 _))
   (if-let $true (has_zbb))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rr_imm12 (AluOPRRI.Zexth) val (imm12_const 0))))
+    (rv_zexth val)))
 
 ;; With `zba` we have a `zext.w` instruction
 (rule 2 (extend val (ExtendOp.Zero) $I32 $I64)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -914,6 +914,11 @@
 (rule (rv_srliw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.SrliW) rs1 imm))
 
+;; Helper for emitting the `sraw` ("Shift Right Arithmetic Word") instruction.
+;; rd ← sext32(rs1 >> rs2)
+(decl rv_sraw (Reg Reg) Reg)
+(rule (rv_sraw rs1 rs2)
+  (alu_rrr (AluOPRRR.Sraw) rs1 rs2))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1111,6 +1111,16 @@
   (rv_adduw rs1 (zero_reg)))
 
 
+;; `Zbb` Extension Instructions
+
+;; Helper for emitting the `andn` ("And Negated") instruction.
+;; rd ← rs1 ∧ ~(rs2)
+(decl rv_andn (Reg Reg) Reg)
+(rule (rv_andn rs1 rs2)
+  (alu_rrr (AluOPRRR.Andn) rs1 rs2))
+
+
+
 
 
 
@@ -2238,11 +2248,6 @@
 
 (decl load_ra () Reg)
 (extern constructor load_ra load_ra)
-
-;;;
-(decl gen_andn (Reg Reg) Reg)
-(rule 1 (gen_andn rs1 rs2)
-  (alu_rrr (AluOPRRR.Andn) rs1 rs2))
 
 ;;;
 (decl gen_orn (Reg Reg) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1103,6 +1103,18 @@
 (rule (rv_adduw rs1 rs2)
   (alu_rrr (AluOPRRR.Adduw) rs1 rs2))
 
+;; Helper for emitting the `zext.w` ("Zero Extend Word") instruction.
+;; This instruction is a mnemonic for `adduw rd, rs1, zero`.
+;; rd ← uext32(rs1)
+(decl rv_zextw (Reg) Reg)
+(rule (rv_zextw rs1)
+  (rv_adduw rs1 (zero_reg)))
+
+
+
+
+
+
 
 ;; for load immediate
 (decl imm (Type u64) Reg)
@@ -1461,7 +1473,7 @@
 (rule 2 (extend val (ExtendOp.Zero) $I32 $I64)
   (if-let $true (has_zba))
   (let ((val Reg (value_regs_get val 0)))
-    (rv_adduw val (zero_reg))))
+    (rv_zextw val)))
 
 ;;; Signed rules extending to I128
 ;; Extend the bottom part, and extract the sign bit from the bottom as the top

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1204,6 +1204,11 @@
 (rule (rv_rolw rs1 rs2)
   (alu_rrr (AluOPRRR.Rolw) rs1 rs2))
 
+;; Helper for emitting the `ror` ("Rotate Right") instruction.
+(decl rv_ror (Reg Reg) Reg)
+(rule (rv_ror rs1 rs2)
+  (alu_rrr (AluOPRRR.Ror) rs1 rs2))
+
 
 
 
@@ -1679,7 +1684,7 @@
 (rule 1
   (lower_rotr $I64 rs amount)
   (if-let $true (has_zbb))
-  (alu_rrr (AluOPRRR.Ror) rs amount))
+  (rv_ror rs amount))
 (rule
   (lower_rotr $I64 rs amount)
   (if-let $false (has_zbb))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -933,6 +933,13 @@
   (alu_rr_imm12 (AluOPRRI.Sraiw) rs1 imm))
 
 
+;; RV32M Extension
+
+;; Helper for emitting the `mul` instruction.
+;; rd ← rs1 × rs2
+(decl rv_mul (Reg Reg) Reg)
+(rule (rv_mul rs1 rs2)
+  (alu_rrr (AluOPRRR.Mul) rs1 rs2))
 
 
 
@@ -1337,7 +1344,7 @@
 (rule
   (lower_umlhi ty rs1 rs2)
   (let
-    ((tmp Reg (alu_rrr (AluOPRRR.Mul) (ext_int_if_need $false rs1 ty) (ext_int_if_need $false rs2 ty))))
+    ((tmp Reg (rv_mul (ext_int_if_need $false rs1 ty) (ext_int_if_need $false rs2 ty))))
     (rv_srli tmp (imm12_const (ty_bits ty)))))
 
 (decl lower_smlhi (Type Reg Reg) Reg)
@@ -1348,7 +1355,7 @@
 (rule
   (lower_smlhi ty rs1 rs2)
   (let
-    ((tmp Reg (alu_rrr (AluOPRRR.Mul) rs1 rs2)))
+    ((tmp Reg (rv_mul rs1 rs2)))
     (rv_srli tmp (imm12_const (ty_bits ty)))))
 
 
@@ -2237,7 +2244,7 @@
 (rule
   (madd n m a)
   (let
-    ((t Reg (alu_rrr (AluOPRRR.Mul) n m)))
+    ((t Reg (rv_mul n m)))
     (rv_add t a)))
 
 (decl umulh (Reg Reg) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -987,6 +987,12 @@
 (rule (rv_mulw rs1 rs2)
   (alu_rrr (AluOPRRR.Mulw) rs1 rs2))
 
+;; Helper for emitting the `divw` ("Divide Word") instruction.
+;; rd ← sext32(rs1) ÷ sext32(rs2)
+(decl rv_divw (Reg Reg) Reg)
+(rule (rv_divw rs1 rs2)
+  (alu_rrr (AluOPRRR.Divw) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -941,6 +941,12 @@
 (rule (rv_mul rs1 rs2)
   (alu_rrr (AluOPRRR.Mul) rs1 rs2))
 
+;; Helper for emitting the `mulh` ("Multiply High Signed Signed") instruction.
+;; rd ← (sext(rs1) × sext(rs2)) » xlen
+(decl rv_mulh (Reg Reg) Reg)
+(rule (rv_mulh rs1 rs2)
+  (alu_rrr (AluOPRRR.Mulh) rs1 rs2))
+
 
 
 
@@ -1350,7 +1356,7 @@
 (decl lower_smlhi (Type Reg Reg) Reg)
 (rule 1
   (lower_smlhi $I64 rs1 rs2)
-  (alu_rrr (AluOPRRR.Mulh) rs1 rs2))
+  (rv_mulh rs1 rs2))
 
 (rule
   (lower_smlhi ty rs1 rs2)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1045,6 +1045,11 @@
 (rule (rv_fsub $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubS) $F32 rs1 rs2))
 (rule (rv_fsub $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fmul` instruction.
+(decl rv_fmul (Type Reg Reg) Reg)
+(rule (rv_fmul $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulS) $F32 rs1 rs2))
+(rule (rv_fmul $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulD) $F64 rs1 rs2))
+
 
 
 
@@ -1873,13 +1878,6 @@
 
 ;; float arithmatic op
 (decl f_arithmatic_op (Type Opcode) FpuOPRRR)
-(rule
-  (f_arithmatic_op $F32 (Opcode.Fmul))
-  (FpuOPRRR.FmulS))
-
-(rule
-  (f_arithmatic_op $F64 (Opcode.Fmul))
-  (FpuOPRRR.FmulD))
 
 (rule
   (f_arithmatic_op $F32 (Opcode.Fdiv))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -862,8 +862,14 @@
 (rule (rv_andi rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Andi) rs1 imm))
 
+;; Helper for emitting the `sltu` ("Set Less Than Unsigned") instruction.
+;; rd ← rs1 < rs2
+(decl rv_sltu (Reg Reg) Reg)
+(rule (rv_sltu rs1 rs2)
+  (alu_rrr (AluOPRRR.SltU) rs1 rs2))
+
 ;; Helper for emiting the `sltiu` ("Set Less Than Immediate Unsigned") instruction.
-;; rd ← rs1 < ux(imm)
+;; rd ← rs1 < imm
 (decl rv_sltiu (Reg Imm12) Reg)
 (rule (rv_sltiu rs1 imm)
   (alu_rr_imm12 (AluOPRRI.SltiU) rs1 imm))
@@ -1976,7 +1982,7 @@
     (;; low part.
       (low Reg (rv_sub (value_regs_get x 0) (value_regs_get y 0)))
       ;; compute borrow.
-      (borrow Reg (alu_rrr (AluOPRRR.SltU) (value_regs_get x 0) low))
+      (borrow Reg (rv_sltu (value_regs_get x 0) low))
       ;;
       (high_tmp Reg (rv_sub (value_regs_get x 1) (value_regs_get y 1)))
       ;;

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -920,6 +920,12 @@
 (rule (rv_sraw rs1 rs2)
   (alu_rrr (AluOPRRR.Sraw) rs1 rs2))
 
+;; Helper for emitting the `sraiw` ("Shift Right Arithmetic Immediate Word") instruction.
+;; rd ← sext32(rs1 >> imm)
+(decl rv_sraiw (Reg Imm12) Reg)
+(rule (rv_sraiw rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Sraiw) rs1 imm))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1114,6 +1114,11 @@
 (decl rv_fgt (Type Reg Reg) Reg)
 (rule (rv_fgt ty rs1 rs2) (rv_flt ty rs2 rs1))
 
+;; Helper for emitting the `fge` ("Float Greater Than or Equal") instruction.
+;; Note: The arguments are reversed
+(decl rv_fge (Type Reg Reg) Reg)
+(rule (rv_fge ty rs1 rs2) (rv_fle ty rs2 rs1))
+
 ;; `Zba` Extension Instructions
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
@@ -2497,9 +2502,6 @@
 (decl is_not_nan (Type Reg) Reg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
-(decl fge (Type Reg Reg) Reg)
-(rule (fge ty a b) (rv_fle ty b a))
-
 (decl ordered (Type Reg Reg) Reg)
 (rule (ordered ty a b) (rv_and (is_not_nan ty a) (is_not_nan ty b)))
 
@@ -2597,13 +2599,13 @@
 ;; a >= b
 (rule
   (emit_fcmp (FloatCC.GreaterThanOrEqual) ty a b)
-  (cmp_result (fge ty a b)))
+  (cmp_result (rv_fge ty a b)))
 
 ;; !(ordered a b) || a < b
 ;; == !(ordered a b && a >= b)
 (rule
   (emit_fcmp (FloatCC.UnorderedOrLessThan) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (fge ty a b))))
+  (cmp_result_invert (rv_and (ordered ty a b) (rv_fge ty a b))))
 
 ;; !(ordered a b) || a <= b
 ;; == !(ordered a b && a > b)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -890,6 +890,21 @@
 (rule (rv_subw rs1 rs2)
   (alu_rrr (AluOPRRR.Subw) rs1 rs2))
 
+;; Helper for emitting the `sllw` ("Shift Left Logical Word") instruction.
+;; rd ← sext32(uext32(rs1) << rs2)
+(decl rv_sllw (Reg Reg) Reg)
+(rule (rv_sllw rs1 rs2)
+  (alu_rrr (AluOPRRR.Sllw) rs1 rs2))
+
+
+
+
+
+
+
+
+
+
 
 ;; for load immediate
 (decl imm (Type u64) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1194,6 +1194,11 @@
 (rule (rv_zexth rs1)
   (alu_rr_imm12 (AluOPRRI.Zexth) rs1 (imm12_const 0)))
 
+;; Helper for emitting the `rol` ("Rotate Left") instruction.
+(decl rv_rol (Reg Reg) Reg)
+(rule (rv_rol rs1 rs2)
+  (alu_rrr (AluOPRRR.Rol) rs1 rs2))
+
 
 
 
@@ -1619,7 +1624,7 @@
 (rule 1
   (lower_rotl $I64 rs amount)
   (if-let $true (has_zbb))
-  (alu_rrr (AluOPRRR.Rol) rs amount))
+  (rv_rol rs amount))
 
 (rule
   (lower_rotl $I64 rs amount)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1109,6 +1109,11 @@
 (rule (rv_fle $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FleS) $I64 rs1 rs2))
 (rule (rv_fle $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FleD) $I64 rs1 rs2))
 
+;; Helper for emitting the `fgt` ("Float Greater Than") instruction.
+;; Note: The arguments are reversed
+(decl rv_fgt (Type Reg Reg) Reg)
+(rule (rv_fgt ty rs1 rs2) (rv_flt ty rs2 rs1))
+
 ;; `Zba` Extension Instructions
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
@@ -2492,9 +2497,6 @@
 (decl is_not_nan (Type Reg) Reg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
-(decl fgt (Type Reg Reg) Reg)
-(rule (fgt ty a b) (rv_flt ty b a))
-
 (decl fge (Type Reg Reg) Reg)
 (rule (fge ty a b) (rv_fle ty b a))
 
@@ -2570,7 +2572,7 @@
 ;; a < b || a > b
 (rule
   (emit_fcmp (FloatCC.OrderedNotEqual) ty a b)
-  (cmp_result (rv_or (rv_flt ty a b) (fgt ty a b))))
+  (cmp_result (rv_or (rv_flt ty a b) (rv_fgt ty a b))))
 
 ;; !(ordered a b) || a == b
 (rule
@@ -2590,7 +2592,7 @@
 ;; a > b
 (rule
   (emit_fcmp (FloatCC.GreaterThan) ty a b)
-  (cmp_result (fgt ty a b)))
+  (cmp_result (rv_fgt ty a b)))
 
 ;; a >= b
 (rule
@@ -2607,7 +2609,7 @@
 ;; == !(ordered a b && a > b)
 (rule
   (emit_fcmp (FloatCC.UnorderedOrLessThanOrEqual) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (fgt ty a b))))
+  (cmp_result_invert (rv_and (ordered ty a b) (rv_fgt ty a b))))
 
 ;; !(ordered a b) || a > b
 ;; == !(ordered a b && a <= b)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1227,7 +1227,10 @@
 (rule (rv_brev8 rs1)
   (alu_rr_funct12 (AluOPRRI.Brev8) rs1))
 
-
+;; Helper for emitting the `bseti` ("Single-Bit Set Immediate") instruction.
+(decl rv_bseti (Reg Imm12) Reg)
+(rule (rv_bseti rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
 
 
 
@@ -1281,25 +1284,6 @@
 (decl imm12_from_u64 (Imm12) u64)
 (extern extractor imm12_from_u64 imm12_from_u64)
 
-
-
-
-;; bseti: Set a single bit in a register, indexed by a constant.
-(decl bseti (Reg u64) Reg)
-(rule (bseti val bit)
-  (if-let $false (has_zbs))
-  (if-let $false (u64_le bit 12))
-  (let ((const Reg (load_u64_constant (u64_shl 1 bit))))
-    (rv_or val const)))
-
-(rule (bseti val bit)
-  (if-let $false (has_zbs))
-  (if-let $true (u64_le bit 12))
-  (rv_ori val (imm12_const (u64_as_i32 (u64_shl 1 bit)))))
-
-(rule (bseti val bit)
-  (if-let $true (has_zbs))
-  (alu_rr_imm12 (AluOPRRI.Bseti) val (imm12_const (u64_as_i32 bit))))
 
 
 ;; Float Helpers
@@ -1406,7 +1390,7 @@
 
 (rule 1 (lower_ctz (fits_in_16 ty) x)
   (if-let $true (has_zbb))
-  (let ((tmp Reg (bseti x (ty_bits ty))))
+  (let ((tmp Reg (gen_bseti x (ty_bits ty))))
     (rv_ctzw tmp)))
 
 (rule 2 (lower_ctz $I32 x)
@@ -1738,6 +1722,25 @@
       ;;
       (part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) part2)))
     (rv_or part1 part3)))
+
+
+
+;; bseti: Set a single bit in a register, indexed by a constant.
+(decl gen_bseti (Reg u64) Reg)
+(rule (gen_bseti val bit)
+  (if-let $false (has_zbs))
+  (if-let $false (u64_le bit 12))
+  (let ((const Reg (load_u64_constant (u64_shl 1 bit))))
+    (rv_or val const)))
+
+(rule (gen_bseti val bit)
+  (if-let $false (has_zbs))
+  (if-let $true (u64_le bit 12))
+  (rv_ori val (imm12_const (u64_as_i32 (u64_shl 1 bit)))))
+
+(rule (gen_bseti val bit)
+  (if-let $true (has_zbs))
+  (rv_bseti val (imm12_const (u64_as_i32 bit))))
 
 
 (decl gen_popcnt (Reg Type) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1094,6 +1094,11 @@
 (rule (rv_fsgnjx $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxS) $F32 rs1 rs2))
 (rule (rv_fsgnjx $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fabs` ("Floating Point Absolute") instruction.
+;; This instruction is a mnemonic for `fsgnjx rd, rs1, rs1`
+(decl rv_fabs (Type Reg) Reg)
+(rule (rv_fabs ty rs1) (rv_fsgnjx ty rs1 rs1))
+
 ;; Helper for emitting the `feq` ("Float Equal") instruction.
 (decl rv_feq (Type Reg Reg) Reg)
 (rule (rv_feq $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqS) $I64 rs1 rs2))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1099,6 +1099,11 @@
 (rule (rv_feq $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqS) $I64 rs1 rs2))
 (rule (rv_feq $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqD) $I64 rs1 rs2))
 
+;; Helper for emitting the `flt` ("Float Less Than") instruction.
+(decl rv_flt (Type Reg Reg) Reg)
+(rule (rv_flt $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FltS) $I64 rs1 rs2))
+(rule (rv_flt $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FltD) $I64 rs1 rs2))
+
 ;; `Zba` Extension Instructions
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
@@ -2482,16 +2487,12 @@
 (decl is_not_nan (Type Reg) Reg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
-(decl flt (Type Reg Reg) Reg)
-(rule (flt $F32 a b) (fpu_rrr (FpuOPRRR.FltS) $I64 a b))
-(rule (flt $F64 a b) (fpu_rrr (FpuOPRRR.FltD) $I64 a b))
-
 (decl fle (Type Reg Reg) Reg)
 (rule (fle $F32 a b) (fpu_rrr (FpuOPRRR.FleS) $I64 a b))
 (rule (fle $F64 a b) (fpu_rrr (FpuOPRRR.FleD) $I64 a b))
 
 (decl fgt (Type Reg Reg) Reg)
-(rule (fgt ty a b) (flt ty b a))
+(rule (fgt ty a b) (rv_flt ty b a))
 
 (decl fge (Type Reg Reg) Reg)
 (rule (fge ty a b) (fle ty b a))
@@ -2568,7 +2569,7 @@
 ;; a < b || a > b
 (rule
   (emit_fcmp (FloatCC.OrderedNotEqual) ty a b)
-  (cmp_result (rv_or (flt ty a b) (fgt ty a b))))
+  (cmp_result (rv_or (rv_flt ty a b) (fgt ty a b))))
 
 ;; !(ordered a b) || a == b
 (rule
@@ -2578,7 +2579,7 @@
 ;; a < b
 (rule
   (emit_fcmp (FloatCC.LessThan) ty a b)
-  (cmp_result (flt ty a b)))
+  (cmp_result (rv_flt ty a b)))
 
 ;; a <= b
 (rule
@@ -2617,4 +2618,4 @@
 ;; == !(ordered a b && a < b)
 (rule
   (emit_fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (flt ty a b))))
+  (cmp_result_invert (rv_and (ordered ty a b) (rv_flt ty a b))))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -959,6 +959,12 @@
 (rule (rv_div rs1 rs2)
   (alu_rrr (AluOPRRR.Div) rs1 rs2))
 
+;; Helper for emitting the `divu` ("Divide Unsigned") instruction.
+;; rd ← rs1 ÷ rs2
+(decl rv_divu (Reg Reg) Reg)
+(rule (rv_divu rs1 rs2)
+  (alu_rrr (AluOPRRR.DivU) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1119,6 +1119,7 @@
 (decl rv_fge (Type Reg Reg) Reg)
 (rule (rv_fge ty rs1 rs2) (rv_fle ty rs2 rs1))
 
+
 ;; `Zba` Extension Instructions
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
@@ -1231,6 +1232,14 @@
 (decl rv_bseti (Reg Imm12) Reg)
 (rule (rv_bseti rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
+
+
+;; `Zbkb` Extension Instructions
+
+;; Helper for emitting the `pack` ("Pack low halves of registers") instruction.
+(decl rv_pack (Reg Reg) Reg)
+(rule (rv_pack rs1 rs2)
+  (alu_rrr (AluOPRRR.Pack) rs1 rs2))
 
 
 
@@ -1550,7 +1559,7 @@
 (rule 1 (extend val (ExtendOp.Zero) $I32 $I64)
   (if-let $true (has_zbkb))
   (let ((val Reg (value_regs_get val 0)))
-    (alu_rrr (AluOPRRR.Pack) val (zero_reg))))
+    (rv_pack val (zero_reg))))
 
 
 ;; If we have the `zbb` extension we can use the dedicated `sext.b` instruction.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -993,6 +993,12 @@
 (rule (rv_divw rs1 rs2)
   (alu_rrr (AluOPRRR.Divw) rs1 rs2))
 
+;; Helper for emitting the `divuw` ("Divide Unsigned Word") instruction.
+;; rd ← uext32(rs1) ÷ uext32(rs2)
+(decl rv_divuw (Reg Reg) Reg)
+(rule (rv_divuw rs1 rs2)
+  (alu_rrr (AluOPRRR.Divuw) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -784,6 +784,12 @@
 (rule (rv_sub rs1 rs2)
   (alu_rrr (AluOPRRR.Sub) rs1 rs2))
 
+;; Helper for emitting the `neg` instruction.
+;; This instruction is a mnemonic for `sub rd, zero, rs1`.
+(decl rv_neg (Reg) Reg)
+(rule (rv_neg rs1)
+  (alu_rrr (AluOPRRR.Sub) (zero_reg) rs1))
+
 ;; Helper for emitting the `sll` ("Shift Left Logical") instruction.
 ;; rd ← rs1 << rs2
 (decl rv_sll (Reg Reg) Reg)
@@ -2239,7 +2245,7 @@
 (decl neg (Type ValueRegs) ValueRegs)
 (rule 1 (neg (fits_in_64 (ty_int ty)) val)
   (value_reg
-    (rv_sub (zero_reg) (value_regs_get val 0))))
+    (rv_neg (value_regs_get val 0))))
 
 (rule 2 (neg $I128 val)
   (i128_sub (value_regs_zero) val))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1119,6 +1119,12 @@
 (rule (rv_andn rs1 rs2)
   (alu_rrr (AluOPRRR.Andn) rs1 rs2))
 
+;; Helper for emitting the `orn` ("Or Negated") instruction.
+;; rd ← rs1 ∨ ~(rs2)
+(decl rv_orn (Reg Reg) Reg)
+(rule (rv_orn rs1 rs2)
+  (alu_rrr (AluOPRRR.Orn) rs1 rs2))
+
 
 
 
@@ -2248,11 +2254,6 @@
 
 (decl load_ra () Reg)
 (extern constructor load_ra load_ra)
-
-;;;
-(decl gen_orn (Reg Reg) Reg)
-(rule 1 (gen_orn rs1 rs2)
-  (alu_rrr (AluOPRRR.Orn) rs1 rs2))
 
 (decl gen_rev8 (Reg) Reg)
 (rule 1

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1150,6 +1150,13 @@
 (rule (rv_cpop rs1)
   (alu_rr_funct12 (AluOPRRI.Cpop) rs1))
 
+;; Helper for emitting the `max` instruction.
+(decl rv_max (Reg Reg) Reg)
+(rule (rv_max rs1 rs2)
+  (alu_rrr (AluOPRRR.Max) rs1 rs2))
+
+
+
 
 
 
@@ -2326,7 +2333,7 @@
 (decl max (Type Reg Reg) Reg)
 (rule (max (fits_in_64 (ty_int ty)) x y)
   (if-let $true (has_zbb))
-  (alu_rrr (AluOPRRR.Max) x y))
+  (rv_max x y))
 
 (rule (max (fits_in_64 (ty_int ty)) x y)
   (if-let $false (has_zbb))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1135,6 +1135,12 @@
 (rule (rv_zextw rs1)
   (rv_adduw rs1 (zero_reg)))
 
+;; Helper for emitting the `slli.uw` ("Shift Left Logical Immediate Unsigned Word") instruction.
+;; rd ← uext32(rs1) << imm
+(decl rv_slliuw (Reg Imm12) Reg)
+(rule (rv_slliuw rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.SlliUw) rs1 imm))
+
 
 ;; `Zbb` Extension Instructions
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -952,6 +952,7 @@
 
 
 ;; RV32M Extension
+;; TODO: Enable these instructions only when we have the M extension
 
 ;; Helper for emitting the `mul` instruction.
 ;; rd ← rs1 × rs2
@@ -998,6 +999,7 @@
 
 
 ;; RV64M Extension
+;; TODO: Enable these instructions only when we have the M extension
 
 ;; Helper for emitting the `mulw` ("Multiply Word") instruction.
 ;; rd ← uext32(rs1) × uext32(rs2)
@@ -1028,6 +1030,16 @@
 (decl rv_remuw (Reg Reg) Reg)
 (rule (rv_remuw rs1 rs2)
   (alu_rrr (AluOPRRR.Remuw) rs1 rs2))
+
+
+;; F and D Extensions
+;; TODO: Enable these instructions only when we have the F or D extensions
+
+;; Helper for emitting the `fadd` instruction.
+(decl rv_fadd (Type Reg Reg) Reg)
+(rule (rv_fadd $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddS) $F32 rs1 rs2))
+(rule (rv_fadd $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddD) $F64 rs1 rs2))
+
 
 
 
@@ -1856,14 +1868,6 @@
 
 ;; float arithmatic op
 (decl f_arithmatic_op (Type Opcode) FpuOPRRR)
-(rule
-  (f_arithmatic_op $F32 (Opcode.Fadd))
-  (FpuOPRRR.FaddS))
-
-(rule
-  (f_arithmatic_op $F64 (Opcode.Fadd))
-  (FpuOPRRR.FaddD))
-
 (rule
   (f_arithmatic_op $F32 (Opcode.Fsub))
   (FpuOPRRR.FsubS))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1199,6 +1199,11 @@
 (rule (rv_rol rs1 rs2)
   (alu_rrr (AluOPRRR.Rol) rs1 rs2))
 
+;; Helper for emitting the `rolw` ("Rotate Left Word") instruction.
+(decl rv_rolw (Reg Reg) Reg)
+(rule (rv_rolw rs1 rs2)
+  (alu_rrr (AluOPRRR.Rolw) rs1 rs2))
+
 
 
 
@@ -1634,7 +1639,7 @@
 (rule 1
   (lower_rotl $I32 rs amount)
   (if-let $true (has_zbb))
-  (alu_rrr (AluOPRRR.Rolw) rs amount))
+  (rv_rolw rs amount))
 
 (rule
   (lower_rotl $I32 rs amount)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1040,6 +1040,11 @@
 (rule (rv_fadd $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddS) $F32 rs1 rs2))
 (rule (rv_fadd $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fsub` instruction.
+(decl rv_fsub (Type Reg Reg) Reg)
+(rule (rv_fsub $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubS) $F32 rs1 rs2))
+(rule (rv_fsub $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubD) $F64 rs1 rs2))
+
 
 
 
@@ -1868,13 +1873,6 @@
 
 ;; float arithmatic op
 (decl f_arithmatic_op (Type Opcode) FpuOPRRR)
-(rule
-  (f_arithmatic_op $F32 (Opcode.Fsub))
-  (FpuOPRRR.FsubS))
-(rule
-  (f_arithmatic_op $F64 (Opcode.Fsub))
-  (FpuOPRRR.FsubD))
-
 (rule
   (f_arithmatic_op $F32 (Opcode.Fmul))
   (FpuOPRRR.FmulS))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1125,6 +1125,11 @@
 (rule (rv_orn rs1 rs2)
   (alu_rrr (AluOPRRR.Orn) rs1 rs2))
 
+;; Helper for emitting the `clz` ("Count Leading Zero Bits") instruction.
+(decl rv_clz (Reg) Reg)
+(rule (rv_clz rs1)
+  (alu_rr_funct12 (AluOPRRI.Clz) rs1))
+
 
 
 
@@ -1336,7 +1341,7 @@
 (rule 1 (lower_clz (fits_in_16 ty) r)
   (if-let $true (has_zbb))
   (let ((tmp Reg (zext r ty $I64))
-        (count Reg (alu_rr_funct12 (AluOPRRI.Clz) tmp))
+        (count Reg (rv_clz tmp))
         ;; We always do the operation on the full 64-bit register, so subtract 64 from the result.
         (result Reg (rv_addi count (imm12_const_add (ty_bits ty) -64))))
     result))
@@ -1347,7 +1352,7 @@
 
 (rule 2 (lower_clz $I64 r)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Clz) r))
+  (rv_clz r))
 
 
 ;; Count leading zeros from a i128 bit value.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -908,6 +908,12 @@
 (rule (rv_srlw rs1 rs2)
   (alu_rrr (AluOPRRR.Srlw) rs1 rs2))
 
+;; Helper for emitting the `srliw` ("Shift Right Logical Immediate Word") instruction.
+;; rd ← sext32(uext32(rs1) >> imm)
+(decl rv_srliw (Reg Imm12) Reg)
+(rule (rv_srliw rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.SrliW) rs1 imm))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -902,6 +902,12 @@
 (rule (rv_addiw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Addiw) rs1 imm))
 
+;; Helper for emitting the `sext.w` ("Sign Extend Word") instruction.
+;; This instruction is a mnemonic for `addiw rd, rs, zero`.
+(decl rv_sextw (Reg) Reg)
+(rule (rv_sextw rs1)
+  (rv_addiw rs1 (imm12_const 0)))
+
 ;; Helper for emitting the `subw` ("Subtract Word") instruction.
 ;; rd ← sext32(rs1) - sext32(rs2)
 (decl rv_subw (Reg Reg) Reg)
@@ -1342,7 +1348,7 @@
 ;; `addiw val 0`. Also known as a `sext.w`
 (rule 1 (extend val (ExtendOp.Signed) $I32 $I64)
   (let ((val Reg (value_regs_get val 0)))
-    (rv_addiw val (imm12_const 0))))
+    (rv_sextw val)))
 
 
 ;; No point in trying to use `packh` here to zero extend 8 bit values

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -953,6 +953,12 @@
 (rule (rv_mulhu rs1 rs2)
   (alu_rrr (AluOPRRR.Mulhu) rs1 rs2))
 
+;; Helper for emitting the `div` instruction.
+;; rd ← rs1 ÷ rs2
+(decl rv_div (Reg Reg) Reg)
+(rule (rv_div rs1 rs2)
+  (alu_rrr (AluOPRRR.Div) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -884,7 +884,11 @@
 (rule (rv_addw rs1 rs2)
   (alu_rrr (AluOPRRR.Addw) rs1 rs2))
 
-
+;; Helper for emitting the `subw` ("Subtract Word") instruction.
+;; rd ← sext32(rs1) - sext32(rs2)
+(decl rv_subw (Reg Reg) Reg)
+(rule (rv_subw rs1 rs2)
+  (alu_rrr (AluOPRRR.Subw) rs1 rs2))
 
 
 ;; for load immediate

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1136,6 +1136,11 @@
   (alu_rr_funct12 (AluOPRRI.Clzw) rs1))
 
 
+;; Helper for emitting the `ctz` ("Count Trailing Zero Bits") instruction.
+(decl rv_ctz (Reg) Reg)
+(rule (rv_ctz rs1)
+  (alu_rr_funct12 (AluOPRRI.Ctz) rs1))
+
 
 
 
@@ -1323,7 +1328,7 @@
 
 (rule 2 (lower_ctz $I64 x)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Ctz) x))
+  (rv_ctz x))
 
 ;; Count trailing zeros from a i128 bit value.
 ;; We count both halves separately and conditionally add them if it makes sense.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1087,6 +1087,11 @@
 (rule (rv_fsgnjn $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnS) $F32 rs1 rs2))
 (rule (rv_fsgnjn $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnD) $F64 rs1 rs2))
 
+;; Helper for emitting the `fneg` ("Floating Point Negate") instruction.
+;; This instruction is a mnemonic for `fsgnjn rd, rs1, rs1`
+(decl rv_fneg (Type Reg) Reg)
+(rule (rv_fneg ty rs1) (rv_fsgnjn ty rs1 rs1))
+
 ;; Helper for emitting the `fsgnjx` ("Floating Point Sign Injection Exclusive") instruction.
 ;; The output of this instruction is `rs1` with the XOR of the sign bits from `rs1` and `rs2`.
 ;; When `rs1 == rs2` this implements `fabs`

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1135,11 +1135,15 @@
 (rule (rv_clzw rs1)
   (alu_rr_funct12 (AluOPRRI.Clzw) rs1))
 
-
 ;; Helper for emitting the `ctz` ("Count Trailing Zero Bits") instruction.
 (decl rv_ctz (Reg) Reg)
 (rule (rv_ctz rs1)
   (alu_rr_funct12 (AluOPRRI.Ctz) rs1))
+
+;; Helper for emitting the `ctzw` ("Count Trailing Zero Bits in Word") instruction.
+(decl rv_ctzw (Reg) Reg)
+(rule (rv_ctzw rs1)
+  (alu_rr_funct12 (AluOPRRI.Ctzw) rs1))
 
 
 
@@ -1320,11 +1324,11 @@
 (rule 1 (lower_ctz (fits_in_16 ty) x)
   (if-let $true (has_zbb))
   (let ((tmp Reg (bseti x (ty_bits ty))))
-    (alu_rr_funct12 (AluOPRRI.Ctzw) tmp)))
+    (rv_ctzw tmp)))
 
 (rule 2 (lower_ctz $I32 x)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Ctzw) x))
+  (rv_ctzw x))
 
 (rule 2 (lower_ctz $I64 x)
   (if-let $true (has_zbb))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1005,6 +1005,12 @@
 (rule (rv_remw rs1 rs2)
   (alu_rrr (AluOPRRR.Remw) rs1 rs2))
 
+;; Helper for emitting the `remuw` ("Remainder Unsigned Word") instruction.
+;; rd ← uext32(rs1) mod uext32(rs2)
+(decl rv_remuw (Reg Reg) Reg)
+(rule (rv_remuw rs1 rs2)
+  (alu_rrr (AluOPRRR.Remuw) rs1 rs2))
+
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1065,6 +1065,10 @@
 (rule (rv_fmadd $F32 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddS) $F32 rs1 rs2 rs3))
 (rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
 
+;; Helper for emitting the `fcvt.d.s` ("Float Convert Double to Single") instruction.
+(decl rv_fcvtds (Reg) Reg)
+(rule (rv_fcvtds rs1) (fpu_rr (FpuOPRR.FcvtDS) $F32 rs1))
+
 ;; Helper for emitting the `fsgnj` ("Floating Point Sign Injection") instruction.
 ;; The output of this instruction is `rs1` with the sign bit from `rs2`
 ;; This implements the `copysign` operation

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -896,6 +896,11 @@
 (rule (rv_sllw rs1 rs2)
   (alu_rrr (AluOPRRR.Sllw) rs1 rs2))
 
+;; Helper for emitting the `slliw` ("Shift Left Logical Immediate Word") instruction.
+;; rd ← sext32(uext32(rs1) << imm)
+(decl rv_slliw (Reg Imm12) Reg)
+(rule (rv_slliw rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Slliw) rs1 imm))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1145,6 +1145,10 @@
 (rule (rv_ctzw rs1)
   (alu_rr_funct12 (AluOPRRI.Ctzw) rs1))
 
+;; Helper for emitting the `cpop` ("Count Population") instruction.
+(decl rv_cpop (Reg) Reg)
+(rule (rv_cpop rs1)
+  (alu_rr_funct12 (AluOPRRI.Cpop) rs1))
 
 
 
@@ -1668,9 +1672,9 @@
     (writable_reg_to_reg sum)))
 
 (decl lower_popcnt (Reg Type) Reg)
-(rule 1 (lower_popcnt rs ty )
+(rule 1 (lower_popcnt rs ty)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Cpop) (ext_int_if_need $false rs ty)))
+  (rv_cpop (ext_int_if_need $false rs ty)))
 (rule (lower_popcnt rs ty)
   (if-let $false (has_zbb))
   (gen_popcnt rs ty))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -947,6 +947,14 @@
 (rule (rv_mulh rs1 rs2)
   (alu_rrr (AluOPRRR.Mulh) rs1 rs2))
 
+;; Helper for emitting the `mulhu` ("Multiply High Unsigned Unsigned") instruction.
+;; rd ← (uext(rs1) × uext(rs2)) » xlen
+(decl rv_mulhu (Reg Reg) Reg)
+(rule (rv_mulhu rs1 rs2)
+  (alu_rrr (AluOPRRR.Mulhu) rs1 rs2))
+
+
+
 
 
 
@@ -1345,7 +1353,7 @@
 (decl lower_umlhi (Type Reg Reg) Reg)
 (rule 1
   (lower_umlhi $I64 rs1 rs2)
-  (alu_rrr (AluOPRRR.Mulhu) rs1 rs2))
+  (rv_mulhu rs1 rs2))
 
 (rule
   (lower_umlhi ty rs1 rs2)
@@ -2252,10 +2260,6 @@
   (let
     ((t Reg (rv_mul n m)))
     (rv_add t a)))
-
-(decl umulh (Reg Reg) Reg)
-(rule (umulh a b)
-  (alu_rrr (AluOPRRR.Mulhu) a b))
 
 ;;;; Helpers for bmask ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1214,6 +1214,11 @@
 (rule (rv_rorw rs1 rs2)
   (alu_rrr (AluOPRRR.Rorw) rs1 rs2))
 
+;; Helper for emitting the `rev8` ("Byte Reverse") instruction.
+(decl rv_rev8 (Reg) Reg)
+(rule (rv_rev8 rs1)
+  (alu_rr_funct12 (AluOPRRI.Rev8) rs1))
+
 
 
 
@@ -2348,7 +2353,7 @@
 (rule 1
   (gen_rev8 rs)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Rev8) rs))
+  (rv_rev8 rs))
 
 (rule
   (gen_rev8 rs)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1130,6 +1130,11 @@
 (rule (rv_clz rs1)
   (alu_rr_funct12 (AluOPRRI.Clz) rs1))
 
+;; Helper for emitting the `clzw` ("Count Leading Zero Bits in Word") instruction.
+(decl rv_clzw (Reg) Reg)
+(rule (rv_clzw rs1)
+  (alu_rr_funct12 (AluOPRRI.Clzw) rs1))
+
 
 
 
@@ -1348,7 +1353,7 @@
 
 (rule 2 (lower_clz $I32 r)
   (if-let $true (has_zbb))
-  (alu_rr_funct12 (AluOPRRI.Clzw) r))
+  (rv_clzw r))
 
 (rule 2 (lower_clz $I64 r)
   (if-let $true (has_zbb))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -152,14 +152,14 @@
 
       ;; 128bit mul formula:
       ;;   dst_lo = x_lo * y_lo
-      ;;   dst_hi = umulhi(x_lo, y_lo) + (x_lo * y_hi) + (x_hi * y_lo)
+      ;;   dst_hi = mulhu(x_lo, y_lo) + (x_lo * y_hi) + (x_hi * y_lo)
       ;;
       ;; We can convert the above formula into the following
-      ;; umulh   dst_hi, x_lo, y_lo
+      ;; mulhu   dst_hi, x_lo, y_lo
       ;; madd    dst_hi, x_lo, y_hi, dst_hi
       ;; madd    dst_hi, x_hi, y_lo, dst_hi
       ;; madd    dst_lo, x_lo, y_lo, zero
-      (dst_hi1 Reg (umulh x_lo y_lo))
+      (dst_hi1 Reg (rv_mulhu x_lo y_lo))
       (dst_hi2 Reg (madd x_lo y_hi dst_hi1))
       (dst_hi Reg (madd x_hi y_lo dst_hi2))
       (dst_lo Reg (madd x_lo y_lo (zero_reg))))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -90,7 +90,7 @@
 (rule 7 (lower (has_type $I128 (iadd x y)))
   (let ((low Reg (rv_add (value_regs_get x 0) (value_regs_get y 0)))
         ;; compute carry.
-        (carry Reg (alu_rrr (AluOPRRR.SltU) low (value_regs_get y 0)))
+        (carry Reg (rv_sltu low (value_regs_get y 0)))
         ;;
         (high_tmp Reg (rv_add (value_regs_get x 1) (value_regs_get y 1)))
         ;; add carry.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -681,9 +681,8 @@
 (rule (lower (has_type ty (fmul x y)))
   (rv_fmul ty x y))
 
-(rule
-  (lower (has_type ty (fdiv x y)))
-  (fpu_rrr (f_arithmatic_op ty (Opcode.Fdiv)) ty x y))
+(rule (lower (has_type ty (fdiv x y)))
+  (rv_fdiv ty x y))
 
 (rule
   (lower (has_type ty (fmin x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -112,7 +112,7 @@
   (rv_sub x y))
 
 (rule -1 (lower (has_type (fits_in_32 ty) (isub x y)))
-  (alu_rrr (AluOPRRR.Subw) x y))
+  (rv_subw x y))
 
 (rule (lower (has_type $I128 (isub x y)))
   (i128_sub x y))
@@ -405,7 +405,7 @@
   (rv_addw x y))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (isub x y)))))
-  (alu_rrr (AluOPRRR.Subw) x y))
+  (rv_subw x y))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ishl x y)))))
   (alu_rrr (AluOPRRR.Sllw) x (value_regs_get y 0)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -427,7 +427,7 @@
   (rv_slliw x y))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ushr x (imm12_from_value y))))))
-  (alu_rr_imm12 (AluOPRRI.SrliW) x y))
+  (rv_srliw x y))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (sshr x (imm12_from_value y))))))
   (alu_rr_imm12 (AluOPRRI.Sraiw) x y))
@@ -475,18 +475,18 @@
   (rv_srlw (ext_int_if_need $false x $I8) (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (ushr x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.SrliW) (ext_int_if_need $false x $I8) (imm12_and y 7)))
+  (rv_srliw (ext_int_if_need $false x $I8) (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (ushr x y)))
   (rv_srlw (ext_int_if_need $false x $I16) (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (ushr x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.SrliW) (ext_int_if_need $false x $I16) (imm12_and y 15)))
+  (rv_srliw (ext_int_if_need $false x $I16) (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (ushr x y)))
   (rv_srlw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (ushr x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.SrliW) x y))
+  (rv_srliw x y))
 
 (rule 2 (lower (has_type $I64 (ushr x (imm12_from_value y))))
   (rv_srli x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -227,7 +227,7 @@
 (rule (lower (has_type $I64 (urem x y)))
   (let
     ((_ InstOutput (gen_div_by_zero y)))
-    (alu_rrr (AluOPRRR.RemU) x y)))
+    (rv_remu x y)))
 
 ;;;; Rules for `and` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule -1 (lower (has_type (fits_in_64 (ty_int ty)) (band x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -418,10 +418,10 @@
 
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (iadd x (imm12_from_value y))))))
-  (alu_rr_imm12 (AluOPRRI.Addiw) x y))
+  (rv_addiw x y))
 
 (rule 3 (lower (has_type $I64 (sextend (has_type $I32 (iadd (imm12_from_value x) y)))))
-  (alu_rr_imm12 (AluOPRRI.Addiw) y x))
+  (rv_addiw y x))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ishl x (imm12_from_value y))))))
   (rv_slliw x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -600,7 +600,7 @@
     (has_type (valid_atomic_transaction ty) (atomic_rmw flags (AtomicRmwOp.Sub) addr x)))
   (let
     ((tmp WritableReg (temp_writable_reg ty))
-     (x2 Reg (rv_sub (zero_reg) x)))
+     (x2 Reg (rv_neg x)))
     (gen_atomic (get_atomic_rmw_op ty (AtomicRmwOp.Add)) addr x2 (atomic_amo))))
 
 (decl gen_atomic_rmw_loop (AtomicRmwOp Type Reg Reg) Reg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -199,7 +199,7 @@
   (let
     ((y2 Reg (ext_int_if_need $false y ty))
       (_ InstOutput (gen_div_by_zero y2)))
-    (alu_rrr (AluOPRRR.Remuw) (ext_int_if_need $false x ty) y2)))
+    (rv_remuw (ext_int_if_need $false x ty) y2)))
 
 (rule -1 (lower (has_type (fits_in_16 ty) (srem x y)))
   (let
@@ -217,7 +217,7 @@
   (let
     ((y2 Reg (ext_int_if_need $false y $I32))
         (_ InstOutput (gen_div_by_zero y2)))
-    (alu_rrr (AluOPRRR.Remuw) x y2)))
+    (rv_remuw x y2)))
 
 (rule (lower (has_type $I64 (srem x y)))
   (let

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -430,7 +430,7 @@
   (rv_srliw x y))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (sshr x (imm12_from_value y))))))
-  (alu_rr_imm12 (AluOPRRI.Sraiw) x y))
+  (rv_sraiw x y))
 
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (popcnt x)))
@@ -513,7 +513,7 @@
 (rule 1 (lower (has_type $I32 (sshr x y)))
   (rv_sraw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (sshr x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.Sraiw) x y))
+  (rv_sraiw x y))
 (rule 1 (lower (has_type $I64 (sshr x y)))
   (rv_sra x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I64 (sshr x (imm12_from_value y))))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -671,10 +671,10 @@
   (fpu_rr (FpuOPRR.FcvtSD) ty x))
 
 
-;;;;;  Rules for `for float arithmatic`
-(rule
-  (lower (has_type ty (fadd x y)))
-  (fpu_rrr (f_arithmatic_op ty (Opcode.Fadd)) ty x y))
+;;;;;  Rules for for float arithmetic
+(rule (lower (has_type ty (fadd x y)))
+  (rv_fadd ty x y))
+
 (rule
   (lower (has_type ty (fsub x y)))
   (fpu_rrr (f_arithmatic_op ty (Opcode.Fsub)) ty x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -424,7 +424,7 @@
   (alu_rr_imm12 (AluOPRRI.Addiw) y x))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ishl x (imm12_from_value y))))))
-  (alu_rr_imm12 (AluOPRRI.Slliw) x y))
+  (rv_slliw x y))
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ushr x (imm12_from_value y))))))
   (alu_rr_imm12 (AluOPRRI.SrliW) x y))
@@ -443,18 +443,18 @@
   (rv_sllw x (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (ishl x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.Slliw) x (imm12_and y 7)))
+  (rv_slliw x (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (ishl x y)))
   (rv_sllw x (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (ishl x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.Slliw) x (imm12_and y 15)))
+  (rv_slliw x (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (ishl x y)))
   (rv_sllw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (ishl x (imm12_from_value y))))
-  (alu_rr_imm12 (AluOPRRI.Slliw) x y))
+  (rv_slliw x y))
 
 (rule 2 (lower (has_type $I64 (ishl x (imm12_from_value y))))
   (rv_slli x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -408,7 +408,7 @@
   (rv_subw x y))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ishl x y)))))
-  (alu_rrr (AluOPRRR.Sllw) x (value_regs_get y 0)))
+  (rv_sllw x (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ushr x y)))))
   (alu_rrr (AluOPRRR.Srlw) x (value_regs_get y 0)))
@@ -440,19 +440,19 @@
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (has_type $I8 (ishl x y)))
-  (alu_rrr (AluOPRRR.Sllw) x (rv_andi (value_regs_get y 0) (imm12_const 7))))
+  (rv_sllw x (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (ishl x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.Slliw) x (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (ishl x y)))
-  (alu_rrr (AluOPRRR.Sllw) x (rv_andi (value_regs_get y 0) (imm12_const 15))))
+  (rv_sllw x (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (ishl x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.Slliw) x (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (ishl x y)))
-  (alu_rrr (AluOPRRR.Sllw) x (value_regs_get y 0)))
+  (rv_sllw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (ishl x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.Slliw) x y))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -302,24 +302,24 @@
 
 (rule 3 (lower (has_type (fits_in_64 (ty_int ty)) (bor x (bnot y))))
   (if-let $true (has_zbb))
-  (gen_orn x y))
+  (rv_orn x y))
 
 (rule 4 (lower (has_type (fits_in_64 (ty_int ty)) (bor (bnot y) x)))
   (if-let $true (has_zbb))
-  (gen_orn x y))
+  (rv_orn x y))
 
 (rule 5 (lower (has_type $I128 (bor x (bnot y))))
   (if-let $true (has_zbb))
   (let
-    ((low Reg (gen_orn (value_regs_get x 0) (value_regs_get y 0)))
-      (high Reg (gen_orn (value_regs_get x 1) (value_regs_get y 1))))
+    ((low Reg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
+      (high Reg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 6 (lower (has_type $I128 (bor (bnot y) x)))
   (if-let $true (has_zbb))
   (let
-    ((low Reg (gen_orn (value_regs_get x 0) (value_regs_get y 0)))
-      (high Reg (gen_orn (value_regs_get x 1) (value_regs_get y 1))))
+    ((low Reg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
+      (high Reg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -464,7 +464,7 @@
 ;; With `Zba` we have a shift that zero extends the LHS argument.
 (rule 3 (lower (has_type $I64 (ishl (uextend x @ (value_type $I32)) (maybe_uextend (imm12_from_value y)))))
   (if-let $true (has_zba))
-  (alu_rr_imm12 (AluOPRRI.SlliUw) x y))
+  (rv_slliuw x y))
 
 ;; I128 cases
 (rule 0 (lower (has_type $I128 (ishl x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -222,7 +222,7 @@
 (rule (lower (has_type $I64 (srem x y)))
   (let
     ((_ InstOutput (gen_div_by_zero y)))
-    (alu_rrr (AluOPRRR.Rem) x y)))
+    (rv_rem x y)))
 
 (rule (lower (has_type $I64 (urem x y)))
   (let

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -538,9 +538,8 @@
 
 
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule
-  (lower (has_type ty (fabs x)))
-  (gen_fabs x ty))
+(rule (lower (has_type ty (fabs x)))
+  (rv_fsgnjx ty x x))
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fneg x)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -191,7 +191,7 @@
 (rule (lower (has_type $I64 (udiv x y)))
   (let
     ((_ InstOutput (gen_div_by_zero y)))
-    (alu_rrr (AluOPRRR.DivU) x y)))
+    (rv_divu x y)))
 
 ;;;; Rules for `rem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -549,7 +549,7 @@
 
 ;;;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fcopysign x y)))
-  (fpu_rrr (f_copysign_op ty) ty x y))
+  (rv_fsgnj ty x y))
 
 ;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fma x y z)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -678,9 +678,9 @@
 (rule (lower (has_type ty (fsub x y)))
   (rv_fsub ty x y))
 
-(rule
-  (lower (has_type ty (fmul x y)))
-  (fpu_rrr (f_arithmatic_op ty (Opcode.Fmul)) ty x y))
+(rule (lower (has_type ty (fmul x y)))
+  (rv_fmul ty x y))
+
 (rule
   (lower (has_type ty (fdiv x y)))
   (fpu_rrr (f_arithmatic_op ty (Opcode.Fdiv)) ty x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -42,11 +42,11 @@
 ;; Needs `Zba`
 (rule 3 (lower (has_type $I64 (iadd x (uextend y @ (value_type $I32)))))
   (if-let $true (has_zba))
-  (alu_rrr (AluOPRRR.Adduw) y x))
+  (rv_adduw y x))
 
 (rule 4 (lower (has_type $I64 (iadd (uextend x @ (value_type $I32)) y)))
   (if-let $true (has_zba))
-  (alu_rrr (AluOPRRR.Adduw) x y))
+  (rv_adduw x y))
 
 ;; Add with const shift. We have a few of these instructions with `Zba`.
 (decl pure partial match_shnadd (Imm64) AluOPRRR)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -180,7 +180,7 @@
       (b Reg (ext_int_if_need $true y ty))
       (_ InstOutput (gen_div_overflow a b ty))
       (_ InstOutput (gen_div_by_zero b)))
-    (alu_rrr (AluOPRRR.Divw) a b)))
+    (rv_divw a b)))
 
 (rule (lower (has_type $I64 (sdiv x y)))
   (let

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -658,9 +658,9 @@
 (rule (lower (fpromote x))
   (rv_fcvtds x))
 
-(rule
-  (lower (has_type ty (fdemote x)))
-  (fpu_rr (FpuOPRR.FcvtSD) ty x))
+;;;;;  Rules for `fdemote`;;;;;;;;;;;;;;;;;;
+(rule (lower (fdemote x))
+  (rv_fcvtsd x))
 
 
 ;;;;;  Rules for for float arithmetic

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -186,7 +186,7 @@
   (let
     ((_ InstOutput (gen_div_overflow x y $I64))
       (_ InstOutput (gen_div_by_zero y))    )
-    (alu_rrr (AluOPRRR.Div) x y)))
+    (rv_div x y)))
 
 (rule (lower (has_type $I64 (udiv x y)))
   (let

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -543,9 +543,8 @@
   (gen_fabs x ty))
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule
-  (lower (has_type ty (fneg x)))
-  (fpu_rrr (f_copy_neg_sign_op ty) ty x x))
+(rule (lower (has_type ty (fneg x)))
+  (rv_fsgnjn ty x x))
 
 ;;;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fcopysign x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -402,7 +402,7 @@
 ;; The instructions below are present in RV64I and sign-extend the result to 64 bits.
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (iadd x y)))))
-  (alu_rrr (AluOPRRR.Addw) x y))
+  (rv_addw x y))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (isub x y)))))
   (alu_rrr (AluOPRRR.Subw) x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -552,10 +552,8 @@
   (fpu_rrr (f_copysign_op ty) ty x y))
 
 ;;;; Rules for `fma` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (has_type $F32 (fma x y z)))
-  (fpu_rrrr (FpuOPRRRR.FmaddS) $F64 x y z))
-(rule (lower (has_type $F64 (fma x y z)))
-  (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 x y z))
+(rule (lower (has_type ty (fma x y z)))
+  (rv_fmadd ty x y z))
 
 
 ;;;; Rules for `sqrt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -128,7 +128,7 @@
 (rule -2 (lower (has_type (fits_in_64 ty) (imul x y)))
   (rv_mul x y))
 (rule -1 (lower (has_type (fits_in_32 ty) (imul x y)))
-  (alu_rrr (AluOPRRR.Mulw) x y))
+  (rv_mulw x y))
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (smulhi x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -172,7 +172,7 @@
   (let
     ((y2 Reg (ext_int_if_need $false y ty))
       (_ InstOutput (gen_div_by_zero y2)))
-    (alu_rrr (AluOPRRR.Divuw) (ext_int_if_need $false x ty) y2)))
+    (rv_divuw (ext_int_if_need $false x ty) y2)))
 
 (rule -1 (lower (has_type (fits_in_32 ty) (sdiv x y)))
   (let

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -255,24 +255,24 @@
 
 (rule 3 (lower (has_type (fits_in_64 (ty_int ty)) (band x (bnot y))))
   (if-let $true (has_zbb))
-  (gen_andn x y))
+  (rv_andn x y))
 
 (rule 4 (lower (has_type (fits_in_64 (ty_int ty)) (band (bnot y) x)))
   (if-let $true (has_zbb))
-  (gen_andn x y))
+  (rv_andn x y))
 
 (rule 5 (lower (has_type $I128 (band x (bnot y))))
   (if-let $true (has_zbb))
   (let
-    ((low Reg (gen_andn (value_regs_get x 0) (value_regs_get y 0)))
-      (high Reg (gen_andn (value_regs_get x 1) (value_regs_get y 1))))
+    ((low Reg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
+      (high Reg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 6 (lower (has_type $I128 (band (bnot y) x)))
   (if-let $true (has_zbb))
   (let
-    ((low Reg (gen_andn (value_regs_get x 0) (value_regs_get y 0)))
-      (high Reg (gen_andn (value_regs_get x 1) (value_regs_get y 1))))
+    ((low Reg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
+      (high Reg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -543,7 +543,7 @@
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fneg x)))
-  (rv_fsgnjn ty x x))
+  (rv_fneg ty x))
 
 ;;;; Rules for `fcopysign` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fcopysign x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -559,11 +559,8 @@
 
 
 ;;;; Rules for `sqrt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (has_type $F32 (sqrt x)))
-  (fpu_rr (FpuOPRR.FsqrtS) $F64 x))
-
-(rule (lower (has_type $F64 (sqrt x)))
-  (fpu_rr (FpuOPRR.FsqrtD) $F64 x))
+(rule (lower (has_type ty (sqrt x)))
+  (rv_fsqrt ty x))
 
 
 ;;;; Rules for `AtomicRMW` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -539,7 +539,7 @@
 
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fabs x)))
-  (rv_fsgnjx ty x x))
+  (rv_fabs ty x))
 
 ;;;; Rules for `fneg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type ty (fneg x)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -411,7 +411,7 @@
   (rv_sllw x (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ushr x y)))))
-  (alu_rrr (AluOPRRR.Srlw) x (value_regs_get y 0)))
+  (rv_srlw x (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (sshr x y)))))
   (alu_rrr (AluOPRRR.Sraw) x (value_regs_get y 0)))
@@ -472,19 +472,19 @@
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (has_type $I8 (ushr x y)))
-  (alu_rrr (AluOPRRR.Srlw) (ext_int_if_need $false x $I8) (rv_andi (value_regs_get y 0) (imm12_const 7))))
+  (rv_srlw (ext_int_if_need $false x $I8) (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (ushr x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.SrliW) (ext_int_if_need $false x $I8) (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (ushr x y)))
-  (alu_rrr (AluOPRRR.Srlw) (ext_int_if_need $false x $I16) (rv_andi (value_regs_get y 0) (imm12_const 15))))
+  (rv_srlw (ext_int_if_need $false x $I16) (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (ushr x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.SrliW) (ext_int_if_need $false x $I16) (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (ushr x y)))
-  (alu_rrr (AluOPRRR.Srlw) x (value_regs_get y 0)))
+  (rv_srlw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (ushr x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.SrliW) x y))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -655,9 +655,8 @@
   (gen_move2 (value_regs_get x 0) ty ty))
 
 ;;;;;  Rules for `fpromote`;;;;;;;;;;;;;;;;;
-(rule
-  (lower (has_type ty (fpromote x)))
-  (fpu_rr (FpuOPRR.FcvtDS) ty x))
+(rule (lower (fpromote x))
+  (rv_fcvtds x))
 
 (rule
   (lower (has_type ty (fdemote x)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -126,7 +126,7 @@
 ;;;; Rules for `imul` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule -2 (lower (has_type (fits_in_64 ty) (imul x y)))
-  (alu_rrr (AluOPRRR.Mul) x y))
+  (rv_mul x y))
 (rule -1 (lower (has_type (fits_in_32 ty) (imul x y)))
   (alu_rrr (AluOPRRR.Mulw) x y))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -414,7 +414,7 @@
   (rv_srlw x (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I64 (sextend (has_type $I32 (sshr x y)))))
-  (alu_rrr (AluOPRRR.Sraw) x (value_regs_get y 0)))
+  (rv_sraw x (value_regs_get y 0)))
 
 
 (rule 2 (lower (has_type $I64 (sextend (has_type $I32 (iadd x (imm12_from_value y))))))
@@ -511,7 +511,7 @@
   (rv_srai (ext_int_if_need $true x $I16) (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (sshr x y)))
-  (alu_rrr (AluOPRRR.Sraw) x (value_regs_get y 0)))
+  (rv_sraw x (value_regs_get y 0)))
 (rule 2 (lower (has_type $I32 (sshr x (imm12_from_value y))))
   (alu_rr_imm12 (AluOPRRI.Sraiw) x y))
 (rule 1 (lower (has_type $I64 (sshr x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -675,9 +675,9 @@
 (rule (lower (has_type ty (fadd x y)))
   (rv_fadd ty x y))
 
-(rule
-  (lower (has_type ty (fsub x y)))
-  (fpu_rrr (f_arithmatic_op ty (Opcode.Fsub)) ty x y))
+(rule (lower (has_type ty (fsub x y)))
+  (rv_fsub ty x y))
+
 (rule
   (lower (has_type ty (fmul x y)))
   (fpu_rrr (f_arithmatic_op ty (Opcode.Fmul)) ty x y))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -205,13 +205,13 @@
   (let
     ((y2 Reg (ext_int_if_need $true y ty))
       (_ InstOutput (gen_div_by_zero y2)))
-    (alu_rrr (AluOPRRR.Remw) (ext_int_if_need $true x ty) y2)))
+    (rv_remw (ext_int_if_need $true x ty) y2)))
 
 (rule (lower (has_type $I32 (srem x y)))
   (let
     ((y2 Reg (ext_int_if_need $true y $I32))
       (_ InstOutput (gen_div_by_zero y2)))
-   (alu_rrr (AluOPRRR.Remw) x y2)))
+   (rv_remw x y2)))
 
 (rule (lower (has_type $I32 (urem x y)))
   (let


### PR DESCRIPTION
👋 Hey,

This change is something we discussed recently. It refactors the RISC-V ISLE files so that all instructions are emitted via helpers, similar to what we have in the x64 backend.

It also unifies them under a common syntax. We currently use 4 different ways of emitting instructions:
```
(alu_rrr (AluOPRRR. ...) ...)
(emit_... )
(alu_... )
(gen_... )
```

These were all different ways of doing the same thing. Sometimes we even used multiple variations of the above for the same instruction.

With this PR, single instructions are now emitted using `rv_...`. Larger patterns are still emitted using one of `gen_...` or `lower_...`.

This is a pretty large refactor. I'm not sure if it helps reviewing but I've tried to restrict changes to one instruction per commit. It also doesn't change any of the golden output tests, so that helps making sure I haven't messed up anywhere.