### PR TITLE
riscv64: Add Newtype Wrappers for Register Classes

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -743,6 +743,13 @@
 (extern constructor xreg_new xreg_new)
 (convert Reg XReg xreg_new)
 
+;; Construct a new `WritableXReg` from a `WritableReg`.
+;;
+;; Asserts that the register has a Integer RegClass.
+(decl writable_xreg_new (WritableReg) WritableXReg)
+(extern constructor writable_xreg_new writable_xreg_new)
+(convert WritableReg WritableXReg writable_xreg_new)
+
 ;; Put a value into a XReg.
 ;;
 ;; Asserts that the value goes into a XReg.
@@ -765,10 +772,29 @@
 (extern constructor writable_xreg_to_writable_reg writable_xreg_to_writable_reg)
 (convert WritableXReg WritableReg writable_xreg_to_writable_reg)
 
+;; Convert a `WritableXReg` to an `Reg`.
+(decl pure writable_xreg_to_reg (WritableXReg) Reg)
+(rule (writable_xreg_to_reg x) (writable_xreg_to_writable_reg x))
+(convert WritableXReg Reg writable_xreg_to_reg)
+
 ;; Convert an `XReg` to a `Reg`.
 (decl pure xreg_to_reg (XReg) Reg)
 (extern constructor xreg_to_reg xreg_to_reg)
 (convert XReg Reg xreg_to_reg)
+
+;; Convert a `XReg` to a `ValueRegs`.
+(decl xreg_to_value_regs (XReg) ValueRegs)
+(rule (xreg_to_value_regs x) (value_reg x))
+(convert XReg ValueRegs xreg_to_reg)
+
+;; Convert a `WritableXReg` to a `ValueRegs`.
+(decl writable_xreg_to_value_regs (WritableXReg) ValueRegs)
+(rule (writable_xreg_to_value_regs x) (value_reg x))
+(convert WritableXReg ValueRegs writable_xreg_to_value_regs)
+
+;; Allocates a new `WritableXReg`.
+(decl temp_writable_xreg () WritableXReg)
+(rule (temp_writable_xreg) (temp_writable_reg $I64))
 
 
 ;; Construct a new `FReg` from a `Reg`.
@@ -777,6 +803,13 @@
 (decl freg_new (Reg) FReg)
 (extern constructor freg_new freg_new)
 (convert Reg FReg freg_new)
+
+;; Construct a new `WritableFReg` from a `WritableReg`.
+;;
+;; Asserts that the register has a Float RegClass.
+(decl writable_freg_new (WritableReg) WritableFReg)
+(extern constructor writable_freg_new writable_freg_new)
+(convert WritableReg WritableFReg writable_freg_new)
 
 ;; Put a value into a FReg.
 ;;
@@ -800,10 +833,30 @@
 (extern constructor writable_freg_to_writable_reg writable_freg_to_writable_reg)
 (convert WritableFReg WritableReg writable_freg_to_writable_reg)
 
+;; Convert a `WritableFReg` to an `Reg`.
+(decl pure writable_freg_to_reg (WritableFReg) Reg)
+(rule (writable_freg_to_reg x) (writable_freg_to_writable_reg x))
+(convert WritableFReg Reg writable_freg_to_reg)
+
 ;; Convert an `FReg` to a `Reg`.
 (decl pure freg_to_reg (FReg) Reg)
 (extern constructor freg_to_reg freg_to_reg)
 (convert FReg Reg freg_to_reg)
+
+;; Convert a `FReg` to a `ValueRegs`.
+(decl freg_to_value_regs (FReg) ValueRegs)
+(rule (freg_to_value_regs x) (value_reg x))
+(convert FReg ValueRegs xreg_to_reg)
+
+;; Convert a `WritableFReg` to a `ValueRegs`.
+(decl writable_freg_to_value_regs (WritableFReg) ValueRegs)
+(rule (writable_freg_to_value_regs x) (value_reg x))
+(convert WritableFReg ValueRegs writable_freg_to_value_regs)
+
+;; Allocates a new `WritableFReg`.
+(decl temp_writable_freg () WritableFReg)
+(rule (temp_writable_freg) (temp_writable_reg $F64))
+
 
 
 ;; Construct a new `VReg` from a `Reg`.
@@ -812,6 +865,13 @@
 (decl vreg_new (Reg) VReg)
 (extern constructor vreg_new vreg_new)
 (convert Reg VReg vreg_new)
+
+;; Construct a new `WritableVReg` from a `WritableReg`.
+;;
+;; Asserts that the register has a Vector RegClass.
+(decl writable_vreg_new (WritableReg) WritableVReg)
+(extern constructor writable_vreg_new writable_vreg_new)
+(convert WritableReg WritableVReg writable_vreg_new)
 
 ;; Put a value into a VReg.
 ;;
@@ -835,11 +895,29 @@
 (extern constructor writable_vreg_to_writable_reg writable_vreg_to_writable_reg)
 (convert WritableVReg WritableReg writable_vreg_to_writable_reg)
 
+;; Convert a `WritableVReg` to an `Reg`.
+(decl pure writable_vreg_to_reg (WritableVReg) Reg)
+(rule (writable_vreg_to_reg x) (writable_vreg_to_writable_reg x))
+(convert WritableVReg Reg writable_vreg_to_reg)
+
 ;; Convert an `VReg` to a `Reg`.
 (decl pure vreg_to_reg (VReg) Reg)
 (extern constructor vreg_to_reg vreg_to_reg)
 (convert VReg Reg vreg_to_reg)
 
+;; Convert a `VReg` to a `ValueRegs`.
+(decl vreg_to_value_regs (VReg) ValueRegs)
+(rule (vreg_to_value_regs x) (value_reg x))
+(convert VReg ValueRegs xreg_to_reg)
+
+;; Convert a `WritableVReg` to a `ValueRegs`.
+(decl writable_vreg_to_value_regs (WritableVReg) ValueRegs)
+(rule (writable_vreg_to_value_regs x) (value_reg x))
+(convert WritableVReg ValueRegs writable_vreg_to_value_regs)
+
+;; Allocates a new `WritableVReg`.
+(decl temp_writable_vreg () WritableVReg)
+(rule (temp_writable_vreg) (temp_writable_reg $I8X16))
 
 
 ;; Converters
@@ -879,8 +957,8 @@
   (gen_float_round op rs ty)
   (let
     ((rd WritableReg (temp_writable_reg ty))
-      (tmp WritableReg (temp_writable_reg $I64))
-      (tmp2 WritableReg (temp_writable_reg $F64))
+      (tmp WritableXReg (temp_writable_xreg))
+      (tmp2 WritableFReg (temp_writable_freg))
       (_ Unit (emit (MInst.FloatRound op rd tmp tmp2 rs ty))))
     (writable_reg_to_reg rd)))
 
@@ -889,7 +967,7 @@
   (gen_float_select_pseudo op x y ty)
   (let
     ((rd WritableReg (temp_writable_reg ty))
-      (tmp WritableReg (temp_writable_reg $I64))
+      (tmp WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.FloatSelectPseudo op rd tmp x y ty))))
     (writable_reg_to_reg rd)))
 
@@ -898,7 +976,7 @@
   (gen_float_select op x y ty)
   (let
     ((rd WritableReg (temp_writable_reg ty))
-      (tmp WritableReg (temp_writable_reg $I64))
+      (tmp WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.FloatSelect op rd tmp x y ty))))
     (writable_reg_to_reg rd)))
 
@@ -909,127 +987,127 @@
 
 ;; Helper for emitting the `add` instruction.
 ;; rd ← rs1 + rs2
-(decl rv_add (Reg Reg) Reg)
+(decl rv_add (XReg XReg) XReg)
 (rule (rv_add rs1 rs2)
   (alu_rrr (AluOPRRR.Add) rs1 rs2))
 
 ;; Helper for emitting the `addi` ("Add Immediate") instruction.
 ;; rd ← rs1 + sext(imm)
-(decl rv_addi (Reg Imm12) Reg)
+(decl rv_addi (XReg Imm12) XReg)
 (rule (rv_addi rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Addi) rs1 imm))
 
 ;; Helper for emitting the `sub` instruction.
 ;; rd ← rs1 - rs2
-(decl rv_sub (Reg Reg) Reg)
+(decl rv_sub (XReg XReg) XReg)
 (rule (rv_sub rs1 rs2)
   (alu_rrr (AluOPRRR.Sub) rs1 rs2))
 
 ;; Helper for emitting the `neg` instruction.
 ;; This instruction is a mnemonic for `sub rd, zero, rs1`.
-(decl rv_neg (Reg) Reg)
+(decl rv_neg (XReg) XReg)
 (rule (rv_neg rs1)
   (alu_rrr (AluOPRRR.Sub) (zero_reg) rs1))
 
 ;; Helper for emitting the `sll` ("Shift Left Logical") instruction.
 ;; rd ← rs1 << rs2
-(decl rv_sll (Reg Reg) Reg)
+(decl rv_sll (XReg XReg) XReg)
 (rule (rv_sll rs1 rs2)
   (alu_rrr (AluOPRRR.Sll) rs1 rs2))
 
 ;; Helper for emitting the `slli` ("Shift Left Logical Immediate") instruction.
 ;; rd ← rs1 << uext(imm)
-(decl rv_slli (Reg Imm12) Reg)
+(decl rv_slli (XReg Imm12) XReg)
 (rule (rv_slli rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Slli) rs1 imm))
 
 ;; Helper for emitting the `srl` ("Shift Right Logical") instruction.
 ;; rd ← rs1 >> rs2
-(decl rv_srl (Reg Reg) Reg)
+(decl rv_srl (XReg XReg) XReg)
 (rule (rv_srl rs1 rs2)
   (alu_rrr (AluOPRRR.Srl) rs1 rs2))
 
 ;; Helper for emitting the `srli` ("Shift Right Logical Immediate") instruction.
 ;; rd ← rs1 >> uext(imm)
-(decl rv_srli (Reg Imm12) Reg)
+(decl rv_srli (XReg Imm12) XReg)
 (rule (rv_srli rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Srli) rs1 imm))
 
 ;; Helper for emitting the `sra` ("Shift Right Arithmetic") instruction.
 ;; rd ← rs1 >> rs2
-(decl rv_sra (Reg Reg) Reg)
+(decl rv_sra (XReg XReg) XReg)
 (rule (rv_sra rs1 rs2)
   (alu_rrr (AluOPRRR.Sra) rs1 rs2))
 
 ;; Helper for emitting the `srai` ("Shift Right Arithmetic Immediate") instruction.
 ;; rd ← rs1 >> uext(imm)
-(decl rv_srai (Reg Imm12) Reg)
+(decl rv_srai (XReg Imm12) XReg)
 (rule (rv_srai rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Srai) rs1 imm))
 
 ;; Helper for emitting the `or` instruction.
 ;; rd ← rs1 ∨ rs2
-(decl rv_or (Reg Reg) Reg)
+(decl rv_or (XReg XReg) XReg)
 (rule (rv_or rs1 rs2)
   (alu_rrr (AluOPRRR.Or) rs1 rs2))
 
 ;; Helper for emitting the `ori` ("Or Immediate") instruction.
 ;; rd ← rs1 ∨ uext(imm)
-(decl rv_ori (Reg Imm12) Reg)
+(decl rv_ori (XReg Imm12) XReg)
 (rule (rv_ori rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Ori) rs1 imm))
 
 ;; Helper for emitting the `xor` instruction.
 ;; rd ← rs1 ⊕ rs2
-(decl rv_xor (Reg Reg) Reg)
+(decl rv_xor (XReg XReg) XReg)
 (rule (rv_xor rs1 rs2)
   (alu_rrr (AluOPRRR.Xor) rs1 rs2))
 
 ;; Helper for emitting the `xori` ("Exlusive Or Immediate") instruction.
 ;; rd ← rs1 ⊕ uext(imm)
-(decl rv_xori (Reg Imm12) Reg)
+(decl rv_xori (XReg Imm12) XReg)
 (rule (rv_xori rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Xori) rs1 imm))
 
 ;; Helper for emitting the `not` instruction.
 ;; This instruction is a mnemonic for `xori rd, rs1, -1`.
-(decl rv_not (Reg) Reg)
+(decl rv_not (XReg) XReg)
 (rule (rv_not rs1)
   (rv_xori rs1 (imm12_const -1)))
 
 ;; Helper for emitting the `and` instruction.
 ;; rd ← rs1 ∧ rs2
-(decl rv_and (Reg Reg) Reg)
+(decl rv_and (XReg XReg) XReg)
 (rule (rv_and rs1 rs2)
   (alu_rrr (AluOPRRR.And) rs1 rs2))
 
 ;; Helper for emitting the `andi` ("And Immediate") instruction.
 ;; rd ← rs1 ∧ uext(imm)
-(decl rv_andi (Reg Imm12) Reg)
+(decl rv_andi (XReg Imm12) XReg)
 (rule (rv_andi rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Andi) rs1 imm))
 
 ;; Helper for emitting the `sltu` ("Set Less Than Unsigned") instruction.
 ;; rd ← rs1 < rs2
-(decl rv_sltu (Reg Reg) Reg)
+(decl rv_sltu (XReg XReg) XReg)
 (rule (rv_sltu rs1 rs2)
   (alu_rrr (AluOPRRR.SltU) rs1 rs2))
 
 ;; Helper for emitting the `snez` instruction.
 ;; This instruction is a mnemonic for `sltu rd, zero, rs`.
-(decl rv_snez (Reg) Reg)
+(decl rv_snez (XReg) XReg)
 (rule (rv_snez rs1)
   (rv_sltu (zero_reg) rs1))
 
 ;; Helper for emiting the `sltiu` ("Set Less Than Immediate Unsigned") instruction.
 ;; rd ← rs1 < imm
-(decl rv_sltiu (Reg Imm12) Reg)
+(decl rv_sltiu (XReg Imm12) XReg)
 (rule (rv_sltiu rs1 imm)
   (alu_rr_imm12 (AluOPRRI.SltiU) rs1 imm))
 
 ;; Helper for emitting the `seqz` instruction.
 ;; This instruction is a mnemonic for `sltiu rd, rs, 1`.
-(decl rv_seqz (Reg) Reg)
+(decl rv_seqz (XReg) XReg)
 (rule (rv_seqz rs1)
   (rv_sltiu rs1 (imm12_const 1)))
 
@@ -1039,61 +1117,61 @@
 
 ;; Helper for emitting the `addw` ("Add Word") instruction.
 ;; rd ← sext32(rs1) + sext32(rs2)
-(decl rv_addw (Reg Reg) Reg)
+(decl rv_addw (XReg XReg) XReg)
 (rule (rv_addw rs1 rs2)
   (alu_rrr (AluOPRRR.Addw) rs1 rs2))
 
 ;; Helper for emitting the `addiw` ("Add Word Immediate") instruction.
 ;; rd ← sext32(rs1) + imm
-(decl rv_addiw (Reg Imm12) Reg)
+(decl rv_addiw (XReg Imm12) XReg)
 (rule (rv_addiw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Addiw) rs1 imm))
 
 ;; Helper for emitting the `sext.w` ("Sign Extend Word") instruction.
 ;; This instruction is a mnemonic for `addiw rd, rs, zero`.
-(decl rv_sextw (Reg) Reg)
+(decl rv_sextw (XReg) XReg)
 (rule (rv_sextw rs1)
   (rv_addiw rs1 (imm12_const 0)))
 
 ;; Helper for emitting the `subw` ("Subtract Word") instruction.
 ;; rd ← sext32(rs1) - sext32(rs2)
-(decl rv_subw (Reg Reg) Reg)
+(decl rv_subw (XReg XReg) XReg)
 (rule (rv_subw rs1 rs2)
   (alu_rrr (AluOPRRR.Subw) rs1 rs2))
 
 ;; Helper for emitting the `sllw` ("Shift Left Logical Word") instruction.
 ;; rd ← sext32(uext32(rs1) << rs2)
-(decl rv_sllw (Reg Reg) Reg)
+(decl rv_sllw (XReg XReg) XReg)
 (rule (rv_sllw rs1 rs2)
   (alu_rrr (AluOPRRR.Sllw) rs1 rs2))
 
 ;; Helper for emitting the `slliw` ("Shift Left Logical Immediate Word") instruction.
 ;; rd ← sext32(uext32(rs1) << imm)
-(decl rv_slliw (Reg Imm12) Reg)
+(decl rv_slliw (XReg Imm12) XReg)
 (rule (rv_slliw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Slliw) rs1 imm))
 
 ;; Helper for emitting the `srlw` ("Shift Right Logical Word") instruction.
 ;; rd ← sext32(uext32(rs1) >> rs2)
-(decl rv_srlw (Reg Reg) Reg)
+(decl rv_srlw (XReg XReg) XReg)
 (rule (rv_srlw rs1 rs2)
   (alu_rrr (AluOPRRR.Srlw) rs1 rs2))
 
 ;; Helper for emitting the `srliw` ("Shift Right Logical Immediate Word") instruction.
 ;; rd ← sext32(uext32(rs1) >> imm)
-(decl rv_srliw (Reg Imm12) Reg)
+(decl rv_srliw (XReg Imm12) XReg)
 (rule (rv_srliw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.SrliW) rs1 imm))
 
 ;; Helper for emitting the `sraw` ("Shift Right Arithmetic Word") instruction.
 ;; rd ← sext32(rs1 >> rs2)
-(decl rv_sraw (Reg Reg) Reg)
+(decl rv_sraw (XReg XReg) XReg)
 (rule (rv_sraw rs1 rs2)
   (alu_rrr (AluOPRRR.Sraw) rs1 rs2))
 
 ;; Helper for emitting the `sraiw` ("Shift Right Arithmetic Immediate Word") instruction.
 ;; rd ← sext32(rs1 >> imm)
-(decl rv_sraiw (Reg Imm12) Reg)
+(decl rv_sraiw (XReg Imm12) XReg)
 (rule (rv_sraiw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Sraiw) rs1 imm))
 
@@ -1103,43 +1181,43 @@
 
 ;; Helper for emitting the `mul` instruction.
 ;; rd ← rs1 × rs2
-(decl rv_mul (Reg Reg) Reg)
+(decl rv_mul (XReg XReg) XReg)
 (rule (rv_mul rs1 rs2)
   (alu_rrr (AluOPRRR.Mul) rs1 rs2))
 
 ;; Helper for emitting the `mulh` ("Multiply High Signed Signed") instruction.
 ;; rd ← (sext(rs1) × sext(rs2)) » xlen
