### PR TITLE
cranelift: Update regalloc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af72b4ad16ae133417b3ab89ad5a179b5103f202a8aadeb7e8adcb530d319744"
+checksum = "d4a52e724646c6c0800fc456ec43b4165d2f91fba88ceaca06d9e0b400023478"
 dependencies = [
  "hashbrown 0.13.2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ serde = "1.0.94"
 serde_json = "1.0.80"
 glob = "0.3.0"
 libfuzzer-sys = "0.4.0"
+regalloc2 = "0.8.1"
 
 [features]
 default = [

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
-regalloc2 = { version = "0.7.0", features = ["checker"] }
+regalloc2 = { workspace = true, features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -254,12 +254,14 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 let next_reg = match rc {
                     RegClass::Int => &mut next_xreg,
                     RegClass::Float => &mut next_vreg,
+                    RegClass::Vector => unreachable!(),
                 };
 
                 if *next_reg < max_per_class_reg_vals && remaining_reg_vals > 0 {
                     let reg = match rc {
                         RegClass::Int => xreg(*next_reg),
                         RegClass::Float => vreg(*next_reg),
+                        RegClass::Vector => unreachable!(),
                     };
                     // Overlay Z-regs on V-regs for parameter passing.
                     let ty = if param.value_type.is_dynamic_vector() {
@@ -707,6 +709,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             match reg.to_reg().class() {
                 RegClass::Int => clobbered_int.push(reg),
                 RegClass::Float => clobbered_vec.push(reg),
+                RegClass::Vector => unreachable!(),
             }
         }
 
@@ -1072,6 +1075,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         match rc {
             RegClass::Int => 1,
             RegClass::Float => vector_size / 8,
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -1174,6 +1178,7 @@ fn is_reg_saved_in_prologue(enable_pinned_reg: bool, sig: &Signature, r: RealReg
                 r.hw_enc() >= 8 && r.hw_enc() <= 15
             }
         }
+        RegClass::Vector => unreachable!(),
     }
 }
 
@@ -1192,6 +1197,7 @@ fn get_regs_restored_in_epilogue(
             match reg.to_reg().class() {
                 RegClass::Int => int_saves.push(reg),
                 RegClass::Float => vec_saves.push(reg),
+                RegClass::Vector => unreachable!(),
             }
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1030,6 +1030,7 @@ impl MachInst for Inst {
                     }
                 }
             }
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -1083,6 +1084,7 @@ impl MachInst for Inst {
         match rc {
             RegClass::Float => types::I8X16,
             RegClass::Int => types::I64,
+            RegClass::Vector => unreachable!(),
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -204,6 +204,8 @@ pub fn create_reg_env(flags: &settings::Flags) -> MachineEnv {
                 preg(vreg(30)),
                 preg(vreg(31)),
             ],
+            // Vector Regclass is unused
+            vec![],
         ],
         non_preferred_regs_by_class: [
             vec![
@@ -228,9 +230,11 @@ pub fn create_reg_env(flags: &settings::Flags) -> MachineEnv {
                 preg(vreg(14)),
                 preg(vreg(15)),
             ],
+            // Vector Regclass is unused
+            vec![],
         ],
         fixed_stack_slots: vec![],
-        scratch_by_class: [None, None],
+        scratch_by_class: [None, None, None],
     };
 
     if !flags.enable_pinned_reg() {
@@ -267,6 +271,7 @@ fn show_reg(reg: Reg) -> String {
         match rreg.class() {
             RegClass::Int => show_ireg(rreg),
             RegClass::Float => show_vreg(rreg),
+            RegClass::Vector => unreachable!(),
         }
     } else {
         format!("%{:?}", reg)

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -43,6 +43,7 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
             let reg = reg.to_real_reg().unwrap().hw_enc() as u16;
             Ok(Register(64 + reg))
         }
+        RegClass::Vector => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -417,6 +417,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 let ty = match r_reg.class() {
                     regalloc2::RegClass::Int => I64,
                     regalloc2::RegClass::Float => F64,
+                    RegClass::Vector => unreachable!(),
                 };
                 if flags.unwind_info() {
                     insts.push(Inst::Unwind {
@@ -463,6 +464,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             let ty = match rreg.class() {
                 regalloc2::RegClass::Int => I64,
                 regalloc2::RegClass::Float => F64,
+                RegClass::Vector => unreachable!(),
             };
             insts.push(Self::gen_load_stack(
                 StackAMode::SPOffset(-cur_offset, ty),
@@ -575,6 +577,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         match rc {
             RegClass::Int => 1,
             RegClass::Float => 1,
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -694,6 +697,7 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
             RegClass::Float => {
                 clobbered_size += 8;
             }
+            RegClass::Vector => unreachable!(),
         }
     }
     align_to(clobbered_size, 16)

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -676,6 +676,7 @@ impl MachInst for Inst {
         match rc {
             regalloc2::RegClass::Int => I64,
             regalloc2::RegClass::Float => F64,
+            regalloc2::RegClass::Vector => unreachable!(),
         }
     }
 
@@ -838,6 +839,7 @@ pub fn reg_name(reg: Reg) -> String {
                 28..=31 => format!("ft{}", real.hw_enc() - 20),
                 _ => unreachable!(),
             },
+            RegClass::Vector => unreachable!(),
         },
         None => {
             format!("{:?}", reg)

--- a/cranelift/codegen/src/isa/riscv64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/regs.rs
@@ -136,7 +136,7 @@ pub fn writable_spilltmp_reg2() -> Writable<Reg> {
 }
 
 pub fn crate_reg_eviroment(_flags: &settings::Flags) -> MachineEnv {
-    let preferred_regs_by_class: [Vec<PReg>; 2] = {
+    let preferred_regs_by_class: [Vec<PReg>; 3] = {
         let mut x_register: Vec<PReg> = vec![];
         x_register.push(PReg::new(5, RegClass::Int));
         for i in 6..=7 {
@@ -159,10 +159,10 @@ pub fn crate_reg_eviroment(_flags: &settings::Flags) -> MachineEnv {
         for i in 28..=31 {
             f_register.push(PReg::new(i, RegClass::Float));
         }
-        [x_register, f_register]
+        [x_register, f_register, vec![]]
     };
 
-    let non_preferred_regs_by_class: [Vec<PReg>; 2] = {
+    let non_preferred_regs_by_class: [Vec<PReg>; 3] = {
         let mut x_register: Vec<PReg> = vec![];
         x_register.push(PReg::new(9, RegClass::Int));
         for i in 18..=27 {
@@ -175,14 +175,14 @@ pub fn crate_reg_eviroment(_flags: &settings::Flags) -> MachineEnv {
         for i in 18..=27 {
             f_register.push(PReg::new(i, RegClass::Float));
         }
-        [x_register, f_register]
+        [x_register, f_register, vec![]]
     };
 
     MachineEnv {
         preferred_regs_by_class,
         non_preferred_regs_by_class,
         fixed_stack_slots: vec![],
-        scratch_by_class: [None, None],
+        scratch_by_class: [None, None, None],
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
@@ -39,6 +39,7 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
             let reg = reg.to_real_reg().unwrap().hw_enc() as u16;
             Ok(Register(32 + reg))
         }
+        RegClass::Vector => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -766,6 +766,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         match rc {
             RegClass::Int => 1,
             RegClass::Float => 2,
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -834,6 +835,7 @@ fn is_reg_saved_in_prologue(_call_conv: isa::CallConv, r: RealReg) -> bool {
             // f8 - f15 inclusive are callee-saves.
             r.hw_enc() >= 8 && r.hw_enc() <= 15
         }
+        RegClass::Vector => unreachable!(),
     }
 }
 
@@ -878,6 +880,7 @@ fn get_clobbered_gpr_fpr(
                 }
             }
             RegClass::Float => clobbered_fpr.push(reg),
+            RegClass::Vector => unreachable!(),
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1117,6 +1117,7 @@ impl MachInst for Inst {
         match rc {
             RegClass::Int => types::I64,
             RegClass::Float => types::I8X16,
+            RegClass::Vector => unreachable!(),
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -125,6 +125,8 @@ pub fn create_machine_env(_flags: &settings::Flags) -> MachineEnv {
                 preg(vr(30)),
                 preg(vr(31)),
             ],
+            // Vector Regclass is unused
+            vec![],
         ],
         non_preferred_regs_by_class: [
             vec![
@@ -149,9 +151,11 @@ pub fn create_machine_env(_flags: &settings::Flags) -> MachineEnv {
                 preg(vr(14)),
                 preg(vr(15)),
             ],
+            // Vector Regclass is unused
+            vec![],
         ],
         fixed_stack_slots: vec![],
-        scratch_by_class: [None, None],
+        scratch_by_class: [None, None, None],
     }
 }
 
@@ -160,6 +164,7 @@ pub fn show_reg(reg: Reg) -> String {
         match rreg.class() {
             RegClass::Int => format!("%r{}", rreg.hw_enc()),
             RegClass::Float => format!("%v{}", rreg.hw_enc()),
+            RegClass::Vector => unreachable!(),
         }
     } else {
         format!("%{:?}", reg)

--- a/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/unwind/systemv.rs
@@ -83,6 +83,7 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
     match reg.class() {
         RegClass::Int => Ok(GPR_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
         RegClass::Float => Ok(VR_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
+        RegClass::Vector => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -514,6 +514,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     ));
                     cur_offset += 16;
                 }
+                RegClass::Vector => unreachable!(),
             };
             if flags.unwind_info() {
                 insts.push(Inst::Unwind {
@@ -566,6 +567,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
                     ));
                     cur_offset += 16;
                 }
+                RegClass::Vector => unreachable!(),
             }
         }
         // Adjust RSP back upward.
@@ -675,6 +677,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         match rc {
             RegClass::Int => 1,
             RegClass::Float => vector_scale / 8,
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -887,6 +890,7 @@ fn is_callee_save_systemv(r: RealReg, enable_pinned_reg: bool) -> bool {
             _ => false,
         },
         RegClass::Float => false,
+        RegClass::Vector => unreachable!(),
     }
 }
 
@@ -903,6 +907,7 @@ fn is_callee_save_fastcall(r: RealReg, enable_pinned_reg: bool) -> bool {
             6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 => true,
             _ => false,
         },
+        RegClass::Vector => unreachable!(),
     }
 }
 
@@ -917,6 +922,7 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
                 clobbered_size = align_to(clobbered_size, 16);
                 clobbered_size += 16;
             }
+            RegClass::Vector => unreachable!(),
         }
     }
     align_to(clobbered_size, 16)

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -606,6 +606,7 @@ impl Inst {
                 };
                 Inst::xmm_unary_rm_r(opcode, RegMem::mem(from_addr), to_reg)
             }
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -625,6 +626,7 @@ impl Inst {
                 };
                 Inst::xmm_mov_r_m(opcode, from_reg, to_addr)
             }
+            RegClass::Vector => unreachable!(),
         }
     }
 }
