### PR TITLE
Use a published version of wit-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4686,7 +4686,8 @@ dependencies = [
 [[package]]
 name = "wit-bindgen"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?branch=wasmtime-2023-05-26-wit-changes#7df2c15f54d7c20593ff2d38db48014889c9a46d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a628591b3905328e886462f75de3b2af1e546b19af5f4c359086b26bec29c4bd"
 dependencies = [
  "bitflags 2.2.1",
  "wit-bindgen-rust-macro",
@@ -4695,7 +4696,8 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?branch=wasmtime-2023-05-26-wit-changes#7df2c15f54d7c20593ff2d38db48014889c9a46d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a19aa69c4f33cb5ac10e55880a899f4d52ec85d4cde4d593b575e7a97e2b08"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -4705,7 +4707,8 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?branch=wasmtime-2023-05-26-wit-changes#7df2c15f54d7c20593ff2d38db48014889c9a46d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a50274c0cf2f8e33fc967825cef0114cdfe222d474c1d78aa77a6a801abaadf"
 dependencies = [
  "heck",
  "wasm-metadata",
@@ -4717,7 +4720,8 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-lib"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?branch=wasmtime-2023-05-26-wit-changes#7df2c15f54d7c20593ff2d38db48014889c9a46d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3d58b5ced269f1a1cdcecfe0317c059fe158da9b670fff9907903b244bb89a"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -4726,7 +4730,8 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-rust-macro"
 version = "0.7.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen?branch=wasmtime-2023-05-26-wit-changes#7df2c15f54d7c20593ff2d38db48014889c9a46d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cce32dd08007af45dbaa00e225eb73d05524096f93933d7ecba852d50d8af3"
 dependencies = [
  "anyhow",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,6 +311,3 @@ debug-assertions = false
 # Omit integer overflow checks, which include failure messages which require
 # string initializers.
 overflow-checks = false
-
-[patch.crates-io]
-wit-bindgen = { git = 'https://github.com/bytecodealliance/wit-bindgen', branch = 'wasmtime-2023-05-26-wit-changes' }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -183,6 +183,41 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen]]
+version = "0.7.0"
+when = "2023-05-26"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-core]]
+version = "0.7.0"
+when = "2023-05-26"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust]]
+version = "0.7.0"
+when = "2023-05-26"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust-lib]]
+version = "0.7.0"
+when = "2023-05-26"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.7.0"
+when = "2023-05-26"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-component]]
 version = "0.8.2"
 when = "2023-04-27"
@@ -228,6 +263,12 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "0.2.2"
 notes = "Inspected it and is a tiny crate with just type definitions"
+
+[[audits.embark-studios.audits.epaint]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+violation = "<0.20.0"
+notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
 
 [[audits.embark-studios.audits.webpki-roots]]
 who = "Johan Andersson <opensource@embark-studios.com>"


### PR DESCRIPTION
Now that Wasmtime's changes landed I've published the relevant wit-bindgen crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