-(decl rv_mulh (Reg Reg) Reg)
+(decl rv_mulh (XReg XReg) XReg)
 (rule (rv_mulh rs1 rs2)
   (alu_rrr (AluOPRRR.Mulh) rs1 rs2))
 
 ;; Helper for emitting the `mulhu` ("Multiply High Unsigned Unsigned") instruction.
 ;; rd ← (uext(rs1) × uext(rs2)) » xlen
-(decl rv_mulhu (Reg Reg) Reg)
+(decl rv_mulhu (XReg XReg) XReg)
 (rule (rv_mulhu rs1 rs2)
   (alu_rrr (AluOPRRR.Mulhu) rs1 rs2))
 
 ;; Helper for emitting the `div` instruction.
 ;; rd ← rs1 ÷ rs2
-(decl rv_div (Reg Reg) Reg)
+(decl rv_div (XReg XReg) XReg)
 (rule (rv_div rs1 rs2)
   (alu_rrr (AluOPRRR.Div) rs1 rs2))
 
 ;; Helper for emitting the `divu` ("Divide Unsigned") instruction.
 ;; rd ← rs1 ÷ rs2
-(decl rv_divu (Reg Reg) Reg)
+(decl rv_divu (XReg XReg) XReg)
 (rule (rv_divu rs1 rs2)
   (alu_rrr (AluOPRRR.DivU) rs1 rs2))
 
 ;; Helper for emitting the `rem` instruction.
 ;; rd ← rs1 mod rs2
-(decl rv_rem (Reg Reg) Reg)
+(decl rv_rem (XReg XReg) XReg)
 (rule (rv_rem rs1 rs2)
   (alu_rrr (AluOPRRR.Rem) rs1 rs2))
 
 ;; Helper for emitting the `remu` ("Remainder Unsigned") instruction.
 ;; rd ← rs1 mod rs2
-(decl rv_remu (Reg Reg) Reg)
+(decl rv_remu (XReg XReg) XReg)
 (rule (rv_remu rs1 rs2)
   (alu_rrr (AluOPRRR.RemU) rs1 rs2))
 
@@ -1150,31 +1228,31 @@
 
 ;; Helper for emitting the `mulw` ("Multiply Word") instruction.
 ;; rd ← uext32(rs1) × uext32(rs2)
-(decl rv_mulw (Reg Reg) Reg)
+(decl rv_mulw (XReg XReg) XReg)
 (rule (rv_mulw rs1 rs2)
   (alu_rrr (AluOPRRR.Mulw) rs1 rs2))
 
 ;; Helper for emitting the `divw` ("Divide Word") instruction.
 ;; rd ← sext32(rs1) ÷ sext32(rs2)
-(decl rv_divw (Reg Reg) Reg)
+(decl rv_divw (XReg XReg) XReg)
 (rule (rv_divw rs1 rs2)
   (alu_rrr (AluOPRRR.Divw) rs1 rs2))
 
 ;; Helper for emitting the `divuw` ("Divide Unsigned Word") instruction.
 ;; rd ← uext32(rs1) ÷ uext32(rs2)
-(decl rv_divuw (Reg Reg) Reg)
+(decl rv_divuw (XReg XReg) XReg)
 (rule (rv_divuw rs1 rs2)
   (alu_rrr (AluOPRRR.Divuw) rs1 rs2))
 
 ;; Helper for emitting the `remw` ("Remainder Word") instruction.
 ;; rd ← sext32(rs1) mod sext32(rs2)
-(decl rv_remw (Reg Reg) Reg)
+(decl rv_remw (XReg XReg) XReg)
 (rule (rv_remw rs1 rs2)
   (alu_rrr (AluOPRRR.Remw) rs1 rs2))
 
 ;; Helper for emitting the `remuw` ("Remainder Unsigned Word") instruction.
 ;; rd ← uext32(rs1) mod uext32(rs2)
-(decl rv_remuw (Reg Reg) Reg)
+(decl rv_remuw (XReg XReg) XReg)
 (rule (rv_remuw rs1 rs2)
   (alu_rrr (AluOPRRR.Remuw) rs1 rs2))
 
@@ -1183,113 +1261,113 @@
 ;; TODO: Enable these instructions only when we have the F or D extensions
 
 ;; Helper for emitting the `fadd` instruction.
-(decl rv_fadd (Type Reg Reg) Reg)
+(decl rv_fadd (Type FReg FReg) FReg)
 (rule (rv_fadd $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddS) $F32 rs1 rs2))
 (rule (rv_fadd $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FaddD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fsub` instruction.
-(decl rv_fsub (Type Reg Reg) Reg)
+(decl rv_fsub (Type FReg FReg) FReg)
 (rule (rv_fsub $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubS) $F32 rs1 rs2))
 (rule (rv_fsub $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsubD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fmul` instruction.
-(decl rv_fmul (Type Reg Reg) Reg)
+(decl rv_fmul (Type FReg FReg) FReg)
 (rule (rv_fmul $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulS) $F32 rs1 rs2))
 (rule (rv_fmul $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FmulD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fdiv` instruction.
-(decl rv_fdiv (Type Reg Reg) Reg)
+(decl rv_fdiv (Type FReg FReg) FReg)
 (rule (rv_fdiv $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivS) $F32 rs1 rs2))
 (rule (rv_fdiv $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FdivD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fsqrt` instruction.
-(decl rv_fsqrt (Type Reg) Reg)
+(decl rv_fsqrt (Type FReg) FReg)
 (rule (rv_fsqrt $F32 rs1) (fpu_rr (FpuOPRR.FsqrtS) $F32 rs1))
 (rule (rv_fsqrt $F64 rs1) (fpu_rr (FpuOPRR.FsqrtD) $F64 rs1))
 
 ;; Helper for emitting the `fmadd` instruction.
-(decl rv_fmadd (Type Reg Reg Reg) Reg)
+(decl rv_fmadd (Type FReg FReg FReg) FReg)
 (rule (rv_fmadd $F32 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddS) $F32 rs1 rs2 rs3))
 (rule (rv_fmadd $F64 rs1 rs2 rs3) (fpu_rrrr (FpuOPRRRR.FmaddD) $F64 rs1 rs2 rs3))
 
 ;; Helper for emitting the `fmv.x.w` instruction.
-(decl rv_fmvxw (Reg) Reg)
+(decl rv_fmvxw (FReg) XReg)
 (rule (rv_fmvxw r) (fpu_rr (FpuOPRR.FmvXW) $I32 r))
 
 ;; Helper for emitting the `fmv.x.d` instruction.
-(decl rv_fmvxd (Reg) Reg)
+(decl rv_fmvxd (FReg) XReg)
 (rule (rv_fmvxd r) (fpu_rr (FpuOPRR.FmvXD) $I64 r))
 
 ;; Helper for emitting the `fmv.w.x` instruction.
-(decl rv_fmvwx (Reg) Reg)
+(decl rv_fmvwx (XReg) FReg)
 (rule (rv_fmvwx r) (fpu_rr (FpuOPRR.FmvWX) $F32 r))
 
 ;; Helper for emitting the `fmv.d.x` instruction.
-(decl rv_fmvdx (Reg) Reg)
+(decl rv_fmvdx (XReg) FReg)
 (rule (rv_fmvdx r) (fpu_rr (FpuOPRR.FmvDX) $F64 r))
 
 ;; Helper for emitting the `fcvt.d.s` ("Float Convert Double to Single") instruction.
-(decl rv_fcvtds (Reg) Reg)
+(decl rv_fcvtds (FReg) FReg)
 (rule (rv_fcvtds rs1) (fpu_rr (FpuOPRR.FcvtDS) $F32 rs1))
 
 ;; Helper for emitting the `fcvt.s.d` ("Float Convert Single to Double") instruction.
-(decl rv_fcvtsd (Reg) Reg)
+(decl rv_fcvtsd (FReg) FReg)
 (rule (rv_fcvtsd rs1) (fpu_rr (FpuOPRR.FcvtSD) $F64 rs1))
 
 ;; Helper for emitting the `fsgnj` ("Floating Point Sign Injection") instruction.
 ;; The output of this instruction is `rs1` with the sign bit from `rs2`
 ;; This implements the `copysign` operation
-(decl rv_fsgnj (Type Reg Reg) Reg)
+(decl rv_fsgnj (Type FReg FReg) FReg)
 (rule (rv_fsgnj $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjS) $F32 rs1 rs2))
 (rule (rv_fsgnj $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fsgnjn` ("Floating Point Sign Injection Negated") instruction.
 ;; The output of this instruction is `rs1` with the negated sign bit from `rs2`
 ;; When `rs1 == rs2` this implements the `neg` operation
-(decl rv_fsgnjn (Type Reg Reg) Reg)
+(decl rv_fsgnjn (Type FReg FReg) FReg)
 (rule (rv_fsgnjn $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnS) $F32 rs1 rs2))
 (rule (rv_fsgnjn $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjnD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fneg` ("Floating Point Negate") instruction.
 ;; This instruction is a mnemonic for `fsgnjn rd, rs1, rs1`
-(decl rv_fneg (Type Reg) Reg)
+(decl rv_fneg (Type FReg) FReg)
 (rule (rv_fneg ty rs1) (rv_fsgnjn ty rs1 rs1))
 
 ;; Helper for emitting the `fsgnjx` ("Floating Point Sign Injection Exclusive") instruction.
 ;; The output of this instruction is `rs1` with the XOR of the sign bits from `rs1` and `rs2`.
 ;; When `rs1 == rs2` this implements `fabs`
-(decl rv_fsgnjx (Type Reg Reg) Reg)
+(decl rv_fsgnjx (Type FReg FReg) FReg)
 (rule (rv_fsgnjx $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxS) $F32 rs1 rs2))
 (rule (rv_fsgnjx $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FsgnjxD) $F64 rs1 rs2))
 
 ;; Helper for emitting the `fabs` ("Floating Point Absolute") instruction.
 ;; This instruction is a mnemonic for `fsgnjx rd, rs1, rs1`
-(decl rv_fabs (Type Reg) Reg)
+(decl rv_fabs (Type FReg) FReg)
 (rule (rv_fabs ty rs1) (rv_fsgnjx ty rs1 rs1))
 
 ;; Helper for emitting the `feq` ("Float Equal") instruction.
-(decl rv_feq (Type Reg Reg) Reg)
+(decl rv_feq (Type FReg FReg) XReg)
 (rule (rv_feq $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqS) $I64 rs1 rs2))
 (rule (rv_feq $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FeqD) $I64 rs1 rs2))
 
 ;; Helper for emitting the `flt` ("Float Less Than") instruction.
-(decl rv_flt (Type Reg Reg) Reg)
+(decl rv_flt (Type FReg FReg) XReg)
 (rule (rv_flt $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FltS) $I64 rs1 rs2))
 (rule (rv_flt $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FltD) $I64 rs1 rs2))
 
 ;; Helper for emitting the `fle` ("Float Less Than or Equal") instruction.
-(decl rv_fle (Type Reg Reg) Reg)
+(decl rv_fle (Type FReg FReg) XReg)
 (rule (rv_fle $F32 rs1 rs2) (fpu_rrr (FpuOPRRR.FleS) $I64 rs1 rs2))
 (rule (rv_fle $F64 rs1 rs2) (fpu_rrr (FpuOPRRR.FleD) $I64 rs1 rs2))
 
 ;; Helper for emitting the `fgt` ("Float Greater Than") instruction.
 ;; Note: The arguments are reversed
-(decl rv_fgt (Type Reg Reg) Reg)
+(decl rv_fgt (Type FReg FReg) XReg)
 (rule (rv_fgt ty rs1 rs2) (rv_flt ty rs2 rs1))
 
 ;; Helper for emitting the `fge` ("Float Greater Than or Equal") instruction.
 ;; Note: The arguments are reversed
-(decl rv_fge (Type Reg Reg) Reg)
+(decl rv_fge (Type FReg FReg) XReg)
 (rule (rv_fge ty rs1 rs2) (rv_fle ty rs2 rs1))
 
 
@@ -1297,20 +1375,20 @@
 
 ;; Helper for emitting the `adduw` ("Add Unsigned Word") instruction.
 ;; rd ← uext32(rs1) + uext32(rs2)
-(decl rv_adduw (Reg Reg) Reg)
+(decl rv_adduw (XReg XReg) XReg)
 (rule (rv_adduw rs1 rs2)
   (alu_rrr (AluOPRRR.Adduw) rs1 rs2))
 
 ;; Helper for emitting the `zext.w` ("Zero Extend Word") instruction.
 ;; This instruction is a mnemonic for `adduw rd, rs1, zero`.
 ;; rd ← uext32(rs1)
-(decl rv_zextw (Reg) Reg)
+(decl rv_zextw (XReg) XReg)
 (rule (rv_zextw rs1)
   (rv_adduw rs1 (zero_reg)))
 
 ;; Helper for emitting the `slli.uw` ("Shift Left Logical Immediate Unsigned Word") instruction.
 ;; rd ← uext32(rs1) << imm
-(decl rv_slliuw (Reg Imm12) Reg)
+(decl rv_slliuw (XReg Imm12) XReg)
 (rule (rv_slliuw rs1 imm)
   (alu_rr_imm12 (AluOPRRI.SlliUw) rs1 imm))
 
@@ -1319,83 +1397,83 @@
 
 ;; Helper for emitting the `andn` ("And Negated") instruction.
 ;; rd ← rs1 ∧ ~(rs2)
-(decl rv_andn (Reg Reg) Reg)
+(decl rv_andn (XReg XReg) XReg)
 (rule (rv_andn rs1 rs2)
   (alu_rrr (AluOPRRR.Andn) rs1 rs2))
 
 ;; Helper for emitting the `orn` ("Or Negated") instruction.
 ;; rd ← rs1 ∨ ~(rs2)
-(decl rv_orn (Reg Reg) Reg)
+(decl rv_orn (XReg XReg) XReg)
 (rule (rv_orn rs1 rs2)
   (alu_rrr (AluOPRRR.Orn) rs1 rs2))
 
 ;; Helper for emitting the `clz` ("Count Leading Zero Bits") instruction.
-(decl rv_clz (Reg) Reg)
+(decl rv_clz (XReg) XReg)
 (rule (rv_clz rs1)
   (alu_rr_funct12 (AluOPRRI.Clz) rs1))
 
 ;; Helper for emitting the `clzw` ("Count Leading Zero Bits in Word") instruction.
-(decl rv_clzw (Reg) Reg)
+(decl rv_clzw (XReg) XReg)
 (rule (rv_clzw rs1)
   (alu_rr_funct12 (AluOPRRI.Clzw) rs1))
 
 ;; Helper for emitting the `ctz` ("Count Trailing Zero Bits") instruction.
-(decl rv_ctz (Reg) Reg)
+(decl rv_ctz (XReg) XReg)
 (rule (rv_ctz rs1)
   (alu_rr_funct12 (AluOPRRI.Ctz) rs1))
 
 ;; Helper for emitting the `ctzw` ("Count Trailing Zero Bits in Word") instruction.
-(decl rv_ctzw (Reg) Reg)
+(decl rv_ctzw (XReg) XReg)
 (rule (rv_ctzw rs1)
   (alu_rr_funct12 (AluOPRRI.Ctzw) rs1))
 
 ;; Helper for emitting the `cpop` ("Count Population") instruction.
-(decl rv_cpop (Reg) Reg)
+(decl rv_cpop (XReg) XReg)
 (rule (rv_cpop rs1)
   (alu_rr_funct12 (AluOPRRI.Cpop) rs1))
 
 ;; Helper for emitting the `max` instruction.
-(decl rv_max (Reg Reg) Reg)
+(decl rv_max (XReg XReg) XReg)
 (rule (rv_max rs1 rs2)
   (alu_rrr (AluOPRRR.Max) rs1 rs2))
 
 ;; Helper for emitting the `sext.b` instruction.
-(decl rv_sextb (Reg) Reg)
+(decl rv_sextb (XReg) XReg)
 (rule (rv_sextb rs1)
   (alu_rr_imm12 (AluOPRRI.Sextb) rs1 (imm12_const 0)))
 
 ;; Helper for emitting the `sext.h` instruction.
-(decl rv_sexth (Reg) Reg)
+(decl rv_sexth (XReg) XReg)
 (rule (rv_sexth rs1)
   (alu_rr_imm12 (AluOPRRI.Sexth) rs1 (imm12_const 0)))
 
 ;; Helper for emitting the `zext.h` instruction.
-(decl rv_zexth (Reg) Reg)
+(decl rv_zexth (XReg) XReg)
 (rule (rv_zexth rs1)
   (alu_rr_imm12 (AluOPRRI.Zexth) rs1 (imm12_const 0)))
 
 ;; Helper for emitting the `rol` ("Rotate Left") instruction.
-(decl rv_rol (Reg Reg) Reg)
+(decl rv_rol (XReg XReg) XReg)
 (rule (rv_rol rs1 rs2)
   (alu_rrr (AluOPRRR.Rol) rs1 rs2))
 
 ;; Helper for emitting the `rolw` ("Rotate Left Word") instruction.
-(decl rv_rolw (Reg Reg) Reg)
+(decl rv_rolw (XReg XReg) XReg)
 (rule (rv_rolw rs1 rs2)
   (alu_rrr (AluOPRRR.Rolw) rs1 rs2))
 
 ;; Helper for emitting the `ror` ("Rotate Right") instruction.
-(decl rv_ror (Reg Reg) Reg)
+(decl rv_ror (XReg XReg) XReg)
 (rule (rv_ror rs1 rs2)
   (alu_rrr (AluOPRRR.Ror) rs1 rs2))
 
 ;; Helper for emitting the `rorw` ("Rotate Right Word") instruction.
-(decl rv_rorw (Reg Reg) Reg)
+(decl rv_rorw (XReg XReg) XReg)
 (rule (rv_rorw rs1 rs2)
   (alu_rrr (AluOPRRR.Rorw) rs1 rs2))
 
 ;; Helper for emitting the `rev8` ("Byte Reverse") instruction.
-(decl rv_rev8 (Reg) Reg)
+(decl rv_rev8 (XReg) XReg)
 (rule (rv_rev8 rs1)
   (alu_rr_funct12 (AluOPRRI.Rev8) rs1))
 
@@ -1403,12 +1481,12 @@
 ;; TODO: This instruction is mentioned in some older versions of the
 ;; spec, but has since disappeared, we should follow up on this.
 ;; It probably was renamed to `rev.b` which seems to be the closest match.
-(decl rv_brev8 (Reg) Reg)
+(decl rv_brev8 (XReg) XReg)
 (rule (rv_brev8 rs1)
   (alu_rr_funct12 (AluOPRRI.Brev8) rs1))
 
 ;; Helper for emitting the `bseti` ("Single-Bit Set Immediate") instruction.
