### PR TITLE
cranelift-interpreter: Fix panic when bitcasting SIMD values

### DIFF
--- a/cranelift/filetests/filetests/runtests/simd-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast.clif
@@ -35,3 +35,19 @@ block0(v0: f64x2):
 }
 ; run: %bitcast_fi64x2([0x0.0 -NaN:0x7ffffffffffff]) == [0 18446744073709551615]
 ; run: %bitcast_fi64x2([-NaN:0x7ffffffffffff 0x0.000000000007fp-1022]) == [-1 127]
+
+function %bitcast_more_lanes_little(i64x2) -> i32x4 {
+block0(v0: i64x2):
+    v1 = bitcast.i32x4 little v0
+    return v1
+}
+; run: %bitcast_more_lanes_little(0x00000000000000000000000000000000) == 0x00000000000000000000000000000000
+; run: %bitcast_more_lanes_little(0x00000000000000ff00000000000000ff) == 0x00000000000000ff00000000000000ff
+
+function %bitcast_fewer_lanes_little(i16x8) -> i64x2 {
+block0(v0: i16x8):
+    v1 = bitcast.i64x2 little v0
+    return v1
+}
+; run: %bitcast_fewer_lanes_little(0x00000000000000000000000000000000) == 0x00000000000000000000000000000000
+; run: %bitcast_fewer_lanes_little(0x00ff0000000000000000000000000000) == 0x00ff0000000000000000000000000000


### PR DESCRIPTION
Fixes panic caused due to exceeding expected bounds when creating vector values, as mentioned over at #5915

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
