### PR TITLE
Make Wasmtime compatible with Stacked Borrows in MIRI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -625,7 +625,7 @@ jobs:
           -p wasmtime-runtime \
           -p wasmtime-environ
       env:
-        MIRIFLAGS: -Zmiri-tree-borrows
+        MIRIFLAGS: -Zmiri-strict-provenance
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2966,6 +2966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4106,6 +4112,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rustix",
+ "sptr",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",

--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -296,14 +296,14 @@ WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* c
  */
 WASM_API_EXTERN void wasmtime_func_from_raw(
     wasmtime_context_t* context,
-    size_t raw,
+    void *raw,
     wasmtime_func_t *ret);
 
 /**
  * \brief Converts a `func`  which belongs to `context` into a `usize`
  * parameter that is suitable for insertion into a #wasmtime_val_raw_t.
  */
-WASM_API_EXTERN size_t wasmtime_func_to_raw(
+WASM_API_EXTERN void *wasmtime_func_to_raw(
     wasmtime_context_t* context,
     const wasmtime_func_t *func);
 

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -70,7 +70,7 @@ WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
  * Note that the returned #wasmtime_externref_t is an owned value that must be
  * deleted via #wasmtime_externref_delete by the caller if it is non-null.
  */
-WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_context_t *context, size_t raw);
+WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_context_t *context, void *raw);
 
 /**
  * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
@@ -82,7 +82,7 @@ WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_conte
  * context of the store. Do not perform a GC between calling this function and
  * passing it to WebAssembly.
  */
