### PR TITLE
Fix export translation for components.

### DIFF
--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -622,8 +622,29 @@ impl<'a, 'data> Translator<'a, 'data> {
                     self.result
                         .initializers
                         .push(LocalInitializer::Export(item));
-                    if let ComponentItem::Type(ty) = item {
-                        self.types.push_component_typedef(ty);
+
+                    // Exports create a new index, so push the item onto the
+                    // appropriate list.
+                    match item {
+                        ComponentItem::Func(idx) => {
+                            self.result
+                                .component_funcs
+                                .push(self.result.component_funcs[idx]);
+                        }
+                        ComponentItem::Module(_idx) => {
+                            // ???
+                        }
+                        ComponentItem::Component(idx) => {
+                            self.result.components.push(self.result.components[idx]);
+                        }
+                        ComponentItem::ComponentInstance(idx) => {
+                            self.result
+                                .component_instances
+                                .push(self.result.component_instances[idx]);
+                        }
+                        ComponentItem::Type(ty) => {
+                            self.types.push_component_typedef(ty);
+                        }
                     }
                 }
             }

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -632,7 +632,9 @@ impl<'a, 'data> Translator<'a, 'data> {
                                 .push(self.result.component_funcs[idx]);
                         }
                         ComponentItem::Module(_idx) => {
-                            // ???
+                            // We don't need to do anything here for modules as
+                            // the type information isn't tracked in the initial
+                            // translation pass.
                         }
                         ComponentItem::Component(idx) => {
                             self.result.components.push(self.result.components[idx]);

--- a/tests/misc_testsuite/component-model/aliasing.wast
+++ b/tests/misc_testsuite/component-model/aliasing.wast
@@ -1,0 +1,17 @@
+(component
+  (component
+    (component
+      (component)
+      (instance (instantiate 0))
+      (export "a" (instance 0))
+    )
+    (instance (instantiate 0))
+    (export "a" (instance 0))
+  )
+
+  (instance (instantiate 0))       ;; instance 0
+  (alias export 0 "a" (instance))  ;; instance 1
+  (export "a" (instance 1))        ;; instance 2
+  (alias export 2 "a" (instance))  ;; instance 3
+  (export "inner-a" (instance 3))  ;; instance 4
+)

--- a/tests/misc_testsuite/component-model/aliasing.wast
+++ b/tests/misc_testsuite/component-model/aliasing.wast
@@ -15,3 +15,15 @@
   (alias export 2 "a" (instance))  ;; instance 3
   (export "inner-a" (instance 3))  ;; instance 4
 )
+
+(component
+  (component
+    (core module)
+    (export "a" (core module 0))
+  )
+
+  (instance (instantiate 0))
+  (alias export 0 "a" (core module))  ;; module 0
+  (export "a" (core module 0))        ;; module 1
+  (core instance (instantiate 1))
+)


### PR DESCRIPTION
Exports in the component model cause a new index to be added to the index space of the item being exported.

This commit updates component translation so that translation of component export sections properly updates internal lists representing those index spaces.
