### PR TITLE
Fix publishing artifacts from the `main` branch

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -18,7 +18,7 @@ jobs:
         sha=${{ github.sha }}
         run_id=$(
           gh api -H 'Accept: application/vnd.github+json' \
-              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?event=push\&exclude_pull_requests=true \
+              /repos/${{ github.repository }}/actions/workflows/main.yml/runs\?exclude_pull_requests=true \
               | jq '.workflow_runs' \
               | jq "map(select(.head_commit.id == \"$sha\"))[0].id" \
         )


### PR DESCRIPTION
Previously an `event` filter was applied to lookup the merge queue's github run ID but this filter doesn't work after #6288. The filter isn't strictly necessary, though, so remove it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
