### PR TITLE
wit-bindgen error types: resolve type definition id by chasing alias ids

### DIFF
--- a/crates/wit-bindgen/src/types.rs
+++ b/crates/wit-bindgen/src/types.rs
@@ -95,7 +95,8 @@ impl Types {
                 _ => continue,
             };
             if let Some(Type::Id(id)) = err {
-                self.type_info.get_mut(id).unwrap().error = true;
+                let id = super::resolve_type_definition_id(resolve, *id);
+                self.type_info.get_mut(&id).unwrap().error = true;
             }
         }
     }


### PR DESCRIPTION
TypeInfo's error field is set when a type is used in a `_ -> result<_, E>` position. When the type is `use`d in another interface, it is given a different identifier. Chase this down to the definition identifier so that the definition is given the error treatment.