-(decl rv_bseti (Reg Imm12) Reg)
+(decl rv_bseti (XReg Imm12) XReg)
 (rule (rv_bseti rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
 
@@ -1416,12 +1494,12 @@
 ;; `Zbkb` Extension Instructions
 
 ;; Helper for emitting the `pack` ("Pack low halves of registers") instruction.
-(decl rv_pack (Reg Reg) Reg)
+(decl rv_pack (XReg XReg) XReg)
 (rule (rv_pack rs1 rs2)
   (alu_rrr (AluOPRRR.Pack) rs1 rs2))
 
 ;; Helper for emitting the `packw` ("Pack low 16-bits of registers") instruction.
-(decl rv_packw (Reg Reg) Reg)
+(decl rv_packw (XReg XReg) XReg)
 (rule (rv_packw rs1 rs2)
   (alu_rrr (AluOPRRR.Packw) rs1 rs2))
 
@@ -1515,7 +1593,7 @@
 ;; Helper for emitting `MInst.AluRRR` instructions.
 (decl alu_rrr (AluOPRRR Reg Reg) Reg)
 (rule (alu_rrr op src1 src2)
-      (let ((dst WritableReg (temp_writable_reg $I64))
+      (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.AluRRR op dst src1 src2))))
         dst))
 
@@ -1542,7 +1620,7 @@
 ;; Helper for emitting `MInst.AluRRImm12` instructions.
 (decl alu_rr_imm12 (AluOPRRI Reg Imm12) Reg)
 (rule (alu_rr_imm12 op src imm)
-      (let ((dst WritableReg (temp_writable_reg $I64))
+      (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.AluRRImm12 op dst src imm))))
         dst))
 
@@ -1550,7 +1628,7 @@
 ;; so we don't need the imm12 paramter.
 (decl alu_rr_funct12 (AluOPRRI Reg) Reg)
 (rule (alu_rr_funct12 op src)
-      (let ((dst WritableReg (temp_writable_reg $I64))
+      (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.AluRRImm12 op dst src (imm12_zero)))))
         dst))
 
@@ -1561,17 +1639,19 @@
 
 (decl gen_bnot (Type ValueRegs) ValueRegs)
 (rule 2 (gen_bnot (ty_scalar_float ty) x)
-  (let ((tmp Reg (move_f_to_x x ty))
-        (tmp2 Reg (rv_not tmp)))
-    (move_x_to_f tmp2 (float_int_of_same_size ty))))
+  (let ((val FReg (value_regs_get x 0))
+        (x_val XReg (move_f_to_x val ty))
+        (inverted XReg (rv_not x_val))
+        (res FReg (move_x_to_f inverted (float_int_of_same_size ty))))
+    (value_reg res)))
 
 (rule 1 (gen_bnot $I128 x)
-  (let ((lo Reg (rv_not (value_regs_get x 0)))
-        (hi Reg (rv_not (value_regs_get x 1))))
+  (let ((lo XReg (rv_not (value_regs_get x 0)))
+        (hi XReg (rv_not (value_regs_get x 1))))
     (value_regs lo hi)))
 
 (rule 0 (gen_bnot (ty_int_ref_scalar_64 _) x)
-  (rv_not x))
+  (rv_not (value_regs_get x 0)))
 
 
 (decl gen_and (Type ValueRegs ValueRegs) ValueRegs)
@@ -1603,23 +1683,23 @@
 (rule
   (lower_bit_reverse r $I16)
   (let
-    ((tmp Reg (gen_brev8 r $I16))
-      (tmp2 Reg (gen_rev8 tmp))
-      (result Reg (rv_srli tmp2 (imm12_const 48))))
+    ((tmp XReg (gen_brev8 r $I16))
+      (tmp2 XReg (gen_rev8 tmp))
+      (result XReg (rv_srli tmp2 (imm12_const 48))))
     result))
 
 (rule
   (lower_bit_reverse r $I32)
   (let
-    ((tmp Reg (gen_brev8 r $I32))
-      (tmp2 Reg (gen_rev8 tmp))
-      (result Reg (rv_srli tmp2 (imm12_const 32))))
+    ((tmp XReg (gen_brev8 r $I32))
+      (tmp2 XReg (gen_rev8 tmp))
+      (result XReg (rv_srli tmp2 (imm12_const 32))))
     result))
 
 (rule
   (lower_bit_reverse r $I64)
   (let
-    ((tmp Reg (gen_rev8 r)))
+    ((tmp XReg (gen_rev8 r)))
     (gen_brev8 tmp $I64)))
 
 
@@ -1644,26 +1724,26 @@
 ;; We count both halves separately and conditionally add them if it makes sense.
 (decl lower_ctz_128 (ValueRegs) ValueRegs)
 (rule (lower_ctz_128 x)
-  (let ((x_lo Reg (value_regs_get x 0))
-        (x_hi Reg (value_regs_get x 1))
+  (let ((x_lo XReg (value_regs_get x 0))
+        (x_hi XReg (value_regs_get x 1))
         ;; Count both halves
-        (high Reg (lower_ctz $I64 x_hi))
-        (low Reg (lower_ctz $I64 x_lo))
+        (high XReg (lower_ctz $I64 x_hi))
+        (low XReg (lower_ctz $I64 x_lo))
         ;; Only add the top half if the bottom is zero
-        (high Reg (gen_select_reg (IntCC.Equal) x_lo (zero_reg) high (zero_reg)))
-        (result Reg (rv_add low high)))
-    (zext result $I64 $I128)))
+        (high XReg (gen_select_reg (IntCC.Equal) x_lo (zero_reg) high (zero_reg)))
+        (result XReg (rv_add low high)))
+    (extend result (ExtendOp.Zero) $I64 $I128)))
 
-(decl lower_clz (Type Reg) Reg)
+(decl lower_clz (Type XReg) XReg)
 (rule (lower_clz ty rs)
   (gen_cltz $true rs ty))
 
 (rule 1 (lower_clz (fits_in_16 ty) r)
   (if-let $true (has_zbb))
-  (let ((tmp Reg (zext r ty $I64))
-        (count Reg (rv_clz tmp))
+  (let ((tmp XReg (zext r ty $I64))
+        (count XReg (rv_clz tmp))
         ;; We always do the operation on the full 64-bit register, so subtract 64 from the result.
-        (result Reg (rv_addi count (imm12_const_add (ty_bits ty) -64))))
+        (result XReg (rv_addi count (imm12_const_add (ty_bits ty) -64))))
     result))
 
 (rule 2 (lower_clz $I32 r)
@@ -1679,22 +1759,22 @@
 ;; We count both halves separately and conditionally add them if it makes sense.
 (decl lower_clz_i128 (ValueRegs) ValueRegs)
 (rule (lower_clz_i128 x)
-  (let ((x_lo Reg (value_regs_get x 0))
-        (x_hi Reg (value_regs_get x 1))
+  (let ((x_lo XReg (value_regs_get x 0))
+        (x_hi XReg (value_regs_get x 1))
         ;; Count both halves
-        (high Reg (lower_clz $I64 x_hi))
-        (low Reg (lower_clz $I64 x_lo))
+        (high XReg (lower_clz $I64 x_hi))
+        (low XReg (lower_clz $I64 x_lo))
         ;; Only add the bottom zeros if the top half is zero
-        (low Reg (gen_select_reg (IntCC.Equal) x_hi (zero_reg) low (zero_reg)))
-        (result Reg (rv_add high low)))
-    (zext result $I64 $I128)))
+        (low XReg (gen_select_reg (IntCC.Equal) x_hi (zero_reg) low (zero_reg)))
+        (result XReg (rv_add high low)))
+    (extend result (ExtendOp.Zero) $I64 $I128)))
 
 
-(decl lower_cls (Type Reg) Reg)
+(decl lower_cls (Type XReg) XReg)
 (rule (lower_cls ty r)
-  (let ((tmp Reg (ext_int_if_need $true r ty))
-        (tmp2 Reg (gen_select_reg (IntCC.SignedLessThan) tmp (zero_reg) (rv_not tmp) tmp))
-        (tmp3 Reg (lower_clz ty tmp2)))
+  (let ((tmp XReg (sext r ty $I64))
+        (tmp2 XReg (gen_select_reg (IntCC.SignedLessThan) tmp (zero_reg) (rv_not tmp) tmp))
+        (tmp3 XReg (lower_clz ty tmp2)))
     (rv_addi tmp3 (imm12_const -1))))
 
 ;; If the sign bit is set, we count the leading zeros of the inverted value.
@@ -1702,21 +1782,21 @@
 ;; Subtract 1 since the sign bit does not count.
 (decl lower_cls_i128 (ValueRegs) ValueRegs)
 (rule (lower_cls_i128 x)
-  (let ((low Reg (value_regs_get x 0))
-        (high Reg (value_regs_get x 1))
-        (low Reg (gen_select_reg (IntCC.SignedLessThan) high (zero_reg) (rv_not low) low))
-        (high Reg (gen_select_reg (IntCC.SignedLessThan) high (zero_reg) (rv_not high) high))
+  (let ((low XReg (value_regs_get x 0))
+        (high XReg (value_regs_get x 1))
+        (low XReg (gen_select_reg (IntCC.SignedLessThan) high (zero_reg) (rv_not low) low))
+        (high XReg (gen_select_reg (IntCC.SignedLessThan) high (zero_reg) (rv_not high) high))
         (tmp ValueRegs (lower_clz_i128 (value_regs low high)))
-        (count Reg (value_regs_get tmp 0))
-        (result Reg (rv_addi count (imm12_const -1))))
-    (zext result $I64 $I128)))
+        (count XReg (value_regs_get tmp 0))
+        (result XReg (rv_addi count (imm12_const -1))))
+    (extend result (ExtendOp.Zero) $I64 $I128)))
 
 
-(decl gen_cltz (bool Reg Type) Reg)
+(decl gen_cltz (bool XReg Type) XReg)
 (rule (gen_cltz leading rs ty)
-  (let ((tmp WritableReg (temp_writable_reg $I64))
-        (step WritableReg (temp_writable_reg $I64))
-        (sum WritableReg (temp_writable_reg $I64))
+  (let ((tmp WritableXReg (temp_writable_xreg))
+        (step WritableXReg (temp_writable_xreg))
+        (sum WritableXReg (temp_writable_xreg))
         (_ Unit (emit (MInst.Cltz leading sum step tmp rs ty))))
     sum))
 
@@ -1725,21 +1805,21 @@
 (decl ext_int_if_need (bool ValueRegs Type) ValueRegs)
 ;;; For values smaller than 64 bits, we need to extend them to 64 bits
 (rule 0 (ext_int_if_need $true val (fits_in_32 (ty_int ty)))
-  (sext val ty $I64))
+  (extend val (ExtendOp.Signed) ty $I64))
 (rule 0 (ext_int_if_need $false val (fits_in_32 (ty_int ty)))
-  (zext val ty $I64))
+  (extend val (ExtendOp.Zero) ty $I64))
 ;; If the value is larger than one machine register, we don't need to do anything
 (rule 1 (ext_int_if_need _ r $I64) r)
 (rule 2 (ext_int_if_need _ r $I128) r)
 
 
 ;; Performs a zero extension of the given value
-(decl zext (ValueRegs Type Type) ValueRegs)
-(rule (zext val from_ty to_ty) (extend val (ExtendOp.Zero) from_ty to_ty))
+(decl zext (XReg Type Type) XReg)
+(rule (zext val from_ty (fits_in_64 to_ty)) (value_regs_get (extend val (ExtendOp.Zero) from_ty to_ty) 0))
 
 ;; Performs a signed extension of the given value
-(decl sext (ValueRegs Type Type) ValueRegs)
-(rule (sext val from_ty to_ty) (extend val (ExtendOp.Signed) from_ty to_ty))
+(decl sext (XReg Type Type) XReg)
+(rule (sext val from_ty (fits_in_64 to_ty)) (value_regs_get (extend val (ExtendOp.Signed) from_ty to_ty) 0))
 
 (type ExtendOp
   (enum
@@ -1757,22 +1837,22 @@
 ;; In the most generic case, we shift left and then shift right.
 ;; The type of right shift is determined by the extend op.
 (rule 0 (extend val extend_op (fits_in_32 from_ty) (fits_in_64 to_ty))
-  (let ((val Reg (value_regs_get val 0))
+  (let ((val XReg (value_regs_get val 0))
         (shift Imm12 (imm_from_bits (u64_sub 64 (ty_bits from_ty))))
-        (left Reg (rv_slli val shift))
+        (left XReg (rv_slli val shift))
         (shift_op AluOPRRI (extend_shift_op extend_op))
-        (right Reg (alu_rr_imm12 shift_op left shift)))
+        (right XReg (alu_rr_imm12 shift_op left shift)))
     right))
 
 ;; If we are zero extending a U8 we can use a `andi` instruction.
 (rule 1 (extend val (ExtendOp.Zero) $I8 (fits_in_64 to_ty))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_andi val (imm12_const 255))))
 
 ;; When signed extending from 32 to 64 bits we can use a
 ;; `addiw val 0`. Also known as a `sext.w`
 (rule 1 (extend val (ExtendOp.Signed) $I32 $I64)
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_sextw val)))
 
 
@@ -1782,54 +1862,54 @@
 ;; If we have the `zbkb` extension `packw` can be used to zero extend 16 bit values
 (rule 1 (extend val (ExtendOp.Zero) $I16 (fits_in_64 _))
   (if-let $true (has_zbkb))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_packw val (zero_reg))))
 
 ;; If we have the `zbkb` extension `pack` can be used to zero extend 32 bit registers
 (rule 1 (extend val (ExtendOp.Zero) $I32 $I64)
   (if-let $true (has_zbkb))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_pack val (zero_reg))))
 
 
 ;; If we have the `zbb` extension we can use the dedicated `sext.b` instruction.
 (rule 1 (extend val (ExtendOp.Signed) $I8 (fits_in_64 _))
   (if-let $true (has_zbb))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_sextb val)))
 
 ;; If we have the `zbb` extension we can use the dedicated `sext.h` instruction.
 (rule 1 (extend val (ExtendOp.Signed) $I16 (fits_in_64 _))
   (if-let $true (has_zbb))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_sexth val)))
 
 ;; If we have the `zbb` extension we can use the dedicated `zext.h` instruction.
 (rule 2 (extend val (ExtendOp.Zero) $I16 (fits_in_64 _))
   (if-let $true (has_zbb))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_zexth val)))
 
 ;; With `zba` we have a `zext.w` instruction
 (rule 2 (extend val (ExtendOp.Zero) $I32 $I64)
   (if-let $true (has_zba))
-  (let ((val Reg (value_regs_get val 0)))
+  (let ((val XReg (value_regs_get val 0)))
     (rv_zextw val)))
 
 ;;; Signed rules extending to I128
 ;; Extend the bottom part, and extract the sign bit from the bottom as the top
 (rule 3 (extend val (ExtendOp.Signed) (fits_in_64 from_ty) $I128)
-  (let ((val Reg (value_regs_get val 0))
-        (low Reg (extend val (ExtendOp.Signed) from_ty $I64))
-        (high Reg (rv_srai low (imm12_const 63))))
+  (let ((val XReg (value_regs_get val 0))
+        (low XReg (sext val from_ty $I64))
+        (high XReg (rv_srai low (imm12_const 63))))
     (value_regs low high)))
 
 ;;; Unsigned rules extending to I128
 ;; Extend the bottom register to I64 and then just zero out the top half.
 (rule 3 (extend val (ExtendOp.Zero) (fits_in_64 from_ty) $I128)
-  (let ((val Reg (value_regs_get val 0))
-        (low Reg (extend val (ExtendOp.Zero) from_ty $I64))
-        (high Reg (load_u64_constant 0)))
+  (let ((val XReg (value_regs_get val 0))
+        (low XReg (zext val from_ty $I64))
+        (high XReg (load_u64_constant 0)))
     (value_regs low high)))
 
 ;; Catch all rule for ignoring extensions of the same type.
@@ -1842,23 +1922,21 @@
   (lower_b128_binary op a b)
   (let
     ( ;; low part.
-      (low Reg (alu_rrr op (value_regs_get a 0) (value_regs_get b 0)))
+      (low XReg (alu_rrr op (value_regs_get a 0) (value_regs_get b 0)))
       ;; high part.
-      (high Reg (alu_rrr op (value_regs_get a 1) (value_regs_get b 1))))
+      (high XReg (alu_rrr op (value_regs_get a 1) (value_regs_get b 1))))
     (value_regs low high)))
 
-(decl lower_umlhi (Type Reg Reg) Reg)
-(rule 1
-  (lower_umlhi $I64 rs1 rs2)
+(decl lower_umlhi (Type XReg XReg) XReg)
+(rule 1 (lower_umlhi $I64 rs1 rs2)
   (rv_mulhu rs1 rs2))
 
-(rule
-  (lower_umlhi ty rs1 rs2)
+(rule (lower_umlhi ty rs1 rs2)
   (let
-    ((tmp Reg (rv_mul (ext_int_if_need $false rs1 ty) (ext_int_if_need $false rs2 ty))))
+    ((tmp XReg (rv_mul (zext rs1 ty $I64) (zext rs2 ty $I64))))
     (rv_srli tmp (imm12_const (ty_bits ty)))))
 
-(decl lower_smlhi (Type Reg Reg) Reg)
+(decl lower_smlhi (Type XReg XReg) XReg)
 (rule 1
   (lower_smlhi $I64 rs1 rs2)
   (rv_mulh rs1 rs2))
@@ -1866,11 +1944,11 @@
 (rule
   (lower_smlhi ty rs1 rs2)
   (let
-    ((tmp Reg (rv_mul rs1 rs2)))
+    ((tmp XReg (rv_mul rs1 rs2)))
     (rv_srli tmp (imm12_const (ty_bits ty)))))
 
 
-(decl lower_rotl (Type Reg Reg) Reg)
+(decl lower_rotl (Type XReg XReg) XReg)
 
 (rule 1
   (lower_rotl $I64 rs amount)
@@ -1897,7 +1975,7 @@
   (lower_rotl_shift ty rs amount))
 
 ;;; using shift to implement rotl.
-(decl lower_rotl_shift (Type Reg Reg) Reg)
+(decl lower_rotl_shift (Type XReg XReg) XReg)
 
 ;;; for I8 and I16 ...
 (rule
@@ -1917,10 +1995,10 @@
 ;;;; construct shift amount.rotl on i128 will use shift to implement. So can call this function.
 ;;;; this will return shift amount and (ty_bits - "shift amount")
 ;;;; if ty_bits is greater than 64 like i128, then shmat will fallback to 64.because We are 64 bit platform.
-(decl gen_shamt (Type Reg) ValueRegs)
+(decl gen_shamt (Type XReg) ValueRegs)
 (extern constructor gen_shamt gen_shamt)
 
-(decl lower_rotr (Type Reg Reg) Reg)
+(decl lower_rotr (Type XReg XReg) XReg)
 
 (rule 1
   (lower_rotr $I64 rs amount)
@@ -1945,21 +2023,21 @@
   (lower_rotr ty rs amount)
   (lower_rotr_shift ty rs amount))
 
-(decl lower_rotr_shift (Type Reg Reg) Reg)
+(decl lower_rotr_shift (Type XReg XReg) XReg)
 
 ;;;
 (rule
   (lower_rotr_shift ty rs amount)
   (let
     ((x ValueRegs (gen_shamt ty amount))
-      (shamt Reg (value_regs_get x 0))
-      (len_sub_shamt Reg (value_regs_get x 1))
+      (shamt XReg (value_regs_get x 0))
+      (len_sub_shamt XReg (value_regs_get x 1))
       ;;
-      (part1 Reg (rv_srl rs shamt))
+      (part1 XReg (rv_srl rs shamt))
       ;;
-      (part2 Reg (rv_sll rs len_sub_shamt))
+      (part2 XReg (rv_sll rs len_sub_shamt))
       ;;
-      (part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) part2)))
+      (part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) part2)))
     (rv_or part1 part3)))
 
 
