### PR TITLE
riscv64: Add `extractlane` and `splat` instructions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -253,14 +253,8 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
                 "simd_load64_lane",
                 "simd_load8_lane",
                 "simd_load_extend",
-                "simd_load_splat",
                 "simd_load_zero",
                 "simd_splat",
-                "simd_store16_lane",
-                "simd_store32_lane",
-                "simd_store64_lane",
-                "simd_store8_lane",
-                "spillslot_size_fuzzbug",
                 "v128_select",
             ]
             .contains(&testname);

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -343,6 +343,12 @@
       (vs Reg)
       (vstate VState))
 
+    (VecAluRImm5
+      (op VecAluOpRImm5)
+      (vd WritableReg)
+      (imm Imm5)
+      (vstate VState))
+
     (VecSetState
       (rd WritableReg)
       (vstate VState))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -337,6 +337,12 @@
       (imm Imm5)
       (vstate VState))
 
+    (VecAluRR
+      (op VecAluOpRR)
+      (vd WritableReg)
+      (vs Reg)
+      (vstate VState))
+
     (VecSetState
       (rd WritableReg)
       (vstate VState))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1358,6 +1358,10 @@
 
 ;; UImm5 Helpers
 
+;; Extract a `UImm5` from an `u8`.
+(decl pure partial uimm5_from_u8 (UImm5) u8)
+(extern extractor uimm5_from_u8 uimm5_from_u8)
+
 (decl uimm5_bitcast_to_imm5 (UImm5) Imm5)
 (extern constructor uimm5_bitcast_to_imm5 uimm5_bitcast_to_imm5)
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1356,9 +1356,6 @@
 
 ;; Imm5 Extractors
 
-(decl pure imm5_zero () Imm5)
-(extern constructor imm5_zero imm5_zero)
-
 (decl imm5_from_u64 (Imm5) u64)
 (extern extractor imm5_from_u64 imm5_from_u64)
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1353,6 +1353,10 @@
 (extractor (replicated_imm5 n)
   (def_inst (splat (iconst (u64_from_imm64 (imm5_from_u64 n))))))
 
+;; UImm5 Helpers
+
+(decl uimm5_bitcast_to_imm5 (UImm5) Imm5)
+(extern constructor uimm5_bitcast_to_imm5 uimm5_bitcast_to_imm5)
 
 ;; Float Helpers
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1344,6 +1344,9 @@
 
 ;; Imm5 Extractors
 
