### PR TITLE
aarch64: Fix usage of `load_addr` in `inst.isle`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3052,35 +3052,20 @@
             (_ Unit (emit (MInst.LoadExtName dst extname offset))))
         dst))
 
-;; Helper for emitting `MInst.LoadAddr` instructions.
-(decl load_addr (AMode) Reg)
-
-(rule (load_addr (AMode.UnsignedOffset r imm))
-      (if (is_zero_uimm12 imm))
-      r)
-
-(rule (load_addr (AMode.Unscaled r imm))
-      (if (is_zero_simm9 imm))
-      r)
-
-(rule (load_addr (AMode.RegOffset r 0 _)) r)
-(rule (load_addr (AMode.FPOffset 0 _)) (fp_reg))
-(rule (load_addr (AMode.SPOffset 0 _)) (stack_reg))
-
-(rule -1 (load_addr addr)
-      (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.LoadAddr dst addr))))
-        dst))
-
 ;; Lower the address of a load or a store.
 (decl amode (Type Value u32) AMode)
 ;; TODO: Port lower_address() to ISLE.
 (extern constructor amode amode)
 
-(decl sink_load_into_amode (Type Inst) AMode)
-(rule (sink_load_into_amode ty x @ (load _ addr offset))
+(decl sink_load_into_addr (Type Inst) Reg)
+(rule (sink_load_into_addr ty x @ (load _ addr (offset32 offset)))
       (let ((_ Unit (sink_inst x)))
-           (amode ty addr offset)))
+        (add_imm_to_addr addr offset)))
+
+(decl add_imm_to_addr (Reg u64) Reg)
+(rule 2 (add_imm_to_addr val 0) val)
+(rule 1 (add_imm_to_addr val (imm12_from_u64 imm)) (add_imm $I64 val imm))
+(rule 0 (add_imm_to_addr val offset) (add $I64 val (imm $I64 (ImmExtend.Zero) offset)))
 
 ;; Lower a constant f32.
 ;;

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2033,9 +2033,8 @@
 
 (rule (lower (has_type ty (splat x @ (load flags _ _))))
       (if-let mem_op (is_sinkable_inst x))
-      (let ((addr AMode (sink_load_into_amode (lane_type ty) mem_op))
-             (address Reg (load_addr addr)))
-            (ld1r address (vector_size ty) flags)))
+      (let ((addr Reg (sink_load_into_addr (lane_type ty) mem_op)))
+            (ld1r addr (vector_size ty) flags)))
 
 ;;;; Rules for `AtomicLoad` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (valid_atomic_transaction ty) (atomic_load flags addr)))
@@ -2604,7 +2603,7 @@
             ;; cset    out_of, ne
             (a_ext Reg (put_in_reg_ext32 a arg_ext))
             (out Reg (alu_rrr_extend alu_op ty a_ext b extend))
-            (out_of Reg (with_flags_reg 
+            (out_of Reg (with_flags_reg
                   (cmp_extend (OperandSize.Size32) out out extend)
                   (cset (Cond.Ne)))))
       (output_pair
@@ -2644,11 +2643,11 @@
            (y_lo Reg (value_regs_get y_regs 0))
            (y_hi Reg (value_regs_get y_regs 1)))
         ;; cannot use the with_flags helper here but it should be fine right now
-        (let    
+        (let
             ((lo_inst ProducesFlags (alu_rrr_with_flags_paired $I64 x_lo y_lo alu_op1))
              (hi_inst ConsumesAndProducesFlags (alu_rrr_with_flags_chained $I64 x_hi y_hi alu_op2))
              (of_inst ConsumesFlags (cset_paired cond))
-             
+
              (result MultiReg (with_flags_chained lo_inst hi_inst of_inst)))
             (multi_reg_to_pair_and_single result)))
 )
