### PR TITLE
ISLE: rewrite operation on `select` to `select` on operation

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -6,44 +6,44 @@
 
 ;; transpose operation on select to select on operation:
 ;; unop(select(cond, x, y)) => select(cond, unop(x), unop(y))
-(rule (simplify (unop op_ty op (select sel_ty cond x y)))
-      (select sel_ty cond (unop op_ty op x) (unop op_ty op y)))
+(rule (simplify (unop ty op (select _ cond x y)))
+      (select ty cond (unop ty op x) (unop ty op y)))
 
 ;; binop(select(cond, x, y), z) => select(cond, binop(x, z), binop(y, z))
-(rule (simplify (binop op_ty op (select sel_ty cond x y) z))
-      (select sel_ty cond (binop op_ty op x z) (binop op_ty op y z)))
+(rule (simplify (binop ty op (select _ cond x y) z))
+      (select ty cond (binop ty op x z) (binop ty op y z)))
 
 ;; binop(x, select(cond, y, z)) => select(cond, binop(x, y), binop(x, z))
-(rule (simplify (binop op_ty op x (select sel_ty cond y z)))
-      (select sel_ty cond (binop op_ty op x y) (binop op_ty op x z)))
+(rule (simplify (binop ty op x (select _ cond y z)))
+      (select ty cond (binop ty op x y) (binop ty op x z)))
 
 ;; ternop(select(cond, w, x), y, z) => select(cond, ternop(w, y, z), ternop(x, y, z))
-(rule (simplify (ternop op_ty op (select sel_ty cond w x) y z))
-      (select sel_ty cond (ternop op_ty op w y z) (ternop op_ty op x y z)))
+(rule (simplify (ternop ty op (select _ cond w x) y z))
+      (select ty cond (ternop ty op w y z) (ternop ty op x y z)))
 
 ;; ternop(w, select(cond, x, y), z) => select(cond, ternop(w, x, z), ternop(w, y, z))
-(rule (simplify (ternop op_ty op w (select sel_ty cond x y) z))
-      (select sel_ty cond (ternop op_ty op w x z) (ternop op_ty op w y z)))
+(rule (simplify (ternop ty op w (select _ cond x y) z))
+      (select ty cond (ternop ty op w x z) (ternop ty op w y z)))
 
 ;; ternop(w, x, select(cond, y, z)) => select(cond, ternop(w, x, y), ternop(w, x, z))
-(rule (simplify (ternop op_ty op w x (select sel_ty cond y z)))
-      (select sel_ty cond (ternop op_ty op w x y) (ternop op_ty op w x z)))
+(rule (simplify (ternop ty op w x (select _ cond y z)))
+      (select ty cond (ternop ty op w x y) (ternop ty op w x z)))
 
 ;; icmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
-(rule (simplify (icmp cmp_ty cc (select sel_ty cond x y) z))
-      (select sel_ty cond (icmp cmp_ty cc x z) (icmp cmp_ty cc y z)))
+(rule (simplify (icmp ty cc (select _ cond x y) z))
+      (select ty cond (icmp ty cc x z) (icmp ty cc y z)))
 
 ;; icmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
-(rule (simplify (icmp cmp_ty cc x (select sel_ty cond y z)))
-      (select sel_ty cond (icmp cmp_ty cc x y) (icmp cmp_ty cc x z)))
+(rule (simplify (icmp ty cc x (select _ cond y z)))
+      (select ty cond (icmp ty cc x y) (icmp ty cc x z)))
 
 ;; fcmp(cc, select(cond, x, y), z) => select(cond, fcmp(cc, x, z), fcmp(cc, y, z))
-(rule (simplify (fcmp cmp_ty cc (select sel_ty cond x y) z))
-      (select sel_ty cond (fcmp cmp_ty cc x z) (fcmp cmp_ty cc y z)))
+(rule (simplify (fcmp ty cc (select _ cond x y) z))
+      (select ty cond (fcmp ty cc x z) (fcmp ty cc y z)))
 
 ;; fcmp(cc, x, select(cond, y, z)) => select(cond, fcmp(cc, x, y), fcmp(cc, x, z))
