### PR TITLE
Mark loads from `VMCallerCheckedAnyfunc` as readonly

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1595,7 +1595,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             .trapz(funcref_ptr, ir::TrapCode::IndirectCallToNull);
 
         // Dereference the funcref pointer to get the function address.
-        let mem_flags = ir::MemFlags::trusted();
+        let mem_flags = ir::MemFlags::trusted().with_readonly();
         let func_addr = builder.ins().load(
             pointer_type,
             mem_flags,
@@ -1631,7 +1631,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     .load(sig_id_type, mem_flags, signatures, offset);
 
                 // Load the callee ID.
-                let mem_flags = ir::MemFlags::trusted();
+                let mem_flags = ir::MemFlags::trusted().with_readonly();
                 let callee_sig_id = builder.ins().load(
                     sig_id_type,
                     mem_flags,
@@ -1703,7 +1703,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let vmctx = self.vmctx(&mut pos.func);
         let base = pos.ins().global_value(pointer_type, vmctx);
 
-        let mem_flags = ir::MemFlags::trusted();
+        let mem_flags = ir::MemFlags::trusted().with_readonly();
 
         // Load the callee address.
         let body_offset =


### PR DESCRIPTION
This commit marks the loads of `*mut VMContext` and the callee function pointer as `readonly` in the context of indirect function calls and additionally calls to imported functions (which are indirect). Once a `VMCallerCheckedAnyfunc` is initialized it's never modified so it should be valid to mark these as readonly and if called in a loop should be hoistable outside of the loop.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
