### PR TITLE
Make cranelift-codegen actually no_std (optionally)

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift/codegen/meta/src/cdsl/typevar.rs
@@ -819,6 +819,7 @@ fn test_typevar_builder_too_high_bound_panic() {
 #[test]
 #[should_panic]
 fn test_typevar_builder_inverted_bounds_panic() {
+    #[allow(clippy::reversed_empty_ranges)]
     TypeSetBuilder::new().ints(32..16).build();
 }
 

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -323,7 +323,7 @@ fn gen_instruction_data_impl(formats: &[&InstructionFormat], fmt: &mut Formatter
                         ("args.as_slice(pool)", "args.len(pool)")
                     } else if format.num_value_operands == 1 {
                         members.push("ref arg");
-                        ("std::slice::from_ref(arg)", "1")
+                        ("core::slice::from_ref(arg)", "1")
                     } else if format.num_value_operands > 0 {
                         members.push("ref args");
                         ("args", "args.len()")
@@ -335,7 +335,7 @@ fn gen_instruction_data_impl(formats: &[&InstructionFormat], fmt: &mut Formatter
                         0 => None,
                         1 => {
                             members.push("ref destination");
-                            Some(("std::slice::from_ref(destination)", "1"))
+                            Some(("core::slice::from_ref(destination)", "1"))
                         }
                         _ => {
                             members.push("ref blocks");

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]

--- a/cranelift/codegen/src/ctxhash.rs
+++ b/cranelift/codegen/src/ctxhash.rs
@@ -4,8 +4,8 @@
 //! node-internal data references some other storage (e.g., offsets into
 //! an array or pool of shared data).
 
+use core::hash::{Hash, Hasher};
 use hashbrown::raw::RawTable;
-use std::hash::{Hash, Hasher};
 
 /// Trait that allows for equality comparison given some external
 /// context.
@@ -94,7 +94,7 @@ impl<K, V> CtxHashMap<K, V> {
         }) {
             Some(bucket) => {
                 let data = unsafe { bucket.as_mut() };
-                Some(std::mem::replace(&mut data.v, v))
+                Some(core::mem::replace(&mut data.v, v))
             }
             None => {
                 let data = BucketData { hash, k, v };
@@ -125,7 +125,7 @@ impl<K, V> CtxHashMap<K, V> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::hash::Hash;
+    use core::hash::Hash;
 
     #[derive(Clone, Copy, Debug)]
     struct Key {

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -234,13 +234,13 @@ impl DataValue {
     /// Write a [DataValue] to a memory location in native-endian byte order.
     pub unsafe fn write_value_to(&self, p: *mut u128) {
         let size = self.ty().bytes() as usize;
-        self.write_to_slice_ne(std::slice::from_raw_parts_mut(p as *mut u8, size));
+        self.write_to_slice_ne(core::slice::from_raw_parts_mut(p as *mut u8, size));
     }
 
     /// Read a [DataValue] from a memory location using a given [Type] in native-endian byte order.
     pub unsafe fn read_value_from(p: *const u128, ty: Type) -> Self {
         DataValue::read_from_slice_ne(
-            std::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
+            core::slice::from_raw_parts(p as *const u8, ty.bytes() as usize),
             ty,
         )
     }
@@ -275,6 +275,7 @@ pub enum DataValueCastFailure {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for DataValueCastFailure {}
 
 impl Display for DataValueCastFailure {

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -17,9 +17,9 @@ use crate::opts::IsleContext;
 use crate::scoped_hash_map::{Entry as ScopedEntry, ScopedHashMap};
 use crate::trace;
 use crate::unionfind::UnionFind;
+use core::hash::Hasher;
 use cranelift_entity::packed_option::ReservedValue;
 use cranelift_entity::SecondaryMap;
-use std::hash::Hasher;
 
 mod cost;
 mod domtree;
@@ -637,7 +637,7 @@ impl<'a> CtxEq<(Type, InstructionData), (Type, InstructionData)> for GVNContext<
 
 impl<'a> CtxHash<(Type, InstructionData)> for GVNContext<'a> {
     fn ctx_hash<H: Hasher>(&self, state: &mut H, (ty, inst): &(Type, InstructionData)) {
-        std::hash::Hash::hash(&ty, state);
+        core::hash::Hash::hash(&ty, state);
         inst.hash(state, self.value_lists, |value| self.union_find.find(value));
     }
 }

--- a/cranelift/codegen/src/egraph/cost.rs
+++ b/cranelift/codegen/src/egraph/cost.rs
@@ -34,7 +34,7 @@ use crate::ir::Opcode;
 pub(crate) struct Cost(u32);
 impl Cost {
     pub(crate) fn at_level(&self, loop_level: usize) -> Cost {
-        let loop_level = std::cmp::min(2, loop_level);
+        let loop_level = core::cmp::min(2, loop_level);
         let multiplier = 1u32 << ((10 * loop_level) as u32);
         Cost(self.0.saturating_mul(multiplier)).finite()
     }
@@ -53,17 +53,17 @@ impl Cost {
     /// conjunction with saturating ops to avoid saturating into
     /// `infinity()`.
     fn finite(self) -> Cost {
-        Cost(std::cmp::min(u32::MAX - 1, self.0))
+        Cost(core::cmp::min(u32::MAX - 1, self.0))
     }
 }
 
-impl std::default::Default for Cost {
+impl core::default::Default for Cost {
     fn default() -> Cost {
         Cost::zero()
     }
 }
 
-impl std::ops::Add<Cost> for Cost {
+impl core::ops::Add<Cost> for Cost {
     type Output = Cost;
     fn add(self, other: Cost) -> Cost {
         Cost(self.0.saturating_add(other.0)).finite()

--- a/cranelift/codegen/src/egraph/elaborate.rs
+++ b/cranelift/codegen/src/egraph/elaborate.rs
@@ -201,7 +201,7 @@ impl<'a> Elaborator<'a> {
                     // the natural comparison works based on cost, and
                     // breaks ties based on value number.
                     trace!(" -> best of {:?} and {:?}", best[x], best[y]);
-                    best[value] = std::cmp::min(best[x], best[y]);
+                    best[value] = core::cmp::min(best[x], best[y]);
                     trace!(" -> {:?}", best[value]);
                 }
                 ValueDef::Param(_, _) => {

--- a/cranelift/codegen/src/incremental_cache.rs
+++ b/cranelift/codegen/src/incremental_cache.rs
@@ -108,7 +108,7 @@ pub trait CacheKvStore {
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub struct CacheKeyHash([u8; 32]);
 
-impl std::fmt::Display for CacheKeyHash {
+impl core::fmt::Display for CacheKeyHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CacheKeyHash:{:?}", self.0)
     }

--- a/cranelift/codegen/src/ir/condcodes.rs
+++ b/cranelift/codegen/src/ir/condcodes.rs
@@ -344,7 +344,7 @@ impl FromStr for FloatCC {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn int_inverse() {

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -260,7 +260,7 @@ impl ConstantPool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn empty() {

--- a/cranelift/codegen/src/ir/extname.rs
+++ b/cranelift/codegen/src/ir/extname.rs
@@ -99,7 +99,7 @@ pub struct TestcaseName(Box<[u8]>);
 impl fmt::Display for TestcaseName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('%')?;
-        f.write_str(std::str::from_utf8(&self.0).unwrap())
+        f.write_str(core::str::from_utf8(&self.0).unwrap())
     }
 }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -308,7 +308,7 @@ impl InstructionData {
         match self {
             Self::Jump {
                 ref destination, ..
-            } => std::slice::from_ref(destination),
+            } => core::slice::from_ref(destination),
             Self::Brif { blocks, .. } => blocks.as_slice(),
             Self::BranchTable { table, .. } => jump_tables.get(*table).unwrap().all_branches(),
             _ => {
@@ -329,7 +329,7 @@ impl InstructionData {
             Self::Jump {
                 ref mut destination,
                 ..
-            } => std::slice::from_mut(destination),
+            } => core::slice::from_mut(destination),
             Self::Brif { blocks, .. } => blocks.as_mut_slice(),
             Self::BranchTable { table, .. } => {
                 jump_tables.get_mut(*table).unwrap().all_branches_mut()
@@ -848,7 +848,7 @@ mod tests {
     fn inst_data_size() {
         // The size of `InstructionData` is performance sensitive, so make sure
         // we don't regress it unintentionally.
-        assert_eq!(std::mem::size_of::<InstructionData>(), 16);
+        assert_eq!(core::mem::size_of::<InstructionData>(), 16);
     }
 
     #[test]

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -31,7 +31,7 @@ impl JumpTableData {
     /// Create a new jump table with the provided blocks
     pub fn new(def: BlockCall, table: &[BlockCall]) -> Self {
         Self {
-            table: std::iter::once(def).chain(table.iter().copied()).collect(),
+            table: core::iter::once(def).chain(table.iter().copied()).collect(),
         }
     }
 
@@ -114,7 +114,7 @@ mod tests {
     use crate::entity::EntityRef;
     use crate::ir::instructions::ValueListPool;
     use crate::ir::{Block, BlockCall, Value};
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn empty() {

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -295,7 +295,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             } else {
                 // Every arg takes a minimum slot of 8 bytes. (16-byte stack
                 // alignment happens separately after all args.)
-                std::cmp::max(size, 8)
+                core::cmp::max(size, 8)
             };
 
             // Align the stack slot.

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -4,8 +4,8 @@ use crate::ir::types::*;
 use crate::ir::Type;
 use crate::isa::aarch64::inst::*;
 use crate::machinst::{ty_bits, MachLabel, PrettyPrint, Reg};
+use alloc::string::String;
 use core::convert::Into;
-use std::string::String;
 
 //=============================================================================
 // Instruction sub-components: shift and extend descriptors

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -5,8 +5,8 @@ use crate::ir::Type;
 use crate::isa::aarch64::inst::{OperandSize, ScalarSize};
 use crate::machinst::{AllocationConsumer, PrettyPrint};
 
+use alloc::string::String;
 use core::convert::TryFrom;
-use std::string::String;
 
 /// An immediate that represents the NZCV flags.
 #[derive(Clone, Copy, Debug)]

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -9,10 +9,10 @@ use crate::{settings, CodegenError, CodegenResult};
 
 use crate::machinst::{PrettyPrint, Reg, RegClass, Writable};
 
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use regalloc2::{PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::string::{String, ToString};
 
 pub(crate) mod regs;
 pub(crate) use self::regs::*;
@@ -139,7 +139,7 @@ fn count_zero_half_words(mut value: u64, num_half_words: u8) -> usize {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(32, std::mem::size_of::<Inst>());
+    assert_eq!(32, core::mem::size_of::<Inst>());
 }
 
 impl Inst {
@@ -2469,7 +2469,7 @@ impl Inst {
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
                     let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
@@ -2479,7 +2479,7 @@ impl Inst {
             &Inst::Ret { ref rets } => {
                 let mut s = "ret".to_string();
                 for ret in rets {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
                     let vreg = pretty_print_reg(ret.vreg, allocs);
                     write!(&mut s, " {}={}", vreg, preg).unwrap();

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -11,7 +11,7 @@ use regalloc2::MachineEnv;
 use regalloc2::PReg;
 use regalloc2::VReg;
 
-use std::string::{String, ToString};
+use alloc::string::{String, ToString};
 
 //=============================================================================
 // Registers, the Universe thereof, and printing

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -75,8 +75,8 @@ mod tests {
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};
     use crate::Context;
+    use core::str::FromStr;
     use gimli::write::Address;
-    use std::str::FromStr;
     use target_lexicon::triple;
 
     #[test]

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -34,10 +34,10 @@ use crate::{
     },
 };
 use crate::{isle_common_prelude_methods, isle_lower_prelude_methods};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use regalloc2::PReg;
-use std::boxed::Box;
-use std::convert::TryFrom;
-use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxCallIndInfo = Box<CallIndInfo>;

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -23,7 +23,7 @@
 //! # #[macro_use] extern crate target_lexicon;
 //! use cranelift_codegen::isa;
 //! use cranelift_codegen::settings::{self, Configurable};
-//! use std::str::FromStr;
+//! use core::str::FromStr;
 //! use target_lexicon::Triple;
 //!
 //! let shared_builder = settings::builder();
@@ -130,6 +130,7 @@ pub enum LookupError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for LookupError {}
 
 impl fmt::Display for LookupError {

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -139,7 +139,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     let size = if args_or_rets == ArgsOrRets::Rets && call_conv.extends_wasmtime() {
                         size
                     } else {
-                        std::cmp::max(size, 8)
+                        core::cmp::max(size, 8)
                     };
                     // Align.
                     debug_assert!(size.is_power_of_two());

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,7 @@ use crate::ir::condcodes::{CondCode, FloatCC};
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 use crate::machinst::isle::WritableReg;
 
-use std::fmt::{Display, Formatter, Result};
+use core::fmt::{Display, Formatter, Result};
 
 /// An addressing mode specified for a load/store operation.
 #[derive(Clone, Debug, Copy)]
@@ -1651,7 +1651,7 @@ pub enum CsrAddress {
     Vlenb = 0xc22,
 }
 
-impl std::fmt::Debug for CsrAddress {
+impl core::fmt::Debug for CsrAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "0x{:x}", self.as_u32())
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -3,7 +3,7 @@
 // Some variants are never constructed, but we still want them as options in the future.
 use super::Inst;
 #[allow(dead_code)]
-use std::fmt::{Debug, Display, Formatter, Result};
+use core::fmt::{Debug, Display, Formatter, Result};
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Imm12 {
@@ -60,7 +60,7 @@ impl Display for Imm12 {
     }
 }
 
-impl std::ops::Neg for Imm12 {
+impl core::ops::Neg for Imm12 {
     type Output = Self;
     fn neg(self) -> Self::Output {
         Self { bits: -self.bits }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -15,11 +15,11 @@ use crate::{settings, CodegenError, CodegenResult};
 
 pub use crate::ir::condcodes::FloatCC;
 
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use regalloc2::{PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::boxed::Box;
-use std::string::{String, ToString};
 
 pub mod regs;
 pub use self::regs::*;
@@ -36,7 +36,7 @@ use crate::isa::riscv64::abi::Riscv64MachineDeps;
 #[cfg(test)]
 mod emit_tests;
 
-use std::fmt::{Display, Formatter};
+use core::fmt::{Display, Formatter};
 
 pub(crate) type OptionReg = Option<Reg>;
 pub(crate) type OptionImm12 = Option<Imm12>;
@@ -128,7 +128,7 @@ impl BranchTarget {
 }
 
 impl Display for BranchTarget {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             BranchTarget::Label(l) => write!(f, "{}", l.to_string()),
             BranchTarget::ResolvedOffset(off) => write!(f, "{}", off),
@@ -1193,7 +1193,7 @@ impl Inst {
                 format!("{} {},{}", "lui", format_reg(rd.to_reg(), allocs), imm.bits)
             }
             &Inst::LoadConst32 { rd, imm } => {
-                use std::fmt::Write;
+                use core::fmt::Write;
 
                 let rd = format_reg(rd.to_reg(), allocs);
                 let mut buf = String::new();
@@ -1204,7 +1204,7 @@ impl Inst {
                 buf
             }
             &Inst::LoadConst64 { rd, imm } => {
-                use std::fmt::Write;
+                use core::fmt::Write;
 
                 let rd = format_reg(rd.to_reg(), allocs);
                 let mut buf = String::new();
@@ -1379,7 +1379,7 @@ impl Inst {
                 let mut s = "args".to_string();
                 let mut empty_allocs = AllocationConsumer::default();
                 for arg in args {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = format_reg(arg.preg, &mut empty_allocs);
                     let def = format_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
@@ -1390,7 +1390,7 @@ impl Inst {
                 let mut s = "ret".to_string();
                 let mut empty_allocs = AllocationConsumer::default();
                 for ret in rets {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = format_reg(ret.preg, &mut empty_allocs);
                     let vreg = format_reg(ret.vreg, allocs);
                     write!(&mut s, " {}={}", vreg, preg).unwrap();

--- a/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
@@ -73,8 +73,8 @@ mod tests {
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};
     use crate::Context;
+    use core::str::FromStr;
     use gimli::write::Address;
-    use std::str::FromStr;
     use target_lexicon::triple;
 
     #[test]

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -21,10 +21,10 @@ use crate::{
     machinst::{ArgPair, InstOutput, Lower},
 };
 use crate::{isle_common_prelude_methods, isle_lower_prelude_methods};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use regalloc2::PReg;
-use std::boxed::Box;
-use std::convert::TryFrom;
-use std::vec::Vec;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxCallIndInfo = Box<CallIndInfo>;
@@ -463,7 +463,7 @@ pub(crate) fn lower_branch(
 }
 
 /// construct destination according to ty.
-fn construct_dest<F: std::ops::FnMut(Type) -> WritableReg>(
+fn construct_dest<F: core::ops::FnMut(Type) -> WritableReg>(
     mut alloc: F,
     ty: Type,
 ) -> WritableValueRegs {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -80,9 +80,9 @@ use crate::machinst::{RealReg, Reg, RegClass, Writable};
 use crate::settings;
 use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 use regalloc2::{PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::convert::TryFrom;
 
 // We use a generic implementation that factors out ABI commonalities.
 
@@ -311,12 +311,12 @@ impl ABIMachineSpec for S390xMachineDeps {
                 {
                     size
                 } else {
-                    std::cmp::max(size, 8)
+                    core::cmp::max(size, 8)
                 };
 
                 // Align the stack slot.
                 debug_assert!(slot_size.is_power_of_two());
-                let slot_align = std::cmp::min(slot_size, 8);
+                let slot_align = core::cmp::min(slot_size, 8);
                 next_stack = align_to(next_stack, slot_align);
 
                 // If the type is actually of smaller size (and the argument

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -6,7 +6,7 @@ use crate::isa::s390x::inst::*;
 use crate::machinst::MachLabel;
 use crate::machinst::{PrettyPrint, Reg};
 
-use std::string::String;
+use alloc::string::String;
 
 //=============================================================================
 // Instruction sub-components (memory addresses): definitions

--- a/cranelift/codegen/src/isa/s390x/inst/imms.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/imms.rs
@@ -1,7 +1,7 @@
 //! S390x ISA definitions: immediate constants.
 
 use crate::machinst::{AllocationConsumer, PrettyPrint};
-use std::string::String;
+use alloc::string::String;
 
 /// An unsigned 12-bit immediate.
 #[derive(Clone, Copy, Debug)]

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -7,10 +7,10 @@ use crate::isa::CallConv;
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use regalloc2::{PRegSet, VReg};
 use smallvec::SmallVec;
-use std::string::{String, ToString};
 pub mod regs;
 pub use self::regs::*;
 pub mod imms;
@@ -64,7 +64,7 @@ pub struct CallIndInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(32, std::mem::size_of::<Inst>());
+    assert_eq!(32, core::mem::size_of::<Inst>());
 }
 
 /// A register pair. Enum so it can be destructured in ISLE.
@@ -3144,7 +3144,7 @@ impl Inst {
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
                     let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
@@ -3155,7 +3155,7 @@ impl Inst {
                 debug_assert_eq!(link, gpr(14));
                 let mut s = format!("br {}", show_reg(link));
                 for ret in rets {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
                     let vreg = pretty_print_reg(ret.vreg, allocs);
                     write!(&mut s, " {}={}", vreg, preg).unwrap();

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -106,8 +106,8 @@ mod tests {
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};
     use crate::Context;
+    use core::str::FromStr;
     use gimli::write::Address;
-    use std::str::FromStr;
     use target_lexicon::triple;
 
     #[test]

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -28,12 +28,12 @@ use crate::{
     },
 };
 use crate::{isle_common_prelude_methods, isle_lower_prelude_methods};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cell::Cell;
+use core::convert::TryFrom;
 use regalloc2::PReg;
 use smallvec::smallvec;
-use std::boxed::Box;
-use std::cell::Cell;
-use std::convert::TryFrom;
-use std::vec::Vec;
 
 /// Information describing a library call to be emitted.
 pub struct LibCallInfo {
@@ -764,7 +764,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     #[inline]
     fn fcvt_to_sint_lb32(&mut self, size: u8) -> u64 {
         let lb = (-2.0_f32).powi((size - 1).into());
-        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits()) as u64
+        core::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits()) as u64
     }
 
     #[inline]
@@ -775,7 +775,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     #[inline]
     fn fcvt_to_sint_lb64(&mut self, size: u8) -> u64 {
         let lb = (-2.0_f64).powi((size - 1).into());
-        std::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
+        core::cmp::max(lb.to_bits() + 1, (lb - 1.0).to_bits())
     }
 
     #[inline]

--- a/cranelift/codegen/src/isa/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/unwind/systemv.rs
@@ -23,10 +23,11 @@ pub enum RegisterMappingError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for RegisterMappingError {}
 
-impl std::fmt::Display for RegisterMappingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for RegisterMappingError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             RegisterMappingError::MissingBank => write!(f, "unable to find bank for register info"),
             RegisterMappingError::UnsupportedArchitecture => write!(

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -11,9 +11,9 @@ use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use args::*;
+use core::convert::TryFrom;
 use regalloc2::{PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::convert::TryFrom;
 
 /// This is the limit for the size of argument and return-value areas on the
 /// stack. We place a reasonable limit here to avoid integer overflow issues
@@ -201,7 +201,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     let size = if args_or_rets == ArgsOrRets::Rets && call_conv.extends_wasmtime() {
                         size
                     } else {
-                        std::cmp::max(size, 8)
+                        core::cmp::max(size, 8)
                     };
                     // Align.
                     debug_assert!(size.is_power_of_two());

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -354,7 +354,7 @@ impl EvexMasking {
 mod tests {
     use super::*;
     use crate::isa::x64::inst::regs;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     // As a sanity test, we verify that the output of `xed-asmparse-main 'vpabsq xmm0{k0},
     // xmm1'` matches this EVEX encoding machinery.

--- a/cranelift/codegen/src/isa/x64/encoding/mod.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/mod.rs
@@ -1,6 +1,6 @@
 //! Contains the encoding machinery for the various x64 instruction formats.
 use crate::{isa::x64, machinst::MachBuffer};
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 pub mod evex;
 pub mod rex;

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -7,10 +7,10 @@ use crate::ir::{MemFlags, Type};
 use crate::isa::x64::inst::regs::pretty_print_reg;
 use crate::isa::x64::inst::Inst;
 use crate::machinst::*;
+use alloc::string::String;
+use core::fmt;
 use regalloc2::VReg;
 use smallvec::{smallvec, SmallVec};
-use std::fmt;
-use std::string::String;
 
 pub use crate::isa::x64::lower::isle::generated_code::DivSignedness;
 
@@ -77,7 +77,7 @@ macro_rules! newtype_of_reg {
         // NB: We cannot implement `DerefMut` because that would let people do
         // nasty stuff like `*my_gpr.deref_mut() = some_xmm_reg`, breaking the
         // invariants that `Gpr` provides.
-        impl std::ops::Deref for $newtype_reg {
+        impl core::ops::Deref for $newtype_reg {
             type Target = Reg;
 
             fn deref(&self) -> &Reg {

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1668,7 +1668,7 @@ pub(crate) fn emit(
             // Emit jump table (table of 32-bit offsets).
             sink.bind_label(start_of_jumptable);
             let jt_off = sink.cur_offset();
-            for &target in targets.iter().chain(std::iter::once(default_target)) {
+            for &target in targets.iter().chain(core::iter::once(default_target)) {
                 let word_off = sink.cur_offset();
                 // off_into_table is an addend here embedded in the label to be later patched at
                 // the end of codegen. The offset is initially relative to this jump table entry;

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -9,11 +9,11 @@ use crate::isa::CallConv;
 use crate::{machinst::*, trace};
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::fmt;
 use regalloc2::{Allocation, PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::fmt;
-use std::string::{String, ToString};
 
 pub mod args;
 mod emit;
@@ -48,7 +48,7 @@ pub struct CallInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    assert_eq!(40, std::mem::size_of::<Inst>());
+    assert_eq!(40, core::mem::size_of::<Inst>());
 }
 
 pub(crate) fn low32_will_sign_extend_to_64(x: u64) -> bool {
@@ -1642,7 +1642,7 @@ impl PrettyPrint for Inst {
             Inst::Args { args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = regs::show_reg(arg.preg);
                     let def = pretty_print_reg(arg.vreg.to_reg(), 8, allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
@@ -1653,7 +1653,7 @@ impl PrettyPrint for Inst {
             Inst::Ret { rets } => {
                 let mut s = "ret".to_string();
                 for ret in rets {
-                    use std::fmt::Write;
+                    use core::fmt::Write;
                     let preg = regs::show_reg(ret.preg);
                     let vreg = pretty_print_reg(ret.vreg, 8, allocs);
                     write!(&mut s, " {}={}", vreg, preg).unwrap();
@@ -1803,7 +1803,7 @@ impl PrettyPrint for Inst {
                 dst,
                 tmp,
             } => {
-                use std::fmt::Write;
+                use core::fmt::Write;
 
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let tmp = allocs.next(tmp.to_reg().to_reg());
@@ -2472,7 +2472,7 @@ impl MachInst for Inst {
     }
 
     fn gen_nop(preferred_size: usize) -> Inst {
-        Inst::nop(std::cmp::min(preferred_size, 15) as u8)
+        Inst::nop(core::cmp::min(preferred_size, 15) as u8)
     }
 
     fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -7,9 +7,9 @@
 
 use crate::machinst::{AllocationConsumer, RealReg, Reg};
 use crate::settings;
+use alloc::string::String;
 use alloc::string::ToString;
 use regalloc2::{MachineEnv, PReg, RegClass, VReg};
-use std::string::String;
 
 // Hardware encodings (note the special rax, rcx, rdx, rbx order).
 

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -102,8 +102,8 @@ mod tests {
     use crate::isa::{lookup, CallConv};
     use crate::settings::{builder, Flags};
     use crate::Context;
+    use core::str::FromStr;
     use gimli::write::Address;
-    use std::str::FromStr;
     use target_lexicon::triple;
 
     #[test]

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -34,11 +34,11 @@ use crate::{
         VCodeConstant, VCodeConstantData,
     },
 };
+use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 use regalloc2::PReg;
 use smallvec::SmallVec;
-use std::boxed::Box;
-use std::convert::TryFrom;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -198,7 +198,7 @@ macro_rules! isle_common_prelude_methods {
 
         #[inline]
         fn ty_bits(&mut self, ty: Type) -> u8 {
-            use std::convert::TryInto;
+            use core::convert::TryInto;
             ty.bits().try_into().unwrap()
         }
 

--- a/cranelift/codegen/src/legalizer/globalvalue.rs
+++ b/cranelift/codegen/src/legalizer/globalvalue.rs
@@ -44,7 +44,7 @@ fn const_vector_scale(inst: ir::Inst, func: &mut ir::Function, ty: ir::Type, isa
     assert!(ty.bytes() <= 16);
 
     // Use a minimum of 128-bits for the base type.
-    let base_bytes = std::cmp::max(ty.bytes(), 16);
+    let base_bytes = core::cmp::max(ty.bytes(), 16);
     let scale = (isa.dynamic_vector_bytes(ty) / base_bytes) as i64;
     assert!(scale > 0);
     let pos = FuncCursor::new(func).at_inst(inst);

--- a/cranelift/codegen/src/loop_analysis.rs
+++ b/cranelift/codegen/src/loop_analysis.rs
@@ -62,13 +62,13 @@ impl LoopLevel {
     /// A clamped loop level from a larger-width (usize) depth.
     pub fn clamped(level: usize) -> Self {
         Self(
-            u8::try_from(std::cmp::min(level, (Self::INVALID as usize) - 1))
+            u8::try_from(core::cmp::min(level, (Self::INVALID as usize) - 1))
                 .expect("Clamped value must always convert"),
         )
     }
 }
 
-impl std::default::Default for LoopLevel {
+impl core::default::Default for LoopLevel {
     fn default() -> Self {
         LoopLevel::invalid()
     }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -110,15 +110,15 @@ use crate::isa::TargetIsa;
 use crate::settings;
 use crate::settings::ProbestackStrategy;
 use crate::CodegenResult;
+use crate::HashMap;
 use crate::{ir, isa};
 use crate::{machinst::*, trace};
 use alloc::vec::Vec;
+use core::convert::TryFrom;
+use core::marker::PhantomData;
+use core::mem;
 use regalloc2::{PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::marker::PhantomData;
-use std::mem;
 
 /// A small vector of instructions (with some reasonable size); appropriate for
 /// a small fixed sequence implementing one operation.
@@ -943,7 +943,7 @@ impl SigSet {
 
 // NB: we do _not_ implement `IndexMut` because these signatures are
 // deduplicated and shared!
-impl std::ops::Index<Sig> for SigSet {
+impl core::ops::Index<Sig> for SigSet {
     type Output = SigData;
 
     fn index(&self, sig: Sig) -> &Self::Output {
@@ -1726,7 +1726,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             // locations defined by the ABI.
             Some(M::gen_args(
                 &self.isa_flags,
-                std::mem::take(&mut self.reg_args),
+                core::mem::take(&mut self.reg_args),
             ))
         } else {
             None
@@ -1768,7 +1768,7 @@ impl<M: ABIMachineSpec> Callee<M> {
         let map_size = (virtual_sp_offset + nominal_sp_to_fp) as u32;
         let bytes = M::word_bytes();
         let map_words = (map_size + bytes - 1) / bytes;
-        let mut bits = std::iter::repeat(false)
+        let mut bits = core::iter::repeat(false)
             .take(map_words as usize)
             .collect::<Vec<bool>>();
 
@@ -2405,6 +2405,6 @@ mod tests {
     fn sig_data_size() {
         // The size of `SigData` is performance sensitive, so make sure
         // we don't regress it unintentionally.
-        assert_eq!(std::mem::size_of::<SigData>(), 24);
+        assert_eq!(core::mem::size_of::<SigData>(), 24);
     }
 }

--- a/cranelift/codegen/src/machinst/blockorder.rs
+++ b/cranelift/codegen/src/machinst/blockorder.rs
@@ -80,7 +80,7 @@ pub struct BlockLoweringOrder {
     lowered_succ_indices: Vec<BlockIndex>,
     /// Ranges in `lowered_succ_indices` giving the successor lists for each lowered
     /// block. Indexed by lowering-order index (`BlockIndex`).
-    lowered_succ_ranges: Vec<(Option<Inst>, std::ops::Range<usize>)>,
+    lowered_succ_ranges: Vec<(Option<Inst>, core::ops::Range<usize>)>,
     /// Cold blocks. These blocks are not reordered in the
     /// `lowered_order` above; the lowered order must respect RPO
     /// (uses after defs) in order for lowering to be

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -148,12 +148,12 @@ use crate::machinst::{
 };
 use crate::timing;
 use crate::trace;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+use core::mem;
 use cranelift_entity::{entity_impl, SecondaryMap};
 use smallvec::SmallVec;
-use std::convert::TryFrom;
-use std::mem;
-use std::string::String;
-use std::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -1500,7 +1500,7 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
     /// Return the code in this mach buffer as a hex string for testing purposes.
     pub fn stringify_code_bytes(&self) -> String {
         // This is pretty lame, but whatever ..
-        use std::fmt::Write;
+        use core::fmt::Write;
         let mut s = String::with_capacity(self.data.len() * 2);
         for b in &self.data {
             write!(&mut s, "{:02X}", b).unwrap();
@@ -1772,8 +1772,8 @@ mod test {
     use crate::isa::aarch64::inst::{BranchTarget, CondBrKind, EmitInfo, Inst};
     use crate::machinst::MachInstEmit;
     use crate::settings;
-    use std::default::Default;
-    use std::vec::Vec;
+    use alloc::vec::Vec;
+    use core::default::Default;
 
     fn label(n: u32) -> MachLabel {
         MachLabel::from_block(BlockIndex::new(n as usize))

--- a/cranelift/codegen/src/machinst/helpers.rs
+++ b/cranelift/codegen/src/machinst/helpers.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous helpers for machine backends.
 
 use crate::ir::Type;
-use std::ops::{Add, BitAnd, Not, Sub};
+use core::ops::{Add, BitAnd, Not, Sub};
 
 /// Returns the size (in bits) of a given type.
 pub fn ty_bits(ty: Type) -> usize {

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -1,8 +1,8 @@
 use crate::ir::{BlockCall, Value, ValueList};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::cell::Cell;
 use smallvec::SmallVec;
-use std::cell::Cell;
 
 pub use super::MachLabel;
 use super::RetPair;
@@ -83,7 +83,7 @@ macro_rules! isle_lower_prelude_methods {
 
         #[inline]
         fn output_builder_new(&mut self) -> InstOutputBuilder {
-            std::cell::Cell::new(InstOutput::new())
+            core::cell::Cell::new(InstOutput::new())
         }
 
         #[inline]

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -20,9 +20,9 @@ use crate::machinst::{
 };
 use crate::{trace, CodegenResult};
 use alloc::vec::Vec;
+use core::fmt::Debug;
 use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
-use std::fmt::Debug;
 
 use super::{VCodeBuildDirection, VRegAllocator};
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -50,12 +50,12 @@ use crate::ir::{DynamicStackSlot, RelSourceLoc, StackSlot, Type};
 use crate::result::CodegenResult;
 use crate::settings::Flags;
 use crate::value_label::ValueLabelsRanges;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use cranelift_entity::PrimaryMap;
 use regalloc2::{Allocation, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::string::String;
 
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
@@ -352,7 +352,7 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
         params: Option<&crate::ir::function::FunctionParameters>,
         cs: &capstone::Capstone,
     ) -> Result<String, anyhow::Error> {
-        use std::fmt::Write;
+        use core::fmt::Write;
 
         let mut buf = String::new();
 

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -84,8 +84,8 @@ impl Reg {
     }
 }
 
-impl std::fmt::Debug for Reg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for Reg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if let Some(rreg) = self.to_real_reg() {
             let preg: PReg = rreg.into();
             write!(f, "{}", preg)
@@ -115,8 +115,8 @@ impl RealReg {
     }
 }
 
-impl std::fmt::Debug for RealReg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for RealReg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         Reg::from(*self).fmt(f)
     }
 }
@@ -141,8 +141,8 @@ impl VirtualReg {
     }
 }
 
-impl std::fmt::Debug for VirtualReg {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Debug for VirtualReg {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         Reg::from(*self).fmt(f)
     }
 }
@@ -189,27 +189,27 @@ impl<T: Clone + Copy + Debug + PartialEq + Eq + PartialOrd + Ord + Hash> Writabl
 // Conversions between regalloc2 types (VReg) and our types
 // (VirtualReg, RealReg, Reg).
 
-impl std::convert::From<regalloc2::VReg> for Reg {
+impl core::convert::From<regalloc2::VReg> for Reg {
     fn from(vreg: regalloc2::VReg) -> Reg {
         Reg(vreg)
     }
 }
 
-impl std::convert::From<regalloc2::VReg> for VirtualReg {
+impl core::convert::From<regalloc2::VReg> for VirtualReg {
     fn from(vreg: regalloc2::VReg) -> VirtualReg {
         debug_assert!(pinned_vreg_to_preg(vreg).is_none());
         VirtualReg(vreg)
     }
 }
 
-impl std::convert::From<regalloc2::VReg> for RealReg {
+impl core::convert::From<regalloc2::VReg> for RealReg {
     fn from(vreg: regalloc2::VReg) -> RealReg {
         debug_assert!(pinned_vreg_to_preg(vreg).is_some());
         RealReg(vreg)
     }
 }
 
-impl std::convert::From<Reg> for regalloc2::VReg {
+impl core::convert::From<Reg> for regalloc2::VReg {
     /// Extract the underlying `regalloc2::VReg`. Note that physical
     /// registers also map to particular (special) VRegs, so this
     /// method can be used either on virtual or physical `Reg`s.
@@ -218,43 +218,43 @@ impl std::convert::From<Reg> for regalloc2::VReg {
     }
 }
 
-impl std::convert::From<VirtualReg> for regalloc2::VReg {
+impl core::convert::From<VirtualReg> for regalloc2::VReg {
     fn from(reg: VirtualReg) -> regalloc2::VReg {
         reg.0
     }
 }
 
-impl std::convert::From<RealReg> for regalloc2::VReg {
+impl core::convert::From<RealReg> for regalloc2::VReg {
     fn from(reg: RealReg) -> regalloc2::VReg {
         reg.0
     }
 }
 
-impl std::convert::From<RealReg> for regalloc2::PReg {
+impl core::convert::From<RealReg> for regalloc2::PReg {
     fn from(reg: RealReg) -> regalloc2::PReg {
         PReg::from_index(reg.0.vreg())
     }
 }
 
-impl std::convert::From<regalloc2::PReg> for RealReg {
+impl core::convert::From<regalloc2::PReg> for RealReg {
     fn from(preg: regalloc2::PReg) -> RealReg {
         RealReg(VReg::new(preg.index(), preg.class()))
     }
 }
 
-impl std::convert::From<regalloc2::PReg> for Reg {
+impl core::convert::From<regalloc2::PReg> for Reg {
     fn from(preg: regalloc2::PReg) -> Reg {
         Reg(VReg::new(preg.index(), preg.class()))
     }
 }
 
-impl std::convert::From<RealReg> for Reg {
+impl core::convert::From<RealReg> for Reg {
     fn from(reg: RealReg) -> Reg {
         Reg(reg.0)
     }
 }
 
-impl std::convert::From<VirtualReg> for Reg {
+impl core::convert::From<VirtualReg> for Reg {
     fn from(reg: VirtualReg) -> Reg {
         Reg(reg.0)
     }
@@ -476,7 +476,7 @@ pub trait PrettyPrint {
 /// provided to the OperandCollector.
 #[derive(Clone)]
 pub struct AllocationConsumer<'a> {
-    allocs: std::slice::Iter<'a, Allocation>,
+    allocs: core::slice::Iter<'a, Allocation>,
 }
 
 impl<'a> AllocationConsumer<'a> {
@@ -525,7 +525,7 @@ impl<'a> AllocationConsumer<'a> {
     }
 }
 
-impl<'a> std::default::Default for AllocationConsumer<'a> {
+impl<'a> core::default::Default for AllocationConsumer<'a> {
     fn default() -> Self {
         Self { allocs: [].iter() }
     }

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -4,7 +4,7 @@
 use regalloc2::{PReg, VReg};
 
 use super::{RealReg, Reg, VirtualReg, Writable};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 const VALUE_REGS_PARTS: usize = 2;
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -31,11 +31,11 @@ use regalloc2::{
     RegClass, VReg,
 };
 
+use crate::hash_map::Entry;
+use crate::HashMap;
 use alloc::vec::Vec;
+use core::fmt;
 use cranelift_entity::{entity_impl, Keys, PrimaryMap};
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::fmt;
 
 /// Index referring to an instruction in VCode.
 pub type InsnIndex = regalloc2::Inst;
@@ -957,9 +957,9 @@ impl<I: VCodeInst> VCode<I> {
                                 .safepoint_slots
                                 .binary_search_by(|(progpoint, _alloc)| {
                                     if progpoint.inst() >= iix {
-                                        std::cmp::Ordering::Greater
+                                        core::cmp::Ordering::Greater
                                     } else {
-                                        std::cmp::Ordering::Less
+                                        core::cmp::Ordering::Less
                                     }
                                 })
                                 .unwrap_err();
@@ -1299,7 +1299,7 @@ impl<I: VCodeInst> RegallocFunction for VCode<I> {
     }
 
     fn num_vregs(&self) -> usize {
-        std::cmp::max(self.vreg_types.len(), first_user_vreg_index())
+        core::cmp::max(self.vreg_types.len(), first_user_vreg_index())
     }
 
     fn reftype_vregs(&self) -> &[VReg] {
@@ -1570,7 +1570,7 @@ impl VCodeConstantData {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::mem::size_of;
+    use core::mem::size_of;
 
     #[test]
     fn size_of_constant_structs() {

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -14,9 +14,9 @@ pub use crate::ir::{
 use crate::isle_common_prelude_methods;
 use crate::machinst::isle::*;
 use crate::trace;
+use core::marker::PhantomData;
 use cranelift_entity::packed_option::ReservedValue;
 use smallvec::{smallvec, SmallVec};
-use std::marker::PhantomData;
 
 #[allow(dead_code)]
 pub type Unit = ();

--- a/cranelift/codegen/src/remove_constant_phis.rs
+++ b/cranelift/codegen/src/remove_constant_phis.rs
@@ -230,7 +230,7 @@ pub fn do_remove_constant_phis(func: &mut Function, domtree: &mut DominatorTree)
     // info.  The solver will iterate over the summaries, rather than having
     // to inspect each instruction in each block.
     let bump =
-        Bump::with_capacity(domtree.cfg_postorder().len() * 4 * std::mem::size_of::<Value>());
+        Bump::with_capacity(domtree.cfg_postorder().len() * 4 * core::mem::size_of::<Value>());
     let mut summaries =
         SecondaryMap::<Block, BlockSummary>::with_capacity(domtree.cfg_postorder().len());
 

--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -3,7 +3,7 @@
 use regalloc2::checker::CheckerErrors;
 
 use crate::{ir::Function, verifier::VerifierErrors};
-use std::string::String;
+use alloc::string::String;
 
 /// A compilation error.
 ///
@@ -48,6 +48,7 @@ pub type CodegenResult<T> = Result<T, CodegenError>;
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for CodegenError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
@@ -62,8 +63,8 @@ impl std::error::Error for CodegenError {
     }
 }
 
-impl std::fmt::Display for CodegenError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
             CodegenError::Verifier(_) => write!(f, "Verifier errors"),
             CodegenError::ImplLimitExceeded => write!(f, "Implementation limit exceeded"),

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -301,6 +301,7 @@ pub enum SetError {
     BadValue(String),
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SetError {}
 
 impl fmt::Display for SetError {

--- a/cranelift/codegen/src/simple_preopt.rs
+++ b/cranelift/codegen/src/simple_preopt.rs
@@ -472,7 +472,7 @@ mod simplify {
         instructions::Opcode,
         types::{I16, I32, I8},
     };
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
 
     pub struct PeepholeOptimizer<'a, 'b> {
         phantom: PhantomData<(&'a (), &'b ())>,

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -25,11 +25,11 @@
 //! candidate.
 
 use crate::ir;
+use alloc::string::String;
+use alloc::vec::Vec;
 use souper_ir::ast;
 use std::collections::{HashMap, HashSet};
-use std::string::String;
 use std::sync::mpsc;
-use std::vec::Vec;
 
 /// Harvest Souper left-hand side candidates from the given function.
 ///

--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -2,11 +2,11 @@
 //!
 //! This modules provides facilities for timing the execution of individual compilation passes.
 
+use alloc::boxed::Box;
+use core::any::Any;
+use core::cell::{Cell, RefCell};
 use core::fmt;
-use std::any::Any;
-use std::boxed::Box;
-use std::cell::{Cell, RefCell};
-use std::mem;
+use core::mem;
 use std::time::{Duration, Instant};
 
 // Each pass that can be timed is predefined with the `define_passes!` macro. Each pass has a
@@ -120,7 +120,7 @@ thread_local! {
 ///
 /// Returns the old profiler.
 pub fn set_thread_profiler(new_profiler: Box<dyn Profiler>) -> Box<dyn Profiler> {
-    PROFILER.with(|profiler| std::mem::replace(&mut *profiler.borrow_mut(), new_profiler))
+    PROFILER.with(|profiler| core::mem::replace(&mut *profiler.borrow_mut(), new_profiler))
 }
 
 /// Start timing `pass` as a child of the currently running pass, if any.

--- a/cranelift/codegen/src/unionfind.rs
+++ b/cranelift/codegen/src/unionfind.rs
@@ -1,8 +1,8 @@
 //! Simple union-find data structure.
 
 use crate::trace;
+use core::hash::Hash;
 use cranelift_entity::{packed_option::ReservedValue, EntityRef, SecondaryMap};
-use std::hash::Hash;
 
 /// A union-find data structure. The data structure can allocate
 /// `Id`s, indicating eclasses, and can merge eclasses together.
@@ -19,7 +19,7 @@ impl<Idx: EntityRef + ReservedValue> Default for Val<Idx> {
     }
 }
 
-impl<Idx: EntityRef + Hash + std::fmt::Display + Ord + ReservedValue> UnionFind<Idx> {
+impl<Idx: EntityRef + Hash + core::fmt::Display + Ord + ReservedValue> UnionFind<Idx> {
     /// Create a new `UnionFind` with the given capacity.
     pub fn with_capacity(cap: usize) -> Self {
         UnionFind {
@@ -64,7 +64,7 @@ impl<Idx: EntityRef + Hash + std::fmt::Display + Ord + ReservedValue> UnionFind<
     pub fn union(&mut self, a: Idx, b: Idx) {
         let a = self.find_and_update(a);
         let b = self.find_and_update(b);
-        let (a, b) = (std::cmp::min(a, b), std::cmp::max(a, b));
+        let (a, b) = (core::cmp::min(a, b), core::cmp::max(a, b));
         if a != b {
             // Always canonicalize toward lower IDs.
             self.parent[b] = Val(a);

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -93,6 +93,7 @@ pub struct VerifierError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for VerifierError {}
 
 impl Display for VerifierError {
@@ -172,6 +173,7 @@ pub struct VerifierErrors(pub Vec<VerifierError>);
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
+#[cfg(feature = "std")]
 impl std::error::Error for VerifierErrors {}
 
 impl VerifierErrors {

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -135,7 +135,7 @@ impl<'a> Codegen<'a> {
         }
 
         writeln!(code, "\nuse super::*;  // Pulls in all external types.").unwrap();
-        writeln!(code, "use std::marker::PhantomData;").unwrap();
+        writeln!(code, "use core::marker::PhantomData;").unwrap();
     }
 
     fn generate_trait_sig(&self, code: &mut String, indent: &str, sig: &ExternalSig) {


### PR DESCRIPTION
`cranelift-codegen` has an optional feature `std`, but when not enabled, it fails to compile demanding `std`.

Most of the issues were an easy fix:
1. Which was on several places used instead of `core` / `alloc` (fixed using simple search-replace)
2. Replacing `std`'s `HashMap` in `scoped_hash_map` with `hashbrown`'s (added little shim)

Currently the only remaining fix is `timing` module which relies on thread locals which in current implementation state are in `std` and `std::time::Instant`.

Here I am not so sure about possible fix. The thread local issue could be worked around by using nightly thread locals implementation, which isn't std dependent if `std` feature not used. The missing `Instant` could be fixed by not having a default timer implementation for no-std / having a no-op one. Both can be fixed by having no-op timer functions under conditional compilation, but that doesn't sound like a particularly nice solution.