### PR TITLE
Split out platform-specific logic for `Mmap`

### DIFF
--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -1,44 +1,33 @@
 //! Low-level abstraction for allocating and managing zero-filled pages
 //! of memory.
 
-use anyhow::anyhow;
 use anyhow::{Context, Result};
-use std::convert::TryFrom;
 use std::fs::File;
 use std::ops::Range;
 use std::path::Path;
-use std::ptr;
-use std::slice;
 use std::sync::Arc;
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        mod windows;
+        use windows as sys;
+    } else {
+        mod unix;
+        use unix as sys;
+    }
+}
 
 /// A simple struct consisting of a page-aligned pointer to page-aligned
 /// and initially-zeroed memory and a length.
 #[derive(Debug)]
 pub struct Mmap {
-    // Note that this is stored as a `usize` instead of a `*const` or `*mut`
-    // pointer to allow this structure to be natively `Send` and `Sync` without
-    // `unsafe impl`. This type is sendable across threads and shareable since
-    // the coordination all happens at the OS layer.
-    ptr: usize,
-    len: usize,
+    sys: sys::Mmap,
     file: Option<Arc<File>>,
 }
 
 impl Mmap {
-    /// Construct a new empty instance of `Mmap`.
-    pub fn new() -> Self {
-        // Rust's slices require non-null pointers, even when empty. `Vec`
-        // contains code to create a non-null dangling pointer value when
-        // constructed empty, so we reuse that here.
-        let empty = Vec::<u8>::new();
-        Self {
-            ptr: empty.as_ptr() as usize,
-            len: 0,
-            file: None,
-        }
-    }
-
-    /// Create a new `Mmap` pointing to at least `size` bytes of page-aligned accessible memory.
+    /// Create a new `Mmap` pointing to at least `size` bytes of page-aligned
+    /// accessible memory.
     pub fn with_at_least(size: usize) -> Result<Self> {
         let page_size = crate::page_size();
         let rounded_size = (size + (page_size - 1)) & !(page_size - 1);
@@ -55,326 +44,134 @@ impl Mmap {
     /// The memory mapping and the length of the file within the mapping are
     /// returned.
     pub fn from_file(path: &Path) -> Result<Self> {
-        #[cfg(unix)]
-        {
-            let file = File::open(path).context("failed to open file")?;
-            let len = file
-                .metadata()
-                .context("failed to get file metadata")?
-                .len();
-            let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
-            let ptr = unsafe {
-                rustix::mm::mmap(
-                    ptr::null_mut(),
-                    len,
-                    rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
-                    rustix::mm::MapFlags::PRIVATE,
-                    &file,
-                    0,
-                )
-                .context(format!("mmap failed to allocate {:#x} bytes", len))?
-            };
+        let (sys, file) = sys::Mmap::from_file(path)?;
+        Ok(Mmap {
+            sys,
+            file: Some(Arc::new(file)),
+        })
+    }
 
-            Ok(Self {
-                ptr: ptr as usize,
-                len,
-                file: Some(Arc::new(file)),
+    /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned
+    /// accessible memory, within a reserved mapping of `mapping_size` bytes.
+    /// `accessible_size` and `mapping_size` must be native page-size multiples.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `accessible_size` is greater than
+    /// `mapping_size` or if either of them are not page-aligned.
+    pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
+        let page_size = crate::page_size();
+        assert!(accessible_size <= mapping_size);
+        assert_eq!(mapping_size & (page_size - 1), 0);
+        assert_eq!(accessible_size & (page_size - 1), 0);
+
+        if mapping_size == 0 {
+            Ok(Mmap {
+                sys: sys::Mmap::new_empty(),
+                file: None,
             })
-        }
-
-        #[cfg(windows)]
-        {
-            use std::fs::OpenOptions;
-            use std::io;
-            use std::os::windows::prelude::*;
-            use windows_sys::Win32::Foundation::*;
-            use windows_sys::Win32::Storage::FileSystem::*;
-            use windows_sys::Win32::System::Memory::*;
-
-            unsafe {
-                // Open the file with read/execute access and only share for
-                // read. This will enable us to perform the proper mmap below
-                // while also disallowing other processes modifying the file
-                // and having those modifications show up in our address space.
-                let file = OpenOptions::new()
-                    .read(true)
-                    .access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE)
-                    .share_mode(FILE_SHARE_READ)
-                    .open(path)
-                    .context("failed to open file")?;
-
-                let len = file
-                    .metadata()
-                    .context("failed to get file metadata")?
-                    .len();
-                let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
-
-                // Create a file mapping that allows PAGE_EXECUTE_WRITECOPY.
-                // This enables up-to these permissions but we won't leave all
-                // of these permissions active at all times. Execution is
-                // necessary for the generated code from Cranelift and the
-                // WRITECOPY part is needed for possibly resolving relocations,
-                // but otherwise writes don't happen.
-                let mapping = CreateFileMappingW(
-                    file.as_raw_handle() as isize,
-                    ptr::null_mut(),
-                    PAGE_EXECUTE_WRITECOPY,
-                    0,
-                    0,
-                    ptr::null(),
-                );
-                if mapping == 0 {
-                    return Err(io::Error::last_os_error())
-                        .context("failed to create file mapping");
-                }
-
-                // Create a view for the entire file using all our requisite
-                // permissions so that we can change the virtual permissions
-                // later on.
-                let ptr = MapViewOfFile(
-                    mapping,
-                    FILE_MAP_READ | FILE_MAP_EXECUTE | FILE_MAP_COPY,
-                    0,
-                    0,
-                    len,
-                ) as *mut std::ffi::c_void;
-                let err = io::Error::last_os_error();
-                CloseHandle(mapping);
-                if ptr.is_null() {
-                    return Err(err)
-                        .context(format!("failed to create map view of {:#x} bytes", len));
-                }
-
-                let ret = Self {
-                    ptr: ptr as usize,
-                    len,
-                    file: Some(Arc::new(file)),
-                };
-
-                // Protect the entire file as PAGE_WRITECOPY to start (i.e.
-                // remove the execute bit)
-                let mut old = 0;
-                if VirtualProtect(ret.ptr as *mut _, ret.len, PAGE_WRITECOPY, &mut old) == 0 {
-                    return Err(io::Error::last_os_error())
-                        .context("failed change pages to `PAGE_READONLY`");
-                }
-
-                Ok(ret)
-            }
-        }
-    }
-
-    /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,
-    /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
-    /// must be native page-size multiples.
-    #[cfg(not(target_os = "windows"))]
-    pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
-        let page_size = crate::page_size();
-        assert!(accessible_size <= mapping_size);
-        assert_eq!(mapping_size & (page_size - 1), 0);
-        assert_eq!(accessible_size & (page_size - 1), 0);
-
-        // Mmap may return EINVAL if the size is zero, so just
-        // special-case that.
-        if mapping_size == 0 {
-            return Ok(Self::new());
-        }
-
-        Ok(if accessible_size == mapping_size {
-            // Allocate a single read-write region at once.
-            let ptr = unsafe {
-                rustix::mm::mmap_anonymous(
-                    ptr::null_mut(),
-                    mapping_size,
-                    rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
-                    rustix::mm::MapFlags::PRIVATE,
-                )
-                .context(format!("mmap failed to allocate {:#x} bytes", mapping_size))?
-            };
-
-            Self {
-                ptr: ptr as usize,
-                len: mapping_size,
+        } else if accessible_size == mapping_size {
+            Ok(Mmap {
+                sys: sys::Mmap::new(mapping_size)
+                    .context(format!("mmap failed to allocate {mapping_size:#x} bytes"))?,
                 file: None,
-            }
+            })
         } else {
-            // Reserve the mapping size.
-            let ptr = unsafe {
-                rustix::mm::mmap_anonymous(
-                    ptr::null_mut(),
-                    mapping_size,
-                    rustix::mm::ProtFlags::empty(),
-                    rustix::mm::MapFlags::PRIVATE,
-                )
-                .context(format!("mmap failed to allocate {:#x} bytes", mapping_size))?
-            };
-
-            let mut result = Self {
-                ptr: ptr as usize,
-                len: mapping_size,
+            let mut result = Mmap {
+                sys: sys::Mmap::reserve(mapping_size)
+                    .context(format!("mmap failed to reserve {mapping_size:#x} bytes"))?,
                 file: None,
             };
-
-            if accessible_size != 0 {
-                // Commit the accessible size.
-                result.make_accessible(0, accessible_size)?;
-            }
-
-            result
-        })
-    }
-
-    /// Create a new `Mmap` pointing to `accessible_size` bytes of page-aligned accessible memory,
-    /// within a reserved mapping of `mapping_size` bytes. `accessible_size` and `mapping_size`
-    /// must be native page-size multiples.
-    #[cfg(target_os = "windows")]
-    pub fn accessible_reserved(accessible_size: usize, mapping_size: usize) -> Result<Self> {
-        use anyhow::bail;
-        use std::io;
-        use windows_sys::Win32::System::Memory::*;
-
-        if mapping_size == 0 {
-            return Ok(Self::new());
+            result.make_accessible(0, accessible_size)?;
+            Ok(result)
         }
-
-        let page_size = crate::page_size();
-        assert!(accessible_size <= mapping_size);
-        assert_eq!(mapping_size & (page_size - 1), 0);
-        assert_eq!(accessible_size & (page_size - 1), 0);
-
-        Ok(if accessible_size == mapping_size {
-            // Allocate a single read-write region at once.
-            let ptr = unsafe {
-                VirtualAlloc(
-                    ptr::null_mut(),
-                    mapping_size,
-                    MEM_RESERVE | MEM_COMMIT,
-                    PAGE_READWRITE,
-                )
-            };
-            if ptr.is_null() {
-                bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
-            }
-
-            Self {
-                ptr: ptr as usize,
-                len: mapping_size,
-                file: None,
-            }
-        } else {
-            // Reserve the mapping size.
-            let ptr =
-                unsafe { VirtualAlloc(ptr::null_mut(), mapping_size, MEM_RESERVE, PAGE_NOACCESS) };
-            if ptr.is_null() {
-                bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
-            }
-
-            let mut result = Self {
-                ptr: ptr as usize,
-                len: mapping_size,
-                file: None,
-            };
-
-            if accessible_size != 0 {
-                // Commit the accessible size.
-                result.make_accessible(0, accessible_size)?;
-            }
-
-            result
-        })
     }
 
-    /// Make the memory starting at `start` and extending for `len` bytes accessible.
-    /// `start` and `len` must be native page-size multiples and describe a range within
-    /// `self`'s reserved memory.
-    #[cfg(not(target_os = "windows"))]
+    /// Make the memory starting at `start` and extending for `len` bytes
+    /// accessible. `start` and `len` must be native page-size multiples and
+    /// describe a range within `self`'s reserved memory.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `start` or `len` is not page aligned or if
+    /// either are outside the bounds of this mapping.
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
-        use rustix::mm::{mprotect, MprotectFlags};
-
         let page_size = crate::page_size();
         assert_eq!(start & (page_size - 1), 0);
         assert_eq!(len & (page_size - 1), 0);
-        assert!(len <= self.len);
-        assert!(start <= self.len - len);
+        assert!(len <= self.len());
+        assert!(start <= self.len() - len);
 
-        // Commit the accessible size.
-        let ptr = self.ptr as *mut u8;
-        unsafe {
-            mprotect(
-                ptr.add(start).cast(),
-                len,
-                MprotectFlags::READ | MprotectFlags::WRITE,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    /// Make the memory starting at `start` and extending for `len` bytes accessible.
-    /// `start` and `len` must be native page-size multiples and describe a range within
-    /// `self`'s reserved memory.
-    #[cfg(target_os = "windows")]
-    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
-        use anyhow::bail;
-        use std::ffi::c_void;
-        use std::io;
-        use windows_sys::Win32::System::Memory::*;
-
-        let page_size = crate::page_size();
-        assert_eq!(start & (page_size - 1), 0);
-        assert_eq!(len & (page_size - 1), 0);
-        assert!(len <= self.len);
-        assert!(start <= self.len - len);
-
-        // Commit the accessible size.
-        let ptr = self.ptr as *const u8;
-        if unsafe {
-            VirtualAlloc(
-                ptr.add(start) as *mut c_void,
-                len,
-                MEM_COMMIT,
-                PAGE_READWRITE,
-            )
-        }
-        .is_null()
-        {
-            bail!("VirtualAlloc failed: {}", io::Error::last_os_error());
-        }
-
-        Ok(())
+        self.sys.make_accessible(start, len)
     }
 
     /// Return the allocated memory as a slice of u8.
-    pub fn as_slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the range of bytes is accessible to the
+    /// program and additionally has previously been initialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics of the `range` provided is outside of the limits of this mmap.
+    pub unsafe fn slice(&self, range: Range<usize>) -> &[u8] {
+        assert!(range.start <= range.end);
+        assert!(range.end <= self.len());
+        std::slice::from_raw_parts(self.as_ptr().add(range.start), range.end - range.start)
     }
 
     /// Return the allocated memory as a mutable slice of u8.
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the range of bytes is accessible to the
+    /// program and additionally has previously been initialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics of the `range` provided is outside of the limits of this mmap.
+    pub unsafe fn slice_mut(&mut self, range: Range<usize>) -> &mut [u8] {
+        assert!(range.start <= range.end);
+        assert!(range.end <= self.len());
+        std::slice::from_raw_parts_mut(self.as_mut_ptr().add(range.start), range.end - range.start)
     }
 
     /// Return the allocated memory as a pointer to u8.
     pub fn as_ptr(&self) -> *const u8 {
-        self.ptr as *const u8
+        self.sys.as_ptr()
     }
 
     /// Return the allocated memory as a mutable pointer to u8.
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.ptr as *mut u8
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.sys.as_mut_ptr()
     }
 
     /// Return the length of the allocated memory.
+    ///
+    /// This is the byte length of this entire mapping which includes both
+    /// addressible and non-addressible memory.
     pub fn len(&self) -> usize {
-        self.len
+        self.sys.len()
     }
 
-    /// Return whether any memory has been allocated.
+    /// Return whether any memory has been allocated or reserved.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// Makes the specified `range` within this `Mmap` to be read/execute.
+    ///
+    /// # Unsafety
+    ///
+    /// This method is unsafe as it's generally not valid to simply make memory
+    /// executable, so it's up to the caller to ensure that everything is in
+    /// order and this doesn't overlap with other memory that should only be
+    /// read or only read/write.
+    ///
+    /// # Panics
+    ///
+    /// Panics of `range` is out-of-bounds or not page-aligned.
     pub unsafe fn make_executable(
         &self,
         range: Range<usize>,
@@ -387,51 +184,9 @@ impl Mmap {
             range.start % crate::page_size() == 0,
             "changing of protections isn't page-aligned",
         );
-        let base = self.as_ptr().add(range.start) as *mut _;
-        let len = range.end - range.start;
-
-        #[cfg(windows)]
-        {
-            use std::io;
-            use windows_sys::Win32::System::Memory::*;
-
-            let flags = if enable_branch_protection {
-                // TODO: We use this check to avoid an unused variable warning,
-                // but some of the CFG-related flags might be applicable
-                PAGE_EXECUTE_READ
-            } else {
-                PAGE_EXECUTE_READ
-            };
-            let mut old = 0;
-            let result = VirtualProtect(base, len, flags, &mut old);
-            if result == 0 {
-                return Err(io::Error::last_os_error().into());
-            }
-        }
-
-        #[cfg(not(windows))]
-        {
-            use rustix::mm::{mprotect, MprotectFlags};
-
-            let flags = MprotectFlags::READ | MprotectFlags::EXEC;
-            let flags = if enable_branch_protection {
-                #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-                if std::arch::is_aarch64_feature_detected!("bti") {
-                    MprotectFlags::from_bits_unchecked(flags.bits() | /* PROT_BTI */ 0x10)
-                } else {
-                    flags
-                }
-
-                #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
-                flags
-            } else {
-                flags
-            };
-
-            mprotect(base, len, flags)?;
-        }
-
-        Ok(())
+        self.sys
+            .make_executable(range, enable_branch_protection)
+            .context("failed to make memory executable")
     }
 
     /// Makes the specified `range` within this `Mmap` to be readonly.
@@ -443,59 +198,14 @@ impl Mmap {
             range.start % crate::page_size() == 0,
             "changing of protections isn't page-aligned",
         );
-        let base = self.as_ptr().add(range.start) as *mut _;
-        let len = range.end - range.start;
-
-        #[cfg(windows)]
-        {
-            use std::io;
-            use windows_sys::Win32::System::Memory::*;
-
-            let mut old = 0;
-            let result = VirtualProtect(base, len, PAGE_READONLY, &mut old);
-            if result == 0 {
-                return Err(io::Error::last_os_error().into());
-            }
-        }
-
-        #[cfg(not(windows))]
-        {
-            use rustix::mm::{mprotect, MprotectFlags};
-            mprotect(base, len, MprotectFlags::READ)?;
-        }
-
-        Ok(())
+        self.sys
+            .make_readonly(range)
+            .context("failed to make memory readonly")
     }
 
     /// Returns the underlying file that this mmap is mapping, if present.
     pub fn original_file(&self) -> Option<&Arc<File>> {
         self.file.as_ref()
-    }
-}
-
-impl Drop for Mmap {
-    #[cfg(not(target_os = "windows"))]
-    fn drop(&mut self) {
-        if self.len != 0 {
-            unsafe { rustix::mm::munmap(self.ptr as *mut std::ffi::c_void, self.len) }
-                .expect("munmap failed");
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    fn drop(&mut self) {
-        if self.len != 0 {
-            use std::ffi::c_void;
-            use windows_sys::Win32::System::Memory::*;
-
-            if self.file.is_none() {
-                let r = unsafe { VirtualFree(self.ptr as *mut c_void, 0, MEM_RELEASE) };
-                assert_ne!(r, 0);
-            } else {
-                let r = unsafe { UnmapViewOfFile(self.ptr as MEMORYMAPPEDVIEW_HANDLE) };
-                assert_ne!(r, 0);
-            }
-        }
     }
 }
 

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -82,7 +82,11 @@ impl Mmap {
                     .context(format!("mmap failed to reserve {mapping_size:#x} bytes"))?,
                 file: None,
             };
-            result.make_accessible(0, accessible_size)?;
+            if accessible_size > 0 {
+                result.make_accessible(0, accessible_size).context(format!(
+                    "mmap failed to allocate {accessible_size:#x} bytes"
+                ))?;
+            }
             Ok(result)
         }
     }

--- a/crates/runtime/src/mmap/unix.rs
+++ b/crates/runtime/src/mmap/unix.rs
@@ -1,0 +1,147 @@
+use anyhow::{anyhow, Context, Result};
+use rustix::mm::{mprotect, MprotectFlags};
+use std::fs::File;
+use std::ops::Range;
+use std::path::Path;
+use std::ptr;
+
+#[derive(Debug)]
+pub struct Mmap {
+    memory: *mut [u8],
+}
+
+// Mmaps are sendable and threadsafe, and otherwise fix the auto-traits on the
+// `*mut [u8]` storage internally.
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
+impl Mmap {
+    pub fn new_empty() -> Mmap {
+        Mmap { memory: &mut [] }
+    }
+
+    pub fn new(size: usize) -> Result<Self> {
+        let ptr = unsafe {
+            rustix::mm::mmap_anonymous(
+                ptr::null_mut(),
+                size,
+                rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
+                rustix::mm::MapFlags::PRIVATE,
+            )?
+        };
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
+        Ok(Mmap { memory })
+    }
+
+    pub fn reserve(size: usize) -> Result<Self> {
+        let ptr = unsafe {
+            rustix::mm::mmap_anonymous(
+                ptr::null_mut(),
+                size,
+                rustix::mm::ProtFlags::empty(),
+                rustix::mm::MapFlags::PRIVATE,
+            )?
+        };
+
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
+        Ok(Mmap { memory })
+    }
+
+    pub fn from_file(path: &Path) -> Result<(Self, File)> {
+        let file = File::open(path).context("failed to open file")?;
+        let len = file
+            .metadata()
+            .context("failed to get file metadata")?
+            .len();
+        let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
+        let ptr = unsafe {
+            rustix::mm::mmap(
+                ptr::null_mut(),
+                len,
+                rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
+                rustix::mm::MapFlags::PRIVATE,
+                &file,
+                0,
+            )
+            .context(format!("mmap failed to allocate {:#x} bytes", len))?
+        };
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), len);
+
+        Ok((Mmap { memory }, file))
+    }
+
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
+        let ptr = self.memory.cast::<u8>();
+        unsafe {
+            mprotect(
+                ptr.add(start).cast(),
+                len,
+                MprotectFlags::READ | MprotectFlags::WRITE,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.memory as *const u8
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.memory.cast()
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { (*self.memory).len() }
+    }
+
+    pub unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        let base = self.memory.cast::<u8>().add(range.start).cast();
+        let len = range.end - range.start;
+
+        let flags = MprotectFlags::READ | MprotectFlags::EXEC;
+        let flags = if enable_branch_protection {
+            #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+            if std::arch::is_aarch64_feature_detected!("bti") {
+                MprotectFlags::from_bits_unchecked(flags.bits() | /* PROT_BTI */ 0x10)
+            } else {
+                flags
+            }
+
+            #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+            flags
+        } else {
+            flags
+        };
+
+        mprotect(base, len, flags)?;
+
+        Ok(())
+    }
+
+    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        let base = self.memory.cast::<u8>().add(range.start).cast();
+        let len = range.end - range.start;
+
+        mprotect(base, len, MprotectFlags::READ)?;
+
+        Ok(())
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        unsafe {
+            let ptr = self.memory.cast();
+            let len = (*self.memory).len();
+            if len == 0 {
+                return;
+            }
+            rustix::mm::munmap(ptr, len).expect("munmap failed");
+        }
+    }
+}

