### PR TITLE
riscv64: Add `VecALUImm` instruction format

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -330,6 +330,13 @@
       (vs1 Reg)
       (vstate VState))
 
+    (VecAluRRImm5
+      (op VecAluOpRRImm5)
+      (vd WritableReg)
+      (vs2 Reg)
+      (imm Imm5)
+      (vstate VState))
+
     (VecSetState
       (rd WritableReg)
       (vstate VState))
@@ -697,6 +704,7 @@
 (type OptionUimm5 (primitive OptionUimm5))
 (type Imm12 (primitive Imm12))
 (type UImm5 (primitive UImm5))
+(type Imm5 (primitive Imm5))
 (type Imm20 (primitive Imm20))
 (type Imm3 (primitive Imm3))
 (type BranchTarget (primitive BranchTarget))
@@ -1322,6 +1330,17 @@
 (decl imm12_from_u64 (Imm12) u64)
 (extern extractor imm12_from_u64 imm12_from_u64)
 
+
+;; Imm5 Extractors
+
+(decl imm5_from_u64 (Imm5) u64)
+(extern extractor imm5_from_u64 imm5_from_u64)
+
+;; Extractor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
+;; TODO: Try matching vconst here as well
+(decl replicated_imm5 (Imm5) Value)
+(extractor (replicated_imm5 n)
+  (def_inst (splat (iconst (u64_from_imm64 (imm5_from_u64 n))))))
 
 
 ;; Float Helpers

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -5,6 +5,7 @@ use crate::ir::RelSourceLoc;
 use crate::ir::TrapCode;
 use crate::isa::riscv64::inst::*;
 use crate::isa::riscv64::inst::{zero_reg, AluOPRRR};
+use crate::isa::riscv64::lower::isle::generated_code::VecOpMasking;
 use crate::machinst::{AllocationConsumer, Reg, Writable};
 use cranelift_control::ControlPlane;
 use regalloc2::Allocation;