-(rule (simplify (fcmp cmp_ty cc x (select sel_ty cond y z)))
-      (select sel_ty cond (fcmp cmp_ty cc x y) (fcmp cmp_ty cc x z)))
+(rule (simplify (fcmp ty cc x (select _ cond y z)))
+      (select ty cond (fcmp ty cc x y) (fcmp ty cc x z)))
 
 ;; Transform select-of-icmp into {u,s}{min,max} instructions where possible.
 (rule (simplify (select ty (sgt _ x y) x y)) (smax ty x y))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -45,6 +45,47 @@
 (rule (simplify (fcmp ty cc x (select _ cond y z)))
       (select ty cond (fcmp ty cc x y) (fcmp ty cc x z)))
 
+;; transpose select on operation to operation on select:
+;; select(cond, unop(x), unop(y)) => unop(select(cond, x, y))
+(rule (simplify (select ty cond (unop _ op x) (unop _ op y)))
+      (unop ty op (select ty cond x y)))
+
+;; select(cond, binop(x, z), binop(y, z)) => binop(select(cond, x, y), z)
+(rule (simplify (select ty cond (binop _ op x z) (binop _ op y z)))
+      (binop ty op (select ty cond x y) z))
+
+;; select(cond, binop(x, y), binop(x, z)) => binop(x, select(cond, y, z))
+(rule (simplify (select ty cond (binop _ op x y) (binop _ op x z)))
+      (binop ty op x (select ty cond y z)))
+
+;; select(cond, ternop(w, y, z), ternop(x, y, z)) => ternop(select(cond, w, x), y, z)
+(rule (simplify (select ty cond (ternop ty op w y z) (ternop ty op x y z)))
+      (ternop ty op (select ty cond w x) y z))
+
+;; select(cond, ternop(w, x, z), ternop(w, y, z)) => ternop(w, select(cond, x, y), z)
+(rule (simplify (select ty cond (ternop _ op w x z) (ternop _ op w y z)))
+      (ternop ty op w (select ty cond x y) z))
+
+;; select(cond, ternop(w, x, y), ternop(w, x, z)) => ternop(w, x, select(cond, y, z))
+(rule (simplify (select ty cond (ternop _ op w x y) (ternop _ op w x z)))
+      (ternop ty op w x (select ty cond y z)))
+
+;; select(cond, icmp(cc, x, z), icmp(cc, y, z)) => icmp(cc, select(cond, x, y), z)
+(rule (simplify (select ty cond (icmp ty cc x z) (icmp ty cc y z)))
+      (icmp ty cc (select ty cond x y) z))
+
+;; select(cond, icmp(cc, x, y), icmp(cc, x, z)) => icmp(cc, x, select(cond, y, z))
+(rule (simplify (select ty cond (icmp ty cc x y) (icmp ty cc x z)))
+      (icmp ty cc x (select ty cond y z)))
+
+;; select(cond, fcmp(cc, x, z), fcmp(cc, y, z)) => fcmp(cc, select(cond, x, y), z)
+(rule (simplify (select ty cond (fcmp ty cc x z) (fcmp ty cc y z)))
+      (fcmp ty cc (select ty cond x y) z))
+
+;; select(cond, fcmp(cc, x, y), fcmp(cc, x, z)) => fcmp(cc, x, select(cond, y, z))
+(rule (simplify (select ty cond (fcmp ty cc x y) (fcmp ty cc x z)))
+      (fcmp ty cc x (select ty cond y z)))
+
 ;; Transform select-of-icmp into {u,s}{min,max} instructions where possible.
 (rule (simplify (select ty (sgt _ x y) x y)) (smax ty x y))
 (rule (simplify (select ty (sge _ x y) x y)) (smax ty x y))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -29,6 +29,22 @@
 (rule (simplify (ternop op_ty op w x (select sel_ty cond y z)))
       (select sel_ty cond (ternop op_ty op w x y) (ternop op_ty op w x z)))
 
