### PR TITLE
Cranelift: Add the ability to pop stack while returning

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -400,7 +400,12 @@ impl ABIMachineSpec for AArch64MachineDeps {
         Inst::Args { args }
     }
 
-    fn gen_ret(setup_frame: bool, isa_flags: &aarch64_settings::Flags, rets: Vec<RetPair>) -> Inst {
+    fn gen_ret(
+        setup_frame: bool,
+        isa_flags: &aarch64_settings::Flags,
+        rets: Vec<RetPair>,
+        stack_bytes_to_pop: u32,
+    ) -> Inst {
         if isa_flags.sign_return_address() && (setup_frame || isa_flags.sign_return_address_all()) {
             let key = if isa_flags.sign_return_address_with_bkey() {
                 APIKey::B
@@ -412,9 +417,13 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 key,
                 is_hint: !isa_flags.has_pauth(),
                 rets,
+                stack_bytes_to_pop,
             }
         } else {
-            Inst::Ret { rets }
+            Inst::Ret {
+                rets,
+                stack_bytes_to_pop,
+            }
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -796,7 +796,8 @@
 
        ;; A machine return instruction.
        (Ret
-        (rets VecRetPair))
+        (rets VecRetPair)
+        (stack_bytes_to_pop u32))
 
        ;; A machine return instruction with pointer authentication using SP as the
        ;; modifier. This instruction requires pointer authentication support
@@ -806,7 +807,8 @@
        (AuthenticatedRet
         (key APIKey)
         (is_hint bool)
-        (rets VecRetPair))
+        (rets VecRetPair)
+        (stack_bytes_to_pop u32))
 
        ;; An unconditional branch.
        (Jump

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -37,12 +37,28 @@ fn test_aarch64_binemit() {
     // Then:
     //
     //      $ echo "mov x1, x2" | aarch64inst.sh
-    insns.push((Inst::Ret { rets: vec![] }, "C0035FD6", "ret"));
+    insns.push((
+        Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 0,
+        },
+        "C0035FD6",
+        "ret",
+    ));
+    insns.push((
+        Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 16,
+        },
+        "FF430091C0035FD6",
+        "add sp, sp, #16 ; ret",
+    ));
     insns.push((
         Inst::AuthenticatedRet {
             key: APIKey::A,
             is_hint: true,
             rets: vec![],
+            stack_bytes_to_pop: 0,
         },
         "BF2303D5C0035FD6",
         "autiasp ; ret",
@@ -52,9 +68,20 @@ fn test_aarch64_binemit() {
             key: APIKey::B,
             is_hint: false,
             rets: vec![],
+            stack_bytes_to_pop: 0,
         },
         "FF0F5FD6",
         "retab",
+    ));
+    insns.push((
+        Inst::AuthenticatedRet {
+            key: APIKey::A,
+            is_hint: false,
+            rets: vec![],
+            stack_bytes_to_pop: 16,
+        },
+        "FF0B5FD6",
+        "add sp, sp, #16 ; retaa",
     ));
     insns.push((Inst::Pacisp { key: APIKey::B }, "7F2303D5", "pacibsp"));
     insns.push((Inst::Xpaclri, "FF2003D5", "xpaclri"));

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -12,6 +12,7 @@ use crate::machinst::{PrettyPrint, Reg, RegClass, Writable};
 use alloc::vec::Vec;
 use regalloc2::{PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
+use std::fmt::Write;
 use std::string::{String, ToString};
 
 pub(crate) mod regs;
@@ -833,7 +834,7 @@ fn aarch64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
                 collector.reg_fixed_def(arg.vreg, arg.preg);
             }
         }
