### PR TITLE
Cranelift: Fix panic when pretty printing `MachInst`s before register allocation

### DIFF
--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -496,7 +496,12 @@ impl<'a> AllocationConsumer<'a> {
             )
         });
 
-        assert_eq!(preg, alloc.unwrap().to_real_reg().unwrap().into());
+        match alloc {
+            Some(alloc) => {
+                assert_eq!(preg, alloc.to_real_reg().unwrap().into());
+            }
+            None => {}
+        }
     }
 
     pub fn next(&mut self, pre_regalloc_reg: Reg) -> Reg {


### PR DESCRIPTION
Fixes #6333 

It seems that when the `next_fixed_nonallocatable` function was added to check if the register allocator allocates these correctly, the check for the case that no allocation is present (e.g. in case the instructions are pretty printed when tracing is enabled) was missed. It is present in the getters below.

I added a check for that and now the tests don't panic anymore when tracing is enabled.