### PR TITLE
Add a limits and trap-on-OOM options to the CLI

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -97,13 +97,18 @@ impl StoreLimits {
 }
 
 impl ResourceLimiter for StoreLimits {
-    fn memory_growing(&mut self, current: usize, desired: usize, _maximum: Option<usize>) -> bool {
-        self.alloc(desired - current)
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> Result<bool> {
+        Ok(self.alloc(desired - current))
     }
 
-    fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+    fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> Result<bool> {
         let delta = (desired - current) as usize * std::mem::size_of::<usize>();
-        self.alloc(delta)
+        Ok(self.alloc(delta))
     }
 }
 

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1874,19 +1874,18 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
     ) -> Result<bool, anyhow::Error> {
         match self.limiter {
             Some(ResourceLimiterInner::Sync(ref mut limiter)) => {
-                Ok(limiter(&mut self.data).memory_growing(current, desired, maximum))
+                limiter(&mut self.data).memory_growing(current, desired, maximum)
             }
             #[cfg(feature = "async")]
             Some(ResourceLimiterInner::Async(ref mut limiter)) => unsafe {
-                Ok(self
-                    .inner
+                self.inner
                     .async_cx()
                     .expect("ResourceLimiterAsync requires async Store")
                     .block_on(
                         limiter(&mut self.data)
                             .memory_growing(current, desired, maximum)
                             .as_mut(),
-                    )?)
+                    )?
             },
             None => Ok(true),
         }
@@ -1923,17 +1922,17 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
 
         match self.limiter {
             Some(ResourceLimiterInner::Sync(ref mut limiter)) => {
-                Ok(limiter(&mut self.data).table_growing(current, desired, maximum))
+                limiter(&mut self.data).table_growing(current, desired, maximum)
             }
             #[cfg(feature = "async")]
             Some(ResourceLimiterInner::Async(ref mut limiter)) => unsafe {
-                Ok(async_cx
+                async_cx
                     .expect("ResourceLimiterAsync requires async Store")
                     .block_on(
                         limiter(&mut self.data)
                             .table_growing(current, desired, maximum)
                             .as_mut(),
-                    )?)
+                    )?
             },
             None => Ok(true),
         }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -9,7 +9,9 @@ use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::thread;
 use std::time::Duration;
-use wasmtime::{Engine, Func, Linker, Module, Store, Val, ValType};
+use wasmtime::{
+    Engine, Func, Linker, Module, Store, StoreLimits, StoreLimitsBuilder, Val, ValType,
+};
 use wasmtime_cli_flags::{CommonOptions, WasiModules};
 use wasmtime_wasi::maybe_exit_on_error;
 use wasmtime_wasi::sync::{ambient_authority, Dir, TcpListener, WasiCtxBuilder};
@@ -166,6 +168,38 @@ pub struct RunCommand {
     /// The arguments to pass to the module
     #[clap(value_name = "ARGS")]
     module_args: Vec<String>,
+
+    /// Maximum size, in bytes, that a linear memory is allowed to reach.
+    ///
+    /// Growth beyond this limit will cause `memory.grow` instructions in
+    /// WebAssembly modules to return -1 and fail.
+    #[clap(long, value_name = "BYTES")]
+    max_memory_size: Option<usize>,
+
+    /// Maximum size, in table elements, that a table is allowed to reach.
+    #[clap(long)]
+    max_table_elements: Option<u32>,
+
+    /// Maximum number of WebAssembly instances allowed to be created.
+    #[clap(long)]
+    max_instances: Option<usize>,
+
+    /// Maximum number of WebAssembly tables allowed to be created.
+    #[clap(long)]
+    max_tables: Option<usize>,
+
+    /// Maximum number of WebAssembly linear memories allowed to be created.
+    #[clap(long)]
+    max_memories: Option<usize>,
+
+    /// Force a trap to be raised on `memory.grow` and `table.grow` failure
+    /// instead of returning -1 from these instructions.
+    ///
+    /// This is not necessarily a spec-compliant option to enable but can be
+    /// useful for tracking down a backtrace of what is requesting so much
+    /// memory, for example.
+    #[clap(long)]
+    trap_on_grow_failure: bool,
 }
 
 impl RunCommand {
@@ -211,6 +245,27 @@ impl RunCommand {
             self.listenfd,
             preopen_sockets,
         )?;
+
+        let mut limits = StoreLimitsBuilder::new();
+        if let Some(max) = self.max_memory_size {
+            limits = limits.memory_size(max);
+        }
+        if let Some(max) = self.max_table_elements {
+            limits = limits.table_elements(max);
+        }
+        if let Some(max) = self.max_instances {
+            limits = limits.instances(max);
+        }
+        if let Some(max) = self.max_tables {
+            limits = limits.tables(max);
+        }
+        if let Some(max) = self.max_memories {
+            limits = limits.memories(max);
+        }
+        store.data_mut().limits = limits
+            .trap_on_grow_failure(self.trap_on_grow_failure)
+            .build();
+        store.limiter(|t| &mut t.limits);
 
         // If fuel has been configured, we want to add the configured
         // fuel amount to this store.
@@ -470,6 +525,7 @@ struct Host {
     wasi_nn: Option<Arc<WasiNnCtx>>,
     #[cfg(feature = "wasi-threads")]
     wasi_threads: Option<Arc<WasiThreadsCtx<Host>>>,
+    limits: StoreLimits,
 }
 
 /// Populates the given `Linker` with WASI APIs.

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -111,16 +111,16 @@ async fn test_limits_async() -> Result<()> {
             _current: usize,
             desired: usize,
             _maximum: Option<usize>,
-        ) -> bool {
-            desired <= self.memory_size
+        ) -> Result<bool> {
+            Ok(desired <= self.memory_size)
         }
         async fn table_growing(
             &mut self,
             _current: u32,
             desired: u32,
             _maximum: Option<u32>,
-        ) -> bool {
-            desired <= self.table_elements
+        ) -> Result<bool> {
+            Ok(desired <= self.table_elements)
         }
     }
 
