### PR TITLE
c-api: Allow for installing wasmtime via cmake

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -123,3 +123,16 @@ endif()
 
 target_include_directories(wasmtime INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
 	${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/include)
+
+include(GNUInstallDirs)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/wasmtime.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/wasi.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/doc-wasm.h
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/include/wasm.h
+	${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/include/wasm.hh
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/wasmtime
+	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${WASMTIME_BUILD_PRODUCT} 
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
This allows for installing the wasmtime c api in an environment when
using CMake. My company builds each external dependency and installs
it locally for builds. With this change we can do that with wasmtime.
