### PR TITLE
Add nop instruction to Winch

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -309,6 +309,7 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | LocalGet { .. }
                         | LocalSet { .. }
                         | Call { .. }
+                        | Nop { .. }
                         | End { .. } => {}
                         _ => {
                             supported = false;

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -53,6 +53,7 @@ macro_rules! def_unsupported {
     (emit LocalSet $($rest:tt)*) => {};
     (emit Call $($rest:tt)*) => {};
     (emit End $($rest:tt)*) => {};
+    (emit Nop $($rest:tt)*) => {};
 
     (emit $unsupported:tt $($rest:tt)*) => {$($rest)*};
 }
@@ -201,6 +202,8 @@ where
     fn visit_call(&mut self, index: u32) {
         self.emit_call(FuncIndex::from_u32(index));
     }
+
+    fn visit_nop(&mut self) {}
 
     wasmparser::for_each_operator!(def_unsupported);
 }

--- a/winch/filetests/filetests/aarch64/nop/nop.wat
+++ b/winch/filetests/filetests/aarch64/nop/nop.wat
@@ -1,0 +1,17 @@
+;;! target = "aarch64"
+
+(module
+    (func
+        nop
+    )
+)
+;;    0:	 fd7bbfa9             	stp	x29, x30, [sp, #-0x10]!
+;;    4:	 fd030091             	mov	x29, sp
+;;    8:	 fc030091             	mov	x28, sp
+;;    c:	 ff2300d1             	sub	sp, sp, #8
+;;   10:	 fc030091             	mov	x28, sp
+;;   14:	 890300f8             	stur	x9, [x28]
+;;   18:	 ff230091             	add	sp, sp, #8
+;;   1c:	 fc030091             	mov	x28, sp
+;;   20:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10
+;;   24:	 c0035fd6             	ret	

--- a/winch/filetests/filetests/x64/nop/nop.wat
+++ b/winch/filetests/filetests/x64/nop/nop.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+    (func
+        nop
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
This change adds support for the [nop instruction](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Control_flow/nop) to Winch and enables programs using the `nop` instruction to be fuzzed.