@@ -394,7 +394,12 @@ struct MemoryContext {
 }
 
 impl ResourceLimiter for MemoryContext {
-    fn memory_growing(&mut self, current: usize, desired: usize, maximum: Option<usize>) -> bool {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> Result<bool> {
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
         assert!(desired < maximum.unwrap_or(usize::MAX));
 
@@ -403,14 +408,19 @@ impl ResourceLimiter for MemoryContext {
 
         if desired + self.host_memory_used > self.memory_limit {
             self.limit_exceeded = true;
-            return false;
+            return Ok(false);
         }
 
         self.wasm_memory_used = desired;
-        true
+        Ok(true)
     }
-    fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
-        true
+    fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
+        Ok(true)
     }
 }
 
@@ -501,7 +511,7 @@ impl ResourceLimiterAsync for MemoryContext {
         current: usize,
         desired: usize,
         maximum: Option<usize>,
-    ) -> bool {
+    ) -> Result<bool> {
         // Show we can await in this async context:
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
@@ -512,14 +522,19 @@ impl ResourceLimiterAsync for MemoryContext {
 
         if desired + self.host_memory_used > self.memory_limit {
             self.limit_exceeded = true;
-            return false;
+            return Ok(false);
         }
 
         self.wasm_memory_used = desired;
-        true
+        Ok(true)
     }
-    async fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
-        true
+    async fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
+        Ok(true)
     }
     fn table_grow_failed(&mut self, _e: &anyhow::Error) {}
 }
@@ -619,20 +634,20 @@ impl ResourceLimiter for TableContext {
         _current: usize,
         _desired: usize,
         _maximum: Option<usize>,
-    ) -> bool {
-        true
+    ) -> Result<bool> {
+        Ok(true)
     }
-    fn table_growing(&mut self, current: u32, desired: u32, maximum: Option<u32>) -> bool {
+    fn table_growing(&mut self, current: u32, desired: u32, maximum: Option<u32>) -> Result<bool> {
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
         assert!(desired < maximum.unwrap_or(u32::MAX));
         assert_eq!(current, self.elements_used);
-        if desired > self.element_limit {
+        Ok(if desired > self.element_limit {
             self.limit_exceeded = true;
-            return false;
+            false
         } else {
             self.elements_used = desired;
             true
-        }
+        })
     }
 }
 
@@ -693,18 +708,23 @@ struct FailureDetector {
 }
 
 impl ResourceLimiter for FailureDetector {
-    fn memory_growing(&mut self, current: usize, desired: usize, _maximum: Option<usize>) -> bool {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> Result<bool> {
         self.memory_current = current;
         self.memory_desired = desired;
-        true
+        Ok(true)
     }
     fn memory_grow_failed(&mut self, err: &anyhow::Error) {
         self.memory_error = Some(err.to_string());
     }
-    fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+    fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> Result<bool> {
         self.table_current = current;
         self.table_desired = desired;
-        true
+        Ok(true)
     }
     fn table_grow_failed(&mut self, err: &anyhow::Error) {
         self.table_error = Some(err.to_string());
@@ -793,21 +813,26 @@ impl ResourceLimiterAsync for FailureDetector {
         current: usize,
         desired: usize,
         _maximum: Option<usize>,
-    ) -> bool {
+    ) -> Result<bool> {
         // Show we can await in this async context:
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         self.memory_current = current;
         self.memory_desired = desired;
-        true
+        Ok(true)
     }
     fn memory_grow_failed(&mut self, err: &anyhow::Error) {
         self.memory_error = Some(err.to_string());
     }
 
-    async fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+    async fn table_growing(
+        &mut self,
+        current: u32,
+        desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
         self.table_current = current;
         self.table_desired = desired;
-        true
+        Ok(true)
     }
     fn table_grow_failed(&mut self, err: &anyhow::Error) {
         self.table_error = Some(err.to_string());
@@ -903,10 +928,15 @@ impl ResourceLimiter for Panic {
         _current: usize,
         _desired: usize,
         _maximum: Option<usize>,
-    ) -> bool {
+    ) -> Result<bool> {
         panic!("resource limiter memory growing");
     }
-    fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
+    fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
         panic!("resource limiter table growing");
     }
 }
@@ -917,10 +947,15 @@ impl ResourceLimiterAsync for Panic {
         _current: usize,
         _desired: usize,
         _maximum: Option<usize>,
-    ) -> bool {
+    ) -> Result<bool> {
         panic!("async resource limiter memory growing");
     }
-    async fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
+    async fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
         panic!("async resource limiter table growing");
     }
 }
