### PR TITLE
winch(fuzz): Initial support for differential fuzzing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -352,7 +352,7 @@ jobs:
     # Check that the ISLE fuzz targets build too.
     - run: cargo fuzz build --dev -s none --fuzz-dir ./cranelift/isle/fuzz
     # Check that winch fuzzing builds too.
-    - run: cargo fuzz build --dev -s none --features winch
+    - run: cargo fuzz build --dev -s none --features fuzz-winch
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -351,6 +351,8 @@ jobs:
     - run: cargo fuzz build --dev -s none
     # Check that the ISLE fuzz targets build too.
     - run: cargo fuzz build --dev -s none --fuzz-dir ./cranelift/isle/fuzz
+    # Check that winch fuzzing builds too.
+    - run: cargo fuzz build --dev -s none --features winch
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "target-lexicon",
+ "wasmparser",
  "wasmtime",
  "wasmtime-fuzzing",
 ]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -46,3 +46,4 @@ wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true, fea
 
 [features]
 fuzz-spec-interpreter = ['wasm-spec-interpreter']
+winch = ["wasmtime/winch"]

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -23,6 +23,8 @@ pub mod table_ops;
 mod value;
 
 pub use codegen_settings::CodegenSettings;
+#[cfg(feature = "winch")]
+pub use config::CompilerStrategy;
 pub use config::{Config, WasmtimeConfig};
 pub use instance_allocation_strategy::InstanceAllocationStrategy;
 pub use memory::{MemoryConfig, NormalMemoryConfig, UnalignedMemory, UnalignedMemoryCreator};

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -168,6 +168,9 @@ impl Config {
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
             .generate_address_map(self.wasmtime.generate_address_map);
 
+        #[cfg(feature = "winch")]
+        cfg.strategy(self.wasmtime.compiler_strategy.to_wasmtime());
+
         self.wasmtime.codegen.configure(&mut cfg);
 
         // If the wasm-smith-generated module use nan canonicalization then we
@@ -392,6 +395,9 @@ pub struct WasmtimeConfig {
     padding_between_functions: Option<u16>,
     generate_address_map: bool,
     native_unwind_info: bool,
+    #[cfg(feature = "winch")]
+    /// Configuration for the compiler to use.
+    pub compiler_strategy: CompilerStrategy,
 }
 
 impl WasmtimeConfig {
@@ -432,6 +438,26 @@ impl OptLevel {
             OptLevel::None => wasmtime::OptLevel::None,
             OptLevel::Speed => wasmtime::OptLevel::Speed,
             OptLevel::SpeedAndSize => wasmtime::OptLevel::SpeedAndSize,
+        }
+    }
+}
+
+#[cfg(feature = "winch")]
+#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
+/// Compiler to use.
+pub enum CompilerStrategy {
+    /// Cranelift compiler.
+    Cranelift,
+    /// Winch compiler.
+    Winch,
+}
+
+#[cfg(feature = "winch")]
+impl CompilerStrategy {
+    fn to_wasmtime(&self) -> wasmtime::Strategy {
+        match self {
+            CompilerStrategy::Cranelift => wasmtime::Strategy::Cranelift,
+            CompilerStrategy::Winch => wasmtime::Strategy::Winch,
         }
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -36,7 +36,7 @@ quote = "1.0"
 component-fuzz-util = { workspace = true }
 
 [features]
-winch = ["wasmtime/winch", "wasmtime-fuzzing/winch", "dep:wasmparser"]
+fuzz-winch = ["wasmtime/winch", "wasmtime-fuzzing/winch", "dep:wasmparser"]
 default = ['fuzz-spec-interpreter']
 fuzz-spec-interpreter = ['wasmtime-fuzzing/fuzz-spec-interpreter']
 chaos = ["cranelift-control/chaos"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,6 +21,7 @@ cranelift-control = { workspace = true }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
 target-lexicon = { workspace = true }
 smallvec = { workspace = true }
+wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true }
 wasmtime-fuzzing = { workspace = true }
 component-test-util = { workspace = true }
@@ -35,6 +36,7 @@ quote = "1.0"
 component-fuzz-util = { workspace = true }
 
 [features]
+winch = ["wasmtime/winch", "wasmtime-fuzzing/winch", "dep:wasmparser"]
 default = ['fuzz-spec-interpreter']
 fuzz-spec-interpreter = ['wasmtime-fuzzing/fuzz-spec-interpreter']
 chaos = ["cranelift-control/chaos"]

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -6,13 +6,13 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Once;
 use wasmtime::Trap;
-#[cfg(feature = "winch")]
+#[cfg(feature = "fuzz-winch")]
 use wasmtime_fuzzing::generators::CompilerStrategy;
 use wasmtime_fuzzing::generators::{Config, DiffValue, DiffValueType, SingleInstModule};
 use wasmtime_fuzzing::oracles::diff_wasmtime::WasmtimeInstance;
 use wasmtime_fuzzing::oracles::engine::{build_allowed_env_list, parse_env_list};
 use wasmtime_fuzzing::oracles::{differential, engine, log_wasm};
-#[cfg(feature = "winch")]
+#[cfg(feature = "fuzz-winch")]
 use wasmtime_fuzzing::wasm_smith::{InstructionKind, InstructionKinds};
 
 // Upper limit on the number of invocations for each WebAssembly function
@@ -39,7 +39,7 @@ fuzz_target!(|data: &[u8]| {
         // `setup_ocaml_runtime`.
         engine::setup_engine_runtimes();
 
-        let (default_engines, default_modules) = if cfg!(feature = "winch") {
+        let (default_engines, default_modules) = if cfg!(feature = "fuzz-winch") {
             (vec!["wasmi"], vec!["wasm-smith", "single-inst"])
         } else {
             (
@@ -78,7 +78,7 @@ fn execute_one(data: &[u8]) -> Result<()> {
     let mut config: Config = u.arbitrary()?;
     config.set_differential_config();
 
-    #[cfg(feature = "winch")]
+    #[cfg(feature = "fuzz-winch")]
     {
         // When fuzzing Winch:
         // 1. Explicitly override the compiler strategy.
@@ -121,7 +121,7 @@ fn execute_one(data: &[u8]) -> Result<()> {
         _ => unreachable!(),
     };
 
-    #[cfg(feature = "winch")]
+    #[cfg(feature = "fuzz-winch")]
     if !winch_supports_module(&wasm) {
         return Ok(());
     }
@@ -290,7 +290,7 @@ impl RuntimeStats {
     }
 }
 
-#[cfg(feature = "winch")]
+#[cfg(feature = "fuzz-winch")]
 // Returns true if the module only contains operators supported by
 // Winch. Winch's x86_64 target has broader support for Wasm operators
 // than the aarch64 target. This list assumes fuzzing on the x86_64


### PR DESCRIPTION
This commit introduces initial support for differential fuzzing for Winch. In order to fuzz winch, this change introduces the `winch` cargo feature. When the `winch` cargo feature is enabled the differential fuzz target uses `wasmi` as the differential engine and `wasm-smith` and `single-inst` as the module sources.

The intention behind this change is to have a *local* approach for fuzzing and verifying programs generated by Winch and to have an initial implementation that will allow us to eventually enable this change by default. Currently it's not worth it to enable this change by default given all the filtering that needs to happen to ensure that the generated modules are supported by Winch.

It's worth noting that the Wasm filtering code will be temporary, until Winch
reaches feature parity in terms of Wasm operators.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
