### PR TITLE
riscv64: Move `bitcast` to isle

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1083,6 +1083,22 @@
 (rule (rv_fmadd $F32 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddS) $F32 rs1 rs2 rs3))
 (rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
 
+;; Helper for emitting the `fmv.x.w` instruction.
+(decl rv_fmvxw (Reg) Reg)
+(rule (rv_fmvxw r) (fpu_rr (FpuOPRR.FmvXW) $I32 r))
+
+;; Helper for emitting the `fmv.x.d` instruction.
+(decl rv_fmvxd (Reg) Reg)
+(rule (rv_fmvxd r) (fpu_rr (FpuOPRR.FmvXD) $I64 r))
+
+;; Helper for emitting the `fmv.w.x` instruction.
+(decl rv_fmvwx (Reg) Reg)
+(rule (rv_fmvwx r) (fpu_rr (FpuOPRR.FmvWX) $F32 r))
+
+;; Helper for emitting the `fmv.d.x` instruction.
+(decl rv_fmvdx (Reg) Reg)
+(rule (rv_fmvdx r) (fpu_rr (FpuOPRR.FmvDX) $F64 r))
+
 ;; Helper for emitting the `fcvt.d.s` ("Float Convert Double to Single") instruction.
 (decl rv_fcvtds (Reg) Reg)
 (rule (rv_fcvtds rs1) (fpu_rr (FpuOPRR.FcvtDS) $F32 rs1))
@@ -1403,12 +1419,17 @@
 
 
 (decl gen_bnot (Type ValueRegs) ValueRegs)
+(rule 2 (gen_bnot (ty_scalar_float ty) x)
+  (let ((tmp Reg (move_f_to_x x ty))
+        (tmp2 Reg (rv_not tmp)))
+    (move_x_to_f tmp2 (float_int_of_same_size ty))))
+
 (rule 1 (gen_bnot $I128 x)
   (let ((lo Reg (rv_not (value_regs_get x 0)))
         (hi Reg (rv_not (value_regs_get x 1))))
     (value_regs lo hi)))
 
-(rule 0 (gen_bnot (fits_in_64 _) x)
+(rule 0 (gen_bnot (ty_int_ref_scalar_64 _) x)
   (rv_not x))
 
 
@@ -2136,21 +2157,8 @@
 )
 
 
-(decl move_f_to_x (Reg Type) Reg)
-(extern constructor move_f_to_x move_f_to_x)
-
-(decl move_x_to_f (Reg Type) Reg)
-(extern constructor move_x_to_f move_x_to_f)
-
 (decl gen_stack_addr (StackSlot Offset32) Reg )
 (extern constructor gen_stack_addr gen_stack_addr)
-
-
-;;; generate a move and reinterprete the data
-;; parameter is "rs" "in_type" "out_type"
-(decl gen_moves (ValueRegs Type Type) ValueRegs)
-(extern constructor gen_moves gen_moves)
-
 
 ;;
 (decl gen_select (Type Reg ValueRegs ValueRegs) ValueRegs)
@@ -2267,25 +2275,10 @@
 (decl lower_float_binary (AluOPRRR Reg Reg Type) Reg)
 (rule
   (lower_float_binary op rs1 rs2 ty)
-  (let
-    ((x_rs1 Reg (move_f_to_x rs1 ty))
-      (x_rs2 Reg (move_f_to_x rs2 ty))
-      ;;;
-      (tmp Reg (alu_rrr op x_rs1 x_rs2)))
-    ;;; move back.
-    (move_x_to_f tmp ty)))
-
-;;;;
-(decl lower_float_bnot (Reg Type) Reg)
-(rule
-  (lower_float_bnot x ty)
-  (let
-    (;; move to x register.
-      (tmp Reg (move_f_to_x x ty))
-      ;; inverse all bits.
-      (tmp2 Reg (rv_not tmp)))
-    ;; move back to float register.
-    (move_x_to_f tmp2 ty)))
+  (let ((x_rs1 Reg (move_f_to_x rs1 ty))
+        (x_rs2 Reg (move_f_to_x rs2 ty))
+        (tmp Reg (alu_rrr op x_rs1 x_rs2)))
+    (move_x_to_f tmp (float_int_of_same_size ty))))
 
 
 ;;; lower icmp
