### PR TITLE
feat(wasi-http): implement basic future incoming response

### DIFF
--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -14,10 +14,12 @@ pub struct WasiHttp {
     pub response_id_base: u32,
     pub fields_id_base: u32,
     pub streams_id_base: u32,
+    pub future_id_base: u32,
     pub requests: HashMap<u32, ActiveRequest>,
     pub responses: HashMap<u32, ActiveResponse>,
     pub fields: HashMap<u32, HashMap<String, Vec<String>>>,
     pub streams: HashMap<u32, Stream>,
+    pub futures: HashMap<u32, ActiveFuture>,
 }
 
 #[derive(Clone)]
@@ -43,10 +45,17 @@ pub struct ActiveResponse {
     pub trailers: u32,
 }
 
+#[derive(Clone)]
+pub struct ActiveFuture {
+    pub id: u32,
+    pub request_id: u32,
+    pub options: Option<crate::default_outgoing_http::RequestOptions>,
+}
+
 impl ActiveRequest {
     pub fn new(id: u32) -> Self {
         Self {
-            id: id,
+            id,
             active_request: false,
             method: Method::Get,
             scheme: Some(Scheme::Http),
@@ -62,12 +71,26 @@ impl ActiveRequest {
 impl ActiveResponse {
     pub fn new(id: u32) -> Self {
         Self {
-            id: id,
+            id,
             active_response: false,
             status: 0,
             body: 0,
             response_headers: HashMap::new(),
             trailers: 0,
+        }
+    }
+}
+
+impl ActiveFuture {
+    pub fn new(
+        id: u32,
+        request_id: u32,
+        options: Option<crate::default_outgoing_http::RequestOptions>,
+    ) -> Self {
+        Self {
+            id,
+            request_id,
+            options,
         }
     }
 }
@@ -96,10 +119,12 @@ impl WasiHttp {
             response_id_base: 1,
             fields_id_base: 1,
             streams_id_base: 1,
+            future_id_base: 1,
             requests: HashMap::new(),
             responses: HashMap::new(),
             fields: HashMap::new(),
             streams: HashMap::new(),
+            futures: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
This will implement the future incoming response where we simply block and return the result right away. Additionally, a few tests have been include to exercise non-happy paths.