### PR TITLE
Fix `bitselect` => `{u,s}{min,max}` rewrite

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -25,24 +25,24 @@
 (rule (simplify (select ty (uge _ x y) y x)) (umin ty x y))
 
 ;; Transform bitselect-of-icmp into {u,s}{min,max} instructions where possible.
-(rule (simplify (bitselect ty (sgt _ x y) x y)) (smax ty x y))
-(rule (simplify (bitselect ty (sge _ x y) x y)) (smax ty x y))
-(rule (simplify (bitselect ty (ugt _ x y) x y)) (umax ty x y))
-(rule (simplify (bitselect ty (uge _ x y) x y)) (umax ty x y))
-(rule (simplify (bitselect ty (slt _ x y) x y)) (smin ty x y))
-(rule (simplify (bitselect ty (sle _ x y) x y)) (smin ty x y))
-(rule (simplify (bitselect ty (ult _ x y) x y)) (umin ty x y))
-(rule (simplify (bitselect ty (ule _ x y) x y)) (umin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sgt _ x y) x y)) (smax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sge _ x y) x y)) (smax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ugt _ x y) x y)) (umax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (uge _ x y) x y)) (umax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (slt _ x y) x y)) (smin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sle _ x y) x y)) (smin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ult _ x y) x y)) (umin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ule _ x y) x y)) (umin ty x y))
 
 ;; These are the same rules as above, but when the operands for select are swapped
-(rule (simplify (bitselect ty (slt _ x y) y x)) (smax ty x y))
-(rule (simplify (bitselect ty (sle _ x y) y x)) (smax ty x y))
-(rule (simplify (bitselect ty (ult _ x y) y x)) (umax ty x y))
-(rule (simplify (bitselect ty (ule _ x y) y x)) (umax ty x y))
-(rule (simplify (bitselect ty (sgt _ x y) y x)) (smin ty x y))
-(rule (simplify (bitselect ty (sge _ x y) y x)) (smin ty x y))
-(rule (simplify (bitselect ty (ugt _ x y) y x)) (umin ty x y))
-(rule (simplify (bitselect ty (uge _ x y) y x)) (umin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (slt _ x y) y x)) (smax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sle _ x y) y x)) (smax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ult _ x y) y x)) (umax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ule _ x y) y x)) (umax ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sgt _ x y) y x)) (smin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (sge _ x y) y x)) (smin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (ugt _ x y) y x)) (umin ty x y))
+(rule (simplify (bitselect ty @ (multi_lane _ _) (uge _ x y) y x)) (umin ty x y))
 
 ;; For floats convert fcmp lt into pseudo_min and gt into pseudo_max
 ;;


### PR DESCRIPTION
The rules rewriting bitselect to {u,s}{min,max} are only sound when selecting between vectors. When selecting between scalars, the result is `(x & 1) | y` or `y`.

Fixed by adding `multi_lane` precondition