### PR TITLE
riscv64: Remove the gen_move2 helper

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2116,10 +2116,6 @@
 (extern constructor gen_stack_addr gen_stack_addr)
 
 
-;; parameter are 'source register' 'in_ty' 'out_ty'
-(decl gen_move2 (Reg Type Type) Reg)
-(extern constructor gen_move2 gen_move2)
-
 ;;; generate a move and reinterprete the data
 ;; parameter is "rs" "in_type" "out_type"
 (decl gen_moves (ValueRegs Type Type) ValueRegs)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -643,7 +643,7 @@
 ;;;;;  Rules for `ireduce`;;;;;;;;;;;;;;;;;
 (rule
   (lower (has_type ty (ireduce x)))
-  (gen_move2 (value_regs_get x 0) ty ty))
+  (value_regs_get x 0))
 
 ;;;;;  Rules for `fpromote`;;;;;;;;;;;;;;;;;
 (rule (lower (fpromote x))
@@ -721,16 +721,16 @@
 (rule
   (lower (isplit x))
   (let
-    ((t1 Reg (gen_move2 (value_regs_get x 0) $I64 $I64))
-      (t2 Reg (gen_move2 (value_regs_get x 1) $I64 $I64)))
+    ((t1 Reg (value_regs_get x 0))
+      (t2 Reg (value_regs_get x 1)))
     (output_pair t1 t2)))
 
 ;;;;;  Rules for `iconcat`;;;;;;;;;
 (rule
   (lower (has_type $I128 (iconcat x y)))
   (let
-    ((t1 Reg (gen_move2 x $I64 $I64))
-      (t2 Reg (gen_move2 y $I64 $I64)))
+    ((t1 Reg x)
+      (t2 Reg y))
     (value_regs t1 t2)))
 
 ;;;;;  Rules for `smax`;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -420,11 +420,10 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   mv a4,a0
+;   mv a1,a0
 ;   li a2,42
-;   mv a0,a2
-;   mv a1,a4
 ;   load_sym a3,%f11+0
+;   mv a0,a2
 ;   callind a3
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -438,15 +437,14 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ; block1: ; offset 0x10
-;   ori a4, a0, 0
+;   ori a1, a0, 0
 ;   addi a2, zero, 0x2a
-;   ori a0, a2, 0
-;   ori a1, a4, 0
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f11 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
+;   ori a0, a2, 0
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -462,13 +460,11 @@ block0(v0: i64, v1: i128):
 ; VCode:
 ; block0:
 ;   mv a0,a1
-;   mv a1,a2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a1, 0
-;   ori a1, a2, 0
 ;   ret
 
 function %f12_call(i64) -> i64 {
@@ -487,11 +483,10 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   mv a4,a0
-;   li a0,42
-;   mv a1,a4
-;   mv a2,a0
+;   mv a1,a0
+;   li a2,42
 ;   load_sym a3,%f12+0
+;   mv a0,a2
 ;   callind a3
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -505,15 +500,14 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ; block1: ; offset 0x10
-;   ori a4, a0, 0
-;   addi a0, zero, 0x2a
-;   ori a1, a4, 0
-;   ori a2, a0, 0
+;   ori a1, a0, 0
+;   addi a2, zero, 0x2a
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f12 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
+;   ori a0, a2, 0
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -529,13 +523,11 @@ block0(v0: i64, v1: i128):
 ; VCode:
 ; block0:
 ;   mv a0,a1
-;   mv a1,a2
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a1, 0
-;   ori a1, a2, 0
 ;   ret
 
 function %f13_call(i64) -> i64 {
@@ -554,11 +546,10 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   mv a4,a0
-;   li a0,42
-;   mv a1,a4
-;   mv a2,a0
+;   mv a1,a0
+;   li a2,42
 ;   load_sym a3,%f13+0
+;   mv a0,a2
 ;   callind a3
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -572,15 +563,14 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ; block1: ; offset 0x10
-;   ori a4, a0, 0
-;   addi a0, zero, 0x2a
-;   ori a1, a4, 0
-;   ori a2, a0, 0
+;   ori a1, a0, 0
+;   addi a2, zero, 0x2a
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f13 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
+;   ori a0, a2, 0
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)


### PR DESCRIPTION
The `gen_move2` helper was only used with integer types to introduce a copy of that value. Since the move to a version of RA2 that requires SSA input, this is a no-op, and only complicates the input program. Additionally, in RA2-0.7.0 support for program moves have been removed, which means that any move present in the input program will always be present after RA2 has run.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