-        &Inst::Ret { ref rets } | &Inst::AuthenticatedRet { ref rets, .. } => {
+        &Inst::Ret { ref rets, .. } | &Inst::AuthenticatedRet { ref rets, .. } => {
             for ret in rets {
                 collector.reg_fixed_use(ret.vreg, ret.preg);
             }
@@ -2510,34 +2511,54 @@ impl Inst {
             &Inst::Args { ref args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    use std::fmt::Write;
                     let preg = pretty_print_reg(arg.preg, &mut empty_allocs);
                     let def = pretty_print_reg(arg.vreg.to_reg(), allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
                 }
                 s
             }
-            &Inst::Ret { ref rets } => {
-                let mut s = "ret".to_string();
+            &Inst::Ret {
+                ref rets,
+                stack_bytes_to_pop,
+            } => {
+                let mut s = if stack_bytes_to_pop == 0 {
+                    "ret".to_string()
+                } else {
+                    format!("add sp, sp, #{} ; ret", stack_bytes_to_pop)
+                };
                 for ret in rets {
-                    use std::fmt::Write;
                     let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
                     let vreg = pretty_print_reg(ret.vreg, allocs);
-                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                    write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
             }
-            &Inst::AuthenticatedRet { key, is_hint, .. } => {
+            &Inst::AuthenticatedRet {
+                key,
+                is_hint,
+                stack_bytes_to_pop,
+                ref rets,
+            } => {
                 let key = match key {
                     APIKey::A => "a",
                     APIKey::B => "b",
                 };
-
-                if is_hint {
-                    "auti".to_string() + key + "sp ; ret"
-                } else {
-                    "reta".to_string() + key
+                let mut s = match (is_hint, stack_bytes_to_pop) {
+                    (false, 0) => format!("reta{key}"),
+                    (false, n) => {
+                        format!("add sp, sp, #{n} ; reta{key}")
+                    }
+                    (true, 0) => format!("auti{key}sp ; ret"),
+                    (true, n) => {
+                        format!("add sp, sp, #{n} ; auti{key} ; ret")
+                    }
+                };
+                for ret in rets {
+                    let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
+                    let vreg = pretty_print_reg(ret.vreg, allocs);
+                    write!(&mut s, " {vreg}={preg}").unwrap();
                 }
+                s
             }
             &Inst::Jump { ref dest } => {
                 let dest = dest.pretty_print(0, allocs);

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -269,8 +269,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         Inst::Args { args }
     }
 
-    fn gen_ret(_setup_frame: bool, _isa_flags: &Self::F, rets: Vec<RetPair>) -> Inst {
-        Inst::Ret { rets }
+    fn gen_ret(
+        _setup_frame: bool,
+        _isa_flags: &Self::F,
+        rets: Vec<RetPair>,
+        stack_bytes_to_pop: u32,
+    ) -> Inst {
+        Inst::Ret {
+            rets,
+            stack_bytes_to_pop,
+        }
     }
 
     fn get_stacklimit_reg() -> Reg {

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -79,7 +79,8 @@
     (Args
       (args VecArgPair))
 
-    (Ret (rets VecRetPair))
+    (Ret (rets VecRetPair)
+         (stack_bytes_to_pop u32))
 
      (Extend
       (rd WritableReg)

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -722,7 +722,15 @@ impl MachInstEmit for Inst {
                 // Nothing: this is a pseudoinstruction that serves
                 // only to constrain registers at a certain point.
             }
-            &Inst::Ret { .. } => {
+            &Inst::Ret {
+                stack_bytes_to_pop, ..
+            } => {
+                if stack_bytes_to_pop != 0 {
+                    Inst::AjustSp {
+                        amount: i64::from(stack_bytes_to_pop),
+                    }
+                    .emit(&[], sink, emit_info, state);
+                }
                 //jalr x0, x1, 0
                 let x: u32 = (0b1100111) | (1 << 15);
                 sink.put4(x);

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -3,26 +3,61 @@ use crate::ir::LibCall;
 use crate::isa::riscv64::inst::*;
 use crate::settings;
 use alloc::vec::Vec;
+use std::borrow::Cow;
 
 #[test]
 fn test_riscv64_binemit() {
     struct TestUnit {
         inst: Inst,
         assembly: &'static str,
-        code: u32,
+        code: TestEncoding,
+    }
+
+    struct TestEncoding(Cow<'static, str>);
+
+    impl From<&'static str> for TestEncoding {
+        fn from(value: &'static str) -> Self {
+            Self(value.into())
+        }
+    }
+
+    impl From<u32> for TestEncoding {
+        fn from(value: u32) -> Self {
+            let value = value.swap_bytes();
+            let value = format!("{value:08X}");
+            Self(value.into())
+        }
     }
 
     impl TestUnit {
-        fn new(i: Inst, ass: &'static str, code: u32) -> Self {
+        fn new(inst: Inst, assembly: &'static str, code: impl Into<TestEncoding>) -> Self {
+            let code = code.into();
             Self {
-                inst: i,
-                assembly: ass,
-                code: code,
+                inst,
+                assembly,
+                code,
             }
         }
     }
 
     let mut insns = Vec::<TestUnit>::with_capacity(500);
+
+    insns.push(TestUnit::new(
+        Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 0,
+        },
+        "ret",
+        0x00008067,
+    ));
+    insns.push(TestUnit::new(
+        Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 16,
+        },
+        "add sp, sp, #16 ; ret",
+        "1301010167800000",
+    ));
 
     insns.push(TestUnit::new(
         Inst::Mov {
@@ -2078,26 +2113,9 @@ fn test_riscv64_binemit() {
         unit.inst
             .emit(&[], &mut buffer, &emit_info, &mut Default::default());
         let buffer = buffer.finish(&Default::default(), &mut Default::default());
-        if buffer.data() != unit.code.to_le_bytes() {
-            {
-                let gnu = DebugRTypeInst::from_bs(&unit.code.to_le_bytes());
-                let my = DebugRTypeInst::from_bs(buffer.data());
-                println!("gnu:{:?}", gnu);
-                println!("my :{:?}", my);
-                // println!("gnu:{:b}", gnu.funct7);
-                // println!("my :{:b}", my.funct7);
-            }
+        let actual_encoding = buffer.stringify_code_bytes();
 
-            {
-                let gnu = DebugITypeInst::from_bs(&unit.code.to_le_bytes());
-                let my = DebugITypeInst::from_bs(buffer.data());
-                println!("gnu:{:?}", gnu);
-                println!("my :{:?}", my);
-                println!("gnu:{:b}", gnu.op_code);
-                println!("my :{:b}", my.op_code);
-            }
-            assert_eq!(buffer.data(), unit.code.to_le_bytes());
-        }
+        assert_eq!(actual_encoding, unit.code.0);
     }
 }
 
@@ -2120,9 +2138,12 @@ pub(crate) struct DebugRTypeInst {
 }
 
 impl DebugRTypeInst {
-    pub(crate) fn from_bs(x: &[u8]) -> Self {
+    pub(crate) fn from_bs(x: &[u8]) -> Option<Self> {
+        if x.len() != 4 {
+            return None;
+        }
         let a = [x[0], x[1], x[2], x[3]];
-        Self::from_u32(u32::from_le_bytes(a))
+        Some(Self::from_u32(u32::from_le_bytes(a)))
     }
 
     pub(crate) fn from_u32(x: u32) -> Self {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -456,10 +456,16 @@ impl ABIMachineSpec for S390xMachineDeps {
         Inst::Args { args }
     }
 
-    fn gen_ret(_setup_frame: bool, _isa_flags: &s390x_settings::Flags, rets: Vec<RetPair>) -> Inst {
+    fn gen_ret(
+        _setup_frame: bool,
+        _isa_flags: &s390x_settings::Flags,
+        rets: Vec<RetPair>,
+        stack_bytes_to_pop: u32,
+    ) -> Inst {
         Inst::Ret {
             link: gpr(14),
             rets,
+            stack_bytes_to_pop,
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -906,7 +906,8 @@
     ;; A machine return instruction.
     (Ret
       (link Reg)
-      (rets VecRetPair))
+      (rets VecRetPair)
+      (stack_bytes_to_pop u32))
 
     ;; An unconditional branch.
     (Jump

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -5,7 +5,7 @@ use crate::ir::{MemFlags, RelSourceLoc, TrapCode};
 use crate::isa::s390x::abi::S390xMachineDeps;
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
-use crate::machinst::{Reg, RegClass};
+use crate::machinst::{ABIMachineSpec, Reg, RegClass};
 use crate::trace;
 use core::convert::TryFrom;
 use cranelift_control::ControlPlane;
@@ -3545,8 +3545,18 @@ impl Inst {
                 }
             }
             &Inst::Args { .. } => {}
-            &Inst::Ret { link, .. } => {
+            &Inst::Ret {
+                link,
+                stack_bytes_to_pop,
+                ..
+            } => {
                 debug_assert_eq!(link, gpr(14));
+
+                for inst in
+                    S390xMachineDeps::gen_sp_reg_adjust(i32::try_from(stack_bytes_to_pop).unwrap())
+                {
+                    inst.emit(&[], sink, emit_info, state);
+                }
 
                 let opcode = 0x07; // BCR
                 put(sink, &enc_rr(opcode, gpr(15), link));

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7022,9 +7022,20 @@ fn test_s390x_binemit() {
         Inst::Ret {
             link: gpr(14),
             rets: vec![],
+            stack_bytes_to_pop: 0,
         },
         "07FE",
         "br %r14",
+    ));
+
+    insns.push((
+        Inst::Ret {
+            link: gpr(14),
+            rets: vec![],
+            stack_bytes_to_pop: 16,
+        },
+        "A7FB001007FE",
+        "aghi %r15, 16 ; br %r14",
     ));
 
     insns.push((Inst::Debugtrap, "0001", ".word 0x0001 # debugtrap"));

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -301,8 +301,9 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         _setup_frame: bool,
         _isa_flags: &x64_settings::Flags,
         rets: Vec<RetPair>,
+        stack_bytes_to_pop: u32,
     ) -> Self::I {
-        Inst::ret(rets)
+        Inst::ret(rets, stack_bytes_to_pop)
     }
 
     fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallInstVec<Self::I> {

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -486,7 +486,8 @@
         (args VecArgPair))
 
        ;; Return.
-       (Ret (rets VecRetPair))
+       (Ret (rets VecRetPair)
+            (stack_bytes_to_pop u32))
 
        ;; Jump to a known target: jmp simm32.
        (JmpKnown (dst MachLabel))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1602,7 +1602,17 @@ pub(crate) fn emit(
 
         Inst::Args { .. } => {}
 
-        Inst::Ret { .. } => sink.put1(0xC3),
+        Inst::Ret {
+            stack_bytes_to_pop: 0,
+            ..
+        } => sink.put1(0xC3),
+
+        Inst::Ret {
+            stack_bytes_to_pop, ..
+        } => {
+            sink.put1(0xC2);
+            sink.put2(u16::try_from(*stack_bytes_to_pop).unwrap());
+        }
 
         Inst::JmpKnown { dst } => {
             let br_start = sink.cur_offset();

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4411,7 +4411,8 @@ fn test_x64_emit() {
 
     // ========================================================
     // Ret
-    insns.push((Inst::ret(vec![]), "C3", "ret"));
+    insns.push((Inst::ret(vec![], 0), "C3", "ret"));
+    insns.push((Inst::ret(vec![], 8), "C20800", "ret 8"));
 
     // ========================================================
     // JmpKnown skipped for now

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 use cranelift_control::ControlPlane;
 use regalloc2::{Allocation, PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
-use std::fmt;
+use std::fmt::{self, Write};
 use std::string::{String, ToString};
 
 pub mod args;
@@ -544,8 +544,11 @@ impl Inst {
         }
     }
 
-    pub(crate) fn ret(rets: Vec<RetPair>) -> Inst {
-        Inst::Ret { rets }
+    pub(crate) fn ret(rets: Vec<RetPair>, stack_bytes_to_pop: u32) -> Inst {
+        Inst::Ret {
+            rets,
+            stack_bytes_to_pop,
+        }
     }
 
     pub(crate) fn jmp_known(dst: MachLabel) -> Inst {
@@ -1657,7 +1660,6 @@ impl PrettyPrint for Inst {
             Inst::Args { args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    use std::fmt::Write;
                     let preg = regs::show_reg(arg.preg);
                     let def = pretty_print_reg(arg.vreg.to_reg(), 8, allocs);
                     write!(&mut s, " {}={}", def, preg).unwrap();
@@ -1665,13 +1667,18 @@ impl PrettyPrint for Inst {
                 s
             }
 
-            Inst::Ret { rets } => {
+            Inst::Ret {
+                rets,
+                stack_bytes_to_pop,
+            } => {
                 let mut s = "ret".to_string();
+                if *stack_bytes_to_pop != 0 {
+                    write!(&mut s, " {stack_bytes_to_pop}").unwrap();
+                }
                 for ret in rets {
-                    use std::fmt::Write;
                     let preg = regs::show_reg(ret.preg);
                     let vreg = pretty_print_reg(ret.vreg, 8, allocs);
-                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                    write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
             }
@@ -1818,8 +1825,6 @@ impl PrettyPrint for Inst {
                 dst,
                 tmp,
             } => {
-                use std::fmt::Write;
-
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let tmp = allocs.next(tmp.to_reg().to_reg());
 
@@ -2353,7 +2358,10 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             }
         }
 
-        Inst::Ret { rets } => {
+        Inst::Ret {
+            rets,
+            stack_bytes_to_pop: _,
+        } => {
             // The return value(s) are live-out; we represent this
             // with register uses on the return instruction.
             for ret in rets.iter() {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4400,4 +4400,3 @@
 
 (rule (lower (nop))
       (invalid_reg))
-

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -431,7 +431,18 @@ pub trait ABIMachineSpec {
     fn gen_args(isa_flags: &Self::F, args: Vec<ArgPair>) -> Self::I;
 
     /// Generate a return instruction.
-    fn gen_ret(setup_frame: bool, isa_flags: &Self::F, rets: Vec<RetPair>) -> Self::I;
+    ///
+    /// Optionally given non-zero number of additional stack bytes to pop after
+    /// popping the return address from the stack, if any, and just before the
+    /// actual return. This is used by the "tail" calling convention to clean up
+    /// stack arguments in the callee because we cannot rely on the caller to do
+    /// it.
+    fn gen_ret(
+        setup_frame: bool,
+        isa_flags: &Self::F,
+        rets: Vec<RetPair>,
+        stack_bytes_to_pop: u32,
+    ) -> Self::I;
 
     /// Generate an add-with-immediate. Note that even if this uses a scratch
     /// register, it must satisfy two requirements:
@@ -1670,8 +1681,22 @@ impl<M: ABIMachineSpec> Callee<M> {
     }
 
     /// Generate a return instruction.
-    pub fn gen_ret(&self, rets: Vec<RetPair>) -> M::I {
-        M::gen_ret(self.setup_frame, &self.isa_flags, rets)
+    pub fn gen_ret(&self, sigs: &SigSet, rets: Vec<RetPair>) -> M::I {
+        M::gen_ret(
+            self.setup_frame,
+            &self.isa_flags,
+            rets,
+            self.stack_bytes_to_pop(sigs),
+        )
+    }
+
+    fn stack_bytes_to_pop(&self, sigs: &SigSet) -> u32 {
+        let sig = &sigs[self.sig];
+        if sig.call_conv == isa::CallConv::Tail {
+            sig.sized_stack_arg_space
+        } else {
+            0
+        }
     }
 
     /// Produce an instruction that computes a sized stackslot address.
@@ -1893,7 +1918,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Note that this must generate the actual return instruction (rather than
     /// emitting this in the lowering logic), because the epilogue code comes
     /// before the return and the two are likely closely related.
-    pub fn gen_epilogue(&self) -> SmallInstVec<M::I> {
+    pub fn gen_epilogue(&self, sigs: &SigSet) -> SmallInstVec<M::I> {
         let mut insts = smallvec![];
 
         // Restore clobbered registers.
@@ -1919,7 +1944,12 @@ impl<M: ABIMachineSpec> Callee<M> {
         // This `ret` doesn't need any return registers attached
         // because we are post-regalloc and don't need to
         // represent the implicit uses anymore.
-        insts.push(M::gen_ret(self.setup_frame, &self.isa_flags, vec![]));
+        insts.push(M::gen_ret(
+            self.setup_frame,
+            &self.isa_flags,
+            vec![],
+            self.stack_bytes_to_pop(sigs),
+        ));
 
         trace!("Epilogue: {:?}", insts);
         insts
@@ -2129,10 +2159,10 @@ impl<M: ABIMachineSpec> CallSite<M> {
     pub fn emit_stack_pre_adjust(&self, ctx: &mut Lower<M::I>) {
         let off =
             ctx.sigs()[self.sig].sized_stack_arg_space + ctx.sigs()[self.sig].sized_stack_ret_space;
-        adjust_stack_and_nominal_sp::<M>(ctx, off as i32, /* is_sub = */ true)
+        adjust_stack_and_nominal_sp::<M>(ctx, off as i32, /* is_sub = */ true);
     }
 
-    /// Emit code to post-adjust the satck, after call return and return-value copies.
+    /// Emit code to post-adjust the stack, after call return and return-value copies.
     pub fn emit_stack_post_adjust(&self, ctx: &mut Lower<M::I>) {
         let off =
             ctx.sigs()[self.sig].sized_stack_arg_space + ctx.sigs()[self.sig].sized_stack_ret_space;

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -2144,7 +2144,10 @@ mod test {
         inst.emit(&[], &mut buf, &info, &mut state);
 
         buf.bind_label(label(7), state.ctrl_plane_mut());
-        let inst = Inst::Ret { rets: vec![] };
+        let inst = Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 0,
+        };
         inst.emit(&[], &mut buf, &info, &mut state);
 
         let buf = buf.finish(&constants, state.ctrl_plane_mut());

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -654,7 +654,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             }
         }
 
-        let inst = self.abi().gen_ret(out_rets);
+        let inst = self.abi().gen_ret(&self.sigs(), out_rets);
         self.emit(inst);
     }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -975,7 +975,7 @@ impl<I: VCodeInst> VCode<I> {
                         // (and don't emit the return; the actual
                         // epilogue will contain it).
                         if self.insts[iix.index()].is_term() == MachTerminator::Ret {
-                            for inst in self.abi.gen_epilogue() {
+                            for inst in self.abi.gen_epilogue(&self.sigs) {
                                 do_emit(&inst, &[], &mut disasm, &mut buffer, &mut state);
                             }
                         } else {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -219,7 +219,10 @@ impl Assembler {
 
     /// Return instruction.
     pub fn ret(&mut self) {
-        self.emit(Inst::Ret { rets: vec![] });
+        self.emit(Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 0,
+        });
     }
 
     // Helpers for ALU operations.

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -124,7 +124,10 @@ impl Assembler {
 
     /// Return instruction.
     pub fn ret(&mut self) {
-        self.emit(Inst::Ret { rets: vec![] });
+        self.emit(Inst::Ret {
+            rets: vec![],
+            stack_bytes_to_pop: 0,
+        });
     }
 
     /// Move instruction variants.


### PR DESCRIPTION
This is necessary for implementing callee-pops calling conventions, as is required for tail calls. This is just a small part of tail calls, and doesn't implement everything, but is a good piece to land on its own so that eventual PR isn't so huge. Just trying to shrink the yak stack.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
