### PR TITLE
Derive `Copy` on `wasmtime::ValType`

### DIFF
--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -19,7 +19,7 @@ pub enum Mutability {
 // Value Types
 
 /// A list of all possible value types in WebAssembly.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum ValType {
     // NB: the ordering here is intended to match the ordering in
     // `wasmtime_types::WasmType` to help improve codegen when converting.


### PR DESCRIPTION
`ValType` is small enough that it can be copiable. By making `ValType` `Copy`, `Copy` structs can have `ValType` fields in them.

The need for this came up in bytecodealliance/wasmtime-rb#158. By making `ValType` `Copy`, we could get rid of [this workaround](https://github.com/bytecodealliance/wasmtime-rb/blob/3d7f7a1671790a829b316b9567379fc3af5cca7e/ext/src/ruby_api/params.rs#L73-L111).

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
