### PR TITLE
Sync with the latest WASI proposal wit files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ regalloc2 = "0.9.0"
 # cap-std family:
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }
 cap-std = "1.0.12"
-cap-rand = "1.0.12"
+cap-rand = { version = "1.0.12", features = ["small_rng"] }
 cap-fs-ext = "1.0.12"
 cap-time-ext = "1.0.0"
 fs-set-times = "0.19.0"

--- a/crates/test-programs/command-tests/src/bin/random.rs
+++ b/crates/test-programs/command-tests/src/bin/random.rs
@@ -1,6 +1,6 @@
 fn main() {
-    let mut byte = [0_u8];
-    getrandom::getrandom(&mut byte).unwrap();
+    let mut bytes = [0_u8; 256];
+    getrandom::getrandom(&mut bytes).unwrap();
 
-    assert_eq!(42, byte[0]);
+    assert!(bytes.iter().any(|x| *x != 0));
 }

--- a/crates/test-programs/reactor-tests/wit/deps/filesystem/filesystem.wit
+++ b/crates/test-programs/reactor-tests/wit/deps/filesystem/filesystem.wit
@@ -138,12 +138,21 @@ default interface filesystem {
         /// True if the resource is considered readable by the containing
         /// filesystem.
         readable,
-        /// True if the resource is considered writeable by the containing
+        /// True if the resource is considered writable by the containing
         /// filesystem.
-        writeable,
+        writable,
         /// True if the resource is considered executable by the containing
         /// filesystem. This does not apply to directories.
         executable,
+    }
+
+    /// Access type used by `access-at`.
+    variant access-type {
+        /// Test for readability, writeability, or executability.
+        access(modes),
+
+        /// Test whether the path exists.
+        exists,
     }
 
     /// Number of hard links to an inode.
@@ -584,6 +593,26 @@ default interface filesystem {
         old-path: string,
         /// The relative destination path at which to create the symbolic link.
         new-path: string,
+    ) -> result<_, error-code>
+
+    /// Check accessibility of a filesystem path.
+    ///
+    /// Check whether the given filesystem path names an object which is
+    /// readable, writable, or executable, or whether it exists.
+    ///
+    /// This does not a guarantee that subsequent accesses will succeed, as
+    /// filesystem permissions may be modified asynchronously by external
+    /// entities.
+    ///
+    /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
+    access-at: func(
+        this: descriptor,
+        /// Flags determining the method of how the path is resolved.
+        path-flags: path-flags,
+        /// The relative path to check.
+        path: string,
+        /// The type of check to perform.
+        %type: access-type
     ) -> result<_, error-code>
 
     /// Unlink a filesystem object that is not a directory.

--- a/crates/test-programs/reactor-tests/wit/deps/random/random.wit
+++ b/crates/test-programs/reactor-tests/wit/deps/random/random.wit
@@ -20,23 +20,4 @@ default interface random {
     /// This function returns the same type of pseudo-random data as
     /// `get-random-bytes`, represented as a `u64`.
     get-random-u64: func() -> u64
-
-    /// Return a 128-bit value that may contain a pseudo-random value.
-    ///
-    /// The returned value is not required to be computed from a CSPRNG, and may
-    /// even be entirely deterministic. Host implementations are encouraged to
-    /// provide pseudo-random values to any program exposed to
-    /// attacker-controlled content, to enable DoS protection built into many
-    /// languages' hash-map implementations.
-    ///
-    /// This function is intended to only be called once, by a source language
-    /// to initialize Denial Of Service (DoS) protection in its hash-map
-    /// implementation.
-    ///
-    /// # Expected future evolution
-    ///
-    /// This will likely be changed to a value import, to prevent it from being
-    /// called multiple times and potentially used for purposes other than DoS
-    /// protection.
-    insecure-random: func() -> tuple<u64, u64>
 }

--- a/crates/test-programs/reactor-tests/wit/deps/wasi-cli-base/preopens.wit
+++ b/crates/test-programs/reactor-tests/wit/deps/wasi-cli-base/preopens.wit
@@ -2,16 +2,6 @@ default interface preopens {
   use filesystem.filesystem.{descriptor}
   use io.streams.{input-stream, output-stream}
 
-  /// Stdio preopens: these are the resources that provide stdin, stdout, and
-  /// stderr.
-  record stdio-preopens {
-    stdin: input-stream,
-    stdout: output-stream,
-    stderr: output-stream,
-  }
-
-  /// Return the set of stdio preopens.
-  get-stdio: func() -> stdio-preopens
   /// Return the set of of preopened directories, and their path.
   get-directories: func() -> list<tuple<descriptor, string>>
 }

