### PR TITLE
`wasmtime`: Fix resetting stack-walking registers when entering/exiting Wasm

### DIFF
--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -248,7 +248,6 @@ where
 // usage of its accessor methods.
 mod call_thread_state {
     use super::*;
-    use std::mem;
 
     /// Temporary state stored on the stack which is registered in the `tls` module
     /// below for calls into wasm.
@@ -262,16 +261,27 @@ mod call_thread_state {
 
         prev: Cell<tls::Ptr>,
 
-        // The values of `VMRuntimeLimits::last_wasm_{exit_{pc,fp},entry_sp}` for
-        // the *previous* `CallThreadState`. Our *current* last wasm PC/FP/SP are
-        // saved in `self.limits`. We save a copy of the old registers here because
-        // the `VMRuntimeLimits` typically doesn't change across nested calls into
-        // Wasm (i.e. they are typically calls back into the same store and
-        // `self.limits == self.prev.limits`) and we must to maintain the list of
+        // The values of `VMRuntimeLimits::last_wasm_{exit_{pc,fp},entry_sp}`
+        // for the *previous* `CallThreadState` for this same store/limits. Our
+        // *current* last wasm PC/FP/SP are saved in `self.limits`. We save a
+        // copy of the old registers here because the `VMRuntimeLimits`
+        // typically doesn't change across nested calls into Wasm (i.e. they are
+        // typically calls back into the same store and `self.limits ==
+        // self.prev.limits`) and we must to maintain the list of
         // contiguous-Wasm-frames stack regions for backtracing purposes.
         old_last_wasm_exit_fp: Cell<usize>,
         old_last_wasm_exit_pc: Cell<usize>,
         old_last_wasm_entry_sp: Cell<usize>,
+    }
+
+    impl Drop for CallThreadState {
+        fn drop(&mut self) {
+            unsafe {
+                *(*self.limits).last_wasm_exit_fp.get() = self.old_last_wasm_exit_fp.get();
+                *(*self.limits).last_wasm_exit_pc.get() = self.old_last_wasm_exit_pc.get();
+                *(*self.limits).last_wasm_entry_sp.get() = self.old_last_wasm_entry_sp.get();
+            }
+        }
     }
 
     impl CallThreadState {
@@ -288,9 +298,9 @@ mod call_thread_state {
                 capture_backtrace,
                 limits,
                 prev: Cell::new(ptr::null()),
-                old_last_wasm_exit_fp: Cell::new(0),
-                old_last_wasm_exit_pc: Cell::new(0),
-                old_last_wasm_entry_sp: Cell::new(0),
+                old_last_wasm_exit_fp: Cell::new(unsafe { *(*limits).last_wasm_exit_fp.get() }),
+                old_last_wasm_exit_pc: Cell::new(unsafe { *(*limits).last_wasm_exit_pc.get() }),
+                old_last_wasm_entry_sp: Cell::new(unsafe { *(*limits).last_wasm_entry_sp.get() }),
             }
         }
 
@@ -314,83 +324,15 @@ mod call_thread_state {
             self.prev.get()
         }
 
-        /// Connect the link to the previous `CallThreadState`.
-        ///
-        /// Synchronizes the last wasm FP, PC, and SP on `self` and the old
-        /// `self.prev` for the given new `prev`, and returns the old
-        /// `self.prev`.
-        pub unsafe fn set_prev(&self, prev: tls::Ptr) -> tls::Ptr {
-            let old_prev = self.prev.get();
+        pub(crate) unsafe fn push(&self) {
+            assert!(self.prev.get().is_null());
+            self.prev.set(tls::raw::replace(self));
+        }
 
-            // Restore the old `prev`'s saved registers in its
-            // `VMRuntimeLimits`. This is necessary for when we are async
-            // suspending the top `CallThreadState` and doing `set_prev(null)`
-            // on it, and so any stack walking we do subsequently will start at
-            // the old `prev` and look at its `VMRuntimeLimits` to get the
-            // initial saved registers.
-            if let Some(old_prev) = old_prev.as_ref() {
-                *(*old_prev.limits).last_wasm_exit_fp.get() = self.old_last_wasm_exit_fp();
-                *(*old_prev.limits).last_wasm_exit_pc.get() = self.old_last_wasm_exit_pc();
-                *(*old_prev.limits).last_wasm_entry_sp.get() = self.old_last_wasm_entry_sp();
-            }
-
-            self.prev.set(prev);
-
-            let mut old_last_wasm_exit_fp = 0;
-            let mut old_last_wasm_exit_pc = 0;
-            let mut old_last_wasm_entry_sp = 0;
-            if let Some(prev) = prev.as_ref() {
-                // We are entering a new `CallThreadState` or resuming a
-                // previously suspended one. This means we will push new Wasm
-                // frames that save the new Wasm FP/SP/PC registers into
-                // `VMRuntimeLimits`, we need to first save the old Wasm
-                // FP/SP/PC registers into this new `CallThreadState` to
-                // maintain our list of contiguous Wasm frame regions that we
-                // use when capturing stack traces.
-                //
-                // NB: the Wasm<--->host trampolines saved the Wasm FP/SP/PC
-                // registers in the active-at-that-time store's
-                // `VMRuntimeLimits`. For the most recent FP/PC/SP that is the
-                // `state.prev.limits` (since we haven't entered this
-                // `CallThreadState` yet). And that can be a different
-                // `VMRuntimeLimits` instance from the currently active
-                // `state.limits`, which will be used by the upcoming call into
-                // Wasm! Consider the case where we have multiple, nested calls
-                // across stores (with host code in between, by necessity, since
-                // only things in the same store can be linked directly
-                // together):
-                //
-                //     | ...             |
-                //     | Host            |  |
-                //     +-----------------+  | stack
-                //     | Wasm in store A |  | grows
-                //     +-----------------+  | down
-                //     | Host            |  |
-                //     +-----------------+  |
-                //     | Wasm in store B |  V
-                //     +-----------------+
-                //
-                // In this scenario `state.limits != state.prev.limits`,
-                // i.e. `B.limits != A.limits`! Therefore we must take care to
-                // read the old FP/SP/PC from `state.prev.limits`, rather than
-                // `state.limits`, and store those saved registers into the
-                // current `state`.
-                //
-                // See also the comment above the
-                // `CallThreadState::old_last_wasm_*` fields.
-                old_last_wasm_exit_fp =
-                    mem::replace(&mut *(*prev.limits).last_wasm_exit_fp.get(), 0);
-                old_last_wasm_exit_pc =
-                    mem::replace(&mut *(*prev.limits).last_wasm_exit_pc.get(), 0);
-                old_last_wasm_entry_sp =
-                    mem::replace(&mut *(*prev.limits).last_wasm_entry_sp.get(), 0);
-            }
-
-            self.old_last_wasm_exit_fp.set(old_last_wasm_exit_fp);
-            self.old_last_wasm_exit_pc.set(old_last_wasm_exit_pc);
-            self.old_last_wasm_entry_sp.set(old_last_wasm_entry_sp);
-
-            old_prev
+        pub(crate) unsafe fn pop(&self) {
+            let prev = self.prev.replace(ptr::null());
+            let head = tls::raw::replace(prev);
+            assert!(std::ptr::eq(head, self));
         }
     }
 }
