### PR TITLE
Default to the native host for `wasmtime compile`

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -5,7 +5,6 @@ use clap::Parser;
 use once_cell::sync::Lazy;
 use std::fs;
 use std::path::PathBuf;
-use target_lexicon::Triple;
 use wasmtime::Engine;
 use wasmtime_cli_flags::CommonOptions;
 
@@ -61,12 +60,7 @@ impl CompileCommand {
     pub fn execute(mut self) -> Result<()> {
         self.common.init_logging();
 
-        let target = self
-            .target
-            .take()
-            .unwrap_or_else(|| Triple::host().to_string());
-
-        let config = self.common.config(Some(&target))?;
+        let config = self.common.config(self.target.as_deref())?;
 
         let engine = Engine::new(&config)?;
 


### PR DESCRIPTION
This commit updates the implementation of the `wasmtime compile` to use the native host as the default targeted output. Previously the string for the native host's target was used as the default target, but this notably disables CPU feature inference meaning that the baseline was always generated.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
