### PR TITLE
cranelift: Add missing control plane parameter to `compile_with_cache`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,6 +263,7 @@ jobs:
     - run: cargo check -p wasmtime --no-default-features --features cranelift,wat,async,cache
     - run: cargo check -p wasmtime --no-default-features --features winch
     - run: cargo check --features component-model
+    - run: cargo check -p wasmtime --features incremental-cache
 
     # Check that benchmarks of the cranelift project build
     - run: cargo check --benches -p cranelift-codegen

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -581,7 +581,7 @@ mod incremental_cache {
 
         let mut cache_store = CraneliftCacheStore(cache_ctx.cache_store.clone());
         let (compiled_code, from_cache) = context
-            .compile_with_cache(isa, &mut cache_store)
+            .compile_with_cache(isa, &mut cache_store, &mut Default::default())
             .map_err(|error| CompileError::Codegen(pretty_error(&error.func, error.inner)))?;
 
         if from_cache {


### PR DESCRIPTION
It seems that this fell through given that the incremental cache is behind a cargo feature. I noticed this while building `cranelift-codegen` via `cargo build --all-features`.

I opted to add a check in CI to hopefully prevent this in the future, but I'm happy to remove it / update it if there's a better way or another way.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
