### PR TITLE
Run full CI once a day on `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,16 @@ on:
     - main
     - 'release-*'
 
+  # Run full CI on the `main` branch once a day to prime the GitHub Actions
+  # caches used by PRs and the merge queue.
+  schedule:
+  - cron: '13 4 * * *'
+
+  # This is the CI that runs for PRs-to-merge.
+  merge_group:
+
   push:
     branches:
-    # This is an alternative to using `merge_group:` which doesn't work at the
-    # time of this writing.
-    - 'gh-readonly-queue/main/*'
     # Right now merge queues can't be used with wildcards in branch protections
     # so full CI runs both on PRs to release branches as well as merges to
     # release branches. Note that the merge to a release branch may produce a


### PR DESCRIPTION
Use this to prime caches used by PRs to `main` and additionally the merge queue used to merge into `main`.

While I'm here additionally update the trigger for merge-queue-based PRs to use `merge_group:` now that it's been fixed.

Closes #6285

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