+;; icmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
+(rule (simplify (icmp cmp_ty cc (select sel_ty cond x y) z))
+      (select sel_ty cond (icmp cmp_ty cc x z) (icmp cmp_ty cc y z)))
+
+;; icmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
+(rule (simplify (icmp cmp_ty cc x (select sel_ty cond y z)))
+      (select sel_ty cond (icmp cmp_ty cc x y) (icmp cmp_ty cc x z)))
+
+;; fcmp(cc, select(cond, x, y), z) => select(cond, fcmp(cc, x, z), fcmp(cc, y, z))
+(rule (simplify (fcmp cmp_ty cc (select sel_ty cond x y) z))
+      (select sel_ty cond (fcmp cmp_ty cc x z) (fcmp cmp_ty cc y z)))
+
+;; fcmp(cc, x, select(cond, y, z)) => select(cond, fcmp(cc, x, y), fcmp(cc, x, z))
+(rule (simplify (fcmp cmp_ty cc x (select sel_ty cond y z)))
+      (select sel_ty cond (fcmp cmp_ty cc x y) (fcmp cmp_ty cc x z)))
+
 ;; Transform select-of-icmp into {u,s}{min,max} instructions where possible.
 (rule (simplify (select ty (sgt _ x y) x y)) (smax ty x y))
 (rule (simplify (select ty (sge _ x y) x y)) (smax ty x y))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -4,6 +4,31 @@
 (rule (simplify (select    ty _ x x)) x)
 (rule (simplify (bitselect ty _ x x)) x)
 
+;; transpose operation on select to select on operation:
+;; unop(select(cond, x, y)) => select(cond, unop(x), unop(y))
+(rule (simplify (unop op_ty op (select sel_ty cond x y)))
+      (select sel_ty cond (unop op_ty op x) (unop op_ty op y)))
+
+;; binop(select(cond, x, y), z) => select(cond, binop(x, z), binop(y, z))
+(rule (simplify (binop op_ty op (select sel_ty cond x y) z))
+      (select sel_ty cond (binop op_ty op x z) (binop op_ty op y z)))
+
+;; binop(x, select(cond, y, z)) => select(cond, binop(x, y), binop(x, z))
+(rule (simplify (binop op_ty op x (select sel_ty cond y z)))
+      (select sel_ty cond (binop op_ty op x y) (binop op_ty op x z)))
+
+;; ternop(select(cond, w, x), y, z) => select(cond, ternop(w, y, z), ternop(x, y, z))
+(rule (simplify (ternop op_ty op (select sel_ty cond w x) y z))
+      (select sel_ty cond (ternop op_ty op w y z) (ternop op_ty op x y z)))
+
+;; ternop(w, select(cond, x, y), z) => select(cond, ternop(w, x, z), ternop(w, y, z))
+(rule (simplify (ternop op_ty op w (select sel_ty cond x y) z))
+      (select sel_ty cond (ternop op_ty op w x z) (ternop op_ty op w y z)))
+
+;; ternop(w, x, select(cond, y, z)) => select(cond, ternop(w, x, y), ternop(w, x, z))
+(rule (simplify (ternop op_ty op w x (select sel_ty cond y z)))
+      (select sel_ty cond (ternop op_ty op w x y) (ternop op_ty op w x z)))
+
 ;; Transform select-of-icmp into {u,s}{min,max} instructions where possible.
 (rule (simplify (select ty (sgt _ x y) x y)) (smax ty x y))
 (rule (simplify (select ty (sge _ x y) x y)) (smax ty x y))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -286,6 +286,15 @@
 
 ;;;; Helper Clif Extractors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(decl unop (Type Opcode Value) Value)
+(extractor (unop ty op x) (inst_data ty (InstructionData.Unary op x)))
+
+(decl binop (Type Opcode Value Value) Value)
+(extractor (binop ty op x y) (inst_data ty (InstructionData.Binary op (value_array_2 x y))))
+
+(decl ternop (Type Opcode Value Value Value) Value)
+(extractor (ternop ty op x y z) (inst_data ty (InstructionData.Ternary op (value_array_3 x y z))))
+
 (decl eq (Type Value Value) Value)
 (extractor (eq ty x y) (icmp ty (IntCC.Equal) x y))
 

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -28,6 +28,12 @@
 (rule (sgt ty x y) (icmp ty (IntCC.SignedGreaterThan) x y))
 (rule (sge ty x y) (icmp ty (IntCC.SignedGreaterThanOrEqual) x y))
 
