### PR TITLE
Rework `only_interfaces` to the `interfaces` field

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -21,13 +21,6 @@ macro_rules! gentest {
                     duplicate_if_necessary: true,
                 });
             }
-            mod interfaces_only {
-                wasmtime::component::bindgen!({
-                    path: $path,
-                    world: $name,
-                    only_interfaces: true,
-                });
-            }
         }
         // ...
     };

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -292,11 +292,11 @@ pub(crate) use self::store::ComponentStoreData;
 ///         interface::ErrorType: RustErrorType,
 ///     },
 ///
-///     // Restrict the code generated to what's needed for the imported
-///     // interfaces of the world file provided. This option is most useful
-///     // in conjunction with the `with` option that permits remapping of
-///     // interface names in generated code.
-///     only_interfaces: true,
+///     // Restrict the code generated to what's needed for the interface
+///     // imports in the inlined WIT document fragment.
+///     interfaces: "
+///         import foo: package.foo;
+///     ",
 ///
 ///     // Remap interface names to module names, imported from elswhere.
 ///     // Using this option will prevent any code from being generated

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -639,15 +639,10 @@ mod with_remapping {
 
     mod interfaces {
         wasmtime::component::bindgen!({
-            inline: "
-            default world result-playground {
-                import imports: interface {
-                    empty-error: func(a: float64) -> result<float64>
-                }
-
-                export empty-error: func(a: float64) -> result<float64>
+            interfaces: "
+            import imports: interface {
+                empty-error: func(a: float64) -> result<float64>
             }",
-            only_interfaces: true,
         });
     }
 


### PR DESCRIPTION
Allow imports to be inlined into a use of the `bindgen!` macro, instead of requiring a full world to be written, or world file to be referenced. The change in syntax is that instead of referencing a world file and passing `only_interfaces`, you now pass just the `interfaces` field with the textual imports you would like to reference.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
