### PR TITLE
[7.0.0] Fix name of tarballs for patch releases

### DIFF
--- a/ci/build-src-tarball.sh
+++ b/ci/build-src-tarball.sh
@@ -4,8 +4,8 @@ set -ex
 
 # Determine the name of the tarball
 tag=dev
-if [[ $GITHUB_REF == refs/tags/v* ]]; then
-  tag=${GITHUB_REF#refs/tags/}
+if [[ $GITHUB_REF == refs/heads/release-* ]]; then
+  tag=v$(./ci/print-current-version.sh)
 fi
 pkgname=wasmtime-$tag-src
 

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -22,7 +22,7 @@ mkdir -p dist
 
 tag=dev
 if [[ $GITHUB_REF == refs/heads/release-* ]]; then
-  tag=v${GITHUB_REF:19}
+  tag=v$(./ci/print-current-version.sh)
 fi
 
 bin_pkgname=wasmtime-$tag-$platform


### PR DESCRIPTION
Same as https://github.com/bytecodealliance/wasmtime/pull/6296, but for `release-7.0.0`