### PR TITLE
test: add cases from `wasi-testsuite`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,7 @@
 [submodule "crates/wasi-http/wasi-http"]
 	path = crates/wasi-http/wasi-http
 	url = https://github.com/WebAssembly/wasi-http
+[submodule "tests/wasi_testsuite/wasi"]
+	path = tests/wasi_testsuite/wasi-common
+	url = https://github.com/WebAssembly/wasi-testsuite.git
+	branch = prod/testsuite-base

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,12 +3385,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -3841,6 +3840,7 @@ dependencies = [
  "tempfile",
  "test-programs",
  "tokio",
+ "walkdir",
  "wasm-coredump-builder",
  "wasmparser",
  "wasmtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ bstr = "0.2.17"
 libc = "0.2.60"
 serde = { workspace = true }
 serde_json = { workspace = true }
+walkdir = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
@@ -209,6 +210,7 @@ serde_json = "1.0.80"
 glob = "0.3.0"
 libfuzzer-sys = "0.4.0"
 regalloc2 = "0.8.1"
+walkdir = "2.3.3"
 
 [features]
 default = [

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -42,7 +42,7 @@ pretty_env_logger = "0.4.0"
 rayon = { version = "1", optional = true }
 indicatif = "0.13.0"
 thiserror = { workspace = true }
-walkdir = "2.2"
+walkdir = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 similar = { workspace = true }

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -21,4 +21,4 @@ openvino = { version = "0.5.0", features = ["runtime-linking"] }
 thiserror = { workspace = true }
 
 [build-dependencies]
-walkdir = "2.3"
+walkdir = { workspace = true }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -868,7 +868,7 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]
-version = "2.3.2"
+version = "2.3.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -10,33 +10,11 @@ use tempfile::{NamedTempFile, TempDir};
 // Run the wasmtime CLI with the provided args and return the `Output`.
 // If the `stdin` is `Some`, opens the file and redirects to the child's stdin.
 pub fn run_wasmtime_for_output(args: &[&str], stdin: Option<&Path>) -> Result<Output> {
-    let runner = std::env::vars()
-        .filter(|(k, _v)| k.starts_with("CARGO_TARGET") && k.ends_with("RUNNER"))
-        .next();
-    let mut me = std::env::current_exe()?;
-    me.pop(); // chop off the file name
-    me.pop(); // chop off `deps`
-    me.push("wasmtime");
-
+    let mut cmd = get_wasmtime_command()?;
     let stdin = stdin
         .map(File::open)
         .transpose()
         .context("Cannot open a file to use as stdin")?;
-
-    // If we're running tests with a "runner" then we might be doing something
-    // like cross-emulation, so spin up the emulator rather than the tests
-    // itself, which may not be natively executable.
-    let mut cmd = if let Some((_, runner)) = runner {
-        let mut parts = runner.split_whitespace();
-        let mut cmd = Command::new(parts.next().unwrap());
-        for arg in parts {
-            cmd.arg(arg);
-        }
-        cmd.arg(&me);
-        cmd
-    } else {
-        Command::new(&me)
-    };
 
     if let Some(mut f) = stdin {
         let mut buf = Vec::new();
@@ -58,6 +36,35 @@ pub fn run_wasmtime_for_output(args: &[&str], stdin: Option<&Path>) -> Result<Ou
     } else {
         cmd.args(args).output().map_err(Into::into)
     }
+}
+
+/// Get the Wasmtime CLI as a [Command].
+pub fn get_wasmtime_command() -> Result<Command> {
+    // Figure out the Wasmtime binary from the current executable.
+    let runner = std::env::vars()
+        .filter(|(k, _v)| k.starts_with("CARGO_TARGET") && k.ends_with("RUNNER"))
+        .next();
+    let mut me = std::env::current_exe()?;
+    me.pop(); // chop off the file name
+    me.pop(); // chop off `deps`
+    me.push("wasmtime");
+
+    // If we're running tests with a "runner" then we might be doing something
+    // like cross-emulation, so spin up the emulator rather than the tests
+    // itself, which may not be natively executable.
+    let cmd = if let Some((_, runner)) = runner {
+        let mut parts = runner.split_whitespace();
+        let mut cmd = Command::new(parts.next().unwrap());
+        for arg in parts {
+            cmd.arg(arg);
+        }
+        cmd.arg(&me);
+        cmd
+    } else {
+        Command::new(&me)
+    };
+
+    Ok(cmd)
 }
 
 // Run the wasmtime CLI with the provided args and, if it succeeds, return

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -25,10 +25,11 @@ fn wasi_testsuite() -> Result<()> {
     //  - wasi-testsuite overspecifies (or incorrectly specifies) a test
     //  - this test runner incorrectly configures Wasmtime's CLI execution.
     //
-    // The easiest way to resolve one of these is to remove the file from the
-    // list and run `cargo test wasi_testsuite -- --nocapture`. The printed
-    // output will show the expected result, the actual result, and a command to
-    // replicate the failure from the command line.
+    // This list is expected to shrink as the failures are resolved. The easiest
+    // way to resolve one of these is to remove the file from the list and run
+    // `cargo test wasi_testsuite -- --nocapture`. The printed output will show
+    // the expected result, the actual result, and a command to replicate the
+    // failure from the command line.
     const WASI_COMMON_IGNORE_LIST: &[&str] = &[
         "environ_get-multiple-variables.wasm",
         "environ_sizes_get-multiple-variables.wasm",

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -5,31 +5,97 @@
 
 #![cfg(not(miri))]
 
-use crate::cli_tests::run_wasmtime_for_output;
-use anyhow::Result;
+use crate::cli_tests::get_wasmtime_command;
+use anyhow::{anyhow, Result};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::ffi::OsStr;
-use std::fs::{self, DirEntry};
+use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Output;
+use std::process::{Command, Output};
+use walkdir::{DirEntry, WalkDir};
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // TODO: https://github.com/WebAssembly/WASI/issues/524
-fn wasi_threads_testsuite() -> Result<()> {
-    for module in list_modules("tests/wasi_testsuite/wasi-threads/test/testsuite")? {
-        println!("Testing {}", module.display());
-        let result = run(&module)?;
-        let spec = parse_spec(&module.with_extension("json"))?;
-        assert_eq!(spec, result);
+fn wasi_testsuite() -> Result<()> {
+    // Currently, Wasmtime's implementation in wasi-common does not line up
+    // exactly with the expectations in wasi-testsuite. This could be for one of
+    // various reasons:
+    //  - wasi-common has a bug
+    //  - wasi-testsuite overspecifies (or incorrectly specifies) a test
+    //  - this test runner incorrectly configures Wasmtime's CLI execution.
+    //
+    // The easiest way to resolve one of these is to remove the file from the
+    // list and run `cargo test wasi_testsuite -- --nocapture`. The printed
+    // output will show the expected result, the actual result, and a command to
+    // replicate the failure from the command line.
+    const WASI_COMMON_IGNORE_LIST: &[&str] = &[
+        "environ_get-multiple-variables.wasm",
+        "environ_sizes_get-multiple-variables.wasm",
+        "fdopendir-with-access.wasm",
+        "fopen-with-access.wasm",
+        "lseek.wasm",
+        "pread-with-access.wasm",
+        "pwrite-with-access.wasm",
+        "stat-dev-ino.wasm",
+        "close_preopen.wasm",
+        "dangling_fd.wasm",
+        "dangling_symlink.wasm",
+        "directory_seek.wasm",
+        "fd_advise.wasm",
+        "fd_filestat_set.wasm",
+        "fd_flags_set.wasm",
+        "fd_readdir.wasm",
+        "interesting_paths.wasm",
+    ];
+    run_all(
+        "tests/wasi_testsuite/wasi-common",
+        &[],
+        WASI_COMMON_IGNORE_LIST,
+    )?;
+    run_all(
+        "tests/wasi_testsuite/wasi-threads",
+        &[
+            "--wasi-modules",
+            "experimental-wasi-threads",
+            "--wasm-features",
+            "threads",
+        ],
+        &[],
+    )?;
+    Ok(())
+}
+
+fn run_all(testsuite_dir: &str, extra_flags: &[&str], ignore: &[&str]) -> Result<()> {
+    for module in list_modules(testsuite_dir) {
+        if should_ignore(&module, ignore) {
+            println!("Ignoring {}", module.display());
+        } else {
+            println!("Testing {}", module.display());
+            let spec = if let Ok(contents) = fs::read_to_string(&module.with_extension("json")) {
+                serde_json::from_str(&contents)?
+            } else {
+                Spec::default()
+            };
+            let mut cmd = build_command(module, extra_flags, &spec)?;
+            let result = cmd.output()?;
+            if spec != result {
+                println!("  command: {cmd:?}");
+                println!("  spec: {spec:#?}");
+                println!("  result: {result:#?}");
+                panic!("FAILED! The result does not match the specification");
+            }
+        }
     }
     Ok(())
 }
 
-fn list_modules(testsuite_dir: &str) -> Result<impl Iterator<Item = PathBuf>> {
-    Ok(fs::read_dir(testsuite_dir)?
+fn list_modules(testsuite_dir: &str) -> impl Iterator<Item = PathBuf> {
+    WalkDir::new(testsuite_dir)
+        .into_iter()
         .filter_map(Result::ok)
         .filter(is_wasm)
-        .map(|e| e.path()))
+        .map(|e| e.path().to_path_buf())
 }
 
 fn is_wasm(entry: &DirEntry) -> bool {
@@ -38,37 +104,55 @@ fn is_wasm(entry: &DirEntry) -> bool {
     path.is_file() && (ext == Some("wat") || ext == Some("wasm"))
 }
 
-fn run<P: AsRef<Path>>(module: P) -> Result<Output> {
-    run_wasmtime_for_output(
-        &[
-            "run",
-            "--wasi-modules",
-            "experimental-wasi-threads",
-            "--wasm-features",
-            "threads",
-            "--disable-cache",
-            module.as_ref().to_str().unwrap(),
-        ],
-        None,
-    )
+fn should_ignore<P: AsRef<Path>>(path: P, ignore_list: &[&str]) -> bool {
+    let file_name = path.as_ref().file_name().unwrap().to_str().unwrap();
+    ignore_list.contains(&file_name)
 }
 
-fn parse_spec<P: AsRef<Path>>(spec_file: P) -> Result<Spec> {
-    let contents = fs::read_to_string(spec_file)?;
-    let spec = serde_json::from_str(&contents)?;
-    Ok(spec)
+fn build_command<P: AsRef<Path>>(module: P, extra_flags: &[&str], spec: &Spec) -> Result<Command> {
+    let mut cmd = get_wasmtime_command()?;
+    let parent_dir = module
+        .as_ref()
+        .parent()
+        .ok_or(anyhow!("module has no parent?"))?;
+
+    // Add arguments.
+    cmd.args(["run", "--disable-cache"]);
+    cmd.args(extra_flags);
+    if let Some(dirs) = &spec.dirs {
+        for dir in dirs {
+            cmd.arg("--dir");
+            cmd.arg(parent_dir.join(dir));
+        }
+    }
+    cmd.arg(module.as_ref().to_str().unwrap());
+    if let Some(spec_args) = &spec.args {
+        cmd.args(spec_args);
+    }
+
+    // Create the environment. This uses the shell environment, but we could also
+    // have used the Wasmtime CLI's `--env` parameter here.
+    cmd.env_clear();
+    if let Some(env) = &spec.env {
+        cmd.envs(env);
+    }
+
+    Ok(cmd)
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 struct Spec {
-    exit_code: i32,
-    stdout: Option<String>,
+    args: Option<Vec<String>>,
+    dirs: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    exit_code: Option<i32>,
     stderr: Option<String>,
+    stdout: Option<String>,
 }
 
 impl PartialEq<Output> for Spec {
     fn eq(&self, other: &Output) -> bool {
-        self.exit_code == other.status.code().unwrap()
+        self.exit_code.unwrap_or(0) == other.status.code().unwrap()
             && matches_or_missing(&self.stdout, &other.stdout)
             && matches_or_missing(&self.stderr, &other.stderr)
     }


### PR DESCRIPTION
This change alters the `wasi_testsuite` test to run all of the available
test cases in [wasi-testsuite]. This involved making the test runner a
bit more robust to the various shapes of JSON specifications in that
project. Unfortunately, the `wasi_testsuite` test fails some of the
cases, so I added a `WASI_COMMON_IGNORE_LIST` to avoid these
temporarily. (This may remind some of the Wasm testsuite ignore lists in
Cranelift; those relied on `build.rs` to create a `#[test]` for each
test case, which I felt is not yet needed here).

It's unclear to me why some tests are failing. It could be because:
- wasi-common has a bug
- wasi-testsuite overspecifies (or incorrectly specifies) a test
- the test runner incorrectly configures Wasmtime's CLI execution.

But this change makes it easier to resolve this. Remove the file from
`WASI_COMMON_IGNORE_LIST` and run `cargo test wasi_testsuite --
--nocapture`. The printed output will show the expected result, the
actual result, and a command to replicate the failure from the command
line.

[wasi-testsuite]: https://github.com/WebAssembly/wasi-testsuite

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
