### PR TITLE
Switch wasmtime-wasi-http to using Wasmtime's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "0.0.2"
+version = "10.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ cranelift-bforest = { path = "cranelift/bforest", version = "0.97.0" }
 cranelift-control = { path = "cranelift/control", version = "0.97.0" }
 cranelift = { path = "cranelift/umbrella", version = "0.97.0" }
 
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=0.0.2" }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=10.0.0" }
 
 winch-codegen = { path = "winch/codegen", version = "=0.8.0" }
 winch-environ = { path = "winch/environ", version = "=0.8.0" }

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-http"
-version = "0.0.2"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"


### PR DESCRIPTION
This should use the same versioning scheme as all the other `wasmtime-*` crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
