### PR TITLE
wasi-http supply chain audit

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,4 +47,9 @@ skip-tree = [
     # This is on and older version of `wasm-encoder` and is one we can't
     # necessarily easily update, so let `wasm-encoder` get duplicated for now.
     { name = "wasm-coredump-builder", depth = 2 },
+
+    # The native-tls crate hasn't kept up with updates to the underlying
+    # windows-sys, while the rest of the ecosystem has. This duplicated
+    # dependency appears to be benign.
+    { name = "windows-sys", depth = 2 },
 ]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -361,6 +361,17 @@ are only created when requested by the application, however, and otherwise
 only does its stated purpose.
 """
 
+[[audits.foreign-types]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = "This crate defined a macro-rules which creates wrappers working with FFI types. The implementation of this crate appears to be safe, but each use of this macro would need to be vetted for correctness as well."
+
+[[audits.foreign-types-shared]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.1"
+
 [[audits.form_urlencoded]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -382,6 +393,40 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "0.18.0 -> 0.18.1"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[audits.futures]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "There are no definitions in this crate, just exports of definitions from child crates."
+
+[[audits.futures-channel]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "build.rs is just detecting the target and setting cfg. unsafety is for implementing a concurrency primitives using atomics and unsafecell, and is not obviously incorrect (this is the sort of thing I wouldn't certify as correct without formal methods)"
+
+[[audits.futures-core]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "Unsafe used to implement a concurrency primitive AtomicWaker. Well-commented and not obviously incorrect. Like my other audits of these concurrency primitives inside the futures family, I couldn't certify that it is correct without formal methods, but that is out of scope for this vetting."
+
+[[audits.futures-executor]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+notes = "Unsafe used to implement the unpark mutex, which is well commented and not obviously incorrect. Like with futures-channel I wouldn't be able to certify it as correct without formal methods."
+
+[[audits.futures-io]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
+
+[[audits.futures-sink]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.27"
 
 [[audits.gimli]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -409,6 +454,23 @@ notes = "Contains `forbid_unsafe` and only uses `std::fmt` from the standard lib
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.3.0"
+
+[[audits.http-body]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0-rc.2"
+
+[[audits.http-body-util]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0-rc.2"
+notes = "only one use of unsafe related to pin projection. unclear to me why pin_project! is used in many modules of the project, but the expanded output of that macro is inlined in either.rs"
+
+[[audits.httpdate]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "No unsafety, no io"
 
 [[audits.id-arena]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -569,6 +631,12 @@ update Rust stylistic conventions, and perhaps some clippy lints. No major
 changes.
 """
 
