### PR TITLE
[9.0.0] Fix support for native profiling

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -568,10 +568,10 @@ impl CompiledModule {
     /// this module, providing both their index and their in-memory body.
     pub fn array_to_wasm_trampolines(
         &self,
-    ) -> impl ExactSizeIterator<Item = (DefinedFuncIndex, &[u8])> + '_ {
+    ) -> impl Iterator<Item = (DefinedFuncIndex, &[u8])> + '_ {
         self.funcs
             .keys()
-            .map(move |i| (i, self.array_to_wasm_trampoline(i).unwrap()))
+            .filter_map(move |i| Some((i, self.array_to_wasm_trampoline(i)?)))
     }
 
     /// Get the native-to-Wasm trampoline for the function `index` points to.
@@ -590,10 +590,10 @@ impl CompiledModule {
     /// this module, providing both their index and their in-memory body.
     pub fn native_to_wasm_trampolines(
         &self,
-    ) -> impl ExactSizeIterator<Item = (DefinedFuncIndex, &[u8])> + '_ {
+    ) -> impl Iterator<Item = (DefinedFuncIndex, &[u8])> + '_ {
         self.funcs
             .keys()
-            .map(move |i| (i, self.native_to_wasm_trampoline(i).unwrap()))
+            .filter_map(move |i| Some((i, self.native_to_wasm_trampoline(i)?)))
     }
 
     /// Get the Wasm-to-native trampoline for the given signature.


### PR DESCRIPTION
This commit fixes a panic that's easy to hit with native profilers by accident. This was introduced in #6262 which made it into the 9.0.0 release but is not present on `main` due to the refactorings of #6361 which are on `main` but not on 9.0.0.

Closes #6433

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
