### PR TITLE
Unify differential result comparison logic

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -421,7 +421,7 @@ pub enum DiffEqResult<T, U> {
     /// Both engines succeeded.
     Success(T, U),
     /// The result has reached the state where engines may have diverged and
-    /// results can no longer be compard.
+    /// results can no longer be compared.
     Poisoned,
     /// Both engines failed with the same error message, and internal state
     /// should still match between the two engines.


### PR DESCRIPTION
Execution of functions handles the case where one instance stack overflows and the other didn't, but instantiation didn't handle this case. This commit fixes this issue by sharing the result comparison logic between the two branches.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
