### PR TITLE
Fix the component_api fuzzer

### DIFF
--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -109,6 +109,7 @@ mod component {
 
             let Declarations {
                 types,
+                type_instantiation_args,
                 params,
                 results,
                 import_and_export,
@@ -121,6 +122,7 @@ mod component {
                 {
                     static DECLS: Declarations = Declarations {
                         types: Cow::Borrowed(#types),
+                        type_instantiation_args: Cow::Borrowed(#type_instantiation_args),
                         params: Cow::Borrowed(#params),
                         results: Cow::Borrowed(#results),
                         import_and_export: Cow::Borrowed(#import_and_export),


### PR DESCRIPTION
This fuzz target was accidentally broken by #6378 and I forgot to update this fuzz target. Namely all the generated types now need names to satisfy possible restrictions depending on the structure. For simplicity everything is given a name to avoid having to special case some vs others which isn't the purpose of this fuzz target.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
