### PR TITLE
Fix tests in `--release` mode

### DIFF
--- a/cranelift/codegen/src/ir/builder.rs
+++ b/cranelift/codegen/src/ir/builder.rs
@@ -218,7 +218,7 @@ mod tests {
     use crate::cursor::{Cursor, FuncCursor};
     use crate::ir::condcodes::*;
     use crate::ir::types::*;
-    use crate::ir::{Function, InstBuilder, Opcode, TrapCode, ValueDef};
+    use crate::ir::{Function, InstBuilder, ValueDef};
 
     #[test]
     fn types() {
@@ -266,7 +266,10 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(debug_assertions)]
     fn panics_when_inserting_wrong_opcode() {
+        use crate::ir::{Opcode, TrapCode};
+
         let mut func = Function::new();
         let block0 = func.dfg.make_block();
         let mut pos = FuncCursor::new(&mut func);

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -254,6 +254,7 @@ mod tests {
             }
 
             #[should_panic]
+            #[cfg(debug_assertions)]
             #[test]
             fn cannot_construct_from_reserved_u32() {
                 use crate::packed_option::ReservedValue;
@@ -262,6 +263,7 @@ mod tests {
             }
 
             #[should_panic]
+            #[cfg(debug_assertions)]
             #[test]
             fn cannot_construct_from_reserved_usize() {
                 use crate::packed_option::ReservedValue;


### PR DESCRIPTION
Add `#[cfg]` annotations to some tests which rely on `debug_assert!` for panics.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
