### PR TITLE
Disable debug information on CI

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -23,11 +23,11 @@ runs:
         rustup default "${{ inputs.toolchain }}"
 
         # Save disk space by avoiding incremental compilation. Also turn down
-        # debuginfo from 2 to 1 to help save disk space.
+        # debuginfo from 2 to 0 to help save disk space.
         cat >> "$GITHUB_ENV" <<EOF
         CARGO_INCREMENTAL=0
-        CARGO_PROFILE_DEV_DEBUG=1
-        CARGO_PROFILE_TEST_DEBUG=1
+        CARGO_PROFILE_DEV_DEBUG=0
+        CARGO_PROFILE_TEST_DEBUG=0
         EOF
 
         # Deny warnings on CI to keep our code warning-free as it lands in-tree.


### PR DESCRIPTION
In #6338 that PR is bouncing on CI due to Windows running out of disk space. Locally a `./ci/run-tests.sh` compile produces a ~13G build directory. Testing on CI it looks like Windows builders have ~13G of free space on them for GitHub Actions. I think something in that PR has tipped us just over the edge of requiring too much space, although I'm not sure exactly what.

To address the issue this commit disables DWARF debug information entirely on all builders on CI. Not only should this save a sliver of compile time but this reduces a local build directory to ~4.7G, over a 50% reduction. That should keep us fitting in CI for more time to come hopefully.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
