### PR TITLE
copy input msg into result of C API wasmtime_error_new

### DIFF
--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -24,8 +24,9 @@ impl Into<Error> for wasmtime_error_t {
 pub extern "C" fn wasmtime_error_new(
     msg: *const std::ffi::c_char,
 ) -> Option<Box<wasmtime_error_t>> {
-    let msg_string = String::from_utf8_lossy(unsafe { std::ffi::CStr::from_ptr(msg).to_bytes() });
-    Some(Box::new(wasmtime_error_t::from(anyhow!("{msg_string}"))))
+    let msg_bytes = unsafe { std::ffi::CStr::from_ptr(msg).to_bytes() };
+    let msg_string = String::from_utf8_lossy(msg_bytes).into_owned();
+    Some(Box::new(wasmtime_error_t::from(anyhow!(msg_string))))
 }
 
 pub(crate) fn handle_result<T>(

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -25,7 +25,7 @@ pub extern "C" fn wasmtime_error_new(
     msg: *const std::ffi::c_char,
 ) -> Option<Box<wasmtime_error_t>> {
     let msg_string = String::from_utf8_lossy(unsafe { std::ffi::CStr::from_ptr(msg).to_bytes() });
-    Some(Box::new(wasmtime_error_t::from(anyhow!(msg_string))))
+    Some(Box::new(wasmtime_error_t::from(anyhow!("{msg_string}"))))
 }
 
 pub(crate) fn handle_result<T>(


### PR DESCRIPTION
Fix for issue discovered in #6359 for issue #6277. Input string was not copied into new `wasmtime_error_t` result.
