### PR TITLE
wasmtime: remove `drop(&mut ...)` used to silence warnings

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1520,7 +1520,7 @@ impl Config {
     }
 
     #[cfg(compiler)]
-    pub(crate) fn build_compiler(&mut self) -> Result<Box<dyn wasmtime_environ::Compiler>> {
+    pub(crate) fn build_compiler(mut self) -> Result<(Self, Box<dyn wasmtime_environ::Compiler>)> {
         let mut compiler = match self.compiler_config.strategy {
             #[cfg(feature = "cranelift")]
             Strategy::Auto => wasmtime_cranelift::builder(),
@@ -1614,7 +1614,7 @@ impl Config {
             compiler.enable_incremental_compilation(cache_store.clone())?;
         }
 
-        compiler.build()
+        Ok((self, compiler.build()?))
     }
 
     /// Internal setting for whether adapter modules for components will have

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -81,12 +81,11 @@ impl Engine {
         debug_builtins::ensure_exported();
 
         let registry = SignatureRegistry::new();
-        let mut config = config.clone();
+        let config = config.clone();
         config.validate()?;
 
         #[cfg(compiler)]
-        let compiler = config.build_compiler()?;
-        drop(&mut config); // silence warnings without `cfg(compiler)`
+        let (config, compiler) = config.build_compiler()?;
 
         let allocator = config.build_allocator()?;
         let profiler = config.build_profiler()?;


### PR DESCRIPTION
The `Config` needs to be mutable while building a compiler, but in a build configuration without a compiler, declaring it as `mut` produces a warning since nothing else needs that.

I found the existing workaround for this warning confusing, so this PR removes `mut` from the binding for `config` and instead re-binds the variable in builds where we call `build_compiler`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
