### PR TITLE
Release Wasmtime 6.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,34 +1775,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -539,14 +539,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "arrayvec",
  "bincode",
@@ -571,18 +571,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.93.1"
+version = "0.93.2"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "serde",
 ]
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -701,7 +701,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "clap 3.2.8",
  "cranelift-codegen",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3110,7 +3110,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3389,14 +3389,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "clap 3.2.8",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3533,11 +3533,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "6.0.1"
+version = "6.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "wasi-cap-std-sync",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3934,7 +3934,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,57 +104,57 @@ exclude = [
 ]
 
 [workspace.package]
-version = "6.0.1"
+version = "6.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 rust-version = "1.66.0"
 
 [workspace.dependencies]
-wasmtime = { path = "crates/wasmtime", version = "6.0.1", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=6.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=6.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=6.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=6.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=6.0.1" }
-wasmtime-types = { path = "crates/types", version = "6.0.1" }
-wasmtime-jit = { path = "crates/jit", version = "=6.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=6.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=6.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=6.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "6.0.1" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "6.0.1" }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "6.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=6.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=6.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=6.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "6.0.2", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=6.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=6.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=6.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=6.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=6.0.2" }
+wasmtime-types = { path = "crates/types", version = "6.0.2" }
+wasmtime-jit = { path = "crates/jit", version = "=6.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=6.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=6.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=6.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "6.0.2" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "6.0.2" }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "6.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=6.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=6.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=6.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=6.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=6.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=6.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=6.0.1" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=6.0.1" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=6.0.1" }
+wiggle = { path = "crates/wiggle", version = "=6.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=6.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=6.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=6.0.2" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=6.0.2" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=6.0.2" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=6.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=6.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=6.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=6.0.2" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.93.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.93.1" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.93.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.93.1" }
-cranelift-native = { path = "cranelift/native", version = "0.93.1" }
-cranelift-module = { path = "cranelift/module", version = "0.93.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.93.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.93.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.93.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.93.2" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.93.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.93.2" }
+cranelift-native = { path = "cranelift/native", version = "0.93.2" }
+cranelift-module = { path = "cranelift/module", version = "0.93.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.93.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.93.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.93.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.93.1" }
+cranelift-object = { path = "cranelift/object", version = "0.93.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.93.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.93.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.93.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.93.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.93.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.4.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.4.2" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.93.1"
+version = "0.93.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.93.1"
+version = "0.93.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -15,7 +15,7 @@ edition.workspace = true
 [dependencies]
 arrayvec = "0.7"
 bumpalo = "3"
-cranelift-codegen-shared = { path = "./shared", version = "0.93.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.93.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 hashbrown = { workspace = true }
@@ -38,8 +38,8 @@ criterion = "0.3"
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.93.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.93.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.93.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.93.2" }
 
 [features]
 default = ["std", "unwind", "trace-log"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.93.1"
+version = "0.93.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -13,7 +13,7 @@ edition.workspace = true
 # rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.93.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.93.2" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.93.1"
+version = "0.93.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.93.1"
+version = "0.93.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.93.1"
+version = "0.93.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.93.1"
+version = "0.93.2"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.93.1"
+version = "0.93.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.93.1"
+version = "0.93.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.93.1"
+version = "0.93.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -199,7 +199,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "6.0.1"
+#define WASMTIME_VERSION "6.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -211,7 +211,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -463,7 +463,7 @@ version = "0.5.1"
 criteria = "safe-to-run"
 
 [[exemptions.mio]]
-version = "0.8.2"
+version = "0.8.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.miow]]

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 6.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