@@ -2429,6 +2422,29 @@
 
 (decl load_ra () Reg)
 (extern constructor load_ra load_ra)
+
+
+;; Generates a bitcast instruction.
+;; Args are: src, src_ty, dst_ty
+(decl gen_bitcast (Reg Type Type) Reg)
+(rule 1 (gen_bitcast r $F32 $I32) (rv_fmvxw r))
+(rule 1 (gen_bitcast r $F64 $I64) (rv_fmvxd r))
+(rule 1 (gen_bitcast r $I32 $F32) (rv_fmvwx r))
+(rule 1 (gen_bitcast r $I64 $F64) (rv_fmvdx r))
+(rule (gen_bitcast r _ _) r)
+
+(decl move_f_to_x (Reg Type) Reg)
+(rule (move_f_to_x r $F32) (gen_bitcast r $F32 $I32))
+(rule (move_f_to_x r $F64) (gen_bitcast r $F64 $I64))
+
+(decl move_x_to_f (Reg Type) Reg)
+(rule (move_x_to_f r $I32) (gen_bitcast r $I32 $F32))
+(rule (move_x_to_f r $I64) (gen_bitcast r $I64 $F64))
+
+(decl float_int_of_same_size (Type) Type)
+(rule (float_int_of_same_size $F32) $I32)
+(rule (float_int_of_same_size $F64) $I64)
+
 
 (decl gen_rev8 (Reg) Reg)
 (rule 1

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -161,33 +161,10 @@ pub(crate) fn gen_moves(rd: &[Writable<Reg>], src: &[Reg]) -> SmallInstVec<Inst>
     assert!(rd.len() > 0);
     let mut insts = SmallInstVec::new();
     for (dst, src) in rd.iter().zip(src.iter()) {
-        let out_ty = Inst::canonical_type_for_rc(dst.to_reg().class());
-        let in_ty = Inst::canonical_type_for_rc(src.class());
-        insts.push(gen_move(*dst, out_ty, *src, in_ty));
+        let ty = Inst::canonical_type_for_rc(dst.to_reg().class());
+        insts.push(Inst::gen_move(*dst, *src, ty));
     }
     insts
-}
-
-/// if input or output is float,
-/// you should use special instruction.
-/// generate a move and re-interpret the data.
-pub(crate) fn gen_move(rd: Writable<Reg>, oty: Type, rm: Reg, ity: Type) -> Inst {
-    match (ity.is_float(), oty.is_float()) {
-        (false, false) => Inst::gen_move(rd, rm, oty),
-        (true, true) => Inst::gen_move(rd, rm, oty),
-        (false, true) => Inst::FpuRR {
-            frm: None,
-            alu_op: FpuOPRR::move_x_to_f_op(oty),
-            rd: rd,
-            rs: rm,
-        },
-        (true, false) => Inst::FpuRR {
-            frm: None,
-            alu_op: FpuOPRR::move_f_to_x_op(ity),
-            rd: rd,
-            rs: rm,
-        },
-    }
 }
 
 impl Inst {

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -370,16 +370,8 @@
   (rv_vxor_vv x y ty))
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule -1 (lower (has_type (ty_int ty) (bnot x)))
+(rule (lower (has_type ty (bnot x)))
   (gen_bnot ty x))
-
-(rule
-  (lower (has_type $F32 (bnot x)))
-  (lower_float_bnot x $F32))
-
-(rule
-  (lower (has_type $F64 (bnot x)))
-  (lower_float_bnot x $F64))
 
 ;;;; Rules for `bit_reverse` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 (ty_int ty)) (bitrev x)))