@@ -1969,7 +2047,7 @@
 (rule (gen_bseti val bit)
   (if-let $false (has_zbs))
   (if-let $false (u64_le bit 12))
-  (let ((const Reg (load_u64_constant (u64_shl 1 bit))))
+  (let ((const XReg (load_u64_constant (u64_shl 1 bit))))
     (rv_or val const)))
 
 (rule (gen_bseti val bit)
@@ -1986,16 +2064,17 @@
 (rule
   (gen_popcnt rs ty)
   (let
-    ((tmp WritableReg (temp_writable_reg $I64))
-      (step WritableReg (temp_writable_reg $I64))
-      (sum WritableReg (temp_writable_reg $I64))
+    ((tmp WritableXReg (temp_writable_xreg))
+      (step WritableXReg (temp_writable_xreg))
+      (sum WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Popcnt sum step tmp rs ty))))
     (writable_reg_to_reg sum)))
 
-(decl lower_popcnt (Reg Type) Reg)
+(decl lower_popcnt (XReg Type) XReg)
 (rule 1 (lower_popcnt rs ty)
   (if-let $true (has_zbb))
-  (rv_cpop (ext_int_if_need $false rs ty)))
+  (rv_cpop (zext rs ty $I64)))
+
 (rule (lower_popcnt rs ty)
   (if-let $false (has_zbb))
   (gen_popcnt rs ty))
@@ -2005,11 +2084,11 @@
   (lower_popcnt_i128 a)
   (let
     ( ;; low part.
-      (low Reg (lower_popcnt (value_regs_get a 0) $I64))
+      (low XReg (lower_popcnt (value_regs_get a 0) $I64))
       ;; high part.
-      (high Reg (lower_popcnt (value_regs_get a 1) $I64))
+      (high XReg (lower_popcnt (value_regs_get a 1) $I64))
       ;; add toghter.
-      (result Reg (rv_add low high)))
+      (result XReg (rv_add low high)))
     (value_regs result (load_u64_constant 0))))
 
 (decl lower_i128_rotl (ValueRegs ValueRegs) ValueRegs)
@@ -2017,22 +2096,22 @@
   (lower_i128_rotl x y)
   (let
     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-      (shamt Reg (value_regs_get tmp 0))
-      (len_sub_shamt Reg (value_regs_get tmp 1))
+      (shamt XReg (value_regs_get tmp 0))
+      (len_sub_shamt XReg (value_regs_get tmp 1))
       ;;
-      (low_part1 Reg (rv_sll (value_regs_get x 0) shamt))
-      (low_part2 Reg (rv_srl (value_regs_get x 1) len_sub_shamt))
+      (low_part1 XReg (rv_sll (value_regs_get x 0) shamt))
+      (low_part2 XReg (rv_srl (value_regs_get x 1) len_sub_shamt))
       ;;; if shamt == 0 low_part2 will overflow we should zero instead.
-      (low_part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
-      (low Reg (rv_or low_part1 low_part3))
+      (low_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
+      (low XReg (rv_or low_part1 low_part3))
       ;;
-      (high_part1 Reg (rv_sll (value_regs_get x 1) shamt))
-      (high_part2 Reg (rv_srl (value_regs_get x 0) len_sub_shamt))
-      (high_part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
-      (high Reg (rv_or high_part1 high_part3))
+      (high_part1 XReg (rv_sll (value_regs_get x 1) shamt))
+      (high_part2 XReg (rv_srl (value_regs_get x 0) len_sub_shamt))
+      (high_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
+      (high XReg (rv_or high_part1 high_part3))
       ;;
-      (const64 Reg (load_u64_constant 64))
-      (shamt_128 Reg (rv_andi (value_regs_get y 0) (imm12_const 127))))
+      (const64 XReg (load_u64_constant 64))
+      (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     ;; right now we only rotate less than 64 bits.
     ;; if shamt is greater than or equal 64 , we should switch low and high.
     (value_regs
@@ -2046,23 +2125,23 @@
   (lower_i128_rotr x y)
   (let
     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-      (shamt Reg (value_regs_get tmp 0))
-      (len_sub_shamt Reg (value_regs_get tmp 1))
+      (shamt XReg (value_regs_get tmp 0))
+      (len_sub_shamt XReg (value_regs_get tmp 1))
       ;;
-      (low_part1 Reg (rv_srl (value_regs_get x 0) shamt))
-      (low_part2 Reg (rv_sll (value_regs_get x 1) len_sub_shamt))
+      (low_part1 XReg (rv_srl (value_regs_get x 0) shamt))
+      (low_part2 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
       ;;; if shamt == 0 low_part2 will overflow we should zero instead.
-      (low_part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
-      (low Reg (rv_or low_part1 low_part3))
+      (low_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part2))
+      (low XReg (rv_or low_part1 low_part3))
       ;;
-      (high_part1 Reg (rv_srl (value_regs_get x 1) shamt))
-      (high_part2 Reg (rv_sll (value_regs_get x 0) len_sub_shamt))
-      (high_part3 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
-      (high Reg (rv_or high_part1 high_part3))
+      (high_part1 XReg (rv_srl (value_regs_get x 1) shamt))
+      (high_part2 XReg (rv_sll (value_regs_get x 0) len_sub_shamt))
+      (high_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
+      (high XReg (rv_or high_part1 high_part3))
 
       ;;
-      (const64 Reg (load_u64_constant 64))
-      (shamt_128 Reg (rv_andi (value_regs_get y 0) (imm12_const 127))))
+      (const64 XReg (load_u64_constant 64))
+      (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     ;; right now we only rotate less than 64 bits.
     ;; if shamt is greater than or equal 64 , we should switch low and high.
     (value_regs
@@ -2076,19 +2155,19 @@
   (lower_i128_ishl x y)
   (let
     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-      (shamt Reg (value_regs_get tmp 0))
-      (len_sub_shamt Reg (value_regs_get tmp 1))
+      (shamt XReg (value_regs_get tmp 0))
+      (len_sub_shamt XReg (value_regs_get tmp 1))
       ;;
-      (low Reg (rv_sll (value_regs_get x 0) shamt))
+      (low XReg (rv_sll (value_regs_get x 0) shamt))
       ;; high part.
-      (high_part1 Reg (rv_srl (value_regs_get x 0) len_sub_shamt))
-      (high_part2 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part1))
+      (high_part1 XReg (rv_srl (value_regs_get x 0) len_sub_shamt))
+      (high_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part1))
       ;;
-      (high_part3 Reg (rv_sll (value_regs_get x 1) shamt))
-      (high Reg (rv_or high_part2 high_part3 ))
+      (high_part3 XReg (rv_sll (value_regs_get x 1) shamt))
+      (high XReg (rv_or high_part2 high_part3 ))
       ;;
-      (const64 Reg (load_u64_constant 64))
-      (shamt_128 Reg (rv_andi (value_regs_get y 0) (imm12_const 127))))
+      (const64 XReg (load_u64_constant 64))
+      (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     (value_regs
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 (zero_reg) low)
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 low high))))
@@ -2098,21 +2177,21 @@
   (lower_i128_ushr x y)
   (let
     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-      (shamt Reg (value_regs_get tmp 0))
-      (len_sub_shamt Reg (value_regs_get tmp 1))
+      (shamt XReg (value_regs_get tmp 0))
+      (len_sub_shamt XReg (value_regs_get tmp 1))
 
       ;; low part.
-      (low_part1 Reg (rv_sll (value_regs_get x 1) len_sub_shamt))
-      (low_part2 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
+      (low_part1 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
+      (low_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
       ;;
-      (low_part3 Reg (rv_srl (value_regs_get x 0) shamt))
-      (low Reg (rv_or low_part2 low_part3 ))
+      (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
+      (low XReg (rv_or low_part2 low_part3 ))
       ;;
-      (const64 Reg (load_u64_constant 64))
+      (const64 XReg (load_u64_constant 64))
 
       ;;
-      (high Reg (rv_srl (value_regs_get x 1) shamt))
-      (shamt_128 Reg (rv_andi (value_regs_get y 0) (imm12_const 127))))
+      (high XReg (rv_srl (value_regs_get x 1) shamt))
+      (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     (value_regs
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 (zero_reg) high))))
@@ -2123,25 +2202,25 @@
   (lower_i128_sshr x y)
   (let
     ((tmp ValueRegs (gen_shamt $I128 (value_regs_get y 0)))
-      (shamt Reg (value_regs_get tmp 0))
-      (len_sub_shamt Reg (value_regs_get tmp 1))
+      (shamt XReg (value_regs_get tmp 0))
+      (len_sub_shamt XReg (value_regs_get tmp 1))
 
       ;; low part.
-      (low_part1 Reg (rv_sll (value_regs_get x 1) len_sub_shamt))
-      (low_part2 Reg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
+      (low_part1 XReg (rv_sll (value_regs_get x 1) len_sub_shamt))
+      (low_part2 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) low_part1))
       ;;
-      (low_part3 Reg (rv_srl (value_regs_get x 0) shamt))
-      (low Reg (rv_or low_part2 low_part3 ))
+      (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
+      (low XReg (rv_or low_part2 low_part3 ))
       ;;
-      (const64 Reg (load_u64_constant 64))
+      (const64 XReg (load_u64_constant 64))
       ;;
-      (high Reg (rv_sra (value_regs_get x 1) shamt))
+      (high XReg (rv_sra (value_regs_get x 1) shamt))
       ;;
-      (const_neg_1 Reg (load_imm12 -1))
+      (const_neg_1 XReg (load_imm12 -1))
       ;;
-      (high_replacement Reg (gen_select_reg (IntCC.SignedLessThan) (value_regs_get x 1) (zero_reg) const_neg_1 (zero_reg)))
-      (const64 Reg (load_u64_constant 64))
-      (shamt_128 Reg (rv_andi (value_regs_get y 0) (imm12_const 127))))
+      (high_replacement XReg (gen_select_reg (IntCC.SignedLessThan) (value_regs_get x 1) (zero_reg) const_neg_1 (zero_reg)))
+      (const64 XReg (load_u64_constant 64))
+      (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     (value_regs
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high_replacement high))))
@@ -2204,7 +2283,7 @@
 (rule
   (gen_atomic op addr src amo)
   (let
-    ((tmp WritableReg (temp_writable_reg $I64))
+    ((tmp WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Atomic op tmp addr src amo))))
     tmp))
 
@@ -2290,7 +2369,7 @@
 (rule
   (gen_atomic_load p ty)
   (let
-    ((tmp WritableReg (temp_writable_reg $I64))
+    ((tmp WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.AtomicLoad tmp ty p))))
     (writable_reg_to_reg tmp)))
 
@@ -2302,7 +2381,7 @@
 )
 
 
-(decl gen_stack_addr (StackSlot Offset32) Reg )
+(decl gen_stack_addr (StackSlot Offset32) Reg)
 (extern constructor gen_stack_addr gen_stack_addr)
 
 ;;
@@ -2317,7 +2396,7 @@
     (vec_writable_to_regs reuslt)))
 
 ;; Parameters are "intcc compare_a compare_b rs1 rs2".
-(decl gen_select_reg (IntCC Reg Reg Reg Reg) Reg)
+(decl gen_select_reg (IntCC XReg XReg XReg XReg) XReg)
 (extern constructor gen_select_reg gen_select_reg)
 
 ;; load a constant into reg.
@@ -2391,25 +2470,25 @@
 (extern constructor int_convert_2_float_op int_convert_2_float_op)
 
 ;;;;
-(decl gen_fcvt_int (bool Reg bool Type Type) Reg)
+(decl gen_fcvt_int (bool FReg bool Type Type) XReg)
 (rule
   (gen_fcvt_int is_sat rs is_signed in_type out_type)
   (let
     ((result WritableReg (temp_writable_reg out_type))
-      (tmp WritableReg (temp_writable_reg $F64))
+      (tmp WritableFReg (temp_writable_freg))
       (_ Unit (emit (MInst.FcvtToInt is_sat result tmp rs is_signed in_type out_type))))
-    result))
+    (writable_reg_to_reg result)))
 
 ;;; some float binary operation
 ;;; 1. need move into x reister.
 ;;; 2. do the operation.
 ;;; 3. move back.
-(decl lower_float_binary (AluOPRRR Reg Reg Type) Reg)
+(decl lower_float_binary (AluOPRRR FReg FReg Type) FReg)
 (rule
   (lower_float_binary op rs1 rs2 ty)
-  (let ((x_rs1 Reg (move_f_to_x rs1 ty))
-        (x_rs2 Reg (move_f_to_x rs2 ty))
-        (tmp Reg (alu_rrr op x_rs1 x_rs2)))
+  (let ((x_rs1 XReg (move_f_to_x rs1 ty))
+        (x_rs2 XReg (move_f_to_x rs2 ty))
+        (tmp XReg (alu_rrr op x_rs1 x_rs2)))
     (move_x_to_f tmp (float_int_of_same_size ty))))
 
 
@@ -2427,31 +2506,31 @@
   (i128_sub x y )
   (let
     (;; low part.
-      (low Reg (rv_sub (value_regs_get x 0) (value_regs_get y 0)))
+      (low XReg (rv_sub (value_regs_get x 0) (value_regs_get y 0)))
       ;; compute borrow.
-      (borrow Reg (rv_sltu (value_regs_get x 0) low))
+      (borrow XReg (rv_sltu (value_regs_get x 0) low))
       ;;
-      (high_tmp Reg (rv_sub (value_regs_get x 1) (value_regs_get y 1)))
+      (high_tmp XReg (rv_sub (value_regs_get x 1) (value_regs_get y 1)))
       ;;
-      (high Reg (rv_sub high_tmp borrow)))
+      (high XReg (rv_sub high_tmp borrow)))
     (value_regs low high)))
 
 
 ;;; Returns the sum in the first register, and the overflow test in the second.
-(decl lower_uadd_overflow (Reg Reg Type) ValueRegs)
+(decl lower_uadd_overflow (XReg XReg Type) ValueRegs)
 
 (rule 1
   (lower_uadd_overflow x y $I64)
-  (let ((tmp Reg (rv_add x y))
-        (test Reg (gen_icmp (IntCC.UnsignedLessThan) tmp x $I64)))
+  (let ((tmp XReg (rv_add x y))
+        (test XReg (gen_icmp (IntCC.UnsignedLessThan) tmp x $I64)))
     (value_regs tmp test)))
 
 (rule
   (lower_uadd_overflow x y (fits_in_32 ty))
-  (let ((tmp_x Reg (ext_int_if_need $false x ty))
-        (tmp_y Reg (ext_int_if_need $false y ty))
-        (sum Reg (rv_add tmp_x tmp_y))
-        (test Reg (rv_srli sum (imm12_const (ty_bits ty)))))
+  (let ((tmp_x XReg (zext x ty $I64))
+        (tmp_y XReg (zext y ty $I64))
+        (sum XReg (rv_add tmp_x tmp_y))
+        (test XReg (rv_srli sum (imm12_const (ty_bits ty)))))
     (value_regs sum test)))
 
 (decl label_to_br_target (MachLabel) BranchTarget)
@@ -2504,12 +2583,12 @@
 ;; Convert a truthy value, possibly of more than one register (an
 ;; I128), to one register. If narrower than 64 bits, must have already
 ;; been masked (e.g. by `normalize_cmp_value`).
-(decl truthy_to_reg (Type ValueRegs) Reg)
+(decl truthy_to_reg (Type ValueRegs) XReg)
 (rule 1 (truthy_to_reg (fits_in_64 _) regs)
       (value_regs_get regs 0))
 (rule 0 (truthy_to_reg $I128 regs)
-      (let ((lo Reg (value_regs_get regs 0))
-            (hi Reg (value_regs_get regs 1)))
+      (let ((lo XReg (value_regs_get regs 0))
+            (hi XReg (value_regs_get regs 1)))
         (rv_or lo hi)))
 
 ;; Default behavior for branching based on an input value.
@@ -2521,7 +2600,7 @@
 (rule 2
   (lower_branch (brif v @ (value_type $I128) _ _) targets)
   (let ((zero ValueRegs (value_regs (zero_reg) (zero_reg)))
-        (cmp Reg (gen_icmp (IntCC.NotEqual) v zero $I128)))
+        (cmp XReg (gen_icmp (IntCC.NotEqual) v zero $I128)))
     (lower_cond_br (IntCC.NotEqual) cmp targets $I64)))
 
 ;; Branching on the result of an icmp
@@ -2565,11 +2644,11 @@
 (rule 1 (gen_bitcast r $I64 $F64) (rv_fmvdx r))
 (rule (gen_bitcast r _ _) r)
 
-(decl move_f_to_x (Reg Type) Reg)
+(decl move_f_to_x (FReg Type) XReg)
 (rule (move_f_to_x r $F32) (gen_bitcast r $F32 $I32))
 (rule (move_f_to_x r $F64) (gen_bitcast r $F64 $I64))
 
-(decl move_x_to_f (Reg Type) Reg)
+(decl move_x_to_f (XReg Type) FReg)
 (rule (move_x_to_f r $I32) (gen_bitcast r $I32 $F32))
 (rule (move_x_to_f r $I64) (gen_bitcast r $I64 $F64))
 
@@ -2578,7 +2657,7 @@
 (rule (float_int_of_same_size $F64) $I64)
 
 
-(decl gen_rev8 (Reg) Reg)
+(decl gen_rev8 (XReg) XReg)
 (rule 1
   (gen_rev8 rs)
   (if-let $true (has_zbb))
@@ -2588,9 +2667,9 @@
   (gen_rev8 rs)
   (if-let $false (has_zbb))
   (let
-    ((rd WritableReg (temp_writable_reg $I64))
-      (tmp WritableReg (temp_writable_reg $I64))
-      (step WritableReg (temp_writable_reg $I64))
+    ((rd WritableXReg (temp_writable_xreg))
+      (tmp WritableXReg (temp_writable_xreg))
+      (step WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Rev8 rs step tmp rd))))
     (writable_reg_to_reg rd)))
 
@@ -2604,10 +2683,10 @@
   (gen_brev8 rs ty)
   (if-let $false (has_zbkb))
   (let
-    ((tmp WritableReg (temp_writable_reg $I64))
-      (tmp2 WritableReg (temp_writable_reg $I64))
-      (step WritableReg (temp_writable_reg $I64))
-      (rd WritableReg (temp_writable_reg $I64))
+    ((tmp WritableXReg (temp_writable_xreg))
+      (tmp2 WritableXReg (temp_writable_xreg))
+      (step WritableXReg (temp_writable_xreg))
+      (rd WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Brev8 rs ty step tmp tmp2 rd))))
     (writable_reg_to_reg rd)))
 
