### PR TITLE
cranelift-native: Detect RISC-V extensions using `/proc/cpuinfo`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -393,7 +393,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: ${{ runner.tool_cache }}/qemu
-        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}
+        key: qemu-${{ matrix.target }}-${{ env.QEMU_BUILD_VERSION }}-patchcpuinfo
       if: matrix.target != '' && matrix.os == 'ubuntu-latest'
     - name: Install cross-compilation tools
       run: |
@@ -426,6 +426,7 @@ jobs:
         # quickly.
         curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
         cd qemu-$QEMU_BUILD_VERSION
+        patch -p1 < $GITHUB_WORKSPACE/ci/qemu-cpuinfo.patch
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache}}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
         touch ${{ runner.tool_cache }}/qemu/built

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -82,7 +82,7 @@ const array = [
     "target": "riscv64gc-unknown-linux-gnu",
     "gcc_package": "gcc-riscv64-linux-gnu",
     "gcc": "riscv64-linux-gnu-gcc",
-    "qemu": "qemu-riscv64 -L /usr/riscv64-linux-gnu",
+    "qemu": "qemu-riscv64 -cpu rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true -L /usr/riscv64-linux-gnu",
     "qemu_target": "riscv64-linux-user",
     "name": "Test Linux riscv64",
     "filter": "linux-riscv64",

--- a/ci/qemu-cpuinfo.patch
+++ b/ci/qemu-cpuinfo.patch
@@ -1,0 +1,125 @@
+From 529c68a118055c95336f91e4d166366a23a943f4 Mon Sep 17 00:00:00 2001
+From: Afonso Bordado <afonsobordado@az8.co>
+Date: Tue, 21 Mar 2023 18:45:20 +0000
+Subject: [PATCH] linux-user: Emulate /proc/cpuinfo output for riscv
+
+RISC-V does not expose all extensions via hwcaps, thus some userspace
+applications may want to query these via /proc/cpuinfo.
+
+Currently when querying this file the host's file is shown instead
+which is slightly confusing. Emulate a basic /proc/cpuinfo file
+with mmu info and an ISA string.
+---
+ linux-user/syscall.c              | 33 +++++++++++++++++++++++++++++--
+ tests/tcg/riscv64/Makefile.target |  1 +
+ tests/tcg/riscv64/cpuinfo.c       | 30 ++++++++++++++++++++++++++++
+ 3 files changed, 62 insertions(+), 2 deletions(-)
+ create mode 100644 tests/tcg/riscv64/cpuinfo.c
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 24b25759be..2b8a588be2 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -8206,7 +8206,8 @@ void target_exception_dump(CPUArchState *env, const char *fmt, int code)
+ }
+ 
+ #if HOST_BIG_ENDIAN != TARGET_BIG_ENDIAN || \
+-    defined(TARGET_SPARC) || defined(TARGET_M68K) || defined(TARGET_HPPA)
++    defined(TARGET_SPARC) || defined(TARGET_M68K) || defined(TARGET_HPPA) || \
++    defined(TARGET_RISCV)
+ static int is_proc(const char *filename, const char *entry)
+ {
+     return strcmp(filename, entry) == 0;
+@@ -8278,6 +8279,34 @@ static int open_cpuinfo(CPUArchState *cpu_env, int fd)
+ }
+ #endif
+ 
++#if defined(TARGET_RISCV)
++static int open_cpuinfo(CPUArchState *cpu_env, int fd)
++{
++    int i;
++    int num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
++    RISCVCPU *cpu = env_archcpu(cpu_env);
++    char *isa_string = riscv_isa_string(cpu);
++    const char *mmu;
++
++    if (cpu->cfg.mmu) {
++        mmu = (cpu_env->xl == MXL_RV32) ? "sv32"  : "sv48";
++    } else {
++        mmu = "none";
++    }
++
++    for (i = 0; i < num_cpus; i++) {
++        dprintf(fd, "processor\t: %d\n", i);
++        dprintf(fd, "hart\t\t: %d\n", i);
++        dprintf(fd, "isa\t\t: %s\n", isa_string);
++        dprintf(fd, "mmu\t\t: %s\n", mmu);
++        dprintf(fd, "uarch\t\t: qemu\n\n");
++    }
++
++    g_free(isa_string);
++    return 0;
++}
++#endif
++
+ #if defined(TARGET_M68K)
+ static int open_hardware(CPUArchState *cpu_env, int fd)
+ {
+@@ -8302,7 +8331,7 @@ static int do_openat(CPUArchState *cpu_env, int dirfd, const char *pathname, int
+ #if HOST_BIG_ENDIAN != TARGET_BIG_ENDIAN
+         { "/proc/net/route", open_net_route, is_proc },
+ #endif
+-#if defined(TARGET_SPARC) || defined(TARGET_HPPA)
++#if defined(TARGET_SPARC) || defined(TARGET_HPPA) || defined(TARGET_RISCV)
+         { "/proc/cpuinfo", open_cpuinfo, is_proc },
+ #endif
+ #if defined(TARGET_M68K)
+diff --git a/tests/tcg/riscv64/Makefile.target b/tests/tcg/riscv64/Makefile.target
+index b5b89dfb0e..f455e19a11 100644
+--- a/tests/tcg/riscv64/Makefile.target
++++ b/tests/tcg/riscv64/Makefile.target
+@@ -4,3 +4,4 @@
+ VPATH += $(SRC_PATH)/tests/tcg/riscv64
+ TESTS += test-div
+ TESTS += noexec
++TESTS += cpuinfo
+\ No newline at end of file
+diff --git a/tests/tcg/riscv64/cpuinfo.c b/tests/tcg/riscv64/cpuinfo.c
+new file mode 100644
+index 0000000000..296abd0a8c
+--- /dev/null
++++ b/tests/tcg/riscv64/cpuinfo.c
+@@ -0,0 +1,30 @@
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <assert.h>
++
++#define BUFFER_SIZE 1024
++
++int main(void)
++{
++    char buffer[BUFFER_SIZE];
++    FILE *fp = fopen("/proc/cpuinfo", "r");
++    assert(fp != NULL);
++
++    while (fgets(buffer, BUFFER_SIZE, fp) != NULL) {
++        if (strstr(buffer, "processor") != NULL) {
++            assert(strstr(buffer, "processor\t: ") == buffer);
++        } else if (strstr(buffer, "hart") != NULL) {
++            assert(strstr(buffer, "hart\t\t: ") == buffer);
++        } else if (strstr(buffer, "isa") != NULL) {
++            assert(strcmp(buffer, "isa\t\t: rv64imafdc_zicsr_zifencei\n") == 0);
++        } else if (strstr(buffer, "mmu") != NULL) {
++            assert(strcmp(buffer, "mmu\t\t: sv48\n") == 0);
++        } else if (strstr(buffer, "uarch") != NULL) {
++            assert(strcmp(buffer, "uarch\t\t: qemu\n") == 0);
++        }
++    }
++
++    fclose(fp);
++    return 0;
++}
+-- 
+2.34.1
+

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -27,6 +27,9 @@ use cranelift_codegen::isa;
 use cranelift_codegen::settings::Configurable;
 use target_lexicon::Triple;
 
+#[cfg(all(target_arch = "riscv64", target_os = "linux"))]
+mod riscv;
+
 /// Return an `isa` builder configured for the current host
 /// machine, or `Err(())` if the host machine is not supported
 /// in the current configuration.
@@ -165,47 +168,8 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
     // getauxval from the libc crate directly as a temporary measure.
     #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
     {
-        let v = unsafe { libc::getauxval(libc::AT_HWCAP) };
-
-        const HWCAP_RISCV_EXT_A: libc::c_ulong = 1 << (b'a' - b'a');
-        const HWCAP_RISCV_EXT_C: libc::c_ulong = 1 << (b'c' - b'a');
-        const HWCAP_RISCV_EXT_D: libc::c_ulong = 1 << (b'd' - b'a');
-        const HWCAP_RISCV_EXT_F: libc::c_ulong = 1 << (b'f' - b'a');
-        const HWCAP_RISCV_EXT_M: libc::c_ulong = 1 << (b'm' - b'a');
-        const HWCAP_RISCV_EXT_V: libc::c_ulong = 1 << (b'v' - b'a');
-
-        if (v & HWCAP_RISCV_EXT_A) != 0 {
-            isa_builder.enable("has_a").unwrap();
-        }
-
-        if (v & HWCAP_RISCV_EXT_C) != 0 {
-            isa_builder.enable("has_c").unwrap();
-        }
-
-        if (v & HWCAP_RISCV_EXT_D) != 0 {
-            isa_builder.enable("has_d").unwrap();
-        }
-
-        if (v & HWCAP_RISCV_EXT_F) != 0 {
-            isa_builder.enable("has_f").unwrap();
-
-            // TODO: There doesn't seem to be a bit associated with this extension
-            // rust enables it with the `f` extension:
-            // https://github.com/rust-lang/stdarch/blob/790411f93c4b5eada3c23abb4c9a063fb0b24d99/crates/std_detect/src/detect/os/linux/riscv.rs#L43
-            isa_builder.enable("has_zicsr").unwrap();
-        }
-
-        if (v & HWCAP_RISCV_EXT_M) != 0 {
-            isa_builder.enable("has_m").unwrap();
-        }
-
-        if (v & HWCAP_RISCV_EXT_V) != 0 {
-            isa_builder.enable("has_v").unwrap();
-        }
-
-        // In general extensions that are longer than one letter
-        // won't have a bit associated with them. The Linux kernel
-        // is currently working on a new way to query the extensions.
+        // Try both hwcap and cpuinfo
+        riscv::hwcap_detect(isa_builder)?;
     }
     Ok(())
 }

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -169,7 +169,13 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
     #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
     {
         // Try both hwcap and cpuinfo
+        // HWCAP only returns single letter extensions, cpuinfo returns all of
+        // them but may not be available in some systems (QEMU < 8.1).
         riscv::hwcap_detect(isa_builder)?;
+
+        // Ignore errors for cpuinfo. QEMU versions prior to 8.1 do not emulate
+        // the cpuinfo interface, so we can't rely on it being present for now.
+        let _ = riscv::cpuinfo_detect(isa_builder);
     }
     Ok(())
 }

