### PR TITLE
Fix table_addr parsing/printing

### DIFF
--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -457,7 +457,15 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             dynamic_stack_slot,
             ..
         } => write!(w, " {}, {}", arg, dynamic_stack_slot),
-        TableAddr { table, arg, .. } => write!(w, " {}, {}", table, arg),
+        TableAddr {
+            table, arg, offset, ..
+        } => {
+            if i32::from(offset) == 0 {
+                write!(w, " {}, {}", table, arg)
+            } else {
+                write!(w, " {}, {}{}", table, arg, offset)
+            }
+        }
         Load {
             flags, arg, offset, ..
         } => write!(w, "{} {}{}", flags, arg, offset),

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -11,7 +11,7 @@ function %table_set(i32, r64, i64 vmctx) {
     table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
 
 block0(v0: i32, v1: r64, v2: i64):
-    v3 = table_addr.i64 table0, v0, +0
+    v3 = table_addr.i64 table0, v0+0
     store.r64 notrap aligned v1, v3
     return
 }

--- a/cranelift/filetests/filetests/parser/memory.clif
+++ b/cranelift/filetests/filetests/parser/memory.clif
@@ -49,3 +49,23 @@ block0:
     v2 = bxor v0, v1
     return v2
 }
+
+function %table_addr(i32) {
+    table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
+
+block0(v0: i32):
+    v1 = table_addr.i32 table0, v0
+    v2 = table_addr.i32 table0, v0+1
+    v3 = table_addr.i32 table0, v0+0
+    return
+}
+
+; sameln: function %table_addr(i32) fast {
+; nextln:     table0 = dynamic gv1, min 0, bound gv2, element_size 1, index_type i32
+; nextln: 
+; nextln: block0(v0: i32):
+; nextln:     v1 = table_addr.i32 table0, v0
+; nextln:     v2 = table_addr.i32 table0, v0+1
+; nextln:     v3 = table_addr.i32 table0, v0
+; nextln:     return
+; nextln: }

--- a/cranelift/filetests/filetests/verifier/table.clif
+++ b/cranelift/filetests/filetests/verifier/table.clif
@@ -41,6 +41,6 @@ function %table_addr_index_type(i64 vmctx, i64) {
     table0 = dynamic gv0, element_size 1, bound gv1, index_type i32
 
 block0(v0: i64, v1: i64):
-    v2 = table_addr.i64 table0, v1, +0; error: index type i64 differs from table index type i32
+    v2 = table_addr.i64 table0, v1+0; error: index type i64 differs from table index type i32
     return
 }

--- a/cranelift/filetests/filetests/wasm/r64.clif
+++ b/cranelift/filetests/filetests/wasm/r64.clif
@@ -22,7 +22,7 @@ function %table_set(i32, r64, i64 vmctx) {
     table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
 
 block0(v0: i32, v1: r64, v2: i64):
-    v3 = table_addr.i64 table0, v0, +0;
+    v3 = table_addr.i64 table0, v0+0;
     store.r64 notrap aligned v1, v3
     return
 }
@@ -34,7 +34,7 @@ function %table_get(i32, i64 vmctx) -> r64 {
     table0 = dynamic gv1, element_size 1, bound gv2, index_type i32
 
 block0(v0: i32, v1: i64):
-    v2 = table_addr.i64 table0, v0, +0;
+    v2 = table_addr.i64 table0, v0+0;
     v3 = load.r64 notrap aligned v2
     return v3
 }

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2731,7 +2731,6 @@ impl<'a> Parser<'a> {
                 ctx.check_table(table, self.loc)?;
                 self.match_token(Token::Comma, "expected ',' between operands")?;
                 let arg = self.match_value("expected SSA value table address")?;
-                self.match_token(Token::Comma, "expected ',' between operands")?;
                 let offset = self.optional_offset32()?;
                 InstructionData::TableAddr {
                     opcode,


### PR DESCRIPTION
Make table_addr parsing more consistent with other uses of `optional_offset32` by not requiring a comma between the index and the offset. Additionally, change the parser to print out the offset.

I added a parser test to ensure that the round-tripping is working as expected, and updated existing tests to expect the new printed format.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