@@ -2514,6 +2516,7 @@ impl MachInst for Inst {
                 };
                 Inst::xmm_unary_rm_r(opcode, RegMem::reg(src_reg), dst_reg)
             }
+            RegClass::Vector => unreachable!(),
         }
     }
 
@@ -2547,6 +2550,7 @@ impl MachInst for Inst {
         match rc {
             RegClass::Float => types::I8X16,
             RegClass::Int => types::I64,
+            RegClass::Vector => unreachable!(),
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -195,15 +195,19 @@ pub(crate) fn create_reg_env_systemv(flags: &settings::Flags) -> MachineEnv {
                 preg(xmm14()),
                 preg(xmm15()),
             ],
+            // The Vector Regclass is unused
+            vec![],
         ],
         non_preferred_regs_by_class: [
             // Non-preferred GPRs: callee-saved in the SysV ABI.
             vec![preg(rbx()), preg(r12()), preg(r13()), preg(r14())],
             // Non-preferred XMMs: none.
             vec![],
+            // The Vector Regclass is unused
+            vec![],
         ],
         fixed_stack_slots: vec![],
-        scratch_by_class: [None, None],
+        scratch_by_class: [None, None, None],
     };
 
     debug_assert_eq!(r15(), pinned_reg());
@@ -256,6 +260,7 @@ pub fn realreg_name(reg: RealReg) -> &'static str {
             15 => "%xmm15",
             _ => panic!("Invalid PReg: {:?}", preg),
         },