+(decl pure imm5_zero () Imm5)
+(extern constructor imm5_zero imm5_zero)
+
 (decl imm5_from_u64 (Imm5) u64)
 (extern extractor imm5_from_u64 imm5_from_u64)
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -469,6 +469,7 @@ impl Inst {
 
             Inst::VecAluRR { vstate, .. } |
             Inst::VecAluRRR { vstate, .. } |
+            Inst::VecAluRImm5 { vstate, .. } |
             Inst::VecAluRRImm5 { vstate, .. } |
             // TODO: Unit-stride loads and stores only need the AVL to be correct, not
             // the full vtype. A future optimization could be to decouple these two when
@@ -2824,6 +2825,11 @@ impl MachInstEmit for Inst {
                 let vd = allocs.next_writable(vd);
 
                 sink.put4(encode_valu_rr(op, vd, vs, VecOpMasking::Disabled));
+            }
+            &Inst::VecAluRImm5 { op, vd, imm, .. } => {
+                let vd = allocs.next_writable(vd);
+
+                sink.put4(encode_valu_r_imm(op, vd, imm, VecOpMasking::Disabled));
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd = allocs.next_writable(rd);

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -2816,6 +2816,13 @@ impl MachInstEmit for Inst {
                 let vs2 = allocs.next(vs2);
                 let vd = allocs.next_writable(vd);
 
+                let imm = if let Some(aux) = op.aux_encoding() {
+                    debug_assert_eq!(imm.bits(), 0);
+                    aux
+                } else {
+                    imm
+                };
+
                 sink.put4(encode_valu_imm(op, vd, imm, vs2, VecOpMasking::Disabled));
             }
             &Inst::VecSetState { rd, ref vstate } => {

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -467,6 +467,7 @@ impl Inst {
             // VecSetState does not expect any vstate, rather it updates it.
             Inst::VecSetState { .. } => None,
 
+            Inst::VecAluRR { vstate, .. } |
             Inst::VecAluRRR { vstate, .. } |
             Inst::VecAluRRImm5 { vstate, .. } |
             // TODO: Unit-stride loads and stores only need the AVL to be correct, not
@@ -2816,14 +2817,13 @@ impl MachInstEmit for Inst {
                 let vs2 = allocs.next(vs2);
                 let vd = allocs.next_writable(vd);
 
-                let imm = if let Some(aux) = op.aux_encoding() {
-                    debug_assert_eq!(imm.bits(), 0);
-                    aux
-                } else {
-                    imm
-                };
-
                 sink.put4(encode_valu_imm(op, vd, imm, vs2, VecOpMasking::Disabled));
+            }
+            &Inst::VecAluRR { op, vd, vs, .. } => {
+                let vs = allocs.next(vs);
+                let vd = allocs.next_writable(vd);
+
+                sink.put4(encode_valu_rr(op, vd, vs, VecOpMasking::Disabled));
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd = allocs.next_writable(rd);

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,7 +9,8 @@
 use super::{Imm12, Imm5, UImm5, VType};
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpCategory, VecOpMasking,
+    VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpCategory,
+    VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
 use crate::Reg;
@@ -153,6 +154,29 @@ pub fn encode_valu_rr(op: VecAluOpRR, vd: WritableReg, vs: Reg, masking: VecOpMa
     } else {
         (reg_to_gpr_num(vs), op.aux_encoding())
     };
+
+    encode_r_type_bits(
+        op.opcode(),
+        reg_to_gpr_num(vd.to_reg()),
+        op.funct3(),
+        vs1,
+        vs2,
+        funct7,
+    )
+}
+
+pub fn encode_valu_r_imm(
+    op: VecAluOpRImm5,
+    vd: WritableReg,
+    imm: Imm5,
+    masking: VecOpMasking,
+) -> u32 {
+    let funct7 = (op.funct6() << 1) | masking.encode();
+
+    // This is true for this opcode, not sure if there are any other ones.
+    debug_assert_eq!(op, VecAluOpRImm5::VmvVI);
+    let vs1 = imm.bits() as u32;
+    let vs2 = op.aux_encoding();
 
     encode_r_type_bits(
         op.opcode(),

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,7 +9,7 @@
 use super::{Imm12, Imm5, UImm5, VType};
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpCategory, VecOpMasking,
+    VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
 use crate::Reg;
@@ -141,6 +141,25 @@ pub fn encode_valu_imm(
         op.funct3(),
         imm,
         reg_to_gpr_num(vs2),
+        funct7,
+    )
+}
+
+pub fn encode_valu_rr(op: VecAluOpRR, vd: WritableReg, vs: Reg, masking: VecOpMasking) -> u32 {
+    let funct7 = (op.funct6() << 1) | masking.encode();
+
+    let (vs1, vs2) = if op.vs_is_vs2_encoded() {
+        (op.aux_encoding(), reg_to_gpr_num(vs))
+    } else {
+        (reg_to_gpr_num(vs), op.aux_encoding())
+    };
+
+    encode_r_type_bits(
+        op.opcode(),
+        reg_to_gpr_num(vd.to_reg()),
+        op.funct3(),
+        vs1,
+        vs2,
         funct7,
     )
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -143,6 +143,12 @@ impl Imm5 {
         }
     }
 
+    pub fn from_bits(value: u8) -> Imm5 {
+        assert_eq!(value & 0x1f, value);
+        let signed = ((value << 3) as i8) >> 3;
+        Imm5 { value: signed }
+    }
+
     /// Bits for encoding.
     pub fn bits(&self) -> u8 {
         self.value as u8 & 0x1f

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -649,6 +649,11 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(vs);
             collector.reg_def(vd);
         }
+        &Inst::VecAluRImm5 { vd, .. } => {
+            debug_assert_eq!(vd.to_reg().class(), RegClass::Vector);
+
+            collector.reg_def(vd);
+        }
         &Inst::VecSetState { rd, .. } => {
             collector.reg_def(rd);
         }
@@ -1612,6 +1617,16 @@ impl Inst {
                 let vd_s = format_reg(vd.to_reg(), allocs);
 
                 format!("{} {},{} {}", op, vd_s, vs_s, vstate)
+            }
+            &Inst::VecAluRImm5 {
+                op,
+                vd,
+                imm,
+                ref vstate,
+            } => {
+                let vd_s = format_reg(vd.to_reg(), allocs);
+
+                format!("{} {},{} {}", op, vd_s, imm, vstate)
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd_s = format_reg(rd.to_reg(), allocs);

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1585,7 +1585,15 @@ impl Inst {
                 let vs2_s = format_reg(vs2, allocs);
                 let vd_s = format_reg(vd.to_reg(), allocs);
 
-                format!("{} {},{},{} {}", op, vd_s, vs2_s, imm, vstate)
+                // Some opcodes interpret the immediate as unsigned, lets show the
+                // correct number here.
+                let imm_s = if op.imm_is_unsigned() {
+                    format!("{}", imm.bits())
+                } else {
+                    format!("{}", imm)
+                };
+
+                format!("{} {},{},{} {}", op, vd_s, vs2_s, imm_s, vstate)
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd_s = format_reg(rd.to_reg(), allocs);

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 
-use super::lower::isle::generated_code::{VecAMode, VecAluOpRRImm5, VecElementWidth};
+use super::lower::isle::generated_code::{VecAMode, VecElementWidth};
 use crate::binemit::{Addend, CodeOffset, Reloc};
 pub use crate::ir::condcodes::IntCC;
 use crate::ir::types::{self, F32, F64, I128, I16, I32, I64, I8, I8X16, R32, R64};
@@ -635,11 +635,18 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_use(vs2);
             collector.reg_def(vd);
         }
-        &Inst::VecAluRRImm5 { op, vd, vs2, .. } => {
-            debug_assert_eq!(vd.to_reg().class(), op.dst_regclass());
-            debug_assert_eq!(vs2.class(), op.src_regclass());
+        &Inst::VecAluRRImm5 { vd, vs2, .. } => {
+            debug_assert_eq!(vd.to_reg().class(), RegClass::Vector);
+            debug_assert_eq!(vs2.class(), RegClass::Vector);
 
             collector.reg_use(vs2);
+            collector.reg_def(vd);
+        }
+        &Inst::VecAluRR { op, vd, vs, .. } => {
+            debug_assert_eq!(vd.to_reg().class(), op.dst_regclass());
+            debug_assert_eq!(vs.class(), op.src_regclass());
+
+            collector.reg_use(vs);
             collector.reg_def(vd);
         }
         &Inst::VecSetState { rd, .. } => {
@@ -1585,25 +1592,26 @@ impl Inst {
                 let vs2_s = format_reg(vs2, allocs);
                 let vd_s = format_reg(vd.to_reg(), allocs);
 
-                match op {
-                    VecAluOpRRImm5::VmvSX
-                    | VecAluOpRRImm5::VmvXS
-                    | VecAluOpRRImm5::VfmvSF
-                    | VecAluOpRRImm5::VfmvFS => {
-                        format!("{} {},{} {}", op, vd_s, vs2_s, vstate)
-                    }
-                    _ => {
-                        // Some opcodes interpret the immediate as unsigned, lets show the
-                        // correct number here.
-                        let imm_s = if op.imm_is_unsigned() {
-                            format!("{}", imm.bits())
-                        } else {
-                            format!("{}", imm)
-                        };
+                // Some opcodes interpret the immediate as unsigned, lets show the
+                // correct number here.
+                let imm_s = if op.imm_is_unsigned() {
+                    format!("{}", imm.bits())
+                } else {
+                    format!("{}", imm)
+                };
 
-                        format!("{} {},{},{} {}", op, vd_s, vs2_s, imm_s, vstate)
-                    }
-                }
+                format!("{} {},{},{} {}", op, vd_s, vs2_s, imm_s, vstate)
+            }
+            &Inst::VecAluRR {
+                op,
+                vd,
+                vs,
+                ref vstate,
+            } => {
+                let vs_s = format_reg(vs, allocs);
+                let vd_s = format_reg(vd.to_reg(), allocs);
+
+                format!("{} {},{} {}", op, vd_s, vs_s, vstate)
             }
             &Inst::VecSetState { rd, ref vstate } => {
                 let rd_s = format_reg(rd.to_reg(), allocs);

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -260,6 +260,7 @@ impl VecAluOpRRR {
             VecAluOpRRR::VandVV => 0b001001,
             VecAluOpRRR::VorVV => 0b001010,
             VecAluOpRRR::VxorVV => 0b001011,
+            VecAluOpRRR::VslidedownVX => 0b001111,
         }
     }
 
@@ -273,9 +274,10 @@ impl VecAluOpRRR {
             VecAluOpRRR::VmulVV | VecAluOpRRR::VmulhVV | VecAluOpRRR::VmulhuVV => {
                 VecOpCategory::OPMVV
             }
-            VecAluOpRRR::VaddVX | VecAluOpRRR::VsubVX | VecAluOpRRR::VrsubVX => {
-                VecOpCategory::OPIVX
-            }
+            VecAluOpRRR::VaddVX
+            | VecAluOpRRR::VsubVX
+            | VecAluOpRRR::VrsubVX
+            | VecAluOpRRR::VslidedownVX => VecOpCategory::OPIVX,
         }
     }
 
@@ -312,6 +314,14 @@ impl VecAluOpRRImm5 {
         match self {
             VecAluOpRRImm5::VaddVI => 0b000000,
             VecAluOpRRImm5::VrsubVI => 0b000011,
+            VecAluOpRRImm5::VslidedownVI => 0b001111,
+        }
+    }
+
+    pub fn imm_is_unsigned(&self) -> bool {
+        match self {
+            VecAluOpRRImm5::VslidedownVI => true,
+            VecAluOpRRImm5::VaddVI | VecAluOpRRImm5::VrsubVI => false,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1,8 +1,8 @@
 use crate::isa::riscv64::inst::AllocationConsumer;
 use crate::isa::riscv64::inst::EmitState;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAMode, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth, VecLmul,
-    VecMaskMode, VecOpCategory, VecOpMasking, VecTailMode,
+    VecAMode, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAvl, VecElementWidth,
+    VecLmul, VecMaskMode, VecOpCategory, VecOpMasking, VecTailMode,
 };
 use crate::machinst::RegClass;
 use crate::Reg;
@@ -433,6 +433,46 @@ impl fmt::Display for VecAluOpRR {
             VecAluOpRR::VmvVV => "vmv.v.v",
             VecAluOpRR::VmvVX => "vmv.v.x",
             VecAluOpRR::VfmvVF => "vfmv.v.f",
+        })
+    }
+}
+
+impl VecAluOpRImm5 {
+    pub fn opcode(&self) -> u32 {
+        // Vector Opcode
+        0x57
+    }
+    pub fn funct3(&self) -> u32 {
+        self.category().encode()
+    }
+
+    pub fn funct6(&self) -> u32 {
+        // See: https://github.com/riscv/riscv-v-spec/blob/master/inst-table.adoc
+        match self {
+            VecAluOpRImm5::VmvVI => 0b010111,
+        }
+    }
+
+    pub fn category(&self) -> VecOpCategory {
+        match self {
+            VecAluOpRImm5::VmvVI => VecOpCategory::OPIVI,
+        }
+    }
+
+    /// Returns the auxiliary encoding field for the instruction, if any.
+    pub fn aux_encoding(&self) -> u32 {
+        match self {
+            // These don't have a explicit encoding table, but Section 11.16 Vector Integer Move Instruction states:
+            // > The first operand specifier (vs2) must contain v0, and any other vector register number in vs2 is reserved.
+            VecAluOpRImm5::VmvVI => 0,
+        }
+    }
+}
+
+impl fmt::Display for VecAluOpRImm5 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            VecAluOpRImm5::VmvVI => "vmv.v.i",
         })
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -154,7 +154,13 @@
   (if-let $I32 (lane_type ty))
   (VecElementWidth.E32))
 (rule (element_width_from_type ty)
+  (if-let $F32 (lane_type ty))
+  (VecElementWidth.E32))
+(rule (element_width_from_type ty)
   (if-let $I64 (lane_type ty))
+  (VecElementWidth.E64))
+(rule (element_width_from_type ty)
+  (if-let $F64 (lane_type ty))
   (VecElementWidth.E64))
 
 (decl pure min_vec_reg_size () u64)
@@ -295,3 +301,40 @@
 (decl rv_vslidedown_vi (Reg UImm5 VState) Reg)
 (rule (rv_vslidedown_vi vs2 imm vstate)
   (vec_alu_rr_uimm5 (VecAluOpRRImm5.VslidedownVI) vs2 imm vstate))
+
+;; Helper for emitting the `vmv.x.s` instruction.
+;; This instruction copies the first element of the source vector to the destination X register.
+(decl rv_vmv_xs (Reg VState) Reg)
+(rule (rv_vmv_xs vs2 vstate)
+  (vec_alu_rr_aux (VecAluOpRRImm5.VmvXS) vs2 vstate))
+
+;; Helper for emitting the `vfmv.f.s` instruction.
+;; This instruction copies the first element of the source vector to the destination F register.
+(decl rv_vfmv_fs (Reg VState) Reg)
+(rule (rv_vfmv_fs vs2 vstate)
+  (vec_alu_rr_aux (VecAluOpRRImm5.VfmvFS) vs2 vstate))
+
+
+;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl gen_extractlane (Type Reg u8) Reg)
+
+;; When extracting lane 0 for floats, we can use `vfmv.f.s` directly.
+(rule 3 (gen_extractlane (ty_vec_fits_in_register ty) src 0)
+  (if (ty_vector_float ty))
+  (rv_vfmv_fs src ty))
+
+;; When extracting lane 0 for integers, we can use `vmv.x.s` directly.
+(rule 2 (gen_extractlane (ty_vec_fits_in_register ty) src 0)
+  (if (ty_vector_not_float ty))
+  (rv_vmv_xs src ty))
+
+;; In the general case, we must first use a `vslidedown` to place the correct lane
+;; in index 0, and then use the appropriate `vmv` instruction.
+;; If the index fits into a 5-bit immediate, we can emit a `vslidedown.vi`.
+(rule 1 (gen_extractlane (ty_vec_fits_in_register ty) src (uimm5_from_u8 idx))
+  (gen_extractlane ty (rv_vslidedown_vi src idx ty) 0))
+
+;; Otherwise lower it into an X register.
+(rule 0 (gen_extractlane (ty_vec_fits_in_register ty) src idx)
+  (gen_extractlane ty (rv_vslidedown_vx src (imm $I64 idx) ty) 0))

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -106,19 +106,27 @@
   (VaddVI)
   (VrsubVI)
   (VslidedownVI)
+))
 
