### PR TITLE
x64: Update all feature tests to pure constructors

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1743,29 +1743,29 @@
 
 ;;;; Helpers for Querying Enabled ISA Extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl avx512vl_enabled (bool) Type)
-(extern extractor infallible avx512vl_enabled avx512vl_enabled)
+(decl pure use_avx512vl_simd () bool)
+(extern constructor use_avx512vl_simd use_avx512vl_simd)
 
-(decl avx512dq_enabled (bool) Type)
-(extern extractor infallible avx512dq_enabled avx512dq_enabled)
+(decl pure use_avx512dq_simd () bool)
+(extern constructor use_avx512dq_simd use_avx512dq_simd)
 
-(decl avx512f_enabled (bool) Type)
-(extern extractor infallible avx512f_enabled avx512f_enabled)
+(decl pure use_avx512f_simd () bool)
+(extern constructor use_avx512f_simd use_avx512f_simd)
 
-(decl avx512bitalg_enabled (bool) Type)
-(extern extractor infallible avx512bitalg_enabled avx512bitalg_enabled)
+(decl pure use_avx512bitalg_simd () bool)
+(extern constructor use_avx512bitalg_simd use_avx512bitalg_simd)
 
-(decl avx512vbmi_enabled (bool) Type)
-(extern extractor infallible avx512vbmi_enabled avx512vbmi_enabled)
+(decl pure use_avx512vbmi_simd () bool)
+(extern constructor use_avx512vbmi_simd use_avx512vbmi_simd)
 
-(decl use_lzcnt (bool) Type)
-(extern extractor infallible use_lzcnt use_lzcnt)
+(decl pure use_lzcnt () bool)
+(extern constructor use_lzcnt use_lzcnt)
 
-(decl use_bmi1 (bool) Type)
-(extern extractor infallible use_bmi1 use_bmi1)
+(decl pure use_bmi1 () bool)
+(extern constructor use_bmi1 use_bmi1)
 
-(decl use_popcnt (bool) Type)
-(extern extractor infallible use_popcnt use_popcnt)
+(decl pure use_popcnt () bool)
+(extern constructor use_popcnt use_popcnt)
 
 (decl pure use_fma () bool)
 (extern constructor use_fma use_fma)

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -321,12 +321,14 @@
 (rule 9 (lower (has_type ty @ (multi_lane _bits _lane) (band (bnot y) x)))
       (sse_and_not ty y x))
 
-(rule 10 (lower (has_type ty @ (use_bmi1 $true) (band x (bnot y))))
+(rule 10 (lower (has_type ty (band x (bnot y))))
       (if (ty_int_ref_scalar_64 ty))
+      (if-let $true (use_bmi1))
       ;; the first argument is the one that gets inverted with andn
       (x64_andn ty y x))
-(rule 11 (lower (has_type ty @ (use_bmi1 $true) (band (bnot y) x)))
+(rule 11 (lower (has_type ty (band (bnot y) x)))
       (if (ty_int_ref_scalar_64 ty))
+      (if-let $true (use_bmi1))
       (x64_andn ty y x))
 
 
@@ -967,10 +969,9 @@
 
 ;; With AVX-512 we can implement `i64x2` multiplication with a single
 ;; instruction.
-(rule 3 (lower (has_type (and (avx512vl_enabled $true)
-                            (avx512dq_enabled $true)
-                            (multi_lane 64 2))
-                       (imul x y)))
+(rule 3 (lower (has_type (multi_lane 64 2) (imul x y)))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512dq_simd))
       (x64_vpmullq x y))
 
 ;; Otherwise, for i64x2 multiplication we describe a lane A as being composed of
@@ -1116,10 +1117,9 @@
       (x64_pabsd x))
 
 ;; When AVX512 is available, we can use a single `vpabsq` instruction.
