### PR TITLE
Cut down on boilerplate in Wasmtime's Cranelift integration

### DIFF
--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -116,30 +116,6 @@ impl Compiler {
         }
     }
 
-    fn take_context(&self) -> CompilerContext {
-        let candidate = self.contexts.lock().unwrap().pop();
-        candidate
-            .map(|mut ctx| {
-                ctx.codegen_context.clear();
-                ctx
-            })
-            .unwrap_or_else(|| CompilerContext {
-                #[cfg(feature = "incremental-cache")]
-                incremental_cache_ctx: self.cache_store.as_ref().map(|cache_store| {
-                    IncrementalCacheContext {
-                        cache_store: cache_store.clone(),
-                        num_hits: 0,
-                        num_cached: 0,
-                    }
-                }),
-                ..Default::default()
-            })
-    }
-
-    fn save_context(&self, ctx: CompilerContext) {
-        self.contexts.lock().unwrap().push(ctx);
-    }
-
     fn get_function_address_map(
         compiled_code: &CompiledCode,
         body: &FunctionBody<'_>,
@@ -195,13 +171,9 @@ impl wasmtime_environ::Compiler for Compiler {
         let sig = translation.module.functions[func_index].signature;
         let wasm_func_ty = &types[sig];
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
+        let mut compiler = self.function_compiler();
 
+        let context = &mut compiler.cx.codegen_context;
         context.func.signature = wasm_call_signature(isa, wasm_func_ty);
         context.func.name = UserFuncName::User(UserExternalName {
             namespace: 0,
@@ -267,85 +239,22 @@ impl wasmtime_environ::Compiler for Compiler {
         });
         context.func.stack_limit = Some(stack_limit);
         let FunctionBodyData { validator, body } = input;
-        let mut validator = validator.into_validator(validator_allocations);
-        func_translator.translate_body(
+        let mut validator =
+            validator.into_validator(mem::take(&mut compiler.cx.validator_allocations));
+        compiler.cx.func_translator.translate_body(
             &mut validator,
             body.clone(),
             &mut context.func,
             &mut func_env,
         )?;
 
-        let (_, code_buf) = compile_maybe_cached(&mut context, isa, cache_ctx.as_mut())?;
-        // compile_maybe_cached returns the compiled_code but that borrow has the same lifetime as
-        // the mutable borrow of `context`, so the borrow checker prohibits other borrows from
-        // `context` while it's alive. Borrow it again to make the borrow checker happy.
-        let compiled_code = context.compiled_code().unwrap();
-        let alignment = compiled_code.alignment;
-
-        let func_relocs = compiled_code
-            .buffer
-            .relocs()
-            .into_iter()
-            .map(|item| mach_reloc_to_reloc(&context.func, item))
-            .collect();
-
-        let traps = compiled_code
-            .buffer
-            .traps()
-            .into_iter()
-            .filter_map(mach_trap_to_trap)
-            .collect();
-
-        let stack_maps = mach_stack_maps_to_stack_maps(compiled_code.buffer.stack_maps());
-
-        let unwind_info = if isa.flags().unwind_info() {
-            compiled_code
-                .create_unwind_info(isa)
-                .map_err(|error| CompileError::Codegen(pretty_error(&context.func, error)))?
-        } else {
-            None
-        };
-
-        let length = u32::try_from(code_buf.len()).unwrap();
-
-        let address_transform =
-            Self::get_function_address_map(compiled_code, &body, length, tunables);
-
-        let ranges = if tunables.generate_native_debuginfo {
-            Some(compiled_code.value_labels_ranges.clone())
-        } else {
-            None
-        };
+        let (info, func) = compiler.finish_with_info(Some((&body, tunables)))?;
 
         let timing = cranelift_codegen::timing::take_current();
         log::debug!("{:?} translated in {:?}", func_index, timing.total());
         log::trace!("{:?} timing info\n{}", func_index, timing);
 
-        let sized_stack_slots = std::mem::take(&mut context.func.sized_stack_slots);
-
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations: validator.into_allocations(),
-        });
-
-        Ok((
-            WasmFunctionInfo {
-                start_srcloc: address_transform.start_srcloc,
-                stack_maps: stack_maps.into(),
-            },
-            Box::new(CompiledFunction {
-                body: code_buf,
-                relocations: func_relocs,
-                value_labels_ranges: ranges.unwrap_or(Default::default()),
-                sized_stack_slots,
-                unwind_info,
-                traps,
-                alignment,
-                address_map: address_transform,
-            }),
-        ))
+        Ok((info, Box::new(func)))
     }
 
     fn compile_array_to_wasm_trampoline(
@@ -363,20 +272,9 @@ impl wasmtime_environ::Compiler for Compiler {
         let wasm_call_sig = wasm_call_signature(isa, wasm_func_ty);
         let array_call_sig = array_call_signature(isa);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(Default::default(), array_call_sig);
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(Default::default(), array_call_sig);
+        let (mut builder, block0) = compiler.builder(func);
 
         let (vmctx, caller_vmctx, values_vec_ptr, values_vec_len) = {
             let params = builder.func.dfg.block_params(block0);
@@ -424,14 +322,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&[]);
         builder.finalize();
 
-        let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func) as _)
+        Ok(Box::new(compiler.finish()?))
     }
 
     fn compile_native_to_wasm_trampoline(
@@ -450,20 +341,9 @@ impl wasmtime_environ::Compiler for Compiler {
         let wasm_call_sig = wasm_call_signature(isa, wasm_func_ty);
         let native_call_sig = native_call_signature(isa, wasm_func_ty);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(Default::default(), native_call_sig);
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(Default::default(), native_call_sig);
+        let (mut builder, block0) = compiler.builder(func);
 
         let args = builder.func.dfg.block_params(block0).to_vec();
         let vmctx = args[0];
@@ -491,14 +371,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func) as _)
+        Ok(Box::new(compiler.finish()?))
     }
 
     fn compile_wasm_to_native_trampoline(
@@ -511,20 +384,9 @@ impl wasmtime_environ::Compiler for Compiler {
         let wasm_call_sig = wasm_call_signature(isa, wasm_func_ty);
         let native_call_sig = native_call_signature(isa, wasm_func_ty);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(Default::default(), wasm_call_sig);
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(Default::default(), wasm_call_sig);
+        let (mut builder, block0) = compiler.builder(func);
 
         let args = builder.func.dfg.block_params(block0).to_vec();
         let callee_vmctx = args[0];
@@ -569,14 +431,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func) as _)
+        Ok(Box::new(compiler.finish()?))
     }
 
     fn append_code(
@@ -882,20 +737,9 @@ impl Compiler {
         let native_call_sig = native_call_signature(isa, ty);
         let array_call_sig = array_call_signature(isa);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(Default::default(), native_call_sig);
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(Default::default(), native_call_sig);
+        let (mut builder, block0) = compiler.builder(func);
 
         let (values_vec_ptr, values_vec_len) =
             self.allocate_stack_array_and_spill_args(ty, &mut builder, block0);
@@ -922,14 +766,7 @@ impl Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations,
-        });
-        Ok(func)
+        compiler.finish()
     }
 
     /// Creates a trampoline for WebAssembly to call a host function defined
