### PR TITLE
Fix opening directories failing on Windows when fdFlags contains NONBLOCK

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/path_open_nonblock.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_nonblock.rs
@@ -1,0 +1,29 @@
+use std::{env, process};
+use wasi_tests::{open_scratch_directory};
+
+unsafe fn try_path_open(dir_fd: wasi::Fd) {
+    let fd = wasi::path_open(dir_fd, 0, ".", 0, 0, 0, wasi::FDFLAGS_NONBLOCK).expect("opening the dir");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { try_path_open(dir_fd) }
+}


### PR DESCRIPTION
### Description

We were testing the new wasmtime 8.0.1 on Windows and are getting "Permission denied" errors opening directories, while reading files under those directories work fine.

### Test Case
The issue is reproducible using the below rust program (built as lister.wasm in the snippets) that directly calls opendir:

```
extern crate libc;
use std::ffi::CString;
use libc::{opendir, closedir, c_char};
use std::env;

fn main() {
    let args: Vec<String> = env::args().collect();
    if args.len() != 2 {
        println!("Usage: listdir <directory>");
        return;
    }
    let dir_name_cstring = CString::new(args[1].clone()).unwrap();
    unsafe {
        let dir_ptr = opendir(dir_name_cstring.as_ptr() as *const c_char);
        if dir_ptr.is_null() {
            println!("Error opening directory");
            return;
        } else {
            closedir(dir_ptr);
            println!("Opening directory worked");
        }
    }
}
``` 
### Steps to Reproduce

Build a wasm module using the test case snippet, and invoke it pointing to a directory using wasmtime-8.0.1 on Windows:

```
$> c:\tests\wasmtime-v8.0.1-x86_64-windows\wasmtime.exe --mapdir /app::c:/tests/ c:\tests\lister.wasm -- /app
Error opening directory
```
The same command works when using 8.0.0:

```
$> c:\tests\wasmtime-v8.0.0-x86_64-windows\wasmtime.exe --mapdir /app::c:/tests/ c:\tests\lister.wasm -- /app
Opening directory worked
```
### Versions and Environment

Wasmtime version or commit: wasmtime 8.0.1
Operating system: Windows 10
Architecture: x86_64

### Extra details

The bug seems to be related to the changes in #6163. The code is failing here:

https://github.com/bytecodealliance/wasmtime/blob/main/crates/wasi-common/cap-std-sync/src/dir.rs#L93

Which was not previously applied to directories. That results on the directory being reopened which ends up calling Windows ReOpenFile, and that returns a "Access denied".

We have "fixed" the issue by moving the code to be executed only for files, but that may not be the best solution. It would be great of you could give us some tips if that is not the proper solution to improve the patch.