@@ -2741,7 +2740,7 @@
              (a_uext Reg (put_in_reg_zext32 a))
              (b_uext Reg (put_in_reg_zext32 b))
              (out Reg (madd ty a_uext b_uext (zero_reg)))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp_extend (OperandSize.Size32) out out extend)
                    (cset (Cond.Ne)))))
        (output_pair
@@ -2754,7 +2753,7 @@
 (rule 2 (lower (has_type $I32 (umul_overflow a b)))
        (let (
              (out Reg (umaddl a b (zero_reg)))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp_extend (OperandSize.Size64) out out (ExtendOp.UXTW))
                    (cset (Cond.Ne)))))
        (output_pair
@@ -2769,7 +2768,7 @@
        (let (
              (out Reg (madd $I64 a b (zero_reg)))
              (tmp Reg (umulh $I64 a b))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp64_imm tmp (u8_into_imm12 0))
                    (cset (Cond.Ne)))))
        (output_pair
@@ -2789,7 +2788,7 @@
              (a_sext Reg (put_in_reg_sext32 a))
              (b_sext Reg (put_in_reg_sext32 b))
              (out Reg (madd ty a_sext b_sext (zero_reg)))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp_extend (OperandSize.Size32) out out extend)
                    (cset (Cond.Ne)))))
        (output_pair
@@ -2802,7 +2801,7 @@
 (rule 2 (lower (has_type $I32 (smul_overflow a b)))
        (let (
              (out Reg (smaddl a b (zero_reg)))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp_extend (OperandSize.Size64) out out (ExtendOp.SXTW))
                    (cset (Cond.Ne)))))
        (output_pair
@@ -2817,7 +2816,7 @@
        (let (
              (out Reg (madd $I64 a b (zero_reg)))
              (tmp Reg (smulh $I64 a b))
-             (out_of Reg (with_flags_reg 
+             (out_of Reg (with_flags_reg
                    (cmp_rr_shift_asr (OperandSize.Size64) tmp out 63)
                    (cset (Cond.Ne)))))
        (output_pair

--- a/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
@@ -1,0 +1,128 @@
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+function %splat_load(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i64 v0
+    v2 = splat.i64x2 v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   ld1r { v0.2d }, [x0]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ld1r {v0.2d}, [x0]
+;   ret
+
+function %splat_load2(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i64 v0+100
+    v2 = splat.i64x2 v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   add x2, x0, #100
+;   ld1r { v0.2d }, [x2]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x2, x0, #0x64
+;   ld1r {v0.2d}, [x2]
+;   ret
+
+function %splat_load3(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = load.i64 v0+0xfff0000
+    v2 = splat.i64x2 v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   movz x2, #4095, LSL #16
+;   add x4, x0, x2
+;   ld1r { v0.2d }, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x2, #0xfff0000
+;   add x4, x0, x2
+;   ld1r {v0.2d}, [x4]
+;   ret
+
+function %splat_load4(i64, i64) -> i64x2 {
+block0(v0: i64, v1: i64):
+    v2 = iadd v0, v1
+    v3 = load.i64 v2
+    v4 = splat.i64x2 v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   add x4, x0, x1
+;   ld1r { v0.2d }, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x4, x0, x1
+;   ld1r {v0.2d}, [x4]
+;   ret
+
+function %splat_load5(i64, i64) -> i64x2 {
+block0(v0: i64, v1: i64):
+    v2 = iadd v0, v1
+    v3 = load.i64 v2+100
+    v4 = splat.i64x2 v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   add x5, x0, x1
+;   add x4, x5, #100
+;   ld1r { v0.2d }, [x4]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   add x5, x0, x1
+;   add x4, x5, #0x64
+;   ld1r {v0.2d}, [x4]
+;   ret
+
+function %splat_load6(i64, i64) -> i64x2 {
+block0(v0: i64, v1: i64):
+    v2 = imul_imm v1, 2
+    v3 = iadd v0, v2
+    v4 = load.i64 v3+100
+    v5 = splat.i64x2 v4
+    return v5
+}
+
+; VCode:
+; block0:
+;   movz x6, #2
+;   madd x6, x1, x6, x0
+;   add x5, x6, #100
+;   ld1r { v0.2d }, [x5]
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   mov x6, #2
+;   madd x6, x1, x6, x0
+;   add x5, x6, #0x64
+;   ld1r {v0.2d}, [x5]
+;   ret
+


### PR DESCRIPTION
This fixes an issue in the AArch64 backend where a `load_addr` helper was used exclusively for lowering `splat`-of-a-loaded-address. This helper expanded in some cases to a pseudo-`LoadAddr` instruction but the lowering of this instruction doesn't actually exhaustively handle all `AMode` values.

The fix in this commit is to remove the `load_addr` helper altogether to remove the need to go from an `AMode` back to a `Reg`, instead going directly from an address to a register. The one small wrinkle is a small helper now to add the immediate offset to the address register, but that's not too too bad to write.

By avoiding the `LoadAddr` instruction the unimplemented cases aren't hit, so the codegen issue should be fixed.

Closes #6313

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
