### PR TITLE
wasmtime-runtime: Re-export backtrace `Frame` type

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::table::{Table, TableElement};
 pub use crate::trampolines::prepare_host_to_wasm_trampoline;
 pub use crate::traphandlers::{
     catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, tls_eager_initialize,
-    Backtrace, SignalHandler, TlsRestore, Trap, TrapReason,
+    Backtrace, Frame, SignalHandler, TlsRestore, Trap, TrapReason,
 };
 pub use crate::vmcontext::{
     VMCallerCheckedFuncRef, VMContext, VMFunctionBody, VMFunctionImport, VMGlobalDefinition,

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -11,7 +11,7 @@ use std::mem::MaybeUninit;
 use std::ptr;
 use std::sync::Once;
 
-pub use self::backtrace::Backtrace;
+pub use self::backtrace::{Backtrace, Frame};
 pub use self::tls::{tls_eager_initialize, TlsRestore};
 
 #[link(name = "wasmtime-helpers")]


### PR DESCRIPTION
This crate re-exports the `Backtrace` type at top-level from a nested module. `Backtrace` in turn has `Frame` in its public API, which is not re-exported anywhere. This is legal and external users can call methods on `Frame`, but it doesn't appear in the rustdocs, making it unnecessarily difficult to figure out how to use this API. Re-exporting `Frame` fixes that, and also allows naming the type directly if needed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
