### PR TITLE
Make libcalls slightly safer

### DIFF
--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -56,7 +56,7 @@
 
 use crate::externref::VMExternRef;
 use crate::table::{Table, TableElementType};
-use crate::vmcontext::{VMContext, VMFuncRef};
+use crate::vmcontext::VMFuncRef;
 use crate::{Instance, TrapReason};
 use anyhow::Result;
 use std::mem;
@@ -73,7 +73,7 @@ use wasmtime_environ::{
 /// now to ensure that the fp/sp on exit are recorded for backtraces to work
 /// properly.
 pub mod trampolines {
-    use crate::{TrapReason, VMContext};
+    use crate::{Instance, TrapReason, VMContext};
 
     macro_rules! libcall {
         (
@@ -111,11 +111,13 @@ pub mod trampolines {
                 // `no_mangle`.
                 #[cfg_attr(target_arch = "s390x", no_mangle)]
                 unsafe extern "C" fn [<impl_ $name>](
-                    vmctx : *mut VMContext,
+                    vmctx: *mut VMContext,
                     $( $pname : libcall!(@ty $param), )*
                 ) $( -> libcall!(@ty $result))? {
                     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        super::$name(vmctx, $($pname),*)
+                        Instance::from_vmctx(vmctx, |instance| {
+                            super::$name(instance, $($pname),*)
+                        })
                     }));
                     match result {
                         Ok(ret) => LibcallResult::convert(ret),
@@ -181,33 +183,28 @@ pub mod trampolines {
     }
 }
 
-unsafe fn memory32_grow(
-    vmctx: *mut VMContext,
+fn memory32_grow(
+    instance: &mut Instance,
     delta: u64,
     memory_index: u32,
 ) -> Result<*mut u8, TrapReason> {
-    Instance::from_vmctx(vmctx, |instance| {
-        let memory_index = MemoryIndex::from_u32(memory_index);
-        let result =
-            match instance
-                .memory_grow(memory_index, delta)
-                .map_err(|error| TrapReason::User {
-                    error,
-                    needs_backtrace: true,
-                })? {
-                Some(size_in_bytes) => size_in_bytes / (wasmtime_environ::WASM_PAGE_SIZE as usize),
-                None => usize::max_value(),
-            };
-        Ok(result as *mut _)
-    })
+    let memory_index = MemoryIndex::from_u32(memory_index);
+    let result =
+        match instance
+            .memory_grow(memory_index, delta)
+            .map_err(|error| TrapReason::User {
+                error,
+                needs_backtrace: true,
+            })? {
+            Some(size_in_bytes) => size_in_bytes / (wasmtime_environ::WASM_PAGE_SIZE as usize),
+            None => usize::max_value(),
+        };
+    Ok(result as *mut _)
 }
 
 // Implementation of `table.grow`.
-//
-// Table grow can invoke user code provided in a ResourceLimiter{,Async}, so we
-// need to catch a possible panic.
 unsafe fn table_grow(
-    vmctx: *mut VMContext,
+    instance: &mut Instance,
     table_index: u32,
     delta: u32,
     // NB: we don't know whether this is a pointer to a `VMFuncRef`
@@ -215,22 +212,20 @@ unsafe fn table_grow(
     init_value: *mut u8,
 ) -> Result<u32> {
     let table_index = TableIndex::from_u32(table_index);
-    Instance::from_vmctx(vmctx, |instance| {
-        let element = match instance.table_element_type(table_index) {
-            TableElementType::Func => (init_value as *mut VMFuncRef).into(),
-            TableElementType::Extern => {
-                let init_value = if init_value.is_null() {
-                    None
-                } else {
-                    Some(VMExternRef::clone_from_raw(init_value))
-                };
-                init_value.into()
-            }
-        };
-        Ok(match instance.table_grow(table_index, delta, element)? {
-            Some(r) => r,
-            None => -1_i32 as u32,
-        })
+    let element = match instance.table_element_type(table_index) {
+        TableElementType::Func => (init_value as *mut VMFuncRef).into(),
+        TableElementType::Extern => {
+            let init_value = if init_value.is_null() {
+                None
+            } else {
+                Some(VMExternRef::clone_from_raw(init_value))
+            };
+            init_value.into()
+        }
+    };
+    Ok(match instance.table_grow(table_index, delta, element)? {
+        Some(r) => r,
+        None => -1_i32 as u32,
     })
 }
 
@@ -239,7 +234,7 @@ use table_grow as table_grow_externref;
 
 // Implementation of `table.fill`.
 unsafe fn table_fill(
-    vmctx: *mut VMContext,
+    instance: &mut Instance,
     table_index: u32,
     dst: u32,
     // NB: we don't know whether this is a `VMExternRef` or a pointer to a
@@ -247,24 +242,22 @@ unsafe fn table_fill(
     val: *mut u8,
     len: u32,
 ) -> Result<(), Trap> {
-    Instance::from_vmctx(vmctx, |instance| {
-        let table_index = TableIndex::from_u32(table_index);
-        let table = &mut *instance.get_table(table_index);
-        match table.element_type() {
-            TableElementType::Func => {
-                let val = val as *mut VMFuncRef;
-                table.fill(dst, val.into(), len)
-            }
-            TableElementType::Extern => {
-                let val = if val.is_null() {
-                    None
-                } else {
-                    Some(VMExternRef::clone_from_raw(val))
-                };
-                table.fill(dst, val.into(), len)
-            }
+    let table_index = TableIndex::from_u32(table_index);
+    let table = &mut *instance.get_table(table_index);
+    match table.element_type() {
+        TableElementType::Func => {
+            let val = val as *mut VMFuncRef;
+            table.fill(dst, val.into(), len)
         }
-    })
+        TableElementType::Extern => {
+            let val = if val.is_null() {
+                None
+            } else {
+                Some(VMExternRef::clone_from_raw(val))
+            };
+            table.fill(dst, val.into(), len)
+        }
+    }
 }
 
 use table_fill as table_fill_func_ref;
@@ -272,7 +265,7 @@ use table_fill as table_fill_externref;
 
 // Implementation of `table.copy`.
 unsafe fn table_copy(
-    vmctx: *mut VMContext,
+    instance: &mut Instance,
     dst_table_index: u32,
     src_table_index: u32,
     dst: u32,
@@ -281,18 +274,16 @@ unsafe fn table_copy(
 ) -> Result<(), Trap> {
     let dst_table_index = TableIndex::from_u32(dst_table_index);
     let src_table_index = TableIndex::from_u32(src_table_index);
-    Instance::from_vmctx(vmctx, |instance| {
-        let dst_table = instance.get_table(dst_table_index);
-        // Lazy-initialize the whole range in the source table first.
-        let src_range = src..(src.checked_add(len).unwrap_or(u32::MAX));
-        let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
-        Table::copy(dst_table, src_table, dst, src, len)
-    })
+    let dst_table = instance.get_table(dst_table_index);
+    // Lazy-initialize the whole range in the source table first.
+    let src_range = src..(src.checked_add(len).unwrap_or(u32::MAX));
+    let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);
+    Table::copy(dst_table, src_table, dst, src, len)
 }
 
 // Implementation of `table.init`.
-unsafe fn table_init(
-    vmctx: *mut VMContext,
+fn table_init(
+    instance: &mut Instance,
     table_index: u32,
     elem_index: u32,
     dst: u32,
@@ -301,20 +292,18 @@ unsafe fn table_init(
 ) -> Result<(), Trap> {
     let table_index = TableIndex::from_u32(table_index);
     let elem_index = ElemIndex::from_u32(elem_index);
-    Instance::from_vmctx(vmctx, |i| {
-        i.table_init(table_index, elem_index, dst, src, len)
-    })
+    instance.table_init(table_index, elem_index, dst, src, len)
 }
 
 // Implementation of `elem.drop`.
-unsafe fn elem_drop(vmctx: *mut VMContext, elem_index: u32) {
+fn elem_drop(instance: &mut Instance, elem_index: u32) {
     let elem_index = ElemIndex::from_u32(elem_index);
-    Instance::from_vmctx(vmctx, |i| i.elem_drop(elem_index))
+    instance.elem_drop(elem_index)
 }
 
-// Implementation of `memory.copy` for locally defined memories.
-unsafe fn memory_copy(
-    vmctx: *mut VMContext,
+// Implementation of `memory.copy`.
+fn memory_copy(
+    instance: &mut Instance,
     dst_index: u32,
     dst: u64,
     src_index: u32,
@@ -323,26 +312,24 @@ unsafe fn memory_copy(
 ) -> Result<(), Trap> {
     let src_index = MemoryIndex::from_u32(src_index);
     let dst_index = MemoryIndex::from_u32(dst_index);
-    Instance::from_vmctx(vmctx, |i| {
-        i.memory_copy(dst_index, dst, src_index, src, len)
-    })
+    instance.memory_copy(dst_index, dst, src_index, src, len)
 }
 
 // Implementation of `memory.fill` for locally defined memories.
-unsafe fn memory_fill(
-    vmctx: *mut VMContext,
+fn memory_fill(
+    instance: &mut Instance,
     memory_index: u32,
     dst: u64,
     val: u32,
     len: u64,
 ) -> Result<(), Trap> {
     let memory_index = MemoryIndex::from_u32(memory_index);
-    Instance::from_vmctx(vmctx, |i| i.memory_fill(memory_index, dst, val as u8, len))
+    instance.memory_fill(memory_index, dst, val as u8, len)
 }
 
 // Implementation of `memory.init`.
-unsafe fn memory_init(
-    vmctx: *mut VMContext,
+fn memory_init(
+    instance: &mut Instance,
     memory_index: u32,
     data_index: u32,
     dst: u64,
@@ -351,46 +338,40 @@ unsafe fn memory_init(
 ) -> Result<(), Trap> {
     let memory_index = MemoryIndex::from_u32(memory_index);
     let data_index = DataIndex::from_u32(data_index);
-    Instance::from_vmctx(vmctx, |i| {
-        i.memory_init(memory_index, data_index, dst, src, len)
-    })
+    instance.memory_init(memory_index, data_index, dst, src, len)
 }
 
 // Implementation of `ref.func`.
-unsafe fn ref_func(vmctx: *mut VMContext, func_index: u32) -> *mut u8 {
-    Instance::from_vmctx(vmctx, |instance| {
-        instance
-            .get_func_ref(FuncIndex::from_u32(func_index))
-            .expect("ref_func: funcref should always be available for given func index")
-            .cast()
-    })
+fn ref_func(instance: &mut Instance, func_index: u32) -> *mut u8 {
+    instance
+        .get_func_ref(FuncIndex::from_u32(func_index))
+        .expect("ref_func: funcref should always be available for given func index")
+        .cast()
 }
 
 // Implementation of `data.drop`.
-unsafe fn data_drop(vmctx: *mut VMContext, data_index: u32) {
+fn data_drop(instance: &mut Instance, data_index: u32) {
     let data_index = DataIndex::from_u32(data_index);
-    Instance::from_vmctx(vmctx, |i| i.data_drop(data_index))
+    instance.data_drop(data_index)
 }
 
 // Returns a table entry after lazily initializing it.
 unsafe fn table_get_lazy_init_func_ref(
-    vmctx: *mut VMContext,
+    instance: &mut Instance,
     table_index: u32,
     index: u32,
 ) -> *mut u8 {
-    Instance::from_vmctx(vmctx, |instance| {
-        let table_index = TableIndex::from_u32(table_index);
-        let table = instance.get_table_with_lazy_init(table_index, std::iter::once(index));
-        let elem = (*table)
-            .get(index)
-            .expect("table access already bounds-checked");
+    let table_index = TableIndex::from_u32(table_index);
+    let table = instance.get_table_with_lazy_init(table_index, std::iter::once(index));
+    let elem = (*table)
+        .get(index)
+        .expect("table access already bounds-checked");
 
-        elem.into_ref_asserting_initialized()
-    })
+    elem.into_ref_asserting_initialized()
 }
 
 // Drop a `VMExternRef`.
-unsafe fn drop_externref(_vmctx: *mut VMContext, externref: *mut u8) {
+unsafe fn drop_externref(_instance: &mut Instance, externref: *mut u8) {
     let externref = externref as *mut crate::externref::VMExternData;
     let externref = NonNull::new(externref).unwrap().into();
     crate::externref::VMExternData::drop_and_dealloc(externref);
@@ -398,47 +379,42 @@ unsafe fn drop_externref(_vmctx: *mut VMContext, externref: *mut u8) {
 
 // Do a GC and insert the given `externref` into the
 // `VMExternRefActivationsTable`.
-unsafe fn activations_table_insert_with_gc(vmctx: *mut VMContext, externref: *mut u8) {
+unsafe fn activations_table_insert_with_gc(instance: &mut Instance, externref: *mut u8) {
     let externref = VMExternRef::clone_from_raw(externref);
-    Instance::from_vmctx(vmctx, |instance| {
-        let limits = *instance.runtime_limits();
-        let (activations_table, module_info_lookup) =
-            (*instance.store()).externref_activations_table();
+    let limits = *instance.runtime_limits();
+    let (activations_table, module_info_lookup) = (*instance.store()).externref_activations_table();
 
-        // Invariant: all `externref`s on the stack have an entry in the activations
-        // table. So we need to ensure that this `externref` is in the table
-        // *before* we GC, even though `insert_with_gc` will ensure that it is in
-        // the table *after* the GC. This technically results in one more hash table
-        // look up than is strictly necessary -- which we could avoid by having an
-        // additional GC method that is aware of these GC-triggering references --
-        // but it isn't really a concern because this is already a slow path.
-        activations_table.insert_without_gc(externref.clone());
+    // Invariant: all `externref`s on the stack have an entry in the activations
+    // table. So we need to ensure that this `externref` is in the table
+    // *before* we GC, even though `insert_with_gc` will ensure that it is in
+    // the table *after* the GC. This technically results in one more hash table
+    // look up than is strictly necessary -- which we could avoid by having an
+    // additional GC method that is aware of these GC-triggering references --
+    // but it isn't really a concern because this is already a slow path.
+    activations_table.insert_without_gc(externref.clone());
 
-        activations_table.insert_with_gc(limits, externref, module_info_lookup);
-    })
+    activations_table.insert_with_gc(limits, externref, module_info_lookup);
 }
 
 // Perform a Wasm `global.get` for `externref` globals.
-unsafe fn externref_global_get(vmctx: *mut VMContext, index: u32) -> *mut u8 {
+unsafe fn externref_global_get(instance: &mut Instance, index: u32) -> *mut u8 {
     let index = GlobalIndex::from_u32(index);
-    Instance::from_vmctx(vmctx, |instance| {
-        let limits = *instance.runtime_limits();
-        let global = instance.defined_or_imported_global_ptr(index);
-        match (*global).as_externref().clone() {
-            None => ptr::null_mut(),
-            Some(externref) => {
-                let raw = externref.as_raw();
-                let (activations_table, module_info_lookup) =
-                    (*instance.store()).externref_activations_table();
-                activations_table.insert_with_gc(limits, externref, module_info_lookup);
-                raw
-            }
+    let limits = *instance.runtime_limits();
+    let global = instance.defined_or_imported_global_ptr(index);
+    match (*global).as_externref().clone() {
+        None => ptr::null_mut(),
+        Some(externref) => {
+            let raw = externref.as_raw();
+            let (activations_table, module_info_lookup) =
+                (*instance.store()).externref_activations_table();
+            activations_table.insert_with_gc(limits, externref, module_info_lookup);
+            raw
         }
-    })
+    }
 }
 
 // Perform a Wasm `global.set` for `externref` globals.
-unsafe fn externref_global_set(vmctx: *mut VMContext, index: u32, externref: *mut u8) {
+unsafe fn externref_global_set(instance: &mut Instance, index: u32, externref: *mut u8) {
     let externref = if externref.is_null() {
         None
     } else {
@@ -446,36 +422,32 @@ unsafe fn externref_global_set(vmctx: *mut VMContext, index: u32, externref: *mu
     };
 
     let index = GlobalIndex::from_u32(index);
-    Instance::from_vmctx(vmctx, |instance| {
-        let global = instance.defined_or_imported_global_ptr(index);
+    let global = instance.defined_or_imported_global_ptr(index);
 
-        // Swap the new `externref` value into the global before we drop the old
-        // value. This protects against an `externref` with a `Drop` implementation
-        // that calls back into Wasm and touches this global again (we want to avoid
-        // it observing a halfway-deinitialized value).
-        let old = mem::replace((*global).as_externref_mut(), externref);
-        drop(old);
-    })
+    // Swap the new `externref` value into the global before we drop the old
+    // value. This protects against an `externref` with a `Drop` implementation
+    // that calls back into Wasm and touches this global again (we want to avoid
+    // it observing a halfway-deinitialized value).
+    let old = mem::replace((*global).as_externref_mut(), externref);
+    drop(old);
 }
 
 // Implementation of `memory.atomic.notify` for locally defined memories.
-unsafe fn memory_atomic_notify(
-    vmctx: *mut VMContext,
+fn memory_atomic_notify(
+    instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
     count: u32,
 ) -> Result<u32, Trap> {
     let memory = MemoryIndex::from_u32(memory_index);
-    Instance::from_vmctx(vmctx, |instance| {
-        instance
-            .get_runtime_memory(memory)
-            .atomic_notify(addr_index, count)
-    })
+    instance
+        .get_runtime_memory(memory)
+        .atomic_notify(addr_index, count)
 }
 
 // Implementation of `memory.atomic.wait32` for locally defined memories.
-unsafe fn memory_atomic_wait32(
-    vmctx: *mut VMContext,
+fn memory_atomic_wait32(
+    instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
     expected: u32,
@@ -484,16 +456,14 @@ unsafe fn memory_atomic_wait32(
     // convert timeout to Instant, before any wait happens on locking
     let timeout = (timeout as i64 >= 0).then(|| Instant::now() + Duration::from_nanos(timeout));
     let memory = MemoryIndex::from_u32(memory_index);
-    Instance::from_vmctx(vmctx, |instance| {
-        Ok(instance
-            .get_runtime_memory(memory)
-            .atomic_wait32(addr_index, expected, timeout)? as u32)
-    })
+    Ok(instance
+        .get_runtime_memory(memory)
+        .atomic_wait32(addr_index, expected, timeout)? as u32)
 }
 
 // Implementation of `memory.atomic.wait64` for locally defined memories.
-unsafe fn memory_atomic_wait64(
-    vmctx: *mut VMContext,
+fn memory_atomic_wait64(
+    instance: &mut Instance,
     memory_index: u32,
     addr_index: u64,
     expected: u64,
@@ -502,21 +472,19 @@ unsafe fn memory_atomic_wait64(
     // convert timeout to Instant, before any wait happens on locking
     let timeout = (timeout as i64 >= 0).then(|| Instant::now() + Duration::from_nanos(timeout));
     let memory = MemoryIndex::from_u32(memory_index);
-    Instance::from_vmctx(vmctx, |instance| {
-        Ok(instance
-            .get_runtime_memory(memory)
-            .atomic_wait64(addr_index, expected, timeout)? as u32)
-    })
+    Ok(instance
+        .get_runtime_memory(memory)
+        .atomic_wait64(addr_index, expected, timeout)? as u32)
 }
 
 // Hook for when an instance runs out of fuel.
-unsafe fn out_of_gas(vmctx: *mut VMContext) -> Result<()> {
-    Instance::from_vmctx(vmctx, |i| (*i.store()).out_of_gas())
+unsafe fn out_of_gas(instance: &mut Instance) -> Result<()> {
+    (*instance.store()).out_of_gas()
 }
 
 // Hook for when an instance observes that the epoch has changed.
-unsafe fn new_epoch(vmctx: *mut VMContext) -> Result<u64> {
-    Instance::from_vmctx(vmctx, |i| (*i.store()).new_epoch())
+unsafe fn new_epoch(instance: &mut Instance) -> Result<u64> {
+    (*instance.store()).new_epoch()
 }
 
 /// This module contains functions which are used for resolving relocations at


### PR DESCRIPTION
Bake in the `*mut VMContext` to `&mut Instance` translation into the macro-generated trampolines to avoid the need to use `Instance::from_vmctx` with an extra level of indentation everywhere. Additionally some libcalls are now entirely safe code as their one unsafe operation was the `VMContext` to `Instance` translation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
