### PR TITLE
Add benchmark for `Module::deserialize` (to compare with `deserialize_file`)

### DIFF
--- a/benches/instantiation.rs
+++ b/benches/instantiation.rs
@@ -156,11 +156,18 @@ fn bench_deserialize_module(c: &mut Criterion, path: &Path) {
     let state = Lazy::new(|| {
         let engine = Engine::default();
         let module = Module::from_file(&engine, path).expect("failed to load WASI example module");
-        std::fs::write(tmpfile.path(), module.serialize().unwrap()).unwrap();
-        (engine, tmpfile.path())
+        let bytes = module.serialize().unwrap();
+        std::fs::write(tmpfile.path(), bytes.clone()).unwrap();
+        (engine, bytes, tmpfile.path())
     });
     group.bench_function(BenchmarkId::new("deserialize", name), |b| {
-        let (engine, path) = &*state;
+        let (engine, bytes, _) = &*state;
+        b.iter(|| unsafe {
+            Module::deserialize(&engine, bytes).unwrap();
+        });
+    });
+    group.bench_function(BenchmarkId::new("deserialize_file", name), |b| {
+        let (engine, _, path) = &*state;
         b.iter(|| unsafe {
             Module::deserialize_file(&engine, path).unwrap();
         });


### PR DESCRIPTION
# PULL REQUEST

## Overview

I was curious how `Module::deserialize` compared with `deserialize_file`. There was already a `bench_deserialize_module` so I expanded it to support `deserialize`.

Some results:

```
Benchmarking deserialize/deserialize/wasi.wasm
Benchmarking deserialize/deserialize/wasi.wasm: Warming up for 3.0000 s
Benchmarking deserialize/deserialize/wasi.wasm: Collecting 100 samples in estimated 5.4918 s (50k iterations)
Benchmarking deserialize/deserialize/wasi.wasm: Analyzing
deserialize/deserialize/wasi.wasm
                        time:   [107.44 µs 108.00 µs 108.56 µs]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
Benchmarking deserialize/deserialize_file/wasi.wasm
Benchmarking deserialize/deserialize_file/wasi.wasm: Warming up for 3.0000 s
Benchmarking deserialize/deserialize_file/wasi.wasm: Collecting 100 samples in estimated 5.0337 s (56k iterations)
Benchmarking deserialize/deserialize_file/wasi.wasm: Analyzing
deserialize/deserialize_file/wasi.wasm
                        time:   [89.572 µs 89.705 µs 89.872 µs]
Found 14 outliers among 100 measurements (14.00%)
  9 (9.00%) high mild
  5 (5.00%) high severe
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
