### PR TITLE
Removes debug assertion that was related to issue 796

### DIFF
--- a/cranelift/codegen/src/cursor.rs
+++ b/cranelift/codegen/src/cursor.rs
@@ -635,28 +635,6 @@ impl<'c, 'f> ir::InstInserterBase<'c> for &'c mut FuncCursor<'f> {
     }
 
     fn insert_built_inst(self, inst: ir::Inst) -> &'c mut ir::DataFlowGraph {
-        // TODO: Remove this assertion once #796 is fixed.
-        #[cfg(debug_assertions)]
-        {
-            if let CursorPosition::At(_) = self.position() {
-                if let Some(curr) = self.current_inst() {
-                    if let Some(prev) = self.layout().prev_inst(curr) {
-                        let prev_op = self.data_flow_graph().insts[prev].opcode();
-                        let inst_op = self.data_flow_graph().insts[inst].opcode();
-                        let curr_op = self.data_flow_graph().insts[curr].opcode();
-                        if prev_op.is_branch()
-                            && !prev_op.is_terminator()
-                            && !inst_op.is_terminator()
-                        {
-                            panic!(
-                                "Inserting instruction {} after {}, and before {}",
-                                inst_op, prev_op, curr_op
-                            )
-                        }
-                    };
-                };
-            };
-        }
         self.insert_inst(inst);
         if !self.srcloc.is_default() {
             self.func.set_srcloc(inst, self.srcloc);

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -249,7 +249,7 @@ impl DataValue {
     ///
     /// Returns true if all bits are equal.
     ///
-    /// This behaviour is different from PartialEq for NaN floats.
+    /// This behavior is different from PartialEq for NaN floats.
     pub fn bitwise_eq(&self, other: &DataValue) -> bool {
         match (self, other) {
             // We need to bit compare the floats to ensure that we produce the correct values

--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -249,7 +249,7 @@ impl DataValue {
     ///
     /// Returns true if all bits are equal.
     ///
-    /// This behavior is different from PartialEq for NaN floats.
+    /// This behaviour is different from PartialEq for NaN floats.
     pub fn bitwise_eq(&self, other: &DataValue) -> bool {
         match (self, other) {
             // We need to bit compare the floats to ensure that we produce the correct values


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

The comment states that when 796 is fixed, that the debug assertion can be removed.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
