### PR TITLE
Expose Config::static_memory_forced to C

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -266,6 +266,16 @@ WASMTIME_CONFIG_PROP(void, cranelift_opt_level, wasmtime_opt_level_t)
 WASMTIME_CONFIG_PROP(void, profiler, wasmtime_profiling_strategy_t)
 
 /**
+ * \brief Configures the “static” style of memory to always be used.
+ *
+ * This setting is `false` by default.
+ *
+ * For more information see the Rust documentation at
+ * https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Config.html#method.static_memory_forced.
+ */
+WASMTIME_CONFIG_PROP(void, static_memory_forced, bool)
+
+/**
  * \brief Configures the maximum size for memory to be considered "static"
  *
  * For more information see the Rust documentation at

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -195,6 +195,11 @@ pub unsafe extern "C" fn wasmtime_config_cache_config_load(
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_static_memory_forced_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.static_memory_forced(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_static_memory_maximum_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.static_memory_maximum_size(size);
 }


### PR DESCRIPTION
This change exposes the [`static_memory_forced`](https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.static_memory_forced) configuration method to C. This matches other methods of the `Config` struct.

I don't believe an issue is needed here as this change is so small, but if you feel otherwise please let me know and I'd be happy to create an issue first 😄 .


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