@@ -934,8 +926,8 @@
 )
 ;;;;;  Rules for `bitcast`;;;;;;;;;
 (rule
-   (lower (has_type out (bitcast _ v @ (value_type in_ty))))
-   (gen_moves v in_ty out))
+   (lower (has_type out_ty (bitcast _ v @ (value_type in_ty))))
+   (gen_bitcast v in_ty out_ty))
 
 ;;;;;  Rules for `ceil`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -158,18 +158,18 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         });
     }
     fn load_ra(&mut self) -> Reg {
-        let tmp = self.temp_writable_reg(I64);
         if self.backend.flags.preserve_frame_pointers() {
+            let tmp = self.temp_writable_reg(I64);
             self.emit(&MInst::Load {
                 rd: tmp,
                 op: LoadOP::Ld,
                 flags: MemFlags::trusted(),
                 from: AMode::FPOffset(8, I64),
             });
+            tmp.to_reg()
         } else {
-            self.emit(&gen_move(tmp, I64, link_reg(), I64));
+            link_reg()
         }
-        tmp.to_reg()
     }
     fn int_zero_reg(&mut self, ty: Type) -> ValueRegs {
         assert!(ty.is_int(), "{:?}", ty);
@@ -192,20 +192,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         v.clone()
     }
 
-    fn gen_moves(&mut self, rs: ValueRegs, in_ty: Type, out_ty: Type) -> ValueRegs {
-        let tmp = construct_dest(|ty| self.temp_writable_reg(ty), out_ty);
-        if in_ty.bits() < 64 {
-            self.emit(&gen_move(tmp.regs()[0], out_ty, rs.regs()[0], in_ty));
-        } else {
-            gen_moves(tmp.regs(), rs.regs())
-                .iter()
-                .for_each(|i| self.emit(i));
-        }
-        tmp.map(|r| r.to_reg())
-    }
     fn imm12_and(&mut self, imm: Imm12, x: i32) -> Imm12 {
         Imm12::from_bits(imm.as_i16() & (x as i16))
     }
+
     fn alloc_vec_writable(&mut self, ty: Type) -> VecWritableReg {
         if ty.is_int() || ty == R32 || ty == R64 {
             if ty.bits() <= 64 {
@@ -355,21 +345,11 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         self.backend.isa_flags.has_zbs()
     }
 
-    fn move_f_to_x(&mut self, r: Reg, ty: Type) -> Reg {
-        let result = self.temp_writable_reg(I64);
-        self.emit(&gen_move(result, I64, r, ty));
-        result.to_reg()
-    }
     fn offset32_imm(&mut self, offset: i32) -> Offset32 {
         Offset32::new(offset)
     }
     fn default_memflags(&mut self) -> MemFlags {
         MemFlags::new()
-    }
-    fn move_x_to_f(&mut self, r: Reg, ty: Type) -> Reg {
-        let result = self.temp_writable_reg(ty);
-        self.emit(&gen_move(result, ty, r, I64));
-        result.to_reg()
     }
 
     fn pack_float_rounding_mode(&mut self, f: &FRM) -> OptionFloatRoundingMode {
@@ -523,22 +503,4 @@ pub(crate) fn lower_branch(
     // internal heap allocations.
     let mut isle_ctx = RV64IsleContext::new(lower_ctx, backend);
     generated_code::constructor_lower_branch(&mut isle_ctx, branch, &targets.to_vec())
-}
-
-/// construct destination according to ty.
-fn construct_dest<F: std::ops::FnMut(Type) -> WritableReg>(
-    mut alloc: F,
-    ty: Type,
-) -> WritableValueRegs {
-    if ty.is_int() || ty.is_ref() {
-        if ty.bits() == 128 {
-            WritableValueRegs::two(alloc(I64), alloc(I64))
-        } else {
-            WritableValueRegs::one(alloc(I64))
-        }
-    } else if ty.is_float() {
-        WritableValueRegs::one(alloc(F64))
-    } else {
-        unimplemented!("vector type not implemented.");
-    }
 }


### PR DESCRIPTION
👋 Hey,

This PR moves the the `bitcast` instruction implementation into ISLE. It also does some surrounding cleanups to remove one of the redundant `gen_move` functions in the backend.