### PR TITLE
add C API for epoch_deadline_callback and wasmtime_error_t creation

### DIFF
--- a/crates/c-api/include/wasmtime/error.h
+++ b/crates/c-api/include/wasmtime/error.h
@@ -31,6 +31,11 @@ extern "C" {
 typedef struct wasmtime_error wasmtime_error_t;
 
 /**
+ * \brief Creates a new error with the provided message.
+ */
+WASM_API_EXTERN wasmtime_error_t *wasmtime_error_new(const char*);
+
+/**
  * \brief Deletes an error.
  */
 WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t *error);

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -206,14 +206,29 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *
 
 /**
  * \brief Configures the relative deadline at which point WebAssembly code will
- * trap.
+ * trap or invoke the callback function.
  *
  * This function configures the store-local epoch deadline after which point
- * WebAssembly code will trap.
+ * WebAssembly code will trap or invoke the callback function.
  *
- * See also #wasmtime_config_epoch_interruption_set.
+ * See also #wasmtime_config_epoch_interruption_set and
+ * #wasmtime_store_epoch_deadline_callback.
  */
 WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t *context, uint64_t ticks_beyond_current);
+
+/**
+ * \brief Configures epoch deadline callback to C function.
+ *
+ * This function configures a store-local callback function that will be
+ * called when the running WebAssembly function has exceeded its epoch
+ * deadline. That function can return a #wasmtime_error_t to terminate
+ * the function, or set the delta argument and return NULL to update the
+ * epoch deadline and resume function execution.
+ *
+ * See also #wasmtime_config_epoch_interruption_set and
+ * #wasmtime_context_set_epoch_deadline.
+ */
+WASM_API_EXTERN void wasmtime_store_epoch_deadline_callback(wasmtime_store_t *store, wasmtime_error_t* (*func)(wasmtime_context_t*, void*, uint64_t*), void *data);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -14,6 +14,21 @@ impl From<Error> for wasmtime_error_t {
     }
 }
 
+impl Into<Error> for wasmtime_error_t {
+    fn into(self) -> Error {
+        self.error
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_error_new(
+    msg: *const std::ffi::c_char,
+) -> Option<Box<wasmtime_error_t>> {
+    Some(Box::new(wasmtime_error_t::from(anyhow!("{:?}", unsafe {
+        std::ffi::CStr::from_ptr(msg)
+    }))))
+}
+
 pub(crate) fn handle_result<T>(
     result: Result<T>,
     ok: impl FnOnce(T),

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -24,9 +24,8 @@ impl Into<Error> for wasmtime_error_t {
 pub extern "C" fn wasmtime_error_new(
     msg: *const std::ffi::c_char,
 ) -> Option<Box<wasmtime_error_t>> {
-    Some(Box::new(wasmtime_error_t::from(anyhow!("{:?}", unsafe {
-        std::ffi::CStr::from_ptr(msg)
-    }))))
+    let msg_string = String::from_utf8_lossy(unsafe { std::ffi::CStr::from_ptr(msg).to_bytes() });
+    Some(Box::new(wasmtime_error_t::from(anyhow!(msg_string))))
 }
 
 pub(crate) fn handle_result<T>(


### PR DESCRIPTION
issue #6277 

This adds C API interfaces to:
1. Set the epoch deadline callback to a C function
2. Create a wasmtime_error_t from C