--- a/crates/runtime/src/mmap/windows.rs
+++ b/crates/runtime/src/mmap/windows.rs
@@ -1,0 +1,207 @@
+use anyhow::{anyhow, bail, Context, Result};
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::ops::Range;
+use std::os::windows::prelude::*;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::Storage::FileSystem::*;
+use windows_sys::Win32::System::Memory::*;
+
+#[derive(Debug)]
+pub struct Mmap {
+    memory: *mut [u8],
+    is_file: bool,
+}
+
+// Mappings are threadsafe and this is fixing up the auto-traits from the usage
+// of a raw pointer in the above structure.
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
+impl Mmap {
+    pub fn new_empty() -> Mmap {
+        Mmap {
+            memory: &mut [],
+            is_file: false,
+        }
+    }
+
+    pub fn new(size: usize) -> Result<Self> {
+        let ptr = unsafe {
+            VirtualAlloc(
+                ptr::null_mut(),
+                size,
+                MEM_RESERVE | MEM_COMMIT,
+                PAGE_READWRITE,
+            )
+        };
+        if ptr.is_null() {
+            bail!(io::Error::last_os_error())
+        }
+
+        Ok(Self {
+            memory: ptr::slice_from_raw_parts_mut(ptr.cast(), size),
+            is_file: false,
+        })
+    }
+
+    pub fn reserve(size: usize) -> Result<Self> {
+        let ptr = unsafe { VirtualAlloc(ptr::null_mut(), size, MEM_RESERVE, PAGE_NOACCESS) };
+        if ptr.is_null() {
+            bail!(io::Error::last_os_error())
+        }
+
+        Ok(Self {
+            memory: ptr::slice_from_raw_parts_mut(ptr.cast(), size),
+            is_file: false,
+        })
+    }
+
+    pub fn from_file(path: &Path) -> Result<(Self, File)> {
+        unsafe {
+            // Open the file with read/execute access and only share for
+            // read. This will enable us to perform the proper mmap below
+            // while also disallowing other processes modifying the file
+            // and having those modifications show up in our address space.
+            let file = OpenOptions::new()
+                .read(true)
+                .access_mode(FILE_GENERIC_READ | FILE_GENERIC_EXECUTE)
+                .share_mode(FILE_SHARE_READ)
+                .open(path)
+                .context("failed to open file")?;
+
+            let len = file
+                .metadata()
+                .context("failed to get file metadata")?
+                .len();
+            let len = usize::try_from(len).map_err(|_| anyhow!("file too large to map"))?;
+
+            // Create a file mapping that allows PAGE_EXECUTE_WRITECOPY.
+            // This enables up-to these permissions but we won't leave all
+            // of these permissions active at all times. Execution is
+            // necessary for the generated code from Cranelift and the
+            // WRITECOPY part is needed for possibly resolving relocations,
+            // but otherwise writes don't happen.
+            let mapping = CreateFileMappingW(
+                file.as_raw_handle() as isize,
+                ptr::null_mut(),
+                PAGE_EXECUTE_WRITECOPY,
+                0,
+                0,
+                ptr::null(),
+            );
+            if mapping == 0 {
+                return Err(io::Error::last_os_error()).context("failed to create file mapping");
+            }
+
+            // Create a view for the entire file using all our requisite
+            // permissions so that we can change the virtual permissions
+            // later on.
+            let ptr = MapViewOfFile(
+                mapping,
+                FILE_MAP_READ | FILE_MAP_EXECUTE | FILE_MAP_COPY,
+                0,
+                0,
+                len,
+            ) as *mut std::ffi::c_void;
+            let err = io::Error::last_os_error();
+            CloseHandle(mapping);
+            if ptr.is_null() {
+                return Err(err).context(format!("failed to create map view of {:#x} bytes", len));
+            }
+
+            let mut ret = Self {
+                memory: ptr::slice_from_raw_parts_mut(ptr.cast(), len),
+                is_file: true,
+            };
+
+            // Protect the entire file as PAGE_WRITECOPY to start (i.e.
+            // remove the execute bit)
+            let mut old = 0;
+            if VirtualProtect(ret.as_mut_ptr().cast(), ret.len(), PAGE_WRITECOPY, &mut old) == 0 {
+                return Err(io::Error::last_os_error())
+                    .context("failed change pages to `PAGE_READONLY`");
+            }
+
+            Ok((ret, file))
+        }
+    }
+
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
+        if unsafe {
+            VirtualAlloc(
+                self.as_ptr().add(start) as _,
+                len,
+                MEM_COMMIT,
+                PAGE_READWRITE,
+            )
+        }
+        .is_null()
+        {
+            bail!(io::Error::last_os_error())
+        }
+
+        Ok(())
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.memory as *const u8
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.memory.cast()
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { (*self.memory).len() }
+    }
+
+    pub unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        let flags = if enable_branch_protection {
+            // TODO: We use this check to avoid an unused variable warning,
+            // but some of the CFG-related flags might be applicable
+            PAGE_EXECUTE_READ
+        } else {
+            PAGE_EXECUTE_READ
+        };
+        let mut old = 0;
+        let base = self.as_ptr().add(range.start);
+        let result = VirtualProtect(base as _, range.end - range.start, flags, &mut old);
+        if result == 0 {
+            bail!(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        let mut old = 0;
+        let base = self.as_ptr().add(range.start);
+        let result = VirtualProtect(base as _, range.end - range.start, PAGE_READONLY, &mut old);
+        if result == 0 {
+            bail!(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        if self.len() == 0 {
+            return;
+        }
+
+        if self.is_file {
+            let r = unsafe { UnmapViewOfFile(self.as_mut_ptr() as MEMORYMAPPEDVIEW_HANDLE) };
+            assert_ne!(r, 0);
+        } else {
+            let r = unsafe { VirtualFree(self.as_mut_ptr().cast(), 0, MEM_RELEASE) };
+            assert_ne!(r, 0);
+        }
+    }
+}


### PR DESCRIPTION
This commit refactors the implementation of the `wasmtime_runtime::Mmap` structure to have the platform-specific bits separated by file rather than interspersed throughout `mmap.rs`. I plan in the near future to add a faux implementation for `cfg(miri)` to get some tests running with miri on CI.

At the same time this additionally updates the interface of `Mmap` to be more miri-friendly in the sense of ensuring that mutability is all in the right place and we don't eagerly mark items as safe too soon. For example it seems questionable that previously you could get a mutable slice to readonly memory. Probably not going to cause any issues, but this interface should hopefully be more verification-friendly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
