### PR TITLE
Remove `maintenance` badges from the Cargo.toml files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,9 +239,6 @@ winch = ["wasmtime/winch"]
 # backend is the default now.
 experimental_x64 = []
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [[test]]
 name = "host_segfault"
 harness = false

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -13,6 +13,3 @@ edition.workspace = true
 
 [dependencies]
 cranelift-entity = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -114,9 +114,6 @@ isle-errors = ["cranelift-isle/fancy-errors"]
 # inspection, rather than inside of target/.
 isle-in-source-tree = []
 
-[badges]
-maintenance = { status = "experimental" }
-
 [[bench]]
 name = "x64-evex-encoding"
 harness = false

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -14,6 +14,3 @@ edition.workspace = true
 
 [dependencies]
 cranelift-codegen-shared = { path = "../shared", version = "0.96.0" }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -16,6 +16,3 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 
 [features]
 enable-serde = ["serde"]
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -24,6 +24,3 @@ similar = { workspace = true }
 default = ["std"]
 std = ["cranelift-codegen/std"]
 core = ["hashbrown", "cranelift-codegen/core"]
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -23,6 +23,3 @@ libm = "0.2.4"
 [dev-dependencies]
 cranelift-frontend = { workspace = true }
 cranelift-reader = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -39,6 +39,3 @@ default = []
 cranelift = { workspace = true }
 cranelift-frontend = { workspace = true }
 cranelift-entity = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -24,6 +24,3 @@ core = ["hashbrown", "cranelift-codegen/core"]
 
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = ["serde", "cranelift-codegen/enable-serde"]
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -21,7 +21,3 @@ libc = "0.2.95"
 default = ["std"]
 std = ["cranelift-codegen/std"]
 core = ["cranelift-codegen/core"]
-
-[badges]
-maintenance = { status = "experimental" }
-

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -21,6 +21,3 @@ log = { workspace = true }
 [dev-dependencies]
 cranelift-frontend = { workspace = true }
 cranelift-entity = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -15,9 +15,6 @@ cranelift-codegen = { workspace = true }
 smallvec = { workspace = true }
 target-lexicon = { workspace = true }
 
-[badges]
-maintenance = { status = "experimental" }
-
 [features]
 default = []
 experimental_x64 = []

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -18,6 +18,3 @@ clap = { workspace = true }
 serde_json = "1.0.26"
 cranelift-codegen = { workspace = true, features = ["enable-serde"] }
 cranelift-reader = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -19,6 +19,3 @@ cranelift-frontend = { workspace = true }
 default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std"]
 core = ["cranelift-codegen/core", "cranelift-frontend/core"]
-
-[badges]
-maintenance = { status = "experimental" }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -32,6 +32,3 @@ default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std"]
 core = ["hashbrown", "cranelift-codegen/core", "cranelift-frontend/core"]
 enable-serde = ["serde"]
-
-[badges]
-maintenance = { status = "experimental" }

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -24,9 +24,6 @@ wasmtime-component-util = { workspace = true }
 wasmtime-wit-bindgen = { workspace = true }
 wit-parser = { workspace = true }
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [dev-dependencies]
 wasmtime = { path = '../wasmtime', features = ['component-model'] }
 component-macro-test-helpers = { path = 'test-helpers' }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -36,9 +36,6 @@ wat = { workspace = true }
 name = "factc"
 required-features = ['component-model']
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 component-model = [
   "dep:wasm-encoder",

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -17,9 +17,6 @@ object = { workspace = true, optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 rustix = { workspace = true, features = ["mm", "param", "time"], optional = true }
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 gdb_jit_int = ["once_cell"]
 perf_jitdump = ["rustix", "object"]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -39,6 +39,3 @@ ittapi = { version = "0.3.3", optional = true  }
 [features]
 jitdump = ['wasmtime-jit-debug']
 vtune = ['ittapi']
-
-[badges]
-maintenance = { status = "actively-developed" }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -50,9 +50,6 @@ once_cell = { workspace = true }
 [build-dependencies]
 cc = "1.0"
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 async = ["wasmtime-fiber"]
 

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -41,9 +41,6 @@ features = [
     "Win32_Networking_WinSock",
 ]
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 default = ["trace_log"]
 # This feature enables the `tracing` logs in the calls to target the `log`

--- a/crates/wasi-crypto/Cargo.toml
+++ b/crates/wasi-crypto/Cargo.toml
@@ -16,6 +16,3 @@ anyhow = { workspace = true }
 wasi-crypto = { path = "spec/implementations/hostcalls/rust", version = "0.1.5" }
 wasmtime = { workspace = true }
 wiggle = { workspace = true }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -22,6 +22,3 @@ thiserror = { workspace = true }
 
 [build-dependencies]
 walkdir = "2.3"
-
-[badges]
-maintenance = { status = "experimental" }

--- a/crates/wasi-threads/Cargo.toml
+++ b/crates/wasi-threads/Cargo.toml
@@ -18,6 +18,3 @@ rand = "0.8"
 wasi-common = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true, features = ["exit"] }
-
-[badges]
-maintenance = { status = "experimental" }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -56,9 +56,6 @@ tempfile = "3.0"
 wasmtime-wasi = { path = "../wasi" }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 default = [
   'async',

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -15,8 +15,5 @@ wasmtime = { workspace = true, features = ['cranelift'] }
 wast = { workspace = true }
 log = { workspace = true }
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [features]
 component-model = ['wasmtime/component-model']

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -20,9 +20,6 @@ async-trait = { workspace = true }
 wasmtime = { workspace = true }
 anyhow = { workspace = true }
 
-[badges]
-maintenance = { status = "actively-developed" }
-
 [dev-dependencies]
 wiggle-test = { path = "test-helpers" }
 proptest = "1.0.0"

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -21,6 +21,3 @@ heck = { workspace = true }
 anyhow = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
 shellexpand = "2.0"
-
-[badges]
-maintenance = { status = "actively-developed" }

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -21,6 +21,3 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt'] }
 env_logger = { workspace = true }
-
-[badges]
-maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Several of these badges were out of date, with some crates in wide production use marked as "experimental". Insted of trying to keep them up to date, just remove them, since they are [no longer displayed on crates.io].

[no longer displayed on crates.io]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