@@ -635,7 +636,7 @@ impl MachInstEmit for Inst {
 
                 sink.put4(encode_r_type(
                     alu_op.op_code(),
-                    rd.to_reg(),
+                    rd,
                     alu_op.funct3(),
                     rs1,
                     rs2,
@@ -2789,19 +2790,7 @@ impl MachInstEmit for Inst {
                 let vs2 = allocs.next(vs2);
                 let vd = allocs.next_writable(vd);
 
-                // This is the mask bit, we don't yet implement masking, so set it to 1, which means
-                // masking disabled.
-                let vm = 1;
-
-                sink.put4(encode_valu(
-                    op.opcode(),
-                    vd.to_reg(),
-                    op.funct3(),
-                    vs1,
-                    vs2,
-                    vm,
-                    op.funct6(),
-                ));
+                sink.put4(encode_valu(op, vd, vs1, vs2, VecOpMasking::Disabled));
             }
             &Inst::VecAluRRImm5 {
                 op, vd, imm, vs2, ..
@@ -2809,19 +2798,7 @@ impl MachInstEmit for Inst {
                 let vs2 = allocs.next(vs2);
                 let vd = allocs.next_writable(vd);
 
-                // This is the mask bit, we don't yet implement masking, so set it to 1, which means
-                // masking disabled.
-                let vm = 1;
-
-                sink.put4(encode_valu_imm(
-                    op.opcode(),
-                    vd.to_reg(),
-                    op.funct3(),
-                    imm,
-                    vs2,
-                    vm,
-                    op.funct6(),
-                ));
+                sink.put4(encode_valu_imm(op, vd, imm, vs2, VecOpMasking::Disabled));
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd = allocs.next_writable(rd);
@@ -2861,17 +2838,14 @@ impl MachInstEmit for Inst {
                     sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
-                // This is the mask bit, we don't yet implement masking, so set it to 1, which means
-                // masking disabled.
-                let vm = 1;
-
                 sink.put4(encode_vmem_load(
                     0x07,
                     to.to_reg(),
                     eew,
                     addr.to_reg(),
                     from.lumop(),
-                    vm,
+                    // We don't implement masking yet.
+                    VecOpMasking::Disabled,
                     from.mop(),
                     from.nf(),
                 ));
@@ -2901,17 +2875,14 @@ impl MachInstEmit for Inst {
                     sink.add_trap(TrapCode::HeapOutOfBounds);
                 }
 
-                // This is the mask bit, we don't yet implement masking, so set it to 1, which means
-                // masking disabled.
-                let vm = 1;
-
                 sink.put4(encode_vmem_store(
                     0x27,
                     from,
                     eew,
                     addr.to_reg(),
                     to.sumop(),
-                    vm,
+                    // We don't implement masking yet.
+                    VecOpMasking::Disabled,
                     to.mop(),
                     to.nf(),
                 ));

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -467,6 +467,7 @@ impl Inst {
             Inst::VecSetState { .. } => None,
 
             Inst::VecAluRRR { vstate, .. } |
+            Inst::VecAluRRImm5 { vstate, .. } |
             // TODO: Unit-stride loads and stores only need the AVL to be correct, not
             // the full vtype. A future optimization could be to decouple these two when
             // updating vstate. This would allow us to avoid emitting a VecSetState in
@@ -2797,6 +2798,26 @@ impl MachInstEmit for Inst {
                     vd.to_reg(),
                     op.funct3(),
                     vs1,
+                    vs2,
+                    vm,
+                    op.funct6(),
+                ));
+            }
+            &Inst::VecAluRRImm5 {
+                op, vd, imm, vs2, ..
+            } => {
+                let vs2 = allocs.next(vs2);
+                let vd = allocs.next_writable(vd);
+
+                // This is the mask bit, we don't yet implement masking, so set it to 1, which means
+                // masking disabled.
+                let vm = 1;
+
+                sink.put4(encode_valu_imm(
+                    op.opcode(),
+                    vd.to_reg(),
+                    op.funct3(),
+                    imm,
                     vs2,
                     vm,
                     op.funct6(),

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,7 +9,7 @@
 use super::{Imm5, UImm5, VType};
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpMasking,
+    VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
 use crate::Reg;
@@ -122,7 +122,7 @@ pub fn encode_vcfg_imm(opcode: u32, rd: Reg, imm: UImm5, vtype: &VType) -> u32 {
     let mut bits = 0;
     bits |= unsigned_field_width(opcode, 7);
     bits |= reg_to_gpr_num(rd) << 7;
-    bits |= 0b111 << 12;
+    bits |= VecOpCategory::OPCFG.encode() << 12;
     bits |= unsigned_field_width(imm.bits(), 5) << 15;
     bits |= unsigned_field_width(vtype.encode(), 10) << 20;
     bits |= 0b11 << 30;

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -6,25 +6,35 @@
 //! Some instructions especially in extensions have slight variations from
 //! the base RISC-V specification.
 
-use super::{UImm5, VType};
+use super::{Imm5, UImm5, VType};
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::VecElementWidth;
 use crate::Reg;
 
-/// Encode an R-type instruction.
-///
 /// Layout:
 /// 0-------6-7-------11-12------14-15------19-20------24-25-------31
 /// | Opcode |   rd     |  funct3  |   rs1    |   rs2    |   funct7  |
-pub fn encode_r_type(opcode: u32, rd: Reg, funct3: u32, rs1: Reg, rs2: Reg, funct7: u32) -> u32 {
+fn encode_r_type_bits(opcode: u32, rd: u32, funct3: u32, rs1: u32, rs2: u32, funct7: u32) -> u32 {
     let mut bits = 0;
     bits |= opcode & 0b1111111;
-    bits |= reg_to_gpr_num(rd) << 7;
+    bits |= (rd & 0b11111) << 7;
     bits |= (funct3 & 0b111) << 12;
-    bits |= reg_to_gpr_num(rs1) << 15;
-    bits |= reg_to_gpr_num(rs2) << 20;
+    bits |= (rs1 & 0b11111) << 15;
+    bits |= (rs2 & 0b11111) << 20;
     bits |= (funct7 & 0b1111111) << 25;
     bits
+}
+
+/// Encode an R-type instruction.
+pub fn encode_r_type(opcode: u32, rd: Reg, funct3: u32, rs1: Reg, rs2: Reg, funct7: u32) -> u32 {
+    encode_r_type_bits(
+        opcode,
+        reg_to_gpr_num(rd),
+        funct3,
+        reg_to_gpr_num(rs1),
+        reg_to_gpr_num(rs2),
+        funct7,
+    )
 }
 
 /// Encodes a Vector ALU instruction.
@@ -48,10 +58,45 @@ pub fn encode_valu(
     vm: u32,
     funct6: u32,
 ) -> u32 {
+    // VALU is just VALUImm with the register in the immediate field.
+    let imm = Imm5::maybe_from_i8((reg_to_gpr_num(vs1) as i8) << 3 >> 3).unwrap();
+    encode_valu_imm(opcode, vd, funct3, imm, vs2, vm, funct6)
+}
+
+/// Encodes a Vector ALU+Imm instruction.
+/// This is just a Vector ALU instruction with an immediate in the VS1 field.
+///
+/// Fields:
+/// - opcode (7 bits)
+/// - vd     (5 bits)
+/// - funct3 (3 bits)
+/// - imm    (5 bits)
+/// - vs2    (5 bits)
+/// - vm     (1 bit)
+/// - funct6 (6 bits)
+///
+/// See: https://github.com/riscv/riscv-v-spec/blob/master/valu-format.adoc
+pub fn encode_valu_imm(
+    opcode: u32,
+    vd: Reg,
+    funct3: u32,
+    imm: Imm5,
+    vs2: Reg,
+    vm: u32,
+    funct6: u32,
+) -> u32 {
     let funct6 = funct6 & 0b111111;
     let vm = vm & 0b1;
     let funct7 = (funct6 << 1) | vm;
-    encode_r_type(opcode, vd, funct3, vs1, vs2, funct7)
+    let imm = (imm.bits() & 0b11111) as u32;
+    encode_r_type_bits(
+        opcode,
+        reg_to_gpr_num(vd),
+        funct3,
+        imm,
+        reg_to_gpr_num(vs2),
+        funct7,
+    )
 }
 
 /// Encodes a Vector CFG Imm instruction.

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -127,6 +127,34 @@ impl Display for UImm5 {
     }
 }
 
+/// A Signed 5-bit immediate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Imm5 {
+    value: i8,
+}
+
+impl Imm5 {
+    /// Create an signed 5-bit immediate from an i8.
+    pub fn maybe_from_i8(value: i8) -> Option<Imm5> {
+        if value >= -16 && value <= 15 {
+            Some(Imm5 { value })
+        } else {
+            None
+        }
+    }
+
+    /// Bits for encoding.
+    pub fn bits(&self) -> u8 {
+        self.value as u8
+    }
+}
+
+impl Display for Imm5 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.value)
+    }
+}
+
 impl Inst {
     pub(crate) fn imm_min() -> i64 {
         let imm20_max: i64 = (1 << 19) << 12;

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -145,7 +145,7 @@ impl Imm5 {
 
     /// Bits for encoding.
     pub fn bits(&self) -> u8 {
-        self.value as u8
+        self.value as u8 & 0x1f
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -646,6 +646,10 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(vs2);
             collector.reg_def(vd);
         }
+        &Inst::VecAluRRImm5 { vd, vs2, .. } => {
+            collector.reg_use(vs2);
+            collector.reg_def(vd);
+        }
         &Inst::VecSetState { rd, .. } => {
             collector.reg_def(rd);
         }
@@ -1582,6 +1586,18 @@ impl Inst {
                 // Note: vs2 and vs1 here are opposite to the standard scalar ordering.
                 // This is noted in Section 10.1 of the RISC-V Vector spec.
                 format!("{} {},{},{} {}", op, vd_s, vs2_s, vs1_s, vstate)
+            }
+            &Inst::VecAluRRImm5 {
+                op,
+                vd,
+                imm,
+                vs2,
+                ref vstate,
+            } => {
+                let vs2_s = format_vec_reg(vs2, allocs);
+                let vd_s = format_vec_reg(vd.to_reg(), allocs);
+
+                format!("{} {},{},{} {}", op, vd_s, vs2_s, imm, vstate)
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd_s = format_reg(rd.to_reg(), allocs);

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1,7 +1,7 @@
 use crate::isa::riscv64::inst::EmitState;
 use crate::isa::riscv64::lower::isle::generated_code::{
     VecAMode, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul, VecMaskMode,
-    VecOpCategory, VecTailMode, VecOpMasking
+    VecOpCategory, VecOpMasking, VecTailMode,
 };
 use crate::Reg;
 use core::fmt;

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1,7 +1,7 @@
 use crate::isa::riscv64::inst::EmitState;
 use crate::isa::riscv64::lower::isle::generated_code::{
     VecAMode, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul, VecMaskMode,
-    VecOpCategory, VecTailMode,
+    VecOpCategory, VecTailMode, VecOpMasking
 };
 use crate::Reg;
 use core::fmt;
@@ -225,6 +225,15 @@ impl VecOpCategory {
             VecOpCategory::OPFVF => 0b101,
             VecOpCategory::OPMVX => 0b110,
             VecOpCategory::OPCFG => 0b111,
+        }
+    }
+}
+
+impl VecOpMasking {
+    pub fn encode(&self) -> u32 {
+        match self {
+            VecOpMasking::Enabled => 0,
+            VecOpMasking::Disabled => 1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1,7 +1,7 @@
 use crate::isa::riscv64::inst::EmitState;
 use crate::isa::riscv64::lower::isle::generated_code::{
     VecAMode, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul, VecMaskMode,
-    VecTailMode,
+    VecOpCategory, VecTailMode,
 };
 use crate::Reg;
 use core::fmt;
@@ -213,23 +213,37 @@ impl fmt::Display for VState {
     }
 }
 
+impl VecOpCategory {
+    pub fn encode(&self) -> u32 {
+        // See: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#101-vector-arithmetic-instruction-encoding
+        match self {
+            VecOpCategory::OPIVV => 0b000,
+            VecOpCategory::OPFVV => 0b001,
+            VecOpCategory::OPMVV => 0b010,
+            VecOpCategory::OPIVI => 0b011,
+            VecOpCategory::OPIVX => 0b100,
+            VecOpCategory::OPFVF => 0b101,
+            VecOpCategory::OPMVX => 0b110,
+            VecOpCategory::OPCFG => 0b111,
+        }
+    }
+}
+
 impl VecAluOpRRR {
     pub fn opcode(&self) -> u32 {
         // Vector Opcode
         0x57
     }
     pub fn funct3(&self) -> u32 {
-        // See: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#101-vector-arithmetic-instruction-encoding
         match self {
-            // OPIVV
             VecAluOpRRR::Vadd
             | VecAluOpRRR::Vsub
             | VecAluOpRRR::Vand
             | VecAluOpRRR::Vor
-            | VecAluOpRRR::Vxor => 0b000,
-            // OPIMV
-            VecAluOpRRR::Vmul | VecAluOpRRR::Vmulh | VecAluOpRRR::Vmulhu => 0b010,
+            | VecAluOpRRR::Vxor => VecOpCategory::OPIVV,
+            VecAluOpRRR::Vmul | VecAluOpRRR::Vmulh | VecAluOpRRR::Vmulhu => VecOpCategory::OPMVV,
         }
+        .encode()
     }
     pub fn funct6(&self) -> u32 {
         // See: https://github.com/riscv/riscv-v-spec/blob/master/inst-table.adoc
@@ -261,8 +275,7 @@ impl VecAluOpRRImm5 {
         0x57
     }
     pub fn funct3(&self) -> u32 {
-        // OPIVI
-        0b011
+        VecOpCategory::OPIVI.encode()
     }
     pub fn funct6(&self) -> u32 {
         // See: https://github.com/riscv/riscv-v-spec/blob/master/inst-table.adoc

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1,6 +1,7 @@
 use crate::isa::riscv64::inst::EmitState;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAMode, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul, VecMaskMode, VecTailMode,
+    VecAMode, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul, VecMaskMode,
+    VecTailMode,
 };
 use crate::Reg;
 use core::fmt;
@@ -218,6 +219,7 @@ impl VecAluOpRRR {
         0x57
     }
     pub fn funct3(&self) -> u32 {
+        // See: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#101-vector-arithmetic-instruction-encoding
         match self {
             // OPIVV
             VecAluOpRRR::Vadd
@@ -249,6 +251,32 @@ impl fmt::Display for VecAluOpRRR {
         let mut s = format!("{self:?}");
         s.make_ascii_lowercase();
         s.push_str(".vv");
+        f.write_str(&s)
+    }
+}
+
+impl VecAluOpRRImm5 {
+    pub fn opcode(&self) -> u32 {
+        // Vector Opcode
+        0x57
+    }
+    pub fn funct3(&self) -> u32 {
+        // OPIVI
+        0b011
+    }
+    pub fn funct6(&self) -> u32 {
+        // See: https://github.com/riscv/riscv-v-spec/blob/master/inst-table.adoc
+        match self {
+            VecAluOpRRImm5::Vadd => 0b000000,
+        }
+    }
+}
+
+impl fmt::Display for VecAluOpRRImm5 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut s = format!("{self:?}");
+        s.make_ascii_lowercase();
+        s.push_str(".vi");
         f.write_str(&s)
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -56,6 +56,22 @@
 (type VType (primitive VType))
 (type VState (primitive VState))
 
+
+;; Vector Opcode Category
+;;
+;; These categories are used to determine the type of operands that are allowed in the
+;; instruction.
+(type VecOpCategory (enum
+  (OPIVV)
+  (OPFVV)
+  (OPMVV)
+  (OPIVI)
+  (OPIVX)
+  (OPFVF)
+  (OPMVX)
+  (OPCFG)
+))
+
 ;; Register to Register ALU Ops
 (type VecAluOpRRR (enum
   (Vadd)

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -72,6 +72,15 @@
   (OPCFG)
 ))
 
+;; Vector Opcode Masking
+;;
+;; When masked, the instruction will only operate on the elements that are dictated by
+;; the mask register. Currently this is always fixed to v0.
+(type VecOpMasking (enum
+  (Enabled)
+  (Disabled)
+))
+
 ;; Register to Register ALU Ops
 (type VecAluOpRRR (enum
   (Vadd)

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -68,6 +68,11 @@
   (Vxor)
 ))
 
+;; Register-Imm ALU Ops
+(type VecAluOpRRImm5 (enum
+  (Vadd)
+))
+
 
 
 ;; Vector Addressing Mode
@@ -128,6 +133,13 @@
             (_ Unit (emit (MInst.VecAluRRR op vd vs2 vs1 vstate))))
         vd))
 
+;; Helper for emitting `MInst.VecAluRRImm5` instructions.
+(decl vec_alu_rr_imm5 (VecAluOpRRImm5 Reg Imm5 VState) Reg)
+(rule (vec_alu_rr_imm5 op vs2 imm vstate)
+      (let ((vd WritableReg (temp_writable_reg $I8X16))
+            (_ Unit (emit (MInst.VecAluRRImm5 op vd vs2 imm vstate))))
+        vd))
+
 ;; Helper for emitting `MInst.VecLoad` instructions.
 (decl vec_load (VecElementWidth VecAMode MemFlags VState) Reg)
 (rule (vec_load eew from flags vstate)
@@ -145,6 +157,11 @@
 (decl rv_vadd_vv (Reg Reg VState) Reg)
 (rule (rv_vadd_vv vs2 vs1 vstate)
   (vec_alu_rrr (VecAluOpRRR.Vadd) vs2 vs1 vstate))
+
+;; Helper for emitting the `vadd.vi` instruction.
+(decl rv_vadd_vi (Reg Imm5 VState) Reg)
+(rule (rv_vadd_vi vs2 imm vstate)
+  (vec_alu_rr_imm5 (VecAluOpRRImm5.Vadd) vs2 imm vstate))
 
 ;; Helper for emitting the `vsub.vv` instruction.
 (decl rv_vsub_vv (Reg Reg VState) Reg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -101,6 +101,12 @@
 (rule 8 (lower (has_type (ty_vec_fits_in_register ty) (iadd x y)))
   (rv_vadd_vv x y ty))
 
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (replicated_imm5 y))))
+  (rv_vadd_vi x y ty))
+
+(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd (replicated_imm5 x) y)))
+  (rv_vadd_vi y x ty))
+
 ;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;
 (rule
   (lower (has_type (fits_in_64 ty) (uadd_overflow_trap x y tc)))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -241,7 +241,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
     #[inline]
     fn imm5_from_u64(&mut self, arg0: u64) -> Option<Imm5> {
-        Imm5::maybe_from_i8(arg0 as i64 as i8)
+        Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
     fn writable_zero_reg(&mut self) -> WritableReg {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -240,6 +240,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm12::maybe_from_u64(arg0)
     }
     #[inline]
+    fn imm5_from_u64(&mut self, arg0: u64) -> Option<Imm5> {
+        Imm5::maybe_from_i8(arg0 as i64 as i8)
+    }
+    #[inline]
     fn writable_zero_reg(&mut self) -> WritableReg {
         writable_zero_reg()
     }

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
@@ -71,3 +71,79 @@ block0(v0: i64x2, v1: i64x2):
 ;   .byte 0x57, 0x85, 0xa5, 0x02
 ;   ret
 
+function %iadd_const_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = iconst.i8 5
+    v2 = splat.i8x16 v1
+    v3 = iadd v0, v2
+    return v3
+}
+
+; VCode:
+; block0:
+;   vadd.vi v10,v10,5 #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x57, 0xb5, 0xa2, 0x02
+;   ret
+
+function %iadd_const_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = iconst.i16 -16
+    v2 = splat.i16x8 v1
+    v3 = iadd v0, v2
+    return v3
+}
+
+; VCode:
+; block0:
+;   vadd.vi v10,v10,-16 #avl=8, #vtype=(e16, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x35, 0xa8, 0x02
+;   ret
+
+function %iadd_const_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 15
+    v2 = splat.i32x4 v1
+    v3 = iadd v0, v2
+    return v3
+}
+
+; VCode:
+; block0:
+;   vadd.vi v10,v10,15 #avl=4, #vtype=(e32, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0xb5, 0xa7, 0x02
+;   ret
+
+function %iadd_const_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i64 -5
+    v2 = splat.i64x2 v1
+    v3 = iadd v2, v0
+    return v3
+}
+
+; VCode:
+; block0:
+;   vadd.vi v10,v10,-5 #avl=2, #vtype=(e64, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xb5, 0xad, 0x02
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -1,0 +1,45 @@
+test interpret
+test run
+target aarch64
+target s390x
+target x86_64 has_sse41=false
+set enable_simd
+target x86_64
+target x86_64 skylake
+target riscv64 has_v
+
+function %iadd_splat_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = iconst.i8 5
+    v2 = splat.i8x16 v1
+    v3 = iadd v0, v2
+    return v3
+}
+; run: %iadd_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21]
+
+function %iadd_splat_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = iconst.i16 -16
+    v2 = splat.i16x8 v1
+    v3 = iadd v0, v2
+    return v3
+}
+; run: %iadd_splat_i16x8([1 2 3 4 5 6 7 8]) == [-15 -14 -13 -12 -11 -10 -9 -8]
+
+function %iadd_splat_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 15
+    v2 = splat.i32x4 v1
+    v3 = iadd v0, v2
+    return v3
+}
+; run: %iadd_splat_i32x4([1 2 3 4]) == [16 17 18 19]
+
+function %iadd_splat_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i64 -5
+    v2 = splat.i64x2 v1
+    v3 = iadd v2, v0
+    return v3
+}
+; run: %iadd_splat_i64x2([1 2]) == [-4 -3]


### PR DESCRIPTION
👋 Hey,

This PR adds a new vector instruction format `Vector+Imm`. The encoding is exactly the same as `v*.vv` but the second register is instead a 5 bit field. This immediate is signed for most ops, but unsigned for some.

