### PR TITLE
Update submodules as part of the release process

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -151,6 +151,7 @@ jobs:
           # commit it, indicating that the commit is what will get tagged and
           # released
           git reset --hard origin/release-$cur
+          git submodule update --init --recursive
           sed -i "s/^Unreleased/Released $(date +'%Y-%m-%d')/" RELEASES.md
           git commit --allow-empty -a -F-<<EOF
           Release Wasmtime $cur


### PR DESCRIPTION
Avoids an accidental submodule reset as shown in #6418 hopefully.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
