### PR TITLE
[9.0.0] Switch wasmtime-wasi-http to using Wasmtime's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "0.0.1"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ cranelift-bforest = { path = "cranelift/bforest", version = "0.96.0" }
 cranelift-control = { path = "cranelift/control", version = "0.96.0" }
 cranelift = { path = "cranelift/umbrella", version = "0.96.0" }
 
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=0.0.1" }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=9.0.0" }
 
 winch-codegen = { path = "winch/codegen", version = "=0.7.0" }
 winch-environ = { path = "winch/environ", version = "=0.7.0" }

--- a/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/uextend-elision.clif
@@ -12,7 +12,8 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     0(%rdi,%rsi,1), %eax
+;   movq    %rdi, %rax
+;   addl    %eax, %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -22,7 +23,8 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leal (%rdi, %rsi), %eax
+;   movq %rdi, %rax
+;   addl %esi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmtime-wasi-http"
-version = "0.0.1"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"


### PR DESCRIPTION
This should use the same versioning scheme as all the other `wasmtime-*` crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
