### PR TITLE
Add an `--emit-clif` option to `wasmtime compile`

### DIFF
--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -14,6 +14,7 @@ use std::any::Any;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt;
+use std::path;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -88,6 +89,11 @@ pub trait CacheStore: Send + Sync + std::fmt::Debug {
 pub trait CompilerBuilder: Send + Sync + fmt::Debug {
     /// Sets the target of compilation to the target specified.
     fn target(&mut self, target: target_lexicon::Triple) -> Result<()>;
+
+    /// Enables clif output in the directory specified.
+    fn clif_dir(&mut self, _path: &path::Path) -> Result<()> {
+        anyhow::bail!("clif output not supported");
+    }
 
     /// Returns the currently configured target triple that compilation will
     /// produce artifacts for.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -112,6 +112,7 @@ struct CompilerConfig {
     flags: HashSet<String>,
     #[cfg(compiler)]
     cache_store: Option<Arc<dyn CacheStore>>,
+    clif_dir: Option<std::path::PathBuf>,
 }
 
 #[cfg(compiler)]
@@ -123,6 +124,7 @@ impl CompilerConfig {
             settings: HashMap::new(),
             flags: HashSet::new(),
             cache_store: None,
+            clif_dir: None,
         }
     }
 
@@ -1539,6 +1541,10 @@ impl Config {
             compiler.target(target.clone())?;
         }
 
+        if let Some(path) = &self.compiler_config.clif_dir {
+            compiler.clif_dir(path)?;
+        }
+
         // If probestack is enabled for a target, Wasmtime will always use the
         // inline strategy which doesn't require us to define a `__probestack`
         // function or similar.
@@ -1623,6 +1629,12 @@ impl Config {
     pub fn debug_adapter_modules(&mut self, debug: bool) -> &mut Self {
         self.tunables.debug_adapter_modules = debug;
         self
+    }
+
+    /// Enables clif output when compiling a WebAssembly module.
+    #[cfg(compiler)]
+    pub fn emit_clif(&mut self, path: &Path) {
+        self.compiler_config.clif_dir = Some(path.to_path_buf());
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-#[cfg(feature = "cache")]
+#[cfg(any(feature = "cache", compiler))]
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -66,11 +66,19 @@ impl CompileCommand {
 
         let mut config = self.common.config(self.target.as_deref())?;
 
-        if let Some(dir) = self.emit_clif {
-            if !dir.is_dir() {
-                std::fs::create_dir(&dir)?;
+        if let Some(path) = self.emit_clif {
+            if !path.exists() {
+                std::fs::create_dir(&path)?;
             }
-            config.emit_clif(&dir);
+
+            if !path.is_dir() {
+                bail!(
+                    "the path passed for '--emit-clif' ({}) must be a directory",
+                    path.display()
+                );
+            }
+
+            config.emit_clif(&path);
         }
 
         let engine = Engine::new(&config)?;

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -50,6 +50,10 @@ pub struct CompileCommand {
     #[clap(short = 'o', long, value_name = "OUTPUT", parse(from_os_str))]
     output: Option<PathBuf>,
 
+    /// Emit one clif file for each function in this directory
+    #[clap(long = "emit-clif", value_name = "PATH", parse(from_os_str))]
+    emit_clif: Option<PathBuf>,
+
     /// The path of the WebAssembly to compile
     #[clap(index = 1, value_name = "MODULE", parse(from_os_str))]
     module: PathBuf,
@@ -60,7 +64,14 @@ impl CompileCommand {
     pub fn execute(mut self) -> Result<()> {
         self.common.init_logging();
 
-        let config = self.common.config(self.target.as_deref())?;
+        let mut config = self.common.config(self.target.as_deref())?;
+
+        if let Some(dir) = self.emit_clif {
+            if !dir.is_dir() {
+                std::fs::create_dir(&dir)?;
+            }
+            config.emit_clif(&dir);
+        }
 
         let engine = Engine::new(&config)?;
 

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -50,7 +50,7 @@ pub struct CompileCommand {
     #[clap(short = 'o', long, value_name = "OUTPUT", parse(from_os_str))]
     output: Option<PathBuf>,
 
-    /// Emit one clif file for each function in this directory
+    /// The directory path to write clif files into, one clif file per wasm function.
     #[clap(long = "emit-clif", value_name = "PATH", parse(from_os_str))]
     emit_clif: Option<PathBuf>,
 


### PR DESCRIPTION
Add the `--emit-clif <PATH>` option to `wasmtime compile`, making it easier to inspect the intermediate clif produced when compiling a wasm module. The path argument is a directory that will be created if its missing, and it will be populated with files named `wasm_func_<idx>.clif`, where `<idx>` is the function index in the wasm module.

Currently this option is only supported when using cranelift to compile a wasm module, and an error will be raised if winch is used instead.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
