### PR TITLE
Run some tests in MIRI on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -588,6 +588,51 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+  # Run a subset of tests under MIRI on CI to help check the `unsafe` code in
+  # Wasmtime to make sure it's at least not obviously incorrect for basic usage.
+  # Note that this doesn't run the full test suite since MIRI can't actually run
+  # WebAssembly itself at this time (aka it doesn't support a JIT). There are a
+  # number of annotations throughout the code which gates some tests on MIRI not
+  # being run.
+  #
+  # Note that `cargo nextest` is used here additionally to get parallel test
+  # execution by default to help cut down on the time in CI.
+  miri:
+    needs: determine
+    if: needs.determine.outputs.run-full
+    name: Miri
+    runs-on: ubuntu-latest
+    env:
+      CARGO_NEXTEST_VERSION: 0.9.51
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2023-03-20
+    - run: rustup component add rust-src miri
+    - uses: actions/cache@v3
+      with:
+        path: ${{ runner.tool_cache }}/cargo-nextest
+        key: cargo-nextest-bin-${{ env.CARGO_NEXTEST_VERSION }}
+    - run: echo "${{ runner.tool_cache }}/cargo-nextest/bin" >> $GITHUB_PATH
+    - run: cargo install --root ${{ runner.tool_cache }}/cargo-nextest --version ${{ env.CARGO_NEXTEST_VERSION }} cargo-nextest
+    - run: |
+        cargo miri nextest run -j4 --no-fail-fast \
+          -p wasmtime \
+          -p wasmtime-cli \
+          -p wasmtime-runtime \
+          -p wasmtime-environ
+      env:
+        MIRIFLAGS: -Zmiri-tree-borrows
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
   # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds a variety
   # of platforms and architectures and then uploads the release artifacts to
   # this workflow run's list of artifacts.
@@ -694,6 +739,7 @@ jobs:
       - meta_deterministic_check
       - verify-publish
       - determine
+      - miri
     if: always()
     steps:
     - name: Dump needs context

