### PR TITLE
Basic guest-profiler documentation for the book

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Profiling WebAssembly](./examples-profiling.md)
     - [Profiling with Perf](./examples-profiling-perf.md)
     - [Profiling with VTune](./examples-profiling-vtune.md)
+    - [Cross-platform Profiling](./examples-profiling-guest.md)
   - [Embedding in Rust](./examples-rust-embed.md)
     - [Hello, world!](./examples-rust-hello-world.md)
     - [Calculating the GCD](./examples-rust-gcd.md)

--- a/docs/examples-profiling-guest.md
+++ b/docs/examples-profiling-guest.md
@@ -1,0 +1,14 @@
+# Using Wasmtime's cross-platform profiler
+
+The guest profiling strategy enables in-process sampling and will write the
+captured profile to a file which can be viewed at
+<https://profiler.firefox.com/>.
+
+To use this profiler with the Wasmtime CLI, pass the
+`--profile=guest[,path[,interval]]` flag.
+
+- `path` is where to write the profile, `wasmtime-guest-profile.json` by default
+- `interval` is the duration between samples, 10ms by default
+
+When used with `--wasm-timeout`, the timeout will be rounded up to the nearest
+multiple of the profiling interval.

--- a/docs/examples-profiling.md
+++ b/docs/examples-profiling.md
@@ -16,8 +16,11 @@ platforms. See the following sections of this book if you're using these
 platforms:
 
 - On Linux, we support [perf](./examples-profiling-perf.md).
+
 - For Intel's x86 CPUs on Linux or Windows, we support
   [VTune](./examples-profiling-vtune.md).
+
+- For everything else, see the cross-platform profiler below.
 
 The native profilers can measure time spent in WebAssembly guest code as well as
 time spent in the Wasmtime host and potentially even time spent in the kernel.

--- a/docs/examples-profiling.md
+++ b/docs/examples-profiling.md
@@ -6,8 +6,25 @@ well your Wasm module is performing! From time to time you might want to dive a
 bit deeper into the performance of your Wasm, and this is where profiling comes
 into the picture.
 
-Profiling support in Wasmtime is still under development, but if you're using
-either [perf](./examples-profiling-perf.md) or
-[VTune](./examples-profiling-vtune.md) the examples in these sections are
-targeted at helping you get some information about the performance of your Wasm
-modules.
+For best results, ideally you'd use hardware performance counters for your
+timing measurements. However, that requires special support from your CPU and
+operating system. Because Wasmtime is a JIT, that also requires hooks from
+Wasmtime to your platform's native profiling tools.
+
+As a result, Wasmtime support for native profiling is limited to certain
+platforms. See the following sections of this book if you're using these
+platforms:
+
+- On Linux, we support [perf](./examples-profiling-perf.md).
+- For Intel's x86 CPUs on Linux or Windows, we support
+  [VTune](./examples-profiling-vtune.md).
+
+The native profilers can measure time spent in WebAssembly guest code as well as
+time spent in the Wasmtime host and potentially even time spent in the kernel.
+This provides a comprehensive view of performance.
+
+If the native profiling tools don't work for you, Wasmtime also provides a
+[cross-platform profiler](./examples-profiling-guest.md). This profiler can only
+measure time spent in WebAssembly guest code, and its timing measurements are
+not as precise as the native profilers. However, it works on every platform that
+Wasmtime supports.


### PR DESCRIPTION
This isn't nearly as detailed as the other profiling chapters but I'm struggling to figure out what's important to say. I'd welcome feedback, although of course we can merge this and fill in details later.

This documentation reflects the changes merged in #6362, but that merged after the 9.0 branch was created. Perhaps we should backport that PR to 9.0 so the older CLI flags never appear in a release?