### PR TITLE
riscv64: Fix select.i64+icmp.i128 lowering

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -731,7 +731,7 @@
   (gen_select ty (truthy_to_reg cty (normalize_cmp_value cty c (ExtendOp.Zero))) x y))
 
 (rule 1
-  (lower (has_type (fits_in_64 ty) (select (icmp cc a b @ (value_type in_ty)) x y)))
+  (lower (has_type (fits_in_64 ty) (select (icmp cc a b @ (value_type (fits_in_64 in_ty))) x y)))
   (let ((a Reg (normalize_cmp_value in_ty a (intcc_to_extend_op cc)))
         (b Reg (normalize_cmp_value in_ty b (intcc_to_extend_op cc))))
     (gen_select_reg cc a b x y)))

--- a/cranelift/filetests/filetests/runtests/i128-select.clif
+++ b/cranelift/filetests/filetests/runtests/i128-select.clif
@@ -35,3 +35,13 @@ block0(v0: i128, v1: i128, v2: i128):
 ; run: %i128_cond_select(1, 0x00000000_00000000_DECAFFFF_C0FFEEEE, 0xFFFFFFFF_FFFFFFFF_C0FFEEEE_DECAFFFF) == 0x00000000_00000000_DECAFFFF_C0FFEEEE
 ; run: %i128_cond_select(0, 0x00000000_00000000_DECAFFFF_C0FFEEEE, 0xFFFFFFFF_FFFFFFFF_C0FFEEEE_DECAFFFF) == 0xFFFFFFFF_FFFFFFFF_C0FFEEEE_DECAFFFF
 ; run: %i128_cond_select(0x1_00000000_00000000, 2, 3) == 2
+
+; See: https://github.com/bytecodealliance/wasmtime/issues/6312
+function %i128_select_of_icmp(i64, i64, i128, i128) -> i64, i8 {
+block0(v0: i64, v1: i64, v2: i128,  v3: i128):
+    v4 = icmp.i128 sle v3, v2
+    v6 = select.i64 v4, v1, v0
+    return v6, v4
+}
+
+; run: %i128_select_of_icmp(0, 13724266, 0, 142088073609408121139349355241191013256) == [0, 0]


### PR DESCRIPTION
👋 Hey,

This fixes #6312. We were accidentally selecting an optimized lowering when the icmp was i128bit. `gen_select_reg` lowers the comparison, but only looking at the bottom registers since it works with `Reg`'s and not `ValueRegs`.

I think this bug was also in part introduced by a rule that we have (in the RISC-V backend) that auto converts `ValueRegs` into `Reg` silently.