### PR TITLE
wasi-tests fd_readdir: delete assertion about ordering of fds

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
+++ b/crates/test-programs/wasi-tests/src/bin/fd_readdir.rs
@@ -118,10 +118,6 @@ unsafe fn test_fd_readdir(dir_fd: wasi::Fd) {
     wasi::path_create_directory(dir_fd, "nested").expect("create a directory");
     let nested_fd =
         wasi::path_open(dir_fd, 0, "nested", 0, 0, 0, 0).expect("failed to open nested directory");
-    assert!(
-        nested_fd > file_fd,
-        "nested directory file descriptor range check",
-    );
     let nested_stat = wasi::fd_filestat_get(nested_fd).expect("failed filestat");
 
     // Execute another readdir


### PR DESCRIPTION
This is an unnecessary restriction: applications shouldn't be relying on any ordering of preview1 fds, besides that other files are not found in the stdio range.

This behavior changed with the introduction of the component adapter, but I am making a separate PR to edit the test rather than make it part of #6391.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
