### PR TITLE
Named models for wasi-nn

### DIFF
--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -19,6 +19,7 @@ wiggle = { workspace = true }
 # These dependencies are necessary for the wasi-nn implementation:
 openvino = { version = "0.4.2", features = ["runtime-linking"] }
 thiserror = { workspace = true }
+dashmap = "5.4.0"
 
 [build-dependencies]
 walkdir = "2.3"

--- a/crates/wasi-nn/src/api.rs
+++ b/crates/wasi-nn/src/api.rs
@@ -14,6 +14,12 @@ pub(crate) trait Backend: Send + Sync {
         builders: &GraphBuilderArray<'_>,
         target: ExecutionTarget,
     ) -> Result<Box<dyn BackendGraph>, BackendError>;
+
+    fn load_from_bytes(
+        &mut self,
+        model_bytes: &Vec<Vec<u8>>,
+        target: ExecutionTarget,
+    ) -> Result<Box<dyn BackendGraph>, BackendError>;
 }
 
 /// A [BackendGraph] can create [BackendExecutionContext]s; this is the backing

--- a/crates/wasi-nn/src/ctx.rs
+++ b/crates/wasi-nn/src/ctx.rs
@@ -3,9 +3,10 @@
 use crate::api::{Backend, BackendError, BackendExecutionContext, BackendGraph};
 use crate::openvino::OpenvinoBackend;
 use crate::r#impl::UsageError;
-use crate::witx::types::{Graph, GraphEncoding, GraphExecutionContext};
+use crate::witx::types::{Graph, GraphEncoding, GraphExecutionContext, ExecutionTarget, GraphBuilderArray};
 use std::collections::HashMap;
 use std::hash::Hash;
+use dashmap::DashMap;
 use thiserror::Error;
 use wiggle::GuestError;
 
@@ -14,6 +15,13 @@ pub struct WasiNnCtx {
     pub(crate) backends: HashMap<u8, Box<dyn Backend>>,
     pub(crate) graphs: Table<Graph, Box<dyn BackendGraph>>,
     pub(crate) executions: Table<GraphExecutionContext, Box<dyn BackendExecutionContext>>,
+    pub(crate) model_registry: DashMap<String, RegisteredModel>
+}
+
+pub(crate) struct RegisteredModel {
+    pub(crate) model_bytes: Vec<Vec<u8>>,
+    pub(crate) encoding: GraphEncoding,
+    pub(crate) target: ExecutionTarget
 }
 
 impl WasiNnCtx {
@@ -30,6 +38,7 @@ impl WasiNnCtx {
             backends,
             graphs: Table::default(),
             executions: Table::default(),
+            model_registry: DashMap::new()
         })
     }
 }

--- a/crates/wasi-nn/src/impl.rs
+++ b/crates/wasi-nn/src/impl.rs
@@ -1,4 +1,5 @@
 //! Implements the wasi-nn API.
+use openvino::TensorDesc;
 use crate::ctx::WasiNnResult as Result;
 use crate::witx::types::{
     ExecutionTarget, Graph, GraphBuilderArray, GraphEncoding, GraphExecutionContext, Tensor,
@@ -39,6 +40,14 @@ impl<'a> WasiEphemeralNn for WasiNnCtx {
         };
         let graph_id = self.graphs.insert(graph);
         Ok(graph_id)
