### PR TITLE
cranelift-interpreter: Propagate traps across calls

### DIFF
--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1397,6 +1397,7 @@ pub enum ControlFlow<'a, V> {
 impl<'a, V> ControlFlow<'a, V> {
     /// For convenience, we can unwrap the [ControlFlow] state assuming that it is a
     /// [ControlFlow::Return], panicking otherwise.
+    #[cfg(test)]
     pub fn unwrap_return(self) -> Vec<V> {
         if let ControlFlow::Return(values) = self {
             values.into_vec()
@@ -1407,6 +1408,7 @@ impl<'a, V> ControlFlow<'a, V> {
 
     /// For convenience, we can unwrap the [ControlFlow] state assuming that it is a
     /// [ControlFlow::Trap], panicking otherwise.
+    #[cfg(test)]
     pub fn unwrap_trap(self) -> CraneliftTrap {
         if let ControlFlow::Trap(trap) = self {
             trap


### PR DESCRIPTION
👋 Hey,

Fuzzgen found a bug in the interpreter (#6155) where if a function called another function and the child function trapped, the interpreter was panicking instead of propagating the trap correctly.

This PR fixes that by propagating the trap up instead of panicking.

Fixes: #6155