### PR TITLE
x64: Add non-SSE 4.1 lowerings for `insertlane` instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2065,6 +2065,7 @@ pub(crate) fn emit(
                 SseOpcode::Xorpd => (LegacyPrefixes::_66, 0x0F57, 2),
                 SseOpcode::Phaddw => (LegacyPrefixes::_66, 0x0F3801, 3),
                 SseOpcode::Phaddd => (LegacyPrefixes::_66, 0x0F3802, 3),
+                SseOpcode::Movss => (LegacyPrefixes::_F3, 0x0F10, 2),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
 
@@ -2270,6 +2271,7 @@ pub(crate) fn emit(
                 AvxOpcode::Vpunpcklqdq => (LP::_66, OM::_0F, 0x6C),
                 AvxOpcode::Vpunpckhqdq => (LP::_66, OM::_0F, 0x6D),
                 AvxOpcode::Vmovsd => (LP::_F2, OM::_0F, 0x10),
+                AvxOpcode::Vmovss => (LP::_F3, OM::_0F, 0x10),
                 _ => panic!("unexpected rmir vex opcode {op:?}"),
             };
             VexInstruction::new()

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1293,11 +1293,25 @@
 ;; the end of the world hopefully as that's a pretty old instruction set, so
 ;; this is the "simplest" version that works on SSE2 for now.
 ;;
-;; This lowering loads a constant with all 1s except for the "hole" where this
-;; value will get placed into. The `val` is zero-extended to 32-bits and moved
-;; into an xmm register with `movd` which zeros upper xmm bits as well. This
-;; 32-bit value is then shuffled to the correct 32x4 lane and or'd into the
-;; final destination.
+;; This lowering masks the original vector with a constant with all 1s except
+;; for the "hole" where this value will get placed into, meaning the desired
+;; lane is guaranteed as all 0s. Next the `val` is shuffled into this hole with
+;; a few operations:
+;;
+;;  1. The `val` is zero-extended to 32-bits to guarantee the lower 32-bits
+;;     are all defined.
+;;  2. An arithmetic shift-left is used with the low two bits of `n`, the
+;;     desired lane, to move the value into the right position within the 32-bit
+;;     register value.
+;;  3. The 32-bit register is moved with `movd` into an XMM register
+;;  4. The XMM register, where all lanes are 0 except for the first lane which
+;;     has the shifted value, is then shuffled with `pshufd` to move the
+;;     shifted value to the correct and final lane. This uses the upper two
+;;     bits of `n` to index the i32x4 lane that we're targeting.
+;;
+;; This all, laboriously, gets the `val` into the desired lane so it's then
+;; `por`'d with the original vec-with-a-hole to produce the final result of the
+;; insertion.
 (rule (vec_insert_lane $I8X16 vec val n)
       (let ((vec_with_hole Xmm (x64_pand vec (insert_i8x16_lane_hole n)))
             (val Gpr (x64_movzx (ExtMode.BL) val))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1284,20 +1284,77 @@
 (decl vec_insert_lane (Type Xmm RegMem u8) Xmm)
 
 ;; i8x16.replace_lane
-(rule (vec_insert_lane $I8X16 vec val idx)
-      (x64_pinsrb vec val idx))
+(rule 1 (vec_insert_lane $I8X16 vec val idx)
+        (if-let $true (use_sse41))
+        (x64_pinsrb vec val idx))
+
+;; This lowering is particularly unoptimized and is mostly just here to work
+;; rather than here to be fast. Requiring SSE 4.1 for the above lowering isn't
+;; the end of the world hopefully as that's a pretty old instruction set, so
+;; this is the "simplest" version that works on SSE2 for now.
+;;
+;; This lowering loads a constant with all 1s except for the "hole" where this
+;; value will get placed into. The `val` is zero-extended to 32-bits and moved
+;; into an xmm register with `movd` which zeros upper xmm bits as well. This
+;; 32-bit value is then shuffled to the correct 32x4 lane and or'd into the
+;; final destination.
+(rule (vec_insert_lane $I8X16 vec val n)
+      (let ((vec_with_hole Xmm (x64_pand vec (insert_i8x16_lane_hole n)))
+            (val Gpr (x64_movzx (ExtMode.BL) val))
+            (val Gpr (x64_shl $I32 val (Imm8Reg.Imm8 (u8_shl (u8_and n 3) 3))))
+            (val Xmm (x64_movd_to_xmm val))
+            (val_at_hole Xmm (x64_pshufd val (insert_i8x16_lane_pshufd_imm (u8_shr n 2)))))
+        (x64_por vec_with_hole val_at_hole)))
+
+(decl insert_i8x16_lane_hole (u8) VCodeConstant)
+(extern constructor insert_i8x16_lane_hole insert_i8x16_lane_hole)
+(decl insert_i8x16_lane_pshufd_imm (u8) u8)
+(rule (insert_i8x16_lane_pshufd_imm 0) 0b01_01_01_00)
+(rule (insert_i8x16_lane_pshufd_imm 1) 0b01_01_00_01)
+(rule (insert_i8x16_lane_pshufd_imm 2) 0b01_00_01_01)
+(rule (insert_i8x16_lane_pshufd_imm 3) 0b00_01_01_01)
 
 ;; i16x8.replace_lane
 (rule (vec_insert_lane $I16X8 vec val idx)
       (x64_pinsrw vec val idx))
 
 ;; i32x4.replace_lane
-(rule (vec_insert_lane $I32X4 vec val idx)
-      (x64_pinsrd vec val idx))
+(rule 1 (vec_insert_lane $I32X4 vec val idx)
+        (if-let $true (use_sse41))
+        (x64_pinsrd vec val idx))
+
+(rule (vec_insert_lane $I32X4 vec val 0)
+      (x64_movss_regmove vec (x64_movd_to_xmm val)))
+
+;; tmp    = [ vec[1] vec[0] val[1] val[0] ]
+;; result = [ vec[3] vec[2] tmp[0] tmp[2] ]
+(rule (vec_insert_lane $I32X4 vec val 1)
+      (let ((val Xmm (x64_movd_to_xmm val))
+            (vec Xmm vec))
+        (x64_shufps (x64_punpcklqdq val vec) vec 0b11_10_00_10)))
+
+;; tmp    = [ vec[0] vec[3] val[0] val[0] ]
+;; result = [ tmp[2] tmp[0] vec[1] vec[0] ]
+(rule (vec_insert_lane $I32X4 vec val 2)
+      (let ((val Xmm (x64_movd_to_xmm val))
+            (vec Xmm vec))
+        (x64_shufps vec (x64_shufps val vec 0b00_11_00_00) 0b10_00_01_00)))
+
+;; tmp    = [ vec[3] vec[2] val[1] val[0] ]
+;; result = [ tmp[0] tmp[2] vec[1] vec[0] ]
+(rule (vec_insert_lane $I32X4 vec val 3)
+      (let ((val Xmm (x64_movd_to_xmm val))
+            (vec Xmm vec))
+        (x64_shufps vec (x64_shufps val vec 0b11_10_01_00) 0b00_10_01_00)))
 
 ;; i64x2.replace_lane
-(rule (vec_insert_lane $I64X2 vec val idx)
-      (x64_pinsrq vec val idx))
+(rule 1 (vec_insert_lane $I64X2 vec val idx)
+        (if-let $true (use_sse41))
+        (x64_pinsrq vec val idx))
+(rule (vec_insert_lane $I64X2 vec val 0)
+      (x64_movsd_regmove vec (x64_movq_to_xmm val)))
+(rule (vec_insert_lane $I64X2 vec val 1)
+      (x64_punpcklqdq vec (x64_movq_to_xmm val)))
 
 ;; f32x4.replace_lane
 (rule 1 (vec_insert_lane $F32X4 vec val idx)
@@ -4053,6 +4110,7 @@
         (if-let $true (use_avx2_simd))
         (x64_vpbroadcastb (bitcast_gpr_to_xmm $I32 src)))
 (rule 2 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
+        (if-let $true (use_sse41))
         (x64_pshufb (x64_pinsrb (xmm_uninit_value) addr 0) (xmm_zero $I8X16)))
 (rule 3 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
         (if-let $true (use_avx2_simd))

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -1047,6 +1047,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     fn xmi_imm(&mut self, imm: u32) -> XmmMemImm {
         XmmMemImm::new(RegMemImm::imm(imm)).unwrap()
     }
+
+    fn insert_i8x16_lane_hole(&mut self, hole_idx: u8) -> VCodeConstant {
+        let mask = -1i128 as u128;
+        self.emit_u128_le_const(mask ^ (0xff << (hole_idx * 8)))
+    }
 }
 
 impl IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -691,6 +691,16 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn u8_shl(&mut self, a: u8, b: u8) -> u8 {
+            a << b
+        }
+
+        #[inline]
+        fn u8_shr(&mut self, a: u8, b: u8) -> u8 {
+            a >> b
+        }
+
+        #[inline]
         fn lane_type(&mut self, ty: Type) -> Type {
             ty.lane_type()
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -111,6 +111,12 @@
 (decl pure u8_and (u8 u8) u8)
 (extern constructor u8_and u8_and)
 
+(decl pure u8_shl (u8 u8) u8)
+(extern constructor u8_shl u8_shl)
+
+(decl pure u8_shr (u8 u8) u8)
+(extern constructor u8_shr u8_shr)
+
 (decl pure u32_add (u32 u32) u32)
 (extern constructor u32_add u32_add)
 

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -2,9 +2,19 @@ test interpret
 test run
 target aarch64
 target s390x
+target x86_64 ssse3 has_sse41=false
 set enable_simd
-target x86_64 has_sse3 has_ssse3 has_sse41
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
+target x86_64 sse42 has_avx
+
+function %insertlane_i8x16_0(i8x16, i8) -> i8x16 {
+block0(v0: i8x16, v1: i8):
+    v2 = insertlane v0, v1, 0
+    return v2
+}
+; run: %insertlane_i8x16_0([1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1], 120) == [120 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
 
 function %insertlane_15(i8x16, i8) -> i8x16 {
 block0(v0: i8x16, v1: i8):
@@ -20,12 +30,33 @@ block0(v0: i16x8, v1: i16):
 }
 ; run: %insertlane_5([1 1 1 1 1 1 1 1], 10000) == [1 1 1 1 1 10000 1 1]
 
-function %insertlane_2(i32x4, i32) -> i32x4 {
+function %insertlane_i32x4_0(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = insertlane v0, v1, 0
+    return v2
+}
+; run: %insertlane_i32x4_0([1 1 1 1], 100000) == [100000 1 1 1]
+
+function %insertlane_i32x4_1(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = insertlane v0, v1, 1
+    return v2
+}
+; run: %insertlane_i32x4_1([1 1 1 1], 100000) == [1 100000 1 1]
+
+function %insertlane_i32x4_2(i32x4, i32) -> i32x4 {
 block0(v0: i32x4, v1: i32):
     v2 = insertlane v0, v1, 2
     return v2
 }
-; run: %insertlane_2([1 1 1 1], 100000) == [1 1 100000 1]
+; run: %insertlane_i32x4_2([1 1 1 1], 100000) == [1 1 100000 1]
+
+function %insertlane_i32x4_3(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = insertlane v0, v1, 3
+    return v2
+}
+; run: %insertlane_i32x4_3([1 1 1 1], 100000) == [1 1 1 100000]
 
 function %insertlane_0(i64x2, i64) -> i64x2 {
 block0(v0: i64x2, v1: i64):


### PR DESCRIPTION
This commit avoids the use of `pinsr*` when SSE 4.1 is enabled by using alternative means of inserting values into vectors.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