+    }
+
+    fn register(
+        &mut self,
+        url: &GuestPtr<'_, u8>,
+        name: &GuestPtr<'_, u8>,
+    ) -> Result<()> {
+        Ok(())
     }
 
     fn init_execution_context(&mut self, graph_id: Graph) -> Result<GraphExecutionContext> {

--- a/crates/wasi-nn/src/impl.rs
+++ b/crates/wasi-nn/src/impl.rs
@@ -1,13 +1,17 @@
 //! Implements the wasi-nn API.
+
 use openvino::TensorDesc;
-use crate::ctx::WasiNnResult as Result;
+use crate::ctx::{RegisteredModel, WasiNnResult as Result};
 use crate::witx::types::{
-    ExecutionTarget, Graph, GraphBuilderArray, GraphEncoding, GraphExecutionContext, Tensor,
+    ExecutionTarget, Graph, GraphBuilderArray, GraphBuilder, GraphEncoding, GraphExecutionContext, Tensor,
 };
 use crate::witx::wasi_ephemeral_nn::WasiEphemeralNn;
 use crate::WasiNnCtx;
 use thiserror::Error;
 use wiggle::GuestPtr;
+
+
+const MAX_GUEST_MODEL_REGISTRATION_SIZE: usize = 10 * 1024 * 1024; //10M
 
 #[derive(Debug, Error)]
 pub enum UsageError {
@@ -23,6 +27,8 @@ pub enum UsageError {
     InvalidExecutionContextHandle,
     #[error("Not enough memory to copy tensor data of size: {0}")]
     NotEnoughMemory(u32),
+    #[error("Model size {0} exceeds allowed quota of {1}")]
+    ModelTooLarge(usize, usize),
 }
 
 impl<'a> WasiEphemeralNn for WasiNnCtx {
@@ -42,10 +48,83 @@ impl<'a> WasiEphemeralNn for WasiNnCtx {
         Ok(graph_id)
     }
 
-    fn register(
+    fn load_by_name<'b>(
         &mut self,
-        url: &GuestPtr<'_, u8>,
-        name: &GuestPtr<'_, u8>,
+        model_name: &GuestPtr<'_, [u8]>,
+    ) -> Result<Graph> {
+        let model_name = String::from_utf8(model_name.to_vec().unwrap()).unwrap();
+        let registered_model = self.model_registry.get(&model_name).unwrap();
+        let model_bytes = &registered_model.model_bytes;
+        let encoding: GraphEncoding = registered_model.encoding;
+        let target: ExecutionTarget = registered_model.target;
+        let encoding_id: u8 = encoding.into();
+
+        let graph = if let Some(backend) = self.backends.get_mut(&encoding_id) {
+            backend.load_from_bytes(model_bytes, target)?
+        } else {
+            return Err(UsageError::InvalidEncoding(encoding).into());
+        };
+        let graph_id = self.graphs.insert(graph);
+        Ok(graph_id)
+    }
+
+    fn register_model_bytes(
+        &mut self,
+        model_name: &GuestPtr<'_, [u8]>,
+        model_bytes: &GraphBuilderArray<'_>,
+        encoding: GraphEncoding,
+        target: ExecutionTarget,
+    ) -> Result<()> {
+        let length: usize = model_bytes.len().try_into().unwrap();
+        if (length > MAX_GUEST_MODEL_REGISTRATION_SIZE) {
+            return Err(UsageError::ModelTooLarge(length, MAX_GUEST_MODEL_REGISTRATION_SIZE).into());
+        }
+        let model_name_bytes = model_name.to_vec().unwrap();
+        let mut model_bytes_vec: Vec<Vec<u8>> = Vec::with_capacity(length.try_into().unwrap());
+        let mut model_bytes = model_bytes.as_ptr();
+        for i in 0..length {
+            let v = model_bytes
+                .read()?
+                .as_slice()?
+                .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)")
+                .to_vec();
+            model_bytes_vec.push(v);
+            model_bytes = model_bytes.add(1)?;
+        }
+
+        self.model_registry.insert(String::from_utf8(model_name_bytes).unwrap(), RegisteredModel {
+            model_bytes: model_bytes_vec,
+            encoding,
+            target,
+        });
+        Ok(())
+    }
+
+    fn unregister(
+        &mut self,
+        model_name: &GuestPtr<'_, [u8]>,
+    ) -> Result<()> {
+        let model_name_bytes = model_name.to_vec().unwrap();
+        self.model_registry.remove(&String::from_utf8(model_name_bytes).unwrap());
+        Ok(())
+    }
+
+    fn is_registered(
+        &mut self,
+        model_name: &GuestPtr<'_, [u8]>,
+    ) -> Result<u32> {
+        let model_name_bytes = model_name.to_vec().unwrap();
+        if self.model_registry.contains_key(&String::from_utf8(model_name_bytes).unwrap()) {
+            Ok(1)
+        } else { Ok(0) }
+    }
+
+    fn register_model_uri(
+        &mut self,
+        url: &GuestPtr<'_, [u8]>,
+        model_name: &GuestPtr<'_, [u8]>,
+        encoding: GraphEncoding,
+        target: ExecutionTarget,
     ) -> Result<()> {
         Ok(())
     }

