### PR TITLE
Fix link integrating with Wasmtime link

### DIFF
--- a/crates/wiggle/README.md
+++ b/crates/wiggle/README.md
@@ -10,7 +10,7 @@ in at least Wasmtime and Lucet.
 
 Read the docs on [docs.rs](https://docs.rs/wiggle/).
 
-There are child crates for [integrating with Wasmtime](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wiggle/wasmtime) and [Lucet](https://github.com/bytecodealliance/lucet/tree/main/lucet-wiggle).
+There are child crates for [integrating with Wasmtime](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wiggle) (this crate), and [Lucet](https://github.com/bytecodealliance/lucet/tree/main/lucet-wiggle).
 
 The [wasi-common crate](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-common) is implemented using Wiggle and the [wasmtime-wasi
 crate](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi) integrates wasi-common with the Wasmtime engine.


### PR DESCRIPTION
This commit updates the "integrating with Wasmtime" link in crates/wiggle/README.md which currently results in a 404 Not Found.

I hope the link in this commit is correct, but if not hopefully someone will point out the correct page this link should point to if this is not the case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
