### PR TITLE
Cranelift/ABI: catch overflow in layout code with large stack slots.

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/too-large-stackframe.clif
+++ b/cranelift/filetests/filetests/isa/x64/too-large-stackframe.clif
@@ -1,0 +1,24 @@
+;; See: https://github.com/bytecodealliance/wasmtime/issues/6431
+
+test compile expect-fail
+target x86_64
+
+;; We expect this to fail: the slots add up to beyond the range of a `u32`.
+function u0:0() system_v {
+    ss0 = explicit_slot 1536000000
+    ss1 = explicit_slot 1536000000
+    ss2 = explicit_slot 1536000000
+    ss3 = explicit_slot 1536000000
+
+block0:
+    trap user0
+}
+
+;; We expect this to fail as well: the rounding-up for alignment after
+;; processing the one stackslot will cause overflow.
+function u0:0() system_v {
+    ss0 = explicit_slot 0xffffffff
+
+block0:
+    trap user0
+}

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -15,16 +15,20 @@ struct TestCompile {
     /// This test assertion is also automatically-update-able to allow tweaking
     /// the code generator and easily updating all affected tests.
     precise_output: bool,
+    /// Flag indicating that we expect compilation to fail, not succeed.
+    expect_fail: bool,
 }
 
 pub fn subtest(parsed: &TestCommand) -> Result<Box<dyn SubTest>> {
     assert_eq!(parsed.command, "compile");
     let mut test = TestCompile {
         precise_output: false,
+        expect_fail: false,
     };
     for option in parsed.options.iter() {
         match option {
             TestOption::Flag("precise-output") => test.precise_output = true,
+            TestOption::Flag("expect-fail") => test.expect_fail = true,
             _ => anyhow::bail!("unknown option on {}", parsed),
         }
     }
@@ -52,9 +56,16 @@ impl SubTest for TestCompile {
         // With `MachBackend`s, we need to explicitly request dissassembly results.
         comp_ctx.set_disasm(true);
 
-        let compiled_code = comp_ctx
-            .compile(isa, &mut Default::default())
-            .map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?;
+        let compiled_code = comp_ctx.compile(isa, &mut Default::default());
+
+        let compiled_code = if self.expect_fail {
+            if compiled_code.is_ok() {
+                anyhow::bail!("Expected compilation failure but compilation succeeded");
+            }
+            return Ok(());
+        } else {
+            compiled_code.map_err(|e| crate::pretty_anyhow_error(&e.func, e.inner))?
+        };
         let total_size = compiled_code.code_info().total_size;
 
         let vcode = compiled_code.vcode.as_ref().unwrap();


### PR DESCRIPTION
This PR catches and successfully errors out of compilation a situation where stackslots exceed the `u32` (4GB) range of the stack-frame layout computation.

Note that this is not reachable from Wasmtime (it does not use stackslots) so does not have security implications there, but could cause issues in other compilers (e.g. cg\_clif) that pass arbitrary stackslot sizes to Cranelift.

Fixes #6431.