--- a/cranelift/native/src/riscv.rs
+++ b/cranelift/native/src/riscv.rs
@@ -1,4 +1,6 @@
 use cranelift_codegen::settings::Configurable;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
 
 pub fn hwcap_detect(isa_builder: &mut dyn Configurable) -> Result<(), &'static str> {
     let v = unsafe { libc::getauxval(libc::AT_HWCAP) };
@@ -43,4 +45,82 @@ pub fn hwcap_detect(isa_builder: &mut dyn Configurable) -> Result<(), &'static s
     // won't have a bit associated with them. The Linux kernel
     // is currently working on a new way to query the extensions.
     Ok(())
+}
+
+/// Read the /proc/cpuinfo file and detect the extensions.
+///
+/// We are looking for the isa line string, which contains the extensions.
+/// The format for this string is specifid in the linux user space ABI for RISC-V:
+/// https://github.com/torvalds/linux/blob/09a9639e56c01c7a00d6c0ca63f4c7c41abe075d/Documentation/riscv/uabi.rst
+///
+/// The format is fairly similar to the one specified in the RISC-V ISA manual, but
+/// all lower case.
+///
+/// An example ISA string is: rv64imafdcvh_zawrs_zba_zbb_zicbom_zicboz_zicsr_zifencei_zihintpause
+pub fn cpuinfo_detect(isa_builder: &mut dyn Configurable) -> Result<(), &'static str> {
+    let file = File::open("/proc/cpuinfo").map_err(|_| "failed to open /proc/cpuinfo")?;
+    let mut reader = BufReader::new(file);
+    let isa_line = reader
+        .by_ref()
+        .lines()
+        .find(|line| line.as_ref().map_or(false, |l| l.starts_with("isa")))
+        .ok_or("no isa line found in /proc/cpuinfo")?
+        .map_err(|_| "failed to read /proc/cpuinfo")?;
+
+    let isa_string = isa_line
+        .split(':')
+        .nth(1)
+        .ok_or("invalid isa string found in /proc/cpuinfo")?
+        .trim();
+
+    for ext in isa_string_extensions(isa_string) {
+        // Try enabling all the extensions that are parsed.
+        // Cranelift won't recognize all of them, but that's okay we just ignore them.
+        // Extensions flags in the RISC-V backend have the format of `has_x` for the `x` extension.
+        let _ = isa_builder.enable(&format!("has_{ext}"));
+    }
+    Ok(())
+}
+
+/// Parses an ISA string and returns an iterator over the extensions.
+fn isa_string_extensions(isa: &str) -> impl Iterator<Item = &str> {
+    isa.split('_').flat_map(|entry| {
+        // The first entry has the form `rv64imafdcvh`, we need to skip the first 4 characters.
+        // Each of the letters after the cpu architecture is an extension, so return them
+        // individually.
+        if entry.starts_with("rv") {
+            entry[4..].split("").filter(|e| !e.is_empty()).collect()
+        } else {
+            vec![entry]
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_isa() {
+        let mut extensions = isa_string_extensions(
+            "rv64imafdcvh_zawrs_zba_zbb_zicbom_zicboz_zicsr_zifencei_zihintpause",
+        );
+        assert_eq!(extensions.next(), Some("i"));
+        assert_eq!(extensions.next(), Some("m"));
+        assert_eq!(extensions.next(), Some("a"));
+        assert_eq!(extensions.next(), Some("f"));
+        assert_eq!(extensions.next(), Some("d"));
+        assert_eq!(extensions.next(), Some("c"));
+        assert_eq!(extensions.next(), Some("v"));
+        assert_eq!(extensions.next(), Some("h"));
+        assert_eq!(extensions.next(), Some("zawrs"));
+        assert_eq!(extensions.next(), Some("zba"));
+        assert_eq!(extensions.next(), Some("zbb"));
+        assert_eq!(extensions.next(), Some("zicbom"));
+        assert_eq!(extensions.next(), Some("zicboz"));
+        assert_eq!(extensions.next(), Some("zicsr"));
+        assert_eq!(extensions.next(), Some("zifencei"));
+        assert_eq!(extensions.next(), Some("zihintpause"));
+        assert_eq!(extensions.next(), None);
+    }
 }

--- a/cranelift/native/src/riscv.rs
+++ b/cranelift/native/src/riscv.rs
@@ -1,0 +1,46 @@
+use cranelift_codegen::settings::Configurable;
+
+pub fn hwcap_detect(isa_builder: &mut dyn Configurable) -> Result<(), &'static str> {
+    let v = unsafe { libc::getauxval(libc::AT_HWCAP) };
+
+    const HWCAP_RISCV_EXT_A: libc::c_ulong = 1 << (b'a' - b'a');
+    const HWCAP_RISCV_EXT_C: libc::c_ulong = 1 << (b'c' - b'a');
+    const HWCAP_RISCV_EXT_D: libc::c_ulong = 1 << (b'd' - b'a');
+    const HWCAP_RISCV_EXT_F: libc::c_ulong = 1 << (b'f' - b'a');
+    const HWCAP_RISCV_EXT_M: libc::c_ulong = 1 << (b'm' - b'a');
+    const HWCAP_RISCV_EXT_V: libc::c_ulong = 1 << (b'v' - b'a');
+
+    if (v & HWCAP_RISCV_EXT_A) != 0 {
+        isa_builder.enable("has_a").unwrap();
+    }
+
+    if (v & HWCAP_RISCV_EXT_C) != 0 {
+        isa_builder.enable("has_c").unwrap();
+    }
+
+    if (v & HWCAP_RISCV_EXT_D) != 0 {
+        isa_builder.enable("has_d").unwrap();
+    }
+
+    if (v & HWCAP_RISCV_EXT_F) != 0 {
+        isa_builder.enable("has_f").unwrap();
+
+        // TODO: There doesn't seem to be a bit associated with this extension
+        // rust enables it with the `f` extension:
+        // https://github.com/rust-lang/stdarch/blob/790411f93c4b5eada3c23abb4c9a063fb0b24d99/crates/std_detect/src/detect/os/linux/riscv.rs#L43
+        isa_builder.enable("has_zicsr").unwrap();
+    }
+
+    if (v & HWCAP_RISCV_EXT_M) != 0 {
+        isa_builder.enable("has_m").unwrap();
+    }
+
+    if (v & HWCAP_RISCV_EXT_V) != 0 {
+        isa_builder.enable("has_v").unwrap();
+    }
+
+    // In general extensions that are longer than one letter
+    // won't have a bit associated with them. The Linux kernel
+    // is currently working on a new way to query the extensions.
+    Ok(())
+}


### PR DESCRIPTION
:wave: Hey,

This PR adds a second method of extension detection to `cranelift-native` for RISC-V. Namely we can now read the ISA string in `/proc/cpuinfo` to query extenstions.

The motivation for this is that HWCAP does not expose bits for multi letter extensions (i.e. Zba, Zbb, Zbs). These are all extension that we already have support for in cranelift, but since we can't detect them, they don't get tested with runtests. (So far I've been testing them by force enabling them).

With this method we can now detect them. The second issue is that the current QEMU version does not do `/proc/cpuinfo` emulation, so we need to patch it. The patch in this PR has already been accepted upstream and is queued for QEMU 8.1. The version included here is slightly different since I had to backport it to 7.2.0.

Additionally as part of the SIMD work for RISC-V, I discovered that [QEMU has a fixed set of bits for HWCAP](https://github.com/qemu/qemu/blob/60ca584b8af0de525656f959991a440f8c191f12/linux-user/elfload.c#L1664-L1673), and so does not correctly expose the enabled extensions (namely vectors), so I can't run runtests with that either.


I've also tested introducing a bug in one of the Zba lowerings and running CI on that just to doublecheck that all fo this works. ([logs](https://github.com/afonso360/wasmtime/actions/runs/4659099051/jobs/8245591771#step:16:935))
