### PR TITLE
x64: Add memory operand support to EVEX instructions

### DIFF
--- a/cranelift/codegen/benches/x64-evex-encoding.rs
+++ b/cranelift/codegen/benches/x64-evex-encoding.rs
@@ -14,12 +14,11 @@ mod x86 {
     fn x64_evex_encoding_benchmarks(c: &mut Criterion) {
         let mut group = c.benchmark_group("x64 EVEX encoding");
         let rax = Register::from(0);
-        let rdx = Register::from(2);
+        let rdx = 2;
 
         group.bench_function("EvexInstruction (builder pattern)", |b| {
-            let mut sink = vec![];
             b.iter(|| {
-                sink.clear();
+                let mut sink = cranelift_codegen::MachBuffer::new();
                 EvexInstruction::new()
                     .prefix(LegacyPrefixes::_66)
                     .map(OpcodeMap::_0F38)

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -244,7 +244,6 @@ impl EvexInstruction {
     // Byte 3:
     const aaa: RangeInclusive<u8> = 24..=26;
     const V_: RangeInclusive<u8> = 27..=27;
-    #[allow(dead_code)] // Will be used once broadcast and rounding controls are exposed.
     const b: RangeInclusive<u8> = 28..=28;
     const LL: RangeInclusive<u8> = 29..=30;
     const z: RangeInclusive<u8> = 31..=31;
@@ -285,7 +284,7 @@ impl EvexInstruction {
 
         match self.tuple_type {
             Some(Full) => {
-                if self.read(Self::B) == 1 {
+                if self.read(Self::b) == 1 {
                     if self.read(Self::W) == 0 {
                         4
                     } else {
@@ -694,6 +693,7 @@ mod tests {
                 .reg(dst.to_real_reg().unwrap().hw_enc())
                 .rm(src.clone())
                 .length(EvexVectorLength::V128)
+                .tuple_type(Avx512TupleType::Full)
                 .encode(&mut sink);
             let bytes0 = sink
                 .finish(&Default::default(), &mut Default::default())

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -10,11 +10,15 @@
 //! Byte 3: │ z │ L'│ L │ b │ V'│ a │ a │ a │
 //!         └───┴───┴───┴───┴───┴───┴───┴───┘
 //!
-//! The prefix is then followeded by the opcode byte, the ModR/M byte, and other optional suffixes
+//! The prefix is then followed by the opcode byte, the ModR/M byte, and other optional suffixes
 //! (e.g. SIB byte, displacements, immediates) based on the instruction (see section 2.6, Intel
 //! Software Development Manual, volume 2A).
-use super::rex::{encode_modrm, LegacyPrefixes, OpcodeMap};
-use super::ByteSink;
+
+use super::rex::{self, LegacyPrefixes, OpcodeMap};
+use crate::ir::TrapCode;
+use crate::isa::x64::args::Amode;
+use crate::isa::x64::inst::Inst;
+use crate::MachBuffer;
 use core::ops::RangeInclusive;
 
 /// Constructs an EVEX-encoded instruction using a builder pattern. This approach makes it visually
@@ -24,7 +28,7 @@ pub struct EvexInstruction {
     bits: u32,
     opcode: u8,
     reg: Register,
-    rm: Register,
+    rm: RegisterOrAmode,
 }
 
 /// Because some of the bit flags in the EVEX prefix are reversed and users of `EvexInstruction` may
@@ -43,7 +47,7 @@ impl Default for EvexInstruction {
             bits: 0x08_7C_F0_62,
             opcode: 0,
             reg: Register::default(),
-            rm: Register::default(),
+            rm: RegisterOrAmode::Register(Register::default()),
         }
     }
 }
@@ -131,17 +135,40 @@ impl EvexInstruction {
         self
     }
 
-    /// Set the register to use for the `rm` bits; many instructions use this as the "read from
-    /// register/memory" operand. Currently this does not support memory addressing (TODO).Setting
-    /// this affects both the ModRM byte (`rm` section) and the EVEX prefix (the extension bits for
-    /// register encodings > 8).
+    /// Set the register to use for the `rm` bits; many instructions use this
+    /// as the "read from register/memory" operand. Setting this affects both
+    /// the ModRM byte (`rm` section) and the EVEX prefix (the extension bits
+    /// for register encodings > 8).
     #[inline(always)]
-    pub fn rm(mut self, reg: impl Into<Register>) -> Self {
+    pub fn rm(mut self, reg: impl Into<RegisterOrAmode>) -> Self {
+        // NB: See Table 2-31. 32-Register Support in 64-bit Mode Using EVEX
+        // with Embedded REX Bits
         self.rm = reg.into();
-        let b = !(self.rm.0 >> 3) & 1;
-        let x = !(self.rm.0 >> 4) & 1;
-        self.write(Self::X, x as u32);
-        self.write(Self::B, b as u32);
+        let x = match &self.rm {
+            RegisterOrAmode::Register(r) => r.0 >> 4,
+            RegisterOrAmode::Amode(Amode::ImmRegRegShift { index, .. }) => {
+                index.to_real_reg().unwrap().hw_enc() >> 3
+            }
+
+            // These two modes technically don't use the X bit, so leave it at
+            // 0.
+            RegisterOrAmode::Amode(Amode::ImmReg { .. }) => 0,
+            RegisterOrAmode::Amode(Amode::RipRelative { .. }) => 0,
+        };
+        self.write(Self::X, u32::from(!x & 1));
+
+        let b = match &self.rm {
+            RegisterOrAmode::Register(r) => r.0 >> 3,
+            RegisterOrAmode::Amode(Amode::ImmReg { base, .. }) => {
+                base.to_real_reg().unwrap().hw_enc() >> 3
+            }
+            RegisterOrAmode::Amode(Amode::ImmRegRegShift { base, .. }) => {
+                base.to_real_reg().unwrap().hw_enc() >> 3
+            }
+            // The 4th bit of %rip is 0
+            RegisterOrAmode::Amode(Amode::RipRelative { .. }) => 0,
+        };
+        self.write(Self::B, u32::from(!b & 1));
         self
     }
 
@@ -151,10 +178,44 @@ impl EvexInstruction {
     /// - finally, the ModR/M byte.
     ///
     /// Eventually this method should support encodings of more than just the reg-reg addressing mode (TODO).
-    pub fn encode<CS: ByteSink + ?Sized>(&self, sink: &mut CS) {
+    pub fn encode(&self, sink: &mut MachBuffer<Inst>) {
+        if let RegisterOrAmode::Amode(amode) = &self.rm {
+            if amode.can_trap() {
+                sink.add_trap(TrapCode::HeapOutOfBounds);
+            }
+        }
         sink.put4(self.bits);
         sink.put1(self.opcode);
-        sink.put1(encode_modrm(3, self.reg.0 & 7, self.rm.0 & 7));
+
+        match &self.rm {
+            RegisterOrAmode::Register(reg) => {
+                let rm: u8 = (*reg).into();
+                sink.put1(rex::encode_modrm(3, self.reg.0 & 7, rm & 7));
+            }
+            RegisterOrAmode::Amode(amode) => {
+                // NB: the `scaling` factor must be passed to
+                // `emit_modrm_sib_disp` because EVEX instructions always use a
+                // scaling factor. Section 2.7.5 in the Intel manual has a lot
+                // of words about this I don't fully understand yet. That being
+                // said for the V128 case the factor is 16 (or so I'm pretty
+                // sure). Assert that that's the "length" of this instruction
+                // (aka the encoding of the default `EvexContext`). If
+                // this assertion trips then the scaling factor probably needs
+                // to be stored on `self` and reassigned whenever the `length`
+                // method is called.
+                let b128 = EvexContext::Other {
+                    length: EvexVectorLength::V128,
+                };
+                let bits = (self.bits >> Self::LL.start()) & ((1 << Self::LL.len()) - 1);
+                assert_eq!(bits, u32::from(b128.bits()));
+                let scaling = 16;
+
+                // NB: when `EvexInstruction` supports a trailing 8-bit
+                // immediate this'll conditionally be 0 or 1
+                let bytes_at_end = 0;
+                rex::emit_modrm_sib_disp(sink, self.reg.0 & 7, amode, bytes_at_end, Some(scaling));
+            }
+        }
     }
 
     // In order to simplify the encoding of the various bit ranges in the prefix, we specify those
@@ -210,7 +271,7 @@ impl EvexInstruction {
 
 /// Describe the register index to use. This wrapper is a type-safe way to pass
 /// around the registers defined in `inst/regs.rs`.
-#[derive(Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct Register(u8);
 impl From<u8> for Register {
     fn from(reg: u8) -> Self {
@@ -221,6 +282,25 @@ impl From<u8> for Register {
 impl Into<u8> for Register {
     fn into(self) -> u8 {
         self.0
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone)]
+pub enum RegisterOrAmode {
+    Register(Register),
+    Amode(Amode),
+}
+
+impl From<u8> for RegisterOrAmode {
+    fn from(reg: u8) -> Self {
+        RegisterOrAmode::Register(reg.into())
+    }
+}
+
+impl From<Amode> for RegisterOrAmode {
+    fn from(amode: Amode) -> Self {
+        RegisterOrAmode::Amode(amode)
     }
 }
 
@@ -353,6 +433,8 @@ impl EvexMasking {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ir::MemFlags;
+    use crate::isa::x64::args::Gpr;
     use crate::isa::x64::inst::regs;
     use std::vec::Vec;
 
@@ -360,21 +442,236 @@ mod tests {
     // xmm1'` matches this EVEX encoding machinery.
     #[test]
     fn vpabsq() {
-        let dst = regs::xmm0();
-        let src = regs::xmm1();
-        let mut sink0 = Vec::new();
+        let mut tmp = MachBuffer::<Inst>::new();
+        let tests: &[(crate::Reg, RegisterOrAmode, Vec<u8>)] = &[
+            // vpabsq %xmm1, %xmm0
+            (
+                regs::xmm0(),
+                regs::xmm1().to_real_reg().unwrap().hw_enc().into(),
+                vec![0x62, 0xf2, 0xfd, 0x08, 0x1f, 0xc1],
+            ),
+            // vpabsq %xmm8, %xmm10
+            (
+                regs::xmm10(),
+                regs::xmm8().to_real_reg().unwrap().hw_enc().into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0xd0],
+            ),
+            // vpabsq %xmm15, %xmm3
+            (
+                regs::xmm3(),
+                regs::xmm15().to_real_reg().unwrap().hw_enc().into(),
+                vec![0x62, 0xd2, 0xfd, 0x08, 0x1f, 0xdf],
+            ),
+            // vpabsq (%rsi), %xmm12
+            (
+                regs::xmm12(),
+                Amode::ImmReg {
+                    simm32: 0,
+                    base: regs::rsi(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x72, 0xfd, 0x08, 0x1f, 0x26],
+            ),
+            // vpabsq 8(%r15), %xmm14
+            (
+                regs::xmm14(),
+                Amode::ImmReg {
+                    simm32: 8,
+                    base: regs::r15(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0xb7, 0x08, 0x00, 0x00, 0x00],
+            ),
+            // vpabsq 16(%r15), %xmm14
+            (
+                regs::xmm14(),
+                Amode::ImmReg {
+                    simm32: 16,
+                    base: regs::r15(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0x77, 0x01],
+            ),
+            // vpabsq 17(%rax), %xmm3
+            (
+                regs::xmm3(),
+                Amode::ImmReg {
+                    simm32: 17,
+                    base: regs::rax(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0xf2, 0xfd, 0x08, 0x1f, 0x98, 0x11, 0x00, 0x00, 0x00],
+            ),
+            // vpabsq (%rbx, %rsi, 8), %xmm9
+            (
+                regs::xmm9(),
+                Amode::ImmRegRegShift {
+                    simm32: 0,
+                    base: Gpr::new(regs::rbx()).unwrap(),
+                    index: Gpr::new(regs::rsi()).unwrap(),
+                    shift: 3,
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x72, 0xfd, 0x08, 0x1f, 0x0c, 0xf3],
+            ),
+            // vpabsq 1(%r11, %rdi, 4), %xmm13
+            (
+                regs::xmm13(),
+                Amode::ImmRegRegShift {
+                    simm32: 1,
+                    base: Gpr::new(regs::r11()).unwrap(),
+                    index: Gpr::new(regs::rdi()).unwrap(),
+                    shift: 2,
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![
+                    0x62, 0x52, 0xfd, 0x08, 0x1f, 0xac, 0xbb, 0x01, 0x00, 0x00, 0x00,
+                ],
+            ),
+            // vpabsq 128(%rsp, %r10, 2), %xmm5
+            (
+                regs::xmm5(),
+                Amode::ImmRegRegShift {
+                    simm32: 128,
+                    base: Gpr::new(regs::rsp()).unwrap(),
+                    index: Gpr::new(regs::r10()).unwrap(),
+                    shift: 1,
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0xb2, 0xfd, 0x08, 0x1f, 0x6c, 0x54, 0x08],
+            ),
+            // vpabsq 112(%rbp, %r13, 1), %xmm6
+            (
+                regs::xmm6(),
+                Amode::ImmRegRegShift {
+                    simm32: 112,
+                    base: Gpr::new(regs::rbp()).unwrap(),
+                    index: Gpr::new(regs::r13()).unwrap(),
+                    shift: 0,
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0xb2, 0xfd, 0x08, 0x1f, 0x74, 0x2d, 0x07],
+            ),
+            // vpabsq (%rbp, %r13, 1), %xmm7
+            (
+                regs::xmm7(),
+                Amode::ImmRegRegShift {
+                    simm32: 0,
+                    base: Gpr::new(regs::rbp()).unwrap(),
+                    index: Gpr::new(regs::r13()).unwrap(),
+                    shift: 0,
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0xb2, 0xfd, 0x08, 0x1f, 0x7c, 0x2d, 0x00],
+            ),
+            // vpabsq 2032(%r12), %xmm8
+            (
+                regs::xmm8(),
+                Amode::ImmReg {
+                    simm32: 2032,
+                    base: regs::r12(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0x44, 0x24, 0x7f],
+            ),
+            // vpabsq 2048(%r13), %xmm9
+            (
+                regs::xmm9(),
+                Amode::ImmReg {
+                    simm32: 2048,
+                    base: regs::r13(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0x8d, 0x00, 0x08, 0x00, 0x00],
+            ),
+            // vpabsq -16(%r14), %xmm10
+            (
+                regs::xmm10(),
+                Amode::ImmReg {
+                    simm32: (-16i32) as u32,
+                    base: regs::r14(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0x56, 0xff],
+            ),
+            // vpabsq -5(%r15), %xmm11
+            (
+                regs::xmm11(),
+                Amode::ImmReg {
+                    simm32: (-5i32) as u32,
+                    base: regs::r15(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x52, 0xfd, 0x08, 0x1f, 0x9f, 0xfb, 0xff, 0xff, 0xff],
+            ),
+            // vpabsq -2048(%rdx), %xmm12
+            (
+                regs::xmm12(),
+                Amode::ImmReg {
+                    simm32: (-2048i32) as u32,
+                    base: regs::rdx(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x72, 0xfd, 0x08, 0x1f, 0x62, 0x80],
+            ),
+            // vpabsq -2064(%rsi), %xmm13
+            (
+                regs::xmm13(),
+                Amode::ImmReg {
+                    simm32: (-2064i32) as u32,
+                    base: regs::rsi(),
+                    flags: MemFlags::trusted(),
+                }
+                .into(),
+                vec![0x62, 0x72, 0xfd, 0x08, 0x1f, 0xae, 0xf0, 0xf7, 0xff, 0xff],
+            ),
+            // a: vpabsq a(%rip), %xmm14
+            (
+                regs::xmm14(),
+                Amode::RipRelative {
+                    target: tmp.get_label(),
+                }
+                .into(),
+                vec![0x62, 0x72, 0xfd, 0x08, 0x1f, 0x35, 0xf6, 0xff, 0xff, 0xff],
+            ),
+        ];
 
-        EvexInstruction::new()
-            .prefix(LegacyPrefixes::_66)
-            .map(OpcodeMap::_0F38)
-            .w(true)
-            .opcode(0x1F)
-            .reg(dst.to_real_reg().unwrap().hw_enc())
-            .rm(src.to_real_reg().unwrap().hw_enc())
-            .length(EvexVectorLength::V128)
-            .encode(&mut sink0);
-
-        assert_eq!(sink0, vec![0x62, 0xf2, 0xfd, 0x08, 0x1f, 0xc1]);
+        for (dst, src, encoding) in tests {
+            let mut sink = MachBuffer::new();
+            let label = sink.get_label();
+            sink.bind_label(label, &mut Default::default());
+            EvexInstruction::new()
+                .prefix(LegacyPrefixes::_66)
+                .map(OpcodeMap::_0F38)
+                .w(true)
+                .opcode(0x1F)
+                .reg(dst.to_real_reg().unwrap().hw_enc())
+                .rm(src.clone())
+                .length(EvexVectorLength::V128)
+                .encode(&mut sink);
+            let bytes0 = sink
+                .finish(&Default::default(), &mut Default::default())
+                .data;
+            assert_eq!(
+                bytes0.as_slice(),
+                encoding.as_slice(),
+                "dst={dst:?} src={src:?}"
+            );
+        }
     }
 
     /// Verify that the defaults are equivalent to an instruction with a `0x00` opcode using the
@@ -383,10 +680,13 @@ mod tests {
     /// representations (e.g. `vvvvv`) so emitting 0s as a default will not work.
     #[test]
     fn default_emission() {
-        let mut sink0 = Vec::new();
-        EvexInstruction::new().encode(&mut sink0);
+        let mut sink = MachBuffer::new();
+        EvexInstruction::new().encode(&mut sink);
+        let bytes0 = sink
+            .finish(&Default::default(), &mut Default::default())
+            .data;
 
-        let mut sink1 = Vec::new();
+        let mut sink = MachBuffer::new();
         EvexInstruction::new()
             .length(EvexVectorLength::V128)
             .prefix(LegacyPrefixes::None)
@@ -396,8 +696,11 @@ mod tests {
             .reg(regs::rax().to_real_reg().unwrap().hw_enc())
             .rm(regs::rax().to_real_reg().unwrap().hw_enc())
             .mask(EvexMasking::None)
-            .encode(&mut sink1);
+            .encode(&mut sink);
+        let bytes1 = sink
+            .finish(&Default::default(), &mut Default::default())
+            .data;
 
-        assert_eq!(sink0, sink1);
+        assert_eq!(bytes0, bytes1);
     }
 }

--- a/cranelift/codegen/src/isa/x64/encoding/vex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/vex.rs
@@ -1,7 +1,7 @@
 //! Encodes VEX instructions. These instructions are those added by the Advanced Vector Extensions
 //! (AVX).
 
-use super::evex::Register;
+use super::evex::{Register, RegisterOrAmode};
 use super::rex::{LegacyPrefixes, OpcodeMap};
 use super::ByteSink;
 use crate::ir::TrapCode;
@@ -23,24 +23,6 @@ pub struct VexInstruction {
     rm: RegisterOrAmode,
     vvvv: Option<Register>,
     imm: Option<u8>,
-}
-
-#[allow(missing_docs)]
-pub enum RegisterOrAmode {
-    Register(Register),
-    Amode(Amode),
-}
-
-impl From<u8> for RegisterOrAmode {
-    fn from(reg: u8) -> Self {
-        RegisterOrAmode::Register(reg.into())
-    }
-}
-
-impl From<Amode> for RegisterOrAmode {
-    fn from(amode: Amode) -> Self {
-        RegisterOrAmode::Amode(amode)
-    }
 }
 
 impl Default for VexInstruction {
@@ -296,7 +278,7 @@ impl VexInstruction {
             // encoding.
             RegisterOrAmode::Amode(amode) => {
                 let bytes_at_end = if self.imm.is_some() { 1 } else { 0 };
-                rex::emit_modrm_sib_disp(sink, self.reg & 7, amode, bytes_at_end);
+                rex::emit_modrm_sib_disp(sink, self.reg & 7, amode, bytes_at_end, None);
             }
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1759,6 +1759,13 @@ pub enum Avx512Opcode {
     Vpopcntb,
 }
 
+#[derive(Copy, Clone, PartialEq)]
+#[allow(missing_docs)]
+pub enum Avx512TupleType {
+    Full,
+    FullMem,
+}
+
 impl Avx512Opcode {
     /// Which `InstructionSet`s support the opcode?
     pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
@@ -1774,6 +1781,22 @@ impl Avx512Opcode {
             Avx512Opcode::Vpopcntb => {
                 smallvec![InstructionSet::AVX512VL, InstructionSet::AVX512BITALG]
             }
+        }
+    }
+
+    /// What is the "TupleType" of this opcode, which affects the scaling factor
+    /// for 8-bit displacements when this instruction uses memory operands.
+    ///
+    /// This can be found in the encoding table for each instruction and is
+    /// interpreted according to Table 2-34 and 2-35 in the Intel instruction
+    /// manual.
+    pub fn tuple_type(&self) -> Avx512TupleType {
+        use Avx512Opcode::*;
+        use Avx512TupleType::*;
+
+        match self {
+            Vcvtudq2ps | Vpabsq | Vpmullq => Full,
+            Vpermi2b | Vpopcntb => FullMem,
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1929,6 +1929,7 @@ pub(crate) fn emit(
                 .map(map)
                 .w(w)
                 .opcode(opcode)
+                .tuple_type(op.tuple_type())
                 .reg(dst.to_real_reg().unwrap().hw_enc())
                 .rm(src)
                 .encode(sink);
@@ -2764,6 +2765,7 @@ pub(crate) fn emit(
                 .map(OpcodeMap::_0F38)
                 .w(w)
                 .opcode(opcode)
+                .tuple_type(op.tuple_type())
                 .reg(dst.to_real_reg().unwrap().hw_enc())
                 .rm(src1)
                 .vvvvv(src2.to_real_reg().unwrap().hw_enc())

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2,13 +2,13 @@ use crate::binemit::{Addend, Reloc};
 use crate::ir::immediates::{Ieee32, Ieee64};
 use crate::ir::TrapCode;
 use crate::ir::{KnownSymbol, LibCall};
-use crate::isa::x64::encoding::evex::{EvexInstruction, EvexVectorLength};
+use crate::isa::x64::encoding::evex::{EvexInstruction, EvexVectorLength, RegisterOrAmode};
 use crate::isa::x64::encoding::rex::{
     emit_simm, emit_std_enc_enc, emit_std_enc_mem, emit_std_reg_mem, emit_std_reg_reg, int_reg_enc,
     low8_will_sign_extend_to_32, low8_will_sign_extend_to_64, reg_enc, LegacyPrefixes, OpcodeMap,
     RexFlags,
 };
-use crate::isa::x64::encoding::vex::{RegisterOrAmode, VexInstruction, VexVectorLength};
+use crate::isa::x64::encoding::vex::{VexInstruction, VexVectorLength};
 use crate::isa::x64::inst::args::*;
 use crate::isa::x64::inst::*;
 use crate::machinst::{inst_common, MachBuffer, MachInstEmit, MachLabel, Reg, Writable};
@@ -1910,7 +1910,12 @@ pub(crate) fn emit(
 
         Inst::XmmUnaryRmREvex { op, src, dst } => {
             let dst = allocs.next(dst.to_reg().to_reg());
-            let src = src.clone().to_reg_mem().with_allocs(allocs);
+            let src = match src.clone().to_reg_mem().with_allocs(allocs) {
+                RegMem::Reg { reg } => {
+                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
+                }
+                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+            };
 
             let (prefix, map, w, opcode) = match op {
                 Avx512Opcode::Vcvtudq2ps => (LegacyPrefixes::_F2, OpcodeMap::_0F, false, 0x7a),
@@ -1918,18 +1923,15 @@ pub(crate) fn emit(
                 Avx512Opcode::Vpopcntb => (LegacyPrefixes::_66, OpcodeMap::_0F38, false, 0x54),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
-            match src {
-                RegMem::Reg { reg: src } => EvexInstruction::new()
-                    .length(EvexVectorLength::V128)
-                    .prefix(prefix)
-                    .map(map)
-                    .w(w)
-                    .opcode(opcode)
-                    .reg(dst.to_real_reg().unwrap().hw_enc())
-                    .rm(src.to_real_reg().unwrap().hw_enc())
-                    .encode(sink),
-                _ => todo!(),
-            };
+            EvexInstruction::new()
+                .length(EvexVectorLength::V128)
+                .prefix(prefix)
+                .map(map)
+                .w(w)
+                .opcode(opcode)
+                .reg(dst.to_real_reg().unwrap().hw_enc())
+                .rm(src)
+                .encode(sink);
         }
 
         Inst::XmmRmR {
@@ -2744,26 +2746,28 @@ pub(crate) fn emit(
                 let src3 = allocs.next(src3.to_reg());
                 debug_assert_eq!(src3, dst);
             }
-            let src1 = src1.clone().to_reg_mem().with_allocs(allocs);
+            let src1 = match src1.clone().to_reg_mem().with_allocs(allocs) {
+                RegMem::Reg { reg } => {
+                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
+                }
+                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+            };
 
             let (w, opcode) = match op {
                 Avx512Opcode::Vpermi2b => (false, 0x75),
                 Avx512Opcode::Vpmullq => (true, 0x40),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
-            match src1 {
-                RegMem::Reg { reg: src } => EvexInstruction::new()
-                    .length(EvexVectorLength::V128)
-                    .prefix(LegacyPrefixes::_66)
-                    .map(OpcodeMap::_0F38)
-                    .w(w)
-                    .opcode(opcode)
-                    .reg(dst.to_real_reg().unwrap().hw_enc())
-                    .rm(src.to_real_reg().unwrap().hw_enc())
-                    .vvvvv(src2.to_real_reg().unwrap().hw_enc())
-                    .encode(sink),
-                _ => todo!(),
-            };
+            EvexInstruction::new()
+                .length(EvexVectorLength::V128)
+                .prefix(LegacyPrefixes::_66)
+                .map(OpcodeMap::_0F38)
+                .w(w)
+                .opcode(opcode)
+                .reg(dst.to_real_reg().unwrap().hw_enc())
+                .rm(src1)
+                .vvvvv(src2.to_real_reg().unwrap().hw_enc())
+                .encode(sink);
         }
 
         Inst::XmmMinMaxSeq {

--- a/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
@@ -1,0 +1,30 @@
+test compile precise-output
+set enable_simd
+target x86_64 icelake-client
+
+function %f1(i64) -> i64x2 {
+block0(v0: i64):
+  v1 = load.i64x2 v0
+  v2 = iabs v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpabsq  0(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpabsq (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
Currently load-sinking is enabled for EVEX instructions (aka AVX512 instructions) but the encoding of these instructions is a `todo!()` which can cause a panic for some wasms if the right features are enabled. This commit fills out the support for memory operands in the same manner as VEX-encoded instructions. The main stickler here was that EVEX instructions always use a scaled 8-bit offset which needed extra handling to ensure that the correct offset is emitted.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
