### PR TITLE
Fix mutability warnings on Nightly rust

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -695,7 +695,7 @@ impl<I: VCodeInst> MachBuffer<I> {
         //    (end of buffer)
         self.data.truncate(b.start as usize);
         self.fixup_records.truncate(b.fixup);
-        while let Some(mut last_srcloc) = self.srclocs.last_mut() {
+        while let Some(last_srcloc) = self.srclocs.last_mut() {
             if last_srcloc.end <= b.start {
                 break;
             }

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -188,7 +188,7 @@ impl crate::types::Host for WasiHttp {
         &mut self,
         request: OutgoingRequest,
     ) -> wasmtime::Result<Result<OutgoingStream, ()>> {
-        let mut req = self
+        let req = self
             .requests
             .get_mut(&request)
             .ok_or_else(|| anyhow!("unknown request: {request}"))?;

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -435,7 +435,7 @@ fn test_custom_memory_limiter() -> Result<()> {
         "",
         "alloc",
         |mut caller: Caller<'_, MemoryContext>, size: u32| -> u32 {
-            let mut ctx = caller.data_mut();
+            let ctx = caller.data_mut();
             let size = size as usize;
 
             if size + ctx.host_memory_used + ctx.wasm_memory_used <= ctx.memory_limit {
@@ -552,7 +552,7 @@ async fn test_custom_memory_limiter_async() -> Result<()> {
         "",
         "alloc",
         |mut caller: Caller<'_, MemoryContext>, size: u32| -> u32 {
-            let mut ctx = caller.data_mut();
+            let ctx = caller.data_mut();
             let size = size as usize;
 
             if size + ctx.host_memory_used + ctx.wasm_memory_used <= ctx.memory_limit {


### PR DESCRIPTION
Looks like some warnings have improved so remove some unused `mut` annotations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
