### PR TITLE
docs(wasi-tut): update error message

### DIFF
--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -182,7 +182,7 @@ Ok, this program needs some command-line arguments. So let's give it some:
 ```
 $ echo hello world > test.txt
 $ wasmtime demo.wasm test.txt /tmp/somewhere.txt
-error opening input test.txt: Capabilities insufficient
+error opening input test.txt: failed to find a pre-opened file descriptor through which "test.txt" could be opened
 ```
 
 Aha, now we're seeing the sandboxing in action. This program is attempting to


### PR DESCRIPTION
I was following the WASI tutorial but got a different error message than described in the documentation.

OS: macOS 13.2.1 (M1)
Rust (cargo) version: 1.67.0
wasmtime-cli version: 7.0.0