### PR TITLE
Re-export cranelift-control from cranelift-codegen

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -64,6 +64,7 @@ pub use crate::verifier::verify_function;
 pub use crate::write::write_function;
 
 pub use cranelift_bforest as bforest;
+pub use cranelift_control as control;
 pub use cranelift_entity as entity;
 #[cfg(feature = "unwind")]
 pub use gimli;


### PR DESCRIPTION
This makes it easier to keep the versions of both in sync and avoids having to specify another dependency for a single type.