@@ -965,21 +802,9 @@ impl Compiler {
         let wasm_call_sig = wasm_call_signature(isa, ty);
         let array_call_sig = array_call_signature(isa);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            incremental_cache_ctx: mut cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(Default::default(), wasm_call_sig);
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
-
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(Default::default(), wasm_call_sig);
+        let (mut builder, block0) = compiler.builder(func);
         let caller_vmctx = builder.func.dfg.block_params(block0)[1];
 
         // Assert that we were really given a core Wasm vmctx, since that's
@@ -1024,14 +849,7 @@ impl Compiler {
         builder.ins().return_(&results);
         builder.finalize();
 
-        let func = self.finish_trampoline(&mut context, cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx: cache_ctx,
-            validator_allocations,
-        });
-        Ok(func)
+        compiler.finish()
     }
 
     /// This function will allocate a stack slot suitable for storing both the
@@ -1146,13 +964,64 @@ impl Compiler {
         results
     }
 
-    fn finish_trampoline(
-        &self,
-        context: &mut Context,
-        cache_ctx: Option<&mut IncrementalCacheContext>,
-        isa: &dyn TargetIsa,
-    ) -> Result<CompiledFunction, CompileError> {
-        let (_, code_buf) = compile_maybe_cached(context, isa, cache_ctx)?;
+    fn function_compiler(&self) -> FunctionCompiler<'_> {
+        let saved_context = self.contexts.lock().unwrap().pop();
+        FunctionCompiler {
+            compiler: self,
+            cx: saved_context
+                .map(|mut ctx| {
+                    ctx.codegen_context.clear();
+                    ctx
+                })
+                .unwrap_or_else(|| CompilerContext {
+                    #[cfg(feature = "incremental-cache")]
+                    incremental_cache_ctx: self.cache_store.as_ref().map(|cache_store| {
+                        IncrementalCacheContext {
+                            cache_store: cache_store.clone(),
+                            num_hits: 0,
+                            num_cached: 0,
+                        }
+                    }),
+                    ..Default::default()
+                }),
+        }
+    }
+}
+
+struct FunctionCompiler<'a> {
+    compiler: &'a Compiler,
+    cx: CompilerContext,
+}
+
+impl FunctionCompiler<'_> {
+    fn builder(&mut self, func: ir::Function) -> (FunctionBuilder<'_>, ir::Block) {
+        self.cx.codegen_context.func = func;
+        let mut builder = FunctionBuilder::new(
+            &mut self.cx.codegen_context.func,
+            self.cx.func_translator.context(),
+        );
+
+        let block0 = builder.create_block();
+        builder.append_block_params_for_function_params(block0);
+        builder.switch_to_block(block0);
+        builder.seal_block(block0);
+        (builder, block0)
+    }
+
+    fn finish(self) -> Result<CompiledFunction, CompileError> {
+        let (info, func) = self.finish_with_info(None)?;
+        assert!(info.stack_maps.is_empty());
+        Ok(func)
+    }
+
+    fn finish_with_info(
+        mut self,
+        body_and_tunables: Option<(&FunctionBody<'_>, &Tunables)>,
+    ) -> Result<(WasmFunctionInfo, CompiledFunction), CompileError> {
+        let context = &mut self.cx.codegen_context;
+        let isa = &*self.compiler.isa;
+        let (_, code_buf) =
+            compile_maybe_cached(context, isa, self.cx.incremental_cache_ctx.as_mut())?;
         let compiled_code = context.compiled_code().unwrap();
 
         let relocations = compiled_code
@@ -1170,6 +1039,25 @@ impl Compiler {
             .collect();
         let alignment = compiled_code.alignment;
 
+        let address_map = match body_and_tunables {
+            Some((body, tunables)) => Compiler::get_function_address_map(
+                compiled_code,
+                body,
+                u32::try_from(code_buf.len()).unwrap(),
+                tunables,
+            ),
+            None => Default::default(),
+        };
+
+        let value_labels_ranges = if body_and_tunables
+            .map(|(_, t)| t.generate_native_debuginfo)
+            .unwrap_or(false)
+        {
+            compiled_code.value_labels_ranges.clone()
+        } else {
+            Default::default()
+        };
+
         let unwind_info = if isa.flags().unwind_info() {
             compiled_code
                 .create_unwind_info(isa)
@@ -1177,17 +1065,26 @@ impl Compiler {
         } else {
             None
         };
+        let stack_maps = mach_stack_maps_to_stack_maps(compiled_code.buffer.stack_maps());
+        let sized_stack_slots = std::mem::take(&mut context.func.sized_stack_slots);
+        self.compiler.contexts.lock().unwrap().push(self.cx);
 
-        Ok(CompiledFunction {
-            body: code_buf,
-            unwind_info,
-            relocations,
-            sized_stack_slots: Default::default(),
-            value_labels_ranges: Default::default(),
-            address_map: Default::default(),
-            traps,
-            alignment,
-        })
+        Ok((
+            WasmFunctionInfo {
+                start_srcloc: address_map.start_srcloc,
+                stack_maps: stack_maps.into(),
+            },
+            CompiledFunction {
+                body: code_buf,
+                unwind_info,
+                relocations,
+                sized_stack_slots,
+                value_labels_ranges,
+                address_map,
+                traps,
+                alignment,
+            },
+        ))
     }
 }
 

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1,7 +1,6 @@
 //! Compilation support for the component model.
 
-use crate::compiler::{Compiler, CompilerContext};
-use crate::CompiledFunction;
+use crate::compiler::Compiler;
 use anyhow::Result;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags};
 use cranelift_frontend::FunctionBuilder;
@@ -31,14 +30,9 @@ impl Compiler {
         let pointer_type = isa.pointer_type();
         let offsets = VMComponentOffsets::new(isa.pointer_bytes(), component);
 
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            mut incremental_cache_ctx,
-            validator_allocations,
-        } = self.take_context();
+        let mut compiler = self.function_compiler();
 
-        context.func = ir::Function::with_name_signature(
+        let func = ir::Function::with_name_signature(
             ir::UserFuncName::user(0, 0),
             match abi {
                 Abi::Wasm => crate::wasm_call_signature(isa, wasm_func_ty),
@@ -46,12 +40,7 @@ impl Compiler {
                 Abi::Array => crate::array_call_signature(isa),
             },
         );
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let (mut builder, block0) = compiler.builder(func);
 
         // Start off by spilling all the wasm arguments into a stack slot to be
         // passed to the host function.
@@ -199,15 +188,7 @@ impl Compiler {
         }
         builder.finalize();
 
-        let func: CompiledFunction =
-            self.finish_trampoline(&mut context, incremental_cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func))
+        Ok(Box::new(compiler.finish()?))
     }
 
     fn compile_always_trap_for_abi(
@@ -216,13 +197,8 @@ impl Compiler {
         abi: Abi,
     ) -> Result<Box<dyn Any + Send>> {
         let isa = &*self.isa;
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            mut incremental_cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-        context.func = ir::Function::with_name_signature(
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(
             ir::UserFuncName::user(0, 0),
             match abi {
                 Abi::Wasm => crate::wasm_call_signature(isa, ty),
@@ -230,25 +206,13 @@ impl Compiler {
                 Abi::Array => crate::array_call_signature(isa),
             },
         );
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let (mut builder, _block0) = compiler.builder(func);
         builder
             .ins()
             .trap(ir::TrapCode::User(super::ALWAYS_TRAP_CODE));
         builder.finalize();
 
-        let func: CompiledFunction =
-            self.finish_trampoline(&mut context, incremental_cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func))
+        Ok(Box::new(compiler.finish()?))
     }
 
     fn compile_transcoder_for_abi(
@@ -261,15 +225,8 @@ impl Compiler {
         let ty = &types[transcoder.signature];
         let isa = &*self.isa;
         let offsets = VMComponentOffsets::new(isa.pointer_bytes(), component);
-
-        let CompilerContext {
-            mut func_translator,
-            codegen_context: mut context,
-            mut incremental_cache_ctx,
-            validator_allocations,
-        } = self.take_context();
-
-        context.func = ir::Function::with_name_signature(
+        let mut compiler = self.function_compiler();
+        let func = ir::Function::with_name_signature(
             ir::UserFuncName::user(0, 0),
             match abi {
                 Abi::Wasm => crate::wasm_call_signature(isa, ty),
@@ -277,12 +234,7 @@ impl Compiler {
                 Abi::Array => crate::array_call_signature(isa),
             },
         );
-
-        let mut builder = FunctionBuilder::new(&mut context.func, func_translator.context());
-        let block0 = builder.create_block();
-        builder.append_block_params_for_function_params(block0);
-        builder.switch_to_block(block0);
-        builder.seal_block(block0);
+        let (mut builder, block0) = compiler.builder(func);
 
         match abi {
             Abi::Wasm => {
@@ -298,15 +250,7 @@ impl Compiler {
         }
 
         builder.finalize();
-        let func: CompiledFunction =
-            self.finish_trampoline(&mut context, incremental_cache_ctx.as_mut(), isa)?;
-        self.save_context(CompilerContext {
-            func_translator,
-            codegen_context: context,
-            incremental_cache_ctx,
-            validator_allocations,
-        });
-        Ok(Box::new(func))
+        Ok(Box::new(compiler.finish()?))
     }
 }
 


### PR DESCRIPTION
Move the setup/teardown of contexts for each function's compile into a new `FunctionCompiler` structure which handles more internally between trampolines and normal wasm functions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
