### PR TITLE
ci: use version tag of `install-openvino-action`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -478,7 +478,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-rust
       - run: rustup target add wasm32-wasi
-      - uses: abrown/install-openvino-action@50a2ab733ef4b504dd7de3ac45c36eae7f9bc228
+      - uses: abrown/install-openvino-action@v6
         with:
           version: 2022.3.0
           apt: true


### PR DESCRIPTION
In #6089, I accidentally left in a change that pegged the `install-openvino-action` to a commit instead of the latest released version. This change uses the latest released version.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