--- a/build.rs
+++ b/build.rs
@@ -155,6 +155,8 @@ fn write_testsuite_tests(
     // Ignore when using QEMU for running tests (limited memory).
     if ignore(testsuite, &testname, strategy) {
         writeln!(out, "#[ignore]")?;
+    } else {
+        writeln!(out, "#[cfg_attr(miri, ignore)]")?;
     }
 
     writeln!(

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -214,7 +214,7 @@ fn isa_constructor(
 
     // Check for compatibility between flags and ISA level
     // requested. In particular, SIMD support requires SSE4.2.
-    if shared_flags.enable_simd() {
+    if !cfg!(miri) && shared_flags.enable_simd() {
         if !isa_flags.has_sse3() || !isa_flags.has_ssse3() || !isa_flags.has_sse41() {
             return Err(CodegenError::Unsupported(
                 "SIMD support requires SSE3, SSSE3, and SSE4.1 on x86_64.".into(),

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -74,6 +74,9 @@ cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod win;
         use win as imp;
+    } else if #[cfg(miri)] {
+        mod miri;
+        use crate::miri as imp;
     } else {
         mod libc;
         use crate::libc as imp;

--- a/crates/jit-icache-coherence/src/miri.rs
+++ b/crates/jit-icache-coherence/src/miri.rs
@@ -1,0 +1,10 @@
+use std::ffi::c_void;
+use std::io::Result;
+
+pub(crate) fn pipeline_flush_mt() -> Result<()> {
+    Ok(())
+}
+
+pub(crate) fn clear_cache(_ptr: *const c_void, _len: usize) -> Result<()> {
+    Ok(())
+}

--- a/crates/jit/src/unwind.rs
+++ b/crates/jit/src/unwind.rs
@@ -2,6 +2,9 @@ cfg_if::cfg_if! {
     if #[cfg(all(windows, any(target_arch = "x86_64", target_arch = "aarch64")))] {
         mod winx64;
         pub use self::winx64::*;
+    } else if #[cfg(miri)] {
+        mod miri;
+        pub use self::miri::*;
     } else if #[cfg(unix)] {
         mod systemv;
         pub use self::systemv::*;

--- a/crates/jit/src/unwind/miri.rs
+++ b/crates/jit/src/unwind/miri.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+
+pub struct UnwindRegistration {}
+
+impl UnwindRegistration {
+    pub const SECTION_NAME: &str = ".eh_frame";
+
+    pub unsafe fn new(
+        _base_address: *const u8,
+        _unwind_info: *const u8,
+        _unwind_len: usize,
+    ) -> Result<UnwindRegistration> {
+        Ok(UnwindRegistration {})
+    }
+}

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -40,10 +40,36 @@ pub struct ComponentInstance {
     /// Size and offset information for the trailing `VMComponentContext`.
     offsets: VMComponentOffsets<HostPtr>,
 
+    /// A self-referential pointer to the `ComponentInstance` itself.
+    ///
+    /// The reason for this field's existence is a bit subtle because if you
+    /// have a pointer to `ComponentInstance` then why have this field which has
+    /// the same information? The subtlety here is due to the fact that this is
+    /// here to handle provenance and aliasing issues with optimizations in LLVM
+    /// and Rustc. Put another way, this is here to make MIRI happy. That's an
+    /// oversimplification, though, since this is actually required for
+    /// correctness to communicate the actual intent to LLVM's optimizations and
+    /// such.
+    ///
+    /// This field is chiefly used during `ComponentInstance::vmctx`. If you
+    /// think of pointers as a pair of address and provenance, this type stores
+    /// the provenance of the entire allocation. That's technically all we need
+    /// here, just the provenance, but that can only be done with storage of a
+    /// pointer hence the storage here.
+    ///
+    /// Finally note that there's a small wrapper around this to add `Send` and
+    /// `Sync` bounds, but serves no other purpose.
+    self_reference: RawComponentInstance,
+
     /// A zero-sized field which represents the end of the struct for the actual
     /// `VMComponentContext` to be allocated behind.
     vmctx: VMComponentContext,
 }
+
+struct RawComponentInstance(NonNull<ComponentInstance>);
+
+unsafe impl Send for RawComponentInstance {}
+unsafe impl Sync for RawComponentInstance {}
 
 /// Type signature for host-defined trampolines that are called from
 /// WebAssembly.
@@ -109,8 +135,7 @@ pub struct VMLowering {
 #[repr(C)]
 // Set an appropriate alignment for this structure where the most-aligned value
 // internally right now is a pointer.
-#[cfg_attr(target_pointer_width = "32", repr(align(4)))]
-#[cfg_attr(target_pointer_width = "64", repr(align(8)))]
+#[repr(align(16))]
 pub struct VMComponentContext {
     /// For more information about this see the equivalent field in `VMContext`
     _marker: marker::PhantomPinned,
@@ -138,7 +163,7 @@ impl ComponentInstance {
     /// the shape of the component being instantiated and `store` is a pointer
     /// back to the Wasmtime store for host functions to have access to.
     unsafe fn new_at(
-        ptr: *mut ComponentInstance,
+        ptr: NonNull<ComponentInstance>,
         alloc_size: usize,
         offsets: VMComponentOffsets<HostPtr>,
         store: *mut dyn Store,
@@ -146,23 +171,37 @@ impl ComponentInstance {
         assert!(alloc_size >= Self::alloc_layout(&offsets).size());
 
         ptr::write(
-            ptr,
+            ptr.as_ptr(),
             ComponentInstance {
                 offsets,
+                self_reference: RawComponentInstance(ptr),
                 vmctx: VMComponentContext {
                     _marker: marker::PhantomPinned,
                 },
             },
         );
 
-        (*ptr).initialize_vmctx(store);
+        (*ptr.as_ptr()).initialize_vmctx(store);
     }
 
     fn vmctx(&self) -> *mut VMComponentContext {
-        &self.vmctx as *const VMComponentContext as *mut VMComponentContext
+        let self_ref = self.self_reference.0.as_ptr();
+        unsafe {
+            self_ref
+                .cast::<u8>()
+                .add(mem::size_of::<ComponentInstance>())
+                .cast()
+        }
     }
 
-    unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *mut T {
+    unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *const T {
+        self.vmctx()
+            .cast::<u8>()
+            .add(usize::try_from(offset).unwrap())
+            .cast()
+    }
+
+    unsafe fn vmctx_plus_offset_mut<T>(&mut self, offset: u32) -> *mut T {
         self.vmctx()
             .cast::<u8>()
             .add(usize::try_from(offset).unwrap())
@@ -172,7 +211,12 @@ impl ComponentInstance {
     /// Returns a pointer to the "may leave" flag for this instance specified
     /// for canonical lowering and lifting operations.
     pub fn instance_flags(&self, instance: RuntimeComponentInstanceIndex) -> InstanceFlags {
-        unsafe { InstanceFlags(self.vmctx_plus_offset(self.offsets.instance_flags(instance))) }
+        unsafe {
+            InstanceFlags(
+                self.vmctx_plus_offset::<VMGlobalDefinition>(self.offsets.instance_flags(instance))
+                    .cast_mut(),
+            )
+        }
     }
 
     /// Returns the store that this component was created with.
@@ -264,7 +308,7 @@ impl ComponentInstance {
                 != INVALID_PTR
         );
         debug_assert!((*ret).vmctx as usize != INVALID_PTR);
-        NonNull::new(ret).unwrap()
+        NonNull::new(ret.cast_mut()).unwrap()
     }
 
     /// Stores the runtime memory pointer at the index specified.
@@ -278,7 +322,7 @@ impl ComponentInstance {
     pub fn set_runtime_memory(&mut self, idx: RuntimeMemoryIndex, ptr: *mut VMMemoryDefinition) {
         unsafe {
             debug_assert!(!ptr.is_null());
-            let storage = self.vmctx_plus_offset(self.offsets.runtime_memory(idx));
+            let storage = self.vmctx_plus_offset_mut(self.offsets.runtime_memory(idx));
             debug_assert!(*storage as usize == INVALID_PTR);
             *storage = ptr;
         }
@@ -287,7 +331,7 @@ impl ComponentInstance {
     /// Same as `set_runtime_memory` but for realloc function pointers.
     pub fn set_runtime_realloc(&mut self, idx: RuntimeReallocIndex, ptr: NonNull<VMFuncRef>) {
         unsafe {
-            let storage = self.vmctx_plus_offset(self.offsets.runtime_realloc(idx));
+            let storage = self.vmctx_plus_offset_mut(self.offsets.runtime_realloc(idx));
             debug_assert!(*storage as usize == INVALID_PTR);
             *storage = ptr.as_ptr();
         }
@@ -300,7 +344,7 @@ impl ComponentInstance {
         ptr: NonNull<VMFuncRef>,
     ) {
         unsafe {
-            let storage = self.vmctx_plus_offset(self.offsets.runtime_post_return(idx));
+            let storage = self.vmctx_plus_offset_mut(self.offsets.runtime_post_return(idx));
             debug_assert!(*storage as usize == INVALID_PTR);
             *storage = ptr.as_ptr();
         }
@@ -331,7 +375,7 @@ impl ComponentInstance {
             debug_assert!(
                 *self.vmctx_plus_offset::<usize>(self.offsets.lowering_data(idx)) == INVALID_PTR
             );
-            *self.vmctx_plus_offset(self.offsets.lowering(idx)) = lowering;
+            *self.vmctx_plus_offset_mut(self.offsets.lowering(idx)) = lowering;
             self.set_func_ref(
                 self.offsets.lowering_func_ref(idx),
                 wasm_call,
@@ -392,7 +436,7 @@ impl ComponentInstance {
     ) {
         debug_assert!(*self.vmctx_plus_offset::<usize>(offset) == INVALID_PTR);
         let vmctx = VMOpaqueContext::from_vmcomponent(self.vmctx());
-        *self.vmctx_plus_offset(offset) = VMFuncRef {
+        *self.vmctx_plus_offset_mut(offset) = VMFuncRef {
             wasm_call: Some(wasm_call),
             native_call,
             array_call,
@@ -402,11 +446,11 @@ impl ComponentInstance {
     }
 
     unsafe fn initialize_vmctx(&mut self, store: *mut dyn Store) {
-        *self.vmctx_plus_offset(self.offsets.magic()) = VMCOMPONENT_MAGIC;
-        *self.vmctx_plus_offset(self.offsets.transcode_libcalls()) =
+        *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
+        *self.vmctx_plus_offset_mut(self.offsets.transcode_libcalls()) =
             &transcode::VMBuiltinTranscodeArray::INIT;
-        *self.vmctx_plus_offset(self.offsets.store()) = store;
-        *self.vmctx_plus_offset(self.offsets.limits()) = (*store).vmruntime_limits();
+        *self.vmctx_plus_offset_mut(self.offsets.store()) = store;
+        *self.vmctx_plus_offset_mut(self.offsets.limits()) = (*store).vmruntime_limits();
 
         for i in 0..self.offsets.num_runtime_component_instances {
             let i = RuntimeComponentInstanceIndex::from_u32(i);
@@ -423,36 +467,36 @@ impl ComponentInstance {
             for i in 0..self.offsets.num_lowerings {
                 let i = LoweredIndex::from_u32(i);
                 let offset = self.offsets.lowering_callee(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
                 let offset = self.offsets.lowering_data(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
                 let offset = self.offsets.lowering_func_ref(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_always_trap {
                 let i = RuntimeAlwaysTrapIndex::from_u32(i);
                 let offset = self.offsets.always_trap_func_ref(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_transcoders {
                 let i = RuntimeTranscoderIndex::from_u32(i);
                 let offset = self.offsets.transcoder_func_ref(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_memories {
                 let i = RuntimeMemoryIndex::from_u32(i);
                 let offset = self.offsets.runtime_memory(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_reallocs {
                 let i = RuntimeReallocIndex::from_u32(i);
                 let offset = self.offsets.runtime_realloc(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
             for i in 0..self.offsets.num_runtime_post_returns {
                 let i = RuntimePostReturnIndex::from_u32(i);
                 let offset = self.offsets.runtime_post_return(i);
-                *self.vmctx_plus_offset(offset) = INVALID_PTR;
+                *self.vmctx_plus_offset_mut(offset) = INVALID_PTR;
             }
         }
     }
@@ -503,7 +547,7 @@ impl OwnedComponentInstance {
             let ptr = alloc::alloc_zeroed(layout) as *mut ComponentInstance;
             let ptr = ptr::NonNull::new(ptr).unwrap();
 
-            ComponentInstance::new_at(ptr.as_ptr(), layout.size(), offsets, store);
+            ComponentInstance::new_at(ptr, layout.size(), offsets, store);
 
             OwnedComponentInstance { ptr }
         }

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -134,7 +134,7 @@ pub struct VMLowering {
 /// `ComponentInstance`.
 #[repr(C)]
 // Set an appropriate alignment for this structure where the most-aligned value
-// internally right now is a pointer.
+// internally right now `VMGlobalDefinition` which has an alignment of 16 bytes.
 #[repr(align(16))]
 pub struct VMComponentContext {
     /// For more information about this see the equivalent field in `VMContext`

--- a/crates/runtime/src/debug_builtins.rs
+++ b/crates/runtime/src/debug_builtins.rs
@@ -45,6 +45,9 @@ pub unsafe extern "C" fn set_vmctx_memory(vmctx_ptr: *mut VMContext) {
 // exported as symbols. It is a workaround: the executable normally ignores
 // `pub extern "C"`, see rust-lang/rust#25057.
 pub fn ensure_exported() {
+    if cfg!(miri) {
+        return;
+    }
     unsafe {
         std::ptr::read_volatile(resolve_vmctx_memory_ptr as *const u8);
         std::ptr::read_volatile(set_vmctx_memory as *const u8);

--- a/crates/runtime/src/instance/allocator/pooling/index_allocator.rs
+++ b/crates/runtime/src/instance/allocator/pooling/index_allocator.rs
@@ -509,7 +509,8 @@ mod test {
         let mut last_id = vec![None; 1000];
 
         let mut hits = 0;
-        for _ in 0..100_000 {
+        let amt = if cfg!(miri) { 100 } else { 100_000 };
+        for _ in 0..amt {
             loop {
                 if !allocated.is_empty() && rng.gen_bool(0.5) {
                     let i = rng.gen_range(0..allocated.len());
@@ -535,7 +536,7 @@ mod test {
         // IDs). Check for at least double that to ensure some sort of
         // affinity is occurring.
         assert!(
-            hits > 20000,
+            hits > (amt / 5),
             "expected at least 20000 (20%) ID-reuses but got {}",
             hits
         );

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -40,6 +40,7 @@ mod memory;
 mod mmap;
 mod mmap_vec;
 mod parking_spot;
+mod store_box;
 mod table;
 mod traphandlers;
 mod vmcontext;
@@ -65,6 +66,7 @@ pub use crate::memory::{
 };
 pub use crate::mmap::Mmap;
 pub use crate::mmap_vec::MmapVec;
+pub use crate::store_box::*;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
     catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, tls_eager_initialize,

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -11,6 +11,9 @@ cfg_if::cfg_if! {
     if #[cfg(windows)] {
         mod windows;
         use windows as sys;
+    } else if #[cfg(miri)] {
+        mod miri;
+        use miri as sys;
     } else {
         mod unix;
         use unix as sys;

--- a/crates/runtime/src/mmap/miri.rs
+++ b/crates/runtime/src/mmap/miri.rs
@@ -1,0 +1,93 @@
+//! A "dummy" implementation of mmaps for miri where "we do the best we can"
+//!
+//! Namely this uses `alloc` to allocate memory for the "mmap" specifically to
+//! create page-aligned allocations. This allocation doesn't handle oeprations
+//! like becoming executable or becoming readonly or being created from files,
+//! but it's enough to get various tests running relying on memories and such.
+
+use anyhow::{bail, Result};
+use std::alloc::{self, Layout};
+use std::fs::File;
+use std::ops::Range;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct Mmap {
+    memory: *mut [u8],
+}
+
+unsafe impl Send for Mmap {}
+unsafe impl Sync for Mmap {}
+
+impl Mmap {
+    pub fn new_empty() -> Mmap {
+        Mmap { memory: &mut [] }
+    }
+
+    pub fn new(size: usize) -> Result<Self> {
+        let mut ret = Mmap::reserve(size)?;
+        ret.make_accessible(0, size)?;
+        Ok(ret)
+    }
+
+    pub fn reserve(size: usize) -> Result<Self> {
+        let layout = Layout::from_size_align(size, crate::page_size()).unwrap();
+        let ptr = unsafe { alloc::alloc(layout) };
+        if ptr.is_null() {
+            bail!("failed to allocate memory");
+        }
+
+        Ok(Mmap {
+            memory: std::ptr::slice_from_raw_parts_mut(ptr, size),
+        })
+    }
+
+    pub fn from_file(_path: &Path) -> Result<(Self, File)> {
+        bail!("not supported on miri");
+    }
+
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
+        // The memory is technically always accessible but this marks it as
+        // initialized for miri-level checking.
+        unsafe {
+            std::ptr::write_bytes(self.memory.cast::<u8>().add(start), 0u8, len);
+        }
+        Ok(())
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.memory as *const u8
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.memory.cast()
+    }
+
+    pub fn len(&self) -> usize {
+        unsafe { (*self.memory).len() }
+    }
+
+    pub unsafe fn make_executable(
+        &self,
+        _range: Range<usize>,
+        _enable_branch_protection: bool,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    pub unsafe fn make_readonly(&self, _range: Range<usize>) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        if self.len() == 0 {
+            return;
+        }
+        unsafe {
+            let layout = Layout::from_size_align(self.len(), crate::page_size()).unwrap();
+            alloc::dealloc(self.as_mut_ptr(), layout);
+        }
+    }
+}

--- a/crates/runtime/src/parking_spot.rs
+++ b/crates/runtime/src/parking_spot.rs
@@ -279,6 +279,7 @@ mod tests {
             )* ) => {
                 $(
                 #[test]
+                #[cfg_attr(miri, ignore)]
                 fn $name() {
                     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
                         return;
@@ -490,7 +491,7 @@ mod tests {
             let atomic_key = addr_of!(atomic) as u64;
 
             const N: u64 = 5;
-            const M: u64 = 1000;
+            const M: u64 = if cfg!(miri) { 10 } else { 1000 };
 
             let thread = s.spawn(move || {
                 while atomic.load(Ordering::SeqCst) != N * M {

--- a/crates/runtime/src/store_box.rs
+++ b/crates/runtime/src/store_box.rs
@@ -1,0 +1,35 @@
+/// A `Box<T>` lookalike for memory that's stored in a `Store<T>`
+///
+/// This is intended to be quite similar to a `Box<T>` except without the
+/// `Deref` implementations. The main motivation for this type's existence is to
+/// appease the aliasing rules in miri to ensure that `StoreBox` can be moved
+/// around without invalidating pointers to the contents within the box. The
+/// standard `Box<T>` type does not implement this for example and moving that
+/// will invalidate derived pointers.
+pub struct StoreBox<T: ?Sized>(*mut T);
+
+unsafe impl<T: Send + ?Sized> Send for StoreBox<T> {}
+unsafe impl<T: Sync + ?Sized> Sync for StoreBox<T> {}
+
+impl<T> StoreBox<T> {
+    /// Allocates space on the heap to store `val` and returns a pointer to it
+    /// living on the heap.
+    pub fn new(val: T) -> StoreBox<T> {
+        StoreBox(Box::into_raw(Box::new(val)))
+    }
+}
+
+impl<T: ?Sized> StoreBox<T> {
+    /// Returns the underlying pointer to `T` which is owned by the store.
+    pub fn get(&self) -> *mut T {
+        self.0
+    }
+}
+
+impl<T: ?Sized> Drop for StoreBox<T> {
+    fn drop(&mut self) {
+        unsafe {
+            drop(Box::from_raw(self.0));
+        }
+    }
+}

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -14,6 +14,9 @@ static mut PREV_SIGILL: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
 static mut PREV_SIGFPE: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
 
 pub unsafe fn platform_init() {
+    if cfg!(miri) {
+        return;
+    }
     let register = |slot: &mut MaybeUninit<libc::sigaction>, signal: i32| {
         let mut handler: libc::sigaction = mem::zeroed();
         // The flags here are relatively careful, and they are...
@@ -312,6 +315,10 @@ pub fn lazy_per_thread_init() {
     });
 
     unsafe fn allocate_sigaltstack() -> Option<Stack> {
+        if cfg!(miri) {
+            return None;
+        }
+
         // Check to see if the existing sigaltstack, if it exists, is big
         // enough. If so we don't need to allocate our own.
         let mut old_stack = mem::zeroed();

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -185,7 +185,7 @@ impl Config {
             async_stack_size: 2 << 20,
             async_support: false,
             module_version: ModuleVersionStrategy::default(),
-            parallel_compilation: true,
+            parallel_compilation: !cfg!(miri),
             memory_init_cow: true,
             memory_guaranteed_dense_image_size: 16 << 20,
             force_memory_init_memfd: false,

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -650,6 +650,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn cache_accounts_for_opt_level() -> Result<()> {
         let td = TempDir::new()?;
         let config_path = td.path().join("config.toml");

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -532,6 +532,7 @@ Caused by:
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_tunables_int_mismatch() -> Result<()> {
         let engine = Engine::default();
         let mut metadata = Metadata::new(&engine);

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -769,7 +769,7 @@ impl SharedMemory {
     pub fn data(&self) -> &[UnsafeCell<u8>] {
         unsafe {
             let definition = &*self.0.vmmemory_ptr();
-            slice::from_raw_parts_mut(definition.base.cast(), definition.current_length())
+            slice::from_raw_parts(definition.base.cast(), definition.current_length())
         }
     }
 

--- a/crates/wasmtime/src/module/registry.rs
+++ b/crates/wasmtime/src/module/registry.rs
@@ -274,6 +274,7 @@ pub fn unregister_code(code: &Arc<CodeMemory>) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_frame_info() -> Result<(), anyhow::Error> {
     use crate::*;
     let mut store = Store::<()>::default();

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -96,7 +96,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use wasmtime_runtime::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleInfo,
-    OnDemandInstanceAllocator, SignalHandler, StorePtr, VMContext, VMExternRef,
+    OnDemandInstanceAllocator, SignalHandler, StoreBox, StorePtr, VMContext, VMExternRef,
     VMExternRefActivationsTable, VMRuntimeLimits, WasmFault,
 };
 
@@ -281,7 +281,7 @@ pub struct StoreOpaque {
     externref_activations_table: VMExternRefActivationsTable,
     modules: ModuleRegistry,
     func_refs: FuncRefs,
-    host_globals: Vec<Box<VMHostGlobalContext>>,
+    host_globals: Vec<StoreBox<VMHostGlobalContext>>,
 
     // Numbers of resources instantiated in this store, and their limits
     instance_count: usize,
@@ -1190,7 +1190,7 @@ impl StoreOpaque {
         self.func_refs.push_instance_pre_func_refs(func_refs);
     }
 
-    pub(crate) fn host_globals(&mut self) -> &mut Vec<Box<VMHostGlobalContext>> {
+    pub(crate) fn host_globals(&mut self) -> &mut Vec<StoreBox<VMHostGlobalContext>> {
         &mut self.host_globals
     }
 

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -5,7 +5,9 @@ use anyhow::Result;
 use std::panic::{self, AssertUnwindSafe};
 use std::ptr::NonNull;
 use wasmtime_jit::{CodeMemory, ProfilingAgent};
-use wasmtime_runtime::{VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMOpaqueContext};
+use wasmtime_runtime::{
+    StoreBox, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMOpaqueContext,
+};
 
 struct TrampolineState<F> {
     func: F,
@@ -113,7 +115,7 @@ pub fn create_array_call_function<F>(
     ft: &FuncType,
     func: F,
     engine: &Engine,
-) -> Result<Box<VMArrayCallHostFuncContext>>
+) -> Result<StoreBox<VMArrayCallHostFuncContext>>
 where
     F: Fn(*mut VMContext, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
 {

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -2,7 +2,7 @@ use crate::store::StoreOpaque;
 use crate::{GlobalType, Mutability, Val};
 use std::ptr;
 use wasmtime_environ::GlobalInit;
-use wasmtime_runtime::VMGlobalDefinition;
+use wasmtime_runtime::{StoreBox, VMGlobalDefinition};
 
 #[repr(C)]
 pub struct VMHostGlobalContext {
@@ -33,40 +33,39 @@ pub fn generate_global_export(
     ty: GlobalType,
     val: Val,
 ) -> wasmtime_runtime::ExportGlobal {
-    let mut ctx = Box::new(VMHostGlobalContext {
+    let global = wasmtime_environ::Global {
+        wasm_ty: ty.content().to_wasm_type(),
+        mutability: match ty.mutability() {
+            Mutability::Const => false,
+            Mutability::Var => true,
+        },
+        // TODO: This is just a dummy value; nothing should actually read
+        // this. We should probably remove this field from the struct.
+        initializer: GlobalInit::I32Const(0),
+    };
+    let ctx = StoreBox::new(VMHostGlobalContext {
         ty,
         global: VMGlobalDefinition::new(),
     });
 
-    unsafe {
+    let definition = unsafe {
+        let global = &mut (*ctx.get()).global;
         match val {
-            Val::I32(x) => *ctx.global.as_i32_mut() = x,
-            Val::I64(x) => *ctx.global.as_i64_mut() = x,
-            Val::F32(x) => *ctx.global.as_f32_bits_mut() = x,
-            Val::F64(x) => *ctx.global.as_f64_bits_mut() = x,
-            Val::V128(x) => *ctx.global.as_u128_mut() = x,
+            Val::I32(x) => *global.as_i32_mut() = x,
+            Val::I64(x) => *global.as_i64_mut() = x,
+            Val::F32(x) => *global.as_f32_bits_mut() = x,
+            Val::F64(x) => *global.as_f64_bits_mut() = x,
+            Val::V128(x) => *global.as_u128_mut() = x,
             Val::FuncRef(f) => {
-                *ctx.global.as_func_ref_mut() = f.map_or(ptr::null_mut(), |f| {
+                *global.as_func_ref_mut() = f.map_or(ptr::null_mut(), |f| {
                     f.caller_checked_func_ref(store).as_ptr()
                 })
             }
-            Val::ExternRef(x) => *ctx.global.as_externref_mut() = x.map(|x| x.inner),
+            Val::ExternRef(x) => *global.as_externref_mut() = x.map(|x| x.inner),
         }
-    }
-
-    let ret = wasmtime_runtime::ExportGlobal {
-        definition: &mut ctx.global as *mut _,
-        global: wasmtime_environ::Global {
-            wasm_ty: ctx.ty.content().to_wasm_type(),
-            mutability: match ctx.ty.mutability() {
-                Mutability::Const => false,
-                Mutability::Var => true,
-            },
-            // TODO: This is just a dummy value; nothing should actually read
-            // this. We should probably remove this field from the struct.
-            initializer: GlobalInit::I32Const(0),
-        },
+        global
     };
+
     store.host_globals().push(ctx);
-    ret
+    wasmtime_runtime::ExportGlobal { definition, global }
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -122,7 +122,7 @@ impl CompileCommand {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod test {
     use super::*;
     use std::io::Write;

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::{anyhow, bail, Result};
 use std::future::Future;
 use std::pin::Pin;

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::{bail, Error, Result};
 use std::future::Future;
 use std::pin::Pin;

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::{bail, Context, Result};
 use std::fs::File;
 use std::io::{Read, Write};

--- a/tests/all/component_model.rs
+++ b/tests/all/component_model.rs
@@ -18,6 +18,7 @@ mod post_return;
 mod strings;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn components_importing_modules() -> Result<()> {
     let engine = engine();
 

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -30,6 +30,7 @@ fn bare_bones() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn mildly_more_interesting() -> Result<()> {
     let engine = super::engine();
     let component = Component::new(

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use wasmtime::component::*;
 use wasmtime::{Store, StoreContextMut, Trap};

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::engine;
 use anyhow::Result;
 use wasmtime::{

--- a/tests/all/component_model/dynamic.rs
+++ b/tests/all/component_model/dynamic.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::{make_echo_component, make_echo_component_with_params, Param, Type};
 use anyhow::Result;
 use component_test_util::FuncExt;

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::{TypedFuncExt, REALLOC_AND_FREE};
 use anyhow::Result;
 use std::rc::Rc;

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use std::ops::Deref;

--- a/tests/all/component_model/macros.rs
+++ b/tests/all/component_model/macros.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::{make_echo_component, TypedFuncExt};
 use anyhow::Result;
 use component_macro_test::{add_variants, flags_test};

--- a/tests/all/component_model/nested.rs
+++ b/tests/all/component_model/nested.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use wasmtime::component::*;

--- a/tests/all/component_model/post_return.rs
+++ b/tests/all/component_model/post_return.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use wasmtime::component::*;
 use wasmtime::{Store, StoreContextMut, Trap};

--- a/tests/all/component_model/strings.rs
+++ b/tests/all/component_model/strings.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use super::REALLOC_AND_FREE;
 use anyhow::Result;
 use wasmtime::component::{Component, Linker};

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -2,6 +2,7 @@
     target_os = "linux",
     all(target_os = "macos", feature = "posix-signals-on-macos")
 ))]
+#[cfg(not(miri))]
 mod tests {
     use anyhow::Result;
     use rustix::mm::{mprotect, MprotectFlags};

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use crate::async_functions::{CountPending, PollOnce};
 use anyhow::{anyhow, Result};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -57,6 +57,7 @@ fn bad_tables() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn cross_store() -> anyhow::Result<()> {
     let mut cfg = Config::new();
     cfg.wasm_reference_types(true);

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -25,6 +25,7 @@ impl<'a> Parse<'a> for FuelWast<'a> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn run() -> Result<()> {
     let test = std::fs::read_to_string("tests/all/fuel.wast")?;
     let buf = ParseBuffer::new(&test)?;
@@ -58,6 +59,7 @@ fn fuel_consumed(wasm: &[u8]) -> u64 {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn iloop() {
     iloop_aborts(
         r#"
@@ -141,6 +143,7 @@ fn manual_fuel() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn host_function_consumes_all() {
     const FUEL: u64 = 10_000;
     let mut config = Config::new();
@@ -185,6 +188,7 @@ fn manual_edge_cases() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping() {
     let mut config = Config::new();
     config.consume_fuel(true);

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_wasm_to_wasm() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -31,6 +32,7 @@ fn call_wasm_to_wasm() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_wasm_to_native() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -55,6 +57,7 @@ fn call_wasm_to_native() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_wasm_to_array() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -88,6 +91,7 @@ fn call_wasm_to_array() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_native_to_wasm() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -125,6 +129,7 @@ fn call_native_to_native() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_native_to_array() -> Result<()> {
     let mut store = Store::<()>::default();
 
@@ -148,6 +153,7 @@ fn call_native_to_array() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_array_to_wasm() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -195,6 +201,7 @@ fn call_array_to_native() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_array_to_array() -> Result<()> {
     let mut store = Store::<()>::default();
     let func = Func::new(
@@ -223,6 +230,7 @@ fn call_array_to_array() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_indirect_native_from_wasm_import_global() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -255,6 +263,7 @@ fn call_indirect_native_from_wasm_import_global() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_indirect_native_from_wasm_import_table() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -283,6 +292,7 @@ fn call_indirect_native_from_wasm_import_table() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_indirect_native_from_wasm_import_func_returns_funcref() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -311,6 +321,7 @@ fn call_indirect_native_from_wasm_import_func_returns_funcref() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_indirect_native_from_exported_table() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -337,6 +348,7 @@ fn call_indirect_native_from_exported_table() -> Result<()> {
 
 // wasm exports global, host puts native-call funcref in global, wasm calls funcref
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_indirect_native_from_exported_global() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -482,6 +494,7 @@ fn signatures_match() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn import_works() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 
@@ -589,6 +602,7 @@ fn trap_smoke() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trap_import() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -645,6 +659,7 @@ fn get_from_wrapper() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn get_from_signature() {
     let mut store = Store::<()>::default();
     let ty = FuncType::new(None, None);
@@ -662,6 +677,7 @@ fn get_from_signature() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn get_from_module() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(
@@ -733,6 +749,7 @@ fn call_wrapped_func() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn caller_memory() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let f = Func::wrap(&mut store, |mut c: Caller<'_, ()>| {
@@ -798,6 +815,7 @@ fn caller_memory() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn func_write_nothing() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let ty = FuncType::new(None, Some(ValType::I32));
@@ -810,6 +828,7 @@ fn func_write_nothing() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn return_cross_store_value() -> anyhow::Result<()> {
     let _ = env_logger::try_init();
 
@@ -875,6 +894,7 @@ fn pass_cross_store_arg() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn externref_signature_no_reference_types() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(false);
@@ -892,6 +912,7 @@ fn externref_signature_no_reference_types() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trampolines_always_valid() -> anyhow::Result<()> {
     // Compile two modules up front
     let mut store = Store::<()>::default();
@@ -918,6 +939,7 @@ fn trampolines_always_valid() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn typed_multiple_results() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(
@@ -954,6 +976,7 @@ fn typed_multiple_results() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trap_doesnt_leak() -> anyhow::Result<()> {
     #[derive(Default)]
     struct Canary(Arc<AtomicBool>);
@@ -994,6 +1017,7 @@ fn trap_doesnt_leak() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn wrap_multiple_results() -> anyhow::Result<()> {
     fn test<T>(store: &mut Store<()>, t: T) -> anyhow::Result<()>
     where
@@ -1158,6 +1182,7 @@ fn wrap_multiple_results() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trampoline_for_declared_elem() -> anyhow::Result<()> {
     let engine = Engine::default();
 
@@ -1185,6 +1210,7 @@ fn trampoline_for_declared_elem() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
     let mut store = Store::<()>::default();
     let debug = Func::wrap(
@@ -1240,6 +1266,7 @@ fn wasm_ty_roundtrip() -> Result<(), anyhow::Error> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn typed_funcs_count_params_correctly_in_error_messages() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(

--- a/tests/all/funcref.rs
+++ b/tests/all/funcref.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use wasmtime::*;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
     let (mut store, module) = ref_types_module(
         false,
@@ -77,6 +78,7 @@ fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn receive_null_funcref_from_wasm() -> anyhow::Result<()> {
     let (mut store, module) = ref_types_module(
         false,
@@ -126,6 +128,7 @@ fn wrong_store() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn func_new_returns_wrong_store() -> anyhow::Result<()> {
     let dropped = Arc::new(AtomicBool::new(false));
     {

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -13,11 +13,13 @@ impl Drop for SetFlagOnDrop {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn smoke_test_gc() -> anyhow::Result<()> {
     smoke_test_gc_impl(false)
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn smoke_test_gc_epochs() -> anyhow::Result<()> {
     smoke_test_gc_impl(true)
 }
@@ -77,6 +79,7 @@ fn smoke_test_gc_impl(use_epochs: bool) -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn wasm_dropping_refs() -> anyhow::Result<()> {
     let (mut store, module) = ref_types_module(
         false,
@@ -120,6 +123,7 @@ fn wasm_dropping_refs() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn many_live_refs() -> anyhow::Result<()> {
     let mut wat = r#"
         (module
@@ -200,6 +204,7 @@ fn many_live_refs() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn drop_externref_via_table_set() -> anyhow::Result<()> {
     let (mut store, module) = ref_types_module(
         false,
@@ -247,6 +252,7 @@ fn drop_externref_via_table_set() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn global_drops_externref() -> anyhow::Result<()> {
     test_engine(&Engine::default())?;
 
@@ -296,6 +302,7 @@ fn global_drops_externref() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn table_drops_externref() -> anyhow::Result<()> {
     test_engine(&Engine::default())?;
 
@@ -346,6 +353,7 @@ fn table_drops_externref() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn gee_i_sure_hope_refcounting_is_atomic() -> anyhow::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(true);
@@ -435,6 +443,7 @@ fn global_init_no_leak() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn no_gc_middle_of_args() -> anyhow::Result<()> {
     let (mut store, module) = ref_types_module(
         false,

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -210,6 +210,7 @@ fn signatures_match() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn import_works() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 
@@ -311,6 +312,7 @@ fn import_works() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_import_many_args() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -370,6 +372,7 @@ fn call_import_many_args() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_wasm_many_args() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -459,6 +462,7 @@ fn trap_smoke() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn trap_import() -> Result<()> {
     let wasm = wat::parse_str(
         r#"
@@ -482,6 +486,7 @@ fn trap_import() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn new_from_signature() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
@@ -592,6 +597,7 @@ fn call_wrapped_func() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn func_return_nothing() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
@@ -608,6 +614,7 @@ fn func_return_nothing() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn call_via_funcref() -> Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
 
@@ -695,6 +702,7 @@ fn store_with_context() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn wasi_imports() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 

--- a/tests/all/import_calling_export.rs
+++ b/tests/all/import_calling_export.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use wasmtime::*;
 

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use wasmtime::*;
 
 #[test]

--- a/tests/all/instance.rs
+++ b/tests/all/instance.rs
@@ -13,6 +13,7 @@ fn wrong_import_numbers() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn initializes_linear_memory() -> Result<()> {
     // Test for https://github.com/bytecodealliance/wasmtime/issues/2784
     let wat = r#"
@@ -33,6 +34,7 @@ fn initializes_linear_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn linear_memory_limits() -> Result<()> {
     // this test will allocate 4GB of virtual memory space, and may not work in
     // situations like CI QEMU emulation where it triggers SIGKILL.

--- a/tests/all/invoke_func_via_table.rs
+++ b/tests/all/invoke_func_via_table.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::{Context as _, Result};
 use wasmtime::*;
 

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -4,6 +4,7 @@ use wasmtime::*;
 const WASM_PAGE_SIZE: usize = wasmtime_environ::WASM_PAGE_SIZE as usize;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_limits() -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(
@@ -91,6 +92,7 @@ fn test_limits() -> Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn test_limits_async() -> Result<()> {
     let mut config = Config::new();
     config.async_support(true);
@@ -425,6 +427,7 @@ impl ResourceLimiter for MemoryContext {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_custom_memory_limiter() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
@@ -540,6 +543,7 @@ impl ResourceLimiterAsync for MemoryContext {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn test_custom_memory_limiter_async() -> Result<()> {
     let mut config = Config::new();
     config.async_support(true);
@@ -840,6 +844,7 @@ impl ResourceLimiterAsync for FailureDetector {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());
@@ -979,6 +984,7 @@ fn panic_in_memory_limiter() {
 
 #[test]
 #[should_panic(expected = "resource limiter memory growing")]
+#[cfg_attr(miri, ignore)]
 fn panic_in_memory_limiter_wasm_stack() {
     // Like the test above, except the memory.grow happens in wasm code
     // instead of a host function call.
@@ -1025,6 +1031,7 @@ fn panic_in_table_limiter() {
 
 #[tokio::test]
 #[should_panic(expected = "async resource limiter memory growing")]
+#[cfg_attr(miri, ignore)]
 async fn panic_in_async_memory_limiter() {
     let mut config = Config::new();
     config.async_support(true);
@@ -1044,6 +1051,7 @@ async fn panic_in_async_memory_limiter() {
 
 #[tokio::test]
 #[should_panic(expected = "async resource limiter memory growing")]
+#[cfg_attr(miri, ignore)]
 async fn panic_in_async_memory_limiter_wasm_stack() {
     // Like the test above, except the memory.grow happens in
     // wasm code instead of a host function call.
@@ -1075,6 +1083,7 @@ async fn panic_in_async_memory_limiter_wasm_stack() {
 
 #[tokio::test]
 #[should_panic(expected = "async resource limiter table growing")]
+#[cfg_attr(miri, ignore)]
 async fn panic_in_async_table_limiter() {
     let mut config = Config::new();
     config.async_support(true);
@@ -1096,6 +1105,7 @@ async fn panic_in_async_table_limiter() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn growth_trap() -> Result<()> {
     let engine = Engine::default();
     let module = Module::new(

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -90,6 +90,7 @@ fn link_twice_bad() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn function_interposition() -> Result<()> {
     let mut store = Store::<()>::default();
     let mut linker = Linker::new(store.engine());
@@ -124,6 +125,7 @@ fn function_interposition() -> Result<()> {
 // Same as `function_interposition`, but the linker's name for the function
 // differs from the module's name.
 #[test]
+#[cfg_attr(miri, ignore)]
 fn function_interposition_renamed() -> Result<()> {
     let mut store = Store::<()>::default();
     let mut linker = Linker::new(store.engine());
@@ -154,6 +156,7 @@ fn function_interposition_renamed() -> Result<()> {
 // Similar to `function_interposition`, but use `Linker::instance` instead of
 // `Linker::define`.
 #[test]
+#[cfg_attr(miri, ignore)]
 fn module_interposition() -> Result<()> {
     let mut store = Store::<()>::default();
     let mut linker = Linker::new(store.engine());
@@ -185,6 +188,7 @@ fn module_interposition() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn allow_unknown_exports() -> Result<()> {
     let mut store = Store::<()>::default();
     let mut linker = Linker::new(store.engine());
@@ -203,6 +207,7 @@ fn allow_unknown_exports() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn no_leak() -> Result<()> {
     struct DropMe(Rc<Cell<bool>>);
 
@@ -231,6 +236,7 @@ fn no_leak() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn no_leak_with_imports() -> Result<()> {
     struct DropMe(Arc<AtomicUsize>);
 
@@ -354,6 +360,7 @@ fn instance_pre() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_trapping_unknown_import() -> Result<()> {
     const WAT: &str = r#"
     (module
@@ -392,6 +399,7 @@ fn test_trapping_unknown_import() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_default_value_unknown_import() -> Result<()> {
     const WAT: &str = r#"
       (module

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(miri, allow(dead_code, unused_imports))]
+
 mod async_functions;
 mod call_hook;
 mod cli_tests;

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -92,6 +92,7 @@ fn test_traps(store: &mut Store<()>, funcs: &[TestFunc], addr: u32, mem: &Memory
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn offsets_static_dynamic_oh_my() -> Result<()> {
     const GB: u64 = 1 << 30;
 
@@ -137,6 +138,7 @@ fn offsets_static_dynamic_oh_my() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn guards_present() -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
 
@@ -185,6 +187,7 @@ fn guards_present() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn guards_present_pooling() -> Result<()> {
     const GUARD_SIZE: u64 = 65536;
 
@@ -322,6 +325,7 @@ fn massive_64_bit_still_limited() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn tiny_static_heap() -> Result<()> {
     // The size of the memory in the module below is the exact same size as
     // the static memory size limit in the configuration. This is intended to
@@ -533,6 +537,7 @@ fn shared_memory_basics() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn shared_memory_wait_notify() -> Result<()> {
     const THREADS: usize = 8;
     const COUNT: usize = 100_000;

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(miri)))]
 mod not_for_windows {
     use wasmtime::*;
     use wasmtime_environ::{WASM32_MAX_PAGES, WASM_PAGE_SIZE};

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -51,6 +51,7 @@ fn caches_across_engines() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn aot_compiles() -> Result<()> {
     let engine = Engine::default();
     let bytes = engine.precompile_module(
@@ -69,6 +70,7 @@ fn aot_compiles() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn serialize_deterministic() {
     let engine = Engine::default();
 
@@ -177,7 +179,7 @@ fn serialize_not_overly_massive() -> Result<()> {
 // This test then also tests that loading modules through various means, e.g.
 // through precompiled artifacts, all works.
 #[test]
-#[cfg_attr(not(target_arch = "x86_64"), ignore)]
+#[cfg_attr(any(not(target_arch = "x86_64"), miri), ignore)]
 fn missing_sse_and_floats_still_works() -> Result<()> {
     let mut config = Config::new();
     config.wasm_simd(false);

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -43,6 +43,7 @@ fn test_version_mismatch() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_module_serialize_simple() -> Result<()> {
     let buffer = serialize(
         &Engine::default(),
@@ -59,6 +60,7 @@ fn test_module_serialize_simple() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_module_serialize_fail() -> Result<()> {
     let buffer = serialize(
         &Engine::default(),
@@ -76,6 +78,7 @@ fn test_module_serialize_fail() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_deserialize_from_file() -> Result<()> {
     serialize_and_call("(module (func (export \"run\") (result i32) i32.const 42))")?;
     serialize_and_call(
@@ -105,6 +108,7 @@ fn test_deserialize_from_file() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn deserialize_from_serialized() -> Result<()> {
     let engine = Engine::default();
     let buffer1 = serialize(

--- a/tests/all/name.rs
+++ b/tests/all/name.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use wasmtime::*;
 
 #[test]

--- a/tests/all/relocs.rs
+++ b/tests/all/relocs.rs
@@ -8,6 +8,8 @@
 //! 32-bits, and right now object files aren't supported larger than 4gb anyway
 //! so we would need a lot of other support necessary to exercise that.
 
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use wasmtime::*;
 

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -53,6 +53,7 @@ fn copy_wrong() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn null_elem_segment_works_with_imported_table() -> Result<()> {
     let mut store = Store::<()>::default();
     let ty = TableType::new(ValType::FuncRef, 1, None);

--- a/tests/all/threads.rs
+++ b/tests/all/threads.rs
@@ -52,6 +52,7 @@ fn test_export_shared_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_sharing_of_shared_memory() -> Result<()> {
     let wat = r#"(module
         (import "env" "memory" (memory 1 5 shared))
@@ -95,6 +96,7 @@ fn test_sharing_of_shared_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_probe_shared_memory_size() -> Result<()> {
     let wat = r#"(module
         (memory (export "memory") 1 2 shared)
@@ -157,6 +159,7 @@ fn test_multi_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_grow_memory_in_multiple_threads() -> Result<()> {
     const NUM_THREADS: usize = 4;
     const NUM_GROW_OPS: usize = 1000;
@@ -226,6 +229,7 @@ fn is_sorted(data: &[u32]) -> bool {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_memory_size_accessibility() -> Result<()> {
     const NUM_GROW_OPS: usize = 1000;
     let wat = r#"(module

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::{bail, Error, Result};
 use std::panic::{self, AssertUnwindSafe};
 use std::process::Command;

--- a/tests/all/wait_notify.rs
+++ b/tests/all/wait_notify.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use anyhow::Result;
 use std::time::Instant;
 use wasmtime::*;

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -3,6 +3,8 @@
 //!
 //! [wasi-testsuite]: https://github.com/WebAssembly/wasi-testsuite
 
+#![cfg(not(miri))]
+
 use crate::cli_tests::run_wasmtime_for_output;
 use anyhow::Result;
 use serde::Deserialize;

--- a/tests/host_segfault.rs
+++ b/tests/host_segfault.rs
@@ -80,6 +80,9 @@ fn dummy_waker() -> Waker {
 }
 
 fn main() {
+    if cfg!(miri) {
+        return;
+    }
     // Skip this tests if it looks like we're in a cross-compiled situation and
     // we're emulating this test for a different platform. In that scenario
     // emulators (like QEMU) tend to not report signals the same way and such.

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -37,6 +37,7 @@ impl ResourceLimiter for MemoryGrowFailureDetector {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn custom_limiter_detect_os_oom_failure() -> Result<()> {
     if std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_ok() {
         return Ok(());


### PR DESCRIPTION
This commit is an implementation of getting at least chunks of Wasmtime to run in MIRI on CI. The full test suite is not possible to run in MIRI because MIRI cannot run Cranelift-produced code at runtime (aka it doesn't support JITs). Running MIRI, however, is still quite valuable if we can manage it because it would have trivially detected GHSA-ch89-5g45-qwc7, our most recent security advisory. The goal of this PR is to select a subset of the test suite to execute in CI under MIRI and boost our confidence in the copious amount of `unsafe` code in Wasmtime's runtime.

Under MIRI's default settings, which is to use the [Stacked Borrows][stacked] model, much of the code in `Instance` and `VMContext` is considered invalid. Under the optional [Tree Borrows][tree] model, however, this same code is accepted. After some [extremely helpful discussion][discuss] on the Rust Zulip my current conclusion is that what we're doing is not fundamentally un-sound but we need to model it in a different way. This PR, however, uses the Tree Borrows model for MIRI to get something onto CI sooner rather than later, and I hope to follow this up with something that passed Stacked Borrows. Additionally that'll hopefully make this diff smaller and easier to digest.

Given all that, the end result of this PR is to get 131 separate unit tests executing on CI. These unit tests largely exercise the embedding API where wasm function compilation is not involved. Some tests compile wasm functions but don't run them, but compiling wasm through Cranelift in MIRI is so slow that it doesn't seem worth it at this time. This does mean that there's a pretty big hole in MIRI's test coverage, but that's to be expected as we're a JIT compiler after all.

To get tests working in MIRI this PR uses a number of strategies:

* When platform-specific code is involved there's now `#[cfg(miri)]` for MIRI's version. For example there's a custom-built "mmap" just for MIRI now. Many of these are simple noops, some are `unimplemented!()` as they shouldn't be reached, and some are slightly nontrivial implementations such as mmaps and trap handling (for native-to-native function calls).

* Many test modules are simply excluded via `#![cfg(not(miri))]` at the top of the file. This excludes the entire module's worth of tests from MIRI. Other modules have `#[cfg_attr(miri, ignore)]` annotations to ignore tests by default on MIRI. The latter form is used in modules where some tests work and some don't. This means that all future test additions will need to be effectively annotated whether they work in MIRI or not. My hope though is that there's enough precedent in the test suite of what to do to not cause too much burden.

* A number of locations are fixed with respect to MIRI's analysis. For example `ComponentInstance`, the component equivalent of `wasmtime_runtime::Instance`, was actually left out from the fix for the CVE by accident. MIRI dutifully highlighted the issues here and I've fixed them locally. Some locations fixed for MIRI are changed to something that looks similar but is subtly different. For example retaining items in a `Store<T>` is now done with a Wasmtime-specific `StoreBox<T>` type. This is because, with MIRI's analyses, moving a `Box<T>` invalidates all pointers derived from this `Box<T>`. We don't want these semantics, so we effectively have a custom `Box<T>` to suit our needs in this regard.

* Some default configuration is different under MIRI. For example most linear memories are dynamic with no guards and no space reserved for growth. Settings such as parallel compilation are disabled. These are applied to make MIRI "work by default" in more places ideally. Some tests which perform N iterations of something perform fewer iterations on MIRI to not take quite so long.

This PR is not intended to be a one-and-done-we-never-look-at-it-again kind of thing. Instead this is intended to lay the groundwork to continuously run MIRI in CI to catch any soundness issues. This feels, to me, overdue given the amount of `unsafe` code inside of Wasmtime. My hope is that over time we can figure out how to run Wasm in MIRI but that may take quite some time. Regardless this will be adding nontrivial maintenance work to contributors to Wasmtime. MIRI will be run on CI for merges, MIRI will have test failures when everything else passes, MIRI's errors will need to be deciphered by those who have probably never run MIRI before, things like that. Despite all this to me it seems worth the cost at this time. Just getting this running caught two possible soundness bugs in the component implementation that could have had a real-world impact in the future!

[stacked]: https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md
[tree]: https://perso.crans.org/vanille/treebor/
[discuss]: https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/Tree.20vs.20Stacked.20Borrows.20.26.20a.20debugging.20question

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