-  ;; Special Opcodes
-  ;; These opcodes use the imm field as auxiliary encoding space, but
-  ;; are otherwise identical to the regular VI opcodes.
+
+;; These are all of the special cases that have weird encodings. They are all
+;; single source, single destination instructions, and usually use one of
+;; the two source registers as auxiliary encoding space.
+(type VecAluOpRR (enum
   (VmvSX)
   (VmvXS)
   (VfmvSF)
   (VfmvFS)
+  ;; vmv.v* is special in that vs2 must be v0 (and is ignored) otherwise the instruction is illegal.
+  (VmvVV)
+  (VmvVX)
+  (VfmvVF)
+  ;; (VmvVI)
 ))
 
 ;; Returns the canonical destination type for a VecAluOpRRImm5.
-(decl pure vec_alu_rr_imm5_dst_type (VecAluOpRRImm5) Type)
-(extern constructor vec_alu_rr_imm5_dst_type vec_alu_rr_imm5_dst_type)
+(decl pure vec_alu_rr_dst_type (VecAluOpRR) Type)
+(extern constructor vec_alu_rr_dst_type vec_alu_rr_dst_type)
 
 
 ;; Vector Addressing Mode
@@ -188,7 +196,7 @@
 ;; Helper for emitting `MInst.VecAluRRImm5` instructions.
 (decl vec_alu_rr_imm5 (VecAluOpRRImm5 Reg Imm5 VState) Reg)
 (rule (vec_alu_rr_imm5 op vs2 imm vstate)
-      (let ((vd WritableReg (temp_writable_reg (vec_alu_rr_imm5_dst_type op)))
+      (let ((vd WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecAluRRImm5 op vd vs2 imm vstate))))
         vd))
 
