### PR TITLE
Fix scheme for URIs, add coverage to detect regressions in the future.

### DIFF
--- a/crates/test-programs/tests/http_tests/runtime/wasi_http_tests.rs
+++ b/crates/test-programs/tests/http_tests/runtime/wasi_http_tests.rs
@@ -18,6 +18,7 @@ async fn test(
     Response::builder()
         .status(http::StatusCode::OK)
         .header("x-wasmtime-test-method", method)
+        .header("x-wasmtime-test-uri", req.uri().to_string())
         .body(req.into_body().boxed())
 }
 

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
@@ -116,6 +116,8 @@ fn main() -> Result<()> {
     assert_eq!(r1.status, 200);
     let method = r1.header("x-wasmtime-test-method").unwrap();
     assert_eq!(method, "GET");
+    let uri = r1.header("x-wasmtime-test-uri").unwrap();
+    assert_eq!(uri, "http://localhost:3000/get?some=arg?goes=here");
     assert_eq!(r1.body, b"");
 
     let r2 = request(

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -82,14 +82,11 @@ impl WasiHttp {
             crate::types::Method::Other(s) => bail!("unknown method {}", s),
         };
 
-        let scheme = format!(
-            "{}://",
-            match request.scheme.as_ref().unwrap_or(&Scheme::Https) {
-                Scheme::Http => "http://",
-                Scheme::Https => "https://",
-                Scheme::Other(s) => bail!("unsupported scheme {}", s),
-            }
-        );
+        let scheme = match request.scheme.as_ref().unwrap_or(&Scheme::Https) {
+            Scheme::Http => "http://",
+            Scheme::Https => "https://",
+            Scheme::Other(s) => bail!("unsupported scheme {}", s),
+        };
 
         // Largely adapted from https://hyper.rs/guides/1/client/basic/
         let authority = match request.authority.find(":") {


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/pull/6357 broke the scheme formatting by adding an extra `://` but the tests didn't have enough coverage to catch it.

Improve the tests, fix the bug.

cc @pchickey @eduardomourar 