+[[audits.native-tls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.11"
+notes = "build is only looking for environment variables to set cfg. only two minor uses of unsafe,on macos, with ffi bindings to digest primitives and libc atexit. otherwise, this is an abstraction over three very complex systems (schannel, security-framework, and openssl) which may end up having subtle differences, but none of those are apparent from the implementation of this crate"
+
 [[audits.object]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
@@ -587,6 +655,17 @@ the changelog says is new in these versions.
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 delta = "1.16.0 -> 1.17.0"
+
+[[audits.openssl-macros]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.openssl-probe]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.5"
+notes = "IO is only checking for the existence of paths in the filesystem"
 
 [[audits.openvino]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
@@ -627,6 +706,17 @@ This crate is a single-file crate that does what it says on the tin. There are
 a few `unsafe` blocks related to utf-8 validation which are locally verifiable
 as correct and otherwise this crate is good to go.
 """
+
+[[audits.pin-utils]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+
+[[audits.pkg-config]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.25"
+notes = "This crate shells out to the pkg-config executable, but it appears to sanitize inputs reasonably."
 
 [[audits.pulldown-cmark]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -716,6 +806,12 @@ criteria = "safe-to-deploy"
 delta = "0.9.9 -> 0.10.2"
 notes = "This upgrade is mostly a code refactor, as far as I can tell. No new uses of unsafe nor any new ambient capabilities usage."
 
+[[audits.slab]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.4.6"
+notes = "provides a datastructure implemented using std's Vec. all uses of unsafe are just delegating to the underlying unsafe Vec methods."
+
 [[audits.spin]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
@@ -776,6 +872,24 @@ issue plus some reorganization around lazy initialization. Altogether nothing
 amiss here.
 """
 
+[[audits.tokio-native-tls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = "unsafety is used for smuggling std::task::Context as a raw pointer. Lifetime and type safety appears to be taken care of correctly."
+
+[[audits.tokio-util]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.7.4"
+notes = "Alex Crichton audited the safety of src/sync/reusable_box.rs, I audited the remainder of the crate."
+
+[[audits.try-lock]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
 [[audits.unicase]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -818,6 +932,17 @@ and suss out bugs. I've historically reviewed this crate in the past and it
 is similar to what it once was back then. Skimming over the crate there is
 nothing suspicious and it's everything you'd expect a Rust URL parser to be.
 """
+
+[[audits.vcpkg]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.2.15"
+notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
+
+[[audits.want]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
 
 [[audits.wasm-coredump-builder]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -145,6 +145,16 @@ criteria = "safe-to-deploy"
 version = "0.6.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.core-foundation]]
+version = "0.9.3"
+criteria = "safe-to-deploy"
+notes = "4kloc of C FFI bindings, with lots of unsafe memory management. very challenging to vet for safety"
+
+[[exemptions.core-foundation-sys]]
+version = "0.8.3"
+criteria = "safe-to-deploy"
+notes = "bindings to a large C FFI"
+
 [[exemptions.cpp_demangle]]
 version = "0.3.5"
 criteria = "safe-to-deploy"
@@ -293,6 +303,21 @@ criteria = "safe-to-run"
 version = "0.1.8"
 criteria = "safe-to-run"
 
+[[exemptions.futures-macro]]
+version = "0.3.27"
+criteria = "safe-to-deploy"
+notes = "deferring this vetting until Alex gets back from vacation"
+
+[[exemptions.futures-task]]
+version = "0.3.27"
+criteria = "safe-to-deploy"
+notes = "deferring this vetting until Alex gets back from vacation"
+
+[[exemptions.futures-util]]
+version = "0.3.27"
+criteria = "safe-to-deploy"
+notes = "this is 25k lines and contains over 149 uses of the substring unsafe. it is a huge grab bag of complexity with no practical way to audit it"
+
 [[exemptions.generic-array]]
 version = "0.14.5"
 criteria = "safe-to-deploy"
@@ -321,6 +346,11 @@ criteria = "safe-to-deploy"
 version = "0.10.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.h2]]
+version = "0.3.16"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
+
 [[exemptions.hermit-abi]]
 version = "0.1.19"
 criteria = "safe-to-deploy"
@@ -337,6 +367,16 @@ criteria = "safe-to-deploy"
 version = "0.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.http]]
+version = "0.2.9"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
+
+[[exemptions.httparse]]
+version = "1.8.0"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
+
 [[exemptions.humantime]]
 version = "1.3.0"
 criteria = "safe-to-deploy"
@@ -344,6 +384,11 @@ criteria = "safe-to-deploy"
 [[exemptions.humantime]]
 version = "2.1.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.hyper]]
+version = "1.0.0-rc.3"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
 
 [[exemptions.indexmap]]
 version = "1.9.1"
@@ -433,6 +478,11 @@ criteria = "safe-to-deploy"
 version = "0.8.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.mio]]
+version = "0.8.6"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
+
 [[exemptions.miow]]
 version = "0.3.7"
 criteria = "safe-to-deploy"
@@ -476,6 +526,16 @@ criteria = "safe-to-deploy"
 [[exemptions.oorandom]]
 version = "11.1.3"
 criteria = "safe-to-run"
+
+[[exemptions.openssl]]
+version = "0.10.48"
+criteria = "safe-to-deploy"
+notes = "required by tokio-native-tls, no practical way to audit at this time"
+
+[[exemptions.openssl-sys]]
+version = "0.9.83"
+criteria = "safe-to-deploy"
+notes = "required by tokio-native-tls, no practical way to audit at this time"
 
 [[exemptions.openvino-finder]]
 version = "0.4.1"
@@ -689,9 +749,24 @@ criteria = "safe-to-deploy"
 version = "1.0.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.schannel]]
+version = "0.1.21"
+criteria = "safe-to-deploy"
+notes = "5kloc of bindings to a C FFI, heavy use of unsafe memory manipulation. very challenging to vet safety."
+
 [[exemptions.scopeguard]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.security-framework]]
+version = "2.8.1"
+criteria = "safe-to-deploy"
+notes = "10kloc of FFI bindings to the mac os security framework: very challenging to vet safety"
+
+[[exemptions.security-framework-sys]]
+version = "2.8.0"
+criteria = "safe-to-deploy"
+notes = "bindings to a large C FFI"
 
 [[exemptions.serde]]
 version = "1.0.137"
@@ -812,6 +887,11 @@ criteria = "safe-to-run"
 [[exemptions.tokio]]
 version = "1.18.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.tokio]]
+version = "1.26.0"
+criteria = "safe-to-deploy"
+notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
 
 [[exemptions.tokio-macros]]
 version = "1.7.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -224,6 +224,12 @@ criteria = "safe-to-deploy"
 delta = "1.13.1 -> 1.16.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.pkg-config]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.25 -> 0.3.26"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.quote]]
 who = "Nika Layzell <nika@thelayzells.com>"
 criteria = "safe-to-deploy"
@@ -238,6 +244,18 @@ This crate contains no unsafe code, and the internal logic, while difficult to
 read, is generally straightforward. I have audited the the quote macros, ident
 formatter, and runtime logic.
 """
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.slab]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.6 -> 0.4.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.socket2]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.4 -> 0.4.7"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.synstructure]]


### PR DESCRIPTION
The audits are straightforward, and took the majority of a day to review. The exemptions, as always, need to be justified:

* core-foundation, core-foundation-sys, security-framework, security-framework-sys: these are large crates which are FFI bindings to Mac OS frameworks. As such they contain tons of unsafe code to make these FFI calls and manage memory. These crates are too big to audit.

* schannel: same as the above, except this is a windows component, which I'm also unfamiliar with.

* openssl, openssl-sys: also large FFI bindings which are impractical to audit.

* futures-macro, futures-task: while not as complex as futures-util, these are beyond my personal understanding of futures to vet practically. I've asked Alex to look at auditing these, and he will after he returns from vacation next week.

* futures-util: 25kloc of code, over 149 instances of the substring "unsafe" (case insensitive), this is impractical to audit in the extreme.

* h2, http, httparse, hyper, mio, tokio: this so-called tokio/hyper family are very large and challenging to audit. @bholley told me he is working to get the AWS engineers who maintain these crates to publish their own audits, which we can then import. We expect to exempt these until those imports are available.

Additionally, there is a cargo-deny exception made for duplicate versions of the windows-sys crate, which is just because part of the ecosystem is lagging a little bit, and looks like a totally benign difference.