### PR TITLE
wasi-common: change behavior of path_readlink to truncate on too-small buffer

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/readlink.rs
+++ b/crates/test-programs/wasi-tests/src/bin/readlink.rs
@@ -22,10 +22,10 @@ unsafe fn test_readlink(dir_fd: wasi::Fd) {
 
     // Read link into smaller buffer than the actual link's length
     let buf = &mut [0u8; 4];
-    let err = wasi::path_readlink(dir_fd, "symlink", buf.as_mut_ptr(), buf.len())
-        .err()
-        .expect("readlink with too-small buffer should fail");
-    assert_errno!(err, wasi::ERRNO_RANGE);
+    let bufused = wasi::path_readlink(dir_fd, "symlink", buf.as_mut_ptr(), buf.len())
+        .expect("readlink with too-small buffer should silently truncate");
+    assert_eq!(bufused, 4);
+    assert_eq!(buf, b"targ");
 
     // Clean up.
     wasi::path_unlink_file(dir_fd, "target").expect("removing a file");

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -795,11 +795,11 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
             .into_string()
             .map_err(|_| Error::illegal_byte_sequence().context("link contents"))?;
         let link_bytes = link.as_bytes();
-        let link_len = link_bytes.len();
-        if link_len > buf_len as usize {
-            return Err(Error::range());
-        }
-        buf.as_array(link_len as u32).copy_from_slice(link_bytes)?;
+        // Like posix readlink(2), silently truncate links when they are larger than the
+        // destination buffer:
+        let link_len = std::cmp::min(link_bytes.len(), buf_len as usize);
+        buf.as_array(link_len as u32)
+            .copy_from_slice(&link_bytes[..link_len])?;
         Ok(link_len as types::Size)
     }
 


### PR DESCRIPTION
This is the same behavior on a too-small buffer as posix readlink(2).

The correct way to call readlink(2), and therefore path_readlink, is to call it multiple times with incrementally larger buffers until the bytes returned is smaller than the buffer passed in, to ensure the value is not being truncated. Userlands are used to this restriction.

Thankfully this nonsense goes away, thanks to the component model, in preview 2, where path_readlink just gives a string. Only the (host) component interfacing with a posix `readlink(2)` needs to do the truncation detection dance.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
