### PR TITLE
Restore the lea-based lowering for iadd in the x64 backend

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -155,7 +155,8 @@
 
        ;; Loads the memory address of addr into dst.
        (LoadEffectiveAddress (addr SyntheticAmode)
-                             (dst WritableGpr))
+                             (dst WritableGpr)
+                             (size OperandSize))
 
        ;; Sign-extended loads and moves: movs (bl bq wl wq lq) addr reg.
        (MovsxRmR (ext_mode ExtMode)
@@ -995,25 +996,6 @@
              ;; the given MachLabel.
              (RipRelative (target MachLabel))))
 
-;; Some Amode constructor helpers.
-
-(decl amode_with_flags (Amode MemFlags) Amode)
-(extern constructor amode_with_flags amode_with_flags)
-
-(decl amode_imm_reg (u32 Gpr) Amode)
-(extern constructor amode_imm_reg amode_imm_reg)
-
-(decl amode_imm_reg_flags (u32 Gpr MemFlags) Amode)
-(rule (amode_imm_reg_flags offset base flags)
-      (amode_with_flags (amode_imm_reg offset base) flags))
-
-(decl amode_imm_reg_reg_shift (u32 Gpr Gpr u8) Amode)
-(extern constructor amode_imm_reg_reg_shift amode_imm_reg_reg_shift)
-
-(decl amode_imm_reg_reg_shift_flags (u32 Gpr Gpr u8 MemFlags) Amode)
-(rule (amode_imm_reg_reg_shift_flags offset base index shift flags)
-      (amode_with_flags (amode_imm_reg_reg_shift offset base index shift) flags))
-
 ;; A helper to both check that the `Imm64` and `Offset32` values sum to less
 ;; than 32-bits AND return this summed `u32` value. Also, the `Imm64` will be
 ;; zero-extended from `Type` up to 64 bits. This is useful for `to_amode`.
@@ -1022,168 +1004,59 @@
 
 ;;;; Amode lowering ;;;;
 
-;; To generate an address for a memory access, we can pattern-match
-;; various CLIF sub-trees to x64's complex addressing modes (`Amode`).
-;;
-;; Information about available addressing modes is available in
-;; Intel's Software Developer's Manual, volume 2, section 2.1.5,
-;; "Addressing-Mode Encoding of ModR/M and SIB Bytes."
-;;
-;; The general strategy to build an `Amode` is to traverse over the
-;; input expression's addends, recursively deconstructing a tree of
-;; `iadd` operators that add up parts of the address, updating the
-;; `Amode` in an incremental fashion as we add in each piece.
-;;
-;; We start with an "immediate + register" form that encapsulates the
-;; load/store's built-in `Offset32` and `invalid_reg` as the
-;; register. This is given by `amode_initial`. Then we add `Value`s
-;; one at a time with `amode_add`. (Why start with `invalid_reg` at
-;; all? Because we don't want to special-case the first input and
-;; duplicate rules; this lets us use the "add a value" logic even for
-;; the first value.)
-;;
-;; It is always valid to use `amode_add` to add the one single
-;; `address` input to the load/store (i.e., the `Value` given to
-;; `to_amode`). In the fallback case, this is what we do. Then we get
-;; an `Amode.ImmReg` with the `Offset32` and `Value` below and nothing
-;; else; this always works and is not *that* bad.
-;;
-;; But we can often do better. The toplevel rule for `iadd` below will
-;; turn an `(amode_add amode (iadd a b))` into two invocations of
-;; `amode_add`, for each operand of the `iadd`. This is what allows us
-;; to handle sums of many parts.
-;;
-;; Then we "just" need to work out how we can incorporate a new
-;; component into an existing addressing mode:
-;;
-;; - Case 1: When we have an `ImmReg` and the register is
-;;   `invalid_reg` (the initial `Amode` above), we can put the new
-;;   addend into a register and insert it into the `ImmReg`.
-;;
-;; - Case 2: When we have an `ImmReg` with a valid register already,
-;;   and we have another register to add, we can transition to an
-;;   `ImmRegRegShift`.
-;;
-;; - Case 3: When we're adding an `ishl`, we can refine the above rule
-;;   and use the built-in multiplier of 1, 2, 4, 8 to implement a
-;;   left-shift by 0, 1, 2, 3.
-;;
-;; - Case 4: When we are adding another constant offset, we can fold
-;;   it into the existing offset, as long as the sum still fits into
-;;   the signed 32-bit field.
-;;
-;; - Case 5: And as a general fallback, we can generate a new `add`
-;;   instruction and add the new addend to an existing component of
-;;   the `Amode`.
+;; Converts a `Value` and a static offset into an `Amode` for x64, attempting
+;; to be as fancy as possible with offsets/registers/shifts/etc to make maximal
+;; use of the x64 addressing modes.
 (decl to_amode (MemFlags Value Offset32) Amode)
 
-;; Initial step in amode processing: create an ImmReg with
-;; (invalid_reg) and encapsulating the flags and offset from the
-;; load/store.
-(decl amode_initial (MemFlags Offset32) Amode)
-(rule (amode_initial flags (offset32 off))
-      (Amode.ImmReg off (invalid_reg) flags))
+;; Base case, "just put it in a register"
+(rule (to_amode flags base offset)
+      (Amode.ImmReg offset base flags))
 
-;; One step in amode processing: take an existing amode and add
-;; another value to it.
-(decl amode_add (Amode Value) Amode)
+;; Slightly-more-fancy case, if the address is the addition of two things then
+;; delegate to the `to_amode_add` helper.
+(rule 1 (to_amode flags (iadd x y) offset)
+      (to_amode_add flags x y offset))
 
-;; -- Top-level driver: pull apart the addends.
-;;
-;; Any amode can absorb an `iadd` by absorbing first the LHS of the
-;; add, then the RHS.
-;;
-;; Priority 2 to take this above fallbacks and ensure we traverse the
-;; `iadd` tree fully.
-(rule 2 (amode_add amode (iadd x y))
-      (let ((amode1 Amode (amode_add amode x))
-            (amode2 Amode (amode_add amode1 y)))
-        amode2))
+;; Same as `to_amode`, except that the base address is computed via the addition
+;; of the two `Value` arguments provided.
+(decl to_amode_add (MemFlags Value Value Offset32) Amode)
 
-;; -- Case 1 (adding a register to the initial Amode with invalid_reg).
-;;
-;; An Amode.ImmReg with invalid_reg (initial state) can absorb a
-;; register as the base register.
-(rule (amode_add (Amode.ImmReg off (invalid_reg) flags) value)
-      (Amode.ImmReg off value flags))
+;; Base case, "just put things in registers". Note that the shift value of 0
+;; here  means `x + (y << 0)` which is the same as `x + y`.
+(rule (to_amode_add flags x y offset)
+      (Amode.ImmRegRegShift offset x y 0 flags))
 
