### PR TITLE
Fix `poll_oneoff`'s handling of non-regular files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.25.6"
+version = "0.25.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1ab6a74e204b606bf397944fa991f3b01046113cc0a4ac269be3ef067cc24b"
+checksum = "928ebd55ab758962e230f51ca63735c5b283f26292297c81404289cda5d78631"
 dependencies = [
  "bitflags",
  "cap-fs-ext",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1140,6 +1140,12 @@ criteria = "safe-to-deploy"
 delta = "0.25.4 -> 0.25.6"
 notes = "Just a dependency version bump"
 
+[[audits.system-interface]]
+who = "Dan Gohman <dev@sunfishcode.online>"
+criteria = "safe-to-deploy"
+delta = "0.25.6 -> 0.25.7"
+notes = "This is a minor bug-fix update."
+
 [[audits.tinyvec]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
`poll_oneoff` uses `system_interface::ReadReady` to compute how many bytes are ready to be read, which is part of the Preview1 `poll_oneoff` API. This updates to system-interface 0.25.7 which has a fix to handle special files such as /dev/urandom and /dev/null properly.

Fixes #6239.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
