### PR TITLE
x64: Update i64x2 `sshr` implementation

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1834,14 +1834,6 @@
             (_ Unit (emit (MInst.XmmUninitializedValue dst))))
         dst))
 
-;; Helper for creating an SSE register holding an `i64x2` from two `i64` values.
-(decl make_i64x2_from_lanes (GprMem GprMem) Xmm)
-(rule (make_i64x2_from_lanes lo hi)
-      (let ((dst Xmm (xmm_uninit_value))
-            (dst Xmm (x64_pinsrq dst lo 0))
-            (dst Xmm (x64_pinsrq dst hi 1)))
-        dst))
-
 ;; Move a `RegMemImm.Reg` operand to an XMM register, if necessary.
 (decl mov_rmi_to_xmm (RegMemImm) XmmMemImm)
 (rule (mov_rmi_to_xmm rmi @ (RegMemImm.Mem _)) (xmm_mem_imm_new rmi))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -755,20 +755,66 @@
 ;; The `sshr.i64x2` CLIF instruction has no single x86 instruction in the older
 ;; feature sets. Newer ones like AVX512VL + AVX512F include `vpsraq`, a 128-bit
 ;; instruction that would fit here, but this backend does not currently have
-;; support for EVEX encodings. To remedy this, we extract each 64-bit lane to a
-;; GPR, shift each using a scalar instruction, and insert the shifted values
-;; back in the `dst` XMM register.
+;; support for EVEX encodings. To remedy this, a small dance is done with an
+;; unsigned right shift plus some extra ops.
 ;;
 ;; (TODO: when EVEX support is available, add an alternate lowering here).
+(rule 1 (lower (has_type $I64X2 (sshr src (iconst (u64_from_imm64 (u64_as_u32 amt))))))
+        (lower_i64x2_sshr_imm src (u32_and amt 63)))
 (rule (lower (has_type $I64X2 (sshr src amt)))
-      (let ((src_ Xmm (put_in_xmm src))
-            (lo Gpr (x64_pextrq src_ 0))
-            (hi Gpr (x64_pextrq src_ 1))
-            (amt_ Imm8Gpr (put_masked_in_imm8_gpr amt $I64))
-            (shifted_lo Gpr (x64_sar $I64 lo amt_))
-            (shifted_hi Gpr (x64_sar $I64 hi amt_)))
-        (make_i64x2_from_lanes shifted_lo
-                               shifted_hi)))
+      (lower_i64x2_sshr_gpr src (x64_and $I64 amt (RegMemImm.Imm 63))))
+
+(decl lower_i64x2_sshr_imm (Xmm u32) Xmm)
+
+;; If the shift amount is less than 32 then do an sshr with 32-bit lanes to
+;; produce the upper halves of each result, followed by a ushr of 64-bit lanes
+;; to produce the lower halves of each result. Interleave results at the end.
+(rule 2 (lower_i64x2_sshr_imm vec imm)
+        (if-let $true (u64_lt imm 32))
+        (let (
+            (high32 Xmm (x64_psrad vec (xmi_imm imm)))
+            (high32 Xmm (x64_pshufd high32 0b11_10_11_01))
+            (low32  Xmm (x64_psrlq vec (xmi_imm imm)))
+            (low32  Xmm (x64_pshufd low32 0b11_10_10_00))
+          )
+          (x64_punpckldq low32 high32)))
+
+;; If the shift amount is 32 then the `psrlq` from the above rule can be avoided
+(rule 1 (lower_i64x2_sshr_imm vec 32)
+        (let (
+            (low32  Xmm (x64_pshufd vec 0b11_10_11_01))
+            (high32 Xmm (x64_psrad vec (xmi_imm 31)))
+            (high32 Xmm (x64_pshufd high32 0b11_10_11_01))
+          )
+          (x64_punpckldq low32 high32)))
+
+;; Shifts >= 32 use one `psrad` to generate the upper bits and second `psrad` to
+;; generate the lower bits. Everything is then woven back together with
+;; shuffles.
+(rule (lower_i64x2_sshr_imm vec imm)
+      (if-let $true (u64_lt 32 imm))
+      (let (
+          (high32 Xmm (x64_psrad vec (xmi_imm 31)))
+          (high32 Xmm (x64_pshufd high32 0b11_10_11_01))
+          (low32  Xmm (x64_psrad vec (xmi_imm (u32_sub imm 32))))
+          (low32  Xmm (x64_pshufd low32 0b11_10_10_01))
+        )
+        (x64_punpckldq low32 high32)))
+
+;; A variable shift amount is slightly more complicated than the immediate
+;; shift amounts from above. The `Gpr` argument is guaranteed to be <= 63 by
+;; earlier masking. A `ushr` operation is used with some xor/sub math to
+;; generate the sign bits.
+(decl lower_i64x2_sshr_gpr (Xmm Gpr) Xmm)
+(rule (lower_i64x2_sshr_gpr vec val)
+      (let (
+          (val                Xmm (x64_movq_to_xmm val))
+          (mask               Xmm (flip_high_bit_mask $I64X2))
+          (sign_bit_loc       Xmm (x64_psrlq mask val))
+          (ushr               Xmm (x64_psrlq vec val))
+          (ushr_sign_bit_flip Xmm (x64_pxor sign_bit_loc ushr))
+        )
+        (x64_psubq ushr_sign_bit_flip sign_bit_loc)))
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -753,12 +753,10 @@
       (x64_psrad src (mov_rmi_to_xmm (mask_xmm_shift ty amt))))
 
 ;; The `sshr.i64x2` CLIF instruction has no single x86 instruction in the older