@@ -533,7 +475,6 @@ impl<T: Copy> Drop for ResetCell<'_, T> {
 // the caller to the trap site.
 mod tls {
     use super::CallThreadState;
-    use std::ptr;
 
     pub use raw::Ptr;
 
@@ -551,7 +492,7 @@ mod tls {
     //
     // Note, though, that if async support is disabled at compile time then
     // these functions are free to be inlined.
-    mod raw {
+    pub(super) mod raw {
         use super::CallThreadState;
         use std::cell::Cell;
         use std::ptr;
@@ -625,8 +566,7 @@ mod tls {
             // accidentally used later.
             let state = raw::get();
             if let Some(state) = state.as_ref() {
-                let prev_state = state.set_prev(ptr::null());
-                raw::replace(prev_state);
+                state.pop();
             } else {
                 // Null case: we aren't in a wasm context, so theres no tls to
                 // save for restoration.
@@ -640,18 +580,12 @@ mod tls {
         /// This is unsafe because it's intended to only be used within the
         /// context of stack switching within wasmtime.
         pub unsafe fn replace(self) {
-            // Null case: we aren't in a wasm context, so theres no tls
-            // to restore.
-            if self.state.is_null() {
-                return;
+            if let Some(state) = self.state.as_ref() {
+                state.push();
+            } else {
+                // Null case: we aren't in a wasm context, so theres no tls
+                // to restore.
             }
-
-            // We need to configure our previous TLS pointer to whatever is in
-            // TLS at this time, and then we set the current state to ourselves.
-            let prev = raw::get();
-            assert!((*self.state).prev().is_null());
-            (*self.state).set_prev(prev);
-            raw::replace(self.state);
         }
     }
 
@@ -668,18 +602,13 @@ mod tls {
             #[inline]
             fn drop(&mut self) {
                 unsafe {
-                    let prev = self.state.set_prev(ptr::null());
-                    let old_state = raw::replace(prev);
-                    debug_assert!(std::ptr::eq(old_state, self.state));
+                    self.state.pop();
                 }
             }
         }
 
-        let prev = raw::replace(state);
-
         unsafe {
-            state.set_prev(prev);
-
+            state.push();
             let reset = Reset { state };
             closure(reset.state)
         }

--- a/crates/runtime/src/traphandlers/backtrace.rs
+++ b/crates/runtime/src/traphandlers/backtrace.rs
@@ -20,7 +20,10 @@
 //! exit FP and stopping once we reach the entry SP (meaning that the next older
 //! frame is a host frame).
 
-use crate::traphandlers::{tls, CallThreadState};
+use crate::{
+    traphandlers::{tls, CallThreadState},
+    VMRuntimeLimits,
+};
 use cfg_if::cfg_if;
 use std::ops::ControlFlow;
 
@@ -80,9 +83,9 @@ impl Backtrace {
     }
 
     /// Capture the current Wasm stack in a backtrace.
-    pub fn new() -> Backtrace {
+    pub fn new(limits: *const VMRuntimeLimits) -> Backtrace {
         tls::with(|state| match state {
-            Some(state) => unsafe { Self::new_with_trap_state(state, None) },
+            Some(state) => unsafe { Self::new_with_trap_state(limits, state, None) },
             None => Backtrace(vec![]),
         })
     }
@@ -93,11 +96,12 @@ impl Backtrace {
     /// Wasm exit trampoline didn't run, and we use the provided PC and FP
     /// instead of looking them up in `VMRuntimeLimits`.
     pub(crate) unsafe fn new_with_trap_state(
+        limits: *const VMRuntimeLimits,
         state: &CallThreadState,
         trap_pc_and_fp: Option<(usize, usize)>,
     ) -> Backtrace {
         let mut frames = vec![];
-        Self::trace_with_trap_state(state, trap_pc_and_fp, |frame| {
+        Self::trace_with_trap_state(limits, state, trap_pc_and_fp, |frame| {
             frames.push(frame);
             ControlFlow::Continue(())
         });
@@ -105,9 +109,9 @@ impl Backtrace {
     }
 
     /// Walk the current Wasm stack, calling `f` for each frame we walk.
-    pub fn trace(f: impl FnMut(Frame) -> ControlFlow<()>) {
+    pub fn trace(limits: *const VMRuntimeLimits, f: impl FnMut(Frame) -> ControlFlow<()>) {
         tls::with(|state| match state {
-            Some(state) => unsafe { Self::trace_with_trap_state(state, None, f) },
+            Some(state) => unsafe { Self::trace_with_trap_state(limits, state, None, f) },
             None => {}
         });
     }
@@ -118,88 +122,63 @@ impl Backtrace {
     /// Wasm exit trampoline didn't run, and we use the provided PC and FP
     /// instead of looking them up in `VMRuntimeLimits`.
     pub(crate) unsafe fn trace_with_trap_state(
+        limits: *const VMRuntimeLimits,
         state: &CallThreadState,
         trap_pc_and_fp: Option<(usize, usize)>,
         mut f: impl FnMut(Frame) -> ControlFlow<()>,
     ) {
         log::trace!("====== Capturing Backtrace ======");
+
         let (last_wasm_exit_pc, last_wasm_exit_fp) = match trap_pc_and_fp {
             // If we exited Wasm by catching a trap, then the Wasm-to-host
             // trampoline did not get a chance to save the last Wasm PC and FP,
             // and we need to use the plumbed-through values instead.
-            Some((pc, fp)) => (pc, fp),
+            Some((pc, fp)) => {
+                assert!(std::ptr::eq(limits, state.limits));
+                (pc, fp)
+            }
             // Either there is no Wasm currently on the stack, or we exited Wasm
             // through the Wasm-to-host trampoline.
             None => {
-                let pc = *(*state.limits).last_wasm_exit_pc.get();
-                let fp = *(*state.limits).last_wasm_exit_fp.get();
-
-                if pc == 0 {
-                    // Host function calling another host function that
-                    // traps. No Wasm on the stack.
-                    assert_eq!(fp, 0);
-                    return;
-                }
-
+                let pc = *(*limits).last_wasm_exit_pc.get();
+                let fp = *(*limits).last_wasm_exit_fp.get();
                 (pc, fp)
             }
         };
 
-        // Trace through the first contiguous sequence of Wasm frames on the
-        // stack.
-        if let ControlFlow::Break(()) = Self::trace_through_wasm(
+        let activations = std::iter::once((
             last_wasm_exit_pc,
             last_wasm_exit_fp,
-            *(*state.limits).last_wasm_entry_sp.get(),
-            &mut f,
-        ) {
-            log::trace!("====== Done Capturing Backtrace ======");
-            return;
-        }
-
-        // And then trace through each of the older contiguous sequences of Wasm
-        // frames on the stack.
-        for state in state.iter() {
-            // If there is no previous call state, then there is nothing more to
-            // trace through (since each `CallTheadState` saves the *previous*
-            // call into Wasm's saved registers, and the youngest call into
-            // Wasm's registers are saved in the `VMRuntimeLimits`)
-            if state.prev().is_null() {
-                debug_assert_eq!(state.old_last_wasm_exit_pc(), 0);
-                debug_assert_eq!(state.old_last_wasm_exit_fp(), 0);
-                debug_assert_eq!(state.old_last_wasm_entry_sp(), 0);
-                log::trace!("====== Done Capturing Backtrace ======");
-                return;
+            *(*limits).last_wasm_entry_sp.get(),
+        ))
+        .chain(
+            state
+                .iter()
+                .filter(|state| std::ptr::eq(limits, state.limits))
+                .map(|state| {
+                    (
+                        state.old_last_wasm_exit_pc(),
+                        state.old_last_wasm_exit_fp(),
+                        state.old_last_wasm_entry_sp(),
+                    )
+                }),
+        )
+        .take_while(|&(pc, fp, sp)| {
+            if pc == 0 {
+                debug_assert_eq!(fp, 0);
+                debug_assert_eq!(sp, 0);
             }
+            pc != 0
+        });
 
-            // We save `CallThreadState` linked list entries for various kinds
-            // of {native,array} x {native,array} calls -- and we technically
-            // "shouldn't" because these calls can't enter Wasm -- because our
-            // Wasm call path unconditionally calls
-            // `wasmtime_runtime::catch_traps` even when the callee is not
-            // actually Wasm. We do this because the host-to-Wasm call path is
-            // very hot and these host-to-host calls that flow through that code
-            // path are very rare and also not hot. Anyways, these unnecessary
-            // `catch_traps` calls result in these null/empty `CallThreadState`
-            // entries. Recognize and ignore them.
-            if state.old_last_wasm_entry_sp() == 0 {
-                debug_assert_eq!(state.old_last_wasm_exit_fp(), 0);
-                debug_assert_eq!(state.old_last_wasm_exit_pc(), 0);
-                continue;
-            }
-
-            if let ControlFlow::Break(()) = Self::trace_through_wasm(
-                state.old_last_wasm_exit_pc(),
-                state.old_last_wasm_exit_fp(),
-                state.old_last_wasm_entry_sp(),
-                &mut f,
-            ) {
-                log::trace!("====== Done Capturing Backtrace ======");
+        for (pc, fp, sp) in activations {
+            if let ControlFlow::Break(()) = Self::trace_through_wasm(pc, fp, sp, &mut f) {
+                log::trace!("====== Done Capturing Backtrace (closure break) ======");
                 return;
             }
         }
 
-        unreachable!()
+        log::trace!("====== Done Capturing Backtrace (reached end of activations) ======");
     }
 
     /// Walk through a contiguous sequence of Wasm frames starting with the

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1228,7 +1228,13 @@ impl StoreOpaque {
     pub fn gc(&mut self) {
         // For this crate's API, we ensure that `set_stack_canary` invariants
         // are upheld for all host-->Wasm calls.
-        unsafe { wasmtime_runtime::gc(&self.modules, &mut self.externref_activations_table) }
+        unsafe {
+            wasmtime_runtime::gc(
+                self.runtime_limits(),
+                &self.modules,
+                &mut self.externref_activations_table,
+            )
+        }
     }
 
     /// Yields the async context, assuming that we are executing on a fiber and

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -263,7 +263,11 @@ impl WasmBacktrace {
     /// always captures a backtrace.
     pub fn force_capture(store: impl AsContext) -> WasmBacktrace {
         let store = store.as_context();
-        Self::from_captured(store.0, wasmtime_runtime::Backtrace::new(), None)
+        Self::from_captured(
+            store.0,
+            wasmtime_runtime::Backtrace::new(store.0.runtime_limits()),
+            None,
+        )
     }
 
     fn from_captured(


### PR DESCRIPTION
Fixes a regression from #6262, originally reported in https://github.com/bytecodealliance/wasmtime-dotnet/pull/245

The issue was that we would enter Wasm and save the stack-walking registers but never clear them after Wasm returns. Then if a host-to-host call tried to capture a stack, we would mistakenly attempt to use those stale registers to start the stack walk. This mistake would be caught by an assertion, triggering a panic.

This commit fixes the issue by managing the save/restore in the `CallThreadState` construction/drop, rather than in the old `set_prev` method.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