@@ -1058,4 +1093,62 @@ async fn panic_in_async_table_limiter() {
         .grow_async(&mut store, 3, Val::FuncRef(None))
         .await
         .unwrap();
+}
+
+#[test]
+fn growth_trap() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"(module
+            (memory $m (export "m") 0)
+            (table (export "t") 0 anyfunc)
+            (func (export "grow") (param i32) (result i32)
+              (memory.grow $m (local.get 0)))
+           )"#,
+    )?;
+
+    let mut store = Store::new(
+        &engine,
+        StoreLimitsBuilder::new()
+            .memory_size(WASM_PAGE_SIZE)
+            .table_elements(1)
+            .trap_on_grow_failure(true)
+            .build(),
+    );
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    // Test instance exports and host objects hitting the limit
+    for memory in [
+        instance.get_memory(&mut store, "m").unwrap(),
+        Memory::new(&mut store, MemoryType::new(0, None))?,
+    ] {
+        memory.grow(&mut store, 1)?;
+        assert!(memory.grow(&mut store, 1).is_err());
+    }
+
+    // Test instance exports and host objects hitting the limit
+    for table in [
+        instance.get_table(&mut store, "t").unwrap(),
+        Table::new(
+            &mut store,
+            TableType::new(ValType::FuncRef, 0, None),
+            Val::FuncRef(None),
+        )?,
+    ] {
+        table.grow(&mut store, 1, Val::FuncRef(None))?;
+        assert!(table.grow(&mut store, 1, Val::FuncRef(None)).is_err());
+    }
+
+    let mut store = Store::new(&engine, store.data().clone());
+    store.limiter(|s| s as &mut dyn ResourceLimiter);
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let grow = instance.get_func(&mut store, "grow").unwrap();
+    let grow = grow.typed::<i32, i32>(&store).unwrap();
+    grow.call(&mut store, 1)?;
+    assert!(grow.call(&mut store, 1).is_err());
+
+    Ok(())
 }

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -306,11 +306,16 @@ fn massive_64_bit_still_limited() -> Result<()> {
             _current: usize,
             _request: usize,
             _max: Option<usize>,
-        ) -> bool {
+        ) -> Result<bool> {
             self.hit = true;
-            true
+            Ok(true)
         }
-        fn table_growing(&mut self, _current: u32, _request: u32, _max: Option<u32>) -> bool {
+        fn table_growing(
+            &mut self,
+            _current: u32,
+            _request: u32,
+            _max: Option<u32>,
+        ) -> Result<bool> {
             unreachable!()
         }
     }

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -528,12 +528,12 @@ fn drop_externref_global_during_module_init() -> Result<()> {
     struct Limiter;
 
     impl ResourceLimiter for Limiter {
-        fn memory_growing(&mut self, _: usize, _: usize, _: Option<usize>) -> bool {
-            false
+        fn memory_growing(&mut self, _: usize, _: usize, _: Option<usize>) -> Result<bool> {
+            Ok(false)
         }
 
-        fn table_growing(&mut self, _: u32, _: u32, _: Option<u32>) -> bool {
-            false
+        fn table_growing(&mut self, _: u32, _: u32, _: Option<u32>) -> Result<bool> {
+            Ok(false)
         }
     }
 

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -13,16 +13,26 @@ struct MemoryGrowFailureDetector {
 }
 
 impl ResourceLimiter for MemoryGrowFailureDetector {
-    fn memory_growing(&mut self, current: usize, desired: usize, _maximum: Option<usize>) -> bool {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        _maximum: Option<usize>,
+    ) -> Result<bool> {
         self.current = current;
         self.desired = desired;
-        true
+        Ok(true)
     }
     fn memory_grow_failed(&mut self, err: &anyhow::Error) {
         self.error = Some(err.to_string());
     }
-    fn table_growing(&mut self, _current: u32, _desired: u32, _maximum: Option<u32>) -> bool {
-        true
+    fn table_growing(
+        &mut self,
+        _current: u32,
+        _desired: u32,
+        _maximum: Option<u32>,
+    ) -> Result<bool> {
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
This commit adds new options to the `wasmtime` CLI to control the `Store::limiter` behavior at runtime. This enables artificially restriction the memory usage of the wasm instance, for example. Additionally a new option is added to `StoreLimits` to force a trap on growth failure. This is intended to help quickly debug modules with backtraces if OOM is happening, or even diagnosing if OOM is happening in the first place.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
