### PR TITLE
Migrate mach to mach2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,7 +4063,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "mach",
+ "mach2",
  "memfd",
  "memoffset 0.8.0",
  "once_cell",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,7 +27,7 @@ paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach = "0.3.2"
+mach2 = "0.4.1"
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["mm"] }

--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -34,25 +34,23 @@
 #![allow(non_snake_case)]
 
 use crate::traphandlers::{tls, wasmtime_longjmp};
-use mach::exception_types::*;
-use mach::kern_return::*;
-use mach::mach_init::*;
-use mach::mach_port::*;
-use mach::message::*;
-use mach::port::*;
-use mach::thread_act::*;
-use mach::traps::*;
+use mach2::exception_types::*;
+use mach2::kern_return::*;
+use mach2::mach_init::*;
+use mach2::mach_port::*;
+use mach2::message::*;
+use mach2::port::*;
+use mach2::thread_act::*;
+use mach2::traps::*;
 use std::mem;
 use std::thread;
 
-/// Other `mach` declarations awaiting <https://github.com/fitzgen/mach/pull/64>
-/// to be merged.
 mod mach_addons {
     #![allow(non_camel_case_types)]
     #![allow(non_upper_case_globals)]
     #![allow(dead_code)]
 
-    use mach::{
+    use mach2::{
         exception_types::*, kern_return::*, mach_types::*, message::*, port::*, thread_status::*,
     };
     use std::mem;
@@ -294,8 +292,8 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
     // * `thread_state_count` - the size to pass to `mach_msg`.
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "x86_64")] {
-            use mach::structs::x86_thread_state64_t;
-            use mach::thread_status::x86_THREAD_STATE64;
+            use mach2::structs::x86_thread_state64_t;
+            use mach2::thread_status::x86_THREAD_STATE64;
 
             type ThreadState = x86_thread_state64_t;
 


### PR DESCRIPTION
There is a RUSTSEC warning about crate mach: https://rustsec.org/advisories/RUSTSEC-2020-0168 (#6000)
This PR migrates mach to mach2
