### PR TITLE
Add links to cranelift.dev site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ command may not install the target for the correct copy of Rust.)
   standards process all along the way too.
 
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
-[Cranelift]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/README.md
+[Cranelift]: https://cranelift.dev/
 [Google's OSS Fuzz]: https://google.github.io/oss-fuzz/
 [security policy]: https://bytecodealliance.org/security
 [RFC process]: https://github.com/bytecodealliance/rfcs

--- a/cranelift/README.md
+++ b/cranelift/README.md
@@ -3,6 +3,8 @@ Cranelift Code Generator
 
 **A [Bytecode Alliance][BA] project**
 
+[Website](https://cranelift.dev/)
+
 Cranelift is a low-level retargetable code generator. It translates a
 [target-independent intermediate representation](docs/ir.md)
 into executable machine code.


### PR DESCRIPTION
This PR updates the link in Wasmtime's README at the root of the repo to link to Cranelift's new website rather than its subdirectory; and also updates the README in `cranelift/` to point to the new website, https://cranelift.dev/.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
