### PR TITLE
Fix typos in C API

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -221,7 +221,7 @@ WASMTIME_CONFIG_PROP(void, wasm_memory64, bool)
 WASMTIME_CONFIG_PROP(void, strategy, wasmtime_strategy_t)
 
 /**
- * \brief Configure wether wasmtime should compile a module using multiple threads.
+ * \brief Configure whether wasmtime should compile a module using multiple threads.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.parallel_compilation.

--- a/crates/c-api/include/wasmtime/memory.h
+++ b/crates/c-api/include/wasmtime/memory.h
@@ -66,7 +66,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_memory_new(
 );
 
 /**
- * \brief Returns the tyep of the memory specified
+ * \brief Returns the type of the memory specified
  */
 WASM_API_EXTERN wasm_memorytype_t* wasmtime_memory_type(
     const wasmtime_context_t *store,

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -170,7 +170,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_add_fuel(wasmtime_context_t *
  *
  * If fuel consumption is not enabled via #wasmtime_config_consume_fuel_set
  * then this function will return false. Otherwise true is returned and the
- * fuel parameter is filled in with fuel consuemd so far.
+ * fuel parameter is filled in with fuel consumed so far.
  *
  * Also note that fuel, if enabled, must be originally configured via
  * #wasmtime_context_add_fuel.

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -212,7 +212,7 @@ typedef struct wasmtime_val {
 } wasmtime_val_t;
 
 /**
- * \brief Delets an owned #wasmtime_val_t.
+ * \brief Deletes an owned #wasmtime_val_t.
  *
  * Note that this only deletes the contents, not the memory that `val` points to
  * itself (which is owned by the caller).


### PR DESCRIPTION
Fixes few typos in C API

Sorry for that many commits, did that from Github UI while reading doc. Feel free to squash on merge.