@@ -2623,7 +2702,7 @@
 
 
 ;; Selects the greatest of two registers as signed values.
-(decl max (Type Reg Reg) Reg)
+(decl max (Type XReg XReg) XReg)
 (rule (max (fits_in_64 (ty_int ty)) x y)
   (if-let $true (has_zbb))
   (rv_max x y))
@@ -2633,7 +2712,7 @@
   (gen_select_reg (IntCC.SignedGreaterThan) x y x y))
 
 
-(decl lower_iabs (Type Reg) Reg)
+(decl lower_iabs (Type XReg) XReg)
 
 ; I64 and lower
 ; Generate the following code:
@@ -2641,37 +2720,37 @@
 ;   neg a1, a0
 ;   max a0, a0, a1
 (rule (lower_iabs (fits_in_64 ty) val)
-  (let ((extended Reg (ext_int_if_need $true val ty))
-        (negated Reg (neg $I64 extended)))
+  (let ((extended XReg (sext val ty $I64))
+        (negated XReg (rv_neg extended)))
     (max $I64 extended negated)))
 
-(decl gen_trapif (Reg TrapCode) InstOutput)
+(decl gen_trapif (XReg TrapCode) InstOutput)
 (rule
   (gen_trapif test trap_code)
   (side_effect (SideEffectNoResult.Inst (MInst.TrapIf test trap_code))))
 
-(decl gen_trapifc (IntCC Reg Reg TrapCode) InstOutput)
+(decl gen_trapifc (IntCC XReg XReg TrapCode) InstOutput)
 (rule
   (gen_trapifc cc a b trap_code)
   (side_effect (SideEffectNoResult.Inst (MInst.TrapIfC a b cc trap_code))))
 
-(decl shift_int_to_most_significant (Reg Type) Reg)
+(decl shift_int_to_most_significant (XReg Type) XReg)
 (extern constructor shift_int_to_most_significant shift_int_to_most_significant)
 
 ;;; generate div overflow.
-(decl gen_div_overflow (Reg Reg Type) InstOutput)
+(decl gen_div_overflow (XReg XReg Type) InstOutput)
 (rule
   (gen_div_overflow rs1 rs2 ty)
   (let
-    ((r_const_neg_1 Reg (load_imm12 -1))
-      (r_const_min Reg (rv_slli (load_imm12 1) (imm12_const 63)))
-      (tmp_rs1 Reg (shift_int_to_most_significant rs1 ty))
-      (t1 Reg (gen_icmp (IntCC.Equal) r_const_neg_1 rs2 ty))
-      (t2 Reg (gen_icmp (IntCC.Equal) r_const_min tmp_rs1 ty))
-      (test Reg (rv_and t1 t2)))
+    ((r_const_neg_1 XReg (load_imm12 -1))
+      (r_const_min XReg (rv_slli (load_imm12 1) (imm12_const 63)))
+      (tmp_rs1 XReg (shift_int_to_most_significant rs1 ty))
+      (t1 XReg (gen_icmp (IntCC.Equal) r_const_neg_1 rs2 ty))
+      (t2 XReg (gen_icmp (IntCC.Equal) r_const_min tmp_rs1 ty))
+      (test XReg (rv_and t1 t2)))
     (gen_trapif test (TrapCode.IntegerOverflow))))
 
-(decl gen_div_by_zero (Reg) InstOutput)
+(decl gen_div_by_zero (XReg) InstOutput)
 (rule
   (gen_div_by_zero r)
   (gen_trapifc (IntCC.Equal) (zero_reg) r (TrapCode.IntegerDivisionByZero)))
@@ -2685,11 +2764,11 @@
 (extern constructor gen_call_indirect gen_call_indirect)
 
 ;;; this is trying to imitate aarch64 `madd` instruction.
-(decl madd (Reg Reg Reg) Reg)
+(decl madd (XReg XReg XReg) XReg)
 (rule
   (madd n m a)
   (let
-    ((t Reg (rv_mul n m)))
+    ((t XReg (rv_mul n m)))
     (rv_add t a)))
 
 ;;;; Helpers for bmask ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2702,8 +2781,8 @@
 (rule
   0
   (lower_bmask (fits_in_64 _) (fits_in_64 in_ty) val)
-  (let ((input Reg (normalize_cmp_value in_ty val (ExtendOp.Zero)))
-        (non_zero Reg (rv_snez input)))
+  (let ((input XReg (truthy_to_reg in_ty (normalize_cmp_value in_ty val (ExtendOp.Zero))))
+        (non_zero XReg (rv_snez input)))
     (value_reg (rv_neg non_zero))))
 
 ;; Bitwise-or the two registers that make up the 128-bit value, then recurse as
@@ -2711,9 +2790,9 @@
 (rule
   1
   (lower_bmask (fits_in_64 ty) $I128 val)
-  (let ((lo Reg (value_regs_get val 0))
-        (hi Reg (value_regs_get val 1))
-        (combined Reg (rv_or lo hi)))
+  (let ((lo XReg (value_regs_get val 0))
+        (hi XReg (value_regs_get val 1))
+        (combined XReg (rv_or lo hi)))
     (lower_bmask ty $I64 (value_reg combined))))
 
 ;; Conversion of one 64-bit value to a 128-bit one. Duplicate the result of the
@@ -2740,7 +2819,7 @@
 
 (rule
   (gen_mov_from_preg rm)
-  (let ((rd WritableReg (temp_writable_reg $I64))
+  (let ((rd WritableXReg (temp_writable_xreg))
         (_ Unit (emit (MInst.MovFromPReg rd rm))))
     rd))
 
@@ -2764,28 +2843,28 @@
 
 ;;;; Helpers for floating point comparisons ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl not (Reg) Reg)
+(decl not (XReg) XReg)
 (rule (not x) (rv_xori x (imm_from_bits 1)))
 
-(decl is_not_nan (Type Reg) Reg)
+(decl is_not_nan (Type FReg) XReg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
-(decl ordered (Type Reg Reg) Reg)
+(decl ordered (Type FReg FReg) XReg)
 (rule (ordered ty a b) (rv_and (is_not_nan ty a) (is_not_nan ty b)))
 
 (type CmpResult (enum
                   (Result
-                    (result Reg)
+                    (result XReg)
                     (invert bool))))
 
 ;; Wrapper for the common case when constructing comparison results. It assumes
 ;; that the result isn't negated.
-(decl cmp_result (Reg) CmpResult)
+(decl cmp_result (XReg) CmpResult)
 (rule (cmp_result result) (CmpResult.Result result $false))
 
 ;; Wrapper for the case where it's more convenient to construct the negated
 ;; version of the comparison.
-(decl cmp_result_invert (Reg) CmpResult)
+(decl cmp_result_invert (XReg) CmpResult)
 (rule (cmp_result_invert result) (CmpResult.Result result $true))
 
 ;; Consume a CmpResult, producing a branch on its result.
@@ -2795,7 +2874,7 @@
         (MInst.CondBr then else (cmp_integer_compare cmp))))
 
 ;; Construct an IntegerCompare value.
-(decl int_compare (IntCC Reg Reg) IntegerCompare)
+(decl int_compare (IntCC XReg XReg) IntegerCompare)
 (extern constructor int_compare int_compare)
 
 ;; Convert a comparison into a branch test.
@@ -2810,12 +2889,12 @@
   (int_compare (IntCC.Equal) res (zero_reg)))
 
 ;; Convert a comparison into a boolean value.
-(decl cmp_value (CmpResult) Reg)
+(decl cmp_value (CmpResult) XReg)
 (rule (cmp_value (CmpResult.Result res $false)) res)
 (rule (cmp_value (CmpResult.Result res $true)) (not res))
 
 ;; Compare two floating point numbers and return a zero/non-zero result.
-(decl emit_fcmp (FloatCC Type Reg Reg) CmpResult)
+(decl emit_fcmp (FloatCC Type FReg FReg) CmpResult)
 
 ;; a is not nan && b is not nan
 (rule

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2390,7 +2390,7 @@
     (vec_writable_to_regs reuslt)))
 
 ;; Parameters are "intcc compare_a compare_b rs1 rs2".
-(decl gen_select_reg (IntCC XReg XReg XReg XReg) XReg)
+(decl gen_select_reg (IntCC XReg XReg Reg Reg) Reg)
 (extern constructor gen_select_reg gen_select_reg)
 
 ;; load a constant into reg.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -926,12 +926,6 @@
 (decl u8_as_i32 (u8) i32)
 (extern constructor u8_as_i32 u8_as_i32)
 
-(decl convert_valueregs_reg (ValueRegs) Reg)
-(rule (convert_valueregs_reg x)
-  (value_regs_get x 0))
-(convert ValueRegs Reg convert_valueregs_reg)
-
-
 ;; ISA Extension helpers
 
 (decl pure has_v () bool)
@@ -2574,9 +2568,9 @@
 (rule (normalize_cmp_value $I64  r _) r)
 (rule (normalize_cmp_value $I128 r _) r)
 
-(decl normalize_fcvt_from_int (ValueRegs Type ExtendOp) ValueRegs)
+(decl normalize_fcvt_from_int (XReg Type ExtendOp) XReg)
 (rule 2 (normalize_fcvt_from_int r (fits_in_16 ty) op)
-  (extend r op ty $I64))
+  (value_regs_get (extend r op ty $I64) 0))
 (rule 1 (normalize_fcvt_from_int r _ _)
   r)
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -726,6 +726,122 @@
 (type AMO (primitive AMO))
 (type VecMachLabel extern (enum))
 
+
+;;;; Newtypes for Different Register Classes ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(type XReg (primitive XReg))
+(type WritableXReg (primitive WritableXReg))
+(type FReg (primitive FReg))
+(type WritableFReg (primitive WritableFReg))
+(type VReg (primitive VReg))
+(type WritableVReg (primitive WritableVReg))
+
+;; Construct a new `XReg` from a `Reg`.
+;;
+;; Asserts that the register has a Integer RegClass.
+(decl xreg_new (Reg) XReg)
+(extern constructor xreg_new xreg_new)
+(convert Reg XReg xreg_new)
+
+;; Put a value into a XReg.
+;;
+;; Asserts that the value goes into a XReg.
+(decl put_in_xreg (Value) XReg)
+(rule (put_in_xreg val) (xreg_new (put_in_reg val)))
+(convert Value XReg put_in_xreg)
+
+;; Construct an `InstOutput` out of a single XReg register.
+(decl output_xreg (XReg) InstOutput)
+(rule (output_xreg x) (output_reg x))
+(convert XReg InstOutput output_xreg)
+
+;; Convert a `WritableXReg` to an `XReg`.
+(decl pure writable_xreg_to_xreg (WritableXReg) XReg)
+(extern constructor writable_xreg_to_xreg writable_xreg_to_xreg)
+(convert WritableXReg XReg writable_xreg_to_xreg)
+
+;; Convert a `WritableXReg` to an `WritableReg`.
+(decl pure writable_xreg_to_writable_reg (WritableXReg) WritableReg)
+(extern constructor writable_xreg_to_writable_reg writable_xreg_to_writable_reg)
+(convert WritableXReg WritableReg writable_xreg_to_writable_reg)
+
+;; Convert an `XReg` to a `Reg`.
+(decl pure xreg_to_reg (XReg) Reg)
+(extern constructor xreg_to_reg xreg_to_reg)
+(convert XReg Reg xreg_to_reg)
+
+
+;; Construct a new `FReg` from a `Reg`.
+;;
+;; Asserts that the register has a Float RegClass.
+(decl freg_new (Reg) FReg)
+(extern constructor freg_new freg_new)
+(convert Reg FReg freg_new)
+
+;; Put a value into a FReg.
+;;
+;; Asserts that the value goes into a FReg.
+(decl put_in_freg (Value) FReg)
+(rule (put_in_freg val) (freg_new (put_in_reg val)))
+(convert Value FReg put_in_freg)
+
+;; Construct an `InstOutput` out of a single FReg register.
+(decl output_freg (FReg) InstOutput)
+(rule (output_freg x) (output_reg x))
+(convert FReg InstOutput output_freg)
+
+;; Convert a `WritableFReg` to an `FReg`.
+(decl pure writable_freg_to_freg (WritableFReg) FReg)
+(extern constructor writable_freg_to_freg writable_freg_to_freg)
+(convert WritableFReg FReg writable_freg_to_freg)
+
+;; Convert a `WritableFReg` to an `WritableReg`.
+(decl pure writable_freg_to_writable_reg (WritableFReg) WritableReg)
+(extern constructor writable_freg_to_writable_reg writable_freg_to_writable_reg)
+(convert WritableFReg WritableReg writable_freg_to_writable_reg)
+
+;; Convert an `FReg` to a `Reg`.
+(decl pure freg_to_reg (FReg) Reg)
+(extern constructor freg_to_reg freg_to_reg)
+(convert FReg Reg freg_to_reg)
+
+
+;; Construct a new `VReg` from a `Reg`.
+;;
+;; Asserts that the register has a Vector RegClass.
+(decl vreg_new (Reg) VReg)
+(extern constructor vreg_new vreg_new)
+(convert Reg VReg vreg_new)
+
+;; Put a value into a VReg.
+;;
+;; Asserts that the value goes into a VReg.
+(decl put_in_vreg (Value) VReg)
+(rule (put_in_vreg val) (vreg_new (put_in_reg val)))
+(convert Value VReg put_in_vreg)
+
+;; Construct an `InstOutput` out of a single VReg register.
+(decl output_vreg (VReg) InstOutput)
+(rule (output_vreg x) (output_reg x))
+(convert VReg InstOutput output_vreg)
+
+;; Convert a `WritableVReg` to an `VReg`.
+(decl pure writable_vreg_to_vreg (WritableVReg) VReg)
+(extern constructor writable_vreg_to_vreg writable_vreg_to_vreg)
+(convert WritableVReg VReg writable_vreg_to_vreg)
+
+;; Convert a `WritableVReg` to an `WritableReg`.
+(decl pure writable_vreg_to_writable_reg (WritableVReg) WritableReg)
+(extern constructor writable_vreg_to_writable_reg writable_vreg_to_writable_reg)
+(convert WritableVReg WritableReg writable_vreg_to_writable_reg)
+
+;; Convert an `VReg` to a `Reg`.
+(decl pure vreg_to_reg (VReg) Reg)
+(extern constructor vreg_to_reg vreg_to_reg)
+(convert VReg Reg vreg_to_reg)
+
+
+
 ;; Converters
 
 (convert u8 i32 u8_as_i32)

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -81,7 +81,7 @@
   (Disabled)
 ))
 
-(decl pure masked (Reg) VecOpMasking)
+(decl pure masked (VReg) VecOpMasking)
 (rule (masked reg) (VecOpMasking.Enabled reg))
 
 (decl pure unmasked () VecOpMasking)
@@ -278,334 +278,334 @@
         vd))
 
 ;; Helper for emitting `MInst.VecStore` instructions.
-(decl vec_store (VecElementWidth VecAMode Reg MemFlags VecOpMasking VState) InstOutput)
+(decl vec_store (VecElementWidth VecAMode VReg MemFlags VecOpMasking VState) InstOutput)
 (rule (vec_store eew to from flags mask vstate)
       (side_effect
         (SideEffectNoResult.Inst (MInst.VecStore eew to from flags mask vstate))))
 
 ;; Helper for emitting the `vadd.vv` instruction.
