### PR TITLE
Honor `ModuleVersionStrategy` in `Engine::precompile_compatibility_hash`

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -68,6 +68,16 @@ impl Default for ModuleVersionStrategy {
     }
 }
 
+impl std::hash::Hash for ModuleVersionStrategy {
+    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        match self {
+            Self::WasmtimeVersion => env!("CARGO_PKG_VERSION").hash(hasher),
+            Self::Custom(s) => s.hash(hasher),
+            Self::None => {}
+        };
+    }
+}
+
 /// Global configuration options used to create an [`Engine`](crate::Engine)
 /// and customize its behavior.
 ///

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -1073,7 +1073,7 @@ impl std::hash::Hash for HashedEngineCompileEnv<'_> {
         config.features.hash(hasher);
 
         // Catch accidental bugs of reusing across crate versions.
-        env!("CARGO_PKG_VERSION").hash(hasher);
+        config.module_version.hash(hasher);
     }
 }
 


### PR DESCRIPTION
When looking into replacing our bespoke implementation of #5826, I noticed it would not make use of a custom versioning strategy. This makes it so we cannot assert compatibility if we determine things work for our use case. This is important because we have to re-serialize _a ton_ of modules when versions change, and don't want to do so unnecessarily.