--- a/crates/wasi-nn/src/openvino.rs
+++ b/crates/wasi-nn/src/openvino.rs
@@ -44,6 +44,31 @@ impl Backend for OpenvinoBackend {
             .read()?
             .as_slice()?
             .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        self.load_from_bytes( &vec![xml.to_vec(), weights.to_vec()], target)
+    }
+
+    fn load_from_bytes(
+        &mut self,
+        model_bytes: &Vec<Vec<u8>>,
+        target: ExecutionTarget,
+    ) -> Result<Box<dyn BackendGraph>, BackendError> {
+        if model_bytes.len() != 2 {
+            return Err(BackendError::InvalidNumberOfBuilders(2, model_bytes.len().try_into().unwrap()).into());
+        }
+
+        // Construct the context if none is present; this is done lazily (i.e.
+        // upon actually loading a model) because it may fail to find and load
+        // the OpenVINO libraries. The laziness limits the extent of the error
+        // only to wasi-nn users, not all WASI users.
+        if self.0.is_none() {
+            self.0.replace(openvino::Core::new(None)?);
+        }
+
+        // Read the guest array.
+        let xml = model_bytes[0].as_slice();
+            // .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
+        let weights = model_bytes[1].as_slice();
+            // .expect("cannot use with shared memories; see https://github.com/bytecodealliance/wasmtime/issues/5235 (TODO)");
 
         // Construct OpenVINO graph structures: `cnn_network` contains the graph
         // structure, `exec_network` can perform inference.
@@ -51,7 +76,7 @@ impl Backend for OpenvinoBackend {
             .0
             .as_mut()
             .expect("openvino::Core was previously constructed");
-        let mut cnn_network = core.read_network_from_buffer(&xml, &weights)?;
+        let mut cnn_network = core.read_network_from_buffer(xml, weights)?;
 
         // TODO this is a temporary workaround. We need a more eligant way to specify the layout in the long run.
         // However, without this newer versions of OpenVINO will fail due to parameter mismatch.

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 // Generate the traits and types of wasi-nn in several Rust modules (e.g. `types`).
 wiggle::from_witx!({
-    witx: ["$WASI_ROOT/phases/ephemeral/witx/wasi_ephemeral_nn.witx"],
+    witx: ["$WASI_ROOT/wasi-nn.witx"],
     errors: { nn_errno => WasiNnError }
 });
 


### PR DESCRIPTION
This PR implements named models for wasi-nn as discussed here WebAssembly/wasi-nn#36.

This PR adds a registry that tracks the byte level form of the models that can be populated from either the host or guest side. This will allow WASM host instances to reuse the same model multiple times without having to fully reload it. It currently imposes a hard-coded 10MB limit on the size of models that can be registered from a guest and extends the Backend wasi-nn API so that it can work directly with byte arrays, instead of passing through GuestPtr instances.

This implementation only caches the compiled graph for CPU execution targets as other targets may consume resources on GPU or TPU hardware, which is not possible to track in a straightforward fashion. In the future, it may become desirable to have visibility over resource usage so that hosts may make more sophisticated decisions about what models are fully cached for execution.

This PR also updates the WITX to the latest version of the spec as it was previously pointing to a much older commit.