### PR TITLE
winch(fuzz): Refactor Winch's fuzzing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,8 +357,6 @@ jobs:
     - run: cargo fuzz build --dev -s none
     # Check that the ISLE fuzz targets build too.
     - run: cargo fuzz build --dev -s none --fuzz-dir ./cranelift/isle/fuzz
-    # Check that winch fuzzing builds too.
-    - run: cargo fuzz build --dev -s none --features fuzz-winch
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -19,7 +19,7 @@ target-lexicon = { workspace = true }
 tempfile = "3.3.0"
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
-wasmtime = { workspace = true, features = ['default'] }
+wasmtime = { workspace = true, features = ['default', 'winch'] }
 wasmtime-wast = { workspace = true }
 wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
@@ -46,4 +46,3 @@ wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true, fea
 
 [features]
 fuzz-spec-interpreter = ['wasm-spec-interpreter']
-winch = ["wasmtime/winch"]

--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -23,7 +23,6 @@ pub mod table_ops;
 mod value;
 
 pub use codegen_settings::CodegenSettings;
-#[cfg(feature = "winch")]
 pub use config::CompilerStrategy;
 pub use config::{Config, WasmtimeConfig};
 pub use instance_allocation_strategy::InstanceAllocationStrategy;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,8 +21,8 @@ cranelift-control = { workspace = true }
 libfuzzer-sys = { workspace = true, features = ["arbitrary-derive"] }
 target-lexicon = { workspace = true }
 smallvec = { workspace = true }
-wasmparser = { workspace = true, optional = true }
-wasmtime = { workspace = true }
+wasmparser = { workspace = true }
+wasmtime = { workspace = true, features = ["winch"] }
 wasmtime-fuzzing = { workspace = true }
 component-test-util = { workspace = true }
 component-fuzz-util = { workspace = true }
@@ -36,7 +36,6 @@ quote = "1.0"
 component-fuzz-util = { workspace = true }
 
 [features]
-fuzz-winch = ["wasmtime/winch", "wasmtime-fuzzing/winch", "dep:wasmparser"]
 default = ['fuzz-spec-interpreter']
 fuzz-spec-interpreter = ['wasmtime-fuzzing/fuzz-spec-interpreter']
 chaos = ["cranelift-control/chaos"]

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -5,14 +5,11 @@ use libfuzzer_sys::fuzz_target;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Once;
-#[cfg(feature = "fuzz-winch")]
 use wasmtime_fuzzing::generators::CompilerStrategy;
 use wasmtime_fuzzing::generators::{Config, DiffValue, DiffValueType, SingleInstModule};
 use wasmtime_fuzzing::oracles::diff_wasmtime::WasmtimeInstance;
 use wasmtime_fuzzing::oracles::engine::{build_allowed_env_list, parse_env_list};
 use wasmtime_fuzzing::oracles::{differential, engine, log_wasm, DiffEqResult};
-#[cfg(feature = "fuzz-winch")]
-use wasmtime_fuzzing::wasm_smith::{InstructionKind, InstructionKinds};
 
 // Upper limit on the number of invocations for each WebAssembly function
 // executed by this fuzz target.
@@ -26,8 +23,10 @@ static SETUP: Once = Once::new();
 // - ALLOWED_ENGINES=wasmi,spec cargo +nightly fuzz run ...
 // - ALLOWED_ENGINES=-v8 cargo +nightly fuzz run ...
 // - ALLOWED_MODULES=single-inst cargo +nightly fuzz run ...
+// - FUZZ_WINCH=1 cargo +nightly fuzz run ...
 static mut ALLOWED_ENGINES: Vec<&str> = vec![];
 static mut ALLOWED_MODULES: Vec<&str> = vec![];
+static mut FUZZ_WINCH: bool = false;
 
 // Statistics about what's actually getting executed during fuzzing
 static STATS: RuntimeStats = RuntimeStats::new();
