### PR TITLE
x64: Swap order of operands in EVEX instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -344,17 +344,17 @@
        ;; XMM (scalar or vector) binary op that relies on the EVEX
        ;; prefix. Takes two inputs.
        (XmmRmREvex (op Avx512Opcode)
-                   (src1 XmmMem)
-                   (src2 Xmm)
+                   (src1 Xmm)
+                   (src2 XmmMem)
                    (dst WritableXmm))
 
        ;; XMM (scalar or vector) binary op that relies on the EVEX
        ;; prefix. Takes three inputs.
        (XmmRmREvex3 (op Avx512Opcode)
-                   (src1 XmmMem)
-                   (src2 Xmm)
-                   (src3 Xmm)
-                   (dst WritableXmm))
+                    (src1 Xmm)
+                    (src2 Xmm)
+                    (src3 XmmMem)
+                    (dst WritableXmm))
 
        ;; XMM (scalar or vector) unary op: mov between XMM registers (32 64)
        ;; (reg addr) reg, sqrt, etc.
@@ -3560,7 +3560,7 @@
       (xmm_unary_rm_r_evex (Avx512Opcode.Vpopcntb) src))
 
 ;; Helper for creating `MInst.XmmRmREvex` instructions.
-(decl xmm_rm_r_evex (Avx512Opcode XmmMem Xmm) Xmm)
+(decl xmm_rm_r_evex (Avx512Opcode Xmm XmmMem) Xmm)
 (rule (xmm_rm_r_evex op src1 src2)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmREvex op
@@ -3572,7 +3572,7 @@
 ;; Helper for creating `vpmullq` instructions.
 ;;
 ;; Requires AVX-512 vl and dq.
-(decl x64_vpmullq (XmmMem Xmm) Xmm)
+(decl x64_vpmullq (Xmm XmmMem) Xmm)
 (rule (x64_vpmullq src1 src2)
       (xmm_rm_r_evex (Avx512Opcode.Vpmullq)
                      src1
@@ -3581,7 +3581,7 @@
 ;; Helper for creating `vpermi2b` instructions.
 ;;
 ;; Requires AVX-512 vl and vbmi extensions.
-(decl x64_vpermi2b (Xmm Xmm Xmm) Xmm)
+(decl x64_vpermi2b (Xmm Xmm XmmMem) Xmm)
 (rule (x64_vpermi2b src1 src2 src3)
       (let ((dst WritableXmm (temp_writable_xmm))
             (_ Unit (emit (MInst.XmmRmREvex3 (Avx512Opcode.Vpermi2b)

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -87,14 +87,14 @@ impl Inst {
         }
     }
 
-    fn xmm_rm_r_evex(op: Avx512Opcode, src1: RegMem, src2: Reg, dst: Writable<Reg>) -> Self {
-        src1.assert_regclass_is(RegClass::Float);
-        debug_assert!(src2.class() == RegClass::Float);
+    fn xmm_rm_r_evex(op: Avx512Opcode, src1: Reg, src2: RegMem, dst: Writable<Reg>) -> Self {
+        src2.assert_regclass_is(RegClass::Float);
+        debug_assert!(src1.class() == RegClass::Float);
         debug_assert!(dst.to_reg().class() == RegClass::Float);
         Inst::XmmRmREvex {
             op,
-            src1: XmmMem::new(src1).unwrap(),
-            src2: Xmm::new(src2).unwrap(),
+            src1: Xmm::new(src1).unwrap(),
+            src2: XmmMem::new(src2).unwrap(),
             dst: WritableXmm::from_writable_reg(dst).unwrap(),
         }
     }
@@ -4776,21 +4776,21 @@ fn test_x64_emit() {
     ));
 
     insns.push((
-        Inst::xmm_rm_r_evex(Avx512Opcode::Vpmullq, RegMem::reg(xmm14), xmm10, w_xmm1),
+        Inst::xmm_rm_r_evex(Avx512Opcode::Vpmullq, xmm10, RegMem::reg(xmm14), w_xmm1),
         "62D2AD0840CE",
-        "vpmullq %xmm14, %xmm10, %xmm1",
+        "vpmullq %xmm10, %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r_evex(Avx512Opcode::Vpermi2b, RegMem::reg(xmm14), xmm10, w_xmm1),
+        Inst::xmm_rm_r_evex(Avx512Opcode::Vpermi2b, xmm10, RegMem::reg(xmm14), w_xmm1),
         "62D22D0875CE",
-        "vpermi2b %xmm14, %xmm10, %xmm1",
+        "vpermi2b %xmm10, %xmm14, %xmm1",
     ));
 
     insns.push((
-        Inst::xmm_rm_r_evex(Avx512Opcode::Vpermi2b, RegMem::reg(xmm1), xmm0, w_xmm2),
+        Inst::xmm_rm_r_evex(Avx512Opcode::Vpermi2b, xmm0, RegMem::reg(xmm1), w_xmm2),
         "62F27D0875D1",
-        "vpermi2b %xmm1, %xmm0, %xmm2",
+        "vpermi2b %xmm0, %xmm1, %xmm2",
     ));
 
     insns.push((

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1130,9 +1130,9 @@ impl PrettyPrint for Inst {
                 ..
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
-                let src1 = src1.pretty_print(8, allocs);
-                format!("{} {}, {}, {}", ljustify(op.to_string()), src1, src2, dst)
+                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
+                let src2 = src2.pretty_print(8, allocs);
+                format!("{} {src1}, {src2}, {dst}", ljustify(op.to_string()))
             }
 
             Inst::XmmRmREvex3 {
@@ -1143,18 +1143,11 @@ impl PrettyPrint for Inst {
                 dst,
                 ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
-                let src3 = pretty_print_reg(src3.to_reg(), 8, allocs);
-                let src1 = src1.pretty_print(8, allocs);
-                format!(
-                    "{} {}, {}, {}, {}",
-                    ljustify(op.to_string()),
-                    src1,
-                    src2,
-                    src3,
-                    dst
-                )
+                let src3 = src3.pretty_print(8, allocs);
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                format!("{} {src1}, {src2}, {src3}, {dst}", ljustify(op.to_string()))
             }
 
             Inst::XmmMinMaxSeq {
@@ -2088,8 +2081,8 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
         } => {
             assert_ne!(*op, Avx512Opcode::Vpermi2b);
             collector.reg_def(dst.to_writable_reg());
-            collector.reg_use(src2.to_reg());
-            src1.get_operands(collector);
+            collector.reg_use(src1.to_reg());
+            src2.get_operands(collector);
         }
         Inst::XmmRmREvex3 {
             op,
@@ -2100,10 +2093,10 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             ..
         } => {
             assert_eq!(*op, Avx512Opcode::Vpermi2b);
-            collector.reg_reuse_def(dst.to_writable_reg(), 2); // Reuse `src3`.
+            collector.reg_use(src1.to_reg());
             collector.reg_use(src2.to_reg());
-            collector.reg_use(src3.to_reg());
-            src1.get_operands(collector);
+            src3.get_operands(collector);
+            collector.reg_reuse_def(dst.to_writable_reg(), 0); // Reuse `src1`.
         }
         Inst::XmmRmRImm {
             src1, src2, dst, ..

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2080,9 +2080,9 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             ..
         } => {
             assert_ne!(*op, Avx512Opcode::Vpermi2b);
-            collector.reg_def(dst.to_writable_reg());
             collector.reg_use(src1.to_reg());
             src2.get_operands(collector);
+            collector.reg_def(dst.to_writable_reg());
         }
         Inst::XmmRmREvex3 {
             op,

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4035,14 +4035,14 @@
 (rule 2 (lower (shuffle a b (vec_mask_from_immediate (perm_from_mask_with_zeros mask zeros))))
       (if-let $true (use_avx512vl_simd))
       (if-let $true (use_avx512vbmi_simd))
-      (x64_andps (x64_vpermi2b b a (x64_xmm_load_const $I8X16 mask)) zeros))
+      (x64_andps (x64_vpermi2b (x64_xmm_load_const $I8X16 mask) a b) zeros))
 
 ;; However, if the shuffle mask contains no out-of-bounds values, we can use
 ;; `vpermi2b` without any masking.
 (rule 1 (lower (shuffle a b (vec_mask_from_immediate mask)))
       (if-let $true (use_avx512vl_simd))
       (if-let $true (use_avx512vbmi_simd))
-      (x64_vpermi2b b a (x64_xmm_load_const $I8X16 (perm_from_mask mask))))
+      (x64_vpermi2b (x64_xmm_load_const $I8X16 (perm_from_mask mask)) a b))
 
 ;; If `lhs` and `rhs` are different, we must shuffle each separately and then OR
 ;; them together. This is necessary due to PSHUFB semantics. As in the case

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm5, %xmm6
-;   vpermi2b %xmm1, %xmm6, %xmm0, %xmm0
+;   vpermi2b %xmm0, %xmm6, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -55,7 +55,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movdqa  %xmm0, %xmm5
 ;   movdqu  const(0), %xmm0
 ;   movdqa  %xmm5, %xmm6
-;   vpermi2b %xmm1, %xmm6, %xmm0, %xmm0
+;   vpermi2b %xmm0, %xmm6, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret


### PR DESCRIPTION
This commit updates the `src1`/`src2`/... operand orderings to match those of other XMM/VEX instructions. This should also match Intel's own documentation for numbered registers in instruction encodings.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