-;; -- Case 2 (adding a register to an Amode with a register already).
-;;
-;; An Amode.ImmReg can absorb another register as the index register.
-(rule (amode_add (Amode.ImmReg off (valid_reg base) flags) value)
-      ;; Shift of 0 --> base + 1*value.
-      (Amode.ImmRegRegShift off base value 0 flags))
-
-;; -- Case 3 (adding a shifted value to an Amode).
-;;
-;; An Amode.ImmReg can absorb a shift of another register as the index register.
-;;
-;; Priority 2 to take these rules above generic case.
-(rule 2 (amode_add (Amode.ImmReg off (valid_reg base) flags) (ishl index (iconst (uimm8 shift))))
+;; If the one of the arguments being added is itself a constant shift then
+;; that can be modeled directly so long as the shift is a modestly small amount.
+(rule 1 (to_amode_add flags x (ishl y (iconst (uimm8 shift))) offset)
       (if (u32_lteq (u8_as_u32 shift) 3))
-      (Amode.ImmRegRegShift off base index shift flags))
+      (Amode.ImmRegRegShift offset x y shift flags))
+(rule 2 (to_amode_add flags (ishl y (iconst (uimm8 shift))) x offset)
+      (if (u32_lteq (u8_as_u32 shift) 3))
+      (Amode.ImmRegRegShift offset x y shift flags))
 
-;; -- Case 4 (absorbing constant offsets).
+;; Constant extraction rules.
 ;;
-;; An Amode can absorb a constant (i64, or extended i32) as long as
-;; the sum still fits in the signed-32-bit offset.
+;; These rules attempt to find a constant within one of `x` or `y`, or deeper
+;; within them if they have their own adds. These only succeed if the constant
+;; itself can be represented with 32-bits and can be infallibly added to the
+;; offset that we already have.
 ;;
-;; Priority 3 in order to take this option above the fallback
-;; (immediate in register). Two rules, for imm+reg and
-;; imm+reg+scale*reg cases.
-(rule 3 (amode_add (Amode.ImmReg off base flags)
-                   (iconst (simm32 c)))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmReg sum base flags))
-(rule 3 (amode_add (Amode.ImmRegRegShift off base index shift flags)
-                   (iconst (simm32 c)))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmRegRegShift sum base index shift flags))
-
-;; Likewise for a zero-extended i32 const, as long as the constant
-;; wasn't negative. (Why nonnegative? Because adding a
-;; non-sign-extended negative to a 64-bit address is not the same as
-;; adding in simm32-space.)
-(rule 3 (amode_add (Amode.ImmReg off base flags)
-                   (uextend (iconst (simm32 (u32_nonnegative c)))))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmReg sum base flags))
-(rule 3 (amode_add (Amode.ImmRegRegShift off base index shift flags)
-                   (uextend (iconst (simm32 (u32_nonnegative c)))))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmRegRegShift sum base index shift flags))
-
-;; Likewise for a sign-extended i32 const.
-(rule 3 (amode_add (Amode.ImmReg off base flags)
-                   (sextend (iconst (simm32 c))))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmReg sum base flags))
-(rule 3 (amode_add (Amode.ImmRegRegShift off base index shift flags)
-                   (sextend (iconst (simm32 c))))
-      (if-let sum (s32_add_fallible off c))
-      (Amode.ImmRegRegShift sum base index shift flags))
-
-;; -- Case 5 (fallback to add a new value to an imm+reg+scale*reg).
-;;
-;; An Amode.ImmRegRegShift can absorb any other value by creating a
-;; new add instruction and replacing the base with
-;; (base+value).
-(rule (amode_add (Amode.ImmRegRegShift off base index shift flags) value)
-      (let ((sum Gpr (x64_add $I64 base value)))
-        (Amode.ImmRegRegShift off sum index shift flags)))
-
-;; Finally, define the toplevel `to_amode`.
-(rule (to_amode flags base @ (value_type (ty_addr64 _)) offset)
-      (amode_finalize (amode_add (amode_initial flags offset) base)))
-
-;; If an amode has no registers at all and only offsets (a constant
-;; value), we need to "finalize" it by sticking in a zero'd reg in
-;; place of the (invalid_reg) produced by (amode_initial).
-(decl amode_finalize (Amode) Amode)
-(rule 1 (amode_finalize (Amode.ImmReg off (invalid_reg) flags))
-      (Amode.ImmReg off (imm $I64 0) flags))
-(rule 0 (amode_finalize amode)
-      amode)
+;; Note the recursion here where this rule is defined in terms of itself to
+;; "peel" layers of constants.
+(rule 3 (to_amode_add flags (iadd x (iconst (simm32 c))) y offset)
+      (if-let sum (s32_add_fallible offset c))
+      (to_amode_add flags x y sum))
+(rule 4 (to_amode_add flags x (iadd y (iconst (simm32 c))) offset)
+      (if-let sum (s32_add_fallible offset c))
+      (to_amode_add flags x y sum))
+(rule 5 (to_amode_add flags x (iconst (simm32 c)) offset)
+      (if-let sum (s32_add_fallible offset c))
+      (to_amode flags x sum))
+(rule 6 (to_amode_add flags (iconst (simm32 c)) x offset)
+      (if-let sum (s32_add_fallible offset c))
+      (to_amode flags x sum))
 
 ;; Offsetting an Amode. Used when we need to do consecutive
 ;; loads/stores to adjacent addresses.
@@ -3965,10 +3838,10 @@
             (inst MInst (MInst.Neg size src dst)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer inst dst)))
 
-(decl x64_lea (SyntheticAmode) Gpr)
-(rule (x64_lea addr)
+(decl x64_lea (Type SyntheticAmode) Gpr)
+(rule (x64_lea ty addr)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.LoadEffectiveAddress addr dst))))
+            (_ Unit (emit (MInst.LoadEffectiveAddress addr dst (operand_size_of_type_32_64 ty)))))
         dst))
 
 ;; Helper for creating `ud2` instructions.

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -926,20 +926,84 @@ pub(crate) fn emit(
             )
         }
 
