### PR TITLE
Don't cancel the github actions run on test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -378,6 +378,7 @@ jobs:
     env:
       QEMU_BUILD_VERSION: 7.2.0
     strategy:
+      fail-fast: true
       matrix: ${{ fromJson(needs.determine.outputs.test-matrix) }}
     steps:
     - uses: actions/checkout@v3
@@ -469,11 +470,10 @@ jobs:
       env:
         RUST_BACKTRACE: 1
 
-    # common logic to cancel the entire run if this job fails
-    - run: gh run cancel ${{ github.run_id }}
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        GH_TOKEN: ${{ github.token }}
+    # NB: the test job here is explicitly lacking in cancellation of this run if
+    # something goes wrong. These take the longest anyway and otherwise if
+    # Windows fails GitHub Actions will confusingly mark the failed Windows job
+    # as cancelled instead of failed.
 
   # Build and test the wasi-nn module.
   test_wasi_nn:


### PR DESCRIPTION
Currently all the jobs in GitHub Actions are configured to cancel the entire run if any of them fail. This is similar to `fail-fast: true` but that can't be used because the jobs aren't all part of the same matrix. The original goal for this was to save CI time on the merge queue where if something failed it should get out of the merge queue quickly instead of waiting for all other jobs to succeed and then report the one quick failure.

This seems to run into an issue, though, where if a Windows builder fails then running cancellation will instead mark the Windows builder as cancelled instead of failed. This can be confusing for test failures because nothing looks obvious and each log needs to be manually pored over.

To help address this the commit here disables auto-cancellation of the "test" matrix of jobs, re-enabling `fail-fast: true` at the same time. This way test if a test job fails it won't actually cancel everything else so everything else will run to completion, but given that tests are typically the longest part of the build that's hopefully ok.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
