### PR TITLE
Use an unaligned write for resolving libcall relocations

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -299,7 +299,11 @@ impl CodeMemory {
                 obj::LibCall::FmaF32 => libcalls::relocs::fmaf32 as usize,
                 obj::LibCall::FmaF64 => libcalls::relocs::fmaf64 as usize,
             };
-            *self.mmap.as_mut_ptr().add(offset).cast::<usize>() = libcall;
+            self.mmap
+                .as_mut_ptr()
+                .add(offset)
+                .cast::<usize>()
+                .write_unaligned(libcall);
         }
         Ok(())
     }


### PR DESCRIPTION
This commit changes resolution of libcall relocations from writing a `usize` into a raw pointer to specifically performing an unaligned write. The addresses of libcalls to write to are not guaranteed to be aligned, so this could technically have caused issues on some platforms perhaps.

This was discovered now that Rust nightly will panic on unaligned writes to pointers, and fuzzing ran into this case when compiled with a more recent Nightly build.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
