### PR TITLE
Bump regalloc2 to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,12 +2577,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80535183cae11b149d618fbd3c37e38d7cda589d82d7769e196ca9a9042d7621"
+checksum = "af72b4ad16ae133417b3ab89ad5a179b5103f202a8aadeb7e8adcb530d319744"
 dependencies = [
- "fxhash",
+ "hashbrown 0.13.2",
  "log",
+ "rustc-hash",
  "serde",
  "slice-group-by",
  "smallvec",
@@ -2673,6 +2674,12 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
-regalloc2 = { version = "0.6.1", features = ["checker"] }
+regalloc2 = { version = "0.7.0", features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -230,6 +230,7 @@ pub fn create_reg_env(flags: &settings::Flags) -> MachineEnv {
             ],
         ],
         fixed_stack_slots: vec![],
+        scratch_by_class: [None, None],
     };
 
     if !flags.enable_pinned_reg() {

--- a/cranelift/codegen/src/isa/riscv64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/regs.rs
@@ -182,6 +182,7 @@ pub fn crate_reg_eviroment(_flags: &settings::Flags) -> MachineEnv {
         preferred_regs_by_class,
         non_preferred_regs_by_class,
         fixed_stack_slots: vec![],
+        scratch_by_class: [None, None],
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -151,6 +151,7 @@ pub fn create_machine_env(_flags: &settings::Flags) -> MachineEnv {
             ],
         ],
         fixed_stack_slots: vec![],
+        scratch_by_class: [None, None],
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -203,6 +203,7 @@ pub(crate) fn create_reg_env_systemv(flags: &settings::Flags) -> MachineEnv {
             vec![],
         ],
         fixed_stack_slots: vec![],
+        scratch_by_class: [None, None],
     };
 
     debug_assert_eq!(r15(), pinned_reg());

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -92,21 +92,23 @@ block3(v7: r64, v8: r64):
 ;   mov fp, sp
 ;   sub sp, sp, #32
 ; block0:
