### PR TITLE
Add a wildcard audit for regalloc2 versions published by me.

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -24,6 +24,14 @@ start = "2020-01-14"
 end = "2024-04-27"
 notes = "I am an author of this crate"
 
+[[wildcard-audits.regalloc2]]
+who = "Chris Fallin <chris@cfallin.org>"
+criteria = "safe-to-deploy"
+user-id = 3726
+start = "2021-12-03"
+end = "2024-05-02"
+notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-develop it with Cranelift/Wasmtime, with the same code-review, testing/fuzzing, and security standards."
+
 [[wildcard-audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -653,10 +653,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.regalloc2]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.regex]]
 version = "1.5.5"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -22,6 +22,13 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.regalloc2]]
+version = "0.6.1"
+when = "2023-02-16"
+user-id = 3726
+user-login = "cfallin"
+user-name = "Chris Fallin"
+
 [[publisher.wasm-mutate]]
 version = "0.2.23"
 when = "2023-04-13"


### PR DESCRIPTION
Diff produced by `cargo vet certify regalloc2 --wildcard cfallin`, for reference.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