@@ -38,25 +37,26 @@ fuzz_target!(|data: &[u8]| {
         // `setup_ocaml_runtime`.
         engine::setup_engine_runtimes();
 
-        let (default_engines, default_modules) = if cfg!(feature = "fuzz-winch") {
-            (vec!["wasmi"], vec!["wasm-smith", "single-inst"])
-        } else {
-            (
-                vec!["wasmtime", "wasmi", "spec", "v8"],
-                vec!["wasm-smith", "single-inst"],
-            )
-        };
-
         // Retrieve the configuration for this fuzz target from `ALLOWED_*`
         // environment variables.
-        let allowed_engines =
-            build_allowed_env_list(parse_env_list("ALLOWED_ENGINES"), &default_engines);
-        let allowed_modules =
-            build_allowed_env_list(parse_env_list("ALLOWED_MODULES"), &default_modules);
+        let allowed_engines = build_allowed_env_list(
+            parse_env_list("ALLOWED_ENGINES"),
+            &["wasmtime", "wasmi", "spec", "v8"],
+        );
+        let allowed_modules = build_allowed_env_list(
+            parse_env_list("ALLOWED_MODULES"),
+            &["wasm-smith", "single-inst"],
+        );
+
+        let fuzz_winch = match std::env::var("FUZZ_WINCH").map(|v| v == "1") {
+            Ok(v) => v,
+            _ => false,
+        };
 
         unsafe {
             ALLOWED_ENGINES = allowed_engines;
             ALLOWED_MODULES = allowed_modules;
+            FUZZ_WINCH = fuzz_winch;
         }
     });
 
@@ -69,6 +69,7 @@ fn execute_one(data: &[u8]) -> Result<()> {
     STATS.bump_attempts();
 
     let mut u = Unstructured::new(data);
+    let fuzz_winch = unsafe { FUZZ_WINCH };
 
     // Generate a Wasmtime and module configuration and update its settings
     // initially to be suitable for differential execution where the generated
@@ -77,14 +78,10 @@ fn execute_one(data: &[u8]) -> Result<()> {
     let mut config: Config = u.arbitrary()?;
     config.set_differential_config();
 
-    #[cfg(feature = "fuzz-winch")]
-    {
-        // When fuzzing Winch:
-        // 1. Explicitly override the compiler strategy.
-        // 2. Explicitly set the allowed instructions for `wasm-smith`.
+    if fuzz_winch {
         config.wasmtime.compiler_strategy = CompilerStrategy::Winch;
-        config.module_config.config.allowed_instructions =
-            InstructionKinds::new(&[InstructionKind::Numeric, InstructionKind::Variable]);
+    } else {
+        config.wasmtime.compiler_strategy = CompilerStrategy::Cranelift;
     }
 
     // Choose an engine that Wasmtime will be differentially executed against.
@@ -120,8 +117,7 @@ fn execute_one(data: &[u8]) -> Result<()> {
         _ => unreachable!(),
     };
 
-    #[cfg(feature = "fuzz-winch")]
-    if !winch_supports_module(&wasm) {
+    if fuzz_winch && !winch_supports_module(&wasm) {
         return Ok(());
     }
 
@@ -277,7 +273,6 @@ impl RuntimeStats {
     }
 }
 
-#[cfg(feature = "fuzz-winch")]
 // Returns true if the module only contains operators supported by
 // Winch. Winch's x86_64 target has broader support for Wasm operators
 // than the aarch64 target. This list assumes fuzzing on the x86_64


### PR DESCRIPTION
This change is a follow-up to the discussion in
https://github.com/bytecodealliance/wasmtime/pull/6281.

The most notable characteristic of this change is that it enables `winch` by default in the fuzzers. If compilation time is a big enough concern I can add the cargo feature back. I opted to enable `winch` by default for several reasons:

* It substantially reduces the `cfg` complexity -- at first I thought I had covered all the places in which a `cfg` check would be needed, but then I realized that I missed the Cranelift specific compiler flags.

* It's the fastest route to enable winch by default in the fuzzers, which we want to do eventually -- the only change we'd need at that point would be to get rid of the winch-specific environment variable.

* We can get rid of the winch-specific checks in CI for fuzzing

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
