### PR TITLE
winch: Handle relocations and traps

### DIFF
--- a/crates/cranelift-shared/src/compiled_function.rs
+++ b/crates/cranelift-shared/src/compiled_function.rs
@@ -1,0 +1,86 @@
+use crate::{mach_reloc_to_reloc, mach_trap_to_trap, Relocation};
+use cranelift_codegen::{
+    ir, ir::UserExternalNameRef, isa::unwind::UnwindInfo, Final, MachBufferFinalized,
+    ValueLabelsRanges,
+};
+use wasmtime_environ::{FilePos, InstructionAddressMap, TrapInformation};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Metadata to translate from binary offsets back to the original
+/// location found in the wasm input.
+pub struct FunctionAddressMap {
+    /// An array of data for the instructions in this function, indicating where
+    /// each instruction maps back to in the original function.
+    ///
+    /// This array is sorted least-to-greatest by the `code_offset` field.
+    /// Additionally the span of each `InstructionAddressMap` is implicitly the
+    /// gap between it and the next item in the array.
+    pub instructions: Box<[InstructionAddressMap]>,
+
+    /// Function's initial offset in the source file, specified in bytes from
+    /// the front of the file.
+    pub start_srcloc: FilePos,
+
+    /// Function's end offset in the source file, specified in bytes from
+    /// the front of the file.
+    pub end_srcloc: FilePos,
+
+    /// Generated function body offset if applicable, otherwise 0.
+    pub body_offset: usize,
+
+    /// Generated function body length.
+    pub body_len: u32,
+}
+
+/// Compiled function: machine code body, jump table offsets, and unwind information.
+#[derive(Default)]
+pub struct CompiledFunction {
+    /// The machine code for this function.
+    pub body: Vec<u8>,
+
+    /// The unwind information.
+    pub unwind_info: Option<UnwindInfo>,
+
+    /// Information used to translate from binary offsets back to the original
+    /// location found in the wasm input.
+    pub address_map: FunctionAddressMap,
+
+    /// Metadata about traps in this module, mapping code offsets to the trap
+    /// that they may cause.
+    pub traps: Vec<TrapInformation>,
+
+    pub relocations: Vec<Relocation>,
+    pub value_labels_ranges: ValueLabelsRanges,
+    pub sized_stack_slots: ir::StackSlots,
+    pub alignment: u32,
+}
+
+impl CompiledFunction {
+    /// Creates a [CompiledFunction] from a [cranelift_codegen::MachBufferFinalized<Final>]
+    /// This function uses the information in the machine buffer to derive the traps and relocations
+    /// fields. The rest of the fields are left with their default value.
+    pub fn new<F>(buffer: &MachBufferFinalized<Final>, body: Vec<u8>, lookup: &mut F) -> Self
+    where
+        F: FnMut(UserExternalNameRef) -> (u32, u32),
+    {
+        let relocations = buffer
+            .relocs()
+            .into_iter()
+            .map(|reloc| mach_reloc_to_reloc(reloc, lookup))
+            .collect();
+        let traps = buffer.traps().into_iter().map(mach_trap_to_trap).collect();
+
+        Self {
+            body,
+            relocations,
+            traps,
+            ..Default::default()
+        }
+    }
+
+    /// Set the traps of the compiled function from
+    /// a [cranelift_codegen::MachBufferFinalized].
+    pub fn set_traps(&mut self, buffer: &MachBufferFinalized<Final>) {
+        self.traps = buffer.traps().into_iter().map(mach_trap_to_trap).collect();
+    }
+}

--- a/crates/cranelift-shared/src/compiled_function.rs
+++ b/crates/cranelift-shared/src/compiled_function.rs
@@ -1,9 +1,15 @@
 use crate::{mach_reloc_to_reloc, mach_trap_to_trap, Relocation};
 use cranelift_codegen::{
-    ir, ir::UserExternalNameRef, isa::unwind::UnwindInfo, Final, MachBufferFinalized,
+    ir, ir::UserExternalNameRef, isa::unwind::UnwindInfo, Final, MachBufferFinalized, MachSrcLoc,
     ValueLabelsRanges,
 };
 use wasmtime_environ::{FilePos, InstructionAddressMap, TrapInformation};