@@ -200,11 +208,11 @@
 
 ;; Helper for emitting `MInst.VecAluRRImm5` instructions that use the Imm5 as
 ;; auxiliary encoding space.
-(decl vec_alu_rr_aux (VecAluOpRRImm5 Reg VState) Reg)
-(rule (vec_alu_rr_aux op vs2 vstate)
-      ;; We can ignore the immediate value here since it gets replaced
-      ;; with the correct value when emitting this instruction.
-      (vec_alu_rr_imm5 op vs2 (imm5_zero) vstate))
+(decl vec_alu_rr (VecAluOpRR Reg VState) Reg)
+(rule (vec_alu_rr op vs vstate)
+      (let ((vd WritableReg (temp_writable_reg (vec_alu_rr_dst_type op)))
+            (_ Unit (emit (MInst.VecAluRR op vd vs vstate))))
+        vd))
 
 ;; Helper for emitting `MInst.VecLoad` instructions.
 (decl vec_load (VecElementWidth VecAMode MemFlags VState) Reg)
@@ -305,14 +313,14 @@
 ;; Helper for emitting the `vmv.x.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination X register.
 (decl rv_vmv_xs (Reg VState) Reg)
-(rule (rv_vmv_xs vs2 vstate)
-  (vec_alu_rr_aux (VecAluOpRRImm5.VmvXS) vs2 vstate))
+(rule (rv_vmv_xs vs vstate)
+  (vec_alu_rr (VecAluOpRR.VmvXS) vs vstate))
 
 ;; Helper for emitting the `vfmv.f.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination F register.
 (decl rv_vfmv_fs (Reg VState) Reg)