+(rule (unop ty op x) (make_inst ty (InstructionData.Unary op x)))
+
+(rule (binop ty op x y) (make_inst ty (InstructionData.Binary op (value_array_2 x y))))
+
+(rule (ternop ty op x y z) (make_inst ty (InstructionData.Ternary op (value_array_3 x y z))))
+
 ;;;;; optimization toplevel ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; The main matcher rule invoked by the toplevel driver.

--- a/cranelift/filetests/filetests/egraph/select.clif
+++ b/cranelift/filetests/filetests/egraph/select.clif
@@ -19,6 +19,78 @@ block0(v0: i32, v1: i32):
     ; check: return v1
 }
 
+;; unop(select(cond, x, y)) => select(cond, unop(x), unop(y))
+function %transpose_unop_select(i8, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = select v0, v1, v2
+    v4 = ineg v3
+    return v4
+    ; check: v5 = ineg v1
+    ; check: v6 = ineg v2
+    ; check: v7 = select v0, v5, v6
+    ; check: return v7
+}
+
+;; binop(select(cond, x, y), z) => select(cond, binop(x, z), binop(y, z))
+function %transpose_binop_select_1(i8, i32, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32, v3: i32):
+    v4 = select v0, v1, v2
+    v5 = isub v4, v3
+    return v5
+    ; check: v6 = isub v1, v3
+    ; check: v7 = isub v2, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
+;; binop(x, select(cond, y, z)) => select(cond, binop(x, y), binop(x, z))
+function %transpose_binop_select_2(i8, i32, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32, v3: i32):
+    v4 = select v0, v2, v3
+    v5 = isub v1, v4
+    return v5
+    ; check: v6 = isub v1, v2
+    ; check: v7 = isub v1, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
+;; ternop(select(cond, w, x), y, z) => select(cond, ternop(w, y, z), ternop(x, y, z))
+function %transpose_ternop_select_1(i8, f32, f32, f32, f32) -> f32 {
+block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
+    v5 = select v0, v1, v2
+    v6 = fma v5, v3, v4
+    return v6
+    ; check: v7 = fma v1, v3, v4
+    ; check: v8 = fma v2, v3, v4
+    ; check: v9 = select v0, v7, v8
+    ; check: return v9
+}
+
+;; ternop(w, select(cond, x, y), z) => select(cond, ternop(w, x, z), ternop(w, y, z))
+function %transpose_ternop_select_2(i8, f32, f32, f32, f32) -> f32 {
+block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
+    v5 = select v0, v2, v3
+    v6 = fma v1, v5, v4
+    return v6
+    ; check: v7 = fma v1, v2, v4
+    ; check: v8 = fma v1, v3, v4
+    ; check: v9 = select v0, v7, v8
+    ; check: return v9
+}
+
+;; ternop(w, x, select(cond, y, z)) => select(cond, ternop(w, x, y), ternop(w, x, z))
+function %transpose_ternop_select_3(i8, f32, f32, f32, f32) -> f32 {
+block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
+    v5 = select v0, v3, v4
+    v6 = fma v1, v2, v5
+    return v6
+    ; check: v7 = fma v1, v2, v3
+    ; check: v8 = fma v1, v2, v4
+    ; check: v9 = select v0, v7, v8
+    ; check: return v9
+}
+
 function %select_sgt_to_smax(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v2 = icmp sgt v0, v1

--- a/cranelift/filetests/filetests/egraph/select.clif
+++ b/cranelift/filetests/filetests/egraph/select.clif
@@ -91,6 +91,54 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
     ; check: return v9
 }
 
