### PR TITLE
Add a regalloc2 wildcard audit for myself

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -24,6 +24,19 @@ start = "2020-01-14"
 end = "2024-04-27"
 notes = "I am an author of this crate"
 
+[[wildcard-audits.regalloc2]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+user-id = 187138
+start = "2022-11-29"
+end = "2024-05-02"
+notes = """
+This is a Bytecode Alliance authored crate maintained in the `regalloc2`
+repository of which I'm one of the maintainers and publishers for. I am employed
+by a member of the Bytecode Alliance and plan to continue doing so and will
+actively maintain this crate over time.
+"""
+
 [[wildcard-audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -653,10 +653,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.regalloc2]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.regex]]
 version = "1.5.5"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -22,6 +22,13 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.regalloc2]]
+version = "0.7.0"
+when = "2023-04-18"
+user-id = 187138
+user-login = "elliottt"
+user-name = "Trevor Elliott"
+
 [[publisher.wasm-mutate]]
 version = "0.2.23"
 when = "2023-04-13"


### PR DESCRIPTION
Add myself to the wildcard audit list for regalloc2, allowing the versions that I upload to be automatically imported.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
