### PR TITLE
Change `asm` to `__asm__` in `helpers.c`

### DIFF
--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -75,7 +75,7 @@ __attribute__((weak, noinline))
 #endif
 void __jit_debug_register_code() {
 #ifndef CFG_TARGET_OS_windows
-  asm("");
+  __asm__("");
 #endif
 }
 
@@ -88,7 +88,7 @@ struct JITDescriptor {
 
 #ifdef CFG_TARGET_OS_windows
   // export required for external access.
-  __declspec(dllexport) 
+  __declspec(dllexport)
 #else
   // Note the `weak` linkage here which is the same purpose as above. We want to
   // let other runtimes be able to override this since our own definition isn't


### PR DESCRIPTION
This is an attempt to fix #6177 since according to [this reference][1] some modes of compilation require `__asm__` instead of `asm`.

[1]: https://en.cppreference.com/w/c/language/asm

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
