### PR TITLE
test: fix more wasi_testsuite test cases

### DIFF
--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -30,11 +30,7 @@ fn wasi_testsuite() -> Result<()> {
     // `cargo test wasi_testsuite -- --nocapture`. The printed output will show
     // the expected result, the actual result, and a command to replicate the
     // failure from the command line.
-    const WASI_COMMON_IGNORE_LIST: &[&str] = &[
-        "environ_get-multiple-variables.wasm",
-        "environ_sizes_get-multiple-variables.wasm",
-        "fd_advise.wasm",
-    ];
+    const WASI_COMMON_IGNORE_LIST: &[&str] = &["fd_advise.wasm"];
     run_all(
         "tests/wasi_testsuite/wasi-common",
         &[],
@@ -127,10 +123,12 @@ fn build_command<P: AsRef<Path>>(module: P, extra_flags: &[&str], spec: &Spec) -
         cmd.args(spec_args);
     }
 
-    // Create the environment. This uses the shell environment, but we could also
-    // have used the Wasmtime CLI's `--env` parameter here.
-    cmd.env_clear();
+    // Add environment variables as CLI arguments.
     if let Some(env) = &spec.env {
+        for env_pair in env {
+            cmd.arg("--env");
+            cmd.arg(format!("{}={}", env_pair.0, env_pair.1));
+        }
         cmd.envs(env);
     }
 


### PR DESCRIPTION
Instead of passing environment variables from the spec file to the sandboxed environment, we set them for the execution environment of the process (therefore they were not available for WASM test application).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