+;; icmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
+function %transpose_icmp_select_1(i8, i32, i32, i32) -> i8 {
+block0(v0: i8, v1: i32, v2: i32, v3: i32):
+    v4 = select v0, v1, v2
+    v5 = icmp ult v4, v3
+    return v5
+    ; check: v6 = icmp ult v1, v3
+    ; check: v7 = icmp ult v2, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
+;; icmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
+function %transpose_icmp_select_2(i8, i32, i32, i32) -> i8 {
+block0(v0: i8, v1: i32, v2: i32, v3: i32):
+    v4 = select v0, v2, v3
+    v5 = icmp ult v1, v4
+    return v5
+    ; check: v6 = icmp ult v1, v2
+    ; check: v7 = icmp ult v1, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
+;; fcmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
+function %transpose_fcmp_select_1(i8, f32, f32, f32) -> i8 {
+block0(v0: i8, v1: f32, v2: f32, v3: f32):
+    v4 = select v0, v1, v2
+    v5 = fcmp ult v4, v3
+    return v5
+    ; check: v6 = fcmp ult v1, v3
+    ; check: v7 = fcmp ult v2, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
+;; fcmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
+function %transpose_fcmp_select_2(i8, f32, f32, f32) -> i8 {
+block0(v0: i8, v1: f32, v2: f32, v3: f32):
+    v4 = select v0, v2, v3
+    v5 = fcmp ult v1, v4
+    return v5
+    ; check: v6 = fcmp ult v1, v2
+    ; check: v7 = fcmp ult v1, v3
+    ; check: v8 = select v0, v6, v7
+    ; check: return v8
+}
+
 function %select_sgt_to_smax(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
     v2 = icmp sgt v0, v1

--- a/cranelift/filetests/filetests/egraph/select.clif
+++ b/cranelift/filetests/filetests/egraph/select.clif
@@ -25,10 +25,54 @@ block0(v0: i8, v1: i32, v2: i32):
     v3 = select v0, v1, v2
     v4 = ineg v3
     return v4
-    ; check: v5 = ineg v1
-    ; check: v6 = ineg v2
-    ; check: v7 = select v0, v5, v6
-    ; check: return v7
+    ; check: v3 = select v0, v1, v2
+    ; check: v12 = ineg v3
+    ; check: return v12
+}
+
+;; select(cond, unop(x), unop(y)) => unop(select(cond, x, y))
+function %transpose_select_unop(i8, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = ineg v1
+    v4 = ineg v2
+    v5 = select v0, v3, v4
+    return v5
+    ; check: v3 = ineg v1
+    ; check: v4 = ineg v2
+    ; check: v12 = select v0, v3, v4
+    ; check: return v12
+}
+
+;; FIXME: `transpose_unop_both_1` and `transpose_unop_both_2` should optimise to identical result
+function %transpose_unop_both_1(i8, i32, i32) -> i32, i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = ineg v1
+    v4 = ineg v2
+    v5 = select v0, v3, v4
+
+    v6 = select v0, v1, v2
+    v7 = ineg v6
+
+    return v5, v7
+    ; check: v3 = ineg v1
+    ; check: v4 = ineg v2
+    ; check: v14 = select v0, v3, v4
+    ; check: return v14, v14
+}
+
+function %transpose_unop_both_2(i8, i32, i32) -> i32, i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = select v0, v1, v2
+    v4 = ineg v3
+
+    v5 = ineg v1
+    v6 = ineg v2
+    v7 = select v0, v5, v6
+
+    return v4, v7
+    ; check: v3 = select v0, v1, v2
+    ; check: v15 = ineg v3
+    ; check: return v15, v15
 }
 
 ;; binop(select(cond, x, y), z) => select(cond, binop(x, z), binop(y, z))
@@ -37,10 +81,9 @@ block0(v0: i8, v1: i32, v2: i32, v3: i32):
     v4 = select v0, v1, v2
     v5 = isub v4, v3
     return v5
-    ; check: v6 = isub v1, v3
-    ; check: v7 = isub v2, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v4 = select v0, v1, v2
+    ; check: v13 = isub v4, v3
+    ; check: return v13
 }
 
 ;; binop(x, select(cond, y, z)) => select(cond, binop(x, y), binop(x, z))
@@ -49,10 +92,9 @@ block0(v0: i8, v1: i32, v2: i32, v3: i32):
     v4 = select v0, v2, v3
     v5 = isub v1, v4
     return v5
-    ; check: v6 = isub v1, v2
-    ; check: v7 = isub v1, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v4 = select v0, v2, v3
+    ; check: v13 = isub v1, v4
+    ; check: return v13
 }
 
 ;; ternop(select(cond, w, x), y, z) => select(cond, ternop(w, y, z), ternop(x, y, z))
