### PR TITLE
cargo-deny: allow the MPL-2.0 and OpenSSL licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,8 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "MPL-2.0",
+    "OpenSSL",
     "Zlib",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,13 @@ allow = [
     "Zlib",
 ]
 
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 multiple-versions = "deny"


### PR DESCRIPTION
These are required in order to merge https://github.com/bytecodealliance/wasmtime/pull/5929.

I discussed this change with Till: we believe that these licenses are compatible with Wasmtime's license and don't add any fundamentally new requirements to the existing allow-list.

In an ideal world, I could imagine making an RFC or asking the Bytecode Alliance board weigh in on this decision, but we don't have any process or guidance for how to go about changing this list, and we don't expect this change to be controversial in any way. So, I've asked all of the BA TSC members (@fitzgen @tschneidereit @ricochet) to please approve this PR before I merge it.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
