### PR TITLE
vet: certify `walkdir` version bump from 2.3.2 to 2.3.3

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1323,6 +1323,12 @@ criteria = "safe-to-deploy"
 version = "0.2.15"
 notes = "no build.rs, no macros, no unsafe. It reads the filesystem and makes copies of DLLs into OUT_DIR."
 
+[[audits.walkdir]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.2 -> 2.3.3"
+notes = "No significant changes: minor refactoring and removes the need to use `winapi`."
+
 [[audits.want]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -868,7 +868,7 @@ version = "0.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.walkdir]]
-version = "2.3.3"
+version = "2.3.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.wasi]]


### PR DESCRIPTION
See @alexcrichton's request [here](https://github.com/bytecodealliance/wasmtime/pull/6341#discussion_r1185470808)