### PR TITLE
Expose remaining fuel 

### DIFF
--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -178,6 +178,19 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_add_fuel(wasmtime_context_t *
 WASM_API_EXTERN bool wasmtime_context_fuel_consumed(const wasmtime_context_t *context, uint64_t *fuel);
 
 /**
+ * \brief Returns the amount of fuel remaining in this context's store execution
+ * before engine traps execution.
+ *
+ * If fuel consumption is not enabled via #wasmtime_config_consume_fuel_set
+ * then this function will return false. Otherwise true is returned and the
+ * fuel parameter is filled in with remaining fuel.
+ *
+ * Also note that fuel, if enabled, must be originally configured via
+ * #wasmtime_context_add_fuel.
+ */
+WASM_API_EXTERN bool wasmtime_context_fuel_remaining(const wasmtime_context_t *context, uint64_t *fuel);
+
+/**
  * \brief Attempt to manually consume fuel from the store.
  *
  * If fuel consumption is not enabled via #wasmtime_config_consume_fuel_set then

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -228,6 +228,20 @@ pub extern "C" fn wasmtime_context_fuel_consumed(store: CStoreContext<'_>, fuel:
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_context_fuel_remaining(
+    store: CStoreContextMut<'_>,
+    fuel: &mut u64,
+) -> bool {
+    match store.fuel_remaining() {
+        Some(remaining) => {
+            *fuel = remaining;
+            true
+        }
+        None => false,
+    }
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_context_consume_fuel(
     mut store: CStoreContextMut<'_>,
     fuel: u64,

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -130,8 +130,10 @@ fn manual_fuel() {
     let mut store = Store::new(&engine, ());
     store.add_fuel(10_000).unwrap();
     assert_eq!(store.fuel_consumed(), Some(0));
+    assert_eq!(store.fuel_remaining(), Some(10_000));
     assert_eq!(store.consume_fuel(1).unwrap(), 9_999);
     assert_eq!(store.fuel_consumed(), Some(1));
+    assert_eq!(store.fuel_remaining(), Some(9_999));
     assert!(store.consume_fuel(10_000).is_err());
     assert_eq!(store.consume_fuel(999).unwrap(), 9_000);
     assert!(store.consume_fuel(10_000).is_err());
@@ -140,6 +142,7 @@ fn manual_fuel() {
     assert_eq!(store.consume_fuel(1).unwrap(), 1);
     assert_eq!(store.consume_fuel(1).unwrap(), 0);
     assert_eq!(store.consume_fuel(0).unwrap(), 0);
+    assert_eq!(store.fuel_remaining(), Some(0));
 }
 
 #[test]
@@ -213,7 +216,9 @@ fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping() {
     .unwrap();
 
     let mut store = Store::new(&engine, ());
-    store.add_fuel(1_000).unwrap();
+    let init_fuel = 1_000;
+    store.add_fuel(init_fuel).unwrap();
+    assert_eq!(init_fuel, store.fuel_remaining().unwrap());
 
     let instance = Instance::new(&mut store, &module, &[]).unwrap();
     let f = instance
@@ -225,5 +230,7 @@ fn unconditionally_trapping_memory_accesses_save_fuel_before_trapping() {
 
     // The `i32.add` consumed some fuel before the unconditionally trapping
     // memory access.
-    assert!(store.fuel_consumed().unwrap() > 0);
+    let consumed_fuel = store.fuel_consumed().unwrap();
+    assert!(consumed_fuel > 0);
+    assert_eq!(init_fuel, consumed_fuel + store.fuel_remaining().unwrap());
 }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

I don't think this was discussed anywhere yet, but it would be nice to have a method that returns remaining fuel. Right now, it is possible only by consuming 0 fuel like `let remaining = consume_fuel(0)?`, which is not really intuitive. That's why I implemented `remaining_fuel`.

The only problem I see here is that it's not super clear/intuitive why when you `add_fuel(u64::max)` then without executing anything `remaining_fuel() == i64::max` and not `remaining_fuel() == u64::max`. 
