### PR TITLE
[9.0.0] Fix readme directive for `wasmtime-wasi-http`

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 repository = "https://github.com/bytecodealliance/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Experimental HTTP library for WebAssembly in Wasmtime"
-readme = "readme.md"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
This points to a nonexistent file which caused the publish to crates.io to fail.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