@@ -61,10 +103,9 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
     v5 = select v0, v1, v2
     v6 = fma v5, v3, v4
     return v6
-    ; check: v7 = fma v1, v3, v4
-    ; check: v8 = fma v2, v3, v4
-    ; check: v9 = select v0, v7, v8
-    ; check: return v9
+    ; check: v5 = select v0, v1, v2
+    ; check: v14 = fma v5, v3, v4
+    ; check: return v14
 }
 
 ;; ternop(w, select(cond, x, y), z) => select(cond, ternop(w, x, z), ternop(w, y, z))
@@ -73,10 +114,9 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
     v5 = select v0, v2, v3
     v6 = fma v1, v5, v4
     return v6
-    ; check: v7 = fma v1, v2, v4
-    ; check: v8 = fma v1, v3, v4
-    ; check: v9 = select v0, v7, v8
-    ; check: return v9
+    ; check: v5 = select v0, v2, v3
+    ; check: v14 = fma v1, v5, v4
+    ; check: return v14
 }
 
 ;; ternop(w, x, select(cond, y, z)) => select(cond, ternop(w, x, y), ternop(w, x, z))
@@ -85,10 +125,9 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32, v4: f32):
     v5 = select v0, v3, v4
     v6 = fma v1, v2, v5
     return v6
-    ; check: v7 = fma v1, v2, v3
-    ; check: v8 = fma v1, v2, v4
-    ; check: v9 = select v0, v7, v8
-    ; check: return v9
+    ; check: v5 = select v0, v3, v4
+    ; check: v14 = fma v1, v2, v5
+    ; check: return v14
 }
 
 ;; icmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
@@ -97,10 +136,9 @@ block0(v0: i8, v1: i32, v2: i32, v3: i32):
     v4 = select v0, v1, v2
     v5 = icmp ult v4, v3
     return v5
-    ; check: v6 = icmp ult v1, v3
-    ; check: v7 = icmp ult v2, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v9 = select v0, v1, v2
+    ; check: v14 = icmp ult v9, v3
+    ; check: return v14
 }
 
 ;; icmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
@@ -109,10 +147,9 @@ block0(v0: i8, v1: i32, v2: i32, v3: i32):
     v4 = select v0, v2, v3
     v5 = icmp ult v1, v4
     return v5
-    ; check: v6 = icmp ult v1, v2
-    ; check: v7 = icmp ult v1, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v9 = select v0, v2, v3
+    ; check: v14 = icmp ult v1, v9
+    ; check: return v14
 }
 
 ;; fcmp(cc, select(cond, x, y), z) => select(cond, icmp(cc, x, z), icmp(cc, y, z))
@@ -121,10 +158,9 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32):
     v4 = select v0, v1, v2
     v5 = fcmp ult v4, v3
     return v5
-    ; check: v6 = fcmp ult v1, v3
-    ; check: v7 = fcmp ult v2, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v9 = select v0, v1, v2
+    ; check: v14 = fcmp ult v9, v3
+    ; check: return v14
 }
 
 ;; fcmp(cc, x, select(cond, y, z)) => select(cond, icmp(cc, x, y), icmp(cc, x, z))
@@ -133,10 +169,9 @@ block0(v0: i8, v1: f32, v2: f32, v3: f32):
     v4 = select v0, v2, v3
     v5 = fcmp ult v1, v4
     return v5
-    ; check: v6 = fcmp ult v1, v2
-    ; check: v7 = fcmp ult v1, v3
-    ; check: v8 = select v0, v6, v7
-    ; check: return v8
+    ; check: v9 = select v0, v2, v3
+    ; check: v14 = fcmp ult v1, v9
+    ; check: return v14
 }
 
 function %select_sgt_to_smax(i32, i32) -> i32 {


### PR DESCRIPTION
Rewrites operations on `select` to `select` on operations (eg `ineg(select(cond, x, y)) => select(cond, ineg(x), ineg(y))`. This transform is not obviously beneficial by itself, but it may expose more opportunities for other rewrite rules to trigger.

I'm not sure I put the extractor/constructor definitions for `unop`/`binop`/`ternop` in the correct places. Let me know if I should move them somewhere else. 
