### PR TITLE
Fix differential fuzzing when Wasmtime hits an OOM

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -130,6 +130,11 @@ impl WasmtimeInstance {
             })
             .collect()
     }
+
+    /// Returns whether or not this instance has hit its OOM condition yet.
+    pub fn is_oom(&self) -> bool {
+        self.store.data().is_oom()
+    }
 }
 
 impl DiffInstance for WasmtimeInstance {


### PR DESCRIPTION
OSS-Fuzz found a case where the `differential` fuzzer was failing and the underlying cause was that Wasmtime was hitting an OOM while Wasmi wasn't. This meant that the two modules were producing "different results" since memories had differing lengths, but this isn't a failure we're interested in. This commit updates the differential fuzzer to discard the test case once the Wasmtime half reaches OOM.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