-        Inst::LoadEffectiveAddress { addr, dst } => {
+        Inst::LoadEffectiveAddress { addr, dst, size } => {
             let dst = allocs.next(dst.to_reg().to_reg());
             let amode = addr.finalize(state, sink).with_allocs(allocs);
 
-            emit_std_reg_mem(
-                sink,
-                LegacyPrefixes::None,
-                0x8D,
-                1,
-                dst,
-                &amode,
-                RexFlags::set_w(),
-                0,
-            );
+            // If this `lea` can actually get encoded as an `add` then do that
+            // instead. Currently all candidate `iadd`s become an `lea`
+            // pseudo-instruction here but maximizing the sue of `lea` is not
+            // necessarily optimal. The `lea` instruction goes through dedicated
+            // address units on cores which are finite and disjoint from the
+            // general ALU, so if everything uses `lea` then those units can get
+            // saturated while leaving the ALU idle.
+            //
+            // To help make use of more parts of a cpu, this attempts to use
+            // `add` when it's semantically equivalent to `lea`, or otherwise
+            // when the `dst` register is the same as the `base` or `index`
+            // register.
+            //
+            // FIXME: ideally regalloc is informed of this constraint. Register
+            // allocation of `lea` should "attempt" to put the `base` in the
+            // same register as `dst` but not at the expense of generating a
+            // `mov` instruction. Currently that's not possible but perhaps one
+            // day it may be worth it.
+            match amode {
+                // If `base == dst` then this is `add $imm, %dst`, so encode
+                // that instead.
+                Amode::ImmReg {
+                    simm32,
+                    base,
+                    flags: _,
+                } if base == dst => {
+                    let inst = Inst::alu_rmi_r(
+                        *size,
+                        AluRmiROpcode::Add,
+                        RegMemImm::imm(simm32),
+                        Writable::from_reg(dst),
+                    );
+                    inst.emit(&[], sink, info, state);
+                }
+                // If the offset is 0 and the shift is 0 (meaning multiplication
+                // by 1) then:
+                //
+                // * If `base == dst`, then this is `add %index, %base`
+                // * If `index == dst`, then this is `add %base, %index`
+                //
+                // Encode the appropriate instruction here in that case.
+                Amode::ImmRegRegShift {
+                    simm32: 0,
+                    base,
+                    index,
+                    shift: 0,
+                    flags: _,
+                } if base == dst || index == dst => {
+                    let (dst, operand) = if base == dst {
+                        (base, index)
+                    } else {
+                        (index, base)
+                    };
+                    let inst = Inst::alu_rmi_r(
+                        *size,
+                        AluRmiROpcode::Add,
+                        RegMemImm::reg(operand.to_reg()),
+                        Writable::from_reg(dst.to_reg()),
+                    );
+                    inst.emit(&[], sink, info, state);
+                }
+
+                // If `lea`'s 3-operand mode is leveraged by regalloc, or if
+                // it's fancy like imm-plus-shift-plus-base, then `lea` is
+                // actually emitted.
+                _ => {
+                    let flags = match size {
+                        OperandSize::Size32 => RexFlags::clear_w(),
+                        OperandSize::Size64 => RexFlags::set_w(),
+                        _ => unreachable!(),
+                    };
+                    emit_std_reg_mem(sink, LegacyPrefixes::None, 0x8D, 1, dst, &amode, flags, 0);
+                }
+            };
         }
 
         Inst::MovsxRmR { ext_mode, src, dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -434,6 +434,7 @@ impl Inst {
         Inst::LoadEffectiveAddress {
             addr: addr.into(),
             dst: WritableGpr::from_writable_reg(dst).unwrap(),
+            size: OperandSize::Size64,
         }
     }
 
@@ -1462,8 +1463,8 @@ impl PrettyPrint for Inst {
                 format!("{} {}, {}", ljustify("movq".to_string()), src, dst)
             }
 
-            Inst::LoadEffectiveAddress { addr, dst } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+            Inst::LoadEffectiveAddress { addr, dst, size } => {
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let addr = addr.pretty_print(8, allocs);
                 format!("{} {}, {}", ljustify("lea".to_string()), addr, dst)
             }
@@ -2214,7 +2215,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             collector.reg_def(dst.to_writable_reg());
             src.get_operands(collector);
         }
-        Inst::LoadEffectiveAddress { addr: src, dst } => {
+        Inst::LoadEffectiveAddress { addr: src, dst, .. } => {
             collector.reg_def(dst.to_writable_reg());
             src.get_operands(collector);
         }

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -41,17 +41,27 @@
 
 ;; `i64` and smaller.
 
-;; Add two registers.
-(rule -5 (lower (has_type (fits_in_64 ty)
+;; Base case for 8 and 16-bit types
+(rule -6 (lower (has_type (fits_in_16 ty)
                        (iadd x y)))
       (x64_add ty x y))
 
-;; The above case handles when the rhs is an immediate or a sinkable load, but
-;; additionally add lhs meets these criteria.
+;; Base case for 32 and 64-bit types which might end up using the `lea`
+;; instruction to fold multiple operations into one.
+;;
+;; Note that at this time this always generates a `lea` pseudo-instruction,
+;; but the actual instruction emitted might be an `add` if it's equivalent.
+;; For more details on this see the `emit.rs` logic to emit
+;; `LoadEffectiveAddress`.
+(rule -5 (lower (has_type (ty_32_or_64 ty) (iadd x y)))
+      (x64_lea ty (to_amode_add (mem_flags_trusted) x y (zero_offset))))
 
+;; Higher-priority cases than the previous two where a load can be sunk into
+;; the add instruction itself. Note that both operands are tested for
+;; sink-ability since addition is commutative
 (rule -4 (lower (has_type (fits_in_64 ty)
-                       (iadd (simm32_from_value x) y)))
-      (x64_add ty y x))
+                       (iadd x (sinkable_load y))))
+      (x64_add ty x y))
 (rule -3 (lower (has_type (fits_in_64 ty)
                        (iadd (sinkable_load x) y)))
       (x64_add ty y x))
@@ -510,13 +520,14 @@
 (extern constructor ishl_i8x16_mask_table ishl_i8x16_mask_table)
 (rule (ishl_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ishl_i8x16_mask_table))
-            (base_mask_addr Gpr (x64_lea mask_table))
+            (base_mask_addr Gpr (x64_lea $I64 mask_table))
             (mask_offset Gpr (x64_shl $I64 amt
                                   (imm8_to_imm8_gpr 4))))
-        (amode_imm_reg_reg_shift 0
-                                 base_mask_addr
-                                 mask_offset
-                                 0)))
+        (Amode.ImmRegRegShift 0
+                              base_mask_addr
+                              mask_offset
+                              0
+                              (mem_flags_trusted))))
 
 (rule (ishl_i8x16_mask (RegMemImm.Mem amt))
       (ishl_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
@@ -614,14 +625,15 @@
 (extern constructor ushr_i8x16_mask_table ushr_i8x16_mask_table)
 (rule (ushr_i8x16_mask (RegMemImm.Reg amt))
       (let ((mask_table SyntheticAmode (ushr_i8x16_mask_table))
-            (base_mask_addr Gpr (x64_lea mask_table))
+            (base_mask_addr Gpr (x64_lea $I64 mask_table))
             (mask_offset Gpr (x64_shl $I64
                                   amt
                                   (imm8_to_imm8_gpr 4))))
-        (amode_imm_reg_reg_shift 0
-                                 base_mask_addr
-                                 mask_offset
-                                 0)))
+        (Amode.ImmRegRegShift 0
+                              base_mask_addr
+                              mask_offset
+                              0
+                              (mem_flags_trusted))))
 
 (rule (ushr_i8x16_mask (RegMemImm.Mem amt))
       (ushr_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -344,21 +344,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn amode_imm_reg_reg_shift(&mut self, simm32: u32, base: Gpr, index: Gpr, shift: u8) -> Amode {
-        Amode::imm_reg_reg_shift(simm32, base, index, shift)
-    }
-
-    #[inline]
-    fn amode_imm_reg(&mut self, simm32: u32, base: Gpr) -> Amode {
-        Amode::imm_reg(simm32, base.to_reg())
-    }
-
-    #[inline]
-    fn amode_with_flags(&mut self, amode: &Amode, flags: MemFlags) -> Amode {
-        amode.with_flags(flags)
-    }
-
-    #[inline]
     fn amode_to_synthetic_amode(&mut self, amode: &Amode) -> SyntheticAmode {
         amode.clone().into()
     }

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -721,6 +721,11 @@ macro_rules! isle_common_prelude_methods {
             offset as u32
         }
 
+        #[inline]
+        fn u32_to_offset32(&mut self, offset: u32) -> Offset32 {
+            Offset32::new(offset as i32)
+        }
+
         fn range(&mut self, start: usize, end: usize) -> Range {
             (start, end)
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -511,6 +511,10 @@
 (decl pure offset32_to_u32 (Offset32) u32)
 (extern constructor offset32_to_u32 offset32_to_u32)
 
+;; Convert a number to an `Offset32`
+(decl pure u32_to_offset32 (u32) Offset32)
+(extern constructor u32_to_offset32 u32_to_offset32)
+
 ;; This is a direct import of `IntCC::unsigned`.
 ;; Get the corresponding IntCC with the signed component removed.
 ;; For conditions without a signed component, this is a no-op.
@@ -563,3 +567,4 @@
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (convert Offset32 u32 offset32_to_u32)
+(convert u32 Offset32 u32_to_offset32)

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -245,8 +245,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r8
-;   addl    %r8d, %edx, %r8d
+;   lea     0(%rsi,%rdx,1), %r8d
 ;   shll    $2, %r8d, %r8d
 ;   movq    -1(%rdi,%r8,1), %rax
 ;   movq    %rbp, %rsp
@@ -258,8 +257,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %r8
-;   addl %edx, %r8d
+;   leal (%rsi, %rdx), %r8d
 ;   shll $2, %r8d
 ;   movq -1(%rdi, %r8), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -11,8 +11,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addl    %eax, %esi, %eax
+;   lea     0(%rdi,%rsi,1), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -22,8 +21,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addl %esi, %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -924,8 +924,7 @@ block5(v5: i32):
 ;   movl    $4, %esi
 ;   jmp     label7
 ; block7:
-;   movq    %rdi, %rax
-;   addl    %eax, %esi, %eax
+;   lea     0(%rdi,%rsi,1), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -965,8 +964,7 @@ block5(v5: i32):
 ; block6: ; offset 0x58
 ;   movl $4, %esi
 ; block7: ; offset 0x5d
-;   movq %rdi, %rax
-;   addl %esi, %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -19,15 +19,15 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r9
-;   addq    %r9, const(0), %r9
-;   movq    %r9, 0(%rsi)
-;   movq    %rdi, %r10
-;   subq    %r10, const(0), %r10
+;   movabsq $-18765284782900, %r10
+;   lea     0(%rdi,%r10,1), %r10
 ;   movq    %r10, 0(%rsi)
 ;   movq    %rdi, %r11
-;   andq    %r11, const(0), %r11
+;   subq    %r11, const(0), %r11
 ;   movq    %r11, 0(%rsi)
+;   movq    %rdi, %rax
+;   andq    %rax, const(0), %rax
+;   movq    %rax, 0(%rsi)
 ;   orq     %rdi, const(0), %rdi
 ;   movq    %rdi, 0(%rsi)
 ;   movq    %rbp, %rsp
@@ -39,24 +39,22 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %r9
-;   addq 0x32(%rip), %r9
-;   movq %r9, (%rsi) ; trap: heap_oob
-;   movq %rdi, %r10
-;   subq 0x25(%rip), %r10
+;   movabsq $18446725308424768716, %r10
+;   addq %rdi, %r10
 ;   movq %r10, (%rsi) ; trap: heap_oob
 ;   movq %rdi, %r11
-;   andq 0x18(%rip), %r11
+;   subq 0x22(%rip), %r11
 ;   movq %r11, (%rsi) ; trap: heap_oob
-;   orq 0xe(%rip), %rdi
+;   movq %rdi, %rax
+;   andq 0x15(%rip), %rax
+;   movq %rax, (%rsi) ; trap: heap_oob
+;   orq 0xb(%rip), %rdi
 ;   movq %rdi, (%rsi) ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ;   addb %al, (%rax)
-;   addb %al, (%rax)
-;   addb %al, (%rax)
-;   int3
+;   addb %cl, %ah
 ;   int3
 ;   fstp %st(5)
 ;   outb %al, %dx

--- a/cranelift/filetests/filetests/isa/x64/lea.clif
+++ b/cranelift/filetests/filetests/isa/x64/lea.clif
@@ -11,8 +11,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addl    %eax, %esi, %eax
+;   lea     0(%rdi,%rsi,1), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -22,8 +21,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addl %esi, %eax
+;   leal (%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -38,8 +36,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addq    %rax, %rsi, %rax
+;   lea     0(%rdi,%rsi,1), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -49,8 +46,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addq %rsi, %rax
+;   leaq (%rdi, %rsi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -66,8 +62,7 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addl    %eax, $100, %eax
+;   lea     100(%rdi), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -77,8 +72,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addl $0x64, %eax
+;   leal 0x64(%rdi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -94,8 +88,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addq    %rax, $100, %rax
+;   lea     100(%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -105,8 +98,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addq $0x64, %rax
+;   leaq 0x64(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -123,9 +115,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addl    %eax, %esi, %eax
-;   addl    %eax, $100, %eax
+;   lea     100(%rdi,%rsi,1), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -135,9 +125,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addl %esi, %eax
-;   addl $0x64, %eax
+;   leal 0x64(%rdi, %rsi), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -154,9 +142,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   addq    %rax, %rsi, %rax
-;   addq    %rax, $100, %rax
+;   lea     100(%rdi,%rsi,1), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -166,9 +152,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   addq %rsi, %rax
-;   addq $0x64, %rax
+;   leaq 0x64(%rdi, %rsi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -187,11 +171,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r8
-;   shll    $2, %r8d, %r8d
-;   movq    %rdi, %rax
-;   addl    %eax, %r8d, %eax
-;   addl    %eax, $100, %eax
+;   lea     100(%rdi,%rsi,4), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -201,11 +181,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %r8
-;   shll $2, %r8d
-;   movq %rdi, %rax
-;   addl %r8d, %eax
-;   addl $0x64, %eax
+;   leal 0x64(%rdi, %rsi, 4), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -224,11 +200,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %r8
-;   shlq    $2, %r8, %r8
-;   movq    %rdi, %rax
-;   addq    %rax, %r8, %rax
-;   addq    %rax, $100, %rax
+;   lea     100(%rdi,%rsi,4), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -238,11 +210,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %r8
-;   shlq $2, %r8
-;   movq %rdi, %rax
-;   addq %r8, %rax
-;   addq $0x64, %rax
+;   leaq 0x64(%rdi, %rsi, 4), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -259,10 +227,7 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rdx
-;   shll    $2, %edx, %edx
-;   movq    %rdi, %rax
-;   addl    %eax, %edx, %eax
+;   lea     0(%rdi,%rsi,4), %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -272,10 +237,7 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rdx
-;   shll $2, %edx
-;   movq %rdi, %rax
-;   addl %edx, %eax
+;   leal (%rdi, %rsi, 4), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -292,10 +254,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rdx
-;   shlq    $2, %rdx, %rdx
-;   movq    %rdi, %rax
-;   addq    %rax, %rdx, %rax
+;   lea     0(%rdi,%rsi,4), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -305,10 +264,7 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rdx
-;   shlq $2, %rdx
-;   movq %rdi, %rax
-;   addq %rdx, %rax
+;   leaq (%rdi, %rsi, 4), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -155,8 +155,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    0(%rdi), %r8
-;   movq    %r8, %r9
-;   addq    %r9, %rdi, %r9
+;   lea     0(%r8,%rdi,1), %r9
 ;   movq    %r9, 0(%rsi)
 ;   movq    0(%r8,%rdi,1), %rax
 ;   movq    %rbp, %rsp
@@ -169,8 +168,7 @@ block0(v0: i64, v1: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq (%rdi), %r8 ; trap: heap_oob
-;   movq %r8, %r9
-;   addq %rdi, %r9
+;   leaq (%r8, %rdi), %r9
 ;   movq %r9, (%rsi) ; trap: heap_oob
 ;   movq (%r8, %rdi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -14,9 +14,9 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %r15, %rsi
-;   addq    %rsi, $1, %rsi
-;   movq    %rsi, %r15
+;   movq    %r15, %rdi
+;   lea     1(%rdi), %rdi
+;   movq    %rdi, %r15
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -26,9 +26,9 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %r15, %rsi
-;   addq $1, %rsi
-;   movq %rsi, %r15
+;   movq %r15, %rdi
+;   addq $1, %rdi
+;   movq %rdi, %r15
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -45,12 +45,12 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
-;   movq    %rsi, 0(%rsp)
+;   movq    %rdi, 0(%rsp)
 ; block0:
-;   movq    %r15, %rsi
-;   addq    %rsi, $1, %rsi
-;   movq    %rsi, %r15
-;   movq    0(%rsp), %rsi
+;   movq    %r15, %rdi
+;   lea     1(%rdi), %rdi
+;   movq    %rdi, %r15
+;   movq    0(%rsp), %rdi
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -61,12 +61,12 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
-;   movq %rsi, (%rsp)
+;   movq %rdi, (%rsp)
 ; block1: ; offset 0xc
-;   movq %r15, %rsi
-;   addq $1, %rsi
-;   movq %rsi, %r15
-;   movq (%rsp), %rsi
+;   movq %r15, %rdi
+;   addq $1, %rdi
+;   movq %rdi, %r15
+;   movq (%rsp), %rdi
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -26,11 +26,10 @@ block0(v0: i32, v1: r64, v2: i64):
 ; block1:
 ;   movl    %edi, %ecx
 ;   movq    0(%rdx), %rax
-;   movq    %rax, %rdx
-;   addq    %rdx, %rcx, %rdx
+;   lea     0(%rax,%rcx,1), %rcx
 ;   cmpl    %r11d, %edi
-;   cmovnbq %rax, %rdx, %rdx
-;   movq    %rsi, 0(%rdx)
+;   cmovnbq %rax, %rcx, %rcx
+;   movq    %rsi, 0(%rcx)
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -44,18 +43,17 @@ block0(v0: i32, v1: r64, v2: i64):
 ; block1: ; offset 0x4
 ;   movl 8(%rdx), %r11d
 ;   cmpl %r11d, %edi
-;   jae 0x2b
+;   jae 0x28
 ; block2: ; offset 0x11
 ;   movl %edi, %ecx
 ;   movq (%rdx), %rax
-;   movq %rax, %rdx
-;   addq %rcx, %rdx
+;   addq %rax, %rcx
 ;   cmpl %r11d, %edi
-;   cmovaeq %rax, %rdx
-;   movq %rsi, (%rdx)
+;   cmovaeq %rax, %rcx
+;   movq %rsi, (%rcx)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x2b
+; block3: ; offset 0x28
 ;   ud2 ; trap: table_oob
 

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -45,17 +45,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r8d
+;;   movq    %r8, %r11
+;;   addq    %r11, const(0), %r11
 ;;   jb #trap=heap_oob
-;;   movq    8(%rdx), %rax
-;;   cmpq    %rax, %rdi
+;;   movq    8(%rdx), %rdi
+;;   cmpq    %rdi, %r11
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movl    %esi, 0(%rdi,%r11,1)
+;;   addq    %r8, 0(%rdx), %r8
+;;   movl    $-65536, %eax
+;;   movl    %esi, 0(%r8,%rax,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,17 +70,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r8d
+;;   movq    %r8, %r11
+;;   addq    %r11, const(0), %r11
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   cmpq    %rax, %rdi
+;;   movq    8(%rsi), %rdi
+;;   cmpq    %rdi, %r11
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movl    0(%rsi,%r11,1), %eax
+;;   addq    %r8, 0(%rsi), %r8
+;;   movl    $-65536, %eax
+;;   movl    0(%r8,%rax,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -45,17 +45,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r8d
+;;   movq    %r8, %r11
+;;   addq    %r11, const(0), %r11
 ;;   jb #trap=heap_oob
-;;   movq    8(%rdx), %rax
-;;   cmpq    %rax, %rdi
+;;   movq    8(%rdx), %rdi
+;;   cmpq    %rdi, %r11
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rdi
-;;   addq    %rdi, const(0), %rdi
-;;   movb    %sil, 0(%rdi,%r11,1)
+;;   addq    %r8, 0(%rdx), %r8
+;;   movl    $-65536, %eax
+;;   movb    %sil, 0(%r8,%rax,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,17 +70,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r11d
-;;   movq    %r11, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r8d
+;;   movq    %r8, %r11
+;;   addq    %r11, const(0), %r11
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   cmpq    %rax, %rdi
+;;   movq    8(%rsi), %rdi
+;;   cmpq    %rdi, %r11
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %rsi
-;;   addq    %rsi, const(0), %rsi
-;;   movzbq  0(%rsi,%r11,1), %rax
+;;   addq    %r8, 0(%rsi), %r8
+;;   movl    $-65536, %eax
+;;   movzbq  0(%r8,%rax,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -48,13 +48,12 @@
 ;;   movl    %edi, %edi
 ;;   movabsq $-4100, %rax
 ;;   addq    %rax, 8(%rdx), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, $4096, %r10
+;;   movq    0(%rdx), %rcx
+;;   lea     4096(%rcx,%rdi,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r10, %r10
-;;   movl    %esi, 0(%r10)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movl    %esi, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -72,13 +71,12 @@
 ;;   movabsq $-4100, %rsi
 ;;   movq    %rax, %rdx
 ;;   addq    %rsi, 8(%rdx), %rsi
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, $4096, %r10
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r11
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %rsi, %rdi
-;;   cmovnbeq %rax, %r10, %r10
-;;   movl    0(%r10), %eax
+;;   cmovnbeq %rax, %r11, %r11
+;;   movl    0(%r11), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,19 +45,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdx, %rax
-;;   movl    %edi, %edx
-;;   movq    %rdx, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r11d
+;;   movq    %r11, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    %rax, %r8
-;;   movq    8(%r8), %rax
-;;   addq    %rdx, 0(%r8), %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rdx, %rdx
-;;   movl    %esi, 0(%rdx)
+;;   movq    8(%rdx), %rcx
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edx
+;;   lea     0(%r11,%rdx,1), %rdi
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movl    %esi, 0(%rdi)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -70,17 +69,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %edx
-;;   movq    %rdx, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r11d
+;;   movq    %r11, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rdx, %rdx
-;;   movl    0(%rdx), %eax
+;;   movq    8(%rsi), %rcx
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %edx
+;;   lea     0(%r11,%rdx,1), %rdi
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movl    0(%rdi), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -48,13 +48,12 @@
 ;;   movl    %edi, %edi
 ;;   movabsq $-4097, %rax
 ;;   addq    %rax, 8(%rdx), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, $4096, %r10
+;;   movq    0(%rdx), %rcx
+;;   lea     4096(%rcx,%rdi,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r10, %r10
-;;   movb    %sil, 0(%r10)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movb    %sil, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -72,13 +71,12 @@
 ;;   movabsq $-4097, %rsi
 ;;   movq    %rax, %rdx
 ;;   addq    %rsi, 8(%rdx), %rsi
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, $4096, %r10
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r11
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %rsi, %rdi
-;;   cmovnbeq %rax, %r10, %r10
-;;   movzbq  0(%r10), %rax
+;;   cmovnbeq %rax, %r11, %r11
+;;   movzbq  0(%r11), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,19 +45,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdx, %rax
-;;   movl    %edi, %edx
-;;   movq    %rdx, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r11d
+;;   movq    %r11, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    %rax, %r8
-;;   movq    8(%r8), %rax
-;;   addq    %rdx, 0(%r8), %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rdx, %rdx
-;;   movb    %sil, 0(%rdx)
+;;   movq    8(%rdx), %rcx
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edx
+;;   lea     0(%r11,%rdx,1), %rdi
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movb    %sil, 0(%rdi)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -70,17 +69,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %edx
-;;   movq    %rdx, %rdi
-;;   addq    %rdi, const(1), %rdi
+;;   movl    %edi, %r11d
+;;   movq    %r11, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, const(0), %rdx
-;;   xorq    %rcx, %rcx, %rcx
-;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %rdx, %rdx
-;;   movzbq  0(%rdx), %rax
+;;   movq    8(%rsi), %rcx
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %edx
+;;   lea     0(%r11,%rdx,1), %rdi
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movzbq  0(%rdi), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -45,14 +45,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movq    8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r8d
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r11
-;;   addq    %r11, const(0), %r11
-;;   movl    %esi, 0(%r11,%r10,1)
+;;   addq    %r8, 0(%rdx), %r8
+;;   movl    $-65536, %edi
+;;   movl    %esi, 0(%r8,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -67,14 +67,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movq    8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r8d
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   addq    %r11, const(0), %r11
-;;   movl    0(%r11,%r10,1), %eax
+;;   addq    %r8, 0(%rsi), %r8
+;;   movl    $-65536, %esi
+;;   movl    0(%r8,%rsi,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -45,14 +45,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movq    8(%rdx), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r8d
+;;   movq    8(%rdx), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r11
-;;   addq    %r11, const(0), %r11
-;;   movb    %sil, 0(%r11,%r10,1)
+;;   addq    %r8, 0(%rdx), %r8
+;;   movl    $-65536, %edi
+;;   movb    %sil, 0(%r8,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -67,14 +67,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %r10d
-;;   movq    8(%rsi), %r11
-;;   cmpq    %r11, %r10
+;;   movl    %edi, %r8d
+;;   movq    8(%rsi), %r10
+;;   cmpq    %r10, %r8
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   addq    %r11, const(0), %r11
-;;   movzbq  0(%r11,%r10,1), %rax
+;;   addq    %r8, 0(%rsi), %r8
+;;   movl    $-65536, %esi
+;;   movzbq  0(%r8,%rsi,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;; block0:
 ;;   movl    %edi, %edi
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rdx), %rcx
+;;   lea     4096(%rcx,%rdi,1), %r10
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r9, %r9
-;;   movl    %esi, 0(%r9)
+;;   cmovnbeq %rcx, %r10, %r10
+;;   movl    %esi, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +65,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %eax
+;;   movl    %edi, %ecx
 ;;   movq    8(%rsi), %rdi
-;;   movq    %rax, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, $4096, %r9
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %rdi, %rax
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movl    0(%r9), %eax
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rcx,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rdi, %rcx
+;;   cmovnbeq %rax, %r10, %r10
+;;   movl    0(%r10), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -47,13 +47,14 @@
 ;; block0:
 ;;   movl    %edi, %edi
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, const(0), %r9
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r9, %r9
-;;   movl    %esi, 0(%r9)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movl    %esi, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +67,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %eax
-;;   movq    8(%rsi), %rdi
-;;   movq    %rax, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, const(0), %r9
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %rdi, %rax
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movl    0(%r9), %eax
+;;   movl    %edi, %edi
+;;   movq    8(%rsi), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rsi), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movl    0(%r11), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;; block0:
 ;;   movl    %edi, %edi
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rdx), %rcx
+;;   lea     4096(%rcx,%rdi,1), %r10
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r9, %r9
-;;   movb    %sil, 0(%r9)
+;;   cmovnbeq %rcx, %r10, %r10
+;;   movb    %sil, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +65,14 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %eax
+;;   movl    %edi, %ecx
 ;;   movq    8(%rsi), %rdi
-;;   movq    %rax, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, $4096, %r9
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %rdi, %rax
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movzbq  0(%r9), %rax
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rcx,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rdi, %rcx
+;;   cmovnbeq %rax, %r10, %r10
+;;   movzbq  0(%r10), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -47,13 +47,14 @@
 ;; block0:
 ;;   movl    %edi, %edi
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, const(0), %r9
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
 ;;   cmpq    %rax, %rdi
-;;   cmovnbeq %rcx, %r9, %r9
-;;   movb    %sil, 0(%r9)
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movb    %sil, 0(%r11)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,15 +67,16 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movl    %edi, %eax
-;;   movq    8(%rsi), %rdi
-;;   movq    %rax, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, const(0), %r9
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %rdi, %rax
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movzbq  0(%r9), %rax
+;;   movl    %edi, %edi
+;;   movq    8(%rsi), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rsi), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r11
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r11, %r11
+;;   movzbq  0(%r11), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -46,15 +46,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %r10
-;;   addq    %r10, const(1), %r10
+;;   addq    %r10, const(0), %r10
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movl    %esi, 0(%rax,%rdi,1)
+;;   addq    %rdi, 0(%rdx), %rdi
+;;   movl    $-65536, %eax
+;;   movl    %esi, 0(%rdi,%rax,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,15 +70,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %r10
-;;   addq    %r10, const(1), %r10
+;;   addq    %r10, const(0), %r10
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   addq    %r11, const(0), %r11
-;;   movl    0(%r11,%rdi,1), %eax
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %eax
+;;   movl    0(%rdi,%rax,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -46,15 +46,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %r10
-;;   addq    %r10, const(1), %r10
+;;   addq    %r10, const(0), %r10
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rdx), %r11
 ;;   cmpq    %r11, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %rax
-;;   addq    %rax, const(0), %rax
-;;   movb    %sil, 0(%rax,%rdi,1)
+;;   addq    %rdi, 0(%rdx), %rdi
+;;   movl    $-65536, %eax
+;;   movb    %sil, 0(%rdi,%rax,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,15 +70,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %r10
-;;   addq    %r10, const(1), %r10
+;;   addq    %r10, const(0), %r10
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rsi), %r11
 ;;   cmpq    %r11, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r11
-;;   addq    %r11, const(0), %r11
-;;   movzbq  0(%r11,%rdi,1), %rax
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %eax
+;;   movzbq  0(%rdi,%rax,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;; block0:
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rdx), %r11
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r10
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r9, %r9
-;;   movl    %esi, 0(%r9)
+;;   cmovnbeq %rax, %r10, %r10
+;;   movl    %esi, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -68,13 +67,12 @@
 ;; block0:
 ;;   movabsq $-4100, %r11
 ;;   addq    %r11, 8(%rsi), %r11
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rdi,1), %r10
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movl    0(%r9), %eax
+;;   cmovnbeq %rsi, %r10, %r10
+;;   movl    0(%r10), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,17 +45,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(1), %rcx
+;;   movq    %rdi, %r8
+;;   addq    %r8, const(0), %r8
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, const(0), %r10
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %rcx
-;;   cmovnbeq %rdi, %r10, %r10
-;;   movl    %esi, 0(%r10)
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %rcx
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rax, %r8
+;;   cmovnbeq %rdx, %rcx, %rcx
+;;   movl    %esi, 0(%rcx)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,16 +70,17 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(1), %rcx
+;;   addq    %rcx, const(0), %rcx
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rsi), %r10
-;;   addq    %r10, const(0), %r10
-;;   xorq    %rdi, %rdi, %rdi
+;;   movq    %rdi, %rdx
+;;   addq    %rdx, 0(%rsi), %rdx
+;;   movl    $-65536, %r8d
+;;   lea     0(%rdx,%r8,1), %rsi
+;;   xorq    %rdx, %rdx, %rdx
 ;;   cmpq    %rax, %rcx
-;;   cmovnbeq %rdi, %r10, %r10
-;;   movl    0(%r10), %eax
+;;   cmovnbeq %rdx, %rsi, %rsi
+;;   movl    0(%rsi), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -47,13 +47,12 @@
 ;; block0:
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rdx), %r11
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rdx), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r10
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r9, %r9
-;;   movb    %sil, 0(%r9)
+;;   cmovnbeq %rax, %r10, %r10
+;;   movb    %sil, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -68,13 +67,12 @@
 ;; block0:
 ;;   movabsq $-4097, %r11
 ;;   addq    %r11, 8(%rsi), %r11
-;;   movq    %rdi, %r9
-;;   addq    %r9, 0(%rsi), %r9
-;;   addq    %r9, $4096, %r9
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rdi,1), %r10
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r9, %r9
-;;   movzbq  0(%r9), %rax
+;;   cmovnbeq %rsi, %r10, %r10
+;;   movzbq  0(%r10), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,17 +45,18 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(1), %rcx
+;;   movq    %rdi, %r8
+;;   addq    %r8, const(0), %r8
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rdx), %r10
-;;   addq    %r10, const(0), %r10
-;;   xorq    %rdi, %rdi, %rdi
-;;   cmpq    %rax, %rcx
-;;   cmovnbeq %rdi, %r10, %r10
-;;   movb    %sil, 0(%r10)
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %rcx
+;;   xorq    %rdx, %rdx, %rdx
+;;   cmpq    %rax, %r8
+;;   cmovnbeq %rdx, %rcx, %rcx
+;;   movb    %sil, 0(%rcx)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,16 +70,17 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(1), %rcx
+;;   addq    %rcx, const(0), %rcx
 ;;   jb #trap=heap_oob
 ;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %r10
-;;   addq    %r10, 0(%rsi), %r10
-;;   addq    %r10, const(0), %r10
-;;   xorq    %rdi, %rdi, %rdi
+;;   movq    %rdi, %rdx
+;;   addq    %rdx, 0(%rsi), %rdx
+;;   movl    $-65536, %r8d
+;;   lea     0(%rdx,%r8,1), %rsi
+;;   xorq    %rdx, %rdx, %rdx
 ;;   cmpq    %rax, %rcx
-;;   cmovnbeq %rdi, %r10, %r10
-;;   movzbq  0(%r10), %rax
+;;   cmovnbeq %rdx, %rsi, %rsi
+;;   movzbq  0(%rsi), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -49,9 +49,10 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r10
-;;   addq    %r10, const(0), %r10
-;;   movl    %esi, 0(%r10,%rdi,1)
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edi
+;;   movl    %esi, 0(%r11,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,9 +71,10 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r9
-;;   addq    %r9, const(0), %r9
-;;   movl    0(%r9,%rdi,1), %eax
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %esi
+;;   movl    0(%r11,%rsi,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -49,9 +49,10 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rdx), %r10
-;;   addq    %r10, const(0), %r10
-;;   movb    %sil, 0(%r10,%rdi,1)
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rdx), %r11
+;;   movl    $-65536, %edi
+;;   movb    %sil, 0(%r11,%rdi,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -70,9 +71,10 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    0(%rsi), %r9
-;;   addq    %r9, const(0), %r9
-;;   movzbq  0(%r9,%rdi,1), %rax
+;;   movq    %rdi, %r11
+;;   addq    %r11, 0(%rsi), %r11
+;;   movl    $-65536, %esi
+;;   movzbq  0(%r11,%rsi,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,13 +46,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    8(%rdx), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r9
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r8, %r8
-;;   movl    %esi, 0(%r8)
+;;   cmovnbeq %rax, %r9, %r9
+;;   movl    %esi, 0(%r9)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,13 +65,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    8(%rsi), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rdi,1), %r9
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movl    0(%r8), %eax
+;;   cmovnbeq %rsi, %r9, %r9
+;;   movl    0(%r9), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,14 +45,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    8(%rdx), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, const(0), %r8
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r8, %r8
-;;   movl    %esi, 0(%r8)
+;;   movq    8(%rdx), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r10
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r10, %r10
+;;   movl    %esi, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -65,14 +66,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    8(%rsi), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, const(0), %r8
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movl    0(%r8), %eax
+;;   movq    8(%rsi), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, 0(%rsi), %rax
+;;   movl    $-65536, %esi
+;;   lea     0(%rax,%rsi,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rcx, %rdi
+;;   cmovnbeq %rax, %r10, %r10
+;;   movl    0(%r10), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -46,13 +46,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    8(%rdx), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %rax
+;;   lea     4096(%rax,%rdi,1), %r9
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r8, %r8
-;;   movb    %sil, 0(%r8)
+;;   cmovnbeq %rax, %r9, %r9
+;;   movb    %sil, 0(%r9)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -66,13 +65,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movq    8(%rsi), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%rdi,1), %r9
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movzbq  0(%r8), %rax
+;;   cmovnbeq %rsi, %r9, %r9
+;;   movzbq  0(%r9), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,14 +45,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    8(%rdx), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, const(0), %r8
-;;   xorq    %rax, %rax, %rax
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rax, %r8, %r8
-;;   movb    %sil, 0(%r8)
+;;   movq    8(%rdx), %rax
+;;   movq    %rdi, %rcx
+;;   addq    %rcx, 0(%rdx), %rcx
+;;   movl    $-65536, %edx
+;;   lea     0(%rcx,%rdx,1), %r10
+;;   xorq    %rcx, %rcx, %rcx
+;;   cmpq    %rax, %rdi
+;;   cmovnbeq %rcx, %r10, %r10
+;;   movb    %sil, 0(%r10)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -65,14 +66,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    8(%rsi), %r11
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, const(0), %r8
-;;   xorq    %rsi, %rsi, %rsi
-;;   cmpq    %r11, %rdi
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movzbq  0(%r8), %rax
+;;   movq    8(%rsi), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, 0(%rsi), %rax
+;;   movl    $-65536, %esi
+;;   lea     0(%rax,%rsi,1), %r10
+;;   xorq    %rax, %rax, %rax
+;;   cmpq    %rcx, %rdi
+;;   cmovnbeq %rax, %r10, %r10
+;;   movzbq  0(%r10), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -44,13 +44,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r11d
-;;   movq    %r11, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %rdi
+;;   lea     4096(%rdi,%r11,1), %r9
 ;;   xorq    %rdi, %rdi, %rdi
 ;;   cmpq    $268431356, %r11
-;;   cmovnbeq %rdi, %r8, %r8
-;;   movl    %esi, 0(%r8)
+;;   cmovnbeq %rdi, %r9, %r9
+;;   movl    %esi, 0(%r9)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -64,13 +63,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r11d
-;;   movq    %r11, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%r11,1), %r9
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    $268431356, %r11
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movl    0(%r8), %eax
+;;   cmovnbeq %rsi, %r9, %r9
+;;   movl    0(%r9), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -44,13 +44,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r11d
-;;   movq    %r11, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %rdi
+;;   lea     4096(%rdi,%r11,1), %r9
 ;;   xorq    %rdi, %rdi, %rdi
 ;;   cmpq    $268431359, %r11
-;;   cmovnbeq %rdi, %r8, %r8
-;;   movb    %sil, 0(%r8)
+;;   cmovnbeq %rdi, %r9, %r9
+;;   movb    %sil, 0(%r9)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -64,13 +63,12 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r11d
-;;   movq    %r11, %r8
-;;   addq    %r8, 0(%rsi), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rsi), %rsi
+;;   lea     4096(%rsi,%r11,1), %r9
 ;;   xorq    %rsi, %rsi, %rsi
 ;;   cmpq    $268431359, %r11
-;;   cmovnbeq %rsi, %r8, %r8
-;;   movzbq  0(%r8), %rax
+;;   cmovnbeq %rsi, %r9, %r9
+;;   movzbq  0(%r9), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -43,9 +43,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431356, %rdi
 ;;   cmovnbeq %r10, %r8, %r8
@@ -62,13 +61,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, $4096, %rdx
+;;   movq    0(%rsi), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431356, %rdi
-;;   cmovnbeq %r10, %rdx, %rdx
-;;   movl    0(%rdx), %eax
+;;   cmovnbeq %r10, %r8, %r8
+;;   movl    0(%r8), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -43,9 +43,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431359, %rdi
 ;;   cmovnbeq %r10, %r8, %r8
@@ -62,13 +61,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, $4096, %rdx
+;;   movq    0(%rsi), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431359, %rdi
-;;   cmovnbeq %r10, %rdx, %rdx
-;;   movzbq  0(%rdx), %rax
+;;   cmovnbeq %r10, %r8, %r8
+;;   movzbq  0(%r8), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -43,9 +43,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431356, %rdi
 ;;   cmovnbeq %r10, %r8, %r8
@@ -62,13 +61,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, $4096, %rdx
+;;   movq    0(%rsi), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431356, %rdi
-;;   cmovnbeq %r10, %rdx, %rdx
-;;   movl    0(%rdx), %eax
+;;   cmovnbeq %r10, %r8, %r8
+;;   movl    0(%r8), %eax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -43,9 +43,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, 0(%rdx), %r8
-;;   addq    %r8, $4096, %r8
+;;   movq    0(%rdx), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431359, %rdi
 ;;   cmovnbeq %r10, %r8, %r8
@@ -62,13 +61,12 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   addq    %rdx, $4096, %rdx
+;;   movq    0(%rsi), %r10
+;;   lea     4096(%r10,%rdi,1), %r8
 ;;   xorq    %r10, %r10, %r10
 ;;   cmpq    $268431359, %rdi
-;;   cmovnbeq %r10, %rdx, %rdx
-;;   movzbq  0(%rdx), %rax
+;;   cmovnbeq %r10, %r8, %r8
+;;   movzbq  0(%r8), %rax
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp


### PR DESCRIPTION
This reverts commit 26ee7eed6f767da98d78a86221145be213a3d1e1.

Bumping to regalloc2-0.9.0 fixes the performance bug that was triggered by the lea-based lowerings for iadd, so we should be clear to restore that commit now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
