### PR TITLE
feat(preview1): implement core I/O functionality

### DIFF
--- a/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
+++ b/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
@@ -136,47 +136,39 @@ async fn clock_time_get() {
     run("clock_time_get", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn close_preopen() {
     run("close_preopen", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn dangling_fd() {
     run("dangling_fd", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn dangling_symlink() {
     run("dangling_symlink", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)] // TODO: remove
 async fn directory_seek() {
     run("directory_seek", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn dir_fd_op_failures() {
     run("dir_fd_op_failures", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn fd_advise() {
     run("fd_advise", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn fd_filestat_get() {
     run("fd_filestat_get", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn fd_filestat_set() {
     run("fd_filestat_set", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn fd_flags_set() {
     run("fd_flags_set", true).await.unwrap()
 }
@@ -186,87 +178,73 @@ async fn fd_readdir() {
     run("fd_readdir", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn file_allocate() {
     run("file_allocate", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn file_pread_pwrite() {
     run("file_pread_pwrite", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn file_seek_tell() {
     run("file_seek_tell", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn file_truncation() {
     run("file_truncation", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn file_unbuffered_write() {
     run("file_unbuffered_write", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)]
 async fn interesting_paths() {
     run("interesting_paths", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn isatty() {
     run("isatty", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)] // TODO: remove
 async fn nofollow_errors() {
     run("nofollow_errors", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn overwrite_preopen() {
     run("overwrite_preopen", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_exists() {
     run("path_exists", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_filestat() {
     run("path_filestat", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)] // TODO: remove
 async fn path_link() {
     run("path_link", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_open_create_existing() {
     run("path_open_create_existing", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_open_dirfd_not_dir() {
     run("path_open_dirfd_not_dir", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_open_missing() {
     run("path_open_missing", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_open_nonblock() {
     run("path_open_nonblock", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_rename_dir_trailing_slashes() {
     run("path_rename_dir_trailing_slashes", true).await.unwrap()
 }
@@ -278,12 +256,11 @@ async fn path_rename_file_trailing_slashes() {
         .unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)] // TODO: remove
 async fn path_rename() {
     run("path_rename", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn path_symlink_trailing_slashes() {
     run("path_symlink_trailing_slashes", true).await.unwrap()
 }
@@ -299,7 +276,6 @@ async fn poll_oneoff_stdio() {
     run("poll_oneoff_stdio", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn readlink() {
     run("readlink", true).await.unwrap()
 }
@@ -311,12 +287,10 @@ async fn remove_directory_trailing_slashes() {
         .unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn remove_nonempty_directory() {
     run("remove_nonempty_directory", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn renumber() {
     run("renumber", true).await.unwrap()
 }
@@ -325,27 +299,23 @@ async fn sched_yield() {
     run("sched_yield", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn stdio() {
     run("stdio", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
+#[cfg_attr(windows, should_panic)] // TODO: remove
 async fn symlink_create() {
     run("symlink_create", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn symlink_filestat() {
     run("symlink_filestat", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn symlink_loop() {
     run("symlink_loop", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[should_panic]
 async fn unlink_file_trailing_slashes() {
     run("unlink_file_trailing_slashes", true).await.unwrap()
 }

--- a/crates/wasi/src/preview2/preview1/mod.rs
+++ b/crates/wasi/src/preview2/preview1/mod.rs
@@ -6,6 +6,7 @@ use crate::preview2::wasi;
 use core::borrow::Borrow;
 
 use anyhow::{anyhow, Context};
+use wiggle::tracing::instrument;
 use wiggle::GuestPtr;
 
 pub struct WasiPreview1Adapter {/* all members private and only used inside this module. also, this struct should be Send. */}
@@ -117,6 +118,7 @@ impl<
             + wasi::wall_clock::Host,
     > wasi_snapshot_preview1::WasiSnapshotPreview1 for T
 {
+    #[instrument(skip(self))]
     async fn args_get<'b>(
         &mut self,
         argv: &GuestPtr<'b, GuestPtr<'b, u8>>,
@@ -144,6 +146,7 @@ impl<
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn args_sizes_get(&mut self) -> Result<(types::Size, types::Size), types::Error> {
         let args = self
             .get_arguments()
@@ -160,6 +163,7 @@ impl<
         Ok((num, len))
     }
 
+    #[instrument(skip(self))]
     async fn environ_get<'b>(
         &mut self,
         environ: &GuestPtr<'b, GuestPtr<'b, u8>>,
@@ -191,6 +195,7 @@ impl<
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn environ_sizes_get(&mut self) -> Result<(types::Size, types::Size), types::Error> {
         let environ = self
             .get_environment()
@@ -210,6 +215,7 @@ impl<
         Ok((num, len))
     }
 
+    #[instrument(skip(self))]
     async fn clock_res_get(
         &mut self,
         id: types::Clockid,
@@ -231,6 +237,7 @@ impl<
         Ok(res)
     }
 
+    #[instrument(skip(self))]
     async fn clock_time_get(
         &mut self,
         id: types::Clockid,
@@ -253,6 +260,7 @@ impl<
         Ok(now)
     }
 
+    #[instrument(skip(self))]
     async fn fd_advise(
         &mut self,
         fd: types::Fd,
@@ -263,6 +271,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_allocate(
         &mut self,
         fd: types::Fd,
@@ -272,18 +281,22 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_close(&mut self, fd: types::Fd) -> Result<(), types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_datasync(&mut self, fd: types::Fd) -> Result<(), types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_fdstat_get(&mut self, fd: types::Fd) -> Result<types::Fdstat, types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_fdstat_set_flags(
         &mut self,
         fd: types::Fd,
@@ -292,6 +305,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_fdstat_set_rights(
         &mut self,
         fd: types::Fd,
@@ -301,10 +315,12 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_filestat_get(&mut self, fd: types::Fd) -> Result<types::Filestat, types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_filestat_set_size(
         &mut self,
         fd: types::Fd,
@@ -313,6 +329,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_filestat_set_times(
         &mut self,
         fd: types::Fd,
@@ -323,6 +340,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_read<'a>(
         &mut self,
         fd: types::Fd,
@@ -331,6 +349,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_pread<'a>(
         &mut self,
         fd: types::Fd,
@@ -340,6 +359,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_write<'a>(
         &mut self,
         fd: types::Fd,
@@ -348,6 +368,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_pwrite<'a>(
         &mut self,
         fd: types::Fd,
@@ -357,10 +378,12 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_prestat_get(&mut self, fd: types::Fd) -> Result<types::Prestat, types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_prestat_dir_name<'a>(
         &mut self,
         fd: types::Fd,
@@ -369,10 +392,13 @@ impl<
     ) -> Result<(), types::Error> {
         todo!()
     }
+
+    #[instrument(skip(self))]
     async fn fd_renumber(&mut self, from: types::Fd, to: types::Fd) -> Result<(), types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_seek(
         &mut self,
         fd: types::Fd,
@@ -382,14 +408,17 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_sync(&mut self, fd: types::Fd) -> Result<(), types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_tell(&mut self, fd: types::Fd) -> Result<types::Filesize, types::Error> {
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn fd_readdir<'a>(
         &mut self,
         fd: types::Fd,
@@ -400,6 +429,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_create_directory<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -408,6 +438,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_filestat_get<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -417,6 +448,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_filestat_set_times<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -429,6 +461,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_link<'a>(
         &mut self,
         src_fd: types::Fd,
@@ -440,6 +473,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_open<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -453,6 +487,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_readlink<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -463,6 +498,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_remove_directory<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -471,6 +507,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_rename<'a>(
         &mut self,
         src_fd: types::Fd,
@@ -481,6 +518,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_symlink<'a>(
         &mut self,
         src_path: &GuestPtr<'a, str>,
@@ -490,6 +528,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn path_unlink_file<'a>(
         &mut self,
         dirfd: types::Fd,
@@ -498,6 +537,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn poll_oneoff<'a>(
         &mut self,
         subs: &GuestPtr<'a, types::Subscription>,
@@ -507,6 +547,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn proc_exit(&mut self, status: types::Exitcode) -> anyhow::Error {
         let status = match status {
             0 => Ok(()),
@@ -518,15 +559,18 @@ impl<
         }
     }
 
+    #[instrument(skip(self))]
     async fn proc_raise(&mut self, _sig: types::Signal) -> Result<(), types::Error> {
         Err(types::Errno::Notsup.into())
     }
 
+    #[instrument(skip(self))]
     async fn sched_yield(&mut self) -> Result<(), types::Error> {
         // TODO: This is not yet covered in Preview2.
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn random_get<'a>(
         &mut self,
         buf: &GuestPtr<'a, u8>,
@@ -541,6 +585,7 @@ impl<
         Ok(())
     }
 
+    #[instrument(skip(self))]
     async fn sock_accept(
         &mut self,
         fd: types::Fd,
@@ -549,6 +594,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn sock_recv<'a>(
         &mut self,
         fd: types::Fd,
@@ -558,6 +604,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn sock_send<'a>(
         &mut self,
         fd: types::Fd,
@@ -567,6 +614,7 @@ impl<
         todo!()
     }
 
+    #[instrument(skip(self))]
     async fn sock_shutdown(
         &mut self,
         fd: types::Fd,

--- a/crates/wasi/src/preview2/preview1/mod.rs
+++ b/crates/wasi/src/preview2/preview1/mod.rs
@@ -1,33 +1,319 @@
 // Temporary for scaffolding this module out:
 #![allow(unused_variables)]
 
-use crate::preview2::wasi;
+use crate::preview2::filesystem::TableFsExt;
+use crate::preview2::{wasi, TableError, WasiView};
 
 use core::borrow::Borrow;
+use core::cell::Cell;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicU64, Ordering};
 
-use anyhow::{anyhow, Context};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context};
 use wiggle::tracing::instrument;
-use wiggle::GuestPtr;
+use wiggle::{GuestPtr, GuestSliceMut, GuestStrCow};
 
-pub struct WasiPreview1Adapter {/* all members private and only used inside this module. also, this struct should be Send. */}
+#[derive(Clone, Debug)]
+struct File {
+    /// The handle to the preview2 descriptor that this file is referencing.
+    fd: wasi::filesystem::Descriptor,
+
+    /// The current-position pointer.
+    position: Arc<AtomicU64>,
+
+    /// In append mode, all writes append to the file.
+    append: bool,
+
+    /// In blocking mode, read and write calls dispatch to blocking_read and
+    /// blocking_write on the underlying streams. When false, read and write
+    /// dispatch to stream's plain read and write.
+    blocking: bool,
+}
+
+#[derive(Clone, Debug)]
+enum Descriptor {
+    Stdin(wasi::preopens::InputStream),
+    Stdout(wasi::preopens::OutputStream),
+    Stderr(wasi::preopens::OutputStream),
+    PreopenDirectory((wasi::filesystem::Descriptor, String)),
+    File(File),
+}
+
+#[derive(Debug, Default)]
+pub struct WasiPreview1Adapter {
+    descriptors: Option<Descriptors>,
+}
+
+#[derive(Debug, Default)]
+struct Descriptors {
+    used: BTreeMap<u32, Descriptor>,
+    free: Vec<u32>,
+}
+
+impl Deref for Descriptors {
+    type Target = BTreeMap<u32, Descriptor>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.used
+    }
+}
+
+impl DerefMut for Descriptors {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.used
+    }
+}
+
+impl Descriptors {
+    /// Initializes [Self] using `preopens`
+    async fn new(
+        preopens: &mut (impl wasi::preopens::Host + ?Sized),
+    ) -> Result<Self, types::Error> {
+        let wasi::preopens::StdioPreopens {
+            stdin,
+            stdout,
+            stderr,
+        } = preopens
+            .get_stdio()
+            .await
+            .context("failed to call `get-stdio`")
+            .map_err(types::Error::trap)?;
+        let directories = preopens
+            .get_directories()
+            .await
+            .context("failed to call `get-directories`")
+            .map_err(types::Error::trap)?;
+
+        let mut descriptors = Self::default();
+        descriptors.push(Descriptor::Stdin(stdin))?;
+        descriptors.push(Descriptor::Stdout(stdout))?;
+        descriptors.push(Descriptor::Stderr(stderr))?;
+        for dir in directories {
+            descriptors.push(Descriptor::PreopenDirectory(dir))?;
+        }
+        Ok(descriptors)
+    }
+
+    /// Returns next descriptor number, which was never assigned
+    fn unused(&self) -> ErrnoResult<u32> {
+        match self.last_key_value() {
+            Some((fd, _)) => {
+                if let Some(fd) = fd.checked_add(1) {
+                    return Ok(fd);
+                }
+                if self.len() == u32::MAX as usize {
+                    return Err(types::Errno::Loop);
+                }
+                // TODO: Optimize
+                Ok((0..u32::MAX)
+                    .rev()
+                    .find(|fd| !self.contains_key(fd))
+                    .expect("failed to find an unused file descriptor"))
+            }
+            None => Ok(0),
+        }
+    }
+
+    /// Removes the [Descriptor] corresponding to `fd`
+    fn remove(&mut self, fd: types::Fd) -> Option<Descriptor> {
+        let fd = fd.into();
+        let desc = self.used.remove(&fd)?;
+        self.free.push(fd);
+        Some(desc)
+    }
+
+    /// Pushes the [Descriptor] returning corresponding number.
+    /// This operation will try to reuse numbers previously removed via [`Self::remove`]
+    /// and rely on [`Self::unused`] if no free numbers are recorded
+    fn push(&mut self, desc: Descriptor) -> ErrnoResult<u32> {
+        let fd = if let Some(fd) = self.free.pop() {
+            fd
+        } else {
+            self.unused()?
+        };
+        assert!(self.insert(fd, desc).is_none());
+        Ok(fd)
+    }
+
+    /// Like [Self::push], but for [`File`]
+    fn push_file(&mut self, file: File) -> ErrnoResult<u32> {
+        self.push(Descriptor::File(file))
+    }
+}
+
 impl WasiPreview1Adapter {
-    // This should be the only public interface of this struct. It should take
-    // no parameters: anything it needs from the preview 2 implementation
-    // should be retrieved lazily.
     pub fn new() -> Self {
-        Self {}
+        Self::default()
     }
 }
 
 // Any context that needs to support preview 1 will impl this trait. They can
 // construct the needed member with WasiPreview1Adapter::new().
-pub trait WasiPreview1View: Send {
+pub trait WasiPreview1View: Send + Sync + WasiView {
     fn adapter(&self) -> &WasiPreview1Adapter;
     fn adapter_mut(&mut self) -> &mut WasiPreview1Adapter;
 }
 
-// This becomes the only way to add preview 1 support to a wasmtime (module)
-// Linker:
+/// A mutably-borrowed [`WasiPreview1View`] implementation, which provides access to the stored
+/// state. It can be thought of as an in-flight [`WasiPreview1Adapter`] transaction, all
+/// changes will be recorded in the underlying [`WasiPreview1Adapter`] returned by
+/// [`WasiPreview1View::adapter_mut`] on [`Drop`] of this struct.
+// NOTE: This exists for the most part just due to the fact that `bindgen` generates methods with
+// `&mut self` receivers and so this struct lets us extend the lifetime of the `&mut self` borrow
+// of the [`WasiPreview1View`] to provide means to return mutably and immutably borrowed [`Descriptors`]
+// without having to rely on something like `Arc<Mutex<Descriptors>>`, while also being able to
+// call methods like [`TableFsExt::is_file`] and hiding complexity from preview1 method implementations.
+struct Transcation<'a, T: WasiPreview1View + ?Sized> {
+    view: &'a mut T,
+    descriptors: Cell<Descriptors>,
+}
+
+impl<T: WasiPreview1View + ?Sized> Drop for Transcation<'_, T> {
+    /// Record changes in the [`WasiPreview1Adapter`] returned by [`WasiPreview1View::adapter_mut`]
+    fn drop(&mut self) {
+        let descriptors = self.descriptors.take();
+        self.view.adapter_mut().descriptors = Some(descriptors);
+    }
+}
+
+impl<T: WasiPreview1View + ?Sized> Transcation<'_, T> {
+    fn get_descriptor(&mut self, fd: types::Fd) -> Option<&Descriptor> {
+        let fd = fd.into();
+        self.descriptors.get_mut().get(&fd)
+    }
+
+    /// Borrows [`File`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] of [`crate::preview2::filesystem::File`] type
+    fn get_file(&mut self, fd: types::Fd) -> ErrnoResult<&File> {
+        let fd = fd.into();
+        match self.descriptors.get_mut().get(&fd) {
+            Some(Descriptor::File(file @ File { fd, .. })) if self.view.table().is_file(*fd) => {
+                Ok(file)
+            }
+            _ => Err(types::Errno::Badf),
+        }
+    }
+
+    /// Mutably borrows [`File`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] of [`crate::preview2::filesystem::File`] type
+    fn get_file_mut(&mut self, fd: types::Fd) -> ErrnoResult<&mut File> {
+        let fd = fd.into();
+        match self.descriptors.get_mut().get_mut(&fd) {
+            Some(Descriptor::File(file)) if self.view.table().is_file(file.fd) => Ok(file),
+            _ => Err(types::Errno::Badf),
+        }
+    }
+
+    /// Borrows [`File`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] of [`crate::preview2::filesystem::File`] type.
+    ///
+    /// # Errors
+    ///
+    /// Returns `types::Errno::Spipe` if a descriptor corresponds to stdio
+    fn get_seekable(&mut self, fd: types::Fd) -> ErrnoResult<&File> {
+        let fd = fd.into();
+        match self.descriptors.get_mut().get(&fd) {
+            Some(Descriptor::File(file @ File { fd, .. })) if self.view.table().is_file(*fd) => {
+                Ok(file)
+            }
+            Some(Descriptor::Stdin(..) | Descriptor::Stdout(..) | Descriptor::Stderr(..)) => {
+                // NOTE: legacy implementation returns SPIPE here
+                Err(types::Errno::Spipe)
+            }
+            _ => Err(types::Errno::Badf),
+        }
+    }
+
+    /// Returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    fn get_fd(&mut self, fd: types::Fd) -> ErrnoResult<wasi::filesystem::Descriptor> {
+        let fd = fd.into();
+        match self.descriptors.get_mut().get(&fd) {
+            Some(Descriptor::File(File { fd, .. })) => Ok(*fd),
+            Some(Descriptor::PreopenDirectory((fd, _))) => Ok(*fd),
+            Some(Descriptor::Stdin(stream)) => Ok(*stream),
+            Some(Descriptor::Stdout(stream) | Descriptor::Stderr(stream)) => Ok(*stream),
+            None => Err(types::Errno::Badf),
+        }
+    }
+
+    /// Returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] of [`crate::preview2::filesystem::File`] type
+    fn get_file_fd(&mut self, fd: types::Fd) -> ErrnoResult<wasi::filesystem::Descriptor> {
+        self.get_file(fd).map(|File { fd, .. }| *fd)
+    }
+
+    /// Returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] or [`Descriptor::PreopenDirectory`]
+    /// of [`crate::preview2::filesystem::Dir`] type
+    fn get_dir_fd(&mut self, fd: types::Fd) -> ErrnoResult<wasi::filesystem::Descriptor> {
+        let fd = fd.into();
+        match self.descriptors.get_mut().get(&fd) {
+            Some(Descriptor::File(File { fd, .. })) if self.view.table().is_dir(*fd) => Ok(*fd),
+            Some(Descriptor::PreopenDirectory((fd, _))) => Ok(*fd),
+            _ => Err(types::Errno::Badf),
+        }
+    }
+}
+
+#[wiggle::async_trait]
+trait WasiPreview1ViewExt: WasiPreview1View + wasi::preopens::Host {
+    /// Lazily initializes [`WasiPreview1Adapter`] returned by [`Self::adapter_mut`]
+    /// and returns [`Transaction`] on success
+    async fn transact(&mut self) -> Result<Transcation<'_, Self>, types::Error> {
+        let descriptors = if let Some(descriptors) = self.adapter_mut().descriptors.take() {
+            descriptors
+        } else {
+            Descriptors::new(self).await?
+        }
+        .into();
+        Ok(Transcation {
+            view: self,
+            descriptors,
+        })
+    }
+
+    /// Lazily initializes [`WasiPreview1Adapter`] returned by [`Self::adapter_mut`]
+    /// and returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    async fn get_fd(
+        &mut self,
+        fd: types::Fd,
+    ) -> Result<wasi::filesystem::Descriptor, types::Error> {
+        let mut st = self.transact().await?;
+        let fd = st.get_fd(fd)?;
+        Ok(fd)
+    }
+
+    /// Lazily initializes [`WasiPreview1Adapter`] returned by [`Self::adapter_mut`]
+    /// and returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] of [`crate::preview2::filesystem::File`] type
+    async fn get_file_fd(
+        &mut self,
+        fd: types::Fd,
+    ) -> Result<wasi::filesystem::Descriptor, types::Error> {
+        let mut st = self.transact().await?;
+        let fd = st.get_file_fd(fd)?;
+        Ok(fd)
+    }
+
+    /// Lazily initializes [`WasiPreview1Adapter`] returned by [`Self::adapter_mut`]
+    /// and returns [`wasi::filesystem::Descriptor`] corresponding to `fd`
+    /// if it describes a [`Descriptor::File`] or [`Descriptor::PreopenDirectory`]
+    /// of [`crate::preview2::filesystem::Dir`] type
+    async fn get_dir_fd(
+        &mut self,
+        fd: types::Fd,
+    ) -> Result<wasi::filesystem::Descriptor, types::Error> {
+        let mut st = self.transact().await?;
+        let fd = st.get_dir_fd(fd)?;
+        Ok(fd)
+    }
+}
+
+impl<T: WasiPreview1View + wasi::preopens::Host> WasiPreview1ViewExt for T {}
+
 pub fn add_to_linker<
     T: WasiPreview1View
         + wasi::environment::Host
@@ -61,6 +347,27 @@ impl wiggle::GuestErrorType for types::Errno {
     }
 }
 
+fn systimespec(
+    set: bool,
+    ts: types::Timestamp,
+    now: bool,
+) -> ErrnoResult<wasi::filesystem::NewTimestamp> {
+    if set && now {
+        Err(types::Errno::Inval)
+    } else if set {
+        Ok(wasi::filesystem::NewTimestamp::Timestamp(
+            wasi::filesystem::Datetime {
+                seconds: ts / 1_000_000_000,
+                nanoseconds: (ts % 1_000_000_000) as _,
+            },
+        ))
+    } else if now {
+        Ok(wasi::filesystem::NewTimestamp::Now)
+    } else {
+        Ok(wasi::filesystem::NewTimestamp::NoChange)
+    }
+}
+
 impl TryFrom<wasi::wall_clock::Datetime> for types::Timestamp {
     type Error = types::Errno;
 
@@ -74,6 +381,159 @@ impl TryFrom<wasi::wall_clock::Datetime> for types::Timestamp {
             .checked_mul(1_000_000_000)
             .and_then(|ns| ns.checked_add(nanoseconds.into()))
             .ok_or(types::Errno::Overflow)
+    }
+}
+
+impl From<types::Lookupflags> for wasi::filesystem::PathFlags {
+    fn from(flags: types::Lookupflags) -> Self {
+        if flags.contains(types::Lookupflags::SYMLINK_FOLLOW) {
+            wasi::filesystem::PathFlags::SYMLINK_FOLLOW
+        } else {
+            wasi::filesystem::PathFlags::empty()
+        }
+    }
+}
+
+impl From<types::Oflags> for wasi::filesystem::OpenFlags {
+    fn from(flags: types::Oflags) -> Self {
+        let mut out = wasi::filesystem::OpenFlags::empty();
+        if flags.contains(types::Oflags::CREAT) {
+            out |= wasi::filesystem::OpenFlags::CREATE;
+        }
+        if flags.contains(types::Oflags::DIRECTORY) {
+            out |= wasi::filesystem::OpenFlags::DIRECTORY;
+        }
+        if flags.contains(types::Oflags::EXCL) {
+            out |= wasi::filesystem::OpenFlags::EXCLUSIVE;
+        }
+        if flags.contains(types::Oflags::TRUNC) {
+            out |= wasi::filesystem::OpenFlags::TRUNCATE;
+        }
+        out
+    }
+}
+
+impl From<types::Advice> for wasi::filesystem::Advice {
+    fn from(advice: types::Advice) -> Self {
+        match advice {
+            types::Advice::Normal => wasi::filesystem::Advice::Normal,
+            types::Advice::Sequential => wasi::filesystem::Advice::Sequential,
+            types::Advice::Random => wasi::filesystem::Advice::Random,
+            types::Advice::Willneed => wasi::filesystem::Advice::WillNeed,
+            types::Advice::Dontneed => wasi::filesystem::Advice::DontNeed,
+            types::Advice::Noreuse => wasi::filesystem::Advice::NoReuse,
+        }
+    }
+}
+
+impl TryFrom<wasi::filesystem::DescriptorType> for types::Filetype {
+    type Error = anyhow::Error;
+
+    fn try_from(ty: wasi::filesystem::DescriptorType) -> Result<Self, Self::Error> {
+        match ty {
+            wasi::filesystem::DescriptorType::RegularFile => Ok(types::Filetype::RegularFile),
+            wasi::filesystem::DescriptorType::Directory => Ok(types::Filetype::Directory),
+            wasi::filesystem::DescriptorType::BlockDevice => Ok(types::Filetype::BlockDevice),
+            wasi::filesystem::DescriptorType::CharacterDevice => {
+                Ok(types::Filetype::CharacterDevice)
+            }
+            // preview1 never had a FIFO code.
+            wasi::filesystem::DescriptorType::Fifo => Ok(types::Filetype::Unknown),
+            // TODO: Add a way to disginguish between FILETYPE_SOCKET_STREAM and
+            // FILETYPE_SOCKET_DGRAM.
+            wasi::filesystem::DescriptorType::Socket => {
+                bail!("sockets are not currently supported")
+            }
+            wasi::filesystem::DescriptorType::SymbolicLink => Ok(types::Filetype::SymbolicLink),
+            wasi::filesystem::DescriptorType::Unknown => Ok(types::Filetype::Unknown),
+        }
+    }
+}
+
+impl From<wasi::filesystem::ErrorCode> for types::Errno {
+    fn from(code: wasi::filesystem::ErrorCode) -> Self {
+        match code {
+            wasi::filesystem::ErrorCode::Access => types::Errno::Acces,
+            wasi::filesystem::ErrorCode::WouldBlock => types::Errno::Again,
+            wasi::filesystem::ErrorCode::Already => types::Errno::Already,
+            wasi::filesystem::ErrorCode::BadDescriptor => types::Errno::Badf,
+            wasi::filesystem::ErrorCode::Busy => types::Errno::Busy,
+            wasi::filesystem::ErrorCode::Deadlock => types::Errno::Deadlk,
+            wasi::filesystem::ErrorCode::Quota => types::Errno::Dquot,
+            wasi::filesystem::ErrorCode::Exist => types::Errno::Exist,
+            wasi::filesystem::ErrorCode::FileTooLarge => types::Errno::Fbig,
+            wasi::filesystem::ErrorCode::IllegalByteSequence => types::Errno::Ilseq,
+            wasi::filesystem::ErrorCode::InProgress => types::Errno::Inprogress,
+            wasi::filesystem::ErrorCode::Interrupted => types::Errno::Intr,
+            wasi::filesystem::ErrorCode::Invalid => types::Errno::Inval,
+            wasi::filesystem::ErrorCode::Io => types::Errno::Io,
+            wasi::filesystem::ErrorCode::IsDirectory => types::Errno::Isdir,
+            wasi::filesystem::ErrorCode::Loop => types::Errno::Loop,
+            wasi::filesystem::ErrorCode::TooManyLinks => types::Errno::Mlink,
+            wasi::filesystem::ErrorCode::MessageSize => types::Errno::Msgsize,
+            wasi::filesystem::ErrorCode::NameTooLong => types::Errno::Nametoolong,
+            wasi::filesystem::ErrorCode::NoDevice => types::Errno::Nodev,
+            wasi::filesystem::ErrorCode::NoEntry => types::Errno::Noent,
+            wasi::filesystem::ErrorCode::NoLock => types::Errno::Nolck,
+            wasi::filesystem::ErrorCode::InsufficientMemory => types::Errno::Nomem,
+            wasi::filesystem::ErrorCode::InsufficientSpace => types::Errno::Nospc,
+            wasi::filesystem::ErrorCode::Unsupported => types::Errno::Notsup,
+            wasi::filesystem::ErrorCode::NotDirectory => types::Errno::Notdir,
+            wasi::filesystem::ErrorCode::NotEmpty => types::Errno::Notempty,
+            wasi::filesystem::ErrorCode::NotRecoverable => types::Errno::Notrecoverable,
+            wasi::filesystem::ErrorCode::NoTty => types::Errno::Notty,
+            wasi::filesystem::ErrorCode::NoSuchDevice => types::Errno::Nxio,
+            wasi::filesystem::ErrorCode::Overflow => types::Errno::Overflow,
+            wasi::filesystem::ErrorCode::NotPermitted => types::Errno::Perm,
+            wasi::filesystem::ErrorCode::Pipe => types::Errno::Pipe,
+            wasi::filesystem::ErrorCode::ReadOnly => types::Errno::Rofs,
+            wasi::filesystem::ErrorCode::InvalidSeek => types::Errno::Spipe,
+            wasi::filesystem::ErrorCode::TextFileBusy => types::Errno::Txtbsy,
+            wasi::filesystem::ErrorCode::CrossDevice => types::Errno::Xdev,
+        }
+    }
+}
+
+impl From<wasi::filesystem::ErrorCode> for types::Error {
+    fn from(code: wasi::filesystem::ErrorCode) -> Self {
+        types::Errno::from(code).into()
+    }
+}
+
+impl TryFrom<wasi::filesystem::Error> for types::Errno {
+    type Error = anyhow::Error;
+
+    fn try_from(err: wasi::filesystem::Error) -> Result<Self, Self::Error> {
+        match err.downcast() {
+            Ok(code) => Ok(code.into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl TryFrom<wasi::filesystem::Error> for types::Error {
+    type Error = anyhow::Error;
+
+    fn try_from(err: wasi::filesystem::Error) -> Result<Self, Self::Error> {
+        match err.downcast() {
+            Ok(code) => Ok(code.into()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+impl From<TableError> for types::Errno {
+    fn from(err: TableError) -> Self {
+        match err {
+            TableError::Full => types::Errno::Nomem,
+            TableError::NotPresent | TableError::WrongType => types::Errno::Badf,
+        }
+    }
+}
+
+impl From<TableError> for types::Error {
+    fn from(err: TableError) -> Self {
+        types::Errno::from(err).into()
     }
 }
 
@@ -99,6 +559,59 @@ fn write_byte<'a>(ptr: impl Borrow<GuestPtr<'a, u8>>, byte: u8) -> ErrnoResult<G
     let ptr = ptr.borrow();
     ptr.write(byte).or(Err(types::Errno::Inval))?;
     ptr.add(1).or(Err(types::Errno::Inval))
+}
+
+fn read_str<'a>(ptr: impl Borrow<GuestPtr<'a, str>>) -> ErrnoResult<GuestStrCow<'a>> {
+    // NOTE: legacy implementation always returns Inval errno
+    ptr.borrow().as_cow().or(Err(types::Errno::Inval))
+}
+
+fn read_string<'a>(ptr: impl Borrow<GuestPtr<'a, str>>) -> ErrnoResult<String> {
+    read_str(ptr).map(|s| s.to_string())
+}
+
+// Find first non-empty buffer.
+fn first_non_empty_ciovec(ciovs: &types::CiovecArray<'_>) -> ErrnoResult<Option<Vec<u8>>> {
+    ciovs
+        .iter()
+        .map(|iov| {
+            let iov = iov
+                .or(Err(types::Errno::Inval))?
+                .read()
+                .or(Err(types::Errno::Inval))?;
+            if iov.buf_len == 0 {
+                return Ok(None);
+            }
+            iov.buf
+                .as_array(iov.buf_len)
+                .to_vec()
+                .or(Err(types::Errno::Inval))
+                .map(Some)
+        })
+        .find_map(Result::transpose)
+        .transpose()
+}
+
+// Find first non-empty buffer.
+fn first_non_empty_iovec<'a>(
+    iovs: &types::IovecArray<'a>,
+) -> ErrnoResult<Option<GuestSliceMut<'a, u8>>> {
+    iovs.iter()
+        .map(|iov| {
+            let iov = iov
+                .or(Err(types::Errno::Inval))?
+                .read()
+                .or(Err(types::Errno::Inval))?;
+            if iov.buf_len == 0 {
+                return Ok(None);
+            }
+            iov.buf
+                .as_array(iov.buf_len)
+                .as_slice_mut()
+                .map_err(|_| types::Errno::Inval)
+        })
+        .find_map(Result::transpose)
+        .transpose()
 }
 
 // Implement the WasiSnapshotPreview1 trait using only the traits that are
@@ -268,9 +781,18 @@ impl<
         len: types::Filesize,
         advice: types::Advice,
     ) -> Result<(), types::Error> {
-        todo!()
+        let fd = self.get_file_fd(fd).await?;
+        self.advise(fd, offset, len, advice.into())
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `advise`")
+                    .unwrap_or_else(types::Error::trap)
+            })
     }
 
+    /// Force the allocation of space in a file.
+    /// NOTE: This is similar to `posix_fallocate` in POSIX.
     #[instrument(skip(self))]
     async fn fd_allocate(
         &mut self,
@@ -278,33 +800,143 @@ impl<
         _offset: types::Filesize,
         _len: types::Filesize,
     ) -> Result<(), types::Error> {
-        todo!()
+        self.get_file_fd(fd).await?;
+        Err(types::Errno::Notsup.into())
     }
 
+    /// Close a file descriptor.
+    /// NOTE: This is similar to `close` in POSIX.
     #[instrument(skip(self))]
     async fn fd_close(&mut self, fd: types::Fd) -> Result<(), types::Error> {
-        todo!()
+        self.transact()
+            .await?
+            .descriptors
+            .get_mut()
+            .remove(fd)
+            .ok_or(types::Errno::Badf)?;
+        Ok(())
     }
 
+    /// Synchronize the data of a file to disk.
+    /// NOTE: This is similar to `fdatasync` in POSIX.
     #[instrument(skip(self))]
     async fn fd_datasync(&mut self, fd: types::Fd) -> Result<(), types::Error> {
-        todo!()
+        let fd = self.get_file_fd(fd).await?;
+        self.sync_data(fd).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `sync-data`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Get the attributes of a file descriptor.
+    /// NOTE: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well as additional fields.
     #[instrument(skip(self))]
     async fn fd_fdstat_get(&mut self, fd: types::Fd) -> Result<types::Fdstat, types::Error> {
-        todo!()
+        let (fd, blocking, append) = match self.transact().await?.get_descriptor(fd) {
+            Some(Descriptor::Stdin(..)) => {
+                let fs_rights_base = types::Rights::FD_READ;
+                return Ok(types::Fdstat {
+                    fs_filetype: types::Filetype::CharacterDevice,
+                    fs_flags: types::Fdflags::empty(),
+                    fs_rights_base,
+                    fs_rights_inheriting: fs_rights_base,
+                });
+            }
+            Some(Descriptor::Stdout(..) | Descriptor::Stderr(..)) => {
+                let fs_rights_base = types::Rights::FD_WRITE;
+                return Ok(types::Fdstat {
+                    fs_filetype: types::Filetype::CharacterDevice,
+                    fs_flags: types::Fdflags::empty(),
+                    fs_rights_base,
+                    fs_rights_inheriting: fs_rights_base,
+                });
+            }
+            Some(Descriptor::PreopenDirectory((fd, _))) => (*fd, false, false),
+            Some(Descriptor::File(File {
+                fd,
+                blocking,
+                append,
+                ..
+            })) => (*fd, *blocking, *append),
+            None => return Err(types::Errno::Badf.into()),
+        };
+
+        // TODO: use `try_join!` to poll both futures async, unfortunately that is not currently
+        // possible, because `bindgen` generates methods with `&mut self` receivers.
+        let flags = self.get_flags(fd).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `get-flags`")
+                .unwrap_or_else(types::Error::trap)
+        })?;
+        let fs_filetype = self
+            .get_type(fd)
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `get-type`")
+                    .unwrap_or_else(types::Error::trap)
+            })?
+            .try_into()
+            .map_err(types::Error::trap)?;
+        let mut fs_flags = types::Fdflags::empty();
+        let mut fs_rights_base = types::Rights::all();
+        if !flags.contains(wasi::filesystem::DescriptorFlags::READ) {
+            fs_rights_base &= !types::Rights::FD_READ;
+        }
+        if !flags.contains(wasi::filesystem::DescriptorFlags::WRITE) {
+            fs_rights_base &= !types::Rights::FD_WRITE;
+        }
+        if flags.contains(wasi::filesystem::DescriptorFlags::DATA_INTEGRITY_SYNC) {
+            fs_flags |= types::Fdflags::DSYNC;
+        }
+        if flags.contains(wasi::filesystem::DescriptorFlags::REQUESTED_WRITE_SYNC) {
+            fs_flags |= types::Fdflags::RSYNC;
+        }
+        if flags.contains(wasi::filesystem::DescriptorFlags::FILE_INTEGRITY_SYNC) {
+            fs_flags |= types::Fdflags::SYNC;
+        }
+        if append {
+            fs_flags |= types::Fdflags::APPEND;
+        }
+        if !blocking {
+            fs_flags |= types::Fdflags::NONBLOCK;
+        }
+        Ok(types::Fdstat {
+            fs_filetype,
+            fs_flags,
+            fs_rights_base,
+            fs_rights_inheriting: fs_rights_base,
+        })
     }
 
+    /// Adjust the flags associated with a file descriptor.
+    /// NOTE: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
     #[instrument(skip(self))]
     async fn fd_fdstat_set_flags(
         &mut self,
         fd: types::Fd,
         flags: types::Fdflags,
     ) -> Result<(), types::Error> {
-        todo!()
+        let mut st = self.transact().await?;
+        let File {
+            append, blocking, ..
+        } = st.get_file_mut(fd)?;
+
+        // Only support changing the NONBLOCK or APPEND flags.
+        if flags.contains(types::Fdflags::DSYNC)
+            || flags.contains(types::Fdflags::SYNC)
+            || flags.contains(types::Fdflags::RSYNC)
+        {
+            return Err(types::Errno::Inval.into());
+        }
+        *append = flags.contains(types::Fdflags::APPEND);
+        *blocking = !flags.contains(types::Fdflags::NONBLOCK);
+        Ok(())
     }
 
+    /// Adjust the rights associated with a file descriptor.
+    /// This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
     #[instrument(skip(self))]
     async fn fd_fdstat_set_rights(
         &mut self,
@@ -315,20 +947,75 @@ impl<
         todo!()
     }
 
+    /// Return the attributes of an open file.
     #[instrument(skip(self))]
     async fn fd_filestat_get(&mut self, fd: types::Fd) -> Result<types::Filestat, types::Error> {
-        todo!()
+        let desc = self.transact().await?.get_descriptor(fd).cloned();
+        match desc {
+            Some(Descriptor::Stdin(..) | Descriptor::Stdout(..) | Descriptor::Stderr(..)) => {
+                Ok(types::Filestat {
+                    dev: 0,
+                    ino: 0,
+                    filetype: types::Filetype::CharacterDevice,
+                    nlink: 0,
+                    size: 0,
+                    atim: 0,
+                    mtim: 0,
+                    ctim: 0,
+                })
+            }
+            Some(Descriptor::PreopenDirectory((fd, _)) | Descriptor::File(File { fd, .. })) => {
+                let wasi::filesystem::DescriptorStat {
+                    device: dev,
+                    inode: ino,
+                    type_,
+                    link_count: nlink,
+                    size,
+                    data_access_timestamp,
+                    data_modification_timestamp,
+                    status_change_timestamp,
+                } = self.stat(fd).await.map_err(|e| {
+                    e.try_into()
+                        .context("failed to call `stat`")
+                        .unwrap_or_else(types::Error::trap)
+                })?;
+                let filetype = type_.try_into().map_err(types::Error::trap)?;
+                let atim = data_access_timestamp.try_into()?;
+                let mtim = data_modification_timestamp.try_into()?;
+                let ctim = status_change_timestamp.try_into()?;
+                Ok(types::Filestat {
+                    dev,
+                    ino,
+                    filetype,
+                    nlink,
+                    size,
+                    atim,
+                    mtim,
+                    ctim,
+                })
+            }
+            None => Err(types::Errno::Badf.into()),
+        }
     }
 
+    /// Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+    /// NOTE: This is similar to `ftruncate` in POSIX.
     #[instrument(skip(self))]
     async fn fd_filestat_set_size(
         &mut self,
         fd: types::Fd,
         size: types::Filesize,
     ) -> Result<(), types::Error> {
-        todo!()
+        let fd = self.get_file_fd(fd).await?;
+        self.set_size(fd, size).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `set-size`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Adjust the timestamps of an open file or directory.
+    /// NOTE: This is similar to `futimens` in POSIX.
     #[instrument(skip(self))]
     async fn fd_filestat_set_times(
         &mut self,
@@ -337,18 +1024,95 @@ impl<
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
     ) -> Result<(), types::Error> {
-        todo!()
+        let atim = systimespec(
+            fst_flags.contains(types::Fstflags::ATIM),
+            atim,
+            fst_flags.contains(types::Fstflags::ATIM_NOW),
+        )?;
+        let mtim = systimespec(
+            fst_flags.contains(types::Fstflags::MTIM),
+            mtim,
+            fst_flags.contains(types::Fstflags::MTIM_NOW),
+        )?;
+
+        let fd = self.get_fd(fd).await?;
+        self.set_times(fd, atim, mtim).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `set-times`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Read from a file descriptor.
+    /// NOTE: This is similar to `readv` in POSIX.
     #[instrument(skip(self))]
     async fn fd_read<'a>(
         &mut self,
         fd: types::Fd,
         iovs: &types::IovecArray<'a>,
     ) -> Result<types::Size, types::Error> {
-        todo!()
+        let desc = self.transact().await?.get_descriptor(fd).cloned();
+        let (mut buf, read, end) = match desc {
+            Some(Descriptor::File(File {
+                fd,
+                blocking,
+                position,
+                ..
+            })) if self.table().is_file(fd) => {
+                let Some(buf) = first_non_empty_iovec(iovs)? else {
+                    return Ok(0)
+                };
+
+                let pos = position.load(Ordering::Relaxed);
+                let stream = self
+                    .read_via_stream(fd, pos)
+                    .await
+                    .context("failed to call `read-via-stream`")
+                    .map_err(types::Error::trap)?;
+                let max = buf.len().try_into().unwrap_or(u64::MAX);
+                let (read, end) = if blocking {
+                    self.blocking_read(stream, max)
+                } else {
+                    wasi::streams::Host::read(self, stream, max)
+                }
+                .await
+                .map_err(|_| types::Errno::Io)?;
+
+                let n = read.len().try_into().or(Err(types::Errno::Overflow))?;
+                let pos = pos.checked_add(n).ok_or(types::Errno::Overflow)?;
+                position.store(pos, Ordering::Relaxed);
+
+                (buf, read, end)
+            }
+            Some(Descriptor::Stdin(stream)) => {
+                let Some(buf) = first_non_empty_iovec(iovs)? else {
+                    return Ok(0)
+                };
+                let (read, end) = wasi::streams::Host::read(
+                    self,
+                    stream,
+                    buf.len().try_into().unwrap_or(u64::MAX),
+                )
+                .await
+                .map_err(|_| types::Errno::Io)?;
+                (buf, read, end)
+            }
+            _ => return Err(types::Errno::Badf.into()),
+        };
+        if read.len() > buf.len() {
+            return Err(types::Errno::Range.into());
+        }
+        if !end && read.len() == 0 {
+            return Err(types::Errno::Intr.into());
+        }
+        let (buf, _) = buf.split_at_mut(read.len());
+        buf.copy_from_slice(&read);
+        let n = read.len().try_into().or(Err(types::Errno::Overflow))?;
+        Ok(n)
     }
 
+    /// Read from a file descriptor, without using and updating the file descriptor's offset.
+    /// NOTE: This is similar to `preadv` in POSIX.
     #[instrument(skip(self))]
     async fn fd_pread<'a>(
         &mut self,
@@ -356,18 +1120,112 @@ impl<
         iovs: &types::IovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, types::Error> {
-        todo!()
+        let desc = self.transact().await?.get_descriptor(fd).cloned();
+        let (mut buf, read, end) = match desc {
+            Some(Descriptor::File(File { fd, blocking, .. })) if self.table().is_file(fd) => {
+                let Some(buf) = first_non_empty_iovec(iovs)? else {
+                    return Ok(0)
+                };
+
+                let stream = self
+                    .read_via_stream(fd, offset)
+                    .await
+                    .context("failed to call `read-via-stream`")
+                    .map_err(types::Error::trap)?;
+                let max = buf.len().try_into().unwrap_or(u64::MAX);
+                let (read, end) = if blocking {
+                    self.blocking_read(stream, max)
+                } else {
+                    wasi::streams::Host::read(self, stream, max)
+                }
+                .await
+                .map_err(|_| types::Errno::Io)?;
+
+                (buf, read, end)
+            }
+            Some(Descriptor::Stdin(..)) => {
+                // NOTE: legacy implementation returns SPIPE here
+                return Err(types::Errno::Spipe.into());
+            }
+            _ => return Err(types::Errno::Badf.into()),
+        };
+        if read.len() > buf.len() {
+            return Err(types::Errno::Range.into());
+        }
+        if !end && read.len() == 0 {
+            return Err(types::Errno::Intr.into());
+        }
+        let (buf, _) = buf.split_at_mut(read.len());
+        buf.copy_from_slice(&read);
+        let n = read.len().try_into().or(Err(types::Errno::Overflow))?;
+        Ok(n)
     }
 
+    /// Write to a file descriptor.
+    /// NOTE: This is similar to `writev` in POSIX.
     #[instrument(skip(self))]
     async fn fd_write<'a>(
         &mut self,
         fd: types::Fd,
         ciovs: &types::CiovecArray<'a>,
     ) -> Result<types::Size, types::Error> {
-        todo!()
+        let desc = self.transact().await?.get_descriptor(fd).cloned();
+        let n = match desc {
+            Some(Descriptor::File(File {
+                fd,
+                blocking,
+                append,
+                position,
+            })) if self.table().is_file(fd) => {
+                let Some(buf) = first_non_empty_ciovec(ciovs)? else {
+                    return Ok(0)
+                };
+                let (stream, pos) = if append {
+                    let stream = self
+                        .append_via_stream(fd)
+                        .await
+                        .context("failed to call `append-via-stream`")
+                        .map_err(types::Error::trap)?;
+                    (stream, 0)
+                } else {
+                    let position = position.load(Ordering::Relaxed);
+                    let stream = self
+                        .write_via_stream(fd, position)
+                        .await
+                        .context("failed to call `write-via-stream`")
+                        .map_err(types::Error::trap)?;
+                    (stream, position)
+                };
+                let n = if blocking {
+                    self.blocking_write(stream, buf)
+                } else {
+                    wasi::streams::Host::write(self, stream, buf)
+                }
+                .await
+                .map_err(|_| types::Errno::Io)?;
+                if !append {
+                    let pos = pos.checked_add(n).ok_or(types::Errno::Overflow)?;
+                    position.store(pos, Ordering::Relaxed);
+                }
+                n
+            }
+            Some(Descriptor::Stdout(stream) | Descriptor::Stderr(stream)) => {
+                let Some(buf) = first_non_empty_ciovec(ciovs)? else {
+                    return Ok(0)
+                };
+                wasi::streams::Host::write(self, stream, buf)
+                    .await
+                    .map_err(|_| types::Errno::Io)?
+            }
+            _ => return Err(types::Errno::Badf.into()),
+        }
+        .try_into()
+        .or(Err(types::Errno::Overflow))?;
+        Ok(n)
     }
 
+    /// Write to a file descriptor, without using and updating the file descriptor's offset.
+    /// NOTE: This is similar to `pwritev` in POSIX.
     #[instrument(skip(self))]
     async fn fd_pwrite<'a>(
         &mut self,
@@ -375,14 +1233,49 @@ impl<
         ciovs: &types::CiovecArray<'a>,
         offset: types::Filesize,
     ) -> Result<types::Size, types::Error> {
-        todo!()
+        let desc = self.transact().await?.get_descriptor(fd).cloned();
+        let n = match desc {
+            Some(Descriptor::File(File { fd, blocking, .. })) if self.table().is_file(fd) => {
+                let Some(buf) = first_non_empty_ciovec(ciovs)? else {
+                    return Ok(0)
+                };
+                let stream = self
+                    .write_via_stream(fd, offset)
+                    .await
+                    .context("failed to call `write-via-stream`")
+                    .map_err(types::Error::trap)?;
+                if blocking {
+                    self.blocking_write(stream, buf)
+                } else {
+                    wasi::streams::Host::write(self, stream, buf)
+                }
+                .await
+                .map_err(|_| types::Errno::Io)?
+            }
+            Some(Descriptor::Stdout(..) | Descriptor::Stderr(..)) => {
+                // NOTE: legacy implementation returns SPIPE here
+                return Err(types::Errno::Spipe.into());
+            }
+            _ => return Err(types::Errno::Badf.into()),
+        }
+        .try_into()
+        .or(Err(types::Errno::Overflow))?;
+        Ok(n)
     }
 
+    /// Return a description of the given preopened file descriptor.
     #[instrument(skip(self))]
     async fn fd_prestat_get(&mut self, fd: types::Fd) -> Result<types::Prestat, types::Error> {
-        todo!()
+        if let Some(Descriptor::PreopenDirectory((_, p))) =
+            self.transact().await?.get_descriptor(fd)
+        {
+            let pr_name_len = p.len().try_into().or(Err(types::Errno::Overflow))?;
+            return Ok(types::Prestat::Dir(types::PrestatDir { pr_name_len }));
+        }
+        Err(types::Errno::Badf.into()) // NOTE: legacy implementation returns BADF here
     }
 
+    /// Return a description of the given preopened file descriptor.
     #[instrument(skip(self))]
     async fn fd_prestat_dir_name<'a>(
         &mut self,
@@ -390,14 +1283,31 @@ impl<
         path: &GuestPtr<'a, u8>,
         path_max_len: types::Size,
     ) -> Result<(), types::Error> {
-        todo!()
+        let path_max_len = path_max_len.try_into().or(Err(types::Errno::Overflow))?;
+        if let Some(Descriptor::PreopenDirectory((_, p))) =
+            self.transact().await?.get_descriptor(fd)
+        {
+            if p.len() > path_max_len {
+                return Err(types::Errno::Nametoolong.into());
+            }
+            write_bytes(path, p)?;
+            return Ok(());
+        }
+        Err(types::Errno::Notdir.into()) // NOTE: legacy implementation returns NOTDIR here
     }
 
+    /// Atomically replace a file descriptor by renumbering another file descriptor.
     #[instrument(skip(self))]
     async fn fd_renumber(&mut self, from: types::Fd, to: types::Fd) -> Result<(), types::Error> {
-        todo!()
+        let mut st = self.transact().await?;
+        let descriptors = st.descriptors.get_mut();
+        let desc = descriptors.remove(from).ok_or(types::Errno::Badf)?;
+        descriptors.insert(to.into(), desc);
+        Ok(())
     }
 
+    /// Move the offset of a file descriptor.
+    /// NOTE: This is similar to `lseek` in POSIX.
     #[instrument(skip(self))]
     async fn fd_seek(
         &mut self,
@@ -405,17 +1315,54 @@ impl<
         offset: types::Filedelta,
         whence: types::Whence,
     ) -> Result<types::Filesize, types::Error> {
-        todo!()
+        let (fd, position) = {
+            let mut st = self.transact().await?;
+            let File { fd, position, .. } = st.get_seekable(fd)?;
+            (*fd, Arc::clone(&position))
+        };
+        let pos = match whence {
+            types::Whence::Set if offset >= 0 => offset as _,
+            types::Whence::Cur => position
+                .load(Ordering::Relaxed)
+                .checked_add_signed(offset)
+                .ok_or(types::Errno::Inval)?,
+            types::Whence::End => {
+                let wasi::filesystem::DescriptorStat { size, .. } =
+                    self.stat(fd).await.map_err(|e| {
+                        e.try_into()
+                            .context("failed to call `stat`")
+                            .unwrap_or_else(types::Error::trap)
+                    })?;
+                size.checked_add_signed(offset).ok_or(types::Errno::Inval)?
+            }
+            _ => return Err(types::Errno::Inval.into()),
+        };
+        position.store(pos, Ordering::Relaxed);
+        Ok(pos)
     }
 
+    /// Synchronize the data and metadata of a file to disk.
+    /// NOTE: This is similar to `fsync` in POSIX.
     #[instrument(skip(self))]
     async fn fd_sync(&mut self, fd: types::Fd) -> Result<(), types::Error> {
-        todo!()
+        let fd = self.get_file_fd(fd).await?;
+        self.sync(fd).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `sync`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Return the current offset of a file descriptor.
+    /// NOTE: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
     #[instrument(skip(self))]
     async fn fd_tell(&mut self, fd: types::Fd) -> Result<types::Filesize, types::Error> {
-        todo!()
+        let pos = self
+            .transact()
+            .await?
+            .get_seekable(fd)
+            .map(|File { position, .. }| position.load(Ordering::Relaxed))?;
+        Ok(pos)
     }
 
     #[instrument(skip(self))]
@@ -435,9 +1382,17 @@ impl<
         dirfd: types::Fd,
         path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = read_string(path)?;
+        self.create_directory_at(dirfd, path).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `create-directory-at`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Return the attributes of a file or directory.
+    /// NOTE: This is similar to `stat` in POSIX.
     #[instrument(skip(self))]
     async fn path_filestat_get<'a>(
         &mut self,
@@ -445,9 +1400,40 @@ impl<
         flags: types::Lookupflags,
         path: &GuestPtr<'a, str>,
     ) -> Result<types::Filestat, types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = read_string(path)?;
+        let wasi::filesystem::DescriptorStat {
+            device: dev,
+            inode: ino,
+            type_,
+            link_count: nlink,
+            size,
+            data_access_timestamp,
+            data_modification_timestamp,
+            status_change_timestamp,
+        } = self.stat_at(dirfd, flags.into(), path).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `stat-at`")
+                .unwrap_or_else(types::Error::trap)
+        })?;
+        let filetype = type_.try_into().map_err(types::Error::trap)?;
+        let atim = data_access_timestamp.try_into()?;
+        let mtim = data_modification_timestamp.try_into()?;
+        let ctim = status_change_timestamp.try_into()?;
+        Ok(types::Filestat {
+            dev,
+            ino,
+            filetype,
+            nlink,
+            size,
+            atim,
+            mtim,
+            ctim,
+        })
     }
 
+    /// Adjust the timestamps of a file or directory.
+    /// NOTE: This is similar to `utimensat` in POSIX.
     #[instrument(skip(self))]
     async fn path_filestat_set_times<'a>(
         &mut self,
@@ -458,9 +1444,30 @@ impl<
         mtim: types::Timestamp,
         fst_flags: types::Fstflags,
     ) -> Result<(), types::Error> {
-        todo!()
+        let atim = systimespec(
+            fst_flags.contains(types::Fstflags::ATIM),
+            atim,
+            fst_flags.contains(types::Fstflags::ATIM_NOW),
+        )?;
+        let mtim = systimespec(
+            fst_flags.contains(types::Fstflags::MTIM),
+            mtim,
+            fst_flags.contains(types::Fstflags::MTIM_NOW),
+        )?;
+
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = read_string(path)?;
+        self.set_times_at(dirfd, flags.into(), path, atim, mtim)
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `set-times-at`")
+                    .unwrap_or_else(types::Error::trap)
+            })
     }
 
+    /// Create a hard link.
+    /// NOTE: This is similar to `linkat` in POSIX.
     #[instrument(skip(self))]
     async fn path_link<'a>(
         &mut self,
@@ -470,9 +1477,21 @@ impl<
         target_fd: types::Fd,
         target_path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let src_fd = self.get_dir_fd(src_fd).await?;
+        let target_fd = self.get_dir_fd(target_fd).await?;
+        let src_path = read_string(src_path)?;
+        let target_path = read_string(target_path)?;
+        self.link_at(src_fd, src_flags.into(), src_path, target_fd, target_path)
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `link-at`")
+                    .unwrap_or_else(types::Error::trap)
+            })
     }
 
+    /// Open a file or directory.
+    /// NOTE: This is similar to `openat` in POSIX.
     #[instrument(skip(self))]
     async fn path_open<'a>(
         &mut self,
@@ -481,12 +1500,69 @@ impl<
         path: &GuestPtr<'a, str>,
         oflags: types::Oflags,
         fs_rights_base: types::Rights,
-        fs_rights_inheriting: types::Rights,
+        _fs_rights_inheriting: types::Rights,
         fdflags: types::Fdflags,
     ) -> Result<types::Fd, types::Error> {
-        todo!()
+        let path = read_string(path)?;
+
+        let mut flags = wasi::filesystem::DescriptorFlags::empty();
+        if fs_rights_base.contains(types::Rights::FD_READ) {
+            flags |= wasi::filesystem::DescriptorFlags::READ;
+        }
+        if fs_rights_base.contains(types::Rights::FD_WRITE) {
+            flags |= wasi::filesystem::DescriptorFlags::WRITE;
+        }
+        if fdflags.contains(types::Fdflags::SYNC) {
+            flags |= wasi::filesystem::DescriptorFlags::FILE_INTEGRITY_SYNC;
+        }
+        if fdflags.contains(types::Fdflags::DSYNC) {
+            flags |= wasi::filesystem::DescriptorFlags::DATA_INTEGRITY_SYNC;
+        }
+        if fdflags.contains(types::Fdflags::RSYNC) {
+            flags |= wasi::filesystem::DescriptorFlags::REQUESTED_WRITE_SYNC;
+        }
+
+        let desc = self.transact().await?.get_descriptor(dirfd).cloned();
+        let dirfd = match desc {
+            Some(Descriptor::PreopenDirectory((fd, _))) => fd,
+            Some(Descriptor::File(File { fd, .. })) if self.table().is_dir(fd) => fd,
+            Some(Descriptor::File(File { fd, .. })) if !self.table().is_dir(fd) => {
+                // NOTE: Unlike most other methods, legacy implementation returns `NOTDIR` here
+                return Err(types::Errno::Notdir.into());
+            }
+            _ => return Err(types::Errno::Badf.into()),
+        };
+        let fd = self
+            .open_at(
+                dirfd,
+                dirflags.into(),
+                path,
+                oflags.into(),
+                flags,
+                wasi::filesystem::Modes::READABLE | wasi::filesystem::Modes::WRITEABLE,
+            )
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `open-at`")
+                    .unwrap_or_else(types::Error::trap)
+            })?;
+        let fd = self
+            .transact()
+            .await?
+            .descriptors
+            .get_mut()
+            .push_file(File {
+                fd,
+                position: Default::default(),
+                append: fdflags.contains(types::Fdflags::APPEND),
+                blocking: !fdflags.contains(types::Fdflags::NONBLOCK),
+            })?;
+        Ok(fd.into())
     }
 
+    /// Read the contents of a symbolic link.
+    /// NOTE: This is similar to `readlinkat` in POSIX.
     #[instrument(skip(self))]
     async fn path_readlink<'a>(
         &mut self,
@@ -495,7 +1571,20 @@ impl<
         buf: &GuestPtr<'a, u8>,
         buf_len: types::Size,
     ) -> Result<types::Size, types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = read_string(path)?;
+        let mut path = self.readlink_at(dirfd, path).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `readlink-at`")
+                .unwrap_or_else(types::Error::trap)
+        })?;
+        if let Ok(buf_len) = buf_len.try_into() {
+            // `path` cannot be longer than `usize`, only truncate if `buf_len` fits in `usize`
+            path.truncate(buf_len);
+        }
+        let n = path.len().try_into().map_err(|_| types::Errno::Overflow)?;
+        write_bytes(buf, &path)?;
+        Ok(n)
     }
 
     #[instrument(skip(self))]
@@ -504,9 +1593,17 @@ impl<
         dirfd: types::Fd,
         path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = read_string(path)?;
+        self.remove_directory_at(dirfd, path).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `remove-directory-at`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
+    /// Rename a file or directory.
+    /// NOTE: This is similar to `renameat` in POSIX.
     #[instrument(skip(self))]
     async fn path_rename<'a>(
         &mut self,
@@ -515,7 +1612,17 @@ impl<
         dest_fd: types::Fd,
         dest_path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let src_fd = self.get_dir_fd(src_fd).await?;
+        let dest_fd = self.get_dir_fd(dest_fd).await?;
+        let src_path = read_string(src_path)?;
+        let dest_path = read_string(dest_path)?;
+        self.rename_at(src_fd, src_path, dest_fd, dest_path)
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `rename-at`")
+                    .unwrap_or_else(types::Error::trap)
+            })
     }
 
     #[instrument(skip(self))]
@@ -525,7 +1632,16 @@ impl<
         dirfd: types::Fd,
         dest_path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let src_path = read_string(src_path)?;
+        let dest_path = read_string(dest_path)?;
+        self.symlink_at(dirfd, src_path, dest_path)
+            .await
+            .map_err(|e| {
+                e.try_into()
+                    .context("failed to call `symlink-at`")
+                    .unwrap_or_else(types::Error::trap)
+            })
     }
 
     #[instrument(skip(self))]
@@ -534,7 +1650,13 @@ impl<
         dirfd: types::Fd,
         path: &GuestPtr<'a, str>,
     ) -> Result<(), types::Error> {
-        todo!()
+        let dirfd = self.get_dir_fd(dirfd).await?;
+        let path = path.as_cow().map_err(|_| types::Errno::Inval)?.to_string();
+        self.unlink_file_at(dirfd, path).await.map_err(|e| {
+            e.try_into()
+                .context("failed to call `unlink-file-at`")
+                .unwrap_or_else(types::Error::trap)
+        })
     }
 
     #[instrument(skip(self))]

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -18,6 +18,7 @@ pub enum TableError {
 ///
 /// The `Table` type is intended to model how the Interface Types concept of Resources is shaping
 /// up. Right now it is just an approximation.
+#[derive(Debug)]
 pub struct Table {
     map: HashMap<u32, Box<dyn Any + Send + Sync>>,
     next_key: u32,


### PR DESCRIPTION
Moved from https://github.com/bytecodealliance/preview2-prototyping/pull/175

Refs https://github.com/bytecodealliance/wasmtime/issues/6370

The implementation tries to follow existing preview1 behavior as much as possible - as a result, there are a few differences in behavior from existing adapter. Please see the original PR for more details.

A follow-up issues/PRs fill be filed for:
- `fd_readdir`
- fixing `windows` support for a few tests (still not sure what's causing the failures)
- making all preview1 implementations consistent
- adding rights handling