### PR TITLE
[8.0.0] Fix name of tarballs for patch releases

### DIFF
--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -5,7 +5,7 @@ set -ex
 # Determine the name of the tarball
 tag=dev
 if [[ $GITHUB_REF == refs/heads/release-* ]]; then
-  tag=v${GITHUB_REF:19}
+  tag=v$(./ci/print-current-version.sh)
 fi
 pkgname=wasmtime-$tag-src
 

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -22,7 +22,7 @@ mkdir -p dist
 
 tag=dev
 if [[ $GITHUB_REF == refs/heads/release-* ]]; then
-  tag=v${GITHUB_REF:19}
+  tag=v$(./ci/print-current-version.sh)
 fi
 
 bin_pkgname=wasmtime-$tag-$platform


### PR DESCRIPTION
Same as https://github.com/bytecodealliance/wasmtime/pull/6295, but for the `release-8.0.0` branch. At this time I don't plan on making another patch release just to fix the tarball names. If necessary we can update the tarball names manually this once.