### PR TITLE
For clarity in examples avoid importing/exporting functions of the same name

### DIFF
--- a/crates/wasmtime/README.md
+++ b/crates/wasmtime/README.md
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
     let engine = Engine::default();
     let wat = r#"
         (module
-            (import "host" "hello" (func $host_hello (param i32)))
+            (import "host" "host_func" (func $host_hello (param i32)))
 
             (func (export "hello")
                 i32.const 3
@@ -84,7 +84,7 @@ fn main() -> Result<()> {
     // Create a `Linker` which will be later used to instantiate this module.
     // Host functionality is defined by name within the `Linker`.
     let mut linker = Linker::new(&engine);
-    linker.func_wrap("host", "hello", |caller: Caller<'_, u32>, param: i32| {
+    linker.func_wrap("host", "host_func", |caller: Caller<'_, u32>, param: i32| {
         println!("Got {} from WebAssembly", param);
         println!("my host state is: {}", caller.data());
     })?;

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -34,7 +34,7 @@
 //!     let engine = Engine::default();
 //!     let wat = r#"
 //!         (module
-//!             (import "host" "hello" (func $host_hello (param i32)))
+//!             (import "host" "host_func" (func $host_hello (param i32)))
 //!
 //!             (func (export "hello")
 //!                 i32.const 3
@@ -47,7 +47,7 @@
 //!     // `Store` has a type parameter to store host-specific data, which in
 //!     // this case we're using `4` for.
 //!     let mut store = Store::new(&engine, 4);
-//!     let host_hello = Func::wrap(&mut store, |caller: Caller<'_, u32>, param: i32| {
+//!     let host_func = Func::wrap(&mut store, |caller: Caller<'_, u32>, param: i32| {
 //!         println!("Got {} from WebAssembly", param);
 //!         println!("my host state is: {}", caller.data());
 //!     });
@@ -55,7 +55,7 @@
 //!     // Instantiation of a module requires specifying its imports and then
 //!     // afterwards we can fetch exports by name, as well as asserting the
 //!     // type signature of the function with `get_typed_func`.
-//!     let instance = Instance::new(&mut store, &module, &[host_hello.into()])?;
+//!     let instance = Instance::new(&mut store, &module, &[host_func.into()])?;
 //!     let hello = instance.get_typed_func::<(), ()>(&mut store, "hello")?;
 //!
 //!     // And finally we can call the wasm!
@@ -146,7 +146,7 @@
 //!     let engine = Engine::default();
 //!     let wat = r#"
 //!         (module
-//!             (import "host" "hello" (func $host_hello (param i32)))
+//!             (import "host" "host_func" (func $host_hello (param i32)))
 //!
 //!             (func (export "hello")
 //!                 i32.const 3
@@ -157,7 +157,7 @@
 //!
 //!     // Create a `Linker` and define our host function in it:
 //!     let mut linker = Linker::new(&engine);
-//!     linker.func_wrap("host", "hello", |caller: Caller<'_, u32>, param: i32| {
+//!     linker.func_wrap("host", "host_func", |caller: Caller<'_, u32>, param: i32| {
 //!         println!("Got {} from WebAssembly", param);
 //!         println!("my host state is: {}", caller.data());
 //!     })?;


### PR DESCRIPTION

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

As someone with barely any experience with wasm, reading through the docs and following along with the examples,
The examples which this patch modifies, both import a function `hello` from the host, and export one named `hello` from wat.

To someone looking at it for the first time, it is quite confusing which instance the string 'hello' is referring to which function.
This renames one the "host" one to the rather unimaginative `host_func`.