### PR TITLE
Add allow list for HTTP methods/schemes/authorities

### DIFF
--- a/crates/test-programs/tests/wasi-http.rs
+++ b/crates/test-programs/tests/wasi-http.rs
@@ -77,12 +77,15 @@ pub fn run(name: &str) -> anyhow::Result<()> {
 
     // Create our wasi context.
     let builder = WasiCtxBuilder::new().inherit_stdio().arg(name)?;
+    let mut wasi_http = WasiHttp::new();
+    wasi_http.allowed_methods = vec!["GET".to_string(), "POST".to_string(), "PUT".to_string()];
+    wasi_http.allowed_authorities = vec!["localhost:3000".to_string()];
 
     let mut store = Store::new(
         &ENGINE,
         Ctx {
             wasi: builder.build(),
-            http: WasiHttp::new(),
+            http: wasi_http,
         },
     );
 

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
@@ -184,5 +184,37 @@ fn main() -> Result<()> {
         "Error::UnexpectedError(\"unsupported scheme WS\")"
     );
 
+    // Delete is not an allowed method in this test.
+    let r6 = request(
+        types::MethodParam::Delete,
+        types::SchemeParam::Http,
+        "localhost:3000",
+        "/",
+        "",
+        &[],
+    );
+
+    let error = r6.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "ErrorResult::UnexpectedError(\"Method DELETE is not allowed.\")"
+    );
+
+    // localhost:8080 is not an allowed authority in this test.
+    let r7 = request(
+        types::MethodParam::Get,
+        types::SchemeParam::Http,
+        "localhost:8080",
+        "/",
+        "",
+        &[],
+    );
+
+    let error = r7.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "ErrorResult::UnexpectedError(\"Authority localhost:8080 is not allowed.\")"
+    );
+
     Ok(())
 }

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request.rs
@@ -186,34 +186,32 @@ fn main() -> Result<()> {
 
     // Delete is not an allowed method in this test.
     let r6 = request(
-        types::MethodParam::Delete,
-        types::SchemeParam::Http,
+        wasi::http::types::Method::Delete,
+        wasi::http::types::Scheme::Http,
         "localhost:3000",
         "/",
-        "",
         &[],
     );
 
     let error = r6.unwrap_err();
     assert_eq!(
         error.to_string(),
-        "ErrorResult::UnexpectedError(\"Method DELETE is not allowed.\")"
+        "Error::UnexpectedError(\"Method DELETE is not allowed.\")"
     );
 
     // localhost:8080 is not an allowed authority in this test.
     let r7 = request(
-        types::MethodParam::Get,
-        types::SchemeParam::Http,
+        wasi::http::types::Method::Get,
+        wasi::http::types::Scheme::Http,
         "localhost:8080",
         "/",
-        "",
         &[],
     );
 
     let error = r7.unwrap_err();
     assert_eq!(
         error.to_string(),
-        "ErrorResult::UnexpectedError(\"Authority localhost:8080 is not allowed.\")"
+        "Error::UnexpectedError(\"Authority localhost:8080 is not allowed.\")"
     );
 
     Ok(())

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -82,11 +82,43 @@ impl WasiHttp {
             crate::wasi::http::types::Method::Other(s) => bail!("unknown method {}", s),
         };
 
+        let mut allowed = false;
+        let method_str = request.method.to_string();
+        for allowed_method in self.allowed_methods.iter() {
+            if allowed_method == "*" {
+                allowed = true;
+                break;
+            }
+            if method_str == *allowed_method {
+                allowed = true;
+                break;
+            }
+        }
+        if !allowed {
+            bail!("Method {} is not allowed.", method.to_string());
+        }
+
         let scheme = match request.scheme.as_ref().unwrap_or(&Scheme::Https) {
             Scheme::Http => "http://",
             Scheme::Https => "https://",
             Scheme::Other(s) => bail!("unsupported scheme {}", s),
         };
+
+        let mut allowed = false;
+        let scheme_str = request.scheme.to_string();
+        for allowed_scheme in self.allowed_schemes.iter() {
+            if allowed_scheme == "*" {
+                allowed = true;
+                break;
+            }
+            if scheme_str == *allowed_scheme {
+                allowed = true;
+                break;
+            }
+        }
+        if !allowed {
+            bail!("Scheme {} is not allowed.", scheme_str);
+        }
 
         // Largely adapted from https://hyper.rs/guides/1/client/basic/
         let authority = match request.authority.find(":") {

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -1,6 +1,36 @@
 use crate::wasi::http::types::{Method, RequestOptions, Scheme};
 use bytes::{BufMut, Bytes, BytesMut};
 use std::collections::HashMap;
+use std::fmt;
+
+impl fmt::Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let scheme_str = match self {
+            Scheme::Http => "http",
+            Scheme::Https => "https",
+            Scheme::Other(s) => s,
+        };
+        write!(f, "{}", scheme_str)
+    }
+}
+
+impl fmt::Display for Method {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let method_str = match self {
+            Method::Get => "GET",
+            Method::Put => "PUT",
+            Method::Post => "POST",
+            Method::Options => "OPTIONS",
+            Method::Head => "HEAD",
+            Method::Patch => "PATCH",
+            Method::Connect => "CONNECT",
+            Method::Delete => "DELETE",
+            Method::Trace => "TRACE",
+            Method::Other(s) => s,
+        };
+        write!(f, "{}", method_str)
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct Stream {
@@ -20,6 +50,9 @@ pub struct WasiHttp {
     pub fields: HashMap<u32, HashMap<String, Vec<Vec<u8>>>>,
     pub streams: HashMap<u32, Stream>,
     pub futures: HashMap<u32, ActiveFuture>,
+
+    pub allowed_methods: Vec<String>,
+    pub allowed_schemes: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -119,6 +152,8 @@ impl WasiHttp {
             fields: HashMap::new(),
             streams: HashMap::new(),
             futures: HashMap::new(),
+            allowed_methods: vec!("*".to_string()),
+            allowed_schemes: vec!("*".to_string()),
         }
     }
 }

--- a/crates/wasi-http/src/struct.rs
+++ b/crates/wasi-http/src/struct.rs
@@ -53,6 +53,7 @@ pub struct WasiHttp {
 
     pub allowed_methods: Vec<String>,
     pub allowed_schemes: Vec<String>,
+    pub allowed_authorities: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -152,8 +153,9 @@ impl WasiHttp {
             fields: HashMap::new(),
             streams: HashMap::new(),
             futures: HashMap::new(),
-            allowed_methods: vec!("*".to_string()),
-            allowed_schemes: vec!("*".to_string()),
+            allowed_methods: vec!["*".to_string()],
+            allowed_schemes: vec!["*".to_string()],
+            allowed_authorities: vec!["*".to_string()],
         }
     }
 }


### PR DESCRIPTION
This adds allow lists to HTTP which enable the creator of the wasm runtime to specify:
* allowed methods
* allowed schemes
* allowed authorities

It also supports a wildcard value `*` which matches everything.

Unit tests to validate the functionality are also included.