### PR TITLE
Allow serializing all cranelift-module data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-control",
  "hashbrown 0.13.2",
+ "serde",
 ]
 
 [[package]]

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -31,7 +31,7 @@ use super::{RelSourceLoc, SourceLoc, UserExternalName};
 
 /// A version marker used to ensure that serialized clif ir is never deserialized with a
 /// different version of Cranelift.
-#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Hash)]
 pub struct VersionMarker;
 
 #[cfg(feature = "enable-serde")]

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -326,11 +326,9 @@ impl JITModule {
                         }
                     }
                 };
-                let name = if let Some(name) = name {
-                    name
-                } else {
-                    panic!("anonymous symbol must be defined locally");
-                };
+                let name = name
+                    .as_ref()
+                    .expect("anonymous symbol must be defined locally");
                 if let Some(ptr) = self.lookup_symbol(name) {
                     ptr
                 } else if linkage == Linkage::Preemptible {

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -1,15 +1,15 @@
 //! Defines `JITModule`.
 
 use crate::{compiled_blob::CompiledBlob, memory::BranchProtection, memory::Memory};
+use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::Configurable;
 use cranelift_codegen::{self, ir, settings, MachReloc};
-use cranelift_codegen::{binemit::Reloc, CodegenError};
 use cranelift_control::ControlPlane;
 use cranelift_entity::SecondaryMap;
 use cranelift_module::{
-    DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleCompiledFunction,
-    ModuleDeclarations, ModuleError, ModuleExtName, ModuleReloc, ModuleResult,
+    DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleDeclarations, ModuleError,
+    ModuleExtName, ModuleReloc, ModuleResult,
 };
 use log::info;
 use std::cell::RefCell;
@@ -647,7 +647,7 @@ impl Module for JITModule {
         id: FuncId,
         ctx: &mut cranelift_codegen::Context,
         ctrl_plane: &mut ControlPlane,
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         info!("defining function {}: {}", id, ctx.func.display());
         let decl = self.declarations.get_function_decl(id);
         if !decl.linkage.is_definable() {
@@ -678,9 +678,7 @@ impl Module for JITModule {
         let alignment = res.alignment as u64;
         let compiled_code = ctx.compiled_code().unwrap();
 
-        let code_size = compiled_code.code_info().total_size;
-
-        let size = code_size as usize;
+        let size = compiled_code.code_info().total_size as usize;
         let align = alignment
             .max(self.isa.function_alignment() as u64)
             .max(self.isa.symbol_alignment());
@@ -739,7 +737,7 @@ impl Module for JITModule {
             self.functions_to_finalize.push(id);
         }
 
-        Ok(ModuleCompiledFunction { size: code_size })
+        Ok(())
     }
 
     fn define_function_bytes(
@@ -749,13 +747,8 @@ impl Module for JITModule {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         info!("defining function {} with bytes", id);
-        let total_size: u32 = match bytes.len().try_into() {
-            Ok(total_size) => total_size,
-            _ => Err(CodegenError::CodeTooLarge)?,
-        };
-
         let decl = self.declarations.get_function_decl(id);
         if !decl.linkage.is_definable() {
             return Err(ModuleError::InvalidImportDefinition(decl.name.clone()));
@@ -812,7 +805,7 @@ impl Module for JITModule {
             self.functions_to_finalize.push(id);
         }
 
-        Ok(ModuleCompiledFunction { size: total_size })
+        Ok(())
     }
 
     fn define_data(&mut self, id: DataId, data: &DataDescription) -> ModuleResult<()> {

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -15,11 +15,15 @@ cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 anyhow = { workspace = true }
+serde = { version = "1.0.94", features = ["derive"], optional = true }
 
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]
 core = ["hashbrown", "cranelift-codegen/core"]
+
+# For dependent crates that want to serialize some parts of cranelift
+enable-serde = ["serde", "cranelift-codegen/enable-serde"]
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -13,6 +13,7 @@ use crate::ModuleExtName;
 
 /// This specifies how data is to be initialized.
 #[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Init {
     /// This indicates that no initialization has been specified yet.
     Uninitialized,
@@ -41,6 +42,7 @@ impl Init {
 
 /// A description of a data object.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DataDescription {
     /// How the data should be initialized.
     pub init: Init,

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -43,8 +43,7 @@ mod traps;
 pub use crate::data_context::{DataDescription, Init};
 pub use crate::module::{
     DataDeclaration, DataId, FuncId, FuncOrDataId, FunctionDeclaration, Linkage, Module,
-    ModuleCompiledFunction, ModuleDeclarations, ModuleError, ModuleExtName, ModuleReloc,
-    ModuleResult,
+    ModuleDeclarations, ModuleError, ModuleExtName, ModuleReloc, ModuleResult,
 };
 pub use crate::traps::TrapSite;
 

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -12,7 +12,7 @@ use cranelift_codegen::binemit::{CodeOffset, Reloc};
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::ir::Function;
 use cranelift_codegen::settings::SetError;
-use cranelift_codegen::{binemit, MachReloc};
+use cranelift_codegen::MachReloc;
 use cranelift_codegen::{ir, isa, CodegenError, CompileError, Context};
 use cranelift_control::ControlPlane;
 use std::borrow::ToOwned;
@@ -520,12 +520,6 @@ impl ModuleDeclarations {
     }
 }
 
-/// Information about the compiled function.
-pub struct ModuleCompiledFunction {
-    /// The size of the compiled function.
-    pub size: binemit::CodeOffset,
-}
-
 /// A `Module` is a utility for collecting functions and data objects, and linking them together.
 pub trait Module {
     /// Return the `TargetIsa` to compile for.
@@ -660,11 +654,7 @@ pub trait Module {
     /// Note: After calling this function the given `Context` will contain the compiled function.
     ///
     /// [`define_function_with_control_plane`]: Self::define_function_with_control_plane
-    fn define_function(
-        &mut self,
-        func: FuncId,
-        ctx: &mut Context,
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    fn define_function(&mut self, func: FuncId, ctx: &mut Context) -> ModuleResult<()> {
         self.define_function_with_control_plane(func, ctx, &mut ControlPlane::default())
     }
 
@@ -678,7 +668,7 @@ pub trait Module {
         func: FuncId,
         ctx: &mut Context,
         ctrl_plane: &mut ControlPlane,
-    ) -> ModuleResult<ModuleCompiledFunction>;
+    ) -> ModuleResult<()>;
 
     /// Define a function, taking the function body from the given `bytes`.
     ///
@@ -694,7 +684,7 @@ pub trait Module {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
-    ) -> ModuleResult<ModuleCompiledFunction>;
+    ) -> ModuleResult<()>;
 
     /// Define a data object, producing the data contents from the given `DataContext`.
     fn define_data(&mut self, data_id: DataId, data: &DataDescription) -> ModuleResult<()>;
@@ -776,11 +766,7 @@ impl<M: Module> Module for &mut M {
         (**self).declare_data_in_data(data_id, data)
     }
 
-    fn define_function(
-        &mut self,
-        func: FuncId,
-        ctx: &mut Context,
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    fn define_function(&mut self, func: FuncId, ctx: &mut Context) -> ModuleResult<()> {
         (**self).define_function(func, ctx)
     }
 
@@ -789,7 +775,7 @@ impl<M: Module> Module for &mut M {
         func: FuncId,
         ctx: &mut Context,
         ctrl_plane: &mut ControlPlane,
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         (**self).define_function_with_control_plane(func, ctx, ctrl_plane)
     }
 
@@ -800,7 +786,7 @@ impl<M: Module> Module for &mut M {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         (**self).define_function_bytes(func_id, func, alignment, bytes, relocs)
     }
 

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -1,17 +1,14 @@
 //! Defines `ObjectModule`.
 
 use anyhow::anyhow;
+use cranelift_codegen::binemit::{Addend, CodeOffset, Reloc};
 use cranelift_codegen::entity::SecondaryMap;
 use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::{self, ir, MachReloc};
-use cranelift_codegen::{
-    binemit::{Addend, CodeOffset, Reloc},
-    CodegenError,
-};
 use cranelift_control::ControlPlane;
 use cranelift_module::{
-    DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleCompiledFunction,
-    ModuleDeclarations, ModuleError, ModuleExtName, ModuleReloc, ModuleResult,
+    DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleDeclarations, ModuleError,
+    ModuleExtName, ModuleReloc, ModuleResult,
 };
 use log::info;
 use object::write::{
@@ -21,7 +18,6 @@ use object::{
     RelocationEncoding, RelocationKind, SectionKind, SymbolFlags, SymbolKind, SymbolScope,
 };
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::mem;
 use target_lexicon::PointerWidth;
 
@@ -321,7 +317,7 @@ impl Module for ObjectModule {
         func_id: FuncId,
         ctx: &mut cranelift_codegen::Context,
         ctrl_plane: &mut ControlPlane,
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         info!("defining function {}: {}", func_id, ctx.func.display());
         let mut code: Vec<u8> = Vec::new();
 
@@ -344,13 +340,8 @@ impl Module for ObjectModule {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
-    ) -> ModuleResult<ModuleCompiledFunction> {
+    ) -> ModuleResult<()> {
         info!("defining function {} with bytes", func_id);
-        let total_size: u32 = match bytes.len().try_into() {
-            Ok(total_size) => total_size,
-            _ => Err(CodegenError::CodeTooLarge)?,
-        };
-
         let decl = self.declarations.get_function_decl(func_id);
         if !decl.linkage.is_definable() {
             return Err(ModuleError::InvalidImportDefinition(decl.name.clone()));
@@ -391,7 +382,7 @@ impl Module for ObjectModule {
             });
         }
 
-        Ok(ModuleCompiledFunction { size: total_size })
+        Ok(())
     }
 
     fn define_data(&mut self, data_id: DataId, data: &DataDescription) -> ModuleResult<()> {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -131,8 +131,6 @@ pub struct ObjectModule {
     libcall_names: Box<dyn Fn(ir::LibCall) -> String + Send + Sync>,
     known_symbols: HashMap<ir::KnownSymbol, SymbolId>,
     per_function_section: bool,
-    anon_func_number: u64,
-    anon_data_number: u64,
 }
 
 impl ObjectModule {
@@ -152,8 +150,6 @@ impl ObjectModule {
             libcall_names: builder.libcall_names,
             known_symbols: HashMap::new(),
             per_function_section: builder.per_function_section,
-            anon_func_number: 0,
-            anon_data_number: 0,
         }
     }
 }
@@ -215,16 +211,15 @@ impl Module for ObjectModule {
     }
 
     fn declare_anonymous_function(&mut self, signature: &ir::Signature) -> ModuleResult<FuncId> {
-        // Symbols starting with .L are completely omitted from the symbol table after linking.
-        // Using hexadecimal instead of decimal for slightly smaller symbol names and often slightly
-        // faster linking.
-        let name = format!(".Lfn{:x}", self.anon_func_number);
-        self.anon_func_number += 1;
-
         let id = self.declarations.declare_anonymous_function(signature)?;
 
         let symbol_id = self.object.add_symbol(Symbol {
-            name: name.as_bytes().to_vec(),
+            name: self
+                .declarations
+                .get_function_decl(id)
+                .linkage_name(id)
+                .into_owned()
+                .into_bytes(),
             value: 0,
             size: 0,
             kind: SymbolKind::Text,
@@ -283,12 +278,6 @@ impl Module for ObjectModule {
     }
 
     fn declare_anonymous_data(&mut self, writable: bool, tls: bool) -> ModuleResult<DataId> {
-        // Symbols starting with .L are completely omitted from the symbol table after linking.
-        // Using hexadecimal instead of decimal for slightly smaller symbol names and often slightly
-        // faster linking.
-        let name = format!(".Ldata{:x}", self.anon_data_number);
-        self.anon_data_number += 1;
-
         let id = self.declarations.declare_anonymous_data(writable, tls)?;
 
         let kind = if tls {
@@ -298,7 +287,12 @@ impl Module for ObjectModule {
         };
 
         let symbol_id = self.object.add_symbol(Symbol {
-            name: name.as_bytes().to_vec(),
+            name: self
+                .declarations
+                .get_data_decl(id)
+                .linkage_name(id)
+                .into_owned()
+                .into_bytes(),
             value: 0,
             size: 0,
             kind,
@@ -344,12 +338,16 @@ impl Module for ObjectModule {
         info!("defining function {} with bytes", func_id);
         let decl = self.declarations.get_function_decl(func_id);
         if !decl.linkage.is_definable() {
-            return Err(ModuleError::InvalidImportDefinition(decl.name.clone()));
+            return Err(ModuleError::InvalidImportDefinition(
+                decl.linkage_name(func_id).into_owned(),
+            ));
         }
 
         let &mut (symbol, ref mut defined) = self.functions[func_id].as_mut().unwrap();
         if *defined {
-            return Err(ModuleError::DuplicateDefinition(decl.name.clone()));
+            return Err(ModuleError::DuplicateDefinition(
+                decl.linkage_name(func_id).into_owned(),
+            ));
         }
         *defined = true;
 
@@ -388,12 +386,16 @@ impl Module for ObjectModule {
     fn define_data(&mut self, data_id: DataId, data: &DataDescription) -> ModuleResult<()> {
         let decl = self.declarations.get_data_decl(data_id);
         if !decl.linkage.is_definable() {
-            return Err(ModuleError::InvalidImportDefinition(decl.name.clone()));
+            return Err(ModuleError::InvalidImportDefinition(
+                decl.linkage_name(data_id).into_owned(),
+            ));
         }
 
         let &mut (symbol, ref mut defined) = self.data_objects[data_id].as_mut().unwrap();
         if *defined {
-            return Err(ModuleError::DuplicateDefinition(decl.name.clone()));
+            return Err(ModuleError::DuplicateDefinition(
+                decl.linkage_name(data_id).into_owned(),
+            ));
         }
         *defined = true;
 


### PR DESCRIPTION
This allows a Module implementation to serialize it's internal state and deserialize it in another compilation session. For example to implement LTO or to load the module into cranelift-interpreter.

This is the last PR in the series for now. The actual implementation of a module that can be serialized is in cg_clif. I may extract it in the future, but for now these are almost all the changes that need to be made on the cranelift side. The previous PR's in this series are https://github.com/bytecodealliance/wasmtime/pull/6169 and https://github.com/bytecodealliance/wasmtime/pull/6170.