### PR TITLE
Turn down default instantiate timeout to 100ms

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -267,7 +267,7 @@ impl Config {
     /// Generates an arbitrary method of timing out an instance, ensuring that
     /// this configuration supports the returned timeout.
     pub fn generate_timeout(&mut self, u: &mut Unstructured<'_>) -> arbitrary::Result<Timeout> {
-        let time_duration = Duration::from_secs(20);
+        let time_duration = Duration::from_millis(100);
         let timeout = u
             .choose(&[Timeout::Fuel(100_000), Timeout::Epoch(time_duration)])?
             .clone();

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -139,6 +139,11 @@ pub enum Timeout {
 pub fn instantiate(wasm: &[u8], known_valid: bool, config: &generators::Config, timeout: Timeout) {
     let mut store = config.to_store();
 
+    let module = match compile_module(store.engine(), wasm, known_valid, config) {
+        Some(module) => module,
+        None => return,
+    };
+
     let mut timeout_state = SignalOnDrop::default();
     match timeout {
         Timeout::Fuel(fuel) => set_fuel(&mut store, fuel),
@@ -159,9 +164,7 @@ pub fn instantiate(wasm: &[u8], known_valid: bool, config: &generators::Config, 
         Timeout::None => {}
     }
 
-    if let Some(module) = compile_module(store.engine(), wasm, known_valid, config) {
-        instantiate_with_dummy(&mut store, &module);
-    }
+    instantiate_with_dummy(&mut store, &module);
 }
 
 /// Represents supported commands to the `instantiate_many` function.


### PR DESCRIPTION
The previous timeout was 20 seconds which while it won't ever time out on OSS-Fuzz a wasm module is highly unlikely to do anything interesting past the first bit as if it takes longer it's probably an uninteresting infinite loop. Additionally this should improve loading a whole corpus as test cases won't randomly take 20 seconds to load.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
