### PR TITLE
Clarify the representation of `icmp` output

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1621,7 +1621,7 @@ pub(crate) fn define(
             - `0` if the condition does not hold.
 
         When comparing vectors, the result is:
-            - `-1` (ie all ones) in each lane where the condition holds.
+            - `-1` (i.e. all ones) in each lane where the condition holds.
             - `0` in each lane where the condition does not hold.
         "#,
             &formats.int_compare,

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1615,6 +1615,13 @@ pub(crate) fn define(
 
         When this instruction compares integer vectors, it returns a vector of
         lane-wise comparisons.
+
+        When comparing scalars, the result is `1` if the condition holds, and
+        `0` if the condition does not hold.
+
+        When comparing vectors, the result is `-1` (ie all ones) in each lane
+        where the condition holds, and `0` in each lane where the condition does
+        not hold.
         "#,
             &formats.int_compare,
         )

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -2749,6 +2749,14 @@ pub(crate) fn define(
 
         When this instruction compares floating point vectors, it returns a
         vector with the results of lane-wise comparisons.
+
+        When comparing scalars, the result is:
+            - `1` if the condition holds.
+            - `0` if the condition does not hold.
+
+        When comparing vectors, the result is:
+            - `-1` (i.e. all ones) in each lane where the condition holds.
+            - `0` in each lane where the condition does not hold.
         "#,
             &formats.float_compare,
         )

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1616,12 +1616,13 @@ pub(crate) fn define(
         When this instruction compares integer vectors, it returns a vector of
         lane-wise comparisons.
 
-        When comparing scalars, the result is `1` if the condition holds, and
-        `0` if the condition does not hold.
+        When comparing scalars, the result is:
+            - `1` if the condition holds.
+            - `0` if the condition does not hold.
 
-        When comparing vectors, the result is `-1` (ie all ones) in each lane
-        where the condition holds, and `0` in each lane where the condition does
-        not hold.
+        When comparing vectors, the result is:
+            - `-1` (ie all ones) in each lane where the condition holds.
+            - `0` in each lane where the condition does not hold.
         "#,
             &formats.int_compare,
         )


### PR DESCRIPTION
Add documentation to `icmp` clarifying the representation of true/false values for scalar and vector comparisons