### PR TITLE
Fix default architecture for winch

### DIFF
--- a/winch/codegen/build.rs
+++ b/winch/codegen/build.rs
@@ -3,9 +3,11 @@ fn main() {
         return;
     }
 
-    if cfg!(target_arch = "x86_64") {
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
+    if arch == "x86_64" {
         println!("cargo:rustc-cfg=feature=\"x64\"");
-    } else if cfg!(target_arch = "aarch64") {
+    } else if arch == "aarch64" {
         println!("cargo:rustc-cfg=feature=\"arm64\"");
     }
     println!("cargo:rerun-if-changed=build.rs");

--- a/winch/codegen/build.rs
+++ b/winch/codegen/build.rs
@@ -9,6 +9,8 @@ fn main() {
         println!("cargo:rustc-cfg=feature=\"x64\"");
     } else if arch == "aarch64" {
         println!("cargo:rustc-cfg=feature=\"arm64\"");
+    } else {
+        println!("cargo:rustc-cfg=feature=\"{arch}\"");
     }
     println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
This updates the `winch/codegen/build.rs` script to default to the target architecture being compiled for as opposed to the host architecture that's performing the compile.

Closes #6241

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
