### PR TITLE
Make streams owned by request/response that they are tied to.

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -38,17 +38,13 @@ pub fn expand(input: &Config) -> Result<TokenStream> {
     Ok(contents)
 }
 
-enum Source {
-    Path(String),
-    Inline(String),
-}
-
 impl Parse for Config {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let call_site = Span::call_site();
         let mut opts = Opts::default();
-        let mut source = None;
         let mut world = None;
+        let mut inline = None;
+        let mut path = None;
 
         if input.peek(token::Brace) {
             let content;
@@ -57,10 +53,10 @@ impl Parse for Config {
             for field in fields.into_pairs() {
                 match field.into_value() {
                     Opt::Path(s) => {
-                        if source.is_some() {
-                            return Err(Error::new(s.span(), "cannot specify second source"));
+                        if path.is_some() {
+                            return Err(Error::new(s.span(), "cannot specify second path"));
                         }
-                        source = Some(Source::Path(s.value()));
+                        path = Some(s.value());
                     }
                     Opt::World(s) => {
                         if world.is_some() {
@@ -69,23 +65,29 @@ impl Parse for Config {
                         world = Some(s.value());
                     }
                     Opt::Inline(s) => {
-                        if source.is_some() {
+                        if inline.is_some() {
                             return Err(Error::new(s.span(), "cannot specify second source"));
                         }
-                        source = Some(Source::Inline(s.value()));
+                        inline = Some(s.value());
                     }
                     Opt::Tracing(val) => opts.tracing = val,
                     Opt::Async(val) => opts.async_ = val,
                     Opt::TrappableErrorType(val) => opts.trappable_error_type = val,
                     Opt::DuplicateIfNecessary(val) => opts.duplicate_if_necessary = val,
                     Opt::Interfaces(s) => {
-                        if source.is_some() {
+                        if inline.is_some() {
                             return Err(Error::new(s.span(), "cannot specify a second source"));
                         }
-                        source = Some(Source::Inline(format!(
-                            "default world interfaces {{ {} }}",
-                            s.value()
-                        )));
+                        inline = Some(format!("default world interfaces {{ {} }}", s.value()));
+
+                        if world.is_some() {
+                            return Err(Error::new(
+                                s.span(),
+                                "cannot specify a world with `interfaces`",
+                            ));
+                        }
+                        world = Some("macro-input.interfaces".to_string());
+
                         opts.only_interfaces = true;
                     }
                     Opt::With(val) => opts.with.extend(val),
@@ -94,11 +96,12 @@ impl Parse for Config {
         } else {
             world = input.parse::<Option<syn::LitStr>>()?.map(|s| s.value());
             if input.parse::<Option<syn::token::In>>()?.is_some() {
-                source = Some(Source::Path(input.parse::<syn::LitStr>()?.value()));
+                path = Some(input.parse::<syn::LitStr>()?.value());
             }
         }
-        let (resolve, pkg, files) =
-            parse_source(&source).map_err(|err| Error::new(call_site, format!("{err:?}")))?;
+        let (resolve, pkg, files) = parse_source(&path, &inline)
+            .map_err(|err| Error::new(call_site, format!("{err:?}")))?;
+
         let world = resolve
             .select_world(pkg, world.as_deref())
             .map_err(|e| Error::new(call_site, format!("{e:?}")))?;
@@ -111,11 +114,15 @@ impl Parse for Config {
     }
 }
 
-fn parse_source(source: &Option<Source>) -> anyhow::Result<(Resolve, PackageId, Vec<PathBuf>)> {
+fn parse_source(
+    path: &Option<String>,
+    inline: &Option<String>,
+) -> anyhow::Result<(Resolve, PackageId, Vec<PathBuf>)> {
     let mut resolve = Resolve::default();
     let mut files = Vec::new();
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let mut parse = |path: &Path| -> anyhow::Result<_> {
+
+    let mut parse = |resolve: &mut Resolve, path: &Path| -> anyhow::Result<_> {
         if path.is_dir() {
             let (pkg, sources) = resolve.push_dir(path)?;
             files = sources;
@@ -126,14 +133,31 @@ fn parse_source(source: &Option<Source>) -> anyhow::Result<(Resolve, PackageId, 
             resolve.push(pkg, &Default::default())
         }
     };
-    let pkg = match source {
-        Some(Source::Inline(s)) => resolve.push(
-            UnresolvedPackage::parse("macro-input".as_ref(), s)?,
-            &Default::default(),
-        )?,
-        Some(Source::Path(s)) => parse(&root.join(s))?,
-        None => parse(&root.join("wit"))?,
+
+    let path_pkg = if let Some(path) = path {
+        Some(parse(&mut resolve, &root.join(&path))?)
+    } else {
+        None
     };
+
+    let inline_pkg = if let Some(inline) = inline {
+        let deps = resolve
+            .packages
+            .iter()
+            .map(|(id, p)| (p.name.clone(), id))
+            .collect();
+
+        Some(resolve.push(
+            UnresolvedPackage::parse("macro-input".as_ref(), &inline)?,
+            &deps,
+        )?)
+    } else {
+        None
+    };
+
+    let pkg = inline_pkg
+        .or(path_pkg)
+        .map_or_else(|| parse(&mut resolve, &root.join("wit")), Ok)?;
 
     Ok((resolve, pkg, files))
 }

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -183,7 +183,7 @@ impl WasiHttp {
         let body = Full::<Bytes>::new(
             self.streams
                 .get(&request.body)
-                .unwrap_or(&Stream::new())
+                .unwrap_or(&Stream::default())
                 .data
                 .clone(),
         );

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -223,13 +223,7 @@ impl WasiHttp {
         }
         response.body = self.streams_id_base;
         self.streams_id_base = self.streams_id_base + 1;
-        self.streams.insert(
-            response.body,
-            Stream {
-                closed: false,
-                data: buf.freeze(),
-            },
-        );
+        self.streams.insert(response.body, buf.freeze().into());
         self.responses.insert(response_id, response);
         Ok(response_id)
     }

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -185,7 +185,8 @@ impl WasiHttp {
                 .get(&request.body)
                 .unwrap_or(&Stream::default())
                 .data
-                .clone(),
+                .clone()
+                .freeze(),
         );
         let t = timeout(first_bytes_timeout, sender.send_request(call.body(body)?)).await?;
         let mut res = t?;

--- a/crates/wasi-http/src/streams_impl.rs
+++ b/crates/wasi-http/src/streams_impl.rs
@@ -1,5 +1,4 @@
 use crate::poll::Pollable;
-use crate::r#struct::Stream;
 use crate::streams::{InputStream, OutputStream, StreamError};
 use crate::WasiHttp;
 use anyhow::{anyhow, bail};
@@ -74,34 +73,23 @@ impl crate::streams::Host for WasiHttp {
         this: OutputStream,
         buf: Vec<u8>,
     ) -> wasmtime::Result<Result<u64, StreamError>> {
+        let len = buf.len();
         match self.streams.get(&this) {
             Some(st) => {
                 if st.closed {
                     bail!("stream is dropped!");
                 }
-                let data = &st.data;
-                let mut new = bytes::BytesMut::with_capacity(data.len() + buf.len());
-                new.put(data.clone());
-                new.put(bytes::Bytes::from(buf.clone()));
-                self.streams.insert(
-                    this,
-                    Stream {
-                        closed: false,
-                        data: new.freeze(),
-                    },
-                );
+                let new_len = st.data.len() + len;
+                let mut new = bytes::BytesMut::with_capacity(new_len);
+                new.put(st.data.clone());
+                new.put(bytes::Bytes::from(buf));
+                self.streams.insert(this, new.freeze().into());
             }
             None => {
-                self.streams.insert(
-                    this,
-                    Stream {
-                        closed: false,
-                        data: bytes::Bytes::from(buf.clone()),
-                    },
-                );
+                self.streams.insert(this, bytes::Bytes::from(buf).into());
             }
         }
-        Ok(Ok(buf.len().try_into()?))
+        Ok(Ok(len.try_into()?))
     }
 
     fn write_zeroes(

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -1,11 +1,11 @@
 use crate::types::{Method, Scheme};
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use std::collections::HashMap;
 
 #[derive(Clone, Default)]
 pub struct Stream {
     pub closed: bool,
-    pub data: Bytes,
+    pub data: BytesMut,
 }
 
 #[derive(Clone)]
@@ -80,9 +80,11 @@ impl Stream {
 
 impl From<Bytes> for Stream {
     fn from(bytes: Bytes) -> Self {
+        let mut buf = BytesMut::with_capacity(bytes.len());
+        buf.put(bytes);
         Self {
             closed: false,
-            data: bytes,
+            data: buf,
         }
     }
 }

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -3,6 +3,12 @@ use bytes::Bytes;
 use std::collections::HashMap;
 
 #[derive(Clone)]
+pub struct Stream {
+    pub closed: bool,
+    pub data: Bytes,
+}
+
+#[derive(Clone)]
 pub struct WasiHttp {
     pub request_id_base: u32,
     pub response_id_base: u32,
@@ -11,7 +17,7 @@ pub struct WasiHttp {
     pub requests: HashMap<u32, ActiveRequest>,
     pub responses: HashMap<u32, ActiveResponse>,
     pub fields: HashMap<u32, HashMap<String, Vec<String>>>,
-    pub streams: HashMap<u32, Bytes>,
+    pub streams: HashMap<u32, Stream>,
 }
 
 #[derive(Clone)]
@@ -62,6 +68,15 @@ impl ActiveResponse {
             body: 0,
             response_headers: HashMap::new(),
             trailers: 0,
+        }
+    }
+}
+
+impl Stream {
+    pub fn new() -> Self {
+        Self {
+            closed: false,
+            data: Bytes::new(),
         }
     }
 }

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -2,7 +2,7 @@ use crate::types::{Method, Scheme};
 use bytes::Bytes;
 use std::collections::HashMap;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Stream {
     pub closed: bool,
     pub data: Bytes,
@@ -74,9 +74,15 @@ impl ActiveResponse {
 
 impl Stream {
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl From<Bytes> for Stream {
+    fn from(bytes: Bytes) -> Self {
         Self {
             closed: false,
-            data: Bytes::new(),
+            data: bytes,
         }
     }
 }

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,5 +1,5 @@
 use crate::poll::Pollable;
-use crate::r#struct::ActiveRequest;
+use crate::r#struct::{ActiveRequest, Stream};
 use crate::types::{
     Error, Fields, FutureIncomingResponse, Headers, IncomingRequest, IncomingResponse,
     IncomingStream, Method, OutgoingRequest, OutgoingResponse, OutgoingStream, ResponseOutparam,
@@ -7,7 +7,7 @@ use crate::types::{
 };
 use crate::WasiHttp;
 use anyhow::{anyhow, bail};
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 impl crate::types::Host for WasiHttp {
     fn drop_fields(&mut self, fields: Fields) -> wasmtime::Result<()> {
@@ -123,12 +123,9 @@ impl crate::types::Host for WasiHttp {
         bail!("unimplemented: drop_incoming_request")
     }
     fn drop_outgoing_request(&mut self, request: OutgoingRequest) -> wasmtime::Result<()> {
-        match self.requests.get(&request) {
-            Some(r) => {
-                self.streams.remove(&r.body);
-                self.requests.remove(&request);
-            }
-            None => { /* pass */ }
+        if let Entry::Occupied(e) = self.requests.entry(request) {
+            let r = e.remove();
+            self.streams.remove(&r.body);
         }
         Ok(())
     }
@@ -198,6 +195,7 @@ impl crate::types::Host for WasiHttp {
         if req.body == 0 {
             req.body = self.streams_id_base;
             self.streams_id_base = self.streams_id_base + 1;
+            self.streams.insert(req.body, Stream::default());
         }
         Ok(Ok(req.body))
     }
@@ -212,12 +210,9 @@ impl crate::types::Host for WasiHttp {
         bail!("unimplemented: set_response_outparam")
     }
     fn drop_incoming_response(&mut self, response: IncomingResponse) -> wasmtime::Result<()> {
-        match self.responses.get(&response) {
-            Some(r) => {
-                self.streams.remove(&r.body);
-                self.responses.remove(&response);
-            }
-            None => { /* pass */ }
+        if let Entry::Occupied(e) = self.responses.entry(response) {
+            let r = e.remove();
+            self.streams.remove(&r.body);
         }
         Ok(())
     }

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -123,7 +123,13 @@ impl crate::types::Host for WasiHttp {
         bail!("unimplemented: drop_incoming_request")
     }
     fn drop_outgoing_request(&mut self, request: OutgoingRequest) -> wasmtime::Result<()> {
-        self.requests.remove(&request);
+        match self.requests.get(&request) {
+            Some(r) => {
+                self.streams.remove(&r.body);
+                self.requests.remove(&request);
+            }
+            None => { /* pass */ }
+        }
         Ok(())
     }
     fn incoming_request_method(&mut self, _request: IncomingRequest) -> wasmtime::Result<Method> {
@@ -206,7 +212,13 @@ impl crate::types::Host for WasiHttp {
         bail!("unimplemented: set_response_outparam")
     }
     fn drop_incoming_response(&mut self, response: IncomingResponse) -> wasmtime::Result<()> {
-        self.responses.remove(&response);
+        match self.responses.get(&response) {
+            Some(r) => {
+                self.streams.remove(&r.body);
+                self.responses.remove(&response);
+            }
+            None => { /* pass */ }
+        }
         Ok(())
     }
     fn drop_outgoing_response(&mut self, _response: OutgoingResponse) -> wasmtime::Result<()> {


### PR DESCRIPTION
This is related to the discussion here: https://github.com/WebAssembly/wasi-http/issues/24

Where we decided that streams should be `child-own` properties of the request or response that they are tied to.

This adds clarity to when it is valid to drop an input or output stream and in what order relative to the response.