### PR TITLE
cranelift-interpreter: Fix incorrect scalar_to_vector result

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
@@ -1,4 +1,5 @@
 test run
+test interpret
 target aarch64
 target s390x
 ; i8 and i16 are invalid source sizes for x86_64
@@ -16,5 +17,6 @@ block0(v0: i16):
     v1 = scalar_to_vector.i16x8 v0
     return v1
 }
+; run: %scalartovector_i16(0) == [0 0 0 0 0 0 0 0]
 ; run: %scalartovector_i16(1) == [1 0 0 0 0 0 0 0]
 ; run: %scalartovector_i16(65535) == [65535 0 0 0 0 0 0 0]

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -1,4 +1,5 @@
 test run
+test interpret
 target aarch64
 target s390x
 set enable_simd
@@ -18,6 +19,7 @@ block0(v0: i64):
     v1 = scalar_to_vector.i64x2 v0
     return v1
 }
+; run: %scalartovector_i64(0) == [0 0]
 ; run: %scalartovector_i64(1) == [1 0]
 ; run: %scalartovector_i64(18446744073709551615) == [18446744073709551615 0]
 


### PR DESCRIPTION
This PR attempts to address #5911.

The `vectorizelanes` function performs a check to see whether there is a single value provided in a given array, and if so returns it as a scalar.

While elsewhere in the interpreter this behaviour is relied upon, it yields an incorrect result when attempting to convert a scalar to a vector.

The original `vectorizelanes` remains untouched (in name and behaviorally), however, an unconditional variant `vectorizelanes_all` has been added.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