--- a/crates/test-programs/tests/command.rs
+++ b/crates/test-programs/tests/command.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use cap_rand::RngCore;
 use cap_std::{ambient_authority, fs::Dir, time::Duration};
 use std::{
     io::{Cursor, Write},
@@ -117,29 +116,8 @@ async fn args() -> Result<()> {
 
 #[test_log::test(tokio::test)]
 async fn random() -> Result<()> {
-    struct FakeRng;
-
-    impl RngCore for FakeRng {
-        fn next_u32(&mut self) -> u32 {
-            42
-        }
-
-        fn next_u64(&mut self) -> u64 {
-            unimplemented!()
-        }
-
-        fn fill_bytes(&mut self, _dest: &mut [u8]) {
-            unimplemented!()
-        }
-
-        fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), cap_rand::Error> {
-            unimplemented!()
-        }
-    }
-
     let mut table = Table::new();
-    let mut wasi = WasiCtxBuilder::new().build(&mut table)?;
-    wasi.random = Box::new(FakeRng);
+    let wasi = WasiCtxBuilder::new().build(&mut table)?;
     let (mut store, command) =
         instantiate(get_component("random"), CommandCtx { table, wasi }).await?;
 

--- a/crates/test-programs/tests/reactor.rs
+++ b/crates/test-programs/tests/reactor.rs
@@ -29,6 +29,9 @@ wasmtime::component::bindgen!({
        "environment": wasi::environment,
        "streams": wasi::streams,
        "preopens": wasi::preopens,
+       "stdin": wasi::stdin,
+       "stdout": wasi::stdout,
+       "stderr": wasi::stderr,
        "filesystem": wasi::filesystem,
        "exit": wasi::exit,
     },
@@ -65,6 +68,9 @@ async fn instantiate(
     wasi::streams::add_to_linker(&mut linker, |x| x)?;
     wasi::environment::add_to_linker(&mut linker, |x| x)?;
     wasi::preopens::add_to_linker(&mut linker, |x| x)?;
+    wasi::stdin::add_to_linker(&mut linker, |x| x)?;
+    wasi::stdout::add_to_linker(&mut linker, |x| x)?;
+    wasi::stderr::add_to_linker(&mut linker, |x| x)?;
     wasi::exit::add_to_linker(&mut linker, |x| x)?;
 
     let mut store = Store::new(&ENGINE, wasi_ctx);

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -140,24 +140,26 @@ impl Descriptors {
             preopens: Cell::new(None),
         };
 
-        let stdio = crate::bindings::preopens::get_stdio();
-        unsafe { set_stderr_stream(stdio.stderr) };
+        let stdin = crate::bindings::stdin::get_stdin();
+        let stdout = crate::bindings::stdout::get_stdout();
+        let stderr = crate::bindings::stderr::get_stderr();
+        unsafe { set_stderr_stream(stderr) };
 
         d.push(Descriptor::Streams(Streams {
-            input: Cell::new(Some(stdio.stdin)),
+            input: Cell::new(Some(stdin)),
             output: Cell::new(None),
             type_: StreamType::Stdio,
         }))
         .trapping_unwrap();
         d.push(Descriptor::Streams(Streams {
             input: Cell::new(None),
-            output: Cell::new(Some(stdio.stdout)),
+            output: Cell::new(Some(stdout)),
             type_: StreamType::Stdio,
         }))
         .trapping_unwrap();
         d.push(Descriptor::Streams(Streams {
             input: Cell::new(None),
-            output: Cell::new(Some(stdio.stderr)),
+            output: Cell::new(Some(stderr)),
             type_: StreamType::Stdio,
         }))
         .trapping_unwrap();

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1364,7 +1364,7 @@ pub unsafe extern "C" fn path_open(
     let at_flags = at_flags_from_lookupflags(dirflags);
     let o_flags = o_flags_from_oflags(oflags);
     let flags = descriptor_flags_from_flags(fs_rights_base, fdflags);
-    let mode = filesystem::Modes::READABLE | filesystem::Modes::WRITEABLE;
+    let mode = filesystem::Modes::READABLE | filesystem::Modes::WRITABLE;
     let append = fdflags & wasi::FDFLAGS_APPEND == wasi::FDFLAGS_APPEND;
 
     State::with_mut(|state| {
@@ -1541,11 +1541,10 @@ impl Drop for Pollables {
     }
 }
 
-impl From<network::Error> for Errno {
-    fn from(error: network::Error) -> Errno {
+impl From<network::ErrorCode> for Errno {
+    fn from(error: network::ErrorCode) -> Errno {
         match error {
-            network::Error::Unknown => unreachable!(), // TODO
-            network::Error::Again => ERRNO_AGAIN,
+            network::ErrorCode::Unknown => unreachable!(), // TODO
             /* TODO
             // Use a black box to prevent the optimizer from generating a
             // lookup table, which would require a static initializer.
@@ -1556,8 +1555,8 @@ impl From<network::Error> for Errno {
             NetworkDown => ERRNO_NETDOWN,
             NetworkUnreachable => ERRNO_NETUNREACH,
             Timedout => ERRNO_TIMEDOUT,
-            _ => unreachable!(),
             */
+            _ => unreachable!(),
         }
     }
 }

--- a/crates/wasi-preview1-component-adapter/wit/command.wit
+++ b/crates/wasi-preview1-component-adapter/wit/command.wit
@@ -11,10 +11,15 @@ default world command {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment
   import preopens: wasi-cli-base.preopens
+  import stdin: wasi-cli-base.stdio.stdin
+  import stdout: wasi-cli-base.stdio.stdout
+  import stderr: wasi-cli-base.stdio.stderr
   import exit: wasi-cli-base.exit
 
   export run: func() -> result

--- a/crates/wasi-preview1-component-adapter/wit/deps/filesystem/filesystem.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/filesystem/filesystem.wit
@@ -138,12 +138,21 @@ default interface filesystem {
         /// True if the resource is considered readable by the containing
         /// filesystem.
         readable,
-        /// True if the resource is considered writeable by the containing
+        /// True if the resource is considered writable by the containing
         /// filesystem.
-        writeable,
+        writable,
         /// True if the resource is considered executable by the containing
         /// filesystem. This does not apply to directories.
         executable,
+    }
+
+    /// Access type used by `access-at`.
+    variant access-type {
+        /// Test for readability, writeability, or executability.
+        access(modes),
+
+        /// Test whether the path exists.
+        exists,
     }
 
     /// Number of hard links to an inode.
@@ -584,6 +593,26 @@ default interface filesystem {
         old-path: string,
         /// The relative destination path at which to create the symbolic link.
         new-path: string,
+    ) -> result<_, error-code>
+
+    /// Check accessibility of a filesystem path.
+    ///
+    /// Check whether the given filesystem path names an object which is
+    /// readable, writable, or executable, or whether it exists.
+    ///
+    /// This does not a guarantee that subsequent accesses will succeed, as
+    /// filesystem permissions may be modified asynchronously by external
+    /// entities.
+    ///
+    /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
+    access-at: func(
+        this: descriptor,
+        /// Flags determining the method of how the path is resolved.
+        path-flags: path-flags,
+        /// The relative path to check.
+        path: string,
+        /// The type of check to perform.
+        %type: access-type
     ) -> result<_, error-code>
 
     /// Unlink a filesystem object that is not a directory.

--- a/crates/wasi-preview1-component-adapter/wit/deps/preview/command-extended.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/preview/command-extended.wit
@@ -11,6 +11,8 @@ default world command-extended {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment

--- a/crates/wasi-preview1-component-adapter/wit/deps/preview/command.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/preview/command.wit
@@ -11,6 +11,8 @@ default world command {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment

--- a/crates/wasi-preview1-component-adapter/wit/deps/preview/proxy.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/preview/proxy.wit
@@ -1,5 +1,7 @@
 default world proxy {
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import console: logging.handler
   import default-outgoing-HTTP: http.outgoing-handler
   export HTTP: http.incoming-handler

--- a/crates/wasi-preview1-component-adapter/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/random/insecure-seed.wit
@@ -1,0 +1,24 @@
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+default interface insecure-seed {
+    /// Return a 128-bit value that may contain a pseudo-random value.
+    ///
+    /// The returned value is not required to be computed from a CSPRNG, and may
+    /// even be entirely deterministic. Host implementations are encouraged to
+    /// provide pseudo-random values to any program exposed to
+    /// attacker-controlled content, to enable DoS protection built into many
+    /// languages' hash-map implementations.
+    ///
+    /// This function is intended to only be called once, by a source language
+    /// to initialize Denial Of Service (DoS) protection in its hash-map
+    /// implementation.
+    ///
+    /// # Expected future evolution
+    ///
+    /// This will likely be changed to a value import, to prevent it from being
+    /// called multiple times and potentially used for purposes other than DoS
+    /// protection.
+    insecure-seed: func() -> tuple<u64, u64>
+}

--- a/crates/wasi-preview1-component-adapter/wit/deps/random/insecure.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/random/insecure.wit
@@ -1,0 +1,21 @@
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+default interface insecure {
+    /// Return `len` insecure pseudo-random bytes.
+    ///
+    /// This function is not cryptographically secure. Do not use it for
+    /// anything related to security.
+    ///
+    /// There are no requirements on the values of the returned bytes, however
+    /// implementations are encouraged to return evenly distributed values with
+    /// a long period.
+    get-insecure-random-bytes: func(len: u64) -> list<u8>
+
+    /// Return an insecure pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of pseudo-random data as
+    /// `get-insecure-random-bytes`, represented as a `u64`.
+    get-insecure-random-u64: func() -> u64
+}

--- a/crates/wasi-preview1-component-adapter/wit/deps/random/random.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/random/random.wit
@@ -20,23 +20,4 @@ default interface random {
     /// This function returns the same type of pseudo-random data as
     /// `get-random-bytes`, represented as a `u64`.
     get-random-u64: func() -> u64
-
-    /// Return a 128-bit value that may contain a pseudo-random value.
-    ///
-    /// The returned value is not required to be computed from a CSPRNG, and may
-    /// even be entirely deterministic. Host implementations are encouraged to
-    /// provide pseudo-random values to any program exposed to
-    /// attacker-controlled content, to enable DoS protection built into many
-    /// languages' hash-map implementations.
-    ///
-    /// This function is intended to only be called once, by a source language
-    /// to initialize Denial Of Service (DoS) protection in its hash-map
-    /// implementation.
-    ///
-    /// # Expected future evolution
-    ///
-    /// This will likely be changed to a value import, to prevent it from being
-    /// called multiple times and potentially used for purposes other than DoS
-    /// protection.
-    insecure-random: func() -> tuple<u64, u64>
 }

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/ip-name-lookup.wit
@@ -1,14 +1,14 @@
 
 default interface ip-name-lookup {
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-address, ip-address-family}
 
 
 	/// Resolve an internet host name to a list of IP addresses.
 	/// 
 	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
 	/// 
-	/// Parameters:
+	/// # Parameters
 	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
 	///     to ASCII using IDNA encoding.
 	/// - `address-family`: If provided, limit the results to addresses of this specific address family.
@@ -18,18 +18,23 @@ default interface ip-name-lookup {
 	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
 	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
 	/// 
-	/// This function never blocks. It either immediately returns successfully with a `resolve-address-stream`
+	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
 	/// that can be used to (asynchronously) fetch the results.
-	/// Or it immediately fails whenever `name` is:
-	/// - empty
-	/// - an IP address
-	/// - a syntactically invalid domain name in another way
 	/// 
-	/// References:
+	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
+	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
+	/// 
+	/// # Typical errors
+	/// - `invalid-name`:                 `name` is a syntactically invalid domain name.
+	/// - `invalid-name`:                 `name` is an IP address.
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAI_FAMILY)
+	/// 
+	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
-	/// 
-	resolve-addresses: func(network: network, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+	resolve-addresses: func(network: network, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>
 
 
 
@@ -43,25 +48,18 @@ default interface ip-name-lookup {
 	/// After which, you should release the stream with `drop-resolve-address-stream`.
 	/// 
 	/// This function never returns IPv4-mapped IPv6 addresses.
-	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error>
-
-
+	/// 
+	/// # Typical errors
+	/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+	/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+	/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+	/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error-code>
 
 	/// Dispose of the specified `resolve-address-stream`, after which it may no longer be used.
 	/// 
 	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
 	drop-resolve-address-stream: func(this: resolve-address-stream)
-
-	/// Get/set the blocking mode of the stream.
-	/// 
-	/// By default a stream is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: resolve-address-stream) -> result<bool, error>
-	set-non-blocking: func(this: resolve-address-stream, value: bool) -> result<_, error>
 
 	/// Create a `pollable` which will resolve once the stream is ready for I/O.
 	/// 

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/network.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/network.wit
@@ -13,11 +13,141 @@ default interface network {
 	drop-network: func(this: network)
 
 
+	/// Error codes.
+	/// 
+	/// In theory, every API can return any error code.
+	/// In practice, API's typically only return the errors documented per API
+	/// combined with a couple of errors that are always possible:
+	/// - `unknown`
+	/// - `access-denied`
+	/// - `not-supported`
+	/// - `out-of-memory`
+	/// 
+	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+	enum error-code {
+		// ### GENERAL ERRORS ###
 
-	enum error {
+		/// Unknown error
 		unknown,
-		again,
-		// TODO ...
+
+		/// Access denied.
+		/// 
+		/// POSIX equivalent: EACCES, EPERM
+		access-denied,
+
+		/// The operation is not supported.
+		/// 
+		/// POSIX equivalent: EOPNOTSUPP
+		not-supported,
+
+		/// Not enough memory to complete the operation.
+		/// 
+		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+		out-of-memory,
+
+		/// The operation timed out before it could finish completely.
+		timeout,
+
+		/// This operation is incompatible with another asynchronous operation that is already in progress.
+		concurrency-conflict,
+
+		/// Trying to finish an asynchronous operation that:
+		/// - has not been started yet, or:
+		/// - was already finished by a previous `finish-*` call.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		not-in-progress,
+
+		/// The operation has been aborted because it could not be completed immediately.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		would-block,
+
+
+		// ### IP ERRORS ###
+
+		/// The specified address-family is not supported.
+		address-family-not-supported,
+
+		/// An IPv4 address was passed to an IPv6 resource, or vice versa.
+		address-family-mismatch,
+
+		/// The socket address is not a valid remote address. E.g. the IP address is set to INADDR_ANY, or the port is set to 0.
+		invalid-remote-address,
+
+		/// The operation is only supported on IPv4 resources.
+		ipv4-only-operation,
+
+		/// The operation is only supported on IPv6 resources.
+		ipv6-only-operation,
+
+
+
+		// ### TCP & UDP SOCKET ERRORS ###
+
+		/// A new socket resource could not be created because of a system limit.
+		new-socket-limit,
+		
+		/// The socket is already attached to another network.
+		already-attached,
+
+		/// The socket is already bound.
+		already-bound,
+
+		/// The socket is already in the Connection state.
+		already-connected,
+
+		/// The socket is not bound to any local address.
+		not-bound,
+
+		/// The socket is not in the Connection state.
+		not-connected,
+
+		/// A bind operation failed because the provided address is not an address that the `network` can bind to.
+		address-not-bindable,
+
+		/// A bind operation failed because the provided address is already in use.
+		address-in-use,
+
+		/// A bind operation failed because there are no ephemeral ports available.
+		ephemeral-ports-exhausted,
+
+		/// The remote address is not reachable
+		remote-unreachable,
+		
+
+		// ### TCP SOCKET ERRORS ###
+		
+		/// The socket is already in the Listener state.
+		already-listening,
+
+		/// The socket is already in the Listener state.
+		not-listening,
+
+		/// The connection was forcefully rejected
+		connection-refused,
+
+		/// The connection was reset.
+		connection-reset,
+		
+
+		// ### UDP SOCKET ERRORS ###
+		datagram-too-large,
+
+
+		// ### NAME LOOKUP ERRORS ###
+		
+		/// The provided name is a syntactically invalid domain name.
+		invalid-name,
+
+		/// Name does not exist or has no suitable associated IP addresses.
+		name-unresolvable,
+
+		/// A temporary failure in name resolution occurred.
+		temporary-resolver-failure,
+
+		/// A permanent failure in name resolution occurred.
+		permanent-resolver-failure,
 	}
 
 	enum ip-address-family {

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/tcp-create-socket.wit
@@ -1,6 +1,6 @@
 
 default interface tcp-create-socket {
-	use pkg.network.{network, error, ip-address-family}
+	use pkg.network.{network, error-code, ip-address-family}
 	use pkg.tcp.{tcp-socket}
 
 	/// Create a new TCP socket.
@@ -11,9 +11,17 @@ default interface tcp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
-	/// References:
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
+	/// # Typical errors
+	/// - `not-supported`:                The host does not support TCP sockets. (EOPNOTSUPP)
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// 
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>
 }

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/tcp.wit
@@ -2,7 +2,7 @@
 default interface tcp {
 	use io.streams.{input-stream, output-stream}
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-socket-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-socket-address, ip-address-family}
 
 	/// A TCP socket handle.
 	type tcp-socket = u32
@@ -29,13 +29,27 @@ default interface tcp {
 	/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 	/// implicitly bind the socket.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
+	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-	bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Connect to a remote endpoint.
 	/// 
@@ -43,30 +57,56 @@ default interface tcp {
 	/// - the socket is transitioned into the Connection state
 	/// - a pair of streams is returned that can be used to read & write to the connection
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
-	/// - the provided network does not allow connections to the specified endpoint.
-	/// - the socket is already in the Connection or Listener state.
-	/// - either the remote IP address or port is 0.
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
+	/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	/// 
-	/// References
+	/// # Typical `finish` errors
+	/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+	/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+	/// - `connection-reset`:          The connection was reset. (ECONNRESET)
+	/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-	connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<tuple<input-stream, output-stream>, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: tcp-socket) -> result<tuple<input-stream, output-stream>, error-code>
 
 	/// Start listening for new connections.
 	/// 
 	/// Transitions the socket into the Listener state.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
-	/// - the provided network does not allow listening on the specified address.
-	/// - the socket is already in the Connection or Listener state.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
+	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `listen` must be identical to the one passed to `bind`.
+	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
+	/// - `already-listening`:         The socket is already in the Listener state.
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)
 	///
-	///  References
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+	/// - `not-in-progress`:           A `listen` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	///
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
-	listen: func(this: tcp-socket, network: network) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+	start-listen: func(this: tcp-socket, network: network) -> result<_, error-code>
+	finish-listen: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Accept a new client socket.
 	/// 
@@ -75,59 +115,89 @@ default interface tcp {
 	/// On success, this function returns the newly accepted client socket along with
 	/// a pair of streams that can be used to read & write to the connection.
 	/// 
-	/// Fails when this socket is not in the Listening state.
+	/// # Typical errors
+	/// - `not-listening`: Socket is not in the Listener state. (EINVAL)
+	/// - `would-block`:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References:
+	/// Host implementations must skip over transient errors returned by the native accept syscall.
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
 	/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
-	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
 
 	/// Get the bound local address.
 	/// 
-	/// Returns an error if the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`: The socket is not bound to any local address.
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-	local-address: func(this: tcp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+	local-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
 
 	/// Get the bound remote address.
 	/// 
-	/// Fails when the socket is not in the Connection state.
+	/// # Typical errors
+	/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: tcp-socket) -> result<ip-address-family, error>
+	address-family: func(this: tcp-socket) -> ip-address-family
 	
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-	/// Implementations are not required to support dual-stack mode. Calling `set-ipv6-only(false)` might fail.
-	/// 
-	/// Fails when called on an IPv4 socket.
 	/// 
 	/// Equivalent to the IPV6_V6ONLY socket option.
-	ipv6-only: func(this: tcp-socket) -> result<bool, error>
-	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
+	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	ipv6-only: func(this: tcp-socket) -> result<bool, error-code>
+	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// Hints the desired listen queue size. Implementations are free to ignore this.
-	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Equivalent to the SO_KEEPALIVE socket option.
-	keep-alive: func(this: tcp-socket) -> result<bool, error>
-	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	keep-alive: func(this: tcp-socket) -> result<bool, error-code>
+	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the TCP_NODELAY socket option.
-	no-delay: func(this: tcp-socket) -> result<bool, error>
-	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	no-delay: func(this: tcp-socket) -> result<bool, error-code>
+	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error-code>
 	
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error>
-	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
+	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -138,24 +208,16 @@ default interface tcp {
 	/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 	/// 	for internal metadata structures.
 	/// 
-	/// Fails when this socket is in the Listening state.
-	/// 
 	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-	receive-buffer-size: func(this: tcp-socket) -> result<u64, error>
-	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error>
-	send-buffer-size: func(this: tcp-socket) -> result<u64, error>
-	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error>
-
-	/// Get/set the blocking mode of the socket.
 	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: tcp-socket) -> result<bool, error>
-	set-non-blocking: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	receive-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
+	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
+	send-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
+	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 
@@ -163,7 +225,7 @@ default interface tcp {
 	/// It's planned to be removed when `future` is natively supported in Preview3.
 	subscribe: func(this: tcp-socket) -> pollable
 
-	/// Gracefully shut down the connection.
+	/// Initiate a graceful shutdown.
 	/// 
 	/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 	///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
@@ -172,16 +234,21 @@ default interface tcp {
 	///   operations on the `output-stream` associated with this socket will return an error.
 	/// - both: same effect as receive & send combined.
 	/// 
-	/// The shutdown function does not close the socket.
+	/// The shutdown function does not close (drop) the socket.
 	/// 
-	/// Fails when the socket is not in the Connection state.
+	/// # Typical errors
+	/// - `not-connected`: The socket is not in the Connection state. (ENOTCONN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
 	/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error-code>
 
 	/// Dispose of the specified `tcp-socket`, after which it may no longer be used.
+	/// 
+	/// Similar to the POSIX `close` function.
 	/// 
 	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
 	drop-tcp-socket: func(this: tcp-socket)

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/udp-create-socket.wit
@@ -1,6 +1,6 @@
 
 default interface udp-create-socket {
-	use pkg.network.{network, error, ip-address-family}
+	use pkg.network.{network, error-code, ip-address-family}
 	use pkg.udp.{udp-socket}
 
 	/// Create a new UDP socket.
@@ -11,9 +11,17 @@ default interface udp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
-	/// References:
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
+	/// # Typical errors
+	/// - `not-supported`:                The host does not support UDP sockets. (EOPNOTSUPP)
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	/// 
+	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// 
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>
 }

--- a/crates/wasi-preview1-component-adapter/wit/deps/sockets/udp.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 
 default interface udp {
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-socket-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-socket-address, ip-address-family}
 
 
 	/// A UDP socket handle.
@@ -28,16 +28,29 @@ default interface udp {
 	/// network interface(s) to bind to.
 	/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
 	/// 
-	/// When a socket is not explicitly bound, the first invocation to a connect, send or receive operation will
-	/// implicitly bind the socket.
+	/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
+	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-	bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+	start-bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: udp-socket) -> result<_, error-code>
 
 	/// Set the destination address.
 	/// 
@@ -49,13 +62,27 @@ default interface udp {
 	/// 
 	/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-	connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+	start-connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: udp-socket) -> result<_, error-code>
 
 	/// Receive a message.
 	/// 
@@ -63,63 +90,93 @@ default interface udp {
 	/// - The sender address of the datagram
 	/// - The number of bytes read.
 	/// 
-	/// Fails when:
-	/// - the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
+	/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
 	/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
-	receive: func(this: udp-socket) -> result<datagram, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+	/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+	receive: func(this: udp-socket) -> result<datagram, error-code>
 
 	/// Send a message to a specific destination address.
 	/// 
 	/// The remote address option is required. To send a message to the "connected" peer,
 	/// call `remote-address` to get their address.
 	/// 
-	/// Fails when:
-	/// - the socket is not bound. Unlike POSIX, this function does not perform an implicit bind.
-	/// - the socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`.
+	/// # Typical errors
+	/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `invalid-remote-address`:  The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `already-connected`:       The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+	/// - `not-bound`:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
+	/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+	/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
 	/// - <https://man7.org/linux/man-pages/man2/send.2.html>
-	send: func(this: udp-socket, datagram: datagram) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+	send: func(this: udp-socket, datagram: datagram) -> result<_, error-code>
 
 	/// Get the current bound address.
 	/// 
-	/// Returns an error if the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`: The socket is not bound to any local address.
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-	local-address: func(this: udp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+	local-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
 
 	/// Get the address set with `connect`.
 	/// 
-	/// References
+	/// # Typical errors
+	/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-	remote-address: func(this: udp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+	remote-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: udp-socket) -> result<ip-address-family, error>
+	address-family: func(this: udp-socket) -> ip-address-family
 
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-	/// Implementations are not required to support dual-stack mode, so calling `set-ipv6-only(false)` might fail.
-	/// 
-	/// Fails when called on an IPv4 socket.
 	/// 
 	/// Equivalent to the IPV6_V6ONLY socket option.
-	ipv6-only: func(this: udp-socket) -> result<bool, error>
-	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
+	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	ipv6-only: func(this: udp-socket) -> result<bool, error-code>
+	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-	unicast-hop-limit: func(this: udp-socket) -> result<u8, error>
-	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
+	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -133,21 +190,13 @@ default interface udp {
 	/// Fails when this socket is in the Listening state.
 	/// 
 	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-	receive-buffer-size: func(this: udp-socket) -> result<u64, error>
-	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error>
-	send-buffer-size: func(this: udp-socket) -> result<u64, error>
-	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error>
-
-	/// Get/set the blocking mode of the socket.
 	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: udp-socket) -> result<bool, error>
-	set-non-blocking: func(this: udp-socket, value: bool) -> result<_, error>
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	receive-buffer-size: func(this: udp-socket) -> result<u64, error-code>
+	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
+	send-buffer-size: func(this: udp-socket) -> result<u64, error-code>
+	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 

--- a/crates/wasi-preview1-component-adapter/wit/deps/wasi-cli-base/preopens.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/wasi-cli-base/preopens.wit
@@ -2,16 +2,6 @@ default interface preopens {
   use filesystem.filesystem.{descriptor}
   use io.streams.{input-stream, output-stream}
 
-  /// Stdio preopens: these are the resources that provide stdin, stdout, and
-  /// stderr.
-  record stdio-preopens {
-    stdin: input-stream,
-    stdout: output-stream,
-    stderr: output-stream,
-  }
-
-  /// Return the set of stdio preopens.
-  get-stdio: func() -> stdio-preopens
   /// Return the set of of preopened directories, and their path.
   get-directories: func() -> list<tuple<descriptor, string>>
 }

--- a/crates/wasi-preview1-component-adapter/wit/deps/wasi-cli-base/stdio.wit
+++ b/crates/wasi-preview1-component-adapter/wit/deps/wasi-cli-base/stdio.wit
@@ -1,0 +1,17 @@
+interface stdin {
+  use io.streams.{input-stream}
+
+  get-stdin: func() -> input-stream
+}
+
+interface stdout {
+  use io.streams.{output-stream}
+
+  get-stdout: func() -> output-stream
+}
+
+interface stderr {
+  use io.streams.{output-stream}
+
+  get-stderr: func() -> output-stream
+}

--- a/crates/wasi-preview1-component-adapter/wit/reactor.wit
+++ b/crates/wasi-preview1-component-adapter/wit/reactor.wit
@@ -11,11 +11,16 @@ default world reactor {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import console: logging.handler
   import default-outgoing-HTTP: http.outgoing-handler
   import environment: wasi-cli-base.environment
   import preopens: wasi-cli-base.preopens
+  import stdin: wasi-cli-base.stdio.stdin
+  import stdout: wasi-cli-base.stdio.stdout
+  import stderr: wasi-cli-base.stdio.stderr
   import exit: wasi-cli-base.exit
 }

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -5,7 +5,7 @@ use crate::preview2::{
     stream::{InputStream, OutputStream, TableStreamExt},
     DirPerms, FilePerms, Table,
 };
-use cap_rand::RngCore;
+use cap_rand::{Rng, RngCore, SeedableRng};
 
 #[derive(Default)]
 pub struct WasiCtxBuilder {
@@ -17,17 +17,32 @@ pub struct WasiCtxBuilder {
     preopens: Vec<(Dir, String)>,
 
     random: Option<Box<dyn RngCore + Send + Sync>>,
+    insecure_random: Option<Box<dyn RngCore + Send + Sync>>,
+    insecure_random_seed: Option<u128>,
     clocks: Option<WasiClocks>,
 }
 
 impl WasiCtxBuilder {
     pub fn new() -> Self {
-        Self::default()
+        // For the insecure random API, use `SmallRng`, which is fast. It's
+        // also insecure, but that's the deal here.
+        let insecure_random = cap_rand::rngs::SmallRng::from_entropy();
+
+        // For the insecure random seed, use a `u128` generated from
+        // `thread_rng()`, so that it's not guessable from the insecure_random
+        // API.
+        let insecure_random_seed =
+            cap_rand::thread_rng(cap_rand::ambient_authority()).gen::<u128>();
+
+        let mut result = Self::default()
             .set_clocks(clocks::host::clocks_ctx())
-            .set_random(random::thread_rng())
+            .set_insecure_random(insecure_random)
+            .set_insecure_random_seed(insecure_random_seed)
             .set_stdin(pipe::ReadPipe::new(std::io::empty()))
             .set_stdout(pipe::WritePipe::new(std::io::sink()))
-            .set_stderr(pipe::WritePipe::new(std::io::sink()))
+            .set_stderr(pipe::WritePipe::new(std::io::sink()));
+        result.random = Some(random::thread_rng());
+        result
     }
 
     pub fn set_stdin(mut self, stdin: impl InputStream + 'static) -> Self {
@@ -88,8 +103,24 @@ impl WasiCtxBuilder {
         self
     }
 
+    /// Set the generator for the secure random number generator. This
+    /// is only avalabile under `cfg(test)` as it's only intended for use
+    /// by tests.
+    #[cfg(test)]
     pub fn set_random(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
         self.random = Some(Box::new(random));
+        self
+    }
+
+    pub fn set_insecure_random(
+        mut self,
+        insecure_random: impl RngCore + Send + Sync + 'static,
+    ) -> Self {
+        self.insecure_random = Some(Box::new(insecure_random));
+        self
+    }
+    pub fn set_insecure_random_seed(mut self, insecure_random_seed: u128) -> Self {
+        self.insecure_random_seed = Some(insecure_random_seed);
         self
     }
     pub fn set_clocks(mut self, clocks: WasiClocks) -> Self {
@@ -120,6 +151,12 @@ impl WasiCtxBuilder {
 
         Ok(WasiCtx {
             random: self.random.context("required member random")?,
+            insecure_random: self
+                .insecure_random
+                .context("required member insecure_random")?,
+            insecure_random_seed: self
+                .insecure_random_seed
+                .context("required member insecure_random_seed")?,
             clocks: self.clocks.context("required member clocks")?,
             env: self.env,
             args: self.args,
@@ -139,7 +176,9 @@ pub trait WasiView: Send {
 }
 
 pub struct WasiCtx {
-    pub random: Box<dyn RngCore + Send + Sync>,
+    pub(crate) random: Box<dyn RngCore + Send + Sync>,
+    pub insecure_random: Box<dyn RngCore + Send + Sync>,
+    pub insecure_random_seed: u128,
     pub clocks: WasiClocks,
     pub env: Vec<(String, String)>,
     pub args: Vec<String>,

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -203,7 +203,7 @@ impl OutputStream for FileOutputStream {
         self.file.is_write_vectored_at()
     }
 
-    /// Test whether this stream is writeable.
+    /// Test whether this stream is writable.
     async fn writable(&self) -> anyhow::Result<()> {
         // FIXME perm check?
         Ok(())
@@ -261,7 +261,7 @@ impl OutputStream for FileAppendStream {
         self.file.is_write_vectored_at()
     }
 
-    /// Test whether this stream is writeable.
+    /// Test whether this stream is writable.
     async fn writable(&self) -> anyhow::Result<()> {
         // FIXME perm check?
         Ok(())

--- a/crates/wasi/src/preview2/preview2/env.rs
+++ b/crates/wasi/src/preview2/preview2/env.rs
@@ -12,16 +12,30 @@ impl<T: WasiView> wasi::environment::Host for T {
 
 #[async_trait::async_trait]
 impl<T: WasiView> wasi::preopens::Host for T {
-    async fn get_stdio(&mut self) -> Result<wasi::preopens::StdioPreopens, anyhow::Error> {
-        Ok(wasi::preopens::StdioPreopens {
-            stdin: self.ctx().stdin,
-            stdout: self.ctx().stdout,
-            stderr: self.ctx().stderr,
-        })
-    }
     async fn get_directories(
         &mut self,
     ) -> Result<Vec<(wasi::filesystem::Descriptor, String)>, anyhow::Error> {
         Ok(self.ctx().preopens.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> wasi::stdin::Host for T {
+    async fn get_stdin(&mut self) -> Result<wasi::streams::InputStream, anyhow::Error> {
+        Ok(self.ctx().stdin)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> wasi::stdout::Host for T {
+    async fn get_stdout(&mut self) -> Result<wasi::streams::OutputStream, anyhow::Error> {
+        Ok(self.ctx().stdout)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> wasi::stderr::Host for T {
+    async fn get_stderr(&mut self) -> Result<wasi::streams::OutputStream, anyhow::Error> {
+        Ok(self.ctx().stderr)
     }
 }

--- a/crates/wasi/src/preview2/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/preview2/filesystem.rs
@@ -641,6 +641,16 @@ impl<T: WasiView> wasi::filesystem::Host for T {
         Ok(())
     }
 
+    async fn access_at(
+        &mut self,
+        _fd: wasi::filesystem::Descriptor,
+        _path_flags: wasi::filesystem::PathFlags,
+        _path: String,
+        _access: wasi::filesystem::AccessType,
+    ) -> Result<(), wasi::filesystem::Error> {
+        todo!()
+    }
+
     async fn change_file_permissions_at(
         &mut self,
         _fd: wasi::filesystem::Descriptor,

--- a/crates/wasi/src/preview2/preview2/random.rs
+++ b/crates/wasi/src/preview2/preview2/random.rs
@@ -14,8 +14,26 @@ impl<T: WasiView> wasi::random::Host for T {
     async fn get_random_u64(&mut self) -> anyhow::Result<u64> {
         Ok(self.ctx_mut().random.sample(Standard))
     }
+}
 
-    async fn insecure_random(&mut self) -> anyhow::Result<(u64, u64)> {
-        Ok((0, 0))
+#[async_trait::async_trait]
+impl<T: WasiView> wasi::insecure_random::Host for T {
+    async fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
+        Ok((&mut self.ctx_mut().insecure_random)
+            .sample_iter(Standard)
+            .take(len as usize)
+            .collect())
+    }
+
+    async fn get_insecure_random_u64(&mut self) -> anyhow::Result<u64> {
+        Ok(self.ctx_mut().insecure_random.sample(Standard))
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> wasi::insecure_random_seed::Host for T {
+    async fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
+        let seed: u128 = self.ctx_mut().insecure_random_seed;
+        Ok((seed as u64, (seed >> 64) as u64))
     }
 }

--- a/crates/wasi/src/preview2/random.rs
+++ b/crates/wasi/src/preview2/random.rs
@@ -1,6 +1,6 @@
 use cap_rand::RngCore;
 
-/// Implement `WasiRandom` using a deterministic cycle of bytes.
+/// Implement `insecure-random` using a deterministic cycle of bytes.
 pub struct Deterministic {
     cycle: std::iter::Cycle<std::vec::IntoIter<u8>>,
 }

--- a/crates/wasi/src/preview2/stream.rs
+++ b/crates/wasi/src/preview2/stream.rs
@@ -151,7 +151,7 @@ pub trait OutputStream: Send + Sync {
         Ok(nwritten)
     }
 
-    /// Test whether this stream is writeable.
+    /// Test whether this stream is writable.
     async fn writable(&self) -> Result<(), Error>;
 }
 

--- a/crates/wasi/src/preview2/wasi/command.rs
+++ b/crates/wasi/src/preview2/wasi/command.rs
@@ -20,6 +20,9 @@ wasmtime::component::bindgen!({
        "environment": crate::preview2::wasi::environment,
        "exit": crate::preview2::wasi::exit,
        "preopens": crate::preview2::wasi::preopens,
+       "stdin": crate::preview2::wasi::stdin,
+       "stdout": crate::preview2::wasi::stdout,
+       "stderr": crate::preview2::wasi::stderr,
     },
 });
 
@@ -34,5 +37,8 @@ pub fn add_to_linker<T: WasiView>(l: &mut wasmtime::component::Linker<T>) -> any
     crate::preview2::wasi::exit::add_to_linker(l, |t| t)?;
     crate::preview2::wasi::environment::add_to_linker(l, |t| t)?;
     crate::preview2::wasi::preopens::add_to_linker(l, |t| t)?;
+    crate::preview2::wasi::stdin::add_to_linker(l, |t| t)?;
+    crate::preview2::wasi::stdout::add_to_linker(l, |t| t)?;
+    crate::preview2::wasi::stderr::add_to_linker(l, |t| t)?;
     Ok(())
 }

--- a/crates/wasi/src/preview2/wasi/mod.rs
+++ b/crates/wasi/src/preview2/wasi/mod.rs
@@ -8,10 +8,15 @@ wasmtime::component::bindgen!({
       import timezone: clocks.timezone
       import filesystem: filesystem.filesystem
       import random: random.random
+      import insecure-random: random.insecure
+      import insecure-random-seed: random.insecure-seed
       import poll: poll.poll
       import streams: io.streams
       import environment: wasi-cli-base.environment
       import preopens: wasi-cli-base.preopens
+      import stdin: wasi-cli-base.stdio.stdin
+      import stdout: wasi-cli-base.stdio.stdout
+      import stderr: wasi-cli-base.stdio.stderr
       import exit: wasi-cli-base.exit
     ",
     tracing: true,

--- a/crates/wasi/wit/command.wit
+++ b/crates/wasi/wit/command.wit
@@ -11,10 +11,15 @@ default world command {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment
   import preopens: wasi-cli-base.preopens
+  import stdin: wasi-cli-base.stdio.stdin
+  import stdout: wasi-cli-base.stdio.stdout
+  import stderr: wasi-cli-base.stdio.stderr
   import exit: wasi-cli-base.exit
 
   export run: func() -> result

--- a/crates/wasi/wit/deps/filesystem/filesystem.wit
+++ b/crates/wasi/wit/deps/filesystem/filesystem.wit
@@ -138,12 +138,21 @@ default interface filesystem {
         /// True if the resource is considered readable by the containing
         /// filesystem.
         readable,
-        /// True if the resource is considered writeable by the containing
+        /// True if the resource is considered writable by the containing
         /// filesystem.
-        writeable,
+        writable,
         /// True if the resource is considered executable by the containing
         /// filesystem. This does not apply to directories.
         executable,
+    }
+
+    /// Access type used by `access-at`.
+    variant access-type {
+        /// Test for readability, writeability, or executability.
+        access(modes),
+
+        /// Test whether the path exists.
+        exists,
     }
 
     /// Number of hard links to an inode.
@@ -584,6 +593,26 @@ default interface filesystem {
         old-path: string,
         /// The relative destination path at which to create the symbolic link.
         new-path: string,
+    ) -> result<_, error-code>
+
+    /// Check accessibility of a filesystem path.
+    ///
+    /// Check whether the given filesystem path names an object which is
+    /// readable, writable, or executable, or whether it exists.
+    ///
+    /// This does not a guarantee that subsequent accesses will succeed, as
+    /// filesystem permissions may be modified asynchronously by external
+    /// entities.
+    ///
+    /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
+    access-at: func(
+        this: descriptor,
+        /// Flags determining the method of how the path is resolved.
+        path-flags: path-flags,
+        /// The relative path to check.
+        path: string,
+        /// The type of check to perform.
+        %type: access-type
     ) -> result<_, error-code>
 
     /// Unlink a filesystem object that is not a directory.

--- a/crates/wasi/wit/deps/preview/command-extended.wit
+++ b/crates/wasi/wit/deps/preview/command-extended.wit
@@ -11,6 +11,8 @@ default world command-extended {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment

--- a/crates/wasi/wit/deps/preview/command.wit
+++ b/crates/wasi/wit/deps/preview/command.wit
@@ -11,6 +11,8 @@ default world command {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import environment: wasi-cli-base.environment

--- a/crates/wasi/wit/deps/preview/proxy.wit
+++ b/crates/wasi/wit/deps/preview/proxy.wit
@@ -1,5 +1,7 @@
 default world proxy {
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import console: logging.handler
   import default-outgoing-HTTP: http.outgoing-handler
   export HTTP: http.incoming-handler

--- a/crates/wasi/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi/wit/deps/random/insecure-seed.wit
@@ -1,0 +1,24 @@
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+default interface insecure-seed {
+    /// Return a 128-bit value that may contain a pseudo-random value.
+    ///
+    /// The returned value is not required to be computed from a CSPRNG, and may
+    /// even be entirely deterministic. Host implementations are encouraged to
+    /// provide pseudo-random values to any program exposed to
+    /// attacker-controlled content, to enable DoS protection built into many
+    /// languages' hash-map implementations.
+    ///
+    /// This function is intended to only be called once, by a source language
+    /// to initialize Denial Of Service (DoS) protection in its hash-map
+    /// implementation.
+    ///
+    /// # Expected future evolution
+    ///
+    /// This will likely be changed to a value import, to prevent it from being
+    /// called multiple times and potentially used for purposes other than DoS
+    /// protection.
+    insecure-seed: func() -> tuple<u64, u64>
+}

--- a/crates/wasi/wit/deps/random/insecure.wit
+++ b/crates/wasi/wit/deps/random/insecure.wit
@@ -1,0 +1,21 @@
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+default interface insecure {
+    /// Return `len` insecure pseudo-random bytes.
+    ///
+    /// This function is not cryptographically secure. Do not use it for
+    /// anything related to security.
+    ///
+    /// There are no requirements on the values of the returned bytes, however
+    /// implementations are encouraged to return evenly distributed values with
+    /// a long period.
+    get-insecure-random-bytes: func(len: u64) -> list<u8>
+
+    /// Return an insecure pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of pseudo-random data as
+    /// `get-insecure-random-bytes`, represented as a `u64`.
+    get-insecure-random-u64: func() -> u64
+}

--- a/crates/wasi/wit/deps/random/random.wit
+++ b/crates/wasi/wit/deps/random/random.wit
@@ -20,23 +20,4 @@ default interface random {
     /// This function returns the same type of pseudo-random data as
     /// `get-random-bytes`, represented as a `u64`.
     get-random-u64: func() -> u64
-
-    /// Return a 128-bit value that may contain a pseudo-random value.
-    ///
-    /// The returned value is not required to be computed from a CSPRNG, and may
-    /// even be entirely deterministic. Host implementations are encouraged to
-    /// provide pseudo-random values to any program exposed to
-    /// attacker-controlled content, to enable DoS protection built into many
-    /// languages' hash-map implementations.
-    ///
-    /// This function is intended to only be called once, by a source language
-    /// to initialize Denial Of Service (DoS) protection in its hash-map
-    /// implementation.
-    ///
-    /// # Expected future evolution
-    ///
-    /// This will likely be changed to a value import, to prevent it from being
-    /// called multiple times and potentially used for purposes other than DoS
-    /// protection.
-    insecure-random: func() -> tuple<u64, u64>
 }

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,14 +1,14 @@
 
 default interface ip-name-lookup {
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-address, ip-address-family}
 
 
 	/// Resolve an internet host name to a list of IP addresses.
 	/// 
 	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
 	/// 
-	/// Parameters:
+	/// # Parameters
 	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
 	///     to ASCII using IDNA encoding.
 	/// - `address-family`: If provided, limit the results to addresses of this specific address family.
@@ -18,18 +18,23 @@ default interface ip-name-lookup {
 	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
 	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
 	/// 
-	/// This function never blocks. It either immediately returns successfully with a `resolve-address-stream`
+	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
 	/// that can be used to (asynchronously) fetch the results.
-	/// Or it immediately fails whenever `name` is:
-	/// - empty
-	/// - an IP address
-	/// - a syntactically invalid domain name in another way
 	/// 
-	/// References:
+	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
+	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
+	/// 
+	/// # Typical errors
+	/// - `invalid-name`:                 `name` is a syntactically invalid domain name.
+	/// - `invalid-name`:                 `name` is an IP address.
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAI_FAMILY)
+	/// 
+	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
-	/// 
-	resolve-addresses: func(network: network, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+	resolve-addresses: func(network: network, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>
 
 
 
@@ -43,25 +48,18 @@ default interface ip-name-lookup {
 	/// After which, you should release the stream with `drop-resolve-address-stream`.
 	/// 
 	/// This function never returns IPv4-mapped IPv6 addresses.
-	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error>
-
-
+	/// 
+	/// # Typical errors
+	/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+	/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+	/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+	/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error-code>
 
 	/// Dispose of the specified `resolve-address-stream`, after which it may no longer be used.
 	/// 
 	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
 	drop-resolve-address-stream: func(this: resolve-address-stream)
-
-	/// Get/set the blocking mode of the stream.
-	/// 
-	/// By default a stream is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: resolve-address-stream) -> result<bool, error>
-	set-non-blocking: func(this: resolve-address-stream, value: bool) -> result<_, error>
 
 	/// Create a `pollable` which will resolve once the stream is ready for I/O.
 	/// 

--- a/crates/wasi/wit/deps/sockets/network.wit
+++ b/crates/wasi/wit/deps/sockets/network.wit
@@ -13,11 +13,141 @@ default interface network {
 	drop-network: func(this: network)
 
 
+	/// Error codes.
+	/// 
+	/// In theory, every API can return any error code.
+	/// In practice, API's typically only return the errors documented per API
+	/// combined with a couple of errors that are always possible:
+	/// - `unknown`
+	/// - `access-denied`
+	/// - `not-supported`
+	/// - `out-of-memory`
+	/// 
+	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+	enum error-code {
+		// ### GENERAL ERRORS ###
 
-	enum error {
+		/// Unknown error
 		unknown,
-		again,
-		// TODO ...
+
+		/// Access denied.
+		/// 
+		/// POSIX equivalent: EACCES, EPERM
+		access-denied,
+
+		/// The operation is not supported.
+		/// 
+		/// POSIX equivalent: EOPNOTSUPP
+		not-supported,
+
+		/// Not enough memory to complete the operation.
+		/// 
+		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+		out-of-memory,
+
+		/// The operation timed out before it could finish completely.
+		timeout,
+
+		/// This operation is incompatible with another asynchronous operation that is already in progress.
+		concurrency-conflict,
+
+		/// Trying to finish an asynchronous operation that:
+		/// - has not been started yet, or:
+		/// - was already finished by a previous `finish-*` call.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		not-in-progress,
+
+		/// The operation has been aborted because it could not be completed immediately.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		would-block,
+
+
+		// ### IP ERRORS ###
+
+		/// The specified address-family is not supported.
+		address-family-not-supported,
+
+		/// An IPv4 address was passed to an IPv6 resource, or vice versa.
+		address-family-mismatch,
+
+		/// The socket address is not a valid remote address. E.g. the IP address is set to INADDR_ANY, or the port is set to 0.
+		invalid-remote-address,
+
+		/// The operation is only supported on IPv4 resources.
+		ipv4-only-operation,
+
+		/// The operation is only supported on IPv6 resources.
+		ipv6-only-operation,
+
+
+
+		// ### TCP & UDP SOCKET ERRORS ###
+
+		/// A new socket resource could not be created because of a system limit.
+		new-socket-limit,
+		
+		/// The socket is already attached to another network.
+		already-attached,
+
+		/// The socket is already bound.
+		already-bound,
+
+		/// The socket is already in the Connection state.
+		already-connected,
+
+		/// The socket is not bound to any local address.
+		not-bound,
+
+		/// The socket is not in the Connection state.
+		not-connected,
+
+		/// A bind operation failed because the provided address is not an address that the `network` can bind to.
+		address-not-bindable,
+
+		/// A bind operation failed because the provided address is already in use.
+		address-in-use,
+
+		/// A bind operation failed because there are no ephemeral ports available.
+		ephemeral-ports-exhausted,
+
+		/// The remote address is not reachable
+		remote-unreachable,
+		
+
+		// ### TCP SOCKET ERRORS ###
+		
+		/// The socket is already in the Listener state.
+		already-listening,
+
+		/// The socket is already in the Listener state.
+		not-listening,
+
+		/// The connection was forcefully rejected
+		connection-refused,
+
+		/// The connection was reset.
+		connection-reset,
+		
+
+		// ### UDP SOCKET ERRORS ###
+		datagram-too-large,
+
+
+		// ### NAME LOOKUP ERRORS ###
+		
+		/// The provided name is a syntactically invalid domain name.
+		invalid-name,
+
+		/// Name does not exist or has no suitable associated IP addresses.
+		name-unresolvable,
+
+		/// A temporary failure in name resolution occurred.
+		temporary-resolver-failure,
+
+		/// A permanent failure in name resolution occurred.
+		permanent-resolver-failure,
 	}
 
 	enum ip-address-family {

--- a/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
@@ -1,6 +1,6 @@
 
 default interface tcp-create-socket {
-	use pkg.network.{network, error, ip-address-family}
+	use pkg.network.{network, error-code, ip-address-family}
 	use pkg.tcp.{tcp-socket}
 
 	/// Create a new TCP socket.
@@ -11,9 +11,17 @@ default interface tcp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
-	/// References:
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
+	/// # Typical errors
+	/// - `not-supported`:                The host does not support TCP sockets. (EOPNOTSUPP)
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// 
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>
 }

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -2,7 +2,7 @@
 default interface tcp {
 	use io.streams.{input-stream, output-stream}
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-socket-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-socket-address, ip-address-family}
 
 	/// A TCP socket handle.
 	type tcp-socket = u32
@@ -29,13 +29,27 @@ default interface tcp {
 	/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 	/// implicitly bind the socket.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
+	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-	bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Connect to a remote endpoint.
 	/// 
@@ -43,30 +57,56 @@ default interface tcp {
 	/// - the socket is transitioned into the Connection state
 	/// - a pair of streams is returned that can be used to read & write to the connection
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
-	/// - the provided network does not allow connections to the specified endpoint.
-	/// - the socket is already in the Connection or Listener state.
-	/// - either the remote IP address or port is 0.
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
+	/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	/// 
-	/// References
+	/// # Typical `finish` errors
+	/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+	/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+	/// - `connection-reset`:          The connection was reset. (ECONNRESET)
+	/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-	connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<tuple<input-stream, output-stream>, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: tcp-socket) -> result<tuple<input-stream, output-stream>, error-code>
 
 	/// Start listening for new connections.
 	/// 
 	/// Transitions the socket into the Listener state.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
-	/// - the provided network does not allow listening on the specified address.
-	/// - the socket is already in the Connection or Listener state.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
+	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `listen` must be identical to the one passed to `bind`.
+	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
+	/// - `already-listening`:         The socket is already in the Listener state.
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)
 	///
-	///  References
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+	/// - `not-in-progress`:           A `listen` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	///
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
-	listen: func(this: tcp-socket, network: network) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+	start-listen: func(this: tcp-socket, network: network) -> result<_, error-code>
+	finish-listen: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Accept a new client socket.
 	/// 
@@ -75,59 +115,89 @@ default interface tcp {
 	/// On success, this function returns the newly accepted client socket along with
 	/// a pair of streams that can be used to read & write to the connection.
 	/// 
-	/// Fails when this socket is not in the Listening state.
+	/// # Typical errors
+	/// - `not-listening`: Socket is not in the Listener state. (EINVAL)
+	/// - `would-block`:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References:
+	/// Host implementations must skip over transient errors returned by the native accept syscall.
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
 	/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
-	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
 
 	/// Get the bound local address.
 	/// 
-	/// Returns an error if the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`: The socket is not bound to any local address.
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-	local-address: func(this: tcp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+	local-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
 
 	/// Get the bound remote address.
 	/// 
-	/// Fails when the socket is not in the Connection state.
+	/// # Typical errors
+	/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: tcp-socket) -> result<ip-address-family, error>
+	address-family: func(this: tcp-socket) -> ip-address-family
 	
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-	/// Implementations are not required to support dual-stack mode. Calling `set-ipv6-only(false)` might fail.
-	/// 
-	/// Fails when called on an IPv4 socket.
 	/// 
 	/// Equivalent to the IPV6_V6ONLY socket option.
-	ipv6-only: func(this: tcp-socket) -> result<bool, error>
-	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
+	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	ipv6-only: func(this: tcp-socket) -> result<bool, error-code>
+	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// Hints the desired listen queue size. Implementations are free to ignore this.
-	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Equivalent to the SO_KEEPALIVE socket option.
-	keep-alive: func(this: tcp-socket) -> result<bool, error>
-	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	keep-alive: func(this: tcp-socket) -> result<bool, error-code>
+	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the TCP_NODELAY socket option.
-	no-delay: func(this: tcp-socket) -> result<bool, error>
-	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	no-delay: func(this: tcp-socket) -> result<bool, error-code>
+	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error-code>
 	
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error>
-	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
+	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -138,24 +208,16 @@ default interface tcp {
 	/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 	/// 	for internal metadata structures.
 	/// 
-	/// Fails when this socket is in the Listening state.
-	/// 
 	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-	receive-buffer-size: func(this: tcp-socket) -> result<u64, error>
-	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error>
-	send-buffer-size: func(this: tcp-socket) -> result<u64, error>
-	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error>
-
-	/// Get/set the blocking mode of the socket.
 	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: tcp-socket) -> result<bool, error>
-	set-non-blocking: func(this: tcp-socket, value: bool) -> result<_, error>
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	receive-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
+	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
+	send-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
+	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 
@@ -163,7 +225,7 @@ default interface tcp {
 	/// It's planned to be removed when `future` is natively supported in Preview3.
 	subscribe: func(this: tcp-socket) -> pollable
 
-	/// Gracefully shut down the connection.
+	/// Initiate a graceful shutdown.
 	/// 
 	/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 	///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
@@ -172,16 +234,21 @@ default interface tcp {
 	///   operations on the `output-stream` associated with this socket will return an error.
 	/// - both: same effect as receive & send combined.
 	/// 
-	/// The shutdown function does not close the socket.
+	/// The shutdown function does not close (drop) the socket.
 	/// 
-	/// Fails when the socket is not in the Connection state.
+	/// # Typical errors
+	/// - `not-connected`: The socket is not in the Connection state. (ENOTCONN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
 	/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error-code>
 
 	/// Dispose of the specified `tcp-socket`, after which it may no longer be used.
+	/// 
+	/// Similar to the POSIX `close` function.
 	/// 
 	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
 	drop-tcp-socket: func(this: tcp-socket)

--- a/crates/wasi/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/udp-create-socket.wit
@@ -1,6 +1,6 @@
 
 default interface udp-create-socket {
-	use pkg.network.{network, error, ip-address-family}
+	use pkg.network.{network, error-code, ip-address-family}
 	use pkg.udp.{udp-socket}
 
 	/// Create a new UDP socket.
@@ -11,9 +11,17 @@ default interface udp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
-	/// References:
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
+	/// # Typical errors
+	/// - `not-supported`:                The host does not support UDP sockets. (EOPNOTSUPP)
+	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
+	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+	/// 
+	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// 
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>
 }

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 
 default interface udp {
 	use poll.poll.{pollable}
-	use pkg.network.{network, error, ip-socket-address, ip-address-family}
+	use pkg.network.{network, error-code, ip-socket-address, ip-address-family}
 
 
 	/// A UDP socket handle.
@@ -28,16 +28,29 @@ default interface udp {
 	/// network interface(s) to bind to.
 	/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
 	/// 
-	/// When a socket is not explicitly bound, the first invocation to a connect, send or receive operation will
-	/// implicitly bind the socket.
+	/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
 	/// 
-	/// Fails when:
-	/// - the socket is already bound.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
+	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-	bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+	start-bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: udp-socket) -> result<_, error-code>
 
 	/// Set the destination address.
 	/// 
@@ -49,13 +62,27 @@ default interface udp {
 	/// 
 	/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
 	/// 
-	/// Fails when:
-	/// - the socket is already bound to a different network.
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// References
+	/// # Typical `start` errors
+	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-	connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
+	start-connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: udp-socket) -> result<_, error-code>
 
 	/// Receive a message.
 	/// 
@@ -63,63 +90,93 @@ default interface udp {
 	/// - The sender address of the datagram
 	/// - The number of bytes read.
 	/// 
-	/// Fails when:
-	/// - the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
+	/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
 	/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
-	receive: func(this: udp-socket) -> result<datagram, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+	/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+	receive: func(this: udp-socket) -> result<datagram, error-code>
 
 	/// Send a message to a specific destination address.
 	/// 
 	/// The remote address option is required. To send a message to the "connected" peer,
 	/// call `remote-address` to get their address.
 	/// 
-	/// Fails when:
-	/// - the socket is not bound. Unlike POSIX, this function does not perform an implicit bind.
-	/// - the socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`.
+	/// # Typical errors
+	/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+	/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `invalid-remote-address`:  The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+	/// - `already-connected`:       The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+	/// - `not-bound`:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
+	/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+	/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
 	/// - <https://man7.org/linux/man-pages/man2/send.2.html>
-	send: func(this: udp-socket, datagram: datagram) -> result<_, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+	send: func(this: udp-socket, datagram: datagram) -> result<_, error-code>
 
 	/// Get the current bound address.
 	/// 
-	/// Returns an error if the socket is not bound.
+	/// # Typical errors
+	/// - `not-bound`: The socket is not bound to any local address.
 	/// 
-	/// References
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-	local-address: func(this: udp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+	/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+	local-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
 
 	/// Get the address set with `connect`.
 	/// 
-	/// References
+	/// # Typical errors
+	/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
+	/// 
+	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-	remote-address: func(this: udp-socket) -> result<ip-socket-address, error>
+	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+	remote-address: func(this: udp-socket) -> result<ip-socket-address, error-code>
 
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
-	address-family: func(this: udp-socket) -> result<ip-address-family, error>
+	address-family: func(this: udp-socket) -> ip-address-family
 
 	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-	/// Implementations are not required to support dual-stack mode, so calling `set-ipv6-only(false)` might fail.
-	/// 
-	/// Fails when called on an IPv4 socket.
 	/// 
 	/// Equivalent to the IPV6_V6ONLY socket option.
-	ipv6-only: func(this: udp-socket) -> result<bool, error>
-	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
+	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	ipv6-only: func(this: udp-socket) -> result<bool, error-code>
+	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-	unicast-hop-limit: func(this: udp-socket) -> result<u8, error>
-	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error>
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
+	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
@@ -133,21 +190,13 @@ default interface udp {
 	/// Fails when this socket is in the Listening state.
 	/// 
 	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-	receive-buffer-size: func(this: udp-socket) -> result<u64, error>
-	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error>
-	send-buffer-size: func(this: udp-socket) -> result<u64, error>
-	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error>
-
-	/// Get/set the blocking mode of the socket.
 	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: udp-socket) -> result<bool, error>
-	set-non-blocking: func(this: udp-socket, value: bool) -> result<_, error>
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
+	receive-buffer-size: func(this: udp-socket) -> result<u64, error-code>
+	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
+	send-buffer-size: func(this: udp-socket) -> result<u64, error-code>
+	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 

--- a/crates/wasi/wit/deps/wasi-cli-base/preopens.wit
+++ b/crates/wasi/wit/deps/wasi-cli-base/preopens.wit
@@ -2,16 +2,6 @@ default interface preopens {
   use filesystem.filesystem.{descriptor}
   use io.streams.{input-stream, output-stream}
 
-  /// Stdio preopens: these are the resources that provide stdin, stdout, and
-  /// stderr.
-  record stdio-preopens {
-    stdin: input-stream,
-    stdout: output-stream,
-    stderr: output-stream,
-  }
-
-  /// Return the set of stdio preopens.
-  get-stdio: func() -> stdio-preopens
   /// Return the set of of preopened directories, and their path.
   get-directories: func() -> list<tuple<descriptor, string>>
 }

--- a/crates/wasi/wit/deps/wasi-cli-base/stdio.wit
+++ b/crates/wasi/wit/deps/wasi-cli-base/stdio.wit
@@ -1,0 +1,17 @@
+interface stdin {
+  use io.streams.{input-stream}
+
+  get-stdin: func() -> input-stream
+}
+
+interface stdout {
+  use io.streams.{output-stream}
+
+  get-stdout: func() -> output-stream
+}
+
+interface stderr {
+  use io.streams.{output-stream}
+
+  get-stderr: func() -> output-stream
+}

--- a/crates/wasi/wit/reactor.wit
+++ b/crates/wasi/wit/reactor.wit
@@ -11,11 +11,16 @@ default world reactor {
   import udp-create-socket: sockets.udp-create-socket
   import udp: sockets.udp
   import random: random.random
+  import insecure-random: random.insecure
+  import insecure-random-seed: random.insecure-seed
   import poll: poll.poll
   import streams: io.streams
   import console: logging.handler
   import default-outgoing-HTTP: http.outgoing-handler
   import environment: wasi-cli-base.environment
   import preopens: wasi-cli-base.preopens
+  import stdin: wasi-cli-base.stdio.stdin
+  import stdout: wasi-cli-base.stdio.stdout
+  import stderr: wasi-cli-base.stdio.stderr
   import exit: wasi-cli-base.exit
 }


### PR DESCRIPTION
Changes include:

 - Add new insecure and insecure-seed random APIs. Also, change the random test to avoid depending on the secure random API returning deterministic data.

 - Split stdio into separate interfaces for stdin, stdout, and stderr.

 - Add `access-at` to wasi-filesystem.

 - Update the sockets wit files to the new non-blocking-style API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