-(rule (rv_vfmv_fs vs2 vstate)
-  (vec_alu_rr_aux (VecAluOpRRImm5.VfmvFS) vs2 vstate))
+(rule (rv_vfmv_fs vs vstate)
+  (vec_alu_rr (VecAluOpRR.VfmvFS) vs vstate))
 
 
 ;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -108,6 +108,10 @@
   (VslidedownVI)
 ))
 
+;; Imm only ALU Ops
+(type VecAluOpRImm5 (enum
+  (VmvVI)
+))
 
 ;; These are all of the special cases that have weird encodings. They are all
 ;; single source, single destination instructions, and usually use one of
@@ -121,7 +125,6 @@
   (VmvVV)
   (VmvVX)
   (VfmvVF)
-  ;; (VmvVI)
 ))
 
 ;; Returns the canonical destination type for a VecAluOpRRImm5.
@@ -212,6 +215,13 @@
 (rule (vec_alu_rr op vs vstate)
       (let ((vd WritableReg (temp_writable_reg (vec_alu_rr_dst_type op)))
             (_ Unit (emit (MInst.VecAluRR op vd vs vstate))))
+        vd))
+
+;; Helper for emitting `MInst.VecAluRImm5` instructions.
+(decl vec_alu_r_imm5 (VecAluOpRImm5 Imm5 VState) Reg)
+(rule (vec_alu_r_imm5 op imm vstate)
+      (let ((vd WritableReg (temp_writable_reg $I8X16))
+            (_ Unit (emit (MInst.VecAluRImm5 op vd imm vstate))))
         vd))
 
 ;; Helper for emitting `MInst.VecLoad` instructions.
@@ -323,15 +333,22 @@
   (vec_alu_rr (VecAluOpRR.VfmvFS) vs vstate))
 
 ;; Helper for emitting the `vmv.v.x` instruction.
+;; This instruction splats the X regsiter into all elements of the destination vector.
 (decl rv_vmv_vx (Reg VState) Reg)
 (rule (rv_vmv_vx vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvVX) vs vstate))
 
 ;; Helper for emitting the `vfmv.v.f` instruction.
+;; This instruction splats the F regsiter into all elements of the destination vector.
 (decl rv_vfmv_vf (Reg VState) Reg)
 (rule (rv_vfmv_vf vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvVF) vs vstate))
 
+;; Helper for emitting the `vmv.v.i` instruction.
+;; This instruction splat's the immediate value into all elements of the destination vector.
+(decl rv_vmv_vi (Imm5 VState) Reg)
+(rule (rv_vmv_vi imm vstate)
+  (vec_alu_r_imm5 (VecAluOpRImm5.VmvVI) imm vstate))
 
 ;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -102,11 +102,23 @@
 
 ;; Register-Imm ALU Ops
 (type VecAluOpRRImm5 (enum
+  ;; Regular VI Opcodes
   (VaddVI)
   (VrsubVI)
   (VslidedownVI)
+
+  ;; Special Opcodes
+  ;; These opcodes use the imm field as auxiliary encoding space, but
+  ;; are otherwise identical to the regular VI opcodes.
+  (VmvSX)
+  (VmvXS)
+  (VfmvSF)
+  (VfmvFS)
 ))
 
+;; Returns the canonical destination type for a VecAluOpRRImm5.
+(decl pure vec_alu_rr_imm5_dst_type (VecAluOpRRImm5) Type)
+(extern constructor vec_alu_rr_imm5_dst_type vec_alu_rr_imm5_dst_type)
 
 
 ;; Vector Addressing Mode
@@ -170,7 +182,7 @@
 ;; Helper for emitting `MInst.VecAluRRImm5` instructions.
 (decl vec_alu_rr_imm5 (VecAluOpRRImm5 Reg Imm5 VState) Reg)
 (rule (vec_alu_rr_imm5 op vs2 imm vstate)
-      (let ((vd WritableReg (temp_writable_reg $I8X16))
+      (let ((vd WritableReg (temp_writable_reg (vec_alu_rr_imm5_dst_type op)))
             (_ Unit (emit (MInst.VecAluRRImm5 op vd vs2 imm vstate))))
         vd))
 
@@ -179,6 +191,14 @@
 (decl vec_alu_rr_uimm5 (VecAluOpRRImm5 Reg UImm5 VState) Reg)
 (rule (vec_alu_rr_uimm5 op vs2 imm vstate)
       (vec_alu_rr_imm5 op vs2 (uimm5_bitcast_to_imm5 imm) vstate))
+
+;; Helper for emitting `MInst.VecAluRRImm5` instructions that use the Imm5 as
+;; auxiliary encoding space.
+(decl vec_alu_rr_aux (VecAluOpRRImm5 Reg VState) Reg)
+(rule (vec_alu_rr_aux op vs2 vstate)
+      ;; We can ignore the immediate value here since it gets replaced
+      ;; with the correct value when emitting this instruction.
+      (vec_alu_rr_imm5 op vs2 (imm5_zero) vstate))
 
 ;; Helper for emitting `MInst.VecLoad` instructions.
 (decl vec_load (VecElementWidth VecAMode MemFlags VState) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -97,12 +97,14 @@
   (VaddVX)
   (VsubVX)
   (VrsubVX)
+  (VslidedownVX)
 ))
 
 ;; Register-Imm ALU Ops
 (type VecAluOpRRImm5 (enum
   (VaddVI)
   (VrsubVI)
+  (VslidedownVI)
 ))
 
 
@@ -171,6 +173,12 @@
       (let ((vd WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.VecAluRRImm5 op vd vs2 imm vstate))))
         vd))