-;; feature sets. Newer ones like AVX512VL + AVX512F include `vpsraq`, a 128-bit
-;; instruction that would fit here, but this backend does not currently have
-;; support for EVEX encodings. To remedy this, a small dance is done with an
-;; unsigned right shift plus some extra ops.
+;; feature sets. To remedy this, a small dance is done with an unsigned right
+;; shift plus some extra ops.
 ;;
-;; (TODO: when EVEX support is available, add an alternate lowering here).
+;; TODO: add a lowering for `vpsraq` with AVX512{VL,F}
 (rule 1 (lower (has_type $I64X2 (sshr src (iconst (u64_from_imm64 (u64_as_u32 amt))))))
         (lower_i64x2_sshr_imm src (u32_and amt 63)))
 (rule (lower (has_type $I64X2 (sshr src amt)))

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -613,6 +613,16 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn u32_sub(&mut self, a: u32, b: u32) -> u32 {
+            a.wrapping_sub(b)
+        }
+
+        #[inline]
+        fn u32_and(&mut self, a: u32, b: u32) -> u32 {
+            a & b
+        }
+
+        #[inline]
         fn s32_add_fallible(&mut self, a: u32, b: u32) -> Option<u32> {
             let a = a as i32;
             let b = b as i32;

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -121,6 +121,12 @@
 (decl pure u32_add (u32 u32) u32)
 (extern constructor u32_add u32_add)
 
+(decl pure u32_sub (u32 u32) u32)
+(extern constructor u32_sub u32_sub)
+
+(decl pure u32_and (u32 u32) u32)
+(extern constructor u32_and u32_and)
+
 ;; Pure/fallible constructor that tries to add two `u32`s, interpreted
 ;; as signed values, and fails to match on overflow.
 (decl pure partial s32_add_fallible (u32 u32) u32)

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -741,6 +741,118 @@ block0(v0: i32x4):
 ;   popq %rbp
 ;   retq
 
+function %sshr_i64x2_imm1(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i32 1
+    v2 = sshr v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movdqa  %xmm0, %xmm2
+;   psrad   %xmm2, $1, %xmm2
+;   pshufd  $237, %xmm2, %xmm4
+;   movdqa  %xmm0, %xmm6
+;   psrlq   %xmm6, $1, %xmm6
+;   pshufd  $232, %xmm6, %xmm0
+;   punpckldq %xmm0, %xmm4, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   psrad $1, %xmm2
+;   pshufd $0xed, %xmm2, %xmm4
+;   movdqa %xmm0, %xmm6
+;   psrlq $1, %xmm6
+;   pshufd $0xe8, %xmm6, %xmm0
+;   punpckldq %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sshr_i64x2_imm32(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i32 32
+    v2 = sshr v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   pshufd  $237, %xmm0, %xmm5
+;   movdqa  %xmm0, %xmm4
+;   psrad   %xmm4, $31, %xmm4
+;   pshufd  $237, %xmm4, %xmm6
+;   movdqa  %xmm5, %xmm0
+;   punpckldq %xmm0, %xmm6, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   pshufd $0xed, %xmm0, %xmm5
+;   movdqa %xmm0, %xmm4
+;   psrad $0x1f, %xmm4
+;   pshufd $0xed, %xmm4, %xmm6
+;   movdqa %xmm5, %xmm0
+;   punpckldq %xmm6, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sshr_i64x2_imm54(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i32 54
+    v2 = sshr v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movdqa  %xmm0, %xmm2
+;   psrad   %xmm2, $31, %xmm2
+;   pshufd  $237, %xmm2, %xmm4
+;   movdqa  %xmm0, %xmm6
+;   psrad   %xmm6, $22, %xmm6
+;   pshufd  $233, %xmm6, %xmm0
+;   punpckldq %xmm0, %xmm4, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movdqa %xmm0, %xmm2
+;   psrad $0x1f, %xmm2
+;   pshufd $0xed, %xmm2, %xmm4
+;   movdqa %xmm0, %xmm6
+;   psrad $0x16, %xmm6
+;   pshufd $0xe9, %xmm6, %xmm0
+;   punpckldq %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
 function %sshr_i64x2_imm(i64x2) -> i64x2 {
 block0(v0: i64x2):
     v1 = iconst.i32 100
@@ -752,13 +864,13 @@ block0(v0: i64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pextrq  $0, %xmm0, %rdx
-;   pextrq  $1, %xmm0, %r9
-;   sarq    $36, %rdx, %rdx
-;   sarq    $36, %r9, %r9
-;   uninit  %xmm0
-;   pinsrd.w $0, %xmm0, %rdx, %xmm0
-;   pinsrd.w $1, %xmm0, %r9, %xmm0
+;   movdqa  %xmm0, %xmm2
+;   psrad   %xmm2, $31, %xmm2
+;   pshufd  $237, %xmm2, %xmm4
+;   movdqa  %xmm0, %xmm6
+;   psrad   %xmm6, $4, %xmm6
+;   pshufd  $233, %xmm6, %xmm0
+;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -768,12 +880,13 @@ block0(v0: i64x2):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   pextrq $0, %xmm0, %rdx
-;   pextrq $1, %xmm0, %r9
-;   sarq $0x24, %rdx
-;   sarq $0x24, %r9
-;   pinsrq $0, %rdx, %xmm0
-;   pinsrq $1, %r9, %xmm0
+;   movdqa %xmm0, %xmm2
+;   psrad $0x1f, %xmm2
+;   pshufd $0xed, %xmm2, %xmm4
+;   movdqa %xmm0, %xmm6
+;   psrad $4, %xmm6
+;   pshufd $0xe9, %xmm6, %xmm0
+;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -788,14 +901,16 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   pextrq  $0, %xmm0, %r8
-;   pextrq  $1, %xmm0, %r10
 ;   movq    %rdi, %rcx
-;   sarq    %cl, %r8, %r8
-;   sarq    %cl, %r10, %r10
-;   uninit  %xmm0
-;   pinsrd.w $0, %xmm0, %r8, %xmm0
-;   pinsrd.w $1, %xmm0, %r10, %xmm0
+;   andq    %rcx, $63, %rcx
+;   movq    %rcx, %xmm5
+;   movdqu  const(0), %xmm8
+;   psrlq   %xmm8, %xmm5, %xmm8
+;   movdqa  %xmm0, %xmm11
+;   psrlq   %xmm11, %xmm5, %xmm11
+;   movdqa  %xmm8, %xmm0
+;   pxor    %xmm0, %xmm11, %xmm0
+;   psubq   %xmm0, %xmm8, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -805,14 +920,24 @@ block0(v0: i64x2, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   pextrq $0, %xmm0, %r8
-;   pextrq $1, %xmm0, %r10
 ;   movq %rdi, %rcx
-;   sarq %cl, %r8
-;   sarq %cl, %r10
-;   pinsrq $0, %r8, %xmm0
-;   pinsrq $1, %r10, %xmm0
+;   andq $0x3f, %rcx
+;   movq %rcx, %xmm5
+;   movdqu 0x27(%rip), %xmm8
+;   psrlq %xmm5, %xmm8
+;   movdqa %xmm0, %xmm11
+;   psrlq %xmm5, %xmm11
+;   movdqa %xmm8, %xmm0
+;   pxor %xmm11, %xmm0
+;   psubq %xmm8, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -1,8 +1,11 @@
 test run
+target x86_64 ssse3 has_sse41=false
 set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 sse41
+target x86_64 sse42
 target x86_64 skylake
 
 
@@ -93,3 +96,25 @@ block0(v0: i64x2):
 ; run: %i64x2_sshr_const([0x1 0xf]) == [0 0]
 ; run: %i64x2_sshr_const([0x100000000 0]) == [1 0]
 ; run: %i64x2_sshr_const([-1 -1]) == [-1 -1]
+
+function %i64x2_sshr_const2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i32 8
+    v2 = sshr v0, v1
+    return v2
+}
+; run: %i64x2_sshr_const2([0x1 0xf]) == [0 0]
+; run: %i64x2_sshr_const2([0x100000000 0]) == [0x1000000 0]
+; run: %i64x2_sshr_const2([-1 -1]) == [-1 -1]
+
+function %i64x2_sshr_const3(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i32 40
+    v2 = sshr v0, v1
+    return v2
+}
+; run: %i64x2_sshr_const3([0x1 0xf]) == [0 0]
+; run: %i64x2_sshr_const3([0x10000000000 0]) == [1 0]
+; run: %i64x2_sshr_const3([-1 -1]) == [-1 -1]
+; run: %i64x2_sshr_const3([0x8000000080000000 0x8000000080000000]) == [0xffffffffff800000 0xffffffffff800000]
+


### PR DESCRIPTION
The previous implementation fell back to a scalar implementation by extracting lanes and re-inserting them. These operations are significantly more complicated without SSE 4.1, however. Comparing against LLVM's lowerings, as well, it looks like a different strategy is used which avoids extracting and inserting lanes. This commit updates to follow the strategy matched by LLVM's lowerings which additionally has the benefit of providing a non-SSE4.1 implementation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
