### PR TITLE
Fix name of tarballs for patch releases

### DIFF
--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -5,7 +5,7 @@ set -ex
 # Determine the name of the tarball
 tag=dev
 if [[ $GITHUB_REF == refs/heads/release-* ]]; then
-  tag=v${GITHUB_REF:19}
+  tag=v$(./ci/print-current-version.sh)
 fi
 pkgname=wasmtime-$tag-src
 

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -22,7 +22,7 @@ mkdir -p dist
 
 tag=dev
 if [[ $GITHUB_REF == refs/heads/release-* ]]; then
-  tag=v${GITHUB_REF:19}
+  tag=v$(./ci/print-current-version.sh)
 fi
 
 bin_pkgname=wasmtime-$tag-$platform


### PR DESCRIPTION
Since the latest updates to our release process which transitioned to merge queues it appears that patch release create incorrectly named tarballs. The version in the tarball is based on the branch name, which doesn't change for patch releases, so the version needs to come from `Cargo.toml`. Thankfully there's already a helpful shell script to do that so use the shell script instead of using the branch name.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