+        RegClass::Vector => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/systemv.rs
@@ -76,6 +76,7 @@ pub fn map_reg(reg: Reg) -> Result<Register, RegisterMappingError> {
             Ok(X86_GP_REG_MAP[reg.to_real_reg().unwrap().hw_enc() as usize])
         }
         RegClass::Float => Ok(X86_XMM_REG_MAP[reg.to_real_reg().unwrap().hw_enc() as usize]),
+        RegClass::Vector => unreachable!(),
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/x64/inst/unwind/winx64.rs
@@ -10,6 +10,7 @@ impl crate::isa::unwind::winx64::RegisterMapper<Reg> for RegisterMapper {
         match reg.class() {
             RegClass::Int => MappedRegister::Int(reg.to_real_reg().unwrap().hw_enc()),
             RegClass::Float => MappedRegister::Xmm(reg.to_real_reg().unwrap().hw_enc()),
+            RegClass::Vector => unreachable!(),
         }
     }
 }

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -9,7 +9,7 @@ use regalloc2::{Allocation, Operand, OperandConstraint, PReg, PRegSet, VReg};
 #[cfg(feature = "enable-serde")]
 use serde::{Deserialize, Serialize};
 
-/// The first 128 vregs (64 int, 64 float/vec) are "pinned" to
+/// The first 192 vregs (64 int, 64 float, 64 vec) are "pinned" to
 /// physical registers: this means that they are always constrained to
 /// the corresponding register at all use/mod/def sites.
 ///
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// particular use/def/mod sites, and this is preferable; but pinned
 /// vregs allow us to migrate code that has been written using
 /// RealRegs directly.
-const PINNED_VREGS: usize = 128;
+const PINNED_VREGS: usize = 192;
 
 /// Convert a `VReg` to its pinned `PReg`, if any.
 pub fn pinned_vreg_to_preg(vreg: VReg) -> Option<PReg> {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -36,6 +36,13 @@ user-id = 187138
 user-login = "elliottt"
 user-name = "Trevor Elliott"
 
+[[publisher.regalloc2]]
+version = "0.8.1"
+when = "2023-05-01"
+user-id = 3726
+user-login = "cfallin"
+user-name = "Chris Fallin"
+
 [[publisher.wasm-mutate]]
 version = "0.2.23"
 when = "2023-04-13"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -17,7 +17,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 # In the next iteration we'll factor out the common bits so that they can be consumed
 # by Cranelift and Winch.
 cranelift-codegen = { workspace = true }
-regalloc2 = "0.7.0"
+regalloc2 = { workspace = true }
 gimli = { workspace = true }
 
 [features]


### PR DESCRIPTION
👋 Hey,

This PR updates regalloc2 to the latest version, which adds a new RegClass. All backends currently do not make use of this third RegClass.

This might also need a cargo vet update.