### PR TITLE
fixes to #6462: make wasi-common API compatible with 9.0.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,26 @@
 --------------------------------------------------------------------------------
+## 9.0.2
+
+Released 2023-05-26.
+
+### Fixed
+
+* Fix Wasi rights system to work with wasi-libc. This regression was
+  introduced in the 9.0.0 release.
+  [#6462](https://github.com/bytecodealliance/wasmtime/pull/6462)
+  [#6471](https://github.com/bytecodealliance/wasmtime/pull/6471)
+
+--------------------------------------------------------------------------------
+
+## 9.0.1
+
+Released 2023-05-22.
+### Fixed
+* A panic which happened when enabling support for native platform profilers was
+  fixed.
+  [#6435](https://github.com/bytecodealliance/wasmtime/pull/6435)
+
+--------------------------------------------------------------------------------
 
 ## 9.0.0
 

--- a/crates/wasi-common/cap-std-sync/src/lib.rs
+++ b/crates/wasi-common/cap-std-sync/src/lib.rs
@@ -49,7 +49,7 @@ pub use sched::sched_ctx;
 use crate::net::Socket;
 use cap_rand::{Rng, RngCore, SeedableRng};
 use std::path::Path;
-use wasi_common::{file::FileAccessMode, table::Table, Error, WasiCtx, WasiFile};
+use wasi_common::{table::Table, Error, WasiCtx, WasiFile};
 
 pub struct WasiCtxBuilder(WasiCtx);
 
@@ -126,8 +126,7 @@ impl WasiCtxBuilder {
     pub fn preopened_socket(self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
         let socket: Socket = socket.into();
         let file: Box<dyn WasiFile> = socket.into();
-        self.0
-            .insert_file(fd, file, FileAccessMode::READ | FileAccessMode::WRITE);
+        self.0.insert_file(fd, file);
         Ok(self)
     }
     pub fn build(self) -> WasiCtx {

--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -51,18 +51,17 @@ impl WasiCtx {
         s
     }
 
-    pub fn insert_file(&self, fd: u32, file: Box<dyn WasiFile>, access_mode: FileAccessMode) {
+    fn insert_file_(&self, fd: u32, file: Box<dyn WasiFile>, access_mode: FileAccessMode) {
         self.table()
             .insert_at(fd, Arc::new(FileEntry::new(file, access_mode)));
     }
+    pub fn insert_file(&self, fd: u32, file: Box<dyn WasiFile>) {
+        self.insert_file_(fd, file, FileAccessMode::all())
+    }
 
-    pub fn push_file(
-        &self,
-        file: Box<dyn WasiFile>,
-        access_mode: FileAccessMode,
-    ) -> Result<u32, Error> {
+    pub fn push_file(&self, file: Box<dyn WasiFile>) -> Result<u32, Error> {
         self.table()
-            .push(Arc::new(FileEntry::new(file, access_mode)))
+            .push(Arc::new(FileEntry::new(file, FileAccessMode::all())))
     }
 
     pub fn insert_dir(&self, fd: u32, dir: Box<dyn WasiDir>, path: PathBuf) {
@@ -98,15 +97,15 @@ impl WasiCtx {
     }
 
     pub fn set_stdin(&self, f: Box<dyn WasiFile>) {
-        self.insert_file(0, f, FileAccessMode::READ);
+        self.insert_file_(0, f, FileAccessMode::READ);
     }
 
     pub fn set_stdout(&self, f: Box<dyn WasiFile>) {
-        self.insert_file(1, f, FileAccessMode::WRITE);
+        self.insert_file_(1, f, FileAccessMode::WRITE);
     }
 
     pub fn set_stderr(&self, f: Box<dyn WasiFile>) {
-        self.insert_file(2, f, FileAccessMode::WRITE);
+        self.insert_file_(2, f, FileAccessMode::WRITE);
     }
 
     pub fn push_preopened_dir(

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -224,7 +224,7 @@ pub(crate) struct FileEntry {
 }
 
 bitflags! {
-    pub struct FileAccessMode : u32 {
+    pub(crate) struct FileAccessMode : u32 {
         const READ = 0b1;
         const WRITE= 0b10;
     }
@@ -239,7 +239,6 @@ impl FileEntry {
         Ok(FdStat {
             filetype: self.file.get_filetype().await?,
             flags: self.file.get_fdflags().await?,
-            access_mode: self.access_mode,
         })
     }
 }
@@ -248,7 +247,6 @@ impl FileEntry {
 pub struct FdStat {
     pub filetype: FileType,
     pub flags: FdFlags,
-    pub access_mode: FileAccessMode,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wasi-common/tokio/src/lib.rs
+++ b/crates/wasi-common/tokio/src/lib.rs
@@ -9,7 +9,7 @@ pub mod stdio;
 use std::future::Future;
 use std::path::Path;
 pub use wasi_cap_std_sync::{clocks_ctx, random_ctx};
-use wasi_common::{file::FileAccessMode, Error, Table, WasiCtx, WasiFile};
+use wasi_common::{Error, Table, WasiCtx, WasiFile};
 
 use crate::sched::sched_ctx;
 pub use dir::Dir;
@@ -96,8 +96,7 @@ impl WasiCtxBuilder {
     pub fn preopened_socket(self, fd: u32, socket: impl Into<Socket>) -> Result<Self, Error> {
         let socket: Socket = socket.into();
         let file: Box<dyn WasiFile> = socket.into();
-        self.0
-            .insert_file(fd, file, FileAccessMode::READ | FileAccessMode::WRITE);
+        self.0.insert_file(fd, file);
         Ok(self)
     }
 


### PR DESCRIPTION
required in order to make 9.0.2 a valid patch release.

* `struct FdStat` is public, so I backed out changes to it, and manually applied the rights bits in the implementation of fd_fdstat_get.

* new `FileAccessMode` changed to be pub(crate), to make sure it doesnt appear in any pub interfaces. WasiCtx::insert_file and push_file reverted to their original type signature. Private helper insert_file_ used for the set_{stdio} implementations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
