### PR TITLE
Update test case generation for component_api fuzzer

### DIFF
--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -6,10 +6,10 @@ fn main() -> anyhow::Result<()> {
 
 mod component {
     use anyhow::{anyhow, Context, Error, Result};
-    use arbitrary::{Arbitrary, Unstructured};
-    use component_fuzz_util::{self, Declarations, TestCase};
+    use arbitrary::Unstructured;
+    use component_fuzz_util::{self, Declarations, TestCase, Type, MAX_TYPE_DEPTH};
     use proc_macro2::TokenStream;
-    use quote::{format_ident, quote};
+    use quote::quote;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
     use std::env;
@@ -50,27 +50,62 @@ mod component {
 
         let mut rng = StdRng::seed_from_u64(seed);
 
+        const TYPE_COUNT: usize = 50;
+        const MAX_ARITY: u32 = 5;
         const TEST_CASE_COUNT: usize = 100;
 
+        let mut type_fuel = 1000;
+        let mut types = Vec::new();
+        let name_counter = &mut 0;
+        let mut declarations = TokenStream::new();
         let mut tests = TokenStream::new();
 
-        let name_counter = &mut 0;
-
-        let mut declarations = TokenStream::new();
-
-        for index in 0..TEST_CASE_COUNT {
-            let mut bytes = Vec::new();
-
-            let case = loop {
-                let count = rng.gen_range(1000..2000);
-                bytes.extend(iter::repeat_with(|| rng.gen::<u8>()).take(count));
-
-                match TestCase::arbitrary(&mut Unstructured::new(&bytes)) {
-                    Ok(case) => break case,
-                    Err(arbitrary::Error::NotEnoughData) => (),
-                    Err(error) => return Err(Error::from(error)),
+        // First generate a set of type to select from.
+        for _ in 0..TYPE_COUNT {
+            let ty = gen(&mut rng, |u| {
+                // Only discount fuel if the generation was successful,
+                // otherwise we'll get more random data and try again.
+                let mut fuel = type_fuel;
+                let ret = Type::generate(u, MAX_TYPE_DEPTH, &mut fuel);
+                if ret.is_ok() {
+                    type_fuel = fuel;
                 }
-            };
+                ret
+            })?;
+
+            let name = component_fuzz_util::rust_type(&ty, name_counter, &mut declarations);
+            types.push((name, ty));
+        }
+
+        // Next generate a set of static API test cases driven by the above
+        // types.
+        for index in 0..TEST_CASE_COUNT {
+            let (case, rust_params, rust_results) = gen(&mut rng, |u| {
+                let mut params = Vec::new();
+                let mut results = Vec::new();
+                let mut rust_params = TokenStream::new();
+                let mut rust_results = TokenStream::new();
+                for _ in 0..u.int_in_range(0..=MAX_ARITY)? {
+                    let (name, ty) = u.choose(&types)?;
+                    params.push(ty);
+                    rust_params.extend(name.clone());
+                    rust_params.extend(quote!(,));
+                }
+                for _ in 0..u.int_in_range(0..=MAX_ARITY)? {
+                    let (name, ty) = u.choose(&types)?;
+                    results.push(ty);
+                    rust_results.extend(name.clone());
+                    rust_results.extend(quote!(,));
+                }
+
+                let case = TestCase {
+                    params,
+                    results,
+                    encoding1: u.arbitrary()?,
+                    encoding2: u.arbitrary()?,
+                };
+                Ok((case, rust_params, rust_results))
+            })?;
 
             let Declarations {
                 types,
@@ -81,27 +116,7 @@ mod component {
                 encoding2,
             } = case.declarations();
 
-            let test = format_ident!("static_api_test{}", case.params.len());
-
-            let rust_params = case
-                .params
-                .iter()
-                .map(|ty| {
-                    let ty = component_fuzz_util::rust_type(&ty, name_counter, &mut declarations);
-                    quote!(#ty,)
-                })
-                .collect::<TokenStream>();
-
-            let rust_results = case
-                .results
-                .iter()
-                .map(|ty| {
-                    let ty = component_fuzz_util::rust_type(&ty, name_counter, &mut declarations);
-                    quote!(#ty,)
-                })
-                .collect::<TokenStream>();
-
-            let test = quote!(#index => component_types::#test::<#rust_params (#rust_results)>(
+            let test = quote!(#index => component_types::static_api_test::<(#rust_params), (#rust_results)>(
                 input,
                 {
                     static DECLS: Declarations = Declarations {
@@ -154,5 +169,22 @@ mod component {
         write!(out, "{module}")?;
 
         Ok(())
+    }
+
+    fn gen<T>(
+        rng: &mut StdRng,
+        mut f: impl FnMut(&mut Unstructured<'_>) -> arbitrary::Result<T>,
+    ) -> Result<T> {
+        let mut bytes = Vec::new();
+        loop {
+            let count = rng.gen_range(1000..2000);
+            bytes.extend(iter::repeat_with(|| rng.gen::<u8>()).take(count));
+
+            match f(&mut Unstructured::new(&bytes)) {
+                Ok(ret) => break Ok(ret),
+                Err(arbitrary::Error::NotEnoughData) => (),
+                Err(error) => break Err(Error::from(error)),
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit updates the test case generation for the `component_api` fuzzer to prepare for an update to the `arbitrary` crate. The current algorithm, with the latest `arbitrary` crate, generates a 20MB source file which is a bit egregious. The goal here was to get that under control by altering the parameters of test case generation and additionally changing the structure of what's generated.

The new strategy is to have a limited set of "type fuel" which is consumed as a type is generated. This bounds the maximal size of a type in addition to its depth as prior. Additionally a fixed set of types are generated first and then test cases select from these types as opposed to test cases always generating types for themselves. Coupled together this brings the size of the generated file back into the 200K range as it was before.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
