### PR TITLE
add supply chain audits for #5929's rustls changes

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -817,6 +817,23 @@ criteria = "safe-to-deploy"
 delta = "0.36.7 -> 0.36.8"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[audits.rustls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.21.0"
+notes = "no unsafe code, ambient capabilities only used in tests"
+
+[[audits.rustls-webpki]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.100.1"
+
+[[audits.sct]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "no unsafe, no build, no ambient capabilities"
+
 [[audits.semver]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -901,6 +918,12 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 notes = "unsafety is used for smuggling std::task::Context as a raw pointer. Lifetime and type safety appears to be taken care of correctly."
 
+[[audits.tokio-rustls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.24.0"
+notes = "no unsafe, no build, no ambient capabilities"
+
 [[audits.tokio-util]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -966,6 +989,11 @@ notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes co
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
+
+[[audits.wasm-bindgen-shared]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.83 -> 0.2.80"
 
 [[audits.wasm-coredump-builder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -1601,6 +1629,11 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.48 -> 1.0.49"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[audits.webpki-roots]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.22.4 -> 0.23.0"
 
 [[audits.windows-sys]]
 who = "Dan Gohman <dev@sunfishcode.online>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -428,6 +428,11 @@ criteria = "safe-to-deploy"
 
 [[exemptions.js-sys]]
 version = "0.3.57"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
+
+[[exemptions.js-sys]]
+version = "0.3.57"
 criteria = "safe-to-run"
 
 [[exemptions.k256]]
@@ -733,6 +738,11 @@ criteria = "safe-to-deploy"
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.ring]]
+version = "0.16.20"
+criteria = "safe-to-deploy"
+notes = "contains assembly language and object file implementations of crypto primitives for a very large number of platforms"
+
 [[exemptions.rsa]]
 version = "0.5.0"
 criteria = "safe-to-deploy"
@@ -963,7 +973,17 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
+
+[[exemptions.wasm-bindgen]]
+version = "0.2.80"
 criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-backend]]
+version = "0.2.80"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
 
 [[exemptions.wasm-bindgen-backend]]
 version = "0.2.80"
@@ -971,15 +991,26 @@ criteria = "safe-to-run"
 
 [[exemptions.wasm-bindgen-macro]]
 version = "0.2.80"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
+
+[[exemptions.wasm-bindgen-macro]]
+version = "0.2.80"
 criteria = "safe-to-run"
+
+[[exemptions.wasm-bindgen-macro-support]]
+version = "0.2.80"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
 
 [[exemptions.wasm-bindgen-macro-support]]
 version = "0.2.80"
 criteria = "safe-to-run"
 
-[[exemptions.wasm-bindgen-shared]]
-version = "0.2.80"
-criteria = "safe-to-run"
+[[exemptions.web-sys]]
+version = "0.3.57"
+criteria = "safe-to-deploy"
+notes = "dependency of ring for wasm32 browser platform, which our project does not target"
 
 [[exemptions.web-sys]]
 version = "0.3.57"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -32,6 +32,12 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 notes = "Inspected it and is a tiny crate with just type definitions"
 
+[[audits.embark-studios.audits.webpki-roots]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.22.4"
+notes = "Inspected it to confirm that it only contains data definitions and no runtime code"
+
 [[audits.google.audits.libfuzzer-sys]]
 who = "ChromeOS"
 criteria = "safe-to-run"
@@ -70,6 +76,16 @@ version = "0.3.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.4.1"
+
+[[audits.isrg.audits.untrusted]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+
+[[audits.isrg.audits.wasm-bindgen-shared]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.2.83"
 
 [[audits.mozilla.audits.autocfg]]
 who = "Josh Stone <jistone@redhat.com>"


### PR DESCRIPTION
The `ring` crate needed to be exempted: it contains a large quantity of asm and native binary implementations of crypto primitives. It is a major undertaking to certify the safety of those implementations.

ring also pulled in the wasm-bindgen family of crates for its wasm32-unknown-unknown target, which this project will not be using. Because we don't care about that platform, I added exemptions for all of these crates, so we don't have to audit them.

The actual supply chain audits for rusttls, rustls-webpki, sct, and tokio-rustls were unremarkable. I also audited a small diff on wasm-bindgen-shared because it was trivial.

cc #5929 

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
