### PR TITLE
Add a WASI test for a creating an absolute-path symlink.

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
+++ b/crates/test-programs/wasi-tests/src/bin/symlink_create.rs
@@ -62,6 +62,11 @@ unsafe fn create_symlink_to_directory(dir_fd: wasi::Fd) {
         .expect("remove_directory on a directory should succeed");
 }
 
+unsafe fn create_symlink_to_root(dir_fd: wasi::Fd) {
+    // Create a symlink.
+    wasi::path_symlink("/", dir_fd, "symlink").expect_err("creating a symlink to an absolute path");
+}
+
 fn main() {
     let mut args = env::args();
     let prog = args.next().unwrap();
@@ -85,5 +90,6 @@ fn main() {
     unsafe {
         create_symlink_to_file(dir_fd);
         create_symlink_to_directory(dir_fd);
+        create_symlink_to_root(dir_fd);
     }
 }


### PR DESCRIPTION
Wasmtime disallows guests from using `path_symlink` to create absolute-path symlinks, as they could confuse other code into accessing resources on the host that the guest otherwise doesn't have access to.

This patch adds a test for this behavior.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
