### PR TITLE
Android release binaries

### DIFF
--- a/.github/actions/binary-compatible-builds/main.js
+++ b/.github/actions/binary-compatible-builds/main.js
@@ -21,6 +21,11 @@ if (process.platform == 'win32') {
   return;
 }
 
+// On Android skip the fancy things with containers
+if (process.env.INPUT_NAME.indexOf("android") >= 0) {
+  return;
+}
+
 // ... and on Linux we do fancy things with containers. We'll spawn an old
 // CentOS container in the background with a super old glibc, and then we'll run
 // commands in there with the `$CENTOS` env var.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -734,16 +734,14 @@ jobs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
       if: contains('android', matrix.target)
-    - uses: actions/cache@v3
-      if: contains('android', matrix.target)
+      uses: actions/cache@v3
       with:
         path: ${{ runner.tool_cache }}/cargo-ndk
         key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}
-    - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
-    - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk 
-
-    - if: contains('android', matrix.target)
-      run: cargo ndk -t "${{ matrix.target }}" build wasmtime --release --features all-arch
+      run: |
+        rustup target add ${{ matrix.target }}
+        echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
+        cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk 
 
     # Build `wasmtime` and executables. Note that we include `all-arch` so our
     # release artifacts can be used to compile `.cwasm`s for other targets.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -742,6 +742,9 @@ jobs:
     - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk 
 
+    - if: contains('android', matrix.target)
+      run: cargo ndk -t "${{ matrix.target }}" build wasmtime --release --features all-arch
+
     # Build `wasmtime` and executables. Note that we include `all-arch` so our
     # release artifacts can be used to compile `.cwasm`s for other targets.
     - run: $CENTOS cargo build --release --bin wasmtime --features all-arch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -729,6 +729,18 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
+    - run: rustup target add aarch64-linux-android
+    - run: rustup target add x86_64-linux-android
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
+    - uses: actions/cache@v3
+      with:
+        path: ${{ runner.tool_cache }}/cargo-ndk
+        key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}
+    - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
+    - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk
+    - run: cargo ndk -t arm64-v8a -t x86_64 check -p wasmtime
+
     # Build `wasmtime` and executables. Note that we include `all-arch` so our
     # release artifacts can be used to compile `.cwasm`s for other targets.
     - run: $CENTOS cargo build --release --bin wasmtime --features all-arch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -681,6 +681,8 @@ jobs:
     needs: determine
     if: needs.determine.outputs.run-full
     name: Release build for ${{ matrix.build }}
+    env:
+      CARGO_NDK_VERSION: 2.12.2
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -731,9 +731,9 @@ jobs:
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
-      if: contains("android", matrix.target)
+      if: contains('android', matrix.target)
     - uses: actions/cache@v3
-      if: contains("android", matrix.target)
+      if: contains('android', matrix.target)
       with:
         path: ${{ runner.tool_cache }}/cargo-ndk
         key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -706,6 +706,12 @@ jobs:
         - build: riscv64gc-linux
           os: ubuntu-latest
           target: riscv64gc-unknown-linux-gnu
+        - build: aarch64-android
+          os: ubuntu-latest
+          target: aarch64-linux-android
+        - build: x86_64-android
+          os: ubuntu-latest
+          target: x86_64-linux-android
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -707,7 +707,7 @@ jobs:
           os: ubuntu-latest
           target: riscv64gc-unknown-linux-gnu
         - build: aarch64-android
-          os: ubuntu-latest
+          os: aarch64-linux
           target: aarch64-linux-android
         - build: x86_64-android
           os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -707,7 +707,7 @@ jobs:
           os: ubuntu-latest
           target: riscv64gc-unknown-linux-gnu
         - build: aarch64-android
-          os: aarch64-linux
+          os: ubuntu-latest
           target: aarch64-linux-android
         - build: x86_64-android
           os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -738,7 +738,7 @@ jobs:
         path: ${{ runner.tool_cache }}/cargo-ndk
         key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}
     - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
-    - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk
+    - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk 
 
     # Build `wasmtime` and executables. Note that we include `all-arch` so our
     # release artifacts can be used to compile `.cwasm`s for other targets.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -731,13 +731,14 @@ jobs:
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
+      if: contains("android", matrix.target)
     - uses: actions/cache@v3
+      if: contains("android", matrix.target)
       with:
         path: ${{ runner.tool_cache }}/cargo-ndk
         key: cargo-ndk-bin-${{ env.CARGO_NDK_VERSION }}
     - run: echo "${{ runner.tool_cache }}/cargo-ndk/bin" >> $GITHUB_PATH
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk
-    - run: cargo ndk -t arm64-v8a -t x86_64 check -p wasmtime
 
     # Build `wasmtime` and executables. Note that we include `all-arch` so our
     # release artifacts can be used to compile `.cwasm`s for other targets.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -729,8 +729,6 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    - run: rustup target add aarch64-linux-android
-    - run: rustup target add x86_64-linux-android
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
     - uses: actions/cache@v3

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -48,6 +48,8 @@ For explanations of what each tier means see below.
 | Target               | `aarch64-apple-darwin`            | CI testing                  |
 | Target               | `aarch64-pc-windows-msvc`         | CI testing, unwinding, full-time maintainer |
 | Target               | `riscv64gc-unknown-linux-gnu`     | full-time maintainer        |
+| Target               | `x86_64-linux-android`            | CI testing, full-time maintainer |
+| Target               | `aarch64-linux-android`           | CI testing, full-time maintainer |
 | WASI Proposal        | `wasi-nn`                         | More expansive CI testing   |
 | WASI Proposal        | `wasi-crypto`                     | CI testing, clear owner     |
 | WebAssembly Proposal | `threads`                         | Complete implementation     |


### PR DESCRIPTION
As discussed [here](https://github.com/bytecodealliance/wasmtime/issues/3867#issuecomment-1563121598). This adds Android targets to the build matrix (Android aarch64 and x86_64) and adds Android to the docs in "tier3". This will make wasmtime more convenient to use on Android devices.

I'm not very familiar with Github actions, so it's very possible that this isn't correct. Unfortunately I wasn't able to work out how to run this action in my fork to test it. If anyone can offer guidance on how to do that it would be much appreciated!