### PR TITLE
Clarify `instructions.rs` documentation for `ushr`/`sshr` (narrow values)

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -2415,7 +2415,7 @@ pub(crate) fn define(
         places, shifting in zero bits to the MSB. Also called a *logical
         shift*.
 
-        The shift amount is masked to the size of the register.
+        The shift amount is masked to the size of ``x``.
 
         When shifting a B-bits integer type, this instruction computes:
 
@@ -2441,7 +2441,7 @@ pub(crate) fn define(
         places, shifting in sign bits to the MSB. Also called an *arithmetic
         shift*.
 
-        The shift amount is masked to the size of the register.
+        The shift amount is masked to the size of ``x``.
         "#,
             &formats.binary,
         )
@@ -2475,7 +2475,7 @@ pub(crate) fn define(
             r#"
         Unsigned shift right by immediate.
 
-        The shift amount is masked to the size of the register.
+        The shift amount is masked to the size of ``x``.
         "#,
             &formats.binary_imm64,
         )
@@ -2492,7 +2492,7 @@ pub(crate) fn define(
             r#"
         Signed shift right by immediate.
 
-        The shift amount is masked to the size of the register.
+        The shift amount is masked to the size of ``x``.
         "#,
             &formats.binary_imm64,
         )


### PR DESCRIPTION
The documentation strings for Clif operations in `instructions.rs` for `ushr`/`sshr` use language that I suspect is stale:  masking to size of the register. Update to match the doc string for `ishl`, which species masking to the size of `x` (which better describes what is done for `i8`/`i16`). 

For example, here the amount is masked based on i8, yielding 0:
```
function %f(i8) -> i8 {
block0(v0: i8):
    v1 = iconst.i8 8
    v2 = ushr v0, v1
    return v2
}

; run: %f(0xFF) == 0xFF
```

This is a documentation-only change. 