### PR TITLE
Exposes new c-api functions for configuring relaxed SIMD

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -166,6 +166,22 @@ WASMTIME_CONFIG_PROP(void, wasm_reference_types, bool)
 WASMTIME_CONFIG_PROP(void, wasm_simd, bool)
 
 /**
+ * \brief Configures whether the WebAssembly relaxed SIMD proposal is
+ * enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_relaxed_simd, bool)
+
+/**
+ * \brief Configures whether the WebAssembly relaxed SIMD proposal is
+ * in deterministic mode.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_relaxed_simd_deterministic, bool)
+
+/**
  * \brief Configures whether the WebAssembly bulk memory proposal is
  * enabled.
  *

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -87,7 +87,10 @@ pub extern "C" fn wasmtime_config_wasm_relaxed_simd_set(c: &mut wasm_config_t, e
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_config_wasm_relaxed_simd_deterministic_set(c: &mut wasm_config_t, enable: bool) {
+pub extern "C" fn wasmtime_config_wasm_relaxed_simd_deterministic_set(
+    c: &mut wasm_config_t,
+    enable: bool,
+) {
     c.config.relaxed_simd_deterministic(enable);
 }
 

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -82,6 +82,16 @@ pub extern "C" fn wasmtime_config_wasm_simd_set(c: &mut wasm_config_t, enable: b
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_relaxed_simd_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_relaxed_simd(enable);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_relaxed_simd_deterministic_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.relaxed_simd_deterministic(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_wasm_bulk_memory_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_bulk_memory(enable);
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -675,6 +675,7 @@ impl Config {
     /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/simd
+    /// [relaxed simd proposal]: https://github.com/WebAssembly/relaxed-simd
     pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
         self.features.simd = enable;
         self

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -666,8 +666,7 @@ impl Config {
     ///
     /// The [WebAssembly SIMD proposal][proposal]. This feature gates items such
     /// as the `v128` type and all of its operators being in a module. Note that
-    /// this does not enable the [relaxed simd proposal] as that is not
-    /// implemented in Wasmtime at this time.
+    /// this does not enable the [relaxed simd proposal].
     ///
     /// On x86_64 platforms note that enabling this feature requires SSE 4.2 and
     /// below to be available on the target platform. Compilation will fail if
@@ -676,7 +675,6 @@ impl Config {
     /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/simd
-    /// [relaxed simd proposal]: https://github.com/WebAssembly/relaxed-simd
     pub fn wasm_simd(&mut self, enable: bool) -> &mut Self {
         self.features.simd = enable;
         self


### PR DESCRIPTION
This allows the new relaxed SIMD features (introduced in https://github.com/bytecodealliance/wasmtime/pull/5892) to be configured through the C API:

Added:
 - wasmtime_config_wasm_relaxed_simd_set(bool)
 - wasmtime_config_wasm_relaxed_simd_deterministic_set(bool)