+
+;; Helper for emitting `MInst.VecAluRRImm5` instructions where the immediate
+;; is zero extended instead of sign extended.
+(decl vec_alu_rr_uimm5 (VecAluOpRRImm5 Reg UImm5 VState) Reg)
+(rule (vec_alu_rr_uimm5 op vs2 imm vstate)
+      (vec_alu_rr_imm5 op vs2 (uimm5_bitcast_to_imm5 imm) vstate))
 
 ;; Helper for emitting `MInst.VecLoad` instructions.
 (decl vec_load (VecElementWidth VecAMode MemFlags VState) Reg)
@@ -254,3 +262,16 @@
 (decl rv_vxor_vv (Reg Reg VState) Reg)
 (rule (rv_vxor_vv vs2 vs1 vstate)
   (vec_alu_rrr (VecAluOpRRR.VxorVV) vs2 vs1 vstate))
+
+;; Helper for emitting the `vslidedown.vx` instruction.
+;; `vslidedown` moves all elements in the vector down by n elements.
+;; The top most elements are up to the tail policy.
+(decl rv_vslidedown_vx (Reg Reg VState) Reg)
+(rule (rv_vslidedown_vx vs2 vs1 vstate)
+  (vec_alu_rrr (VecAluOpRRR.VslidedownVX) vs2 vs1 vstate))
+
+;; Helper for emitting the `vslidedown.vi` instruction.
+;; Unlike other `vi` instructions the immediate is zero extended.
+(decl rv_vslidedown_vi (Reg UImm5 VState) Reg)
+(rule (rv_vslidedown_vi vs2 imm vstate)
+  (vec_alu_rr_uimm5 (VecAluOpRRImm5.VslidedownVI) vs2 imm vstate))

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -322,6 +322,16 @@
 (rule (rv_vfmv_fs vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvFS) vs vstate))
 
+;; Helper for emitting the `vmv.v.x` instruction.
+(decl rv_vmv_vx (Reg VState) Reg)
+(rule (rv_vmv_vx vs vstate)
+  (vec_alu_rr (VecAluOpRR.VmvVX) vs vstate))
+
+;; Helper for emitting the `vfmv.v.f` instruction.
+(decl rv_vfmv_vf (Reg VState) Reg)
+(rule (rv_vfmv_vf vs vstate)
+  (vec_alu_rr (VecAluOpRR.VfmvVF) vs vstate))
+
 
 ;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1035,3 +1035,14 @@
 
 (rule (lower (extractlane x @ (value_type ty) (u8_from_uimm8 idx)))
   (gen_extractlane ty x idx))