+
+/// Trait used in the [CompiledFunction] to resolve the locations of
+/// external name references in a compiled function.
+pub trait CompiledFuncEnv {
+    fn resolve_user_external_name_ref(&self, external: UserExternalNameRef) -> (u32, u32);
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 /// Metadata to translate from binary offsets back to the original
@@ -32,55 +38,187 @@ pub struct FunctionAddressMap {
     pub body_len: u32,
 }
 
-/// Compiled function: machine code body, jump table offsets, and unwind information.
+/// The metadata for the compiled function.
 #[derive(Default)]
-pub struct CompiledFunction {
-    /// The machine code for this function.
-    pub body: Vec<u8>,
-
+pub struct CompiledFunctionMetadata {
+    /// The function address map to translate from binary
+    /// back to the original source.
+    pub address_map: FunctionAddressMap,
     /// The unwind information.
     pub unwind_info: Option<UnwindInfo>,
-
-    /// Information used to translate from binary offsets back to the original
-    /// location found in the wasm input.
-    pub address_map: FunctionAddressMap,
-
-    /// Metadata about traps in this module, mapping code offsets to the trap
-    /// that they may cause.
-    pub traps: Vec<TrapInformation>,
-
-    pub relocations: Vec<Relocation>,
+    /// Mapping of value labels and their locations.
     pub value_labels_ranges: ValueLabelsRanges,
+    /// Allocated stack slots.
     pub sized_stack_slots: ir::StackSlots,
-    pub alignment: u32,
+    /// Start source location.
+    pub start_srcloc: FilePos,
+    /// End source location.
+    pub end_srcloc: FilePos,
 }
 
-impl CompiledFunction {
+/// Compiled function: machine code body, jump table offsets, and unwind information.
+pub struct CompiledFunction<E: CompiledFuncEnv> {
+    /// The machine code buffer for this function.
+    pub buffer: MachBufferFinalized<Final>,
+    /// The environment for the compiled function.
+    env: E,
+    /// The alignment for the compiled function.
+    pub alignment: u32,
+    /// The metadata for the compiled function, including unwind information
+    /// the function address map.
+    metadata: CompiledFunctionMetadata,
+}
+
+impl<E: CompiledFuncEnv> CompiledFunction<E>
+where
+    E: CompiledFuncEnv,
+{
     /// Creates a [CompiledFunction] from a [cranelift_codegen::MachBufferFinalized<Final>]
     /// This function uses the information in the machine buffer to derive the traps and relocations
-    /// fields. The rest of the fields are left with their default value.
-    pub fn new<F>(buffer: &MachBufferFinalized<Final>, body: Vec<u8>, lookup: &mut F) -> Self
-    where
-        F: FnMut(UserExternalNameRef) -> (u32, u32),
-    {
-        let relocations = buffer
-            .relocs()
-            .into_iter()
-            .map(|reloc| mach_reloc_to_reloc(reloc, lookup))
-            .collect();
-        let traps = buffer.traps().into_iter().map(mach_trap_to_trap).collect();
-
+    /// fields. The compiled function metadata is loaded with the default values.
+    pub fn new(buffer: MachBufferFinalized<Final>, env: E, alignment: u32) -> Self {
         Self {
-            body,
-            relocations,
-            traps,
-            ..Default::default()
+            buffer,
+            env,
+            alignment,
+            metadata: Default::default(),
         }
     }
 
-    /// Set the traps of the compiled function from
-    /// a [cranelift_codegen::MachBufferFinalized].
-    pub fn set_traps(&mut self, buffer: &MachBufferFinalized<Final>) {
-        self.traps = buffer.traps().into_iter().map(mach_trap_to_trap).collect();
+    /// Returns an iterator to the function's relocation information.
+    pub fn relocations(&self) -> impl Iterator<Item = Relocation> + '_ {
+        self.buffer.relocs().iter().map(|r| {
+            mach_reloc_to_reloc(r, |external| {
+                self.env.resolve_user_external_name_ref(external)
+            })
+        })
+    }
+
+    /// Returns an iterator to the function's trap information.
+    pub fn traps(&self) -> impl Iterator<Item = TrapInformation> + '_ {
+        self.buffer.traps().iter().filter_map(mach_trap_to_trap)
+    }
+
+    /// Get the function's address map from the metadata.
+    pub fn address_map(&self) -> &FunctionAddressMap {
+        &self.metadata.address_map
+    }
+
+    /// Create and return the compiled function address map from the original source offset
+    /// and length.
+    pub fn set_address_map(&mut self, offset: u32, length: u32, with_instruction_addresses: bool) {
+        assert!((offset + length) <= u32::max_value());
+        let len = self.buffer.data().len();
+        let srclocs = self
+            .buffer
+            .get_srclocs_sorted()
+            .into_iter()
+            .map(|&MachSrcLoc { start, end, loc }| (loc, start, (end - start)));
+        let instructions = if with_instruction_addresses {
+            collect_address_maps(len as u32, srclocs)
+        } else {
+            Default::default()
+        };
+        let start_srcloc = FilePos::new(offset);
+        let end_srcloc = FilePos::new(offset + length);
+
+        let address_map = FunctionAddressMap {
+            instructions: instructions.into(),
+            start_srcloc,
+            end_srcloc,
+            body_offset: 0,
+            body_len: len as u32,
+        };
+
+        self.metadata.address_map = address_map;
+    }
+
+    /// Get a reference to the unwind information from the
+    /// function's metadata.
+    pub fn unwind_info(&self) -> Option<&UnwindInfo> {
+        self.metadata.unwind_info.as_ref()
+    }
+
+    /// Get a reference to the compiled function metadata.
+    pub fn metadata(&self) -> &CompiledFunctionMetadata {
+        &self.metadata
+    }
+
+    /// Set the value labels ranges in the function's metadata.
+    pub fn set_value_labels_ranges(&mut self, ranges: ValueLabelsRanges) {
+        self.metadata.value_labels_ranges = ranges;
+    }
+
+    /// Set the unwind info in the function's metadata.
+    pub fn set_unwind_info(&mut self, unwind: UnwindInfo) {
+        self.metadata.unwind_info = Some(unwind);
+    }
+
+    /// Set the sized stack slots.
+    pub fn set_sized_stack_slots(&mut self, slots: ir::StackSlots) {
+        self.metadata.sized_stack_slots = slots;
+    }
+}
+
+// Collects an iterator of `InstructionAddressMap` into a `Vec` for insertion
+// into a `FunctionAddressMap`. This will automatically coalesce adjacent
+// instructions which map to the same original source position.
+fn collect_address_maps(
+    code_size: u32,
+    iter: impl IntoIterator<Item = (ir::SourceLoc, u32, u32)>,
+) -> Vec<InstructionAddressMap> {
+    let mut iter = iter.into_iter();
+    let (mut cur_loc, mut cur_offset, mut cur_len) = match iter.next() {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let mut ret = Vec::new();
+    for (loc, offset, len) in iter {
+        // If this instruction is adjacent to the previous and has the same
+        // source location then we can "coalesce" it with the current
+        // instruction.
+        if cur_offset + cur_len == offset && loc == cur_loc {
+            cur_len += len;
+            continue;
+        }
+
+        // Push an entry for the previous source item.
+        ret.push(InstructionAddressMap {
+            srcloc: cvt(cur_loc),
+            code_offset: cur_offset,
+        });
+        // And push a "dummy" entry if necessary to cover the span of ranges,
+        // if any, between the previous source offset and this one.
+        if cur_offset + cur_len != offset {
+            ret.push(InstructionAddressMap {
+                srcloc: FilePos::default(),
+                code_offset: cur_offset + cur_len,
+            });
+        }
+        // Update our current location to get extended later or pushed on at
+        // the end.
+        cur_loc = loc;
+        cur_offset = offset;
+        cur_len = len;
+    }
+    ret.push(InstructionAddressMap {
+        srcloc: cvt(cur_loc),
+        code_offset: cur_offset,
+    });
+    if cur_offset + cur_len != code_size {
+        ret.push(InstructionAddressMap {
+            srcloc: FilePos::default(),
+            code_offset: cur_offset + cur_len,
+        });
+    }
+
+    return ret;
+
+    fn cvt(loc: ir::SourceLoc) -> FilePos {
+        if loc.is_default() {
+            FilePos::default()
+        } else {
+            FilePos::new(loc.bits())
+        }
     }
 }

--- a/crates/cranelift-shared/src/lib.rs
+++ b/crates/cranelift-shared/src/lib.rs
@@ -1,11 +1,16 @@
-use cranelift_codegen::binemit;
-use cranelift_codegen::ir;
-use cranelift_codegen::settings;
+use cranelift_codegen::{
+    binemit,
+    ir::{self, ExternalName, UserExternalNameRef},
+    settings, MachReloc, MachTrap,
+};
 use std::collections::BTreeMap;
-use wasmtime_environ::{FlagValue, FuncIndex};
+use wasmtime_environ::{FlagValue, FuncIndex, Trap, TrapInformation};
 
 pub mod isa_builder;
-pub mod obj;
+mod obj;
+pub use obj::*;
+mod compiled_function;
+pub use compiled_function::*;
 
 /// A record of a relocation to perform.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,5 +50,62 @@ fn to_flag_value(v: &settings::Value) -> FlagValue {
         settings::SettingKind::Num => FlagValue::Num(v.as_num().unwrap()),
         settings::SettingKind::Bool => FlagValue::Bool(v.as_bool().unwrap()),
         settings::SettingKind::Preset => unreachable!(),
+    }
+}
+
+/// Code used as the user-defined trap code.
+pub const ALWAYS_TRAP_CODE: u16 = 100;
+
+/// Converts machine traps to trap information.
+pub fn mach_trap_to_trap(trap: &MachTrap) -> TrapInformation {
+    let &MachTrap { offset, code } = trap;
+    TrapInformation {
+        code_offset: offset,
+        trap_code: match code {
+            ir::TrapCode::StackOverflow => Trap::StackOverflow,
+            ir::TrapCode::HeapOutOfBounds => Trap::MemoryOutOfBounds,
+            ir::TrapCode::HeapMisaligned => Trap::HeapMisaligned,
+            ir::TrapCode::TableOutOfBounds => Trap::TableOutOfBounds,
+            ir::TrapCode::IndirectCallToNull => Trap::IndirectCallToNull,
+            ir::TrapCode::BadSignature => Trap::BadSignature,
+            ir::TrapCode::IntegerOverflow => Trap::IntegerOverflow,
+            ir::TrapCode::IntegerDivisionByZero => Trap::IntegerDivisionByZero,
+            ir::TrapCode::BadConversionToInteger => Trap::BadConversionToInteger,
+            ir::TrapCode::UnreachableCodeReached => Trap::UnreachableCodeReached,
+            ir::TrapCode::Interrupt => Trap::Interrupt,
+            ir::TrapCode::User(ALWAYS_TRAP_CODE) => Trap::AlwaysTrapAdapter,
+
+            // these should never be emitted by wasmtime-cranelift
+            ir::TrapCode::User(_) => unreachable!(),
+        },
+    }
+}
+
+/// Converts machine relocations to relocation information
+/// to perform.
+fn mach_reloc_to_reloc<F>(reloc: &MachReloc, transform_user_func_ref: &mut F) -> Relocation
+where
+    F: FnMut(UserExternalNameRef) -> (u32, u32),
+{
+    let &MachReloc {
+        offset,
+        kind,
+        ref name,
+        addend,
+    } = reloc;
+    let reloc_target = if let ExternalName::User(user_func_ref) = *name {
+        let (namespace, index) = transform_user_func_ref(user_func_ref);
+        debug_assert_eq!(namespace, 0);
+        RelocationTarget::UserFunc(FuncIndex::from_u32(index))
+    } else if let ExternalName::LibCall(libcall) = *name {
+        RelocationTarget::LibCall(libcall)
+    } else {
+        panic!("unrecognized external name")
+    };
+    Relocation {
+        reloc: kind,
+        reloc_target,
+        offset,
+        addend,
     }
 }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -1,15 +1,15 @@
 use crate::debug::{DwarfSectionRelocTarget, ModuleMemoryOffset};
 use crate::func_environ::FuncEnvironment;
 use crate::{array_call_signature, native_call_signature, DEBUG_ASSERT_TRAP_CODE};
-use crate::{
-    builder::LinkOptions, value_type, wasm_call_signature,
-};
+use crate::{builder::LinkOptions, value_type, wasm_call_signature};
 use anyhow::{Context as _, Result};
-use cranelift_codegen::ir::{self, InstBuilder, MemFlags, UserExternalName, UserFuncName, Value};
+use cranelift_codegen::ir::{
+    self, InstBuilder, MemFlags, UserExternalName, UserExternalNameRef, UserFuncName, Value,
+};
 use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::print_errors::pretty_error;
 use cranelift_codegen::Context;
-use cranelift_codegen::{CompiledCode, MachSrcLoc, MachStackMap};
+use cranelift_codegen::{CompiledCode, MachStackMap};
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::{
@@ -26,11 +26,11 @@ use std::convert::TryFrom;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use wasmparser::{FuncValidatorAllocations, FunctionBody};
-use wasmtime_cranelift_shared::{CompiledFunction, FunctionAddressMap, ModuleTextBuilder};
+use wasmtime_cranelift_shared::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
-    AddressMapSection, CacheStore, CompileError, FilePos, FlagValue, FunctionBodyData, FunctionLoc,
-    InstructionAddressMap, ModuleTranslation, ModuleTypes, PtrSize, StackMapInformation,
-    TrapEncodingBuilder, Tunables, VMOffsets, WasmFunctionInfo,
+    AddressMapSection, CacheStore, CompileError, FlagValue, FunctionBodyData, FunctionLoc,
+    ModuleTranslation, ModuleTypes, PtrSize, StackMapInformation, TrapEncodingBuilder, Tunables,
+    VMOffsets, WasmFunctionInfo,
 };
 
 #[cfg(feature = "component-model")]
@@ -109,45 +109,6 @@ impl Compiler {
             isa,
             linkopts,
             cache_store,
-        }
-    }
-
-    fn get_function_address_map(
-        compiled_code: &CompiledCode,
-        body: &FunctionBody<'_>,
-        body_len: u32,
-        tunables: &Tunables,
-    ) -> FunctionAddressMap {
-        // Generate artificial srcloc for function start/end to identify boundary
-        // within module.
-        let data = body.get_binary_reader();
-        let offset = data.original_position();
-        let len = data.bytes_remaining();
-        assert!((offset + len) <= u32::max_value() as usize);
-        let start_srcloc = FilePos::new(offset as u32);
-        let end_srcloc = FilePos::new((offset + len) as u32);
-
-        // New-style backend: we have a `CompiledCode` that will give us `MachSrcLoc` mapping
-        // tuples.
-        let instructions = if tunables.generate_address_map {
-            collect_address_maps(
-                body_len,
-                compiled_code
-                    .buffer
-                    .get_srclocs_sorted()
-                    .into_iter()
-                    .map(|&MachSrcLoc { start, end, loc }| (loc, start, (end - start))),
-            )
-        } else {
-            Vec::new()
-        };
-
-        FunctionAddressMap {
-            instructions: instructions.into(),
-            start_srcloc,
-            end_srcloc,
-            body_offset: 0,
-            body_len,
         }
     }
 }
