### PR TITLE
Remove the initializer from a global's type information

### DIFF
--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -149,8 +149,12 @@ impl<'data> ModuleEnvironment<'data> for ModuleEnv {
         self.inner.declare_memory(memory)
     }
 
-    fn declare_global(&mut self, global: cranelift_wasm::Global) -> cranelift_wasm::WasmResult<()> {
-        self.inner.declare_global(global)
+    fn declare_global(
+        &mut self,
+        global: cranelift_wasm::Global,
+        init: cranelift_wasm::GlobalInit,
+    ) -> cranelift_wasm::WasmResult<()> {
+        self.inner.declare_global(global, init)
     }
 
     fn declare_func_export(

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -10,8 +10,9 @@ use crate::func_translator::FuncTranslator;
 use crate::state::FuncTranslationState;
 use crate::WasmType;
 use crate::{
-    DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex, Heap, HeapData,
-    HeapStyle, Memory, MemoryIndex, Table, TableIndex, TypeIndex, WasmFuncType, WasmResult,
+    DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Heap,
+    HeapData, HeapStyle, Memory, MemoryIndex, Table, TableIndex, TypeIndex, WasmFuncType,
+    WasmResult,
 };
 use core::convert::TryFrom;
 use cranelift_codegen::cursor::FuncCursor;
@@ -714,7 +715,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
         Ok(())
     }
 
-    fn declare_global(&mut self, global: Global) -> WasmResult<()> {
+    fn declare_global(&mut self, global: Global, _init: GlobalInit) -> WasmResult<()> {
         self.info.globals.push(Exportable::new(global));
         Ok(())
     }

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -8,9 +8,9 @@
 
 use crate::state::FuncTranslationState;
 use crate::{
-    DataIndex, ElemIndex, FuncIndex, Global, GlobalIndex, Heap, HeapData, Memory, MemoryIndex,
-    SignatureIndex, Table, TableIndex, Tag, TagIndex, TypeIndex, WasmError, WasmFuncType,
-    WasmResult, WasmType,
+    DataIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Heap, HeapData, Memory,
+    MemoryIndex, SignatureIndex, Table, TableIndex, Tag, TagIndex, TypeIndex, WasmError,
+    WasmFuncType, WasmResult, WasmType,
 };
 use core::convert::From;
 use cranelift_codegen::cursor::FuncCursor;
@@ -664,7 +664,7 @@ pub trait ModuleEnvironment<'data> {
     }
 
     /// Declares a global to the environment.
-    fn declare_global(&mut self, global: Global) -> WasmResult<()>;
+    fn declare_global(&mut self, global: Global, init: GlobalInit) -> WasmResult<()>;
 
     /// Provides the number of exports up front. By default this does nothing, but
     /// implementations can use this to preallocate memory if desired.

--- a/cranelift/wasm/src/sections_translator.rs
+++ b/cranelift/wasm/src/sections_translator.rs
@@ -50,11 +50,10 @@ fn table(ty: TableType) -> WasmResult<Table> {
     })
 }
 
-fn global(ty: GlobalType, initializer: GlobalInit) -> WasmResult<Global> {
+fn global(ty: GlobalType) -> WasmResult<Global> {
     Ok(Global {
         wasm_ty: ty.content_type.try_into()?,
         mutability: ty.mutable,
-        initializer,
     })
 }
 
@@ -100,7 +99,7 @@ pub fn parse_import_section<'data>(
                 environ.declare_tag_import(tag(e), import.module, import.name)?;
             }
             TypeRef::Global(ty) => {
-                let ty = global(ty, GlobalInit::Import)?;
+                let ty = global(ty)?;
                 environ.declare_global_import(ty, import.module, import.name)?;
             }
             TypeRef::Table(ty) => {
@@ -212,8 +211,8 @@ pub fn parse_global_section(
                 ));
             }
         };
-        let ty = global(ty, initializer)?;
-        environ.declare_global(ty)?;
+        let ty = global(ty)?;
+        environ.declare_global(ty, initializer)?;
     }
 
     Ok(())

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1,7 +1,5 @@
 use crate::component::{MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
-use crate::{
-    EntityType, Global, GlobalInit, ModuleTypes, ModuleTypesBuilder, PrimaryMap, SignatureIndex,
-};
+use crate::{EntityType, Global, ModuleTypes, ModuleTypesBuilder, PrimaryMap, SignatureIndex};
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
 use indexmap::IndexMap;
@@ -534,9 +532,7 @@ impl ComponentTypesBuilder {
             }
             wasmparser::TypeRef::Table(ty) => EntityType::Table(ty.clone().try_into()?),
             wasmparser::TypeRef::Memory(ty) => EntityType::Memory(ty.clone().into()),
-            wasmparser::TypeRef::Global(ty) => {
-                EntityType::Global(Global::new(ty.clone(), GlobalInit::Import)?)
-            }
+            wasmparser::TypeRef::Global(ty) => EntityType::Global(Global::new(ty.clone())?),
             wasmparser::TypeRef::Tag(_) => bail!("exceptions proposal not implemented"),
         })
     }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -828,6 +828,9 @@ pub struct Module {
 
     /// WebAssembly global variables.
     pub globals: PrimaryMap<GlobalIndex, Global>,
+
+    /// WebAssembly global initializers for locally-defined globals.
+    pub global_initializers: PrimaryMap<DefinedGlobalIndex, GlobalInit>,
 }
 
 /// Initialization routines for creating an instance, encompassing imports,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -267,7 +267,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         }
                         TypeRef::Global(ty) => {
                             self.result.module.num_imported_globals += 1;
-                            EntityType::Global(Global::new(ty, GlobalInit::Import)?)
+                            EntityType::Global(Global::new(ty)?)
                         }
                         TypeRef::Table(ty) => {
                             self.result.module.num_imported_tables += 1;
@@ -361,8 +361,9 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             )));
                         }
                     };