-WASM_API_EXTERN size_t wasmtime_externref_to_raw(
+WASM_API_EXTERN void *wasmtime_externref_to_raw(
     wasmtime_context_t *context,
     const wasmtime_externref_t *ref);
 
@@ -180,7 +180,7 @@ typedef union wasmtime_val_raw {
   /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
   ///
   /// Note that this field is always stored in a little-endian format.
-  size_t funcref;
+  void *funcref;
   /// Field for when this val is a WebAssembly `externref` value.
   ///
   /// If this is set to 0 then it's a null externref, otherwise this must be
@@ -188,7 +188,7 @@ typedef union wasmtime_val_raw {
   /// `wasmtime_externref_t`.
   ///
   /// Note that this field is always stored in a little-endian format.
-  size_t externref;
+  void *externref;
 } wasmtime_val_raw_t;
 
 /**

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -420,13 +420,16 @@ pub unsafe extern "C" fn wasmtime_caller_export_get(
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_func_from_raw(
     store: CStoreContextMut<'_>,
-    raw: usize,
+    raw: *mut c_void,
     func: &mut Func,
 ) {
     *func = Func::from_raw(store, raw).unwrap();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn wasmtime_func_to_raw(store: CStoreContextMut<'_>, func: &Func) -> usize {
+pub unsafe extern "C" fn wasmtime_func_to_raw(
+    store: CStoreContextMut<'_>,
+    func: &Func,
+) -> *mut c_void {
     func.to_raw(store)
 }

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -296,17 +296,17 @@ pub extern "C" fn wasmtime_externref_delete(_val: Option<ExternRef>) {}
 pub unsafe extern "C" fn wasmtime_externref_to_raw(
     cx: CStoreContextMut<'_>,
     val: Option<ManuallyDrop<ExternRef>>,
-) -> usize {
+) -> *mut c_void {
     match val {
         Some(ptr) => ptr.to_raw(cx),
-        None => 0,
+        None => ptr::null_mut(),
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_externref_from_raw(
     _cx: CStoreContextMut<'_>,
-    val: usize,
+    val: *mut c_void,
 ) -> Option<ExternRef> {
     ExternRef::from_raw(val)
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = { workspace = true }
 memfd = "0.6.2"
 paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
+sptr = "0.3.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach = "0.3.2"

--- a/crates/runtime/src/cow.rs
+++ b/crates/runtime/src/cow.rs
@@ -436,9 +436,10 @@ impl MemoryImageSlot {
     pub(crate) fn dummy() -> MemoryImageSlot {
         MemoryImageSlot {
             // This pointer isn't ever actually used so its value doesn't
-            // matter, but we need to satisfy `NonNull` so pass a "1" value to
-            // handle that. Otherwise this shouldn't be used anywhere else.
-            base: NonNull::new(sptr::invalid_mut(1)).unwrap().into(),
+            // matter but we need to satisfy `NonNull` requirement so create a
+            // `dangling` pointer as a sentinel that should cause problems if
+            // it's actually used.
+            base: NonNull::dangling().into(),
             static_size: 0,
             image: None,
             accessible: 0,

--- a/crates/runtime/src/cow.rs
+++ b/crates/runtime/src/cow.rs
@@ -3,10 +3,11 @@
 
 #![cfg_attr(any(not(unix), miri), allow(unused_imports, unused_variables))]
 
-use crate::MmapVec;
+use crate::{MmapVec, SendSyncPtr};
 use anyhow::Result;
 use libc::c_void;
 use std::fs::File;
+use std::ptr::NonNull;
 use std::sync::Arc;
 use std::{convert::TryFrom, ops::Range};
 use wasmtime_environ::{
@@ -202,18 +203,18 @@ impl MemoryImage {
         }
     }
 
-    unsafe fn map_at(&self, base: usize) -> Result<()> {
+    unsafe fn map_at(&self, base: *mut u8) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(all(unix, not(miri)))] {
                 let ptr = rustix::mm::mmap(
-                    (base + self.linear_memory_offset) as *mut c_void,
+                    base.add(self.linear_memory_offset).cast(),
                     self.len,
                     rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
                     rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
                     self.fd.as_file(),
                     self.fd_offset,
                 )?;
-                assert_eq!(ptr as usize, base + self.linear_memory_offset);
+                assert_eq!(ptr, base.add(self.linear_memory_offset).cast());
                 Ok(())
             } else {
                 match self.fd {}
@@ -221,16 +222,16 @@ impl MemoryImage {
         }
     }
 
-    unsafe fn remap_as_zeros_at(&self, base: usize) -> Result<()> {
+    unsafe fn remap_as_zeros_at(&self, base: *mut u8) -> Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(unix)] {
                 let ptr = rustix::mm::mmap_anonymous(
-                    (base + self.linear_memory_offset) as *mut c_void,
+                    base.add(self.linear_memory_offset).cast(),
                     self.len,
                     rustix::mm::ProtFlags::READ | rustix::mm::ProtFlags::WRITE,
                     rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
                 )?;
-                assert_eq!(ptr as usize, base + self.linear_memory_offset);
+                assert_eq!(ptr.cast(), base.add(self.linear_memory_offset));
                 Ok(())
             } else {
                 match self.fd {}
@@ -372,10 +373,7 @@ pub struct MemoryImageSlot {
     /// The base address in virtual memory of the actual heap memory.
     ///
     /// Bytes at this address are what is seen by the Wasm guest code.
-    ///
-    /// Note that this is stored as `usize` instead of `*mut u8` to not deal
-    /// with `Send`/`Sync.
-    base: usize,
+    base: SendSyncPtr<u8>,
 
     /// The maximum static memory size which `self.accessible` can grow to.
     static_size: usize,
@@ -424,9 +422,8 @@ impl MemoryImageSlot {
     /// and all memory from `accessible` from `static_size` should be mapped as
     /// `PROT_NONE` backed by zero-bytes.
     pub(crate) fn create(base_addr: *mut c_void, accessible: usize, static_size: usize) -> Self {
-        let base = base_addr as usize;
         MemoryImageSlot {
-            base,
+            base: NonNull::new(base_addr.cast()).unwrap().into(),
             static_size,
             accessible,
             image: None,
@@ -438,7 +435,7 @@ impl MemoryImageSlot {
     #[cfg(feature = "pooling-allocator")]
     pub(crate) fn dummy() -> MemoryImageSlot {
         MemoryImageSlot {
-            base: 0,
+            base: NonNull::new(sptr::invalid_mut(1)).unwrap().into(),
             static_size: 0,
             image: None,
             accessible: 0,
@@ -547,7 +544,7 @@ impl MemoryImageSlot {
                 );
                 if image.len > 0 {
                     unsafe {
-                        image.map_at(self.base)?;
+                        image.map_at(self.base.as_ptr())?;
                     }
                 }
             }
@@ -564,7 +561,7 @@ impl MemoryImageSlot {
     pub(crate) fn remove_image(&mut self) -> Result<()> {
         if let Some(image) = &self.image {
             unsafe {
-                image.remap_as_zeros_at(self.base)?;
+                image.remap_as_zeros_at(self.base.as_ptr())?;
             }
             self.image = None;
         }
@@ -642,17 +639,13 @@ impl MemoryImageSlot {
                         (keep_resident - image.linear_memory_offset).min(mem_after_image);
 
                     // This is memset (1)
-                    std::ptr::write_bytes(self.base as *mut u8, 0u8, image.linear_memory_offset);
+                    std::ptr::write_bytes(self.base.as_ptr(), 0u8, image.linear_memory_offset);
 
                     // This is madvise (2)
                     self.madvise_reset(image.linear_memory_offset, image.len)?;
 
                     // This is memset (3)
-                    std::ptr::write_bytes(
-                        (self.base + image_end) as *mut u8,
-                        0u8,
-                        remaining_memset,
-                    );
+                    std::ptr::write_bytes(self.base.as_ptr().add(image_end), 0u8, remaining_memset);
 
                     // This is madvise (4)
                     self.madvise_reset(
@@ -680,7 +673,7 @@ impl MemoryImageSlot {
                     // Note that the memset may be zero bytes here.
 
                     // This is memset (1)
-                    std::ptr::write_bytes(self.base as *mut u8, 0u8, keep_resident);
+                    std::ptr::write_bytes(self.base.as_ptr(), 0u8, keep_resident);
 
                     // This is madvise (2)
                     self.madvise_reset(keep_resident, self.accessible - keep_resident)?;
@@ -692,7 +685,7 @@ impl MemoryImageSlot {
             // the rest.
             None => {
                 let size_to_memset = keep_resident.min(self.accessible);
-                std::ptr::write_bytes(self.base as *mut u8, 0u8, size_to_memset);
+                std::ptr::write_bytes(self.base.as_ptr(), 0u8, size_to_memset);
                 self.madvise_reset(size_to_memset, self.accessible - size_to_memset)?;
             }
         }
@@ -709,7 +702,7 @@ impl MemoryImageSlot {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {
                 rustix::mm::madvise(
-                    (self.base + base) as *mut c_void,
+                    self.base.as_ptr().add(base).cast(),
                     len,
                     rustix::mm::Advice::LinuxDontNeed,
                 )?;
@@ -723,16 +716,16 @@ impl MemoryImageSlot {
     fn set_protection(&self, range: Range<usize>, readwrite: bool) -> Result<()> {
         assert!(range.start <= range.end);
         assert!(range.end <= self.static_size);
-        let start = self.base.checked_add(range.start).unwrap();
         if range.len() == 0 {
             return Ok(());
         }
 
         unsafe {
+            let start = self.base.as_ptr().add(range.start);
             cfg_if::cfg_if! {
                 if #[cfg(miri)] {
                     if readwrite {
-                        std::ptr::write_bytes(start as *mut u8, 0u8, range.len());
+                        std::ptr::write_bytes(start, 0u8, range.len());
                     }
                 } else if #[cfg(unix)] {
                     let flags = if readwrite {
@@ -740,14 +733,14 @@ impl MemoryImageSlot {
                     } else {
                         rustix::mm::MprotectFlags::empty()
                     };
-                    rustix::mm::mprotect(start as *mut _, range.len(), flags)?;
+                    rustix::mm::mprotect(start.cast(), range.len(), flags)?;
                 } else {
                     use windows_sys::Win32::System::Memory::*;
 
                     let failure = if readwrite {
-                        VirtualAlloc(start as _, range.len(), MEM_COMMIT, PAGE_READWRITE).is_null()
+                        VirtualAlloc(start.cast(), range.len(), MEM_COMMIT, PAGE_READWRITE).is_null()
                     } else {
-                        VirtualFree(start as _, range.len(), MEM_DECOMMIT) == 0
+                        VirtualFree(start.cast(), range.len(), MEM_DECOMMIT) == 0
                     };
                     if failure {
                         return Err(std::io::Error::last_os_error().into());
@@ -780,18 +773,18 @@ impl MemoryImageSlot {
         unsafe {
             cfg_if::cfg_if! {
                 if #[cfg(miri)] {
-                    std::ptr::write_bytes(self.base as *mut u8, 0, self.static_size);
+                    std::ptr::write_bytes(self.base.as_ptr(), 0, self.static_size);
                 } else if #[cfg(unix)] {
                     let ptr = rustix::mm::mmap_anonymous(
-                        self.base as *mut c_void,
+                        self.base.as_ptr().cast(),
                         self.static_size,
                         rustix::mm::ProtFlags::empty(),
                         rustix::mm::MapFlags::PRIVATE | rustix::mm::MapFlags::FIXED,
                     )?;
-                    assert_eq!(ptr as usize, self.base);
+                    assert_eq!(ptr, self.base.as_ptr().cast());
                 } else {
                     use windows_sys::Win32::System::Memory::*;
-                    if VirtualFree(self.base as _, self.static_size, MEM_DECOMMIT) == 0 {
+                    if VirtualFree(self.base.as_ptr().cast(), self.static_size, MEM_DECOMMIT) == 0 {
                         return Err(std::io::Error::last_os_error().into());
                     }
                 }

--- a/crates/runtime/src/cow.rs
+++ b/crates/runtime/src/cow.rs
@@ -435,6 +435,9 @@ impl MemoryImageSlot {
     #[cfg(feature = "pooling-allocator")]
     pub(crate) fn dummy() -> MemoryImageSlot {
         MemoryImageSlot {
+            // This pointer isn't ever actually used so its value doesn't
+            // matter, but we need to satisfy `NonNull` so pass a "1" value to
+            // handle that. Otherwise this shouldn't be used anywhere else.
             base: NonNull::new(sptr::invalid_mut(1)).unwrap().into(),
             static_size: 0,
             image: None,

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -99,7 +99,7 @@
 //! Examination of Deferred Reference Counting and Cycle Detection* by Quinane:
 //! <https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf>
 
-use crate::{Backtrace, VMRuntimeLimits};
+use crate::{Backtrace, SendSyncPtr, VMRuntimeLimits};
 use std::alloc::Layout;
 use std::any::Any;
 use std::cell::UnsafeCell;
@@ -164,17 +164,13 @@ use wasmtime_environ::StackMap;
 /// ```
 #[derive(Debug)]
 #[repr(transparent)]
-pub struct VMExternRef(NonNull<VMExternData>);
+pub struct VMExternRef(SendSyncPtr<VMExternData>);
 
 impl std::fmt::Pointer for VMExternRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Pointer::fmt(&self.0, f)
     }
 }
-
-// Data contained is always Send+Sync so these should be safe.
-unsafe impl Send for VMExternRef {}
-unsafe impl Sync for VMExternRef {}
 
 #[repr(C)]
 pub(crate) struct VMExternData {
@@ -195,7 +191,7 @@ pub(crate) struct VMExternData {
 
     /// Always points to the implicit, dynamically-sized `value` member that
     /// precedes this `VMExternData`.
-    value_ptr: NonNull<dyn Any + Send + Sync>,
+    value_ptr: SendSyncPtr<dyn Any + Send + Sync>,
 }
 
 impl Clone for VMExternRef {
@@ -261,7 +257,7 @@ impl VMExternData {
     }
 
     /// Drop the inner value and then free this `VMExternData` heap allocation.
-    pub(crate) unsafe fn drop_and_dealloc(mut data: NonNull<VMExternData>) {
+    pub(crate) unsafe fn drop_and_dealloc(mut data: SendSyncPtr<VMExternData>) {
         log::trace!("Dropping externref data @ {:p}", data);
 
         // Note: we introduce a block scope so that we drop the live
@@ -279,13 +275,13 @@ impl VMExternData {
             };
 
             ptr::drop_in_place(data.value_ptr.as_ptr());
-            let alloc_ptr = data.value_ptr.cast::<u8>();
+            let alloc_ptr = data.value_ptr.as_ptr().cast::<u8>();
 
             (alloc_ptr, layout)
         };
 
         ptr::drop_in_place(data.as_ptr());
-        std::alloc::dealloc(alloc_ptr.as_ptr(), layout);
+        std::alloc::dealloc(alloc_ptr, layout);
     }
 
     #[inline]
@@ -336,17 +332,18 @@ impl VMExternRef {
 
             let extern_data_ptr =
                 alloc_ptr.cast::<u8>().as_ptr().add(footer_offset) as *mut VMExternData;
+
             ptr::write(
                 extern_data_ptr,
                 VMExternData {
                     ref_count: AtomicUsize::new(1),
                     // Cast from `*mut T` to `*mut dyn Any` here.
-                    value_ptr: NonNull::new_unchecked(value_ptr.as_ptr()),
+                    value_ptr: SendSyncPtr::new(NonNull::new_unchecked(value_ptr.as_ptr())),
                 },
             );
 
             log::trace!("New externref data @ {:p}", extern_data_ptr);
-            VMExternRef(NonNull::new_unchecked(extern_data_ptr))
+            VMExternRef(NonNull::new_unchecked(extern_data_ptr).into())
         }
     }
 
@@ -361,7 +358,7 @@ impl VMExternRef {
     ///  `clone_from_raw` is called.
     #[inline]
     pub fn as_raw(&self) -> *mut u8 {
-        let ptr = self.0.cast::<u8>().as_ptr();
+        let ptr = self.0.as_ptr().cast::<u8>();
         ptr
     }
 
@@ -374,7 +371,7 @@ impl VMExternRef {
     ///
     /// Use `from_raw` to recreate the `VMExternRef`.
     pub unsafe fn into_raw(self) -> *mut u8 {
-        let ptr = self.0.cast::<u8>().as_ptr();
+        let ptr = self.0.as_ptr().cast::<u8>();
         std::mem::forget(self);
         ptr
     }
@@ -389,7 +386,7 @@ impl VMExternRef {
     /// function.
     pub unsafe fn from_raw(ptr: *mut u8) -> Self {
         debug_assert!(!ptr.is_null());
-        VMExternRef(NonNull::new_unchecked(ptr).cast())
+        VMExternRef(NonNull::new_unchecked(ptr).cast().into())
     }
 
     /// Recreate a `VMExternRef` from a pointer returned from a previous call to
@@ -405,7 +402,7 @@ impl VMExternRef {
     /// so will result in use after free!
     pub unsafe fn clone_from_raw(ptr: *mut u8) -> Self {
         debug_assert!(!ptr.is_null());
-        let x = VMExternRef(NonNull::new_unchecked(ptr).cast());
+        let x = VMExternRef(NonNull::new_unchecked(ptr).cast().into());
         x.extern_data().increment_ref_count();
         x
     }
@@ -996,7 +993,7 @@ mod tests {
 
         let extern_data = VMExternData {
             ref_count: AtomicUsize::new(0),
-            value_ptr: NonNull::new(s).unwrap(),
+            value_ptr: NonNull::new(s).unwrap().into(),
         };
 
         let extern_data_ptr = &extern_data as *const _;

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -941,7 +941,10 @@ impl Instance {
         })
     }
 
-    /// TODO
+    /// Gets the raw runtime table data structure owned by this instance
+    /// given the provided `idx`.
+    ///
+    /// The `range` specified is eagerly initialized for funcref tables.
     pub fn get_defined_table_with_lazy_init(
         &mut self,
         idx: DefinedTableIndex,
@@ -1211,7 +1214,8 @@ pub struct InstanceHandle {
 }
 
 impl InstanceHandle {
-    /// TODO
+    /// Creates an "empty" instance handle which internally has a null pointer
+    /// to an instance.
     pub fn null() -> InstanceHandle {
         InstanceHandle { instance: None }
     }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use anyhow::Error;
 use anyhow::Result;
-use memoffset::offset_of;
+use sptr::Strict;
 use std::alloc::{self, Layout};
 use std::any::Any;
 use std::convert::TryFrom;
@@ -54,7 +54,7 @@ pub use allocator::*;
 /// This `Instance` type is used as a ubiquitous representation for WebAssembly
 /// values, whether or not they were created on the host or through a module.
 #[repr(C)] // ensure that the vmctx field is last.
-pub(crate) struct Instance {
+pub struct Instance {
     /// The runtime info (corresponding to the "compiled module"
     /// abstraction in higher layers) that is retained and needed for
     /// lazy initialization. This provides access to the underlying
@@ -95,11 +95,62 @@ pub(crate) struct Instance {
     /// index of the slot in the pooling allocator.
     index: usize,
 
+    /// A pointer to the `vmctx` field at the end of the `Instance`.
+    ///
+    /// If you're looking at this a reasonable question would be "why do we need
+    /// a pointer to ourselves?" because after all the pointer's valid is
+    /// trivially derivable from any `&Instance` pointer. The rationale for this
+    /// field's existence is subtle, but it's required for correctness. The
+    /// short version is "this makes miri happy".
+    ///
+    /// The long version of why this field exists is that the rules that MIRI
+    /// uses to ensure pointers are used correctly have various conditions on
+    /// them depend on how pointers are used. More specifically if `*mut T` is
+    /// derived from `&mut T`, then that invalidates all prior pointers drived
+    /// from the `&mut T`. This means that while we liberally want to re-acquire
+    /// a `*mut VMContext` throughout the implementation of `Instance` the
+    /// trivial way, a function `fn vmctx(&mut Instance) -> *mut VMContext`
+    /// would effectively invalidate all prior `*mut VMContext` pointers
+    /// acquired. The purpose of this field is to serve as a sort of
+    /// source-of-truth for where `*mut VMContext` pointers come from.
+    ///
+    /// This field is initialized when the `Instance` is created with the
+    /// original allocation's pointer. That means that the provenance of this
+    /// pointer contains the entire allocation (both instance and `VMContext`).
+    /// This provenance bit is then "carried through" where `fn vmctx` will base
+    /// all returned pointers on this pointer itself. This provides the means of
+    /// never invalidating this pointer throughout MIRI and additionally being
+    /// able to still temporarily have `&mut Instance` methods and such.
+    ///
+    /// It's important to note, though, that this is not here purely for MIRI.
+    /// The careful construction of the `fn vmctx` method has ramifications on
+    /// the LLVM IR generated, for example. A historical CVE on Wasmtime,
+    /// GHSA-ch89-5g45-qwc7, was caused due to relying on undefined behavior. By
+    /// deriving VMContext pointers from this pointer it specifically hints to
+    /// LLVM that trickery is afoot and it properly informs `noalias` and such
+    /// annotations and analysis. More-or-less this pointer is actually loaded
+    /// in LLVM IR which helps defeat otherwise present aliasing optimizations,
+    /// which we want, since writes to this should basically never be optimized
+    /// out.
+    ///
+    /// As a final note it's worth pointing out that the machine code generated
+    /// for accessing `fn vmctx` is still as one would expect. This member isn't
+    /// actually ever loaded at runtime (or at least shouldn't be). Perhaps in
+    /// the future if the memory consumption of this field is a problem we could
+    /// shrink it slightly, but for now one extra pointer per wasm instance
+    /// seems not too bad.
+    vmctx_self_reference: VMContextSelfReference,
+
     /// Additional context used by compiled wasm code. This field is last, and
     /// represents a dynamically-sized array that extends beyond the nominal
     /// end of the struct (similar to a flexible array member).
     vmctx: VMContext,
 }
+
+struct VMContextSelfReference(NonNull<VMContext>);
+
+unsafe impl Send for VMContextSelfReference {}
+unsafe impl Sync for VMContextSelfReference {}
 
 #[allow(clippy::cast_ptr_alignment)]
 impl Instance {
@@ -135,6 +186,9 @@ impl Instance {
                 dropped_elements,
                 dropped_data,
                 host_state: req.host_state,
+                vmctx_self_reference: VMContextSelfReference(
+                    NonNull::new(ptr.cast::<u8>().add(mem::size_of::<Instance>()).cast()).unwrap(),
+                ),
                 vmctx: VMContext {
                     _marker: std::marker::PhantomPinned,
                 },
@@ -145,16 +199,46 @@ impl Instance {
         InstanceHandle { instance: ptr }
     }
 
+    /// Converts the provided `*mut VMContext` to an `Instance` pointer and runs
+    /// the provided closure with the instance.
+    ///
+    /// This method will move the `vmctx` pointer backwards to point to the
+    /// original `Instance` that precedes it. The closure is provided a
+    /// temporary version of the `Instance` pointer with a constrained lifetime
+    /// to the closure to ensure it doesn't accidentally escape.
+    ///
+    /// # Unsafety
+    ///
+    /// Callers must validate that the `vmctx` pointer is a valid allocation
+    /// and that it's valid to acquire `&mut Instance` at this time. For example
+    /// this can't be called twice on the same `VMContext` to get two active
+    /// pointers to the same `Instance`.
+    pub unsafe fn from_vmctx<R>(vmctx: *mut VMContext, f: impl FnOnce(&mut Instance) -> R) -> R {
+        let ptr = vmctx
+            .cast::<u8>()
+            .offset(-(mem::size_of::<Instance>() as isize))
+            .cast::<Instance>();
+        f(&mut *ptr)
+    }
+
     /// Helper function to access various locations offset from our `*mut
     /// VMContext` object.
+    ///
+    /// # Safety
+    ///
+    /// This method is unsafe because the `offset` must be within bounds of the
+    /// `VMContext` object trailing this instance.
     unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *const T {
-        (std::ptr::addr_of!(self.vmctx).cast::<u8>())
+        self.vmctx()
+            .cast::<u8>()
             .add(usize::try_from(offset).unwrap())
             .cast()
     }
 
+    /// Dual of `vmctx_plus_offset`, but for mutability.
     unsafe fn vmctx_plus_offset_mut<T>(&mut self, offset: u32) -> *mut T {
-        (std::ptr::addr_of_mut!(self.vmctx).cast::<u8>())
+        self.vmctx()
+            .cast::<u8>()
             .add(usize::try_from(offset).unwrap())
             .cast()
     }
@@ -222,8 +306,11 @@ impl Instance {
             unsafe { &mut *self.get_defined_memory(defined_index) }
         } else {
             let import = self.imported_memory(index);
-            let ctx = unsafe { &mut *import.vmctx };
-            unsafe { &mut *ctx.instance_mut().get_defined_memory(import.index) }
+            unsafe {
+                let ptr =
+                    Instance::from_vmctx(import.vmctx, |i| i.get_defined_memory(import.index));
+                &mut *ptr
+            }
         }
     }
 
@@ -302,7 +389,7 @@ impl Instance {
         ptr
     }
 
-    pub unsafe fn set_store(&mut self, store: Option<*mut dyn Store>) {
+    pub(crate) unsafe fn set_store(&mut self, store: Option<*mut dyn Store>) {
         if let Some(store) = store {
             *self.vmctx_plus_offset_mut(self.offsets().vmctx_store()) = store;
             *self.runtime_limits() = (*store).vmruntime_limits();
@@ -329,14 +416,29 @@ impl Instance {
 
     /// Return a reference to the vmctx used by compiled wasm code.
     #[inline]
-    pub fn vmctx(&self) -> &VMContext {
-        &self.vmctx
-    }
-
-    /// Return a raw pointer to the vmctx used by compiled wasm code.
-    #[inline]
-    pub fn vmctx_ptr(&self) -> *mut VMContext {
-        self.vmctx() as *const VMContext as *mut VMContext
+    pub fn vmctx(&self) -> *mut VMContext {
+        // The definition of this method is subtle but intentional. The goal
+        // here is that effectively this should return `&mut self.vmctx`, but
+        // it's not quite so simple. Some more documentation is available on the
+        // `vmctx_self_reference` field, but the general idea is that we're
+        // creating a pointer to return with proper provenance. Provenance is
+        // still in the works in Rust at the time of this writing but the load
+        // of the `self.vmctx_self_reference` field is important here as it
+        // affects how LLVM thinks about aliasing with respect to the returned
+        // pointer.
+        //
+        // The intention of this method is to codegen to machine code as `&mut
+        // self.vmctx`, however. While it doesn't show up like this in LLVM IR
+        // (there's an actual load of the field) it does look like that by the
+        // time the backend runs. (that's magic to me, the backend removing
+        // loads...)
+        //
+        // As a final minor note, strict provenance APIs are not stable on Rust
+        // today so the `sptr` crate is used. This crate provides the extension
+        // trait `Strict` but the method names conflict with the nightly methods
+        // so a different syntax is used to invoke methods here.
+        let addr = std::ptr::addr_of!(self.vmctx);
+        Strict::with_addr(self.vmctx_self_reference.0.as_ptr(), Strict::addr(addr))
     }
 
     fn get_exported_func(&mut self, index: FuncIndex) -> ExportFunction {
@@ -348,7 +450,7 @@ impl Instance {
     fn get_exported_table(&mut self, index: TableIndex) -> ExportTable {
         let (definition, vmctx) = if let Some(def_index) = self.module().defined_table_index(index)
         {
-            (self.table_ptr(def_index), self.vmctx_ptr())
+            (self.table_ptr(def_index), self.vmctx())
         } else {
             let import = self.imported_table(index);
             (import.from, import.vmctx)
@@ -363,7 +465,7 @@ impl Instance {
     fn get_exported_memory(&mut self, index: MemoryIndex) -> ExportMemory {
         let (definition, vmctx, def_index) =
             if let Some(def_index) = self.module().defined_memory_index(index) {
-                (self.memory_ptr(def_index), self.vmctx_ptr(), def_index)
+                (self.memory_ptr(def_index), self.vmctx(), def_index)
             } else {
                 let import = self.imported_memory(index);
                 (import.from, import.vmctx, import.index)
@@ -402,14 +504,8 @@ impl Instance {
         &*self.host_state
     }
 
-    /// Return the offset from the vmctx pointer to its containing Instance.
-    #[inline]
-    pub(crate) fn vmctx_offset() -> isize {
-        offset_of!(Self, vmctx) as isize
-    }
-
     /// Return the table index for the given `VMTableDefinition`.
-    unsafe fn table_index(&mut self, table: &VMTableDefinition) -> DefinedTableIndex {
+    pub unsafe fn table_index(&mut self, table: &VMTableDefinition) -> DefinedTableIndex {
         let index = DefinedTableIndex::new(
             usize::try_from(
                 (table as *const VMTableDefinition)
@@ -431,17 +527,26 @@ impl Instance {
         index: MemoryIndex,
         delta: u64,
     ) -> Result<Option<usize>, Error> {
-        let (idx, instance) = if let Some(idx) = self.module().defined_memory_index(index) {
-            (idx, self)
-        } else {
-            let import = self.imported_memory(index);
-            unsafe {
-                let foreign_instance = (*import.vmctx).instance_mut();
-                (import.index, foreign_instance)
+        match self.module().defined_memory_index(index) {
+            Some(idx) => self.defined_memory_grow(idx, delta),
+            None => {
+                let import = self.imported_memory(index);
+                unsafe {
+                    Instance::from_vmctx(import.vmctx, |i| {
+                        i.defined_memory_grow(import.index, delta)
+                    })
+                }
             }
-        };
-        let store = unsafe { &mut *instance.store() };
-        let memory = &mut instance.memories[idx];
+        }
+    }
+
+    fn defined_memory_grow(
+        &mut self,
+        idx: DefinedMemoryIndex,
+        delta: u64,
+    ) -> Result<Option<usize>, Error> {
+        let store = unsafe { &mut *self.store() };
+        let memory = &mut self.memories[idx];
 
         let result = unsafe { memory.grow(delta, Some(store)) };
 
@@ -449,7 +554,7 @@ impl Instance {
         // pointer and/or the length changed.
         if memory.as_shared_memory().is_none() {
             let vmmemory = memory.vmmemory();
-            instance.set_memory(idx, vmmemory);
+            self.set_memory(idx, vmmemory);
         }
 
         result
@@ -470,9 +575,9 @@ impl Instance {
         delta: u32,
         init_value: TableElement,
     ) -> Result<Option<u32>, Error> {
-        let (defined_table_index, instance) =
-            self.get_defined_table_index_and_instance(table_index);
-        instance.defined_table_grow(defined_table_index, delta, init_value)
+        self.with_defined_table_index_and_instance(table_index, |i, instance| {
+            instance.defined_table_grow(i, delta, init_value)
+        })
     }
 
     fn defined_table_grow(
@@ -532,7 +637,7 @@ impl Instance {
                     .array_to_wasm_trampoline(def_index)
                     .expect("should have array-to-Wasm trampoline for escaping function"),
                 wasm_call: Some(self.runtime_info.function(def_index)),
-                vmctx: VMOpaqueContext::from_vmcontext(self.vmctx_ptr()),
+                vmctx: VMOpaqueContext::from_vmcontext(self.vmctx()),
                 type_index,
             }
         } else {
@@ -679,7 +784,7 @@ impl Instance {
     }
 
     /// Get a locally-defined memory.
-    pub(crate) fn get_defined_memory(&mut self, index: DefinedMemoryIndex) -> *mut Memory {
+    pub fn get_defined_memory(&mut self, index: DefinedMemoryIndex) -> *mut Memory {
         ptr::addr_of_mut!(self.memories[index])
     }
 
@@ -835,12 +940,22 @@ impl Instance {
         table_index: TableIndex,
         range: impl Iterator<Item = u32>,
     ) -> *mut Table {
-        let (idx, instance) = self.get_defined_table_index_and_instance(table_index);
-        let elt_ty = instance.tables[idx].element_type();
+        self.with_defined_table_index_and_instance(table_index, |idx, instance| {
+            instance.get_defined_table_with_lazy_init(idx, range)
+        })
+    }
+
+    /// TODO
+    pub fn get_defined_table_with_lazy_init(
+        &mut self,
+        idx: DefinedTableIndex,
+        range: impl Iterator<Item = u32>,
+    ) -> *mut Table {
+        let elt_ty = self.tables[idx].element_type();
 
         if elt_ty == TableElementType::Func {
             for i in range {
-                let value = match instance.tables[idx].get(i) {
+                let value = match self.tables[idx].get(i) {
                     Some(value) => value,
                     None => {
                         // Out-of-bounds; caller will handle by likely
@@ -850,14 +965,15 @@ impl Instance {
                     }
                 };
                 if value.is_uninit() {
-                    let table_init = match &instance.module().table_initialization {
+                    let module = self.module();
+                    let table_init = match &self.module().table_initialization {
                         // We unfortunately can't borrow `tables` outside the
                         // loop because we need to call `get_func_ref` (a `&mut`
                         // method) below; so unwrap it dynamically here.
                         TableInitialization::FuncTable { tables, .. } => tables,
                         _ => break,
                     }
-                    .get(table_index);
+                    .get(module.table_index(idx));
 
                     // The TableInitialization::FuncTable elements table may
                     // be smaller than the current size of the table: it
@@ -870,26 +986,27 @@ impl Instance {
                     let func_index =
                         table_init.and_then(|indices| indices.get(i as usize).cloned());
                     let func_ref = func_index
-                        .and_then(|func_index| instance.get_func_ref(func_index))
+                        .and_then(|func_index| self.get_func_ref(func_index))
                         .unwrap_or(std::ptr::null_mut());
 
                     let value = TableElement::FuncRef(func_ref);
 
-                    instance.tables[idx]
+                    self.tables[idx]
                         .set(i, value)
                         .expect("Table type should match and index should be in-bounds");
                 }
             }
         }
 
-        ptr::addr_of_mut!(instance.tables[idx])
+        ptr::addr_of_mut!(self.tables[idx])
     }
 
     /// Get a table by index regardless of whether it is locally-defined or an
     /// imported, foreign table.
     pub(crate) fn get_table(&mut self, table_index: TableIndex) -> *mut Table {
-        let (idx, instance) = self.get_defined_table_index_and_instance(table_index);
-        ptr::addr_of_mut!(instance.tables[idx])
+        self.with_defined_table_index_and_instance(table_index, |idx, instance| {
+            ptr::addr_of_mut!(instance.tables[idx])
+        })
     }
 
     /// Get a locally-defined table.
@@ -897,19 +1014,21 @@ impl Instance {
         ptr::addr_of_mut!(self.tables[index])
     }
 
-    pub(crate) fn get_defined_table_index_and_instance(
+    pub(crate) fn with_defined_table_index_and_instance<R>(
         &mut self,
         index: TableIndex,
-    ) -> (DefinedTableIndex, &mut Instance) {
+        f: impl FnOnce(DefinedTableIndex, &mut Instance) -> R,
+    ) -> R {
         if let Some(defined_table_index) = self.module().defined_table_index(index) {
-            (defined_table_index, self)
+            f(defined_table_index, self)
         } else {
             let import = self.imported_table(index);
             unsafe {
-                let foreign_instance = (*import.vmctx).instance_mut();
-                let foreign_table_def = &*import.from;
-                let foreign_table_index = foreign_instance.table_index(foreign_table_def);
-                (foreign_table_index, foreign_instance)
+                Instance::from_vmctx(import.vmctx, |foreign_instance| {
+                    let foreign_table_def = import.from;
+                    let foreign_table_index = foreign_instance.table_index(&*foreign_table_def);
+                    f(foreign_table_index, foreign_instance)
+                })
             }
         }
     }
@@ -1107,29 +1226,17 @@ fn _assert_send_sync() {
 }
 
 impl InstanceHandle {
-    /// Create a new `InstanceHandle` pointing at the instance
-    /// pointed to by the given `VMContext` pointer.
-    ///
-    /// # Safety
-    /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `Instance`.
-    #[inline]
-    pub unsafe fn from_vmctx(vmctx: *mut VMContext) -> Self {
-        let instance = (&mut *vmctx).instance();
-        Self {
-            instance: instance as *const Instance as *mut Instance,
+    /// TODO
+    pub fn null() -> InstanceHandle {
+        InstanceHandle {
+            instance: ptr::null_mut(),
         }
-    }
-
-    /// Return a reference to the vmctx used by compiled wasm code.
-    pub fn vmctx(&self) -> &VMContext {
-        self.instance().vmctx()
     }
 
     /// Return a raw pointer to the vmctx used by compiled wasm code.
     #[inline]
-    pub fn vmctx_ptr(&self) -> *mut VMContext {
-        self.instance().vmctx_ptr()
+    pub fn vmctx(&self) -> *mut VMContext {
+        self.instance().vmctx()
     }
 
     /// Return a reference to a module.
@@ -1179,16 +1286,6 @@ impl InstanceHandle {
     /// Return a reference to the custom state attached to this instance.
     pub fn host_state(&self) -> &dyn Any {
         self.instance().host_state()
-    }
-
-    /// Get a memory defined locally within this module.
-    pub fn get_defined_memory(&mut self, index: DefinedMemoryIndex) -> *mut Memory {
-        self.instance_mut().get_defined_memory(index)
-    }
-
-    /// Return the table index for the given `VMTableDefinition` in this instance.
-    pub unsafe fn table_index(&mut self, table: &VMTableDefinition) -> DefinedTableIndex {
-        self.instance_mut().table_index(table)
     }
 
     /// Get a table defined locally within this module.

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -212,7 +212,7 @@ impl Instance {
     pub unsafe fn from_vmctx<R>(vmctx: *mut VMContext, f: impl FnOnce(&mut Instance) -> R) -> R {
         let ptr = vmctx
             .cast::<u8>()
-            .offset(-(mem::size_of::<Instance>() as isize))
+            .sub(mem::size_of::<Instance>())
             .cast::<Instance>();
         f(&mut *ptr)
     }

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -97,7 +97,7 @@ pub struct Instance {
     /// A pointer to the `vmctx` field at the end of the `Instance`.
     ///
     /// If you're looking at this a reasonable question would be "why do we need
-    /// a pointer to ourselves?" because after all the pointer's valid is
+    /// a pointer to ourselves?" because after all the pointer's value is
     /// trivially derivable from any `&Instance` pointer. The rationale for this
     /// field's existence is subtle, but it's required for correctness. The
     /// short version is "this makes miri happy".

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1153,7 +1153,7 @@ impl Instance {
                     }
                 }
                 GlobalInit::RefFunc(f) => {
-                    *(*to).as_func_ref_mut() = self.get_func_ref(f).unwrap() as *const VMFuncRef;
+                    *(*to).as_func_ref_mut() = self.get_func_ref(f).unwrap();
                 }
                 GlobalInit::RefNullConst => match global.wasm_ty {
                     // `VMGlobalDefinition::new()` already zeroed out the bits

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -133,9 +133,9 @@ pub unsafe trait InstanceAllocator {
         self.deallocate_tables(index, &mut handle.instance_mut().tables);
         unsafe {
             let layout = Instance::alloc_layout(handle.instance().offsets());
-            ptr::drop_in_place(handle.instance);
-            alloc::dealloc(handle.instance.cast(), layout);
-            handle.instance = std::ptr::null_mut();
+            let ptr = handle.instance.take().unwrap();
+            ptr::drop_in_place(ptr.as_ptr());
+            alloc::dealloc(ptr.as_ptr().cast(), layout);
         }
         self.deallocate_index(index);
     }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -794,12 +794,8 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
                 MemoryStyle::Dynamic { .. } => {}
             }
 
-            let memory = unsafe {
-                std::slice::from_raw_parts_mut(
-                    self.memories.get_base(index, defined_index),
-                    self.memories.max_accessible,
-                )
-            };
+            let base_ptr = self.memories.get_base(index, defined_index);
+            let base_capacity = self.memories.max_accessible;
 
             let mut slot = self.memories.take_memory_image_slot(index, defined_index);
             let image = req.runtime_info.memory_image(defined_index)?;
@@ -822,7 +818,8 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
 
             memories.push(Memory::new_static(
                 plan,
-                memory,
+                base_ptr,
+                base_capacity,
                 slot,
                 self.memories.memory_and_guard_size,
                 unsafe { &mut *req.store.get().unwrap() },

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -53,13 +53,13 @@ pub use wasmtime_jit_debug::gdb_jit_int::GdbJitImageRegistration;
 pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
+#[cfg(feature = "pooling-allocator")]
+pub use crate::instance::{
+    Instance, InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig,
+};
 pub use crate::instance::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
     StorePtr,
-};
-#[cfg(feature = "pooling-allocator")]
-pub use crate::instance::{
-    InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig,
 };
 pub use crate::memory::{
     DefaultMemoryCreator, Memory, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -40,6 +40,7 @@ mod memory;
 mod mmap;
 mod mmap_vec;
 mod parking_spot;
+mod send_sync_ptr;
 mod store_box;
 mod table;
 mod traphandlers;
@@ -53,13 +54,13 @@ pub use wasmtime_jit_debug::gdb_jit_int::GdbJitImageRegistration;
 pub use crate::export::*;
 pub use crate::externref::*;
 pub use crate::imports::Imports;
+pub use crate::instance::{
+    Instance, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
+    OnDemandInstanceAllocator, StorePtr,
+};
 #[cfg(feature = "pooling-allocator")]
 pub use crate::instance::{
-    Instance, InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig,
-};
-pub use crate::instance::{
-    InstanceAllocationRequest, InstanceAllocator, InstanceHandle, OnDemandInstanceAllocator,
-    StorePtr,
+    InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig,
 };
 pub use crate::memory::{
     DefaultMemoryCreator, Memory, RuntimeLinearMemory, RuntimeMemoryCreator, SharedMemory,
@@ -79,6 +80,7 @@ pub use crate::vmcontext::{
     VMRuntimeLimits, VMSharedSignatureIndex, VMTableDefinition, VMTableImport, VMWasmCallFunction,
     ValRaw,
 };
+pub use send_sync_ptr::SendSyncPtr;
 
 mod module_id;
 pub use module_id::{CompiledModuleId, CompiledModuleIdAllocator};

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -392,7 +392,7 @@ unsafe fn table_get_lazy_init_func_ref(
 // Drop a `VMExternRef`.
 unsafe fn drop_externref(_vmctx: *mut VMContext, externref: *mut u8) {
     let externref = externref as *mut crate::externref::VMExternData;
-    let externref = NonNull::new(externref).unwrap();
+    let externref = NonNull::new(externref).unwrap().into();
     crate::externref::VMExternData::drop_and_dealloc(externref);
 }
 

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -57,7 +57,7 @@
 use crate::externref::VMExternRef;
 use crate::table::{Table, TableElementType};
 use crate::vmcontext::{VMContext, VMFuncRef};
-use crate::TrapReason;
+use crate::{Instance, TrapReason};
 use anyhow::Result;
 use std::mem;
 use std::ptr::{self, NonNull};
@@ -114,9 +114,9 @@ pub mod trampolines {
                     vmctx : *mut VMContext,
                     $( $pname : libcall!(@ty $param), )*
                 ) $( -> libcall!(@ty $result))? {
-                    let result = std::panic::catch_unwind(|| {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         super::$name(vmctx, $($pname),*)
-                    });
+                    }));
                     match result {
                         Ok(ret) => LibcallResult::convert(ret),
                         Err(panic) => crate::traphandlers::resume_panic(panic),
@@ -186,19 +186,20 @@ unsafe fn memory32_grow(
     delta: u64,
     memory_index: u32,
 ) -> Result<*mut u8, TrapReason> {
-    let instance = (*vmctx).instance_mut();
-    let memory_index = MemoryIndex::from_u32(memory_index);
-    let result =
-        match instance
-            .memory_grow(memory_index, delta)
-            .map_err(|error| TrapReason::User {
-                error,
-                needs_backtrace: true,
-            })? {
-            Some(size_in_bytes) => size_in_bytes / (wasmtime_environ::WASM_PAGE_SIZE as usize),
-            None => usize::max_value(),
-        };
-    Ok(result as *mut _)
+    Instance::from_vmctx(vmctx, |instance| {
+        let memory_index = MemoryIndex::from_u32(memory_index);
+        let result =
+            match instance
+                .memory_grow(memory_index, delta)
+                .map_err(|error| TrapReason::User {
+                    error,
+                    needs_backtrace: true,
+                })? {
+                Some(size_in_bytes) => size_in_bytes / (wasmtime_environ::WASM_PAGE_SIZE as usize),
+                None => usize::max_value(),
+            };
+        Ok(result as *mut _)
+    })
 }
 
 // Implementation of `table.grow`.
@@ -213,22 +214,23 @@ unsafe fn table_grow(
     // or is a `VMExternRef` until we look at the table type.
     init_value: *mut u8,
 ) -> Result<u32> {
-    let instance = (*vmctx).instance_mut();
     let table_index = TableIndex::from_u32(table_index);
-    let element = match instance.table_element_type(table_index) {
-        TableElementType::Func => (init_value as *mut VMFuncRef).into(),
-        TableElementType::Extern => {
-            let init_value = if init_value.is_null() {
-                None
-            } else {
-                Some(VMExternRef::clone_from_raw(init_value))
-            };
-            init_value.into()
-        }
-    };
-    Ok(match instance.table_grow(table_index, delta, element)? {
-        Some(r) => r,
-        None => -1_i32 as u32,
+    Instance::from_vmctx(vmctx, |instance| {
+        let element = match instance.table_element_type(table_index) {
+            TableElementType::Func => (init_value as *mut VMFuncRef).into(),
+            TableElementType::Extern => {
+                let init_value = if init_value.is_null() {
+                    None
+                } else {
+                    Some(VMExternRef::clone_from_raw(init_value))
+                };
+                init_value.into()
+            }
+        };
+        Ok(match instance.table_grow(table_index, delta, element)? {
+            Some(r) => r,
+            None => -1_i32 as u32,
+        })
     })
 }
 
@@ -245,23 +247,24 @@ unsafe fn table_fill(
     val: *mut u8,
     len: u32,
 ) -> Result<(), Trap> {
-    let instance = (*vmctx).instance_mut();
-    let table_index = TableIndex::from_u32(table_index);
-    let table = &mut *instance.get_table(table_index);
-    match table.element_type() {
-        TableElementType::Func => {
-            let val = val as *mut VMFuncRef;
-            table.fill(dst, val.into(), len)
+    Instance::from_vmctx(vmctx, |instance| {
+        let table_index = TableIndex::from_u32(table_index);
+        let table = &mut *instance.get_table(table_index);
+        match table.element_type() {
+            TableElementType::Func => {
+                let val = val as *mut VMFuncRef;
+                table.fill(dst, val.into(), len)
+            }
+            TableElementType::Extern => {
+                let val = if val.is_null() {
+                    None
+                } else {
+                    Some(VMExternRef::clone_from_raw(val))
+                };
+                table.fill(dst, val.into(), len)
+            }
         }
-        TableElementType::Extern => {
-            let val = if val.is_null() {
-                None
-            } else {
-                Some(VMExternRef::clone_from_raw(val))
-            };
-            table.fill(dst, val.into(), len)
-        }
-    }
+    })
 }
 
 use table_fill as table_fill_func_ref;
@@ -278,12 +281,13 @@ unsafe fn table_copy(
 ) -> Result<(), Trap> {
     let dst_table_index = TableIndex::from_u32(dst_table_index);
     let src_table_index = TableIndex::from_u32(src_table_index);
-    let instance = (*vmctx).instance_mut();
-    let dst_table = instance.get_table(dst_table_index);
-    // Lazy-initialize the whole range in the source table first.
-    let src_range = src..(src.checked_add(len).unwrap_or(u32::MAX));
-    let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
-    Table::copy(dst_table, src_table, dst, src, len)
+    Instance::from_vmctx(vmctx, |instance| {
+        let dst_table = instance.get_table(dst_table_index);
+        // Lazy-initialize the whole range in the source table first.
+        let src_range = src..(src.checked_add(len).unwrap_or(u32::MAX));
+        let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
+        Table::copy(dst_table, src_table, dst, src, len)
+    })
 }
 
 // Implementation of `table.init`.
@@ -297,15 +301,15 @@ unsafe fn table_init(
 ) -> Result<(), Trap> {
     let table_index = TableIndex::from_u32(table_index);
     let elem_index = ElemIndex::from_u32(elem_index);
-    let instance = (*vmctx).instance_mut();
-    instance.table_init(table_index, elem_index, dst, src, len)
+    Instance::from_vmctx(vmctx, |i| {
+        i.table_init(table_index, elem_index, dst, src, len)
+    })
 }
 
 // Implementation of `elem.drop`.
 unsafe fn elem_drop(vmctx: *mut VMContext, elem_index: u32) {
     let elem_index = ElemIndex::from_u32(elem_index);
-    let instance = (*vmctx).instance_mut();
-    instance.elem_drop(elem_index);
+    Instance::from_vmctx(vmctx, |i| i.elem_drop(elem_index))
 }
 
 // Implementation of `memory.copy` for locally defined memories.
@@ -319,8 +323,9 @@ unsafe fn memory_copy(
 ) -> Result<(), Trap> {
     let src_index = MemoryIndex::from_u32(src_index);
     let dst_index = MemoryIndex::from_u32(dst_index);
-    let instance = (*vmctx).instance_mut();
-    instance.memory_copy(dst_index, dst, src_index, src, len)
+    Instance::from_vmctx(vmctx, |i| {
+        i.memory_copy(dst_index, dst, src_index, src, len)
+    })
 }
 
 // Implementation of `memory.fill` for locally defined memories.
@@ -332,8 +337,7 @@ unsafe fn memory_fill(
     len: u64,
 ) -> Result<(), Trap> {
     let memory_index = MemoryIndex::from_u32(memory_index);
-    let instance = (*vmctx).instance_mut();
-    instance.memory_fill(memory_index, dst, val as u8, len)
+    Instance::from_vmctx(vmctx, |i| i.memory_fill(memory_index, dst, val as u8, len))
 }
 
 // Implementation of `memory.init`.
@@ -347,24 +351,25 @@ unsafe fn memory_init(
 ) -> Result<(), Trap> {
     let memory_index = MemoryIndex::from_u32(memory_index);
     let data_index = DataIndex::from_u32(data_index);
-    let instance = (*vmctx).instance_mut();
-    instance.memory_init(memory_index, data_index, dst, src, len)
+    Instance::from_vmctx(vmctx, |i| {
+        i.memory_init(memory_index, data_index, dst, src, len)
+    })
 }
 
 // Implementation of `ref.func`.
 unsafe fn ref_func(vmctx: *mut VMContext, func_index: u32) -> *mut u8 {
-    let instance = (*vmctx).instance_mut();
-    let func_ref = instance
-        .get_func_ref(FuncIndex::from_u32(func_index))
-        .expect("ref_func: `get_func_ref` should always be available for our given func index");
-    func_ref as *mut _
+    Instance::from_vmctx(vmctx, |instance| {
+        instance
+            .get_func_ref(FuncIndex::from_u32(func_index))
+            .expect("ref_func: funcref should always be available for given func index")
+            .cast()
+    })
 }
 
 // Implementation of `data.drop`.
 unsafe fn data_drop(vmctx: *mut VMContext, data_index: u32) {
     let data_index = DataIndex::from_u32(data_index);
-    let instance = (*vmctx).instance_mut();
-    instance.data_drop(data_index)
+    Instance::from_vmctx(vmctx, |i| i.data_drop(data_index))
 }
 
 // Returns a table entry after lazily initializing it.
@@ -373,14 +378,15 @@ unsafe fn table_get_lazy_init_func_ref(
     table_index: u32,
     index: u32,
 ) -> *mut u8 {
-    let instance = (*vmctx).instance_mut();
-    let table_index = TableIndex::from_u32(table_index);
-    let table = instance.get_table_with_lazy_init(table_index, std::iter::once(index));
-    let elem = (*table)
-        .get(index)
-        .expect("table access already bounds-checked");
+    Instance::from_vmctx(vmctx, |instance| {
+        let table_index = TableIndex::from_u32(table_index);
+        let table = instance.get_table_with_lazy_init(table_index, std::iter::once(index));
+        let elem = (*table)
+            .get(index)
+            .expect("table access already bounds-checked");
 
-    elem.into_ref_asserting_initialized() as *mut _
+        elem.into_ref_asserting_initialized() as *mut u8
+    })
 }
 
 // Drop a `VMExternRef`.
@@ -394,38 +400,41 @@ unsafe fn drop_externref(_vmctx: *mut VMContext, externref: *mut u8) {
 // `VMExternRefActivationsTable`.
 unsafe fn activations_table_insert_with_gc(vmctx: *mut VMContext, externref: *mut u8) {
     let externref = VMExternRef::clone_from_raw(externref);
-    let instance = (*vmctx).instance_mut();
-    let limits = *instance.runtime_limits();
-    let (activations_table, module_info_lookup) = (*instance.store()).externref_activations_table();
+    Instance::from_vmctx(vmctx, |instance| {
+        let limits = *instance.runtime_limits();
+        let (activations_table, module_info_lookup) =
+            (*instance.store()).externref_activations_table();
 
-    // Invariant: all `externref`s on the stack have an entry in the activations
-    // table. So we need to ensure that this `externref` is in the table
-    // *before* we GC, even though `insert_with_gc` will ensure that it is in
-    // the table *after* the GC. This technically results in one more hash table
-    // look up than is strictly necessary -- which we could avoid by having an
-    // additional GC method that is aware of these GC-triggering references --
-    // but it isn't really a concern because this is already a slow path.
-    activations_table.insert_without_gc(externref.clone());
+        // Invariant: all `externref`s on the stack have an entry in the activations
+        // table. So we need to ensure that this `externref` is in the table
+        // *before* we GC, even though `insert_with_gc` will ensure that it is in
+        // the table *after* the GC. This technically results in one more hash table
+        // look up than is strictly necessary -- which we could avoid by having an
+        // additional GC method that is aware of these GC-triggering references --
+        // but it isn't really a concern because this is already a slow path.
+        activations_table.insert_without_gc(externref.clone());
 
-    activations_table.insert_with_gc(limits, externref, module_info_lookup);
+        activations_table.insert_with_gc(limits, externref, module_info_lookup);
+    })
 }
 
 // Perform a Wasm `global.get` for `externref` globals.
 unsafe fn externref_global_get(vmctx: *mut VMContext, index: u32) -> *mut u8 {
     let index = GlobalIndex::from_u32(index);
-    let instance = (*vmctx).instance_mut();
-    let limits = *instance.runtime_limits();
-    let global = instance.defined_or_imported_global_ptr(index);
-    match (*global).as_externref().clone() {
-        None => ptr::null_mut(),
-        Some(externref) => {
-            let raw = externref.as_raw();
-            let (activations_table, module_info_lookup) =
-                (*instance.store()).externref_activations_table();
-            activations_table.insert_with_gc(limits, externref, module_info_lookup);
-            raw
+    Instance::from_vmctx(vmctx, |instance| {
+        let limits = *instance.runtime_limits();
+        let global = instance.defined_or_imported_global_ptr(index);
+        match (*global).as_externref().clone() {
+            None => ptr::null_mut(),
+            Some(externref) => {
+                let raw = externref.as_raw();
+                let (activations_table, module_info_lookup) =
+                    (*instance.store()).externref_activations_table();
+                activations_table.insert_with_gc(limits, externref, module_info_lookup);
+                raw
+            }
         }
-    }
+    })
 }
 
 // Perform a Wasm `global.set` for `externref` globals.
@@ -437,15 +446,16 @@ unsafe fn externref_global_set(vmctx: *mut VMContext, index: u32, externref: *mu
     };
 
     let index = GlobalIndex::from_u32(index);
-    let instance = (*vmctx).instance_mut();
-    let global = instance.defined_or_imported_global_ptr(index);
+    Instance::from_vmctx(vmctx, |instance| {
+        let global = instance.defined_or_imported_global_ptr(index);
 
-    // Swap the new `externref` value into the global before we drop the old
-    // value. This protects against an `externref` with a `Drop` implementation
-    // that calls back into Wasm and touches this global again (we want to avoid
-    // it observing a halfway-deinitialized value).
-    let old = mem::replace((*global).as_externref_mut(), externref);
-    drop(old);
+        // Swap the new `externref` value into the global before we drop the old
+        // value. This protects against an `externref` with a `Drop` implementation
+        // that calls back into Wasm and touches this global again (we want to avoid
+        // it observing a halfway-deinitialized value).
+        let old = mem::replace((*global).as_externref_mut(), externref);
+        drop(old);
+    })
 }
 
 // Implementation of `memory.atomic.notify` for locally defined memories.
@@ -456,10 +466,11 @@ unsafe fn memory_atomic_notify(
     count: u32,
 ) -> Result<u32, Trap> {
     let memory = MemoryIndex::from_u32(memory_index);
-    let instance = (*vmctx).instance_mut();
-    instance
-        .get_runtime_memory(memory)
-        .atomic_notify(addr_index, count)
+    Instance::from_vmctx(vmctx, |instance| {
+        instance
+            .get_runtime_memory(memory)
+            .atomic_notify(addr_index, count)
+    })
 }
 
 // Implementation of `memory.atomic.wait32` for locally defined memories.
@@ -473,10 +484,11 @@ unsafe fn memory_atomic_wait32(
     // convert timeout to Instant, before any wait happens on locking
     let timeout = (timeout as i64 >= 0).then(|| Instant::now() + Duration::from_nanos(timeout));
     let memory = MemoryIndex::from_u32(memory_index);
-    let instance = (*vmctx).instance_mut();
-    Ok(instance
-        .get_runtime_memory(memory)
-        .atomic_wait32(addr_index, expected, timeout)? as u32)
+    Instance::from_vmctx(vmctx, |instance| {
+        Ok(instance
+            .get_runtime_memory(memory)
+            .atomic_wait32(addr_index, expected, timeout)? as u32)
+    })
 }
 
 // Implementation of `memory.atomic.wait64` for locally defined memories.
@@ -490,20 +502,21 @@ unsafe fn memory_atomic_wait64(
     // convert timeout to Instant, before any wait happens on locking
     let timeout = (timeout as i64 >= 0).then(|| Instant::now() + Duration::from_nanos(timeout));
     let memory = MemoryIndex::from_u32(memory_index);
-    let instance = (*vmctx).instance_mut();
-    Ok(instance
-        .get_runtime_memory(memory)
-        .atomic_wait64(addr_index, expected, timeout)? as u32)
+    Instance::from_vmctx(vmctx, |instance| {
+        Ok(instance
+            .get_runtime_memory(memory)
+            .atomic_wait64(addr_index, expected, timeout)? as u32)
+    })
 }
 
 // Hook for when an instance runs out of fuel.
 unsafe fn out_of_gas(vmctx: *mut VMContext) -> Result<()> {
-    (*(*vmctx).instance().store()).out_of_gas()
+    Instance::from_vmctx(vmctx, |i| (*i.store()).out_of_gas())
 }
 
 // Hook for when an instance observes that the epoch has changed.
 unsafe fn new_epoch(vmctx: *mut VMContext) -> Result<u64> {
-    (*(*vmctx).instance().store()).new_epoch()
+    Instance::from_vmctx(vmctx, |i| (*i.store()).new_epoch())
 }
 
 /// This module contains functions which are used for resolving relocations at

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -385,7 +385,7 @@ unsafe fn table_get_lazy_init_func_ref(
             .get(index)
             .expect("table access already bounds-checked");
 
-        elem.into_ref_asserting_initialized() as *mut u8
+        elem.into_ref_asserting_initialized()
     })
 }
 

--- a/crates/runtime/src/send_sync_ptr.rs
+++ b/crates/runtime/src/send_sync_ptr.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+use std::ptr::NonNull;
+
+/// A helper type in Wasmtime to store a raw pointer to `T` while automatically
+/// inferring the `Send` and `Sync` traits for the container based on the
+/// properties of `T`.
+#[repr(transparent)]
+pub struct SendSyncPtr<T: ?Sized>(NonNull<T>);
+
+unsafe impl<T: Send + ?Sized> Send for SendSyncPtr<T> {}
+unsafe impl<T: Sync + ?Sized> Sync for SendSyncPtr<T> {}
+
+impl<T: ?Sized> SendSyncPtr<T> {
+    /// Creates a new pointer wrapping the non-nullable pointer provided.
+    pub fn new(ptr: NonNull<T>) -> SendSyncPtr<T> {
+        SendSyncPtr(ptr)
+    }
+
+    /// Returns the underlying raw pointer.
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
+
+    /// Unsafely assert that this is a pointer to valid contents and it's also
+    /// valid to get a shared reference to it at this time.
+    pub unsafe fn as_ref<'a>(&self) -> &'a T {
+        self.0.as_ref()
+    }
+
+    /// Unsafely assert that this is a pointer to valid contents and it's also
+    /// valid to get a mutable reference to it at this time.
+    pub unsafe fn as_mut<'a>(&mut self) -> &'a mut T {
+        self.0.as_mut()
+    }
+
+    /// Returns the underlying `NonNull<T>` wrapper.
+    pub fn as_non_null(&self) -> NonNull<T> {
+        self.0
+    }
+}
+
+impl<T: ?Sized, U> From<U> for SendSyncPtr<T>
+where
+    U: Into<NonNull<T>>,
+{
+    fn from(ptr: U) -> SendSyncPtr<T> {
+        SendSyncPtr::new(ptr.into())
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for SendSyncPtr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ptr().fmt(f)
+    }
+}
+
+impl<T: ?Sized> fmt::Pointer for SendSyncPtr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ptr().fmt(f)
+    }
+}
+
+impl<T: ?Sized> Clone for SendSyncPtr<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: ?Sized> Copy for SendSyncPtr<T> {}

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -3,11 +3,12 @@
 //! `Table` is to WebAssembly tables what `LinearMemory` is to WebAssembly linear memories.
 
 use crate::vmcontext::{VMFuncRef, VMTableDefinition};
-use crate::{Store, VMExternRef};
+use crate::{SendSyncPtr, Store, VMExternRef};
 use anyhow::{bail, format_err, Error, Result};
+use sptr::Strict;
 use std::convert::{TryFrom, TryInto};
 use std::ops::Range;
-use std::ptr;
+use std::ptr::{self, NonNull};
 use wasmtime_environ::{TablePlan, Trap, WasmType, FUNCREF_INIT_BIT, FUNCREF_MASK};
 
 /// An element going into or coming out of a table.
@@ -45,13 +46,17 @@ impl TableElement {
     /// This is unsafe as it will *not* clone any externref, leaving the reference count unchanged.
     ///
     /// This should only be used if the raw pointer is no longer in use.
-    unsafe fn from_table_value(ty: TableElementType, ptr: usize) -> Self {
+    unsafe fn from_table_value(ty: TableElementType, ptr: TableValue) -> Self {
         match (ty, ptr) {
-            (TableElementType::Func, 0) => Self::UninitFunc,
-            (TableElementType::Func, ptr) => Self::FuncRef((ptr & FUNCREF_MASK) as _),
-            (TableElementType::Extern, 0) => Self::ExternRef(None),
-            (TableElementType::Extern, ptr) => {
-                Self::ExternRef(Some(VMExternRef::from_raw(ptr as *mut u8)))
+            (TableElementType::Func, None) => Self::UninitFunc,
+            (TableElementType::Func, Some(ptr)) => {
+                let ptr = ptr.as_ptr();
+                let masked = Strict::map_addr(ptr, |a| a & FUNCREF_MASK);
+                Self::FuncRef(masked.cast())
+            }
+            (TableElementType::Extern, None) => Self::ExternRef(None),
+            (TableElementType::Extern, Some(ptr)) => {
+                Self::ExternRef(Some(VMExternRef::from_raw(ptr.as_ptr())))
             }
         }
     }
@@ -61,13 +66,13 @@ impl TableElement {
     /// # Safety
     ///
     /// This is unsafe as it will clone any externref, incrementing the reference count.
-    unsafe fn clone_from_table_value(ty: TableElementType, ptr: usize) -> Self {
-        match (ty, ptr) {
-            (TableElementType::Func, 0) => Self::UninitFunc,
-            (TableElementType::Func, ptr) => Self::FuncRef((ptr & FUNCREF_MASK) as _),
-            (TableElementType::Extern, 0) => Self::ExternRef(None),
-            (TableElementType::Extern, ptr) => {
-                Self::ExternRef(Some(VMExternRef::clone_from_raw(ptr as *mut u8)))
+    unsafe fn clone_from_table_value(ty: TableElementType, ptr: TableValue) -> Self {
+        match ty {
+            // Functions have no ownership, so defer to the prior method.
+            TableElementType::Func => TableElement::from_table_value(ty, ptr),
+
+            TableElementType::Extern => {
+                Self::ExternRef(ptr.map(|p| VMExternRef::clone_from_raw(p.as_ptr())))
             }
         }
     }
@@ -81,12 +86,14 @@ impl TableElement {
     /// This is unsafe as it will consume any underlying externref into a raw pointer without modifying
     /// the reference count.
     ///
-    /// Use `from_raw` to properly drop any table elements stored as raw pointers.
-    unsafe fn into_table_value(self) -> usize {
+    unsafe fn into_table_value(self) -> TableValue {
         match self {
-            Self::UninitFunc => 0,
-            Self::FuncRef(e) => (e as usize) | FUNCREF_INIT_BIT,
-            Self::ExternRef(e) => e.map_or(0, |e| e.into_raw() as usize),
+            Self::UninitFunc => None,
+            Self::FuncRef(e) => {
+                let tagged = Strict::map_addr(e, |e| e | FUNCREF_INIT_BIT);
+                Some(NonNull::new(tagged.cast()).unwrap().into())
+            }
+            Self::ExternRef(e) => e.map(|e| NonNull::new(e.into_raw()).unwrap().into()),
         }
     }
 
@@ -144,7 +151,7 @@ pub enum Table {
     Static {
         /// Where data for this table is stored. The length of this list is the
         /// maximum size of the table.
-        data: &'static mut [usize],
+        data: &'static mut [TableValue],
         /// The current size of the table.
         size: u32,
         /// The type of this table.
@@ -155,13 +162,15 @@ pub enum Table {
     Dynamic {
         /// Dynamically managed storage space for this table. The length of this
         /// vector is the current size of the table.
-        elements: Vec<usize>,
+        elements: Vec<TableValue>,
         /// The type of this table.
         ty: TableElementType,
         /// Maximum size that `elements` can grow to.
         maximum: Option<u32>,
     },
 }
+
+pub type TableValue = Option<SendSyncPtr<u8>>;
 
 fn wasm_to_table_type(ty: WasmType) -> Result<TableElementType> {
     match ty {
@@ -175,7 +184,7 @@ impl Table {
     /// Create a new dynamic (movable) table instance for the specified table plan.
     pub fn new_dynamic(plan: &TablePlan, store: &mut dyn Store) -> Result<Self> {
         Self::limit_new(plan, store)?;
-        let elements = vec![0; plan.table.minimum as usize];
+        let elements = vec![None; plan.table.minimum as usize];
         let ty = wasm_to_table_type(plan.table.wasm_ty)?;
         let maximum = plan.table.maximum;
 
@@ -189,7 +198,7 @@ impl Table {
     /// Create a new static (immovable) table instance for the specified table plan.
     pub fn new_static(
         plan: &TablePlan,
-        data: &'static mut [usize],
+        data: &'static mut [TableValue],
         store: &mut dyn Store,
     ) -> Result<Self> {
         Self::limit_new(plan, store)?;
@@ -360,11 +369,11 @@ impl Table {
             Table::Static { size, data, .. } => {
                 debug_assert!(data[*size as usize..new_size as usize]
                     .iter()
-                    .all(|x| *x == 0));
+                    .all(|x| x.is_none()));
                 *size = new_size;
             }
             Table::Dynamic { elements, .. } => {
-                elements.resize(new_size as usize, 0);
+                elements.resize(new_size as usize, None);
             }
         }
 
@@ -465,21 +474,21 @@ impl Table {
         }
     }
 
-    fn elements(&self) -> &[usize] {
+    fn elements(&self) -> &[TableValue] {
         match self {
             Table::Static { data, size, .. } => &data[..*size as usize],
             Table::Dynamic { elements, .. } => &elements[..],
         }
     }
 
-    fn elements_mut(&mut self) -> &mut [usize] {
+    fn elements_mut(&mut self) -> &mut [TableValue] {
         match self {
             Table::Static { data, size, .. } => &mut data[..*size as usize],
             Table::Dynamic { elements, .. } => &mut elements[..],
         }
     }
 
-    fn set_raw(ty: TableElementType, elem: &mut usize, val: TableElement) {
+    fn set_raw(ty: TableElementType, elem: &mut TableValue, val: TableElement) {
         unsafe {
             let old = *elem;
             *elem = val.into_table_value();

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -108,10 +108,10 @@ impl TableElement {
     /// # Safety
     ///
     /// The same warnings as for `into_table_values()` apply.
-    pub(crate) unsafe fn into_ref_asserting_initialized(self) -> usize {
+    pub(crate) unsafe fn into_ref_asserting_initialized(self) -> *mut u8 {
         match self {
-            Self::FuncRef(e) => e as usize,
-            Self::ExternRef(e) => e.map_or(0, |e| e.into_raw() as usize),
+            Self::FuncRef(e) => e.cast(),
+            Self::ExternRef(e) => e.map_or(ptr::null_mut(), |e| e.into_raw()),
             Self::UninitFunc => panic!("Uninitialized table element value outside of table slot"),
         }
     }

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -3,7 +3,7 @@
 
 mod backtrace;
 
-use crate::{VMContext, VMRuntimeLimits};
+use crate::{Instance, VMContext, VMRuntimeLimits};
 use anyhow::Error;
 use std::any::Any;
 use std::cell::{Cell, UnsafeCell};
@@ -257,7 +257,7 @@ pub unsafe fn catch_traps<'a, F>(
 where
     F: FnMut(*mut VMContext),
 {
-    let limits = (*caller).instance_mut().runtime_limits();
+    let limits = Instance::from_vmctx(caller, |i| i.runtime_limits());
 
     let result = CallThreadState::new(signal_handler, capture_backtrace, *limits).with(|cx| {
         wasmtime_setjmp(

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -4,8 +4,6 @@
 mod vm_host_func_context;
 
 use crate::externref::VMExternRef;
-use crate::instance::Instance;
-use std::any::Any;
 use std::cell::UnsafeCell;
 use std::marker;
 use std::ptr::NonNull;
@@ -965,32 +963,6 @@ impl VMContext {
         // opposed to a regular assertion.
         debug_assert_eq!((*opaque).magic, VMCONTEXT_MAGIC);
         opaque.cast()
-    }
-
-    /// Return a mutable reference to the associated `Instance`.
-    ///
-    /// # Safety
-    /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `Instance`.
-    #[allow(clippy::cast_ptr_alignment)]
-    #[inline]
-    pub(crate) unsafe fn instance(&self) -> &Instance {
-        &*((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *const Instance)
-    }
-
-    #[inline]
-    pub(crate) unsafe fn instance_mut(&mut self) -> &mut Instance {
-        &mut *((self as *const Self as *mut u8).offset(-Instance::vmctx_offset()) as *mut Instance)
-    }
-
-    /// Return a reference to the host state associated with this `Instance`.
-    ///
-    /// # Safety
-    /// This is unsafe because it doesn't work on just any `VMContext`, it must
-    /// be a `VMContext` allocated as part of an `Instance`.
-    #[inline]
-    pub unsafe fn host_state(&self) -> &dyn Any {
-        self.instance().host_state()
     }
 }
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -4,7 +4,9 @@
 mod vm_host_func_context;
 
 use crate::externref::VMExternRef;
+use sptr::Strict;
 use std::cell::UnsafeCell;
+use std::ffi::c_void;
 use std::marker;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -568,18 +570,14 @@ impl VMGlobalDefinition {
 
     /// Return a reference to the value as a `VMFuncRef`.
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn as_func_ref(&self) -> *const VMFuncRef {
-        *(self.storage.as_ref().as_ptr().cast::<*const VMFuncRef>())
+    pub unsafe fn as_func_ref(&self) -> *mut VMFuncRef {
+        *(self.storage.as_ref().as_ptr().cast::<*mut VMFuncRef>())
     }
 
     /// Return a mutable reference to the value as a `VMFuncRef`.
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn as_func_ref_mut(&mut self) -> &mut *const VMFuncRef {
-        &mut *(self
-            .storage
-            .as_mut()
-            .as_mut_ptr()
-            .cast::<*const VMFuncRef>())
+    pub unsafe fn as_func_ref_mut(&mut self) -> &mut *mut VMFuncRef {
+        &mut *(self.storage.as_mut().as_mut_ptr().cast::<*mut VMFuncRef>())
     }
 }
 
@@ -1036,7 +1034,7 @@ pub union ValRaw {
     /// carefully calling the correct functions throughout the runtime.
     ///
     /// This value is always stored in a little-endian format.
-    funcref: usize,
+    funcref: *mut c_void,
 
     /// A WebAssembly `externref` value.
     ///
@@ -1046,8 +1044,13 @@ pub union ValRaw {
     /// carefully calling the correct functions throughout the runtime.
     ///
     /// This value is always stored in a little-endian format.
-    externref: usize,
+    externref: *mut c_void,
 }
+
+// This type is just a bag-of-bits so it's up to the caller to figure out how
+// to safely deal with threading concerns and safely access interior bits.
+unsafe impl Send for ValRaw {}
+unsafe impl Sync for ValRaw {}
 
 impl ValRaw {
     /// Creates a WebAssembly `i32` value
@@ -1104,15 +1107,17 @@ impl ValRaw {
 
     /// Creates a WebAssembly `funcref` value
     #[inline]
-    pub fn funcref(i: usize) -> ValRaw {
-        ValRaw { funcref: i.to_le() }
+    pub fn funcref(i: *mut c_void) -> ValRaw {
+        ValRaw {
+            funcref: Strict::map_addr(i, |i| i.to_le()),
+        }
     }
 
     /// Creates a WebAssembly `externref` value
     #[inline]
-    pub fn externref(i: usize) -> ValRaw {
+    pub fn externref(i: *mut c_void) -> ValRaw {
         ValRaw {
-            externref: i.to_le(),
+            externref: Strict::map_addr(i, |i| i.to_le()),
         }
     }
 
@@ -1160,14 +1165,14 @@ impl ValRaw {
 
     /// Gets the WebAssembly `funcref` value
     #[inline]
-    pub fn get_funcref(&self) -> usize {
-        unsafe { usize::from_le(self.funcref) }
+    pub fn get_funcref(&self) -> *mut c_void {
+        unsafe { Strict::map_addr(self.funcref, |i| usize::from_le(i)) }
     }
 
     /// Gets the WebAssembly `externref` value
     #[inline]
-    pub fn get_externref(&self) -> usize {
-        unsafe { usize::from_le(self.externref) }
+    pub fn get_externref(&self) -> *mut c_void {
+        unsafe { Strict::map_addr(self.externref, |i| usize::from_le(i)) }
     }
 }
 

--- a/crates/runtime/src/vmcontext/vm_host_func_context.rs
+++ b/crates/runtime/src/vmcontext/vm_host_func_context.rs
@@ -21,11 +21,6 @@ pub struct VMArrayCallHostFuncContext {
     host_state: Box<dyn Any + Send + Sync>,
 }
 
-// Declare that this type is send/sync, it's the responsibility of
-// `VMHostFuncContext::new` callers to uphold this guarantee.
-unsafe impl Send for VMArrayCallHostFuncContext {}
-unsafe impl Sync for VMArrayCallHostFuncContext {}
-
 impl VMArrayCallHostFuncContext {
     /// Create the context for the given host function.
     ///
@@ -95,11 +90,6 @@ fn vmnative_call_host_func_context_offsets() {
         offset_of!(VMNativeCallHostFuncContext, func_ref)
     );
 }
-
-// Declare that this type is send/sync, it's the responsibility of
-// `VMHostFuncContext::new` callers to uphold this guarantee.
-unsafe impl Send for VMNativeCallHostFuncContext {}
-unsafe impl Sync for VMNativeCallHostFuncContext {}
 
 impl VMNativeCallHostFuncContext {
     /// Create the context for the given host function.

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -280,7 +280,7 @@ impl Global {
                         .map(|inner| ExternRef { inner }),
                 ),
                 ValType::FuncRef => {
-                    Val::FuncRef(Func::from_raw(store, definition.as_func_ref() as usize))
+                    Val::FuncRef(Func::from_raw(store, definition.as_func_ref().cast()))
                 }
                 ValType::V128 => Val::V128(*definition.as_u128()),
             }
@@ -319,7 +319,7 @@ impl Global {
                 Val::F32(f) => *definition.as_u32_mut() = f,
                 Val::F64(f) => *definition.as_u64_mut() = f,
                 Val::FuncRef(f) => {
-                    *definition.as_func_ref_mut() = f.map_or(ptr::null(), |f| {
+                    *definition.as_func_ref_mut() = f.map_or(ptr::null_mut(), |f| {
                         f.caller_checked_func_ref(store).as_ptr().cast()
                     });
                 }

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::{anyhow, bail, Result};
 use std::mem;
 use std::ptr;
-use wasmtime_runtime::{self as runtime, InstanceHandle};
+use wasmtime_runtime::{self as runtime};
 
 // Externals
 
@@ -477,9 +477,10 @@ impl Table {
     ) -> *mut runtime::Table {
         unsafe {
             let export = &store[self.0];
-            let mut handle = InstanceHandle::from_vmctx(export.vmctx);
-            let idx = handle.table_index(&*export.definition);
-            handle.get_defined_table_with_lazy_init(idx, lazy_init_range)
+            wasmtime_runtime::Instance::from_vmctx(export.vmctx, |handle| {
+                let idx = handle.table_index(&*export.definition);
+                handle.get_defined_table_with_lazy_init(idx, lazy_init_range)
+            })
         }
     }
 

--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -347,7 +347,7 @@ unsafe impl WasmTy for Option<ExternRef> {
 
     #[inline]
     unsafe fn abi_into_raw(abi: *mut u8, raw: *mut ValRaw) {
-        *raw = ValRaw::externref(abi as usize);
+        *raw = ValRaw::externref(abi.cast());
     }
 
     #[inline]
@@ -433,7 +433,7 @@ unsafe impl WasmTy for Option<Func> {
 
     #[inline]
     unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
-        *raw = ValRaw::funcref(abi as usize);
+        *raw = ValRaw::funcref(abi.cast());
     }
 
     #[inline]

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -340,7 +340,7 @@ impl Instance {
         // trap-handling configuration in `store` as well.
         let instance = store.0.instance_mut(id);
         let f = instance.get_exported_func(start);
-        let caller_vmctx = instance.vmctx_ptr();
+        let caller_vmctx = instance.vmctx();
         unsafe {
             super::func::invoke_wasm_and_catch_traps(store, |_default_caller| {
                 let func = mem::transmute::<

--- a/crates/wasmtime/src/ref.rs
+++ b/crates/wasmtime/src/ref.rs
@@ -2,6 +2,7 @@
 
 use crate::AsContextMut;
 use std::any::Any;
+use std::ffi::c_void;
 use wasmtime_runtime::VMExternRef;
 
 /// Represents an opaque reference to any data within WebAssembly.
@@ -70,8 +71,8 @@ impl ExternRef {
     /// [`Store`]: crate::Store
     /// [`TypedFunc`]: crate::TypedFunc
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn from_raw(raw: usize) -> Option<ExternRef> {
-        let raw = raw as *mut u8;
+    pub unsafe fn from_raw(raw: *mut c_void) -> Option<ExternRef> {
+        let raw = raw.cast::<u8>();
         if raw.is_null() {
             None
         } else {
@@ -91,13 +92,13 @@ impl ExternRef {
     /// into the store.
     ///
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> usize {
+    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> *mut c_void {
         let externref_ptr = self.inner.as_raw();
         store
             .as_context_mut()
             .0
             .insert_vmexternref_without_gc(self.inner.clone());
-        externref_ptr as usize
+        externref_ptr.cast()
     }
 }
 

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -111,14 +111,14 @@ impl Val {
             Val::ExternRef(e) => {
                 let externref = match e {
                     Some(e) => e.to_raw(store),
-                    None => 0,
+                    None => ptr::null_mut(),
                 };
                 ValRaw::externref(externref)
             }
             Val::FuncRef(f) => {
                 let funcref = match f {
                     Some(f) => f.to_raw(store),
-                    None => 0,
+                    None => ptr::null_mut(),
                 };
                 ValRaw::funcref(funcref)
             }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1190,6 +1190,16 @@ and does what it says on the tin, providing spin-based synchronization
 primitives.
 """
 
+[[audits.sptr]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.3.2"
+notes = """
+This crate is 90% documentation and does contain a good deal of `unsafe` code,
+but it's all doing what it says on the tin: being a stable polyfill for strict
+provenance APIs in the standard library while they're on Nightly.
+"""
+
 [[audits.system-interface]]
 who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
This is a series of commits hot on the tail of https://github.com/bytecodealliance/wasmtime/pull/6332. Previously Wasmtime was only valid under the Tree Borrows model in MIRI which is a much newer but less restrictive model for Rust's borrowing. After some discussion on Zulip though I concluded that there's no reason for us to rely purely on Tree Borrows and it's probably best to work under Stacked Borrows as well. This commit does that.

This commit also goes a bit further and gets everything working under strict provenance as well to fix any warnings coming out of MIRI. This means that we should be in a pretty strong position with respect to the verification running on CI, where the main remaining hole is lack of coverage.