### PR TITLE
Disable tests for all proc-macros

### DIFF
--- a/crates/c-api/macros/Cargo.toml
+++ b/crates/c-api/macros/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [lib]
 proc-macro = true
 test = false
+doctest = false
 
 [dependencies]
 quote = "1.0"

--- a/crates/component-macro/test-helpers/Cargo.toml
+++ b/crates/component-macro/test-helpers/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0 WITH LLVM-exception"
 
 [lib]
 proc-macro = true
+test = false
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/misc/component-macro-test/Cargo.toml
+++ b/crates/misc/component-macro-test/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [lib]
 proc-macro = true
+test = false
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/wasi-preview1-component-adapter/byte-array-literals/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/byte-array-literals/Cargo.toml
@@ -7,3 +7,5 @@ publish = false
 
 [lib]
 proc-macro = true
+test = false
+doctest = false

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -13,6 +13,7 @@ include = ["src/**/*", "LICENSE"]
 [lib]
 proc-macro = true
 test = false
+doctest = false
 
 [dependencies]
 wiggle-generate = { workspace = true }

--- a/winch/test-macros/Cargo.toml
+++ b/winch/test-macros/Cargo.toml
@@ -10,6 +10,8 @@ edition.workspace = true
 
 [lib]
 proc-macro = true
+test = false
+doctest = false
 
 [dependencies]
 quote = "1.0"


### PR DESCRIPTION
This commit goes through all proc-macros we have in this repository and ensures that they're all flagged with `test = false` and `doctest = false`. This comes about as I was curious why CI time was 40m which felt a little long and upon inspection the cross-compiled builders were taking upwards of 30 minutes just to build everything (not including running tests) where the non-cross-compiled builders took only about 10-15 minutes to build everything.

Further investigation into this discrepancy showed that a lot of crates are being double-compiled in a cross-compiled situation. This is expected at a base level and something Cargo transparently handles, for example if a build script and the final binary need the same dependency then it's gotta get compiled twice. What was odd is that large portions of the Wasmtime crate graph were being compiled more than they should be.

I tracked this down to some `dev-dependencies` for procedural macros pointing at wasmtime crates. This makes sense for the `tests/*.rs`-style tests which are always compiled for the target, but tests for the proc-macro itself would be compiled for the host. By disabling tests and doctests for the proc macro itself this removes the need for the host-compiled version of these dependencies.

Overall this reduces a full compile of all tests from ~840 units of work to 700 units of work according to Cargo. The set of extra crates compiled in a cross-compiled workflow is not much smaller than in a non-cross-compiled workflow and they all generally "make sense" as core shared dependencies which are rooted in both Wasmtime and some proc-macro's dependency tree, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