-                    let ty = Global::new(ty, initializer)?;
+                    let ty = Global::new(ty)?;
                     self.result.module.globals.push(ty);
+                    self.result.module.global_initializers.push(initializer);
                 }
             }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -1015,7 +1015,7 @@ impl Instance {
             // Initialize the global before writing to it
             ptr::write(to, VMGlobalDefinition::new());
 
-            match global.initializer {
+            match module.global_initializers[def_index] {
                 GlobalInit::I32Const(x) => *(*to).as_i32_mut() = x,
                 GlobalInit::I64Const(x) => *(*to).as_i64_mut() = x,
                 GlobalInit::F32Const(x) => *(*to).as_f32_bits_mut() = x,
@@ -1046,7 +1046,6 @@ impl Instance {
                     WasmType::ExternRef => {}
                     ty => panic!("unsupported reference type for global: {:?}", ty),
                 },
-                GlobalInit::Import => panic!("locally-defined global initialized as import"),
             }
         }
     }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -310,8 +310,8 @@ pub struct Global {
     pub wasm_ty: crate::WasmType,
     /// A flag indicating whether the value may change at runtime.
     pub mutability: bool,
-    /// The source of the initial value.
-    pub initializer: GlobalInit,
+    // /// The source of the initial value.
+    // pub initializer: GlobalInit,
 }
 
 /// Globals are initialized via the `const` operators or by referring to another import.
@@ -333,17 +333,14 @@ pub enum GlobalInit {
     RefNullConst,
     /// A `ref.func <index>`.
     RefFunc(FuncIndex),
-    ///< The global is imported from, and thus initialized by, a different module.
-    Import,
 }
 
 impl Global {
     /// Creates a new `Global` type from wasmparser's representation.
-    pub fn new(ty: wasmparser::GlobalType, initializer: GlobalInit) -> WasmResult<Global> {
+    pub fn new(ty: wasmparser::GlobalType) -> WasmResult<Global> {
         Ok(Global {
             wasm_ty: ty.content_type.try_into()?,
             mutability: ty.mutable,
-            initializer,
         })
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -310,8 +310,6 @@ pub struct Global {
     pub wasm_ty: crate::WasmType,
     /// A flag indicating whether the value may change at runtime.
     pub mutability: bool,
-    // /// The source of the initial value.
-    // pub initializer: GlobalInit,
 }
 
 /// Globals are initialized via the `const` operators or by referring to another import.

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -13,7 +13,7 @@ use wasmtime_environ::component::{
     ExtractPostReturn, ExtractRealloc, GlobalInitializer, InstantiateModule, LowerImport,
     RuntimeImportIndex, RuntimeInstanceIndex, RuntimeModuleIndex, Transcoder,
 };
-use wasmtime_environ::{EntityIndex, EntityType, Global, GlobalInit, PrimaryMap, WasmType};
+use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmType};
 use wasmtime_runtime::component::{ComponentInstance, OwnedComponentInstance};
 
 use super::component::AllCallFuncPointers;
@@ -140,7 +140,6 @@ impl InstanceData {
                     global: Global {
                         wasm_ty: WasmType::I32,
                         mutability: true,
-                        initializer: GlobalInit::I32Const(0),
                     },
                 })
             }

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -1,7 +1,6 @@
 use crate::store::StoreOpaque;
 use crate::{GlobalType, Mutability, Val};
 use std::ptr;
-use wasmtime_environ::GlobalInit;
 use wasmtime_runtime::{StoreBox, VMGlobalDefinition};
 
 #[repr(C)]
@@ -39,9 +38,6 @@ pub fn generate_global_export(
             Mutability::Const => false,
             Mutability::Var => true,
         },
-        // TODO: This is just a dummy value; nothing should actually read
-        // this. We should probably remove this field from the struct.
-        initializer: GlobalInit::I32Const(0),
     };
     let ctx = StoreBox::new(VMHostGlobalContext {
         ty,


### PR DESCRIPTION
This commit removes the `Global::initializer` field to instead only store type information about the global rather than its initialization state. Instead now the initializer is stored separately from the type of the global, and only for defined globals. This removes the need in a few locations to synthesize dummy initializers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
