### PR TITLE
Slightly shrink compiled wasm modules

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -3,7 +3,7 @@
 use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::types::{F32, F64, I128, I16, I32, I64, I8, I8X16, R32, R64};
 use crate::ir::{types, ExternalName, MemFlags, Opcode, Type};
-use crate::isa::CallConv;
+use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 
@@ -1117,6 +1117,15 @@ impl MachInst for Inst {
             })
         } else {
             None
+        }
+    }
+
+    fn function_alignment() -> FunctionAlignment {
+        // We use 32-byte alignment for performance reasons, but for correctness
+        // we would only need 4-byte alignment.
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 32,
         }
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -5,7 +5,7 @@ use crate::ir::{Function, Type};
 use crate::isa::aarch64::settings as aarch64_settings;
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv;
-use crate::isa::{Builder as IsaBuilder, TargetIsa};
+use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
@@ -189,10 +189,13 @@ impl TargetIsa for AArch64Backend {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
     }
 
-    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
-        // We use 32-byte alignment for performance reasons, but for correctness we would only need
-        // 4-byte alignment.
-        (4, 32)
+    fn function_alignment(&self) -> FunctionAlignment {
+        // We use 32-byte alignment for performance reasons, but for correctness
+        // we would only need 4-byte alignment.
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 32,
+        }
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -7,7 +7,7 @@ use crate::isa::aarch64::settings as aarch64_settings;
 use crate::isa::unwind::systemv;
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
-    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
+    compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
@@ -190,12 +190,7 @@ impl TargetIsa for AArch64Backend {
     }
 
     fn function_alignment(&self) -> FunctionAlignment {
-        // We use 32-byte alignment for performance reasons, but for correctness
-        // we would only need 4-byte alignment.
-        FunctionAlignment {
-            minimum: 4,
-            preferred: 32,
-        }
+        inst::Inst::function_alignment()
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -189,10 +189,10 @@ impl TargetIsa for AArch64Backend {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
     }
 
-    fn function_alignment(&self) -> u32 {
+    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
         // We use 32-byte alignment for performance reasons, but for correctness we would only need
         // 4-byte alignment.
-        32
+        (4, 32)
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -318,7 +318,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
     /// Returns the minimum function alignment and the preferred function
     /// alignment, for performance, required by this ISA.
-    fn min_and_preferred_function_alignment(&self) -> (u32, u32);
+    fn function_alignment(&self) -> FunctionAlignment;
 
     /// Create a polymorphic TargetIsa from this specific implementation.
     fn wrapped(self) -> OwnedTargetIsa
@@ -340,6 +340,19 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Currently this only returns false on x86 when some native features are
     /// not detected.
     fn has_native_fma(&self) -> bool;
+}
+
+/// Function alignment specifications as required by an ISA, returned by
+/// [`TargetIsa::function_alignment`].
+#[derive(Copy, Clone)]
+pub struct FunctionAlignment {
+    /// The minimum alignment required by an ISA, where all functions must be
+    /// aligned to at least this amount.
+    pub minimum: u32,
+    /// A "preferred" alignment which should be used for more
+    /// performance-sensitive situations. This can involve cache-line-aligning
+    /// for example to get more of a small function into fewer cache lines.
+    pub preferred: u32,
 }
 
 /// Methods implemented for free for target ISA!

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -316,8 +316,9 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// of defined functions in the object file.
     fn text_section_builder(&self, num_labeled_funcs: usize) -> Box<dyn TextSectionBuilder>;
 
-    /// The function alignment required by this ISA.
-    fn function_alignment(&self) -> u32;
+    /// Returns the minimum function alignment and the preferred function
+    /// alignment, for performance, required by this ISA.
+    fn min_and_preferred_function_alignment(&self) -> (u32, u32);
 
     /// Create a polymorphic TargetIsa from this specific implementation.
     fn wrapped(self) -> OwnedTargetIsa

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -10,7 +10,7 @@ pub use crate::ir::condcodes::IntCC;
 use crate::ir::types::{self, F32, F64, I128, I16, I32, I64, I8, R32, R64};
 
 pub use crate::ir::{ExternalName, MemFlags, Opcode, SourceLoc, Type, ValueLabel};
-use crate::isa::CallConv;
+use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 
@@ -800,6 +800,13 @@ impl MachInst for Inst {
 
     fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {
         RegClass::Int
+    }
+
+    fn function_alignment() -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 4,
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -5,7 +5,7 @@ use crate::ir;
 use crate::ir::Function;
 
 use crate::isa::riscv64::settings as riscv_settings;
-use crate::isa::{Builder as IsaBuilder, TargetIsa};
+use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
@@ -167,8 +167,11 @@ impl TargetIsa for Riscv64Backend {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
     }
 
-    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
-        (4, 4)
+    fn function_alignment(&self) -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 4,
+        }
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -7,7 +7,7 @@ use crate::ir::Function;
 use crate::isa::riscv64::settings as riscv_settings;
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
-    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
+    compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
@@ -168,10 +168,7 @@ impl TargetIsa for Riscv64Backend {
     }
 
     fn function_alignment(&self) -> FunctionAlignment {
-        FunctionAlignment {
-            minimum: 4,
-            preferred: 4,
-        }
+        inst::Inst::function_alignment()
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -167,8 +167,8 @@ impl TargetIsa for Riscv64Backend {
         inst::unwind::systemv::map_reg(reg).map(|reg| reg.0)
     }
 
-    fn function_alignment(&self) -> u32 {
-        4
+    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
+        (4, 4)
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -3,7 +3,7 @@
 use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::{types, ExternalName, Opcode, Type};
 use crate::isa::s390x::abi::S390xMachineDeps;
-use crate::isa::CallConv;
+use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
@@ -1141,6 +1141,13 @@ impl MachInst for Inst {
 
     fn gen_dummy_use(reg: Reg) -> Inst {
         Inst::DummyUse { reg }
+    }
+
+    fn function_alignment() -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 4,
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -5,7 +5,7 @@ use crate::ir::{Function, Type};
 use crate::isa::s390x::settings as s390x_settings;
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv::RegisterMappingError;
-use crate::isa::{Builder as IsaBuilder, TargetIsa};
+use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
@@ -167,8 +167,11 @@ impl TargetIsa for S390xBackend {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 
-    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
-        (4, 4)
+    fn function_alignment(&self) -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 4,
+            preferred: 4,
+        }
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -167,8 +167,8 @@ impl TargetIsa for S390xBackend {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 
-    fn function_alignment(&self) -> u32 {
-        4
+    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
+        (4, 4)
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -7,7 +7,7 @@ use crate::isa::s390x::settings as s390x_settings;
 use crate::isa::unwind::systemv::RegisterMappingError;
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment, TargetIsa};
 use crate::machinst::{
-    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
+    compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
 };
 use crate::result::CodegenResult;
@@ -168,10 +168,7 @@ impl TargetIsa for S390xBackend {
     }
 
     fn function_alignment(&self) -> FunctionAlignment {
-        FunctionAlignment {
-            minimum: 4,
-            preferred: 4,
-        }
+        inst::Inst::function_alignment()
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -5,7 +5,7 @@ use crate::ir::{types, ExternalName, LibCall, Opcode, RelSourceLoc, TrapCode, Ty
 use crate::isa::x64::abi::X64ABIMachineSpec;
 use crate::isa::x64::inst::regs::{pretty_print_reg, show_ireg_sized};
 use crate::isa::x64::settings as x64_settings;
-use crate::isa::CallConv;
+use crate::isa::{CallConv, FunctionAlignment};
 use crate::{machinst::*, trace};
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
@@ -2573,6 +2573,15 @@ impl MachInst for Inst {
             | Inst::TrapIf { .. }
             | Inst::Ud2 { .. } => true,
             _ => false,
+        }
+    }
+
+    fn function_alignment() -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 1,
+            // Prefer an alignment of 16-bytes to hypothetically get the whole
+            // function into a minimum number of lines.
+            preferred: 16,
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -8,7 +8,7 @@ use crate::ir::{Function, Type};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv;
 use crate::isa::x64::{inst::regs::create_reg_env_systemv, settings as x64_settings};
-use crate::isa::Builder as IsaBuilder;
+use crate::isa::{Builder as IsaBuilder, FunctionAlignment};
 use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
@@ -166,10 +166,13 @@ impl TargetIsa for X64Backend {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 
-    /// Prefer an alignment of 16-bytes to hypothetically get the whole function
-    /// into a minimum number of lines.
-    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
-        (1, 16)
+    fn function_alignment(&self) -> FunctionAlignment {
+        FunctionAlignment {
+            minimum: 1,
+            // Prefer an alignment of 16-bytes to hypothetically get the whole
+            // function into a minimum number of lines.
+            preferred: 16,
+        }
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -10,7 +10,7 @@ use crate::isa::unwind::systemv;
 use crate::isa::x64::{inst::regs::create_reg_env_systemv, settings as x64_settings};
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment};
 use crate::machinst::{
-    compile, CompiledCode, CompiledCodeStencil, MachTextSectionBuilder, Reg, SigSet,
+    compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
 };
 use crate::result::{CodegenError, CodegenResult};
@@ -167,12 +167,7 @@ impl TargetIsa for X64Backend {
     }
 
     fn function_alignment(&self) -> FunctionAlignment {
-        FunctionAlignment {
-            minimum: 1,
-            // Prefer an alignment of 16-bytes to hypothetically get the whole
-            // function into a minimum number of lines.
-            preferred: 16,
-        }
+        Inst::function_alignment()
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -166,10 +166,10 @@ impl TargetIsa for X64Backend {
         Box::new(MachTextSectionBuilder::<inst::Inst>::new(num_funcs))
     }
 
-    /// Align functions on x86 to 16 bytes, ensuring that rip-relative loads to SSE registers are
-    /// always from aligned memory.
-    fn function_alignment(&self) -> u32 {
-        16
+    /// Prefer an alignment of 16-bytes to hypothetically get the whole function
+    /// into a minimum number of lines.
+    fn min_and_preferred_function_alignment(&self) -> (u32, u32) {
+        (1, 16)
     }
 
     #[cfg(feature = "disas")]

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -47,6 +47,7 @@
 use crate::binemit::{Addend, CodeInfo, CodeOffset, Reloc, StackMap};
 use crate::ir::function::FunctionParameters;
 use crate::ir::{DynamicStackSlot, RelSourceLoc, StackSlot, Type};
+use crate::isa::FunctionAlignment;
 use crate::result::CodegenResult;
 use crate::settings::Flags;
 use crate::value_label::ValueLabelsRanges;
@@ -174,6 +175,10 @@ pub trait MachInst: Clone + Debug {
     ) -> Option<Self> {
         None
     }
+
+    /// Returns a description of the alignment required for functions for this
+    /// architecture.
+    fn function_alignment() -> FunctionAlignment;
 
     /// A label-use kind: a type that describes the types of label references that
     /// can occur in an instruction.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1047,7 +1047,7 @@ impl<I: VCodeInst> VCode<I> {
         *ctrl_plane = state.take_ctrl_plane();
 
         // Emit the constants used by the function.
-        let mut alignment = 1;
+        let mut alignment = I::function_alignment().minimum;
         for (constant, data) in self.constants.iter() {
             alignment = data.alignment().max(alignment);
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1046,10 +1046,13 @@ impl<I: VCodeInst> VCode<I> {
         // emission state is not needed anymore, move control plane back out
         *ctrl_plane = state.take_ctrl_plane();
 
-        // Emit the constants used by the function.
-        let mut alignment = I::function_alignment().minimum;
+        // Emit the constants used by the function, and additionally collect
+        // this function's alignment at the same time. The alignment start at
+        // the ISA-defined minimum, and can possibly get increased if necessary
+        // for constants.
+        let mut function_alignment = I::function_alignment().minimum;
         for (constant, data) in self.constants.iter() {
-            alignment = data.alignment().max(alignment);
+            function_alignment = data.alignment().max(function_alignment);
 
             let label = buffer.get_label_for_constant(constant);
             buffer.defer_constant(label, data.alignment(), data.as_slice(), u32::max_value());
@@ -1093,7 +1096,7 @@ impl<I: VCodeInst> VCode<I> {
             dynamic_stackslot_offsets: self.abi.dynamic_stackslot_offsets().clone(),
             value_labels_ranges,
             frame_size,
-            alignment,
+            alignment: function_alignment,
         }
     }
 

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -255,7 +255,7 @@ impl JITModule {
                 std::mem::size_of::<[u8; 16]>(),
                 self.isa
                     .symbol_alignment()
-                    .max(self.isa.min_and_preferred_function_alignment().0 as u64),
+                    .max(self.isa.function_alignment().minimum as u64),
             )
             .unwrap()
             .cast::<[u8; 16]>();
@@ -692,7 +692,7 @@ impl Module for JITModule {
 
         let size = compiled_code.code_info().total_size as usize;
         let align = alignment
-            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
+            .max(self.isa.function_alignment().minimum as u64)
             .max(self.isa.symbol_alignment());
         let ptr = self
             .memory
@@ -776,7 +776,7 @@ impl Module for JITModule {
 
         let size = bytes.len();
         let align = alignment
-            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
+            .max(self.isa.function_alignment().minimum as u64)
             .max(self.isa.symbol_alignment());
         let ptr = self
             .memory

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -255,7 +255,7 @@ impl JITModule {
                 std::mem::size_of::<[u8; 16]>(),
                 self.isa
                     .symbol_alignment()
-                    .max(self.isa.function_alignment() as u64),
+                    .max(self.isa.min_and_preferred_function_alignment().0 as u64),
             )
             .unwrap()
             .cast::<[u8; 16]>();
@@ -692,7 +692,7 @@ impl Module for JITModule {
 
         let size = compiled_code.code_info().total_size as usize;
         let align = alignment
-            .max(self.isa.function_alignment() as u64)
+            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
             .max(self.isa.symbol_alignment());
         let ptr = self
             .memory
@@ -776,7 +776,7 @@ impl Module for JITModule {
 
         let size = bytes.len();
         let align = alignment
-            .max(self.isa.function_alignment() as u64)
+            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
             .max(self.isa.symbol_alignment());
         let ptr = self
             .memory

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -352,7 +352,7 @@ impl Module for ObjectModule {
         *defined = true;
 
         let align = alignment
-            .max(self.isa.function_alignment() as u64)
+            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
             .max(self.isa.symbol_alignment());
         let (section, offset) = if self.per_function_section {
             let symbol_name = self.object.symbol(symbol).name.clone();

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -352,7 +352,7 @@ impl Module for ObjectModule {
         *defined = true;
 
         let align = alignment
-            .max(self.isa.min_and_preferred_function_alignment().0 as u64)
+            .max(self.isa.function_alignment().minimum.into())
             .max(self.isa.symbol_alignment());
         let (section, offset) = if self.per_function_section {
             let symbol_name = self.object.symbol(symbol).name.clone();

--- a/crates/cranelift-shared/src/obj.rs
+++ b/crates/cranelift-shared/src/obj.rs
@@ -115,12 +115,9 @@ impl<'a> ModuleTextBuilder<'a> {
         resolve_reloc_target: impl Fn(FuncIndex) -> usize,
     ) -> (SymbolId, Range<u64>) {
         let body_len = body.len() as u64;
-        let off = self.text.append(
-            true,
-            &body,
-            self.compiler.min_function_alignment().max(alignment),
-            &mut self.ctrl_plane,
-        );
+        let off = self
+            .text
+            .append(true, &body, alignment, &mut self.ctrl_plane);
 
         let symbol_id = self.obj.add_symbol(Symbol {
             name: name.as_bytes().to_vec(),

--- a/crates/cranelift-shared/src/obj.rs
+++ b/crates/cranelift-shared/src/obj.rs
@@ -118,7 +118,7 @@ impl<'a> ModuleTextBuilder<'a> {
         let off = self.text.append(
             true,
             &body,
-            self.compiler.function_alignment().max(alignment),
+            self.compiler.min_function_alignment().max(alignment),
             &mut self.ctrl_plane,
         );
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -630,10 +630,6 @@ impl wasmtime_environ::Compiler for Compiler {
         Ok(())
     }
 
-    fn min_function_alignment(&self) -> u32 {
-        self.isa.function_alignment().minimum
-    }
-
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
         self.isa.create_systemv_cie()
     }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -631,7 +631,7 @@ impl wasmtime_environ::Compiler for Compiler {
     }
 
     fn min_function_alignment(&self) -> u32 {
-        self.isa.min_and_preferred_function_alignment().0
+        self.isa.function_alignment().minimum
     }
 
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
@@ -1042,7 +1042,7 @@ impl FunctionCompiler<'_> {
         // instead of the minimum alignment as this can help perf in niche
         // situations.
         let preferred_alignment = if body_and_tunables.is_some() {
-            self.compiler.isa.min_and_preferred_function_alignment().1
+            self.compiler.isa.function_alignment().preferred
         } else {
             1
         };

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -363,8 +363,8 @@ pub trait Compiler: Send + Sync {
         funcs: &PrimaryMap<DefinedFuncIndex, (SymbolId, &(dyn Any + Send))>,
     ) -> Result<()>;
 
-    /// The function alignment required by this ISA.
-    fn function_alignment(&self) -> u32;
+    /// The minimum function alignment required by this ISA.
+    fn min_function_alignment(&self) -> u32;
 
     /// Creates a new System V Common Information Entry for the ISA.
     ///

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -363,9 +363,6 @@ pub trait Compiler: Send + Sync {
         funcs: &PrimaryMap<DefinedFuncIndex, (SymbolId, &(dyn Any + Send))>,
     ) -> Result<()>;
 
-    /// The minimum function alignment required by this ISA.
-    fn min_function_alignment(&self) -> u32;
-
     /// Creates a new System V Common Information Entry for the ISA.
     ///
     /// Returns `None` if the ISA does not support System V unwind information.

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -129,7 +129,7 @@ impl wasmtime_environ::Compiler for Compiler {
             let (sym, range) = builder.append_func(
                 &sym,
                 func.data(),
-                self.min_function_alignment(),
+                self.isa.function_alignment(),
                 None,
                 &[],
                 |idx| resolve_reloc(i, idx),
@@ -185,10 +185,6 @@ impl wasmtime_environ::Compiler for Compiler {
         _funcs: &PrimaryMap<DefinedFuncIndex, (SymbolId, &(dyn Any + Send))>,
     ) -> Result<()> {
         todo!()
-    }
-
-    fn min_function_alignment(&self) -> u32 {
-        self.isa.function_alignment()
     }
 
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -129,7 +129,7 @@ impl wasmtime_environ::Compiler for Compiler {
             let (sym, range) = builder.append_func(
                 &sym,
                 func.data(),
-                self.function_alignment(),
+                self.min_function_alignment(),
                 None,
                 &[],
                 |idx| resolve_reloc(i, idx),
@@ -187,7 +187,7 @@ impl wasmtime_environ::Compiler for Compiler {
         todo!()
     }
 
-    fn function_alignment(&self) -> u32 {
+    fn min_function_alignment(&self) -> u32 {
         self.isa.function_alignment()
     }
 


### PR DESCRIPTION
This commit shuffles trampolines to the end of a compiled ELF file instead of interspersed throughout. Additionally trampolines are no longer given a higher alignment requirement than is required by the ISA as is given to functions since they're not perf critical.

The savings here are quite minor, only 0.3% locally on spidermonkey.wasm.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
