### PR TITLE
Allow inline source and the `path` attribute in the host bindgen! macro

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -79,7 +79,15 @@ impl Parse for Config {
                             return Err(Error::new(s.span(), "cannot specify a second source"));
                         }
                         inline = Some(format!("default world interfaces {{ {} }}", s.value()));
+
+                        if world.is_some() {
+                            return Err(Error::new(
+                                s.span(),
+                                "cannot specify a world with `interfaces`",
+                            ));
+                        }
                         world = Some("macro-input.interfaces".to_string());
+
                         opts.only_interfaces = true;
                     }
                     Opt::With(val) => opts.with.extend(val),


### PR DESCRIPTION
Allow both the `path:` attribute and inline source in the host `bindgen!` macro, which enables the `interfaces:` attribute to refer to interfaces defined locally in that package.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