@@ -447,19 +408,15 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let mut ret = Vec::with_capacity(funcs.len());
         for (i, (sym, func)) in funcs.iter().enumerate() {
-            let func = func.downcast_ref::<CompiledFunction>().unwrap();
-            let (sym, range) = builder.append_func(
-                &sym,
-                &func.body,
-                func.alignment,
-                func.unwind_info.as_ref(),
-                &func.relocations,
-                |idx| resolve_reloc(i, idx),
-            );
+            let func = func
+                .downcast_ref::<CompiledFunction<CompiledFuncEnv>>()
+                .unwrap();
+            let (sym, range) = builder.append_func(&sym, func, |idx| resolve_reloc(i, idx));
             if tunables.generate_address_map {
-                addrs.push(range.clone(), &func.address_map.instructions);
+                let addr = func.address_map();
+                addrs.push(range.clone(), &addr.instructions);
             }
-            traps.push(range.clone(), &func.traps);
+            traps.push(range.clone(), &func.traps().collect::<Vec<_>>());
             builder.append_padding(self.linkopts.padding_between_functions);
             let info = FunctionLoc {
                 start: u32::try_from(range.start).unwrap(),
@@ -484,27 +441,15 @@ impl wasmtime_environ::Compiler for Compiler {
         host_fn: usize,
         obj: &mut Object<'static>,
     ) -> Result<(FunctionLoc, FunctionLoc)> {
-        let wasm_to_array = self.wasm_to_array_trampoline(ty, host_fn)?;
-        let native_to_array = self.native_to_array_trampoline(ty, host_fn)?;
+        let mut wasm_to_array = self.wasm_to_array_trampoline(ty, host_fn)?;
+        let mut native_to_array = self.native_to_array_trampoline(ty, host_fn)?;
 
         let mut builder = ModuleTextBuilder::new(obj, self, self.isa.text_section_builder(2));
 
-        let (_, wasm_to_array) = builder.append_func(
-            "wasm_to_array",
-            &wasm_to_array.body,
-            wasm_to_array.alignment,
-            wasm_to_array.unwind_info.as_ref(),
-            &wasm_to_array.relocations,
-            |_| unreachable!(),
-        );
-        let (_, native_to_array) = builder.append_func(
-            "native_to_array",
-            &native_to_array.body,
-            native_to_array.alignment,
-            native_to_array.unwind_info.as_ref(),
-            &native_to_array.relocations,
-            |_| unreachable!(),
-        );
+        let (_, wasm_to_array) =
+            builder.append_func("wasm_to_array", &mut wasm_to_array, |_| unreachable!());
+        let (_, native_to_array) =
+            builder.append_func("native_to_array", &mut native_to_array, |_| unreachable!());
 
         let wasm_to_array = FunctionLoc {
             start: u32::try_from(wasm_to_array.start).unwrap(),
@@ -575,14 +520,17 @@ impl wasmtime_environ::Compiler for Compiler {
         } else {
             ModuleMemoryOffset::None
         };
-        let compiled_funcs = funcs
+        let functions_info = funcs
             .iter()
-            .map(|(_, (_, func))| func.downcast_ref().unwrap())
+            .map(|(_, (_, func))| {
+                let f: &CompiledFunction<CompiledFuncEnv> = func.downcast_ref().unwrap();
+                f.metadata()
+            })
             .collect();
         let dwarf_sections = crate::debug::emit_dwarf(
             &*self.isa,
             &translation.debuginfo,
-            &compiled_funcs,
+            &functions_info,
             &memory_offset,
         )
         .with_context(|| "failed to emit DWARF debug information")?;
@@ -723,7 +671,7 @@ impl Compiler {
         &self,
         ty: &WasmFuncType,
         host_fn: usize,
-    ) -> Result<CompiledFunction, CompileError> {
+    ) -> Result<CompiledFunction<CompiledFuncEnv>, CompileError> {
         let isa = &*self.isa;
         let pointer_type = isa.pointer_type();
         let native_call_sig = native_call_signature(isa, ty);
@@ -788,7 +736,7 @@ impl Compiler {
         &self,
         ty: &WasmFuncType,
         host_fn: usize,
-    ) -> Result<CompiledFunction, CompileError> {
+    ) -> Result<CompiledFunction<CompiledFuncEnv>, CompileError> {
         let isa = &*self.isa;
         let pointer_type = isa.pointer_type();
         let wasm_call_sig = wasm_call_signature(isa, ty);
@@ -980,6 +928,20 @@ impl Compiler {
     }
 }
 
+/// The compiled function environment.
+pub struct CompiledFuncEnv {
+    /// Map to resolve external name references.
+    map: PrimaryMap<UserExternalNameRef, UserExternalName>,
+}
+
+impl wasmtime_cranelift_shared::CompiledFuncEnv for CompiledFuncEnv {
+    fn resolve_user_external_name_ref(&self, external: ir::UserExternalNameRef) -> (u32, u32) {
+        let UserExternalName { index, namespace } = self.map[external];
+
+        (namespace, index)
+    }
+}
+
 struct FunctionCompiler<'a> {
     compiler: &'a Compiler,
     cx: CompilerContext,
@@ -1000,7 +962,7 @@ impl FunctionCompiler<'_> {
         (builder, block0)
     }
 
-    fn finish(self) -> Result<CompiledFunction, CompileError> {
+    fn finish(self) -> Result<CompiledFunction<CompiledFuncEnv>, CompileError> {
         let (info, func) = self.finish_with_info(None)?;
         assert!(info.stack_maps.is_empty());
         Ok(func)
@@ -1009,15 +971,12 @@ impl FunctionCompiler<'_> {
     fn finish_with_info(
         mut self,
         body_and_tunables: Option<(&FunctionBody<'_>, &Tunables)>,
-    ) -> Result<(WasmFunctionInfo, CompiledFunction), CompileError> {
+    ) -> Result<(WasmFunctionInfo, CompiledFunction<CompiledFuncEnv>), CompileError> {
         let context = &mut self.cx.codegen_context;
         let isa = &*self.compiler.isa;
-        let (_, code_buf) =
+        let (_, _code_buf) =
             compile_maybe_cached(context, isa, self.cx.incremental_cache_ctx.as_mut())?;
         let compiled_code = context.compiled_code().unwrap();
-
-        assert!(compiled_code.buffer.relocs().is_empty());
-        let mut compiled_function = CompiledFunction::default();
 
         // Give wasm functions, user defined code, a "preferred" alignment
         // instead of the minimum alignment as this can help perf in niche
@@ -1027,110 +986,54 @@ impl FunctionCompiler<'_> {
         } else {
             1
         };
+
         let alignment = compiled_code.alignment.max(preferred_alignment);
-
-        let address_map = match body_and_tunables {
-            Some((body, tunables)) => Compiler::get_function_address_map(
-                compiled_code,
-                body,
-                u32::try_from(code_buf.len()).unwrap(),
-                tunables,
-            ),
-            None => Default::default(),
+        let env = CompiledFuncEnv {
+            map: context.func.params.user_named_funcs().clone(),
         };
+        let mut compiled_function =
+            CompiledFunction::new(compiled_code.buffer.clone(), env, alignment);
 
-        compiled_function.value_labels_ranges = if body_and_tunables
+        if let Some((body, tunables)) = body_and_tunables {
+            let data = body.get_binary_reader();
+            let offset = data.original_position();
+            let len = data.bytes_remaining();
+            compiled_function.set_address_map(
+                offset as u32,
+                len as u32,
+                tunables.generate_address_map,
+            );
+        }
+
+        if body_and_tunables
             .map(|(_, t)| t.generate_native_debuginfo)
             .unwrap_or(false)
         {
-            compiled_code.value_labels_ranges.clone()
-        } else {
-            Default::default()
-        };
+            compiled_function.set_value_labels_ranges(compiled_code.value_labels_ranges.clone());
+        }
 
-        compiled_function.body = code_buf;
-        compiled_function.set_traps(&compiled_code.buffer);
-        compiled_function.alignment = alignment;
-        compiled_function.unwind_info = if isa.flags().unwind_info() {
-            compiled_code
+        if isa.flags().unwind_info() {
+            let unwind = compiled_code
                 .create_unwind_info(isa)
-                .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
-        } else {
-            None
-        };
+                .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?;
+
+            if let Some(unwind_info) = unwind {
+                compiled_function.set_unwind_info(unwind_info);
+            }
+        }
+
         let stack_maps = mach_stack_maps_to_stack_maps(compiled_code.buffer.stack_maps());
-        compiled_function.sized_stack_slots = std::mem::take(&mut context.func.sized_stack_slots);
+        compiled_function
+            .set_sized_stack_slots(std::mem::take(&mut context.func.sized_stack_slots));
         self.compiler.contexts.lock().unwrap().push(self.cx);
 
-        Ok((WasmFunctionInfo {
-            start_srcloc: address_map.start_srcloc,
-            stack_maps: stack_maps.into(),
-        },
-        compiled_function
+        Ok((
+            WasmFunctionInfo {
+                start_srcloc: compiled_function.metadata().address_map.start_srcloc,
+                stack_maps: stack_maps.into(),
+            },
+            compiled_function,
         ))
-    }
-}
-
-// Collects an iterator of `InstructionAddressMap` into a `Vec` for insertion
-// into a `FunctionAddressMap`. This will automatically coalesce adjacent
-// instructions which map to the same original source position.
-fn collect_address_maps(
-    code_size: u32,
-    iter: impl IntoIterator<Item = (ir::SourceLoc, u32, u32)>,
-) -> Vec<InstructionAddressMap> {
-    let mut iter = iter.into_iter();
-    let (mut cur_loc, mut cur_offset, mut cur_len) = match iter.next() {
-        Some(i) => i,
-        None => return Vec::new(),
-    };
-    let mut ret = Vec::new();
-    for (loc, offset, len) in iter {
-        // If this instruction is adjacent to the previous and has the same
-        // source location then we can "coalesce" it with the current
-        // instruction.
-        if cur_offset + cur_len == offset && loc == cur_loc {
-            cur_len += len;
-            continue;
-        }
-
-        // Push an entry for the previous source item.
-        ret.push(InstructionAddressMap {
-            srcloc: cvt(cur_loc),
-            code_offset: cur_offset,
-        });
-        // And push a "dummy" entry if necessary to cover the span of ranges,
-        // if any, between the previous source offset and this one.
-        if cur_offset + cur_len != offset {
-            ret.push(InstructionAddressMap {
-                srcloc: FilePos::default(),
-                code_offset: cur_offset + cur_len,
-            });
-        }
-        // Update our current location to get extended later or pushed on at
-        // the end.
-        cur_loc = loc;
-        cur_offset = offset;
-        cur_len = len;
-    }
-    ret.push(InstructionAddressMap {
-        srcloc: cvt(cur_loc),
-        code_offset: cur_offset,
-    });
-    if cur_offset + cur_len != code_size {
-        ret.push(InstructionAddressMap {
-            srcloc: FilePos::default(),
-            code_offset: cur_offset + cur_len,
-        });
-    }
-
-    return ret;
-
-    fn cvt(loc: ir::SourceLoc) -> FilePos {
-        if loc.is_default() {
-            FilePos::default()
-        } else {
-            FilePos::new(loc.bits())
-        }
     }
 }
 

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags};
 use cranelift_frontend::FunctionBuilder;
 use std::any::Any;
+use wasmtime_cranelift_shared::ALWAYS_TRAP_CODE;
 use wasmtime_environ::component::{
     AllCallFunc, CanonicalOptions, Component, ComponentCompiler, ComponentTypes, FixedEncoding,
     LowerImport, RuntimeMemoryIndex, Transcode, Transcoder, VMComponentOffsets,
@@ -209,7 +210,7 @@ impl Compiler {
         let (mut builder, _block0) = compiler.builder(func);
         builder
             .ins()
-            .trap(ir::TrapCode::User(super::ALWAYS_TRAP_CODE));
+            .trap(ir::TrapCode::User(ALWAYS_TRAP_CODE));
         builder.finalize();
 
         Ok(Box::new(compiler.finish()?))

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -208,9 +208,7 @@ impl Compiler {
             },
         );
         let (mut builder, _block0) = compiler.builder(func);
-        builder
-            .ins()
-            .trap(ir::TrapCode::User(ALWAYS_TRAP_CODE));
+        builder.ins().trap(ir::TrapCode::User(ALWAYS_TRAP_CODE));
         builder.finalize();
 
         Ok(Box::new(compiler.finish()?))

--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -1,7 +1,8 @@
-use crate::{CompiledFunctions, FunctionAddressMap};
+use crate::CompiledFunctions;
 use gimli::write;
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
+use wasmtime_cranelift_shared::FunctionAddressMap;
 use wasmtime_environ::{DefinedFuncIndex, EntityRef, FilePos, PrimaryMap, WasmFileInfo};
 
 pub type GeneratedAddress = usize;
@@ -605,11 +606,11 @@ impl AddressTransform {
 #[cfg(test)]
 mod tests {
     use super::{build_function_lookup, get_wasm_code_offset, AddressTransform};
-    use crate::{CompiledFunction, FunctionAddressMap};
     use cranelift_entity::PrimaryMap;
     use gimli::write::Address;
     use std::iter::FromIterator;
     use std::mem;
+    use wasmtime_cranelift_shared::{CompiledFunction, FunctionAddressMap};
     use wasmtime_environ::{FilePos, InstructionAddressMap, WasmFileInfo};
 
     #[test]

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1112,8 +1112,8 @@ mod tests {
     }
 
     fn create_mock_address_transform() -> AddressTransform {
-        use crate::FunctionAddressMap;
         use cranelift_entity::PrimaryMap;
+        use wasmtime_cranelift_shared::FunctionAddressMap;
         use wasmtime_environ::InstructionAddressMap;
         use wasmtime_environ::WasmFileInfo;
         let mut module_map = PrimaryMap::new();

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -782,7 +782,7 @@ mod tests {
         compile_expression, AddressTransform, CompiledExpression, CompiledExpressionPart,
         FunctionFrameInfo, JumpTargetMarker, ValueLabel, ValueLabelsRanges,
     };
-    use crate::CompiledFunction;
+    use crate::CompiledFunctionMetadata;
     use gimli::{self, constants, Encoding, EndianSlice, Expression, RunTimeEndian};
     use wasmtime_environ::FilePos;
 
@@ -1116,9 +1116,10 @@ mod tests {
         use wasmtime_cranelift_shared::FunctionAddressMap;
         use wasmtime_environ::InstructionAddressMap;
         use wasmtime_environ::WasmFileInfo;
+
         let mut module_map = PrimaryMap::new();
         let code_section_offset: u32 = 100;
-        let func = CompiledFunction {
+        let func = CompiledFunctionMetadata {
             address_map: FunctionAddressMap {
                 instructions: vec![
                     InstructionAddressMap {

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -3,7 +3,7 @@ use self::simulate::generate_simulated_dwarf;
 use self::unit::clone_unit;
 use crate::debug::gc::build_dependencies;
 use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctions;
+use crate::CompiledFunctionsMetadata;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::{
@@ -51,7 +51,7 @@ where
 pub fn transform_dwarf(
     isa: &dyn TargetIsa,
     di: &DebugInfoData,
-    funcs: &CompiledFunctions,
+    funcs: &CompiledFunctionsMetadata,
     memory_offset: &ModuleMemoryOffset,
 ) -> Result<write::Dwarf, Error> {
     let addr_tr = AddressTransform::new(funcs, &di.wasm_file);

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -2,7 +2,7 @@ use super::expression::{CompiledExpression, FunctionFrameInfo};
 use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
 use super::AddressTransform;
 use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctions;
+use crate::CompiledFunctionsMetadata;
 use anyhow::{Context, Error};
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_wasm::get_vmctx_value_label;
@@ -282,7 +282,7 @@ pub fn generate_simulated_dwarf(
     addr_tr: &AddressTransform,
     di: &DebugInfoData,
     memory_offset: &ModuleMemoryOffset,
-    funcs: &CompiledFunctions,
+    funcs: &CompiledFunctionsMetadata,
     translated: &HashSet<DefinedFuncIndex>,
     out_encoding: gimli::Encoding,
     out_units: &mut write::UnitTable,

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -7,7 +7,7 @@ use super::refs::{PendingDebugInfoRefs, PendingUnitRefs, UnitRefsMap};
 use super::utils::{add_internal_types, append_vmctx_info, get_function_frame_info};
 use super::{DebugInputContext, Reader, TransformError};
 use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctions;
+use crate::CompiledFunctionsMetadata;
 use anyhow::{Context, Error};
 use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::TargetIsa;
@@ -258,7 +258,7 @@ pub(crate) fn clone_unit<'a, R>(
     unit: Unit<R, R::Offset>,
     context: &DebugInputContext<R>,
     addr_tr: &'a AddressTransform,
-    funcs: &'a CompiledFunctions,
+    funcs: &'a CompiledFunctionsMetadata,
     memory_offset: &ModuleMemoryOffset,
     out_encoding: gimli::Encoding,
     out_units: &mut write::UnitTable,

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -1,7 +1,7 @@
 use super::address_transform::AddressTransform;
 use super::expression::{CompiledExpression, FunctionFrameInfo};
 use crate::debug::ModuleMemoryOffset;
-use crate::CompiledFunctions;
+use crate::CompiledFunctionsMetadata;
 use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
@@ -167,7 +167,7 @@ pub(crate) fn append_vmctx_info(
 
 pub(crate) fn get_function_frame_info<'a, 'b, 'c>(
     memory_offset: &ModuleMemoryOffset,
-    funcs: &'b CompiledFunctions,
+    funcs: &'b CompiledFunctionsMetadata,
     func_index: DefinedFuncIndex,
 ) -> Option<FunctionFrameInfo<'a>>
 where

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -8,7 +8,7 @@ use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, WasmFuncType, WasmType};
 use target_lexicon::{Architecture, CallingConvention};
-use wasmtime_cranelift_shared::CompiledFunction;
+use wasmtime_cranelift_shared::CompiledFunctionMetadata;
 
 pub use builder::builder;
 
@@ -17,7 +17,7 @@ mod compiler;
 mod debug;
 mod func_environ;
 
-type CompiledFunctions<'a> = PrimaryMap<DefinedFuncIndex, &'a CompiledFunction>;
+type CompiledFunctionsMetadata<'a> = PrimaryMap<DefinedFuncIndex, &'a CompiledFunctionMetadata>;
 
 /// Trap code used for debug assertions we emit in our JIT code.
 const DEBUG_ASSERT_TRAP_CODE: u16 = u16::MAX;

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -4,12 +4,11 @@
 //! and `wasmtime_environ::CompilerBuilder` traits.
 
 use cranelift_codegen::ir;
-use cranelift_codegen::isa::{unwind::UnwindInfo, CallConv, TargetIsa};
+use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, WasmFuncType, WasmType};
 use target_lexicon::{Architecture, CallingConvention};
-use wasmtime_cranelift_shared::Relocation;
-use wasmtime_environ::{FilePos, InstructionAddressMap, TrapInformation};
+use wasmtime_cranelift_shared::CompiledFunction;
 
 pub use builder::builder;
 
@@ -22,55 +21,6 @@ type CompiledFunctions<'a> = PrimaryMap<DefinedFuncIndex, &'a CompiledFunction>;
 
 /// Trap code used for debug assertions we emit in our JIT code.
 const DEBUG_ASSERT_TRAP_CODE: u16 = u16::MAX;
-
-/// Compiled function: machine code body, jump table offsets, and unwind information.
-#[derive(Default)]
-pub struct CompiledFunction {
-    /// The machine code for this function.
-    body: Vec<u8>,
-
-    /// The unwind information.
-    unwind_info: Option<UnwindInfo>,
-
-    /// Information used to translate from binary offsets back to the original
-    /// location found in the wasm input.
-    address_map: FunctionAddressMap,
-
-    /// Metadata about traps in this module, mapping code offsets to the trap
-    /// that they may cause.
-    traps: Vec<TrapInformation>,
-
-    relocations: Vec<Relocation>,
-    value_labels_ranges: cranelift_codegen::ValueLabelsRanges,
-    sized_stack_slots: ir::StackSlots,
-    alignment: u32,
-}
-
-/// Function and its instructions addresses mappings.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-struct FunctionAddressMap {
-    /// An array of data for the instructions in this function, indicating where
-    /// each instruction maps back to in the original function.
-    ///
-    /// This array is sorted least-to-greatest by the `code_offset` field.
-    /// Additionally the span of each `InstructionAddressMap` is implicitly the
-    /// gap between it and the next item in the array.
-    instructions: Box<[InstructionAddressMap]>,
-
-    /// Function's initial offset in the source file, specified in bytes from
-    /// the front of the file.
-    start_srcloc: FilePos,
-
-    /// Function's end offset in the source file, specified in bytes from
-    /// the front of the file.
-    end_srcloc: FilePos,
-
-    /// Generated function body offset if applicable, otherwise 0.
-    body_offset: usize,
-
-    /// Generated function body length.
-    body_len: u32,
-}
 
 /// Creates a new cranelift `Signature` with no wasm params/results for the
 /// given calling convention.


### PR DESCRIPTION
This change introduces handling of traps and relocations in Winch, which was left out in https://github.com/bytecodealliance/wasmtime/pull/6119.

In order to so, this change moves the `CompiledFunction` struct to the `wasmtime-cranelift-shared` crate, allowing Cranelift and Winch to operate on a single, shared representation, following some of the ideas discussed in https://github.com/bytecodealliance/wasmtime/pull/5944.

Even though Winch doesn't rely on all the fields of `CompiledFunction`, it eventually will. With the addition of relocations and traps it started to be more evident that even if we wanted to have different representations of a compiled function, they would end up being very similar.

This change also consolidates where the `traps` and `relocations` of the `CompiledFunction` get created, by introducing a constructor that operates on a `MachBufferFinalized<Final>`, esentially encapsulating this process in a single place for both Winch and Cranelift.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