-(decl rv_vadd_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vadd_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vadd_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VaddVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vadd.vx` instruction.
-(decl rv_vadd_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vadd_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vadd_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VaddVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vadd.vi` instruction.
-(decl rv_vadd_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vadd_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vadd_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VaddVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vsadd.vv` instruction.
-(decl rv_vsadd_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsadd_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vsadd_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsaddVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsadd.vx` instruction.
-(decl rv_vsadd_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsadd_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vsadd_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsaddVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsadd.vi` instruction.
-(decl rv_vsadd_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vsadd_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vsadd_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VsaddVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vsaddu.vv` instruction.
-(decl rv_vsaddu_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsaddu_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vsaddu_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsadduVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsaddu.vx` instruction.
-(decl rv_vsaddu_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsaddu_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vsaddu_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsadduVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsaddu.vi` instruction.
-(decl rv_vsaddu_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vsaddu_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vsaddu_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VsadduVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vsub.vv` instruction.
-(decl rv_vsub_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsub_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vsub_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsubVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsub.vx` instruction.
-(decl rv_vsub_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vsub_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vsub_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsubVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vrsub.vx` instruction.
-(decl rv_vrsub_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vrsub_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vrsub_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VrsubVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vssub.vv` instruction.
-(decl rv_vssub_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vssub_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vssub_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VssubVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vssub.vx` instruction.
-(decl rv_vssub_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vssub_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vssub_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VssubVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vssubu.vv` instruction.
-(decl rv_vssubu_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vssubu_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vssubu_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VssubuVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vssubu.vx` instruction.
-(decl rv_vssubu_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vssubu_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vssubu_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VssubuVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vneg.v` pseudo-instruction.
-(decl rv_vneg_v (Reg VecOpMasking VState) Reg)
+(decl rv_vneg_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vneg_v vs2 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VrsubVX) vs2 (zero_reg) mask vstate))
 
 ;; Helper for emitting the `vrsub.vi` instruction.
-(decl rv_vrsub_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vrsub_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vrsub_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VrsubVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vmul.vv` instruction.
-(decl rv_vmul_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmul_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmul_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmulVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmulh.vv` instruction.
-(decl rv_vmulh_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmulh_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmulh_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmulhVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmulhu.vv` instruction.
-(decl rv_vmulhu_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmulhu_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmulhu_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmulhuVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vand.vv` instruction.
-(decl rv_vand_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vand_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vand_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VandVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vand.vx` instruction.
-(decl rv_vand_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vand_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vand_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VandVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vand.vi` instruction.
-(decl rv_vand_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vand_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vand_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VandVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vor.vv` instruction.
-(decl rv_vor_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vor_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vor_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VorVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vor.vx` instruction.
-(decl rv_vor_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vor_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vor_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VorVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vor.vi` instruction.
-(decl rv_vor_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vor_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vor_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VorVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vxor.vv` instruction.
-(decl rv_vxor_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vxor_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vxor_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VxorVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vxor.vx` instruction.
-(decl rv_vxor_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vxor_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vxor_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VxorVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vxor.vi` instruction.
-(decl rv_vxor_vi (Reg Imm5 VecOpMasking VState) Reg)
+(decl rv_vxor_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vxor_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VxorVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vnot.v` instruction.
 ;; This is just a mnemonic for `vxor.vi vd, vs, -1`
-(decl rv_vnot_v (Reg VecOpMasking VState) Reg)
+(decl rv_vnot_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vnot_v vs2 mask vstate)
   (if-let neg1 (imm5_from_i8 -1))
   (rv_vxor_vi vs2 neg1 mask vstate))
 
 ;; Helper for emitting the `vmax.vv` instruction.
-(decl rv_vmax_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmax_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmax_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmaxVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmax.vx` instruction.
-(decl rv_vmax_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmax_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vmax_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmaxVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmin.vv` instruction.
-(decl rv_vmin_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmin_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmin_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VminVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmin.vx` instruction.
-(decl rv_vmin_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmin_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vmin_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VminVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmaxu.vv` instruction.
-(decl rv_vmaxu_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmaxu_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmaxu_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmaxuVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmaxu.vx` instruction.
-(decl rv_vmaxu_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vmaxu_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vmaxu_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmaxuVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vminu.vv` instruction.
-(decl rv_vminu_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vminu_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vminu_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VminuVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vminu.vx` instruction.
-(decl rv_vminu_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vminu_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vminu_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VminuVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfadd.vv` instruction.
-(decl rv_vfadd_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfadd_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vfadd_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfaddVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfadd.vf` instruction.
-(decl rv_vfadd_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfadd_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfadd_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfaddVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfsub.vv` instruction.
-(decl rv_vfsub_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfsub_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vfsub_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfsubVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfsub.vf` instruction.
-(decl rv_vfsub_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfsub_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfsub_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfsubVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfrsub.vf` instruction.
-(decl rv_vfrsub_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfrsub_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfrsub_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfrsubVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfmul.vv` instruction.
-(decl rv_vfmul_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfmul_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vfmul_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfmulVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfmul.vf` instruction.
-(decl rv_vfmul_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfmul_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfmul_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfmulVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfdiv.vv` instruction.
-(decl rv_vfdiv_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfdiv_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vfdiv_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfdivVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfdiv.vf` instruction.
-(decl rv_vfdiv_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfdiv_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfdiv_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfdivVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfrdiv.vf` instruction.
-(decl rv_vfrdiv_vf (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfrdiv_vf (VReg FReg VecOpMasking VState) VReg)
 (rule (rv_vfrdiv_vf vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfrdivVF) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfsgnjn.vv` ("Floating Point Sign Injection Negated") instruction.
 ;; The output of this instruction is `vs2` with the negated sign bit from `vs1`
-(decl rv_vfsgnjn_vv (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vfsgnjn_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vfsgnjn_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfsgnjnVV) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vfneg.v` instruction.
 ;; This instruction is a mnemonic for `vfsgnjn.vv vd, vs, vs`
-(decl rv_vfneg_v (Reg VecOpMasking VState) Reg)
+(decl rv_vfneg_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vfneg_v vs mask vstate) (rv_vfsgnjn_vv vs vs mask vstate))
 
 ;; Helper for emitting the `vfsqrt.v` instruction.
 ;; This instruction splats the F regsiter into all elements of the destination vector.
-(decl rv_vfsqrt_v (Reg VecOpMasking VState) Reg)
+(decl rv_vfsqrt_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vfsqrt_v vs mask vstate)
   (vec_alu_rr (VecAluOpRR.VfsqrtV) vs mask vstate))
 
 ;; Helper for emitting the `vslidedown.vx` instruction.
 ;; `vslidedown` moves all elements in the vector down by n elements.
 ;; The top most elements are up to the tail policy.
-(decl rv_vslidedown_vx (Reg Reg VecOpMasking VState) Reg)
+(decl rv_vslidedown_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vslidedown_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VslidedownVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vslidedown.vi` instruction.
 ;; Unlike other `vi` instructions the immediate is zero extended.
-(decl rv_vslidedown_vi (Reg UImm5 VecOpMasking VState) Reg)
+(decl rv_vslidedown_vi (VReg UImm5 VecOpMasking VState) VReg)
 (rule (rv_vslidedown_vi vs2 imm mask vstate)
   (vec_alu_rr_uimm5 (VecAluOpRRImm5.VslidedownVI) vs2 imm mask vstate))
 
 ;; Helper for emitting the `vmv.x.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination X register.
 ;; Masked versions of this instuction are not supported.
-(decl rv_vmv_xs (Reg VState) Reg)
+(decl rv_vmv_xs (VReg VState) XReg)
 (rule (rv_vmv_xs vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvXS) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.f.s` instruction.
 ;; This instruction copies the first element of the source vector to the destination F register.
 ;; Masked versions of this instuction are not supported.
-(decl rv_vfmv_fs (Reg VState) Reg)
+(decl rv_vfmv_fs (VReg VState) FReg)
 (rule (rv_vfmv_fs vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvFS) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vmv.s.x` instruction.
 ;; This instruction copies the source X register into first element of the source vector.
 ;; Masked versions of this instuction are not supported.
-(decl rv_vmv_sx (Reg VState) Reg)
+(decl rv_vmv_sx (XReg VState) VReg)
 (rule (rv_vmv_sx vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvSX) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.s.f` instruction.
 ;; This instruction copies the source F register into first element of the source vector.
 ;; Masked versions of this instuction are not supported.
-(decl rv_vfmv_sf (Reg VState) Reg)
+(decl rv_vfmv_sf (FReg VState) VReg)
 (rule (rv_vfmv_sf vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvSF) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vmv.v.x` instruction.
 ;; This instruction splats the X regsiter into all elements of the destination vector.
 ;; Masked versions of this instruction are called `vmerge`
-(decl rv_vmv_vx (Reg VState) Reg)
+(decl rv_vmv_vx (XReg VState) VReg)
 (rule (rv_vmv_vx vs vstate)
   (vec_alu_rr (VecAluOpRR.VmvVX) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vfmv.v.f` instruction.
 ;; This instruction splats the F regsiter into all elements of the destination vector.
 ;; Masked versions of this instruction are called `vmerge`
-(decl rv_vfmv_vf (Reg VState) Reg)
+(decl rv_vfmv_vf (FReg VState) VReg)
 (rule (rv_vfmv_vf vs vstate)
   (vec_alu_rr (VecAluOpRR.VfmvVF) vs (unmasked) vstate))
 
 ;; Helper for emitting the `vmv.v.i` instruction.
 ;; This instruction splat's the immediate value into all elements of the destination vector.
 ;; Masked versions of this instruction are called `vmerge`
-(decl rv_vmv_vi (Imm5 VState) Reg)
+(decl rv_vmv_vi (Imm5 VState) VReg)
 (rule (rv_vmv_vi imm vstate)
   (vec_alu_r_imm5 (VecAluOpRImm5.VmvVI) imm (unmasked) vstate))
 
@@ -615,7 +615,7 @@
 ;; and from the second source vector if the mask bit is set. This instruction is always masked.
 ;;
 ;; vd[i] = v0.mask[i] ? vs1[i] : vs2[i]
-(decl rv_vmerge_vvm (Reg Reg Reg VState) Reg)
+(decl rv_vmerge_vvm (VReg VReg VReg VState) VReg)
 (rule (rv_vmerge_vvm vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmergeVVM) vs2 vs1 (masked mask) vstate))
 
@@ -624,7 +624,7 @@
 ;; register if the mask bit is set. This instruction is always masked.
 ;;
 ;; vd[i] = v0.mask[i] ? x[rs1] : vs2[i]
-(decl rv_vmerge_vxm (Reg Reg Reg VState) Reg)
+(decl rv_vmerge_vxm (VReg XReg VReg VState) VReg)
 (rule (rv_vmerge_vxm vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmergeVXM) vs2 vs1 (masked mask) vstate))
 
@@ -633,7 +633,7 @@
 ;; register if the mask bit is set. This instruction is always masked.
 ;;
 ;; vd[i] = v0.mask[i] ? f[rs1] : vs2[i]
-(decl rv_vfmerge_vfm (Reg Reg Reg VState) Reg)
+(decl rv_vfmerge_vfm (VReg FReg VReg VState) VReg)
 (rule (rv_vfmerge_vfm vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VfmergeVFM) vs2 vs1 (masked mask) vstate))
 
@@ -642,14 +642,14 @@
 ;; immediate value if the mask bit is set. This instruction is always masked.
 ;;
 ;; vd[i] = v0.mask[i] ? imm : vs2[i]
-(decl rv_vmerge_vim (Reg Imm5 Reg VState) Reg)
+(decl rv_vmerge_vim (VReg Imm5 VReg VState) VReg)
 (rule (rv_vmerge_vim vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VmergeVIM) vs2 imm (masked mask) vstate))
 
 
 ;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl gen_extractlane (Type Reg u8) Reg)
+(decl gen_extractlane (Type VReg u8) Reg)
 
 ;; When extracting lane 0 for floats, we can use `vfmv.f.s` directly.
 (rule 3 (gen_extractlane (ty_vec_fits_in_register ty) src 0)
@@ -676,7 +676,7 @@
 ;; TODO: We should merge this with the `vconst` rules, and take advantage of
 ;; the other existing `vconst` rules. One example is using `vmv.v.i` which
 ;; can represent some of these masks.
-(decl gen_vec_mask (u64) Reg)
+(decl gen_vec_mask (u64) VReg)
 
 ;; Materialize the mask into an X register, and move it into the bottom of
 ;; the vector register.

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -238,14 +238,14 @@
 ;; Helper for emitting `MInst.VecAluRRR` instructions.
 (decl vec_alu_rrr (VecAluOpRRR Reg Reg VecOpMasking VState) Reg)
 (rule (vec_alu_rrr op vs2 vs1 mask vstate)
-      (let ((vd WritableReg (temp_writable_reg $I8X16))
+      (let ((vd WritableVReg (temp_writable_vreg))
             (_ Unit (emit (MInst.VecAluRRR op vd vs2 vs1 mask vstate))))
         vd))
 
 ;; Helper for emitting `MInst.VecAluRRImm5` instructions.
 (decl vec_alu_rr_imm5 (VecAluOpRRImm5 Reg Imm5 VecOpMasking  VState) Reg)
 (rule (vec_alu_rr_imm5 op vs2 imm mask vstate)
-      (let ((vd WritableReg (temp_writable_reg $I8X16))
+      (let ((vd WritableVReg (temp_writable_vreg))
             (_ Unit (emit (MInst.VecAluRRImm5 op vd vs2 imm mask vstate))))
         vd))
 
@@ -266,14 +266,14 @@
 ;; Helper for emitting `MInst.VecAluRImm5` instructions.
 (decl vec_alu_r_imm5 (VecAluOpRImm5 Imm5 VecOpMasking VState) Reg)
 (rule (vec_alu_r_imm5 op imm mask vstate)
-      (let ((vd WritableReg (temp_writable_reg $I8X16))
+      (let ((vd WritableVReg (temp_writable_vreg))
             (_ Unit (emit (MInst.VecAluRImm5 op vd imm mask vstate))))
         vd))
 
 ;; Helper for emitting `MInst.VecLoad` instructions.
 (decl vec_load (VecElementWidth VecAMode MemFlags VecOpMasking VState) Reg)
 (rule (vec_load eew from flags mask vstate)
-      (let ((vd WritableReg (temp_writable_reg $I8X16))
+      (let ((vd WritableVReg (temp_writable_vreg))
             (_ Unit (emit (MInst.VecLoad eew vd from flags mask vstate))))
         vd))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -98,13 +98,13 @@
 
 ;; I128 cases
 (rule 7 (lower (has_type $I128 (iadd x y)))
-  (let ((low Reg (rv_add (value_regs_get x 0) (value_regs_get y 0)))
+  (let ((low XReg (rv_add (value_regs_get x 0) (value_regs_get y 0)))
         ;; compute carry.
-        (carry Reg (rv_sltu low (value_regs_get y 0)))
+        (carry XReg (rv_sltu low (value_regs_get y 0)))
         ;;
-        (high_tmp Reg (rv_add (value_regs_get x 1) (value_regs_get y 1)))
+        (high_tmp XReg (rv_add (value_regs_get x 1) (value_regs_get y 1)))
         ;; add carry.
-        (high Reg (rv_add high_tmp carry)))
+        (high XReg (rv_add high_tmp carry)))
     (value_regs low high)))
 
 ;; SIMD Vectors
@@ -178,13 +178,13 @@
 (rule 2 (lower (has_type $I128 (imul x y)))
   (let
     ((x_regs ValueRegs x)
-      (x_lo Reg (value_regs_get x_regs 0))
-      (x_hi Reg (value_regs_get x_regs 1))
+      (x_lo XReg (value_regs_get x_regs 0))
+      (x_hi XReg (value_regs_get x_regs 1))
 
       ;; Get the high/low registers for `y`.
       (y_regs ValueRegs y)
-      (y_lo Reg (value_regs_get y_regs 0))
-      (y_hi Reg (value_regs_get y_regs 1))
+      (y_lo XReg (value_regs_get y_regs 0))
+      (y_hi XReg (value_regs_get y_regs 1))
 
       ;; 128bit mul formula:
       ;;   dst_lo = x_lo * y_lo
@@ -195,10 +195,10 @@
       ;; madd    dst_hi, x_lo, y_hi, dst_hi
       ;; madd    dst_hi, x_hi, y_lo, dst_hi
       ;; madd    dst_lo, x_lo, y_lo, zero
-      (dst_hi1 Reg (rv_mulhu x_lo y_lo))
-      (dst_hi2 Reg (madd x_lo y_hi dst_hi1))
-      (dst_hi Reg (madd x_hi y_lo dst_hi2))
-      (dst_lo Reg (madd x_lo y_lo (zero_reg))))
+      (dst_hi1 XReg (rv_mulhu x_lo y_lo))
+      (dst_hi2 XReg (madd x_lo y_hi dst_hi1))
+      (dst_hi XReg (madd x_hi y_lo dst_hi2))
+      (dst_lo XReg (madd x_lo y_lo (zero_reg))))
     (value_regs dst_lo dst_hi)))
 
 (rule 3 (lower (has_type (ty_vec_fits_in_register ty) (imul x y)))
@@ -206,14 +206,14 @@
 
 ;;;; Rules for `smulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (smulhi x y)))
-  (lower_smlhi ty (ext_int_if_need $true x ty) (ext_int_if_need $true y ty)))
+  (lower_smlhi ty (sext x ty $I64) (sext y ty $I64)))
 
 (rule 1 (lower (has_type (ty_vec_fits_in_register ty) (smulhi x y)))
   (rv_vmulh_vv x y (unmasked) ty))
 
 ;;;; Rules for `umulhi` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (umulhi x y)))
-  (lower_umlhi ty (ext_int_if_need $false x ty) (ext_int_if_need $false y ty)))
+  (lower_umlhi ty (zext x ty $I64) (zext y ty $I64)))
 
 (rule 1 (lower (has_type (ty_vec_fits_in_register ty) (umulhi x y)))
   (rv_vmulhu_vv x y (unmasked) ty))
@@ -222,14 +222,14 @@
 
 (rule -1 (lower (has_type (fits_in_32 ty) (udiv x y)))
   (let
-    ((y2 Reg (ext_int_if_need $false y ty))
+    ((y2 XReg (zext y ty $I64))
       (_ InstOutput (gen_div_by_zero y2)))
-    (rv_divuw (ext_int_if_need $false x ty) y2)))
+    (rv_divuw (zext x ty $I64) y2)))
 
 (rule -1 (lower (has_type (fits_in_32 ty) (sdiv x y)))
   (let
-    ((a Reg (ext_int_if_need $true x ty))
-      (b Reg (ext_int_if_need $true y ty))
+    ((a XReg (sext x ty $I64))
+      (b XReg (sext y ty $I64))
       (_ InstOutput (gen_div_overflow a b ty))
       (_ InstOutput (gen_div_by_zero b)))
     (rv_divw a b)))
@@ -249,25 +249,25 @@
 
 (rule -1 (lower (has_type (fits_in_16 ty) (urem x y)))
   (let
-    ((y2 Reg (ext_int_if_need $false y ty))
+    ((y2 XReg (zext y ty $I64))
       (_ InstOutput (gen_div_by_zero y2)))
-    (rv_remuw (ext_int_if_need $false x ty) y2)))
+    (rv_remuw (zext x ty $I64) y2)))
 
 (rule -1 (lower (has_type (fits_in_16 ty) (srem x y)))
   (let
-    ((y2 Reg (ext_int_if_need $true y ty))
+    ((y2 XReg (sext y ty $I64))
       (_ InstOutput (gen_div_by_zero y2)))
-    (rv_remw (ext_int_if_need $true x ty) y2)))
+    (rv_remw (sext x ty $I64) y2)))
 
 (rule (lower (has_type $I32 (srem x y)))
   (let
-    ((y2 Reg (ext_int_if_need $true y $I32))
+    ((y2 XReg (sext y $I32 $I64))
       (_ InstOutput (gen_div_by_zero y2)))
    (rv_remw x y2)))
 
 (rule (lower (has_type $I32 (urem x y)))
   (let
-    ((y2 Reg (ext_int_if_need $false y $I32))
+    ((y2 XReg (zext y $I32 $I64))
         (_ InstOutput (gen_div_by_zero y2)))
     (rv_remuw x y2)))
 
@@ -309,14 +309,14 @@
 
 (rule 6 (lower (has_type $I128 (band x (bnot y))))
   (if-let $true (has_zbb))
-  (let ((low Reg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
-        (high Reg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
+  (let ((low XReg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
+        (high XReg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 7 (lower (has_type $I128 (band (bnot y) x)))
   (if-let $true (has_zbb))
-  (let ((low Reg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
-        (high Reg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
+  (let ((low XReg (rv_andn (value_regs_get x 0) (value_regs_get y 0)))
+        (high XReg (rv_andn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 8 (lower (has_type (ty_vec_fits_in_register ty) (band x y)))
@@ -365,14 +365,14 @@
 
 (rule 6 (lower (has_type $I128 (bor x (bnot y))))
   (if-let $true (has_zbb))
-  (let ((low Reg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
-        (high Reg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
+  (let ((low XReg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
+        (high XReg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 7 (lower (has_type $I128 (bor (bnot y) x)))
   (if-let $true (has_zbb))
-  (let ((low Reg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
-        (high Reg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
+  (let ((low XReg (rv_orn (value_regs_get x 0) (value_regs_get y 0)))
+        (high XReg (rv_orn (value_regs_get x 1) (value_regs_get y 1))))
     (value_regs low high)))
 
 (rule 8 (lower (has_type (ty_vec_fits_in_register ty) (bor x y)))
@@ -441,8 +441,8 @@
 
 (rule 1 (lower (has_type $I128 (bitrev x)))
   (let ((val ValueRegs x)
-    (lo_rev Reg (lower_bit_reverse (value_regs_get val 0) $I64))
-    (hi_rev Reg (lower_bit_reverse (value_regs_get val 1) $I64)))
+    (lo_rev XReg (lower_bit_reverse (value_regs_get val 0) $I64))
+    (hi_rev XReg (lower_bit_reverse (value_regs_get val 1) $I64)))
     (value_regs hi_rev lo_rev)))
 
 
@@ -469,11 +469,11 @@
 
 ;;;; Rules for `uextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type out_ty (uextend val @ (value_type in_ty))))
-  (zext val in_ty out_ty))
+  (extend val (ExtendOp.Zero) in_ty out_ty))
 
 ;;;; Rules for `sextend` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type out_ty (sextend val @ (value_type in_ty))))
-  (sext val in_ty out_ty))
+  (extend val (ExtendOp.Signed) in_ty out_ty))
 
 ;; The instructions below are present in RV64I and sign-extend the result to 64 bits.
 
@@ -548,16 +548,16 @@
 
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (has_type $I8 (ushr x y)))
-  (rv_srlw (ext_int_if_need $false x $I8) (rv_andi (value_regs_get y 0) (imm12_const 7))))
+  (rv_srlw (zext x $I8 $I64) (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (ushr x (imm12_from_value y))))
-  (rv_srliw (ext_int_if_need $false x $I8) (imm12_and y 7)))
+  (rv_srliw (zext x $I8 $I64) (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (ushr x y)))
-  (rv_srlw (ext_int_if_need $false x $I16) (rv_andi (value_regs_get y 0) (imm12_const 15))))
+  (rv_srlw (zext x $I16 $I64) (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (ushr x (imm12_from_value y))))
-  (rv_srliw (ext_int_if_need $false x $I16) (imm12_and y 15)))
+  (rv_srliw (zext x $I16 $I64) (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (ushr x y)))
   (rv_srlw x (value_regs_get y 0)))
@@ -575,16 +575,16 @@
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 1 (lower (has_type $I8 (sshr x y)))
-  (rv_sra (ext_int_if_need $true x $I8) (rv_andi (value_regs_get y 0) (imm12_const 7))))
+  (rv_sra (sext x $I8 $I64) (rv_andi (value_regs_get y 0) (imm12_const 7))))
 
 (rule 2 (lower (has_type $I8 (sshr x (imm12_from_value y))))
-  (rv_srai (ext_int_if_need $true x $I8) (imm12_and y 7)))
+  (rv_srai (sext x $I8 $I64) (imm12_and y 7)))
 
 (rule 1 (lower (has_type $I16 (sshr x y)))
-  (rv_sra (ext_int_if_need $true x $I16) (rv_andi (value_regs_get y 0) (imm12_const 15))))
+  (rv_sra (sext x $I16 $I64) (rv_andi (value_regs_get y 0) (imm12_const 15))))
 
 (rule 2 (lower (has_type $I16 (sshr x (imm12_from_value y))))
-  (rv_srai (ext_int_if_need $true x $I16) (imm12_and y 15)))
+  (rv_srai (sext x $I16 $I64) (imm12_and y 15)))
 
 (rule 1 (lower (has_type $I32 (sshr x y)))
   (rv_sraw x (value_regs_get y 0)))
@@ -600,14 +600,14 @@
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (rotl x y)))
-  (lower_rotl ty (ext_int_if_need $false x ty) (value_regs_get y 0)))
+  (lower_rotl ty (zext x ty $I64) (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I128 (rotl x y)))
   (lower_i128_rotl x y))
 
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (rotr x y)))
-  (lower_rotr ty (ext_int_if_need $false x ty) (value_regs_get y 0)))
+  (lower_rotr ty (zext x ty $I64) (value_regs_get y 0)))
 
 (rule 1 (lower (has_type $I128 (rotr x y)))
   (lower_i128_rotr x y))
@@ -658,7 +658,7 @@
 (rule 2
   (lower
     (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw flags (is_atomic_rmw_max_etc op $true) addr x)))
-  (gen_atomic_rmw_loop op ty addr (ext_int_if_need $true x ty)))
+  (gen_atomic_rmw_loop op ty addr (sext x ty $I64)))
 
 
 (rule 2
@@ -666,7 +666,7 @@
   (lower
     (has_type (valid_atomic_transaction (fits_in_16 ty)) (atomic_rmw flags (is_atomic_rmw_max_etc op $false) addr x)))
   ;;
-  (gen_atomic_rmw_loop op ty addr (ext_int_if_need $false x ty)))
+  (gen_atomic_rmw_loop op ty addr (zext x ty $I64)))
 
 ;;;;;  Rules for `AtomicRmwOp.Sub`
 (rule
@@ -677,12 +677,12 @@
      (x2 Reg (rv_neg x)))
     (gen_atomic (get_atomic_rmw_op ty (AtomicRmwOp.Add)) addr x2 (atomic_amo))))
 
-(decl gen_atomic_rmw_loop (AtomicRmwOp Type Reg Reg) Reg)
+(decl gen_atomic_rmw_loop (AtomicRmwOp Type XReg XReg) XReg)
 (rule
   (gen_atomic_rmw_loop op ty addr x)
   (let
-    ((dst WritableReg (temp_writable_reg $I64))
-      (t0 WritableReg (temp_writable_reg $I64))
+    ((dst WritableXReg (temp_writable_xreg))
+      (t0 WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.AtomicRmwLoop (gen_atomic_offset addr ty) op dst ty (gen_atomic_p addr ty) x t0))))
     (writable_reg_to_reg dst)))
 
@@ -706,14 +706,14 @@
   (lower (atomic_store flags src @ (value_type (valid_atomic_transaction ty)) p))
   (gen_atomic_store p ty src))
 
-(decl gen_atomic_offset (Reg Type) Reg)
+(decl gen_atomic_offset (XReg Type) XReg)
 (rule 1 (gen_atomic_offset p (fits_in_16 ty))
   (rv_slli (rv_andi p (imm12_const 3)) (imm12_const 3)))
 
 (rule (gen_atomic_offset p _)
   (zero_reg))
 
-(decl gen_atomic_p (Reg Type) Reg)
+(decl gen_atomic_p (XReg Type) XReg)
 (rule 1 (gen_atomic_p p (fits_in_16 ty))
   (rv_andi p (imm12_const -4)))
 
@@ -727,7 +727,7 @@
   (let
     ((t0 WritableReg (temp_writable_reg ty))
       (dst WritableReg (temp_writable_reg ty))
-      (_ Unit (emit (MInst.AtomicCas (gen_atomic_offset p ty) t0 dst (ext_int_if_need $false e ty) (gen_atomic_p p ty) x ty))))
+      (_ Unit (emit (MInst.AtomicCas (gen_atomic_offset p ty) t0 dst (zext e ty $I64) (gen_atomic_p p ty) x ty))))
     (writable_reg_to_reg dst)))
 
 ;;;;;  Rules for `ireduce`;;;;;;;;;;;;;;;;;
@@ -844,17 +844,17 @@
 
 (rule 1
   (lower (has_type (fits_in_64 ty) (select (icmp cc a b @ (value_type (fits_in_64 in_ty))) x y)))
-  (let ((a Reg (normalize_cmp_value in_ty a (intcc_to_extend_op cc)))
-        (b Reg (normalize_cmp_value in_ty b (intcc_to_extend_op cc))))
+  (let ((a XReg (truthy_to_reg in_ty (normalize_cmp_value in_ty a (intcc_to_extend_op cc))))
+        (b XReg (truthy_to_reg in_ty (normalize_cmp_value in_ty b (intcc_to_extend_op cc)))))
     (gen_select_reg cc a b x y)))
 
 ;;;;;  Rules for `bitselect`;;;;;;;;;
 
 ;; Do a (c & x) | (~c & y) operation.
 (rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (bitselect c x y)))
-  (let ((tmp_x Reg (rv_and c x))
-        (c_inverse Reg (rv_not c))
-        (tmp_y Reg (rv_and c_inverse y)))
+  (let ((tmp_x XReg (rv_and c x))
+        (c_inverse XReg (rv_not c))
+        (tmp_y XReg (rv_and c_inverse y)))
     (rv_or tmp_x tmp_y)))
 
 ;; For vectors, we also do the same operation.
@@ -872,16 +872,16 @@
 (rule
   (lower (isplit x))
   (let
-    ((t1 Reg (value_regs_get x 0))
-      (t2 Reg (value_regs_get x 1)))
+    ((t1 XReg (value_regs_get x 0))
+      (t2 XReg (value_regs_get x 1)))
     (output_pair t1 t2)))
 
 ;;;;;  Rules for `iconcat`;;;;;;;;;
 (rule
   (lower (has_type $I128 (iconcat x y)))
   (let
-    ((t1 Reg x)
-      (t2 Reg y))
+    ((t1 XReg x)
+      (t2 XReg y))
     (value_regs t1 t2)))
 
 
@@ -1033,11 +1033,11 @@
   (let ((eew VecElementWidth (element_width_from_type ty)))
     (vec_store eew (VecAMode.UnitStride (gen_amode p offset $I64)) x flags (unmasked) ty)))
 
-(decl gen_icmp (IntCC ValueRegs ValueRegs Type) Reg)
+(decl gen_icmp (IntCC ValueRegs ValueRegs Type) XReg)
 (rule
   (gen_icmp cc x y ty)
   (let
-    ((result WritableReg (temp_writable_reg $I64))
+    ((result WritableXReg (temp_writable_xreg))
       (_ Unit (emit (MInst.Icmp cc result x y ty))))
     result))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1078,13 +1078,17 @@
 
 ;;;;;  Rules for `fcvt_from_sint`;;;;;;;;;
 (rule
-  (lower (has_type to (fcvt_from_sint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $true to) to (normalize_fcvt_from_int v from (ExtendOp.Signed))))
+  (lower (has_type to (fcvt_from_sint v @ (value_type from_ty))))
+  (let ((float_op FpuOPRR (int_convert_2_float_op from_ty $true to))
+        (value XReg (normalize_fcvt_from_int v from_ty (ExtendOp.Signed))))
+    (fpu_rr float_op to value)))
 
 ;;;;;  Rules for `fcvt_from_uint`;;;;;;;;;
 (rule
-  (lower (has_type to (fcvt_from_uint v @ (value_type from))))
-  (fpu_rr (int_convert_2_float_op from $false to) to (normalize_fcvt_from_int v from (ExtendOp.Zero))))
+  (lower (has_type to (fcvt_from_uint v @ (value_type from_ty))))
+  (let ((float_op FpuOPRR (int_convert_2_float_op from_ty $false to))
+        (value XReg (normalize_fcvt_from_int v from_ty (ExtendOp.Zero))))
+    (fpu_rr float_op to value)))
 
 ;;;;;  Rules for `symbol_value`;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -863,9 +863,9 @@
 ;; `vsetvl` instructions. It's likeley that the vector unit is already
 ;; configured for that type.
 (rule 1 (lower (has_type (ty_vec_fits_in_register ty) (bitselect c x y)))
-  (let ((tmp_x Reg (rv_vand_vv c x (unmasked) ty))
-        (c_inverse Reg (rv_vnot_v c (unmasked) ty))
-        (tmp_y Reg (rv_vand_vv c_inverse y (unmasked) ty)))
+  (let ((tmp_x VReg (rv_vand_vv c x (unmasked) ty))
+        (c_inverse VReg (rv_vnot_v c (unmasked) ty))
+        (tmp_y VReg (rv_vand_vv c_inverse y (unmasked) ty)))
     (rv_vor_vv tmp_x tmp_y (unmasked) ty)))
 
 ;;;;;  Rules for `isplit`;;;;;;;;;
@@ -1183,14 +1183,14 @@
 (rule 0 (lower (insertlane vec @ (value_type (ty_vec_fits_in_register ty))
                            val @ (value_type (ty_int _))
                            (u8_from_uimm8 lane)))
-  (let ((mask Reg (gen_vec_mask (u64_shl 1 lane))))
+  (let ((mask VReg (gen_vec_mask (u64_shl 1 lane))))
     (rv_vmerge_vxm vec val mask ty)))
 
 ;; Similar to above, but using the float variants of the instructions.
 (rule 1 (lower (insertlane vec @ (value_type (ty_vec_fits_in_register ty))
                            val @ (value_type (ty_scalar_float _))
                            (u8_from_uimm8 lane)))
-  (let ((mask Reg (gen_vec_mask (u64_shl 1 lane))))
+  (let ((mask VReg (gen_vec_mask (u64_shl 1 lane))))
     (rv_vfmerge_vfm vec val mask ty)))
 
 ;; If we are inserting from an Imm5 const we can use the immediate
@@ -1198,7 +1198,7 @@
 (rule 2 (lower (insertlane vec @ (value_type (ty_vec_fits_in_register ty))
                            (iconst (u64_from_imm64 (imm5_from_u64 imm)))
                            (u8_from_uimm8 lane)))
-  (let ((mask Reg (gen_vec_mask (u64_shl 1 lane))))
+  (let ((mask VReg (gen_vec_mask (u64_shl 1 lane))))
     (rv_vmerge_vim vec imm mask ty)))
 
 ;;;; Rules for `splat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -75,6 +75,9 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn vreg_new(&mut self, r: Reg) -> VReg {
         VReg::new(r).unwrap()
     }
+    fn writable_vreg_new(&mut self, r: WritableReg) -> WritableVReg {
+        r.map(|wr| VReg::new(wr).unwrap())
+    }
     fn writable_vreg_to_vreg(&mut self, arg0: WritableVReg) -> VReg {
         arg0.to_reg()
     }
@@ -87,6 +90,9 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn xreg_new(&mut self, r: Reg) -> XReg {
         XReg::new(r).unwrap()
     }
+    fn writable_xreg_new(&mut self, r: WritableReg) -> WritableXReg {
+        r.map(|wr| XReg::new(wr).unwrap())
+    }
     fn writable_xreg_to_xreg(&mut self, arg0: WritableXReg) -> XReg {
         arg0.to_reg()
     }
@@ -98,6 +104,9 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
     fn freg_new(&mut self, r: Reg) -> FReg {
         FReg::new(r).unwrap()
+    }
+    fn writable_freg_new(&mut self, r: WritableReg) -> WritableFReg {
+        r.map(|wr| FReg::new(wr).unwrap())
     }
     fn writable_freg_to_freg(&mut self, arg0: WritableFReg) -> FReg {
         arg0.to_reg()
@@ -281,19 +290,19 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn gen_default_frm(&mut self) -> OptionFloatRoundingMode {
         None
     }
-    fn gen_select_reg(&mut self, cc: &IntCC, a: Reg, b: Reg, rs1: Reg, rs2: Reg) -> Reg {
+    fn gen_select_reg(&mut self, cc: &IntCC, a: XReg, b: XReg, rs1: XReg, rs2: XReg) -> XReg {
         let rd = self.temp_writable_reg(MInst::canonical_type_for_rc(rs1.class()));
         self.emit(&MInst::SelectReg {
             rd,
-            rs1,
-            rs2,
+            rs1: rs1.to_reg(),
+            rs2: rs2.to_reg(),
             condition: IntegerCompare {
                 kind: *cc,
-                rs1: a,
-                rs2: b,
+                rs1: a.to_reg(),
+                rs2: b.to_reg(),
             },
         });
-        rd.to_reg()
+        self.xreg_new(rd.to_reg())
     }
     fn load_u64_constant(&mut self, val: u64) -> Reg {
         let rd = self.temp_writable_reg(I64);
@@ -318,14 +327,14 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
 
     //
-    fn gen_shamt(&mut self, ty: Type, shamt: Reg) -> ValueRegs {
+    fn gen_shamt(&mut self, ty: Type, shamt: XReg) -> ValueRegs {
         let ty_bits = if ty.bits() > 64 { 64 } else { ty.bits() };
         let shamt = {
             let tmp = self.temp_writable_reg(I64);
             self.emit(&MInst::AluRRImm12 {
                 alu_op: AluOPRRI::Andi,
                 rd: tmp,
-                rs: shamt,
+                rs: shamt.to_reg(),
                 imm12: Imm12::from_bits((ty_bits - 1) as i16),
             });
             tmp.to_reg()
@@ -466,7 +475,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         px_reg(2)
     }
 
-    fn shift_int_to_most_significant(&mut self, v: Reg, ty: Type) -> Reg {
+    fn shift_int_to_most_significant(&mut self, v: XReg, ty: Type) -> XReg {
         assert!(ty.is_int() && ty.bits() <= 64);
         if ty == I64 {
             return v;
@@ -475,19 +484,19 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         self.emit(&MInst::AluRRImm12 {
             alu_op: AluOPRRI::Slli,
             rd: tmp,
-            rs: v,
+            rs: v.to_reg(),
             imm12: Imm12::from_bits((64 - ty.bits()) as i16),
         });
 
-        tmp.to_reg()
+        self.xreg_new(tmp.to_reg())
     }
 
     #[inline]
-    fn int_compare(&mut self, kind: &IntCC, rs1: Reg, rs2: Reg) -> IntegerCompare {
+    fn int_compare(&mut self, kind: &IntCC, rs1: XReg, rs2: XReg) -> IntegerCompare {
         IntegerCompare {
             kind: *kind,
-            rs1,
-            rs2,
+            rs1: rs1.to_reg(),
+            rs2: rs2.to_reg(),
         }
     }
 

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -9,6 +9,9 @@ use generated_code::{Context, ExtendOp, MInst};
 use self::generated_code::VecAluOpRR;
 use super::{writable_zero_reg, zero_reg};
 use crate::isa::riscv64::abi::Riscv64ABICallSite;
+use crate::isa::riscv64::lower::args::{
+    FReg, VReg, WritableFReg, WritableVReg, WritableXReg, XReg,
+};
 use crate::isa::riscv64::Riscv64Backend;
 use crate::machinst::Reg;
 use crate::machinst::{isle::*, MachInst, SmallInstVec};
@@ -68,6 +71,43 @@ impl<'a, 'b> RV64IsleContext<'a, 'b, MInst, Riscv64Backend> {
 impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> {
     isle_lower_prelude_methods!();
     isle_prelude_caller_methods!(Riscv64MachineDeps, Riscv64ABICallSite);
+
+    fn vreg_new(&mut self, r: Reg) -> VReg {
+        VReg::new(r).unwrap()
+    }
+    fn writable_vreg_to_vreg(&mut self, arg0: WritableVReg) -> VReg {
+        arg0.to_reg()
+    }
+    fn writable_vreg_to_writable_reg(&mut self, arg0: WritableVReg) -> WritableReg {
+        arg0.map(|vr| vr.to_reg())
+    }
+    fn vreg_to_reg(&mut self, arg0: VReg) -> Reg {
+        *arg0
+    }
+    fn xreg_new(&mut self, r: Reg) -> XReg {
+        XReg::new(r).unwrap()
+    }
+    fn writable_xreg_to_xreg(&mut self, arg0: WritableXReg) -> XReg {
+        arg0.to_reg()
+    }
+    fn writable_xreg_to_writable_reg(&mut self, arg0: WritableXReg) -> WritableReg {
+        arg0.map(|xr| xr.to_reg())
+    }
+    fn xreg_to_reg(&mut self, arg0: XReg) -> Reg {
+        *arg0
+    }
+    fn freg_new(&mut self, r: Reg) -> FReg {
+        FReg::new(r).unwrap()
+    }
+    fn writable_freg_to_freg(&mut self, arg0: WritableFReg) -> FReg {
+        arg0.to_reg()
+    }
+    fn writable_freg_to_writable_reg(&mut self, arg0: WritableFReg) -> WritableReg {
+        arg0.map(|fr| fr.to_reg())
+    }
+    fn freg_to_reg(&mut self, arg0: FReg) -> Reg {
+        *arg0
+    }
 
     fn vec_writable_to_regs(&mut self, val: &VecWritableReg) -> ValueRegs {
         match val.len() {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -290,19 +290,19 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn gen_default_frm(&mut self) -> OptionFloatRoundingMode {
         None
     }
-    fn gen_select_reg(&mut self, cc: &IntCC, a: XReg, b: XReg, rs1: XReg, rs2: XReg) -> XReg {
+    fn gen_select_reg(&mut self, cc: &IntCC, a: XReg, b: XReg, rs1: Reg, rs2: Reg) -> Reg {
         let rd = self.temp_writable_reg(MInst::canonical_type_for_rc(rs1.class()));
         self.emit(&MInst::SelectReg {
             rd,
-            rs1: rs1.to_reg(),
-            rs2: rs2.to_reg(),
+            rs1,
+            rs2,
             condition: IntegerCompare {
                 kind: *cc,
                 rs1: a.to_reg(),
                 rs2: b.to_reg(),
             },
         });
-        self.xreg_new(rd.to_reg())
+        rd.to_reg()
     }
     fn load_u64_constant(&mut self, val: u64) -> Reg {
         let rd = self.temp_writable_reg(I64);

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -18,7 +18,7 @@
 (type InstOutputBuilder extern (enum))
 
 ;; Type to hold multiple Regs
-(type MultiReg 
+(type MultiReg
       (enum
        (Empty)
        (One (a Reg))
@@ -216,7 +216,7 @@
            (value_list_slice (value_slice_unwrap head1 (value_slice_unwrap head2 tail))))
 
 ;; Turn a `Writable<Reg>` into a `Reg` via `Writable::to_reg`.
-(decl writable_reg_to_reg (WritableReg) Reg)
+(decl pure writable_reg_to_reg (WritableReg) Reg)
 (extern constructor writable_reg_to_reg writable_reg_to_reg)
 
 ;; Extract the result values for the given instruction.

--- a/cranelift/filetests/filetests/isa/riscv64/select-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select-float.clif
@@ -1,0 +1,285 @@
+test compile precise-output
+set unwind_info=false
+target riscv64
+
+
+function %select_icmp_i8_f32(i8, f32, f32) -> f32 {
+block0(v0: i8, v1: f32, v2: f32):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a2,a0,255
+;   andi a4,a4,255
+;   select_reg fa0,fa0,fa1##condition=(a2 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a2, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a2, a4, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i8_f64(i8, f64, f64) -> f64 {
+block0(v0: i8, v1: f64, v2: f64):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a2,a0,255
+;   andi a4,a4,255
+;   select_reg fa0,fa0,fa1##condition=(a2 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a2, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a2, a4, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_f32(i16, f32, f32) -> f32 {
+block0(v0: i16, v1: f32, v2: f32):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a2,a0,48
+;   srli a4,a2,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a2, a0, 0x30
+;   srli a4, a2, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_f64(i16, f64, f64) -> f64 {
+block0(v0: i16, v1: f64, v2: f64):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a2,a0,48
+;   srli a4,a2,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a2, a0, 0x30
+;   srli a4, a2, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_f32(i32, f32, f32) -> f32 {
+block0(v0: i32, v1: f32, v2: f32):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a2,a0,32
+;   srli a4,a2,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a2, a0, 0x20
+;   srli a4, a2, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_f64(i32, f64, f64) -> f64 {
+block0(v0: i32, v1: f64, v2: f64):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a2,a0,32
+;   srli a4,a2,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a2, a0, 0x20
+;   srli a4, a2, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_f32(i64, f32, f32) -> f32 {
+block0(v0: i64, v1: f32, v2: f32):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a2,42
+;   select_reg fa0,fa0,fa1##condition=(a0 eq a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a2, zero, 0x2a
+;   beq a0, a2, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_f64(i64, f64, f64) -> f64 {
+block0(v0: i64, v1: f64, v2: f64):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a2,42
+;   select_reg fa0,fa0,fa1##condition=(a0 eq a2)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a2, zero, 0x2a
+;   beq a0, a2, 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i128_f32(i128, f32, f32) -> f32 {
+block0(v0: i128, v1: f32, v2: f32):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.f32 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   fmv.d fa6,fa0
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_f32 fa0,fa6,fa1##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d fa6, fa0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   fmv.d fa0, fa6
+;   j 8
+;   fmv.d fa0, fa1
+;   ret
+
+function %select_icmp_i128_f64(i128, f64, f64) -> f64 {
+block0(v0: i128, v1: f64, v2: f64):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.f64 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   fmv.d fa6,fa0
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_f64 fa0,fa6,fa1##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   fmv.d fa6, fa0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   fmv.d fa0, fa6
+;   j 8
+;   fmv.d fa0, fa1
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select.clif
@@ -1,0 +1,780 @@
+test compile precise-output
+set unwind_info=false
+target riscv64
+
+function %select_icmp_i8_i8(i8, i8, i8) -> i8 {
+block0(v0: i8, v1: i8, v2: i8):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a3,a0,255
+;   andi a4,a4,255
+;   select_reg a0,a1,a2##condition=(a3 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a3, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a3, a4, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i8_i16(i8, i16, i16) -> i16 {
+block0(v0: i8, v1: i16, v2: i16):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a3,a0,255
+;   andi a4,a4,255
+;   select_reg a0,a1,a2##condition=(a3 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a3, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a3, a4, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i8_i32(i8, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a3,a0,255
+;   andi a4,a4,255
+;   select_reg a0,a1,a2##condition=(a3 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a3, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a3, a4, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i8_i64(i8, i64, i64) -> i64 {
+block0(v0: i8, v1: i64, v2: i64):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   andi a3,a0,255
+;   andi a4,a4,255
+;   select_reg a0,a1,a2##condition=(a3 eq a4)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   andi a3, a0, 0xff
+;   andi a4, a4, 0xff
+;   beq a3, a4, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i8_i128(i8, i128, i128) -> i128 {
+block0(v0: i8, v1: i128, v2: i128):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   mv a5,a1
+;   li t4,42
+;   andi a7,a0,255
+;   andi t4,t4,255
+;   eq t1,a7,t4##ty=i8
+;   andi a7,t1,255
+;   select_i128 [a0,a1],[a5,a2],[a3,a4]##condition=a7
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a5, a1, 0
+;   addi t4, zero, 0x2a
+;   andi a7, a0, 0xff
+;   andi t4, t4, 0xff
+;   bne a7, t4, 0xc
+;   addi t1, zero, 1
+;   j 8
+;   mv t1, zero
+;   andi a7, t1, 0xff
+;   beqz a7, 0x10
+;   ori a0, a5, 0
+;   ori a1, a2, 0
+;   j 0xc
+;   ori a0, a3, 0
+;   ori a1, a4, 0
+;   ret
+
+function %select_icmp_i16_i8(i16, i8, i8) -> i8 {
+block0(v0: i16, v1: i8, v2: i8):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,48
+;   srli a4,a3,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x30
+;   srli a4, a3, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_i16(i16, i16, i16) -> i16 {
+block0(v0: i16, v1: i16, v2: i16):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,48
+;   srli a4,a3,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x30
+;   srli a4, a3, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_i32(i16, i32, i32) -> i32 {
+block0(v0: i16, v1: i32, v2: i32):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,48
+;   srli a4,a3,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x30
+;   srli a4, a3, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_i64(i16, i64, i64) -> i64 {
+block0(v0: i16, v1: i64, v2: i64):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,48
+;   srli a4,a3,48
+;   slli a6,a6,48
+;   srli t3,a6,48
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x30
+;   srli a4, a3, 0x30
+;   slli a6, a6, 0x30
+;   srli t3, a6, 0x30
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i16_i128(i16, i128, i128) -> i128 {
+block0(v0: i16, v1: i128, v2: i128):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   mv a6,a1
+;   li t1,42
+;   slli a7,a0,48
+;   srli t4,a7,48
+;   slli t1,t1,48
+;   srli a0,t1,48
+;   eq a5,t4,a0##ty=i16
+;   andi t4,a5,255
+;   select_i128 [a0,a1],[a6,a2],[a3,a4]##condition=t4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a6, a1, 0
+;   addi t1, zero, 0x2a
+;   slli a7, a0, 0x30
+;   srli t4, a7, 0x30
+;   slli t1, t1, 0x30
+;   srli a0, t1, 0x30
+;   bne t4, a0, 0xc
+;   addi a5, zero, 1
+;   j 8
+;   mv a5, zero
+;   andi t4, a5, 0xff
+;   beqz t4, 0x10
+;   ori a0, a6, 0
+;   ori a1, a2, 0
+;   j 0xc
+;   ori a0, a3, 0
+;   ori a1, a4, 0
+;   ret
+
+function %select_icmp_i32_i8(i32, i8, i8) -> i8 {
+block0(v0: i32, v1: i8, v2: i8):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,32
+;   srli a4,a3,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x20
+;   srli a4, a3, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_i16(i32, i16, i16) -> i16 {
+block0(v0: i32, v1: i16, v2: i16):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,32
+;   srli a4,a3,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x20
+;   srli a4, a3, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,32
+;   srli a4,a3,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x20
+;   srli a4, a3, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_i64(i32, i64, i64) -> i64 {
+block0(v0: i32, v1: i64, v2: i64):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   slli a3,a0,32
+;   srli a4,a3,32
+;   slli a6,a6,32
+;   srli t3,a6,32
+;   select_reg a0,a1,a2##condition=(a4 eq t3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   slli a3, a0, 0x20
+;   srli a4, a3, 0x20
+;   slli a6, a6, 0x20
+;   srli t3, a6, 0x20
+;   beq a4, t3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i32_i128(i32, i128, i128) -> i128 {
+block0(v0: i32, v1: i128, v2: i128):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   mv a6,a1
+;   li t1,42
+;   slli a7,a0,32
+;   srli t4,a7,32
+;   slli t1,t1,32
+;   srli a0,t1,32
+;   eq a5,t4,a0##ty=i32
+;   andi t4,a5,255
+;   select_i128 [a0,a1],[a6,a2],[a3,a4]##condition=t4
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a6, a1, 0
+;   addi t1, zero, 0x2a
+;   slli a7, a0, 0x20
+;   srli t4, a7, 0x20
+;   slli t1, t1, 0x20
+;   srli a0, t1, 0x20
+;   bne t4, a0, 0xc
+;   addi a5, zero, 1
+;   j 8
+;   mv a5, zero
+;   andi t4, a5, 0xff
+;   beqz t4, 0x10
+;   ori a0, a6, 0
+;   ori a1, a2, 0
+;   j 0xc
+;   ori a0, a3, 0
+;   ori a1, a4, 0
+;   ret
+
+function %select_icmp_i64_i8(i64, i8, i8) -> i8 {
+block0(v0: i64, v1: i8, v2: i8):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   select_reg a0,a1,a2##condition=(a0 eq a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   beq a0, a3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_i16(i64, i16, i16) -> i16 {
+block0(v0: i64, v1: i16, v2: i16):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   select_reg a0,a1,a2##condition=(a0 eq a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   beq a0, a3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_i32(i64, i32, i32) -> i32 {
+block0(v0: i64, v1: i32, v2: i32):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   select_reg a0,a1,a2##condition=(a0 eq a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   beq a0, a3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   select_reg a0,a1,a2##condition=(a0 eq a3)
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   beq a0, a3, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a1, 0
+;   ret
+
+function %select_icmp_i64_i128(i64, i128, i128) -> i128 {
+block0(v0: i64, v1: i128, v2: i128):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   mv t1,a1
+;   li a7,42
+;   eq a7,a0,a7##ty=i64
+;   andi a5,a7,255
+;   select_i128 [a0,a1],[t1,a2],[a3,a4]##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   ori t1, a1, 0
+;   addi a7, zero, 0x2a
+;   bne a0, a7, 0xc
+;   addi a7, zero, 1
+;   j 8
+;   mv a7, zero
+;   andi a5, a7, 0xff
+;   beqz a5, 0x10
+;   ori a0, t1, 0
+;   ori a1, a2, 0
+;   j 0xc
+;   ori a0, a3, 0
+;   ori a1, a4, 0
+;   ret
+
+function %select_icmp_i128_i8(i128, i8, i8) -> i8 {
+block0(v0: i128, v1: i8, v2: i8):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.i8 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_i8 a0,a2,a3##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a3, 0
+;   ret
+
+function %select_icmp_i128_i16(i128, i16, i16) -> i16 {
+block0(v0: i128, v1: i16, v2: i16):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.i16 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_i16 a0,a2,a3##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a3, 0
+;   ret
+
+function %select_icmp_i128_i32(i128, i32, i32) -> i32 {
+block0(v0: i128, v1: i32, v2: i32):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.i32 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_i32 a0,a2,a3##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a3, 0
+;   ret
+
+function %select_icmp_i128_i64(i128, i64, i64) -> i64 {
+block0(v0: i128, v1: i64, v2: i64):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.i64 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   li a6,42
+;   li a7,0
+;   eq a6,[a0,a1],[a6,a7]##ty=i128
+;   andi a5,a6,255
+;   select_i64 a0,a2,a3##condition=a5
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a6, zero, 0x2a
+;   mv a7, zero
+;   bne a1, a7, 0x10
+;   bne a0, a6, 0xc
+;   addi a6, zero, 1
+;   j 8
+;   mv a6, zero
+;   andi a5, a6, 0xff
+;   beqz a5, 0xc
+;   ori a0, a2, 0
+;   j 8
+;   ori a0, a3, 0
+;   ret
+
+function %select_icmp_i128_i128(i128, i128, i128) -> i128 {
+block0(v0: i128, v1: i128, v2: i128):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.i128 v5, v1, v2
+  return v6
+}
+
+; VCode:
+; block0:
+;   li t4,42
+;   li t0,0
+;   eq t4,[a0,a1],[t4,t0]##ty=i128
+;   andi a7,t4,255
+;   select_i128 [a0,a1],[a2,a3],[a4,a5]##condition=a7
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   addi t4, zero, 0x2a
+;   mv t0, zero
+;   bne a1, t0, 0x10
+;   bne a0, t4, 0xc
+;   addi t4, zero, 1
+;   j 8
+;   mv t4, zero
+;   andi a7, t4, 0xff
+;   beqz a7, 0x10
+;   ori a0, a2, 0
+;   ori a1, a3, 0
+;   j 0xc
+;   ori a0, a4, 0
+;   ori a1, a5, 0
+;   ret
+


### PR DESCRIPTION
👋 Hey,

This PR is a followup to a [suggestion made by @alexcrichton](https://github.com/bytecodealliance/wasmtime/pull/6430#discussion_r1201233156), it adds newtype wrappers for the different register classes that we have in the RISC-V Backend.

These are `XReg`, `FReg` and `VReg`, for Integer, Float and Vector. The newtypes are contained only to the ISLE layer, and do not propagate throughout the rest of the backend. However It would be a good idea to iteratively do so, I just felt that it would be too big a step for a first PR.

This change was further complicated by a rule that we have in the backend where we auto convert `ValueRegs` into `Reg`. This rule has caused issues in the past ([1](https://github.com/bytecodealliance/wasmtime/pull/5460#issue-1500769397), [2](https://github.com/bytecodealliance/wasmtime/pull/6317#issue-1691054353)), and was also conflicting with the newtype wrappers. Instead of adding similar rules to the newtypes, I've removed the rule and all usages of it.

Most of this change was in `ext_int_if_need` which returns ValueRegs, but most of its uses don't actually need more than one register. To that end I've repurposed the `zext` and `sext` rules, to act as single register zero or sign extends, and replaced the uses where only one register was necessary with those. Extends that do need multiple registers can use `ext_int_if_need` or `extend`.

These changes haven't changed any of the golden lowerings, but since it's such a broad change, I suspect we might be missing some coverage and I'm going to be fuzzing this overnight to doublecheck.