-(rule 1 (lower (has_type (and (avx512vl_enabled $true)
-                            (avx512f_enabled $true)
-                            $I64X2)
-                       (iabs x)))
+(rule 1 (lower (has_type $I64X2 (iabs x)))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512f_simd))
       (x64_vpabsq x))
 
 ;; Otherwise, we use a separate register, `neg`, to contain the results of `0 -
@@ -1926,18 +1926,11 @@
 ;; special handling is required for zero inputs, because the machine
 ;; instruction does what the CLIF expects for zero, i.e. it returns
 ;; zero.
-(rule 2 (lower
-         (has_type (and
-                    (ty_32_or_64 ty)
-                    (use_lzcnt $true))
-                   (clz src)))
+(rule 3 (lower (has_type (ty_32_or_64 ty) (clz src)))
+      (if-let $true (use_lzcnt))
       (x64_lzcnt ty src))
 
-(rule 2 (lower
-         (has_type (and
-                    (ty_32_or_64 ty)
-                    (use_lzcnt $false))
-                 (clz src)))
+(rule 2 (lower (has_type (ty_32_or_64 ty) (clz src)))
       (do_clz ty ty src))
 
 (rule 1 (lower
@@ -1970,18 +1963,11 @@
 ;; Analogous to `clz` cases above, but using mirror instructions
 ;; (tzcnt vs lzcnt, bsf vs bsr).
 
-(rule 2 (lower
-         (has_type (and
-                    (ty_32_or_64 ty)
-                    (use_bmi1 $true))
-                   (ctz src)))
+(rule 3 (lower (has_type (ty_32_or_64 ty) (ctz src)))
+      (if-let $true (use_bmi1))
       (x64_tzcnt ty src))
 
-(rule 2 (lower
-          (has_type (and
-                     (ty_32_or_64 ty)
-                     (use_bmi1 $false))
-                 (ctz src)))
+(rule 2 (lower (has_type (ty_32_or_64 ty) (ctz src)))
       (do_ctz ty ty src))
 
 (rule 1 (lower
@@ -2008,25 +1994,16 @@
 
 ;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 3 (lower
-         (has_type (and
-                    (ty_32_or_64 ty)
-                    (use_popcnt $true))
-                   (popcnt src)))
+(rule 3 (lower (has_type (ty_32_or_64 ty) (popcnt src)))
+      (if-let $true (use_popcnt))
       (x64_popcnt ty src))
 
-(rule 2 (lower
-         (has_type (and
-                    (ty_8_or_16 ty)
-                    (use_popcnt $true))
-                   (popcnt src)))
+(rule 2 (lower (has_type (ty_8_or_16 ty) (popcnt src)))
+      (if-let $true (use_popcnt))
       (x64_popcnt $I32 (extend_to_gpr src $I32 (ExtendKind.Zero))))
 
-(rule 1 (lower
-         (has_type (and
-                    $I128
-                    (use_popcnt $true))
-                   (popcnt src)))
+(rule 1 (lower (has_type $I128 (popcnt src)))
+      (if-let $true (use_popcnt))
       (let ((lo_count Gpr (x64_popcnt $I64 (value_regs_get_gpr src 0)))
             (hi_count Gpr (x64_popcnt $I64 (value_regs_get_gpr src 1))))
         (value_regs (x64_add $I64 lo_count hi_count) (imm $I64 0))))
@@ -2114,13 +2091,10 @@
         final))
 
 
-(rule 1 (lower (has_type (and
-                          $I8X16
-                          (avx512vl_enabled $true)
-                          (avx512bitalg_enabled $true))
-                         (popcnt src)))
+(rule 1 (lower (has_type $I8X16 (popcnt src)))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512bitalg_simd))
       (x64_vpopcntb src))
-
 
 
 ;; For SSE 4.2 we use Mula's algorithm (https://arxiv.org/pdf/1611.07612.pdf):
@@ -3240,8 +3214,9 @@
 
 ;; When AVX512VL and AVX512F are available,
 ;; `fcvt_from_uint` can be lowered to a single instruction.
-(rule 2 (lower (has_type (and (avx512vl_enabled $true) (avx512f_enabled $true) $F32X4)
-                         (fcvt_from_uint src)))
+(rule 2 (lower (has_type $F32X4 (fcvt_from_uint src)))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512f_simd))
       (x64_vcvtudq2ps src))
 
 ;; Converting packed unsigned integers to packed floats
@@ -4045,15 +4020,16 @@
 ;; For the case where the shuffle mask contains out-of-bounds values (values
 ;; greater than 31) we must mask off those resulting values in the result of
 ;; `vpermi2b`.
-(rule 2 (lower (has_type (and (avx512vl_enabled $true) (avx512vbmi_enabled $true))
-                         (shuffle a b (vec_mask_from_immediate
-                                        (perm_from_mask_with_zeros mask zeros)))))
+(rule 2 (lower (shuffle a b (vec_mask_from_immediate (perm_from_mask_with_zeros mask zeros))))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512vbmi_simd))
       (x64_andps (x64_vpermi2b b a (x64_xmm_load_const $I8X16 mask)) zeros))
 
 ;; However, if the shuffle mask contains no out-of-bounds values, we can use
 ;; `vpermi2b` without any masking.
-(rule 1 (lower (has_type (and (avx512vl_enabled $true) (avx512vbmi_enabled $true))
-                       (shuffle a b (vec_mask_from_immediate mask))))
+(rule 1 (lower (shuffle a b (vec_mask_from_immediate mask)))
+      (if-let $true (use_avx512vl_simd))
+      (if-let $true (use_avx512vbmi_simd))
       (x64_vpermi2b b a (x64_xmm_load_const $I8X16 (perm_from_mask mask))))
 
 ;; If `lhs` and `rhs` are different, we must shuffle each separately and then OR

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -180,42 +180,42 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn avx512vl_enabled(&mut self, _: Type) -> bool {
+    fn use_avx512vl_simd(&mut self) -> bool {
         self.backend.x64_flags.use_avx512vl_simd()
     }
 
     #[inline]
-    fn avx512dq_enabled(&mut self, _: Type) -> bool {
+    fn use_avx512dq_simd(&mut self) -> bool {
         self.backend.x64_flags.use_avx512dq_simd()
     }
 
     #[inline]
-    fn avx512f_enabled(&mut self, _: Type) -> bool {
+    fn use_avx512f_simd(&mut self) -> bool {
         self.backend.x64_flags.use_avx512f_simd()
     }
 
     #[inline]
-    fn avx512bitalg_enabled(&mut self, _: Type) -> bool {
+    fn use_avx512bitalg_simd(&mut self) -> bool {
         self.backend.x64_flags.use_avx512bitalg_simd()
     }
 
     #[inline]
-    fn avx512vbmi_enabled(&mut self, _: Type) -> bool {
+    fn use_avx512vbmi_simd(&mut self) -> bool {
         self.backend.x64_flags.use_avx512vbmi_simd()
     }
 
     #[inline]
-    fn use_lzcnt(&mut self, _: Type) -> bool {
+    fn use_lzcnt(&mut self) -> bool {
         self.backend.x64_flags.use_lzcnt()
     }
 
     #[inline]
-    fn use_bmi1(&mut self, _: Type) -> bool {
+    fn use_bmi1(&mut self) -> bool {
         self.backend.x64_flags.use_bmi1()
     }
 
     #[inline]
-    fn use_popcnt(&mut self, _: Type) -> bool {
+    fn use_popcnt(&mut self) -> bool {
         self.backend.x64_flags.use_popcnt()
     }
 


### PR DESCRIPTION
Many of the tests for lowering features use `extractor`s I think since when they were added that was the only option. Nowadays a `pure constructor` with `if-let` feels more natural for this, so this commit updates all existing extractors used to test features to use a `pure constructor` instead. This additionally updates the names to match the cranelift codegen setting name to ensure that a consistent name is used.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
