### PR TITLE
wasmtime component bindgen: when tracing is enabled, emit an event for args & results

### DIFF
--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1142,9 +1142,7 @@ impl<'a> InterfaceGenerator<'a> {
                     format!("{name} = tracing::field::debug(&arg{i})")
                 })
                 .collect::<Vec<String>>();
-            if event_fields.is_empty() {
-                event_fields.push(format!("\"call\""));
-            }
+            event_fields.push(format!("\"call\""));
             uwrite!(
                 self.src,
                 "tracing::event!(tracing::Level::TRACE, {});\n",
@@ -1167,7 +1165,7 @@ impl<'a> InterfaceGenerator<'a> {
         if self.gen.opts.tracing {
             uwrite!(
                 self.src,
-                "tracing::event!(tracing::Level::TRACE, result = tracing::field::debug(&r));"
+                "tracing::event!(tracing::Level::TRACE, result = tracing::field::debug(&r), \"return\");"
             );
         }
 

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1295,7 +1295,7 @@ impl<'a> InterfaceGenerator<'a> {
                 "
                    let span = tracing::span!(
                        tracing::Level::TRACE,
-                       \"wit-bindgen guest export\",
+                       \"wit-bindgen export\",
                        module = \"{}\",
                        function = \"{}\",
                    );

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -1112,11 +1112,12 @@ impl<'a> InterfaceGenerator<'a> {
         }
 
         if self.gen.opts.tracing {
-            self.src.push_str(&format!(
+            uwrite!(
+                self.src,
                 "
                    let span = tracing::span!(
                        tracing::Level::TRACE,
-                       \"wit-bindgen guest import\",
+                       \"wit-bindgen import\",
                        module = \"{}\",
                        function = \"{}\",
                    );
@@ -1131,7 +1132,24 @@ impl<'a> InterfaceGenerator<'a> {
                     TypeOwner::None => "<no owner>",
                 },
                 func.name,
-            ));
+            );
+            let mut event_fields = func
+                .params
+                .iter()
+                .enumerate()
+                .map(|(i, (name, _ty))| {
+                    let name = to_rust_ident(&name);
+                    format!("{name} = tracing::field::debug(&arg{i})")
+                })
+                .collect::<Vec<String>>();
+            if event_fields.is_empty() {
+                event_fields.push(format!("\"call\""));
+            }
+            uwrite!(
+                self.src,
+                "tracing::event!(tracing::Level::TRACE, {});\n",
+                event_fields.join(", ")
+            );
         }
 
         self.src.push_str("let host = get(caller.data_mut());\n");
@@ -1144,6 +1162,13 @@ impl<'a> InterfaceGenerator<'a> {
             uwrite!(self.src, ").await;\n");
         } else {
             uwrite!(self.src, ");\n");
+        }
+
+        if self.gen.opts.tracing {
+            uwrite!(
+                self.src,
+                "tracing::event!(tracing::Level::TRACE, result = tracing::field::debug(&r));"
+            );
         }
 
         if self


### PR DESCRIPTION

This is consistient with what wiggle does (see
https://github.com/bytecodealliance/wasmtime/blob/main/crates/wiggle/generate/src/funcs.rs#L266), with the exceptions that
1. wiggle has a facility for disabling tracing on a per-function basis, a requirement which was driven by functions which pass secrets into wasm. this will be added to wasmtime-wit-bindgen at a later date.
2. wiggle doesn't actually emit an event when calling a function which takes no arguments (see `&& func.params.len() > 0` in predicate), in this case we emit an event with the body `"call"`, to ensure these calls are observable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
