### PR TITLE
wasi-common: export StringArray type

### DIFF
--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -69,5 +69,5 @@ pub use dir::WasiDir;
 pub use error::{Error, ErrorExt, I32Exit};
 pub use file::WasiFile;
 pub use sched::{Poll, WasiSched};
-pub use string_array::StringArrayError;
+pub use string_array::{StringArray, StringArrayError};
 pub use table::Table;


### PR DESCRIPTION
reusable elsewhere: @mtr is gonna use it in wasi-nn.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
