### PR TITLE
Fix typo 'oeprations' ⇒ 'operations'

### DIFF
--- a/crates/runtime/src/mmap/miri.rs
+++ b/crates/runtime/src/mmap/miri.rs
@@ -1,7 +1,7 @@
 //! A "dummy" implementation of mmaps for miri where "we do the best we can"
 //!
 //! Namely this uses `alloc` to allocate memory for the "mmap" specifically to
-//! create page-aligned allocations. This allocation doesn't handle oeprations
+//! create page-aligned allocations. This allocation doesn't handle operations
 //! like becoming executable or becoming readonly or being created from files,
 //! but it's enough to get various tests running relying on memories and such.
 


### PR DESCRIPTION
Fix typo in crates/runtime/src/mmap/miri.rs on line 4  'oeprations' ⇒ 'operations'.
Found while looking at: https://github.com/bytecodealliance/wasmtime/pull/6332.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