-;   str x0, [sp, #8]
+;   mov x3, x0
 ;   str x1, [sp, #16]
+;   mov x0, x3
+;   str x3, [sp, #8]
 ;   load_ext_name x12, TestCase(%f)+0
 ;   blr x12
 ;   mov x11, sp
-;   ldr x2, [sp, #8]
-;   str x2, [x11]
+;   ldr x3, [sp, #8]
+;   str x3, [x11]
 ;   uxtb w12, w0
 ;   cbnz x12, label2 ; b label1
 ; block1:
-;   mov x1, x2
+;   mov x1, x3
 ;   ldr x0, [sp, #16]
 ;   b label3
 ; block2:
-;   mov x0, x2
+;   mov x0, x3
 ;   ldr x1, [sp, #16]
 ;   b label3
 ; block3:
@@ -122,26 +124,28 @@ block3(v7: r64, v8: r64):
 ;   mov x29, sp
 ;   sub sp, sp, #0x20
 ; block1: ; offset 0xc
-;   stur x0, [sp, #8]
+;   mov x3, x0
 ;   stur x1, [sp, #0x10]
-;   ldr x12, #0x1c
-;   b #0x24
+;   mov x0, x3
+;   stur x3, [sp, #8]
+;   ldr x12, #0x24
+;   b #0x2c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   blr x12
 ;   mov x11, sp
-;   ldur x2, [sp, #8]
-;   str x2, [x11]
+;   ldur x3, [sp, #8]
+;   str x3, [x11]
 ;   uxtb w12, w0
-;   cbnz x12, #0x48
-; block2: ; offset 0x3c
-;   mov x1, x2
+;   cbnz x12, #0x50
+; block2: ; offset 0x44
+;   mov x1, x3
 ;   ldur x0, [sp, #0x10]
-;   b #0x50
-; block3: ; offset 0x48
-;   mov x0, x2
+;   b #0x58
+; block3: ; offset 0x50
+;   mov x0, x3
 ;   ldur x1, [sp, #0x10]
-; block4: ; offset 0x50
+; block4: ; offset 0x58
 ;   mov x15, sp
 ;   ldr x2, [x15]
 ;   add sp, sp, #0x20

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -93,22 +93,24 @@ block3(v7: r64, v8: r64):
 ;   sd s3,-8(sp)
 ;   add sp,-48
 ; block0:
-;   sd a0,8(nominal_sp)
+;   mv a6,a0
 ;   sd a1,16(nominal_sp)
 ;   mv s3,a2
+;   mv a6,a0
+;   sd a6,8(nominal_sp)
 ;   load_sym t0,%f+0
 ;   callind t0
 ;   load_addr t4,nsp+0
-;   ld a5,8(nominal_sp)
-;   sd a5,0(t4)
+;   ld a6,8(nominal_sp)
+;   sd a6,0(t4)
 ;   andi t0,a0,255
 ;   bne t0,zero,taken(label2),not_taken(label1)
 ; block1:
-;   mv a1,a5
+;   mv a1,a6
 ;   ld a0,16(nominal_sp)
 ;   j label3
 ; block2:
-;   mv a0,a5
+;   mv a0,a6
 ;   ld a1,16(nominal_sp)
 ;   j label3
 ; block3:
@@ -132,9 +134,11 @@ block3(v7: r64, v8: r64):
 ;   sd s3, -8(sp)
 ;   addi sp, sp, -0x30
 ; block1: ; offset 0x18
-;   sd a0, 8(sp)
+;   ori a6, a0, 0
 ;   sd a1, 0x10(sp)
 ;   ori s3, a2, 0
+;   ori a0, a6, 0
+;   sd a6, 8(sp)
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
@@ -142,18 +146,18 @@ block3(v7: r64, v8: r64):
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   jalr t0
 ;   mv t4, sp
-;   ld a5, 8(sp)
-;   sd a5, 0(t4)
+;   ld a6, 8(sp)
+;   sd a6, 0(t4)
 ;   andi t0, a0, 0xff
 ;   bnez t0, 0x10
-; block2: ; offset 0x50
-;   ori a1, a5, 0
+; block2: ; offset 0x58
+;   ori a1, a6, 0
 ;   ld a0, 0x10(sp)
 ;   j 0xc
-; block3: ; offset 0x5c
-;   ori a0, a5, 0
+; block3: ; offset 0x64
+;   ori a0, a6, 0
 ;   ld a1, 0x10(sp)
-; block4: ; offset 0x64
+; block4: ; offset 0x6c
 ;   mv a2, sp
 ;   ld a2, 0(a2)
 ;   ori t3, s3, 0

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -97,22 +97,24 @@ block3(v7: r64, v8: r64):
 ;   aghi %r15, -184
 ;   virtual_sp_offset_adjust 160
 ; block0:
-;   stg %r2, 168(%r15)
+;   lgr %r5, %r2
 ;   stg %r3, 176(%r15)
+;   lgr %r2, %r5
+;   stg %r5, 168(%r15)
 ;   bras %r1, 12 ; data %f + 0 ; lg %r3, 0(%r1)
 ;   basr %r14, %r3
-;   la %r5, 160(%r15)
-;   lg %r4, 168(%r15)
-;   stg %r4, 0(%r5)
+;   la %r3, 160(%r15)
+;   lg %r5, 168(%r15)
+;   stg %r5, 0(%r3)
 ;   lbr %r2, %r2
 ;   chi %r2, 0
 ;   jglh label2 ; jg label1
 ; block1:
-;   lgr %r3, %r4
+;   lgr %r3, %r5
 ;   lg %r2, 176(%r15)
 ;   jg label3
 ; block2:
-;   lgr %r2, %r4
+;   lgr %r2, %r5
 ;   lg %r3, 176(%r15)
 ;   jg label3
 ; block3:
@@ -126,29 +128,31 @@ block3(v7: r64, v8: r64):
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xb8
 ; block1: ; offset 0xa
-;   stg %r2, 0xa8(%r15)
+;   lgr %r5, %r2
 ;   stg %r3, 0xb0(%r15)
-;   bras %r1, 0x22
+;   lgr %r2, %r5
+;   stg %r5, 0xa8(%r15)
+;   bras %r1, 0x2a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %f 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   lg %r3, 0(%r1)
 ;   basr %r14, %r3
-;   la %r5, 0xa0(%r15)
-;   lg %r4, 0xa8(%r15)
-;   stg %r4, 0(%r5)
+;   la %r3, 0xa0(%r15)
+;   lg %r5, 0xa8(%r15)
+;   stg %r5, 0(%r3)
 ;   lbr %r2, %r2
 ;   chi %r2, 0
-;   jglh 0x58
-; block2: ; offset 0x48
-;   lgr %r3, %r4
+;   jglh 0x60
+; block2: ; offset 0x50
+;   lgr %r3, %r5
 ;   lg %r2, 0xb0(%r15)
-;   jg 0x62
-; block3: ; offset 0x58
-;   lgr %r2, %r4
+;   jg 0x6a
+; block3: ; offset 0x60
+;   lgr %r2, %r5
 ;   lg %r3, 0xb0(%r15)
-; block4: ; offset 0x62
+; block4: ; offset 0x6a
 ;   la %r4, 0xa0(%r15)
 ;   lg %r4, 0(%r4)
 ;   lmg %r14, %r15, 0x128(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
@@ -1226,11 +1226,11 @@ block0(v0: i64x2, v1: i64x2):
 ;   vlgvg %r5, %v24, 0
 ;   vlgvg %r3, %v25, 0
 ;   mgrk %r2, %r5, %r3
-;   lgr %r5, %r2
+;   lgr %r4, %r2
 ;   vlgvg %r2, %v24, 1
-;   vlgvg %r4, %v25, 1
-;   mgrk %r2, %r2, %r4
-;   vlvgp %v24, %r5, %r2
+;   vlgvg %r5, %v25, 1
+;   mgrk %r2, %r2, %r5
+;   vlvgp %v24, %r4, %r2
 ;   br %r14
 ; 
 ; Disassembled:
@@ -1238,11 +1238,11 @@ block0(v0: i64x2, v1: i64x2):
 ;   vlgvg %r5, %v24, 0
 ;   vlgvg %r3, %v25, 0
 ;   mgrk %r2, %r5, %r3
-;   lgr %r5, %r2
+;   lgr %r4, %r2
 ;   vlgvg %r2, %v24, 1
-;   vlgvg %r4, %v25, 1
-;   mgrk %r2, %r2, %r4
-;   vlvgp %v24, %r5, %r2
+;   vlgvg %r5, %v25, 1
+;   mgrk %r2, %r2, %r5
+;   vlvgp %v24, %r4, %r2
 ;   br %r14
 
 function %smulhi_i32x4(i32x4, i32x4) -> i32x4 {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1039,6 +1039,12 @@ criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.6.1"
 notes = "Bytecode Alliance is the author of this crate."
 
+[[audits.regalloc2]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.1 -> 0.7.0"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[audits.rustc-demangle]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -303,6 +303,13 @@ formatter, and runtime logic.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.rustc-hash]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+version = "1.1.0"
+notes = "Straightforward crate with no unsafe code, does what it says on the tin."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.slab]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 # In the next iteration we'll factor out the common bits so that they can be consumed
 # by Cranelift and Winch.
 cranelift-codegen = { workspace = true }
-regalloc2 = "0.6.0"
+regalloc2 = "0.7.0"
 gimli = { workspace = true }
 
 [features]


### PR DESCRIPTION
Bump regalloc2 to version 0.7.0, which removes program moves and adds back in support for scratch registers. This bump also brings with it a new dependency on `hashbrown-0.13.2` and `rustc-hash`. The latter had an audit that we could import, while the former was updated in #6238.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
