### PR TITLE
aarch64: Remove unnecessary saves on calls with differing ABIs

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -975,7 +975,10 @@ impl MachInst for Inst {
         // more information on this ABI-implementation hack.
         let caller_clobbers = AArch64MachineDeps::get_regs_clobbered_by_call(caller_callconv);
         let callee_clobbers = AArch64MachineDeps::get_regs_clobbered_by_call(callee_callconv);
-        caller_clobbers != callee_clobbers
+
+        let mut all_clobbers = caller_clobbers;
+        all_clobbers.union_from(callee_clobbers);
+        all_clobbers != caller_clobbers
     }
 
     fn is_trap(&self) -> bool {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -955,22 +955,27 @@ impl MachInst for Inst {
     }
 
     fn is_included_in_clobbers(&self) -> bool {
+        let (caller_callconv, callee_callconv) = match self {
+            Inst::Args { .. } => return false,
+            Inst::Call { info } => (info.caller_callconv, info.callee_callconv),
+            Inst::CallInd { info } => (info.caller_callconv, info.callee_callconv),
+            _ => return true,
+        };
+
         // We exclude call instructions from the clobber-set when they are calls
-        // from caller to callee with the same ABI. Such calls cannot possibly
-        // force any new registers to be saved in the prologue, because anything
-        // that the callee clobbers, the caller is also allowed to clobber. This
-        // both saves work and enables us to more precisely follow the
+        // from caller to callee that both clobber the same register (such as
+        // using the same or similar ABIs). Such calls cannot possibly force any
+        // new registers to be saved in the prologue, because anything that the
+        // callee clobbers, the caller is also allowed to clobber. This both
+        // saves work and enables us to more precisely follow the
         // half-caller-save, half-callee-save SysV ABI for some vector
         // registers.
         //
         // See the note in [crate::isa::aarch64::abi::is_caller_save_reg] for
         // more information on this ABI-implementation hack.
-        match self {
-            &Inst::Args { .. } => false,
-            &Inst::Call { ref info } => info.caller_callconv != info.callee_callconv,
-            &Inst::CallInd { ref info } => info.caller_callconv != info.callee_callconv,
-            _ => true,
-        }
+        let caller_clobbers = AArch64MachineDeps::get_regs_clobbered_by_call(caller_callconv);
+        let callee_clobbers = AArch64MachineDeps::get_regs_clobbered_by_call(callee_callconv);
+        caller_clobbers != callee_clobbers
     }
 
     fn is_trap(&self) -> bool {

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -932,3 +932,33 @@ block0(v0: i64):
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 
+function %f19() system_v {
+    fn0 = %g() fast
+
+block0:
+    call fn0()
+    return
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   load_ext_name x0, TestCase(%g)+0
+;   blr x0
+;   ldp fp, lr, [sp], #16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldr x0, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x0
+;   ldp x29, x30, [sp], #0x10
+;   ret
+


### PR DESCRIPTION
The AArch64 AAPCS calling convention, which all our backends use for register allocation, indicates that the low 64-bits of the v8-v15 registers are all caller-saved. Cranelift doesn't track precisely which registers are used, however, so it says the entire register is a caller-saved register. This currently interacts poorly where a call from one function to another where the ABIs differ forces the caller to save all of v8-v15 in the prologue and restore it in the epilogue.

Currently in all cases, however, this isn't actually necessary. The AArch64 backend also has an optimization where if both the caller and the callee are using the same ABI then the clobbers of a `call` instruction are not counted in the clobber set for the function since nothing new can be clobbered. This way if `v8` is never used, for example, it's not considered clobbered and it's not saved. This logic, however, is comparing ABIs exactly which means that different names for the same ABI, which don't differ in register allocation, force saves to happen.

This comes up with trampolines generated by Wasmtime where the calling convention of the trampoline is `WasmtimeSystemV`, for example, where the callee (a wasm function) is `Fast`. Because these differ it means that all trampolines are generating saves/restores of registers, despite the actual underlying calling convention being the same.

This commit updates the optimization that skips including a `call` instruction in the clobber set by comparing the caller and callee's ABI clobber sets. If both clobber the same registers then for the purposes of clobbers it's as-if they were the same ABI, so the `call` can be skipped.

Overall this removes unnecessary saves/restores in trampolines generated by Cranelift and shrinks the size of spidermonkey.wasm by 2% after #6262.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
