### PR TITLE
Fix some warnings on nightly Rust

### DIFF
--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -101,7 +101,7 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// Called after the locals for a function have been parsed, and the number
     /// of variables defined by this function is provided.
     fn after_locals(&mut self, num_locals_defined: usize) {
-        drop(num_locals_defined);
+        let _ = num_locals_defined;
     }
 
     /// Set up the necessary preamble definitions in `func` to access the global variable
@@ -560,7 +560,7 @@ pub trait ModuleEnvironment<'data> {
     /// Translates a type index to its signature index, only called for type
     /// indices which point to functions.
     fn type_to_signature(&self, index: TypeIndex) -> WasmResult<SignatureIndex> {
-        drop(index);
+        let _ = index;
         Err(WasmError::Unsupported("module linking".to_string()))
     }
 
@@ -601,7 +601,7 @@ pub trait ModuleEnvironment<'data> {
         module: &'data str,
         field: &'data str,
     ) -> WasmResult<()> {
-        drop((tag, module, field));
+        let _ = (tag, module, field);
         Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
@@ -653,7 +653,7 @@ pub trait ModuleEnvironment<'data> {
 
     /// Declares an tag to the environment
     fn declare_tag(&mut self, tag: Tag) -> WasmResult<()> {
-        drop(tag);
+        let _ = tag;
         Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
@@ -688,7 +688,7 @@ pub trait ModuleEnvironment<'data> {
 
     /// Declares an tag export to the environment.
     fn declare_tag_export(&mut self, tag_index: TagIndex, name: &'data str) -> WasmResult<()> {
-        drop((tag_index, name));
+        let _ = (tag_index, name);
         Err(WasmError::Unsupported("wasm tags".to_string()))
     }
 
@@ -732,7 +732,7 @@ pub trait ModuleEnvironment<'data> {
     /// Indicates that a declarative element segment was seen in the wasm
     /// module.
     fn declare_elements(&mut self, elements: Box<[FuncIndex]>) -> WasmResult<()> {
-        drop(elements);
+        let _ = elements;
         Ok(())
     }
 
@@ -751,7 +751,7 @@ pub trait ModuleEnvironment<'data> {
     /// Indicates how many functions the code section reports and the byte
     /// offset of where the code sections starts.
     fn reserve_function_bodies(&mut self, bodies: u32, code_section_offset: u64) {
-        drop((bodies, code_section_offset));
+        let _ = (bodies, code_section_offset);
     }
 
     /// Provides the contents of a function body.

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -670,12 +670,11 @@ impl<'a, 'data> Translator<'a, 'data> {
                 for alias in s {
                     let init = match alias? {
                         wasmparser::ComponentAlias::InstanceExport {
-                            kind,
+                            kind: _,
                             instance_index,
                             name,
                         } => {
                             let instance = ComponentInstanceIndex::from_u32(instance_index);
-                            drop(kind);
                             self.alias_component_instance_export(instance, name);
                             LocalInitializer::AliasComponentExport(instance, name)
                         }

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -263,7 +263,7 @@ mod tests {
         let b = SetOnDrop(a.clone());
         let fiber =
             Fiber::<(), (), ()>::new(FiberStack::new(1024 * 1024).unwrap(), move |(), _s| {
-                drop(&b);
+                let _ = &b;
                 panic!();
             })
             .unwrap();

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -508,7 +508,7 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
 
             ApiCall::InstanceDrop { id } => {
                 log::trace!("dropping instance {}", id);
-                drop(instances.remove(&id));
+                instances.remove(&id);
             }
 
             ApiCall::CallExportedFunc { instance, nth } => {

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -41,7 +41,7 @@ impl DiffEngine for SpecInterpreter {
 
     fn assert_error_match(&self, trap: &Trap, err: &Error) {
         // TODO: implement this for the spec interpreter
-        drop((trap, err));
+        let _ = (trap, err);
     }
 
     fn is_stack_overflow(&self, err: &Error) -> bool {

--- a/crates/runtime/src/externref.rs
+++ b/crates/runtime/src/externref.rs
@@ -219,8 +219,6 @@ impl Drop for VMExternRef {
         }
         atomic::fence(Ordering::Acquire);
 
-        // Drop our live reference to `data` before we drop it itself.
-        drop(data);
         unsafe {
             VMExternData::drop_and_dealloc(self.0);
         }

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -90,7 +90,7 @@ impl StorePtr {
 pub unsafe trait InstanceAllocator {
     /// Validates that a module is supported by the allocator.
     fn validate(&self, module: &Module, offsets: &VMOffsets<HostPtr>) -> Result<()> {
-        drop((module, offsets));
+        let _ = (module, offsets);
         Ok(())
     }
 
@@ -419,7 +419,7 @@ pub struct OnDemandInstanceAllocator {
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
     pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
-        drop(stack_size); // suppress unused warnings w/o async feature
+        let _ = stack_size; // suppress unused warnings w/o async feature
         Self {
             mem_creator,
             #[cfg(feature = "async")]

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -251,7 +251,7 @@ unsafe fn get_pc_and_fp(cx: *mut libc::c_void, _signum: libc::c_int) -> (*const 
 unsafe fn set_pc(cx: *mut libc::c_void, pc: usize, arg1: usize) {
     cfg_if::cfg_if! {
         if #[cfg(not(target_os = "macos"))] {
-            drop((cx, pc, arg1));
+            let _ = (cx, pc, arg1);
             unreachable!(); // not used on these platforms
         } else if #[cfg(target_arch = "x86_64")] {
             let cx = &mut *(cx as *mut libc::ucontext_t);

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -356,7 +356,7 @@ where
     T: std::ops::DerefMut<Target = StoreOpaque>,
 {
     pub fn new(mut store: T) -> Self {
-        drop(&mut store);
+        let _ = &mut store;
         #[cfg(debug_assertions)]
         {
             let prev_okay = store.externref_activations_table.set_gc_okay(false);
@@ -1979,7 +1979,7 @@ impl<T> StoreInner<T> {
         {
             self.epoch_deadline_behavior = EpochDeadline::YieldAndExtendDeadline { delta };
         }
-        drop(delta); // suppress warning in non-async build
+        let _ = delta; // suppress warning in non-async build
     }
 
     fn get_epoch_deadline(&self) -> u64 {

--- a/tests/all/async_functions.rs
+++ b/tests/all/async_functions.rs
@@ -275,7 +275,7 @@ async fn cancel_during_run() {
                 // SetOnDrop is not destroyed when dropping the reference of it
                 // here. Instead, it is moved into the future where it's forced
                 // to live in and will be destroyed at the end of the future.
-                drop(&dtor);
+                let _ = &dtor;
                 tokio::task::yield_now().await;
                 Ok(())
             })

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -416,7 +416,7 @@ fn dtor_runs() {
     let a = A;
     assert_eq!(HITS.load(SeqCst), 0);
     Func::wrap(&mut store, move || {
-        drop(&a);
+        let _ = &a;
     });
     drop(store);
     assert_eq!(HITS.load(SeqCst), 1);
@@ -436,7 +436,9 @@ fn dtor_delayed() -> Result<()> {
 
     let mut store = Store::<()>::default();
     let a = A;
-    let func = Func::wrap(&mut store, move || drop(&a));
+    let func = Func::wrap(&mut store, move || {
+        let _ = &a;
+    });
 
     assert_eq!(HITS.load(SeqCst), 0);
     let wasm = wat::parse_str(r#"(import "" "" (func))"#)?;
@@ -993,7 +995,7 @@ fn trap_doesnt_leak() -> anyhow::Result<()> {
     let canary1 = Canary::default();
     let dtor1_run = canary1.0.clone();
     let f1 = Func::wrap(&mut store, move || -> Result<()> {
-        drop(&canary1);
+        let _ = &canary1;
         bail!("")
     });
     assert!(f1.typed::<(), ()>(&store)?.call(&mut store, ()).is_err());
@@ -1003,7 +1005,7 @@ fn trap_doesnt_leak() -> anyhow::Result<()> {
     let canary2 = Canary::default();
     let dtor2_run = canary2.0.clone();
     let f2 = Func::new(&mut store, FuncType::new(None, None), move |_, _, _| {
-        drop(&canary2);
+        let _ = &canary2;
         bail!("")
     });
     assert!(f2.typed::<(), ()>(&store)?.call(&mut store, ()).is_err());

--- a/tests/all/funcref.rs
+++ b/tests/all/funcref.rs
@@ -110,7 +110,9 @@ fn wrong_store() -> anyhow::Result<()> {
         let mut store2 = Store::<()>::default();
 
         let set = SetOnDrop(dropped.clone());
-        let f1 = Func::wrap(&mut store1, move || drop(&set));
+        let f1 = Func::wrap(&mut store1, move || {
+            let _ = &set;
+        });
         let f2 = Func::wrap(&mut store2, move || Some(f1.clone()));
         assert!(f2.call(&mut store2, &[], &mut []).is_err());
     }
@@ -136,7 +138,9 @@ fn func_new_returns_wrong_store() -> anyhow::Result<()> {
         let mut store2 = Store::<()>::default();
 
         let set = SetOnDrop(dropped.clone());
-        let f1 = Func::wrap(&mut store1, move || drop(&set));
+        let f1 = Func::wrap(&mut store1, move || {
+            let _ = &set;
+        });
         let f2 = Func::new(
             &mut store2,
             FuncType::new(None, Some(ValType::FuncRef)),

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -73,7 +73,6 @@ fn use_after_drop() -> anyhow::Result<()> {
     let g = instance.get_global(&mut store, "foo").unwrap();
     assert_eq!(g.get(&mut store).i32(), Some(100));
     g.set(&mut store, 101.into())?;
-    drop(instance);
     assert_eq!(g.get(&mut store).i32(), Some(101));
     Instance::new(&mut store, &module, &[])?;
     assert_eq!(g.get(&mut store).i32(), Some(101));

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -61,7 +61,7 @@ fn drop_func() -> Result<()> {
 
     let a = A;
     linker.func_wrap("", "", move || {
-        drop(&a);
+        let _ = &a;
     })?;
 
     assert_eq!(HITS.load(SeqCst), 0);
@@ -70,7 +70,7 @@ fn drop_func() -> Result<()> {
 
     let a = A;
     linker.func_wrap("", "", move || {
-        drop(&a);
+        let _ = &a;
     })?;
 
     assert_eq!(HITS.load(SeqCst), 1);
@@ -98,7 +98,9 @@ fn drop_delayed() -> Result<()> {
     let mut linker = Linker::<()>::new(&engine);
 
     let a = A;
-    linker.func_wrap("", "", move || drop(&a))?;
+    linker.func_wrap("", "", move || {
+        let _ = &a;
+    })?;
 
     assert_eq!(HITS.load(SeqCst), 0);
 
@@ -642,7 +644,7 @@ fn call_via_funcref() -> Result<()> {
     let mut linker = Linker::new(&engine);
     let a = A;
     linker.func_wrap("", "", move |x: i32, y: i32| {
-        drop(&a);
+        let _ = &a;
         x + y
     })?;
 

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -251,7 +251,9 @@ fn no_leak_with_imports() -> Result<()> {
         let mut store = Store::new(&Engine::default(), DropMe(flag.clone()));
         let mut linker = Linker::new(store.engine());
         let drop_me = DropMe(flag.clone());
-        linker.func_wrap("", "", move || drop(&drop_me))?;
+        linker.func_wrap("", "", move || {
+            let _ = &drop_me;
+        })?;
         let module = Module::new(
             store.engine(),
             r#"
@@ -296,7 +298,9 @@ fn funcs_live_on_to_fight_another_day() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
     let drop_me = DropMe(flag.clone());
-    linker.func_wrap("", "", move || drop(&drop_me))?;
+    linker.func_wrap("", "", move || {
+        let _ = &drop_me;
+    })?;
     assert_eq!(flag.load(SeqCst), 0);
 
     let get_and_call = || -> Result<()> {

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -587,7 +587,7 @@ fn drop_externref_global_during_module_init() -> Result<()> {
     )?;
 
     let mut store = Store::new(&engine, Limiter);
-    drop(Instance::new(&mut store, &module, &[])?);
+    Instance::new(&mut store, &module, &[])?;
     drop(store);
 
     let module = Module::new(

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -26,7 +26,7 @@ macro_rules! def_unsupported {
 		$op
 
 		fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
-		    $($(drop($arg);)*)?
+		    $($(let _ = $arg;)*)?
 		    todo!(stringify!($op))
 		}
 	    );


### PR DESCRIPTION
Upstream rust has decided that ignoring a value is not spelled `drop(foo)` but instead it's spelled `let _ = foo`

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
