### PR TITLE
Avoid introducing a move for struct return

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -396,6 +396,8 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                         sret_reg = Some(regs);
                     }
                 }
+
+                assert!(sret_reg.is_some());
             }
         }
 

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -850,16 +850,14 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   mov x5, x8
-;   movz x4, #42
-;   str x4, [x8]
+;   movz x2, #42
+;   str x2, [x8]
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov x5, x8
-;   mov x4, #0x2a
-;   str x4, [x8]
+;   mov x2, #0x2a
+;   str x2, [x8]
 ;   ret
 
 function %f18(i64) -> i64 {
@@ -905,13 +903,14 @@ block0(v0: i64):
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   str x24, [sp, #-16]!
+;   str x23, [sp, #-16]!
 ; block0:
-;   mov x24, x8
-;   load_ext_name x4, TestCase(%g)+0
-;   blr x4
-;   mov x8, x24
-;   ldr x24, [sp], #16
+;   mov x23, x8
+;   load_ext_name x2, TestCase(%g)+0
+;   mov x8, x23
+;   blr x2
+;   mov x8, x23
+;   ldr x23, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
 ; 
@@ -919,16 +918,17 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   str x24, [sp, #-0x10]!
+;   str x23, [sp, #-0x10]!
 ; block1: ; offset 0xc
-;   mov x24, x8
-;   ldr x4, #0x18
+;   mov x23, x8
+;   ldr x2, #0x18
 ;   b #0x20
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x4
-;   mov x8, x24
-;   ldr x24, [sp], #0x10
+;   mov x8, x23
+;   blr x2
+;   mov x8, x23
+;   ldr x23, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -12,9 +12,9 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   movl    $42, %eax
+;   movq    %rax, 0(%rdi)
 ;   movq    %rdi, %rax
-;   movl    $42, %edx
-;   movq    %rdx, 0(%rdi)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -24,9 +24,9 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   movl $0x2a, %eax
+;   movq %rax, (%rdi) ; trap: heap_oob
 ;   movq %rdi, %rax
-;   movl $0x2a, %edx
-;   movq %rdx, (%rdi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -79,8 +79,9 @@ block0(v0: i64):
 ;   movq    %r15, 0(%rsp)
 ; block0:
 ;   movq    %rdi, %r15
-;   load_ext_name %f4+0, %rdx
-;   call    *%rdx
+;   load_ext_name %f4+0, %rax
+;   movq    %r15, %rdi
+;   call    *%rax
 ;   movq    %r15, %rax
 ;   movq    0(%rsp), %r15
 ;   addq    %rsp, $16, %rsp
@@ -96,8 +97,9 @@ block0(v0: i64):
 ;   movq %r15, (%rsp)
 ; block1: ; offset 0xc
 ;   movq %rdi, %r15
-;   movabsq $0, %rdx ; reloc_external Abs8 %f4 0
-;   callq *%rdx
+;   movabsq $0, %rax ; reloc_external Abs8 %f4 0
+;   movq %r15, %rdi
+;   callq *%rax
 ;   movq %r15, %rax
 ;   movq (%rsp), %r15
 ;   addq $0x10, %rsp


### PR DESCRIPTION
RA2-0.7.0 removes support for processing program moves, and as such we need to burn down the list of moves present in VCode prior to it being handed of to RA2.

The handling of struct return currently will allocate a fresh VReg in `Lower::new` that will be copied into during `Lower::gen_arg_setup`. That new VReg will be used when a return is processed, to ensure that the `sret` param is threaded out correctly.

If we cache the `sret` param in `Lower::new` instead, we can avoid allocating the temporary and instead use it directly when processing a return. This has a mixed effect on the filetests: you can see some cases where eagerly introducing the temporary register avoids a move later, and some where avoiding the temporary allocation also avoids a move.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