+
+;;;; Rules for `splat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type ty (splat n @ (value_type (ty_scalar_float _)))))
+  (rv_vfmv_vf n ty))
+
+(rule 1 (lower (has_type ty (splat n @ (value_type (ty_int_ref_scalar_64 _)))))
+  (rv_vmv_vx n ty))
+
+;; (rule (lower (has_type ty (replicated_imm5 imm)))
+;;   (rv_vmv_vi imm ty))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1044,5 +1044,8 @@
 (rule 1 (lower (has_type ty (splat n @ (value_type (ty_int_ref_scalar_64 _)))))
   (rv_vmv_vx n ty))
 
-;; (rule (lower (has_type ty (replicated_imm5 imm)))
-;;   (rv_vmv_vi imm ty))
+(rule 2 (lower (has_type ty (splat (iconst (u64_from_imm64 (imm5_from_u64 imm))))))
+  (rv_vmv_vi imm ty))
+
+;; TODO: We can splat out more patterns by using for example a vmv.v.i i8x16 for
+;; a i64x2 const with a compatible bit pattern.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1030,3 +1030,8 @@
 
 (rule (lower (call_indirect sig_ref val inputs))
   (gen_call_indirect sig_ref val inputs))
+
+;;;; Rules for `extractlane` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (extractlane x @ (value_type ty) (u8_from_uimm8 idx)))
+  (gen_extractlane ty x idx))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -214,6 +214,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::from_bits(arg0.bits() as u8)
     }
     #[inline]
+    fn uimm5_from_u8(&mut self, arg0: u8) -> Option<UImm5> {
+        UImm5::maybe_from_u8(arg0)
+    }
+    #[inline]
     fn writable_zero_reg(&mut self) -> WritableReg {
         writable_zero_reg()
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -6,7 +6,7 @@ pub mod generated_code;
 use generated_code::{Context, ExtendOp, MInst};
 
 // Types that the generated ISLE code uses via `use super::*`.
-use self::generated_code::VecAluOpRRImm5;
+use self::generated_code::VecAluOpRR;
 use super::{writable_zero_reg, zero_reg};
 use crate::isa::riscv64::abi::Riscv64ABICaller;
 use crate::isa::riscv64::Riscv64Backend;
@@ -469,7 +469,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         }
     }
 
-    fn vec_alu_rr_imm5_dst_type(&mut self, op: &VecAluOpRRImm5) -> Type {
+    fn vec_alu_rr_dst_type(&mut self, op: &VecAluOpRR) -> Type {
         MInst::canonical_type_for_rc(op.dst_regclass())
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -205,6 +205,12 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
+    fn uimm5_bitcast_to_imm5(&mut self, arg0: UImm5) -> Imm5 {
+        let bits = arg0.bits() as u8;
+        let signed = ((bits << 3) as i8) >> 3;
+        Imm5::maybe_from_i8(signed).unwrap()
+    }
+    #[inline]
     fn writable_zero_reg(&mut self) -> WritableReg {
         writable_zero_reg()
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -206,10 +206,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
-    fn imm5_zero(&mut self) -> Imm5 {
-        Imm5::from_bits(0)
-    }
-    #[inline]
     fn uimm5_bitcast_to_imm5(&mut self, arg0: UImm5) -> Imm5 {
         Imm5::from_bits(arg0.bits() as u8)
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -6,6 +6,7 @@ pub mod generated_code;
 use generated_code::{Context, ExtendOp, MInst};
 
 // Types that the generated ISLE code uses via `use super::*`.
+use self::generated_code::VecAluOpRRImm5;
 use super::{writable_zero_reg, zero_reg};
 use crate::isa::riscv64::abi::Riscv64ABICaller;
 use crate::isa::riscv64::Riscv64Backend;
@@ -205,10 +206,12 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
+    fn imm5_zero(&mut self) -> Imm5 {
+        Imm5::from_bits(0)
+    }
+    #[inline]
     fn uimm5_bitcast_to_imm5(&mut self, arg0: UImm5) -> Imm5 {
-        let bits = arg0.bits() as u8;
-        let signed = ((bits << 3) as i8) >> 3;
-        Imm5::maybe_from_i8(signed).unwrap()
+        Imm5::from_bits(arg0.bits() as u8)
     }
     #[inline]
     fn writable_zero_reg(&mut self) -> WritableReg {
@@ -460,6 +463,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         } else {
             None
         }
+    }
+
+    fn vec_alu_rr_imm5_dst_type(&mut self, op: &VecAluOpRRImm5) -> Type {
+        MInst::canonical_type_for_rc(op.dst_regclass())
     }
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
@@ -1,0 +1,446 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %extractlane_i8x16_idx_0(i8x16) -> i8 {
+block0(v0: i8x16):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.x.s a0,v0 #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x25, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i16x8_idx_0(i16x8) -> i16 {
+block0(v0: i16x8):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.x.s a0,v0 #avl=8, #vtype=(e16, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x25, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i32x4_idx_0(i32x4) -> i32 {
+block0(v0: i32x4):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.x.s a0,v0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x25, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i64x2_idx_0(i64x2) -> i64 {
+block0(v0: i64x2):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.x.s a0,v0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0x25, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_f32x4_idx_0(f32x4) -> f32 {
+block0(v0: f32x4):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vfmv.f.s fa0,v0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x15, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_f64x2_idx_0(f64x2) -> f64 {
+block0(v0: f64x2):
+    v1 = extractlane v0, 0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vfmv.f.s fa0,v0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0x15, 0x00, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i8x16_idx_1(i8x16) -> i8 {
+block0(v0: i8x16):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.x.s a0,v2 #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x25, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i16x8_idx_1(i16x8) -> i16 {
+block0(v0: i16x8):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vmv.x.s a0,v2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x25, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i32x4_idx_1(i32x4) -> i32 {
+block0(v0: i32x4):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vmv.x.s a0,v2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x25, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_i64x2_idx_1(i64x2) -> i64 {
+block0(v0: i64x2):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.x.s a0,v2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x25, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_f32x4_idx_1(f32x4) -> f32 {
+block0(v0: f32x4):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vfmv.f.s fa0,v2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x15, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %extractlane_f64x2_idx_1(f64x2) -> f64 {
+block0(v0: f64x2):
+    v1 = extractlane v0, 1
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v2,v0,1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vfmv.f.s fa0,v2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xb1, 0x00, 0x3e
+;   .byte 0x57, 0x15, 0x20, 0x42
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
@@ -90,17 +90,15 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a1,2
-;   vmv.v.x v3,a1 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.i v2,2 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a1, zero, 2
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xd7, 0xc1, 0x05, 0x5e
-;   .byte 0xa7, 0x01, 0x05, 0x02
+;   .byte 0x57, 0x31, 0x01, 0x5e
+;   .byte 0x27, 0x01, 0x05, 0x02
 ;   ret
 
 function %splat_const_i16x8() -> i16x8 {
@@ -112,18 +110,16 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a1,2
-;   vmv.v.x v3,a1 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.i v2,2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a1, zero, 2
 ;   .byte 0x57, 0x70, 0x84, 0xcc
-;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x31, 0x01, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x01, 0x05, 0x02
+;   .byte 0x27, 0x01, 0x05, 0x02
 ;   ret
 
 function %splat_const_i32x4() -> i32x4 {
@@ -135,18 +131,16 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a1,2
-;   vmv.v.x v3,a1 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.i v2,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a1, zero, 2
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x31, 0x01, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x01, 0x05, 0x02
+;   .byte 0x27, 0x01, 0x05, 0x02
 ;   ret
 
 function %splat_const_i64x2() -> i64x2 {
@@ -158,18 +152,16 @@ block0:
 
 ; VCode:
 ; block0:
-;   li a1,2
-;   vmv.v.x v3,a1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.i v2,2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
 ; 
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a1, zero, 2
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x31, 0x01, 0x5e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x01, 0x05, 0x02
+;   .byte 0x27, 0x01, 0x05, 0x02
 ;   ret
 
 function %splat_f32x4(f32) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
@@ -1,0 +1,214 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %splat_i8x16(i8) -> i8x16 {
+block0(v0: i8):
+    v1 = splat.i8x16 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vmv.v.x v3,a0 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xd7, 0x41, 0x05, 0x5e
+;   .byte 0xa7, 0x81, 0x05, 0x02
+;   ret
+
+function %splat_i16x8(i16) -> i16x8 {
+block0(v0: i16):
+    v1 = splat.i16x8 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vmv.v.x v3,a0 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x41, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x81, 0x05, 0x02
+;   ret
+
+function %splat_i32x4(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = splat.i32x4 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vmv.v.x v3,a0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x41, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x81, 0x05, 0x02
+;   ret
+
+function %splat_i64x2(i64) -> i64x2 {
+block0(v0: i64):
+    v1 = splat.i64x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vmv.v.x v3,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x41, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x81, 0x05, 0x02
+;   ret
+
+function %splat_const_i8x16() -> i8x16 {
+block0:
+    v0 = iconst.i8 2
+    v1 = splat.i8x16 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   li a1,2
+;   vmv.v.x v3,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+
+function %splat_const_i16x8() -> i16x8 {
+block0:
+    v0 = iconst.i16 2
+    v1 = splat.i16x8 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   li a1,2
+;   vmv.v.x v3,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 2
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+
+function %splat_const_i32x4() -> i32x4 {
+block0:
+    v0 = iconst.i32 2
+    v1 = splat.i32x4 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   li a1,2
+;   vmv.v.x v3,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 2
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+
+function %splat_const_i64x2() -> i64x2 {
+block0:
+    v0 = iconst.i64 2
+    v1 = splat.i64x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   li a1,2
+;   vmv.v.x v3,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 2
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0xc1, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+
+function %splat_f32x4(f32) -> f32x4 {
+block0(v0: f32):
+    v1 = splat.f32x4 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vfmv.v.f v3,fa0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x51, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+
+function %splat_f64x2(f64) -> f64x2 {
+block0(v0: f64):
+    v1 = splat.f64x2 v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   vfmv.v.f v3,fa0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x51, 0x05, 0x5e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x01, 0x05, 0x02
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -8,6 +8,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+target riscv64 has_v
 
 function %extractlane_4(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -1,0 +1,25 @@
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64 has_sse3 has_ssse3 has_sse41
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target x86_64 has_sse3 has_ssse3 has_sse41 has_avx has_avx2
+
+function %splat_f32x4_2(f32x4) -> f32x4 {
+block0(v0: f32x4):
+  v1 = f32const 0x1.5
+  v2 = splat.f32x4 v1
+  v3 = fadd v0, v2
+  return v3
+}
+; run: %splat_f32x4_2([0x0.0 NaN 0x1.0 0x2.0]) == [0x1.5 NaN 0x2.5 0x3.5]
+
+function %splat_f64x2_2(f64x2) -> f64x2 {
+block0(v0: f64x2):
+  v1 = f64const 0x7.5
+  v2 = splat.f64x2 v1
+  v3 = fadd v0, v2
+  return v3
+}
+; run: %splat_f64x2_2([0x0.0 0x1.0]) == [0x7.5 0x8.5]

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -1,10 +1,12 @@
 test run
 target aarch64
 target s390x
+target x86_64 ssse3 has_sse41=false
 set enable_simd
-target x86_64 has_sse3 has_ssse3 has_sse41
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx has_avx2
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
+target x86_64 sse42 has_avx
 
 function %splat_f32x4_2(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -6,6 +6,7 @@ set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx has_avx2
+target riscv64 has_v
 
 function %splat_i8x16(i8) -> i8x16 {
 block0(v0: i8):
@@ -126,24 +127,6 @@ block0(v0: i64x2):
     return v3
 }
 ; run: %splat_i64x2_2([-1 0]) == [-2 -1]
-
-function %splat_f32x4_2(f32x4) -> f32x4 {
-block0(v0: f32x4):
-  v1 = f32const 0x1.5
-  v2 = splat.f32x4 v1
-  v3 = fadd v0, v2
-  return v3
-}
-; run: %splat_f32x4_2([0x0.0 NaN 0x1.0 0x2.0]) == [0x1.5 NaN 0x2.5 0x3.5]
-
-function %splat_f64x2_2(f64x2) -> f64x2 {
-block0(v0: f64x2):
-  v1 = f64const 0x7.5
-  v2 = splat.f64x2 v1
-  v3 = fadd v0, v2
-  return v3
-}
-; run: %splat_f64x2_2([0x0.0 0x1.0]) == [0x7.5 0x8.5]
 
 function %load_splat_i8x16(i8) -> i8x16 {
     ss0 = explicit_slot 8


### PR DESCRIPTION
👋 Hey,

This PR implements both `extractlane` and `splat`. 

`splat` is fairly simple in that we have a bunch of move instructions that by default splat the source X or F register into the vector register. These are `vmv.v.x`, `vfmv.v.f` and `vmv.v.i`, for X, F and immediate sources. The only noteworthy thing about these instructions is that they have weird encodings, and I've added two new instruction formats to deal with this. `vmv.v.i` has no source operands, only a destination register. And the other ones could maybe be encoded using the existing Imm5 instruction format it was becoming a bit weird keeping all of the variations together.

For `extractlane` we have two additional move instructions `vfmv.f.s` and `vmv.x.s` these move element 0 of the source vector into the appropriate X or F register. Additionally for extracting other elements we use `vslidedown` that moves all elements of a vector down by n positions and then emit the appropriate move into the destination register.
