### PR TITLE
Fix adapter build on CI, rename the adapter artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,7 @@ jobs:
       test-capi: ${{ steps.calculate.outputs.test-capi }}
       build-fuzz: ${{ steps.calculate.outputs.build-fuzz }}
       audit: ${{ steps.calculate.outputs.audit }}
+      preview1-adapter: ${{ steps.calculate.outputs.preview1-adapter }}
     steps:
     - uses: actions/checkout@v3
     - id: calculate
@@ -159,6 +160,9 @@ jobs:
           if grep -q supply-chain names.log; then
             echo audit=true >> $GITHUB_OUTPUT
           fi
+          if grep -q component-adapter names.log; then
+            echo preview1-adapter=true >> $GITHUB_OUTPUT
+          fi
         fi
         matrix="$(node ./ci/build-test-matrix.js ./commits.log ./names.log $run_full)"
         echo "test-matrix={\"include\":$(echo $matrix)}" >> $GITHUB_OUTPUT
@@ -169,6 +173,7 @@ jobs:
             echo test-capi=true >> $GITHUB_OUTPUT
             echo build-fuzz=true >> $GITHUB_OUTPUT
             echo audit=true >> $GITHUB_OUTPUT
+            echo preview1-adapter=true >> $GITHUB_OUTPUT
         fi
 
   # Build all documentation of Wasmtime, including the C API documentation,
@@ -524,7 +529,7 @@ jobs:
   build-preview1-component-adapter:
     name: Build wasi-preview1-component-adapter
     needs: determine
-    if: needs.determine.outputs.run-full
+    if: needs.determine.outputs.preview1-adapter
     runs-on: ubuntu-latest
     permissions:
       deployments: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -553,7 +553,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: bins-wasi-preview1-component-adapter
-        path: target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.*.wasm
+        path: target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.*.wasm
 
 
     # common logic to cancel the entire run if this job fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -775,6 +775,7 @@ jobs:
       - verify-publish
       - determine
       - miri
+      - build-preview1-component-adapter
     if: always()
     steps:
     - name: Dump needs context

--- a/ci/build-wasi-preview1-component-adapter.sh
+++ b/ci/build-wasi-preview1-component-adapter.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -ex
 
+build_adapter="cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown"
+verify="cargo run -p verify-component-adapter --"
+
+debug="target/wasm32-unknown-unknown/debug/wasi_preview1_component_adapter.wasm"
+release="target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm"
+
 # Debug build, default features (reactor)
-cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown
-cargo run -p verify-component-adapter -- target/wasm32-unknown-unknown/debug/wasi_preview1_component_adapter.wasm
+$build_adapter
+$verify $debug
 
 # Debug build, command
-cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --no-default-features --features command
-cargo run -p verify-component-adapter -- target/wasm32-unknown-unknown/debug/wasi_preview1_component_adapter.wasm
+$build_adapter --no-default-features --features command
+$verify $debug
 
 # Release build, command
-cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --release --no-default-features --features command
-cargo run -p verify-component-adapter -- target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm
-wasm-tools metadata add --name "wasi_preview1_component_adapter.command.adapter:${VERSION}" target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm -o target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.command.wasm
+$build_adapter --release --no-default-features --features command
+$verify $release
+wasm-tools metadata add --name "wasi_preview1_component_adapter.command.adapter:${VERSION}" $release \
+  -o target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.command.wasm
 
 # Release build, default features (reactor)
-cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --release
-cargo run -p verify-component-adapter -- ./target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm
-wasm-tools metadata add --name "wasi_preview1_component_adapter.reactor.adapter:${VERSION}" target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm -o target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.reactor.wasm
+$build_adapter --release
+$verify $release
+wasm-tools metadata add --name "wasi_preview1_component_adapter.reactor.adapter:${VERSION}" $release \
+  -o target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.reactor.wasm

--- a/crates/wasi-preview1-component-adapter/verify/src/main.rs
+++ b/crates/wasi-preview1-component-adapter/verify/src/main.rs
@@ -21,6 +21,9 @@ const ALLOWED_IMPORT_MODULES: &[&str] = &[
     "preopens",
     "exit",
     "canonical_abi",
+    "stdin",
+    "stdout",
+    "stderr",
     "__main_module__",
 ];
 


### PR DESCRIPTION
This fixes an issue on `main` where the adapter is not validating currently. This slipped through because the GitHub Actions job was accidentally not listed in the "join" step of CI so nothing in our merge queue configuration was requiring it to succeed.

While I was here I went ahead and renamed the adapters as well to `wasi_snapshot_preview1.command.wasm` (and `reactor`) to match what `wit-component` expects as an `--adapt` argument where the basename of the provided file is used as the default name of what to adapt.