### PR TITLE
Refactor the x64 pretty-printer

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -692,21 +692,14 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(src1.to_reg(), size_bytes, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes, allocs);
                 let src2 = src2.pretty_print(size_bytes, allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify2(op.to_string(), suffix_bwlq(*size)),
-                    src1,
-                    src2,
-                    dst
-                )
+                let op = ljustify2(op.to_string(), suffix_bwlq(*size));
+                format!("{op} {src1}, {src2}, {dst}")
             }
             Inst::AluConstOp { op, dst, size } => {
                 let size_bytes = size.to_bytes();
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size_bytes, allocs);
-                format!(
-                    "{} {dst}, {dst}, {dst}",
-                    ljustify2(op.to_string(), suffix_lqb(*size)),
-                )
+                let op = ljustify2(op.to_string(), suffix_lqb(*size));
+                format!("{op} {dst}, {dst}, {dst}")
             }
             Inst::AluRM {
                 size,
@@ -717,12 +710,8 @@ impl PrettyPrint for Inst {
                 let size_bytes = size.to_bytes();
                 let src2 = pretty_print_reg(src2.to_reg(), size_bytes, allocs);
                 let src1_dst = src1_dst.pretty_print(size_bytes, allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2(op.to_string(), suffix_bwlq(*size)),
-                    src2,
-                    src1_dst,
-                )
+                let op = ljustify2(op.to_string(), suffix_bwlq(*size));
+                format!("{op} {src2}, {src1_dst}")
             }
             Inst::AluRmRVex {
                 size,
@@ -735,45 +724,28 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let src1 = pretty_print_reg(src1.to_reg(), size_bytes, allocs);
                 let src2 = pretty_print_reg(src2.to_reg(), size_bytes, allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify2(op.to_string(), String::new()),
-                    src2,
-                    src1,
-                    dst,
-                )
+                let op = ljustify2(op.to_string(), String::new());
+                format!("{op} {src2}, {src1}, {dst}")
             }
             Inst::UnaryRmR { src, dst, op, size } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let src = src.pretty_print(size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2(op.to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst,
-                )
+                let op = ljustify2(op.to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::Not { size, src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("not".to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst,
-                )
+                let op = ljustify2("not".to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::Neg { size, src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("neg".to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst,
-                )
+                let op = ljustify2("neg".to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::Div {
@@ -793,17 +765,12 @@ impl PrettyPrint for Inst {
                     pretty_print_reg(dst_quotient.to_reg().to_reg(), size.to_bytes(), allocs);
                 let dst_remainder =
                     pretty_print_reg(dst_remainder.to_reg().to_reg(), size.to_bytes(), allocs);
+                let op = ljustify(match sign {
+                    DivSignedness::Signed => "idiv".to_string(),
+                    DivSignedness::Unsigned => "div".to_string(),
+                });
                 format!(
-                    "{} {}, {}, {}, {}, {} ; trap={trap}",
-                    ljustify(match sign {
-                        DivSignedness::Signed => "idiv".to_string(),
-                        DivSignedness::Unsigned => "div".to_string(),
-                    }),
-                    dividend_lo,
-                    dividend_hi,
-                    divisor,
-                    dst_quotient,
-                    dst_remainder,
+                    "{op} {dividend_lo}, {dividend_hi}, {divisor}, {dst_quotient}, {dst_remainder} ; trap={trap}"
                 )
             }
 
@@ -817,13 +784,11 @@ impl PrettyPrint for Inst {
                 let divisor = divisor.pretty_print(1, allocs);
                 let dividend = pretty_print_reg(dividend.to_reg(), 1, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
-                format!(
-                    "{} {dividend}, {divisor}, {dst} ; trap={trap}",
-                    ljustify(match sign {
-                        DivSignedness::Signed => "idiv".to_string(),
-                        DivSignedness::Unsigned => "div".to_string(),
-                    }),
-                )
+                let op = ljustify(match sign {
+                    DivSignedness::Signed => "idiv".to_string(),
+                    DivSignedness::Unsigned => "div".to_string(),
+                });
+                format!("{op} {dividend}, {divisor}, {dst} ; trap={trap}")
             }
 
             Inst::MulHi {
@@ -838,18 +803,12 @@ impl PrettyPrint for Inst {
                 let dst_lo = pretty_print_reg(dst_lo.to_reg().to_reg(), size.to_bytes(), allocs);
                 let dst_hi = pretty_print_reg(dst_hi.to_reg().to_reg(), size.to_bytes(), allocs);
                 let src2 = src2.pretty_print(size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}, {}, {}",
-                    ljustify(if *signed {
-                        "imul".to_string()
-                    } else {
-                        "mul".to_string()
-                    }),
-                    src1,
-                    src2,
-                    dst_lo,
-                    dst_hi,
-                )
+                let op = ljustify(if *signed {
+                    "imul".to_string()
+                } else {
+                    "mul".to_string()
+                });
+                format!("{op} {src1}, {src2}, {dst_lo}, {dst_hi}")
             }
 
             Inst::UMulLo {
@@ -861,13 +820,8 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(src1.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let src2 = src2.pretty_print(size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify2("mul".to_string(), suffix_bwlq(*size)),
-                    src1,
-                    src2,
-                    dst,
-                )
+                let op = ljustify2("mul".to_string(), suffix_bwlq(*size));
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::CheckedSRemSeq {
@@ -905,29 +859,27 @@ impl PrettyPrint for Inst {
             Inst::SignExtendData { size, src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    match size {
-                        OperandSize::Size8 => "cbw",
-                        OperandSize::Size16 => "cwd",
-                        OperandSize::Size32 => "cdq",
-                        OperandSize::Size64 => "cqo",
-                    },
-                    src,
-                    dst,
-                )
+                let op = match size {
+                    OperandSize::Size8 => "cbw",
+                    OperandSize::Size16 => "cwd",
+                    OperandSize::Size32 => "cdq",
+                    OperandSize::Size64 => "cqo",
+                };
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmUnaryRmR { op, src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
                 let src = src.pretty_print(op.src_size(), allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRUnaligned { op, src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
                 let src = src.pretty_print(op.src_size(), allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRImm {
@@ -935,13 +887,15 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), op.src_size(), allocs);
                 let src = src.pretty_print(op.src_size(), allocs);
-                format!("{} ${}, {}, {}", ljustify(op.to_string()), imm, src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRVex { op, src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmUnaryRmRImmVex {
@@ -949,25 +903,29 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(8, allocs);
-                format!("{} ${imm}, {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmUnaryRmREvex { op, src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmMovRM { op, src, dst, .. } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = dst.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmMovRMVex { op, src, dst, .. } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = dst.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmMovRMImm {
@@ -975,7 +933,8 @@ impl PrettyPrint for Inst {
             } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = dst.pretty_print(8, allocs);
-                format!("{} ${imm}, {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmMovRMImmVex {
@@ -983,7 +942,8 @@ impl PrettyPrint for Inst {
             } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = dst.pretty_print(8, allocs);
-                format!("{} ${imm}, {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmRmR {
@@ -996,7 +956,8 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!("{} {}, {}, {}", ljustify(op.to_string()), src1, src2, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::XmmRmRUnaligned {
@@ -1009,7 +970,8 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!("{} {}, {}, {}", ljustify(op.to_string()), src1, src2, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::XmmRmRBlend {
@@ -1029,14 +991,8 @@ impl PrettyPrint for Inst {
                 };
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!(
-                    "{} {}, {}, {}{}",
-                    ljustify(op.to_string()),
-                    src1,
-                    src2,
-                    dst,
-                    mask
-                )
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {dst}{mask}")
             }
 
             Inst::XmmRmiRVex {
@@ -1049,8 +1005,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-
-                format!("{} {}, {}, {}", ljustify(op.to_string()), src1, src2, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::XmmRmRImmVex {
@@ -1064,8 +1020,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-
-                format!("{} ${imm}, {src1}, {src2}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src1}, {src2}, {dst}")
             }
 
             Inst::XmmVexPinsr {
@@ -1079,8 +1035,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-
-                format!("{} ${imm}, {src1}, {src2}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src1}, {src2}, {dst}")
             }
 
             Inst::XmmRmRVex3 {
@@ -1095,15 +1051,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
                 let src3 = src3.pretty_print(8, allocs);
-
-                format!(
-                    "{} {}, {}, {}, {}",
-                    ljustify(op.to_string()),
-                    src1,
-                    src2,
-                    src3,
-                    dst
-                )
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {src3}, {dst}")
             }
 
             Inst::XmmRmRBlendVex {
@@ -1118,8 +1067,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
                 let mask = pretty_print_reg(mask.to_reg(), 8, allocs);
-
-                format!("{} {src1}, {src2}, {mask}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {mask}, {dst}")
             }
 
             Inst::XmmRmREvex {
@@ -1132,7 +1081,8 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!("{} {src1}, {src2}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::XmmRmREvex3 {
@@ -1147,7 +1097,8 @@ impl PrettyPrint for Inst {
                 let src2 = pretty_print_reg(src2.to_reg(), 8, allocs);
                 let src3 = src3.pretty_print(8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} {src1}, {src2}, {src3}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} {src1}, {src2}, {src3}, {dst}")
             }
 
             Inst::XmmMinMaxSeq {
@@ -1160,20 +1111,15 @@ impl PrettyPrint for Inst {
                 let rhs = pretty_print_reg(rhs.to_reg(), 8, allocs);
                 let lhs = pretty_print_reg(lhs.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify2(
-                        if *is_min {
-                            "xmm min seq ".to_string()
-                        } else {
-                            "xmm max seq ".to_string()
-                        },
-                        format!("f{}", size.to_bits())
-                    ),
-                    lhs,
-                    rhs,
-                    dst
-                )
+                let op = ljustify2(
+                    if *is_min {
+                        "xmm min seq ".to_string()
+                    } else {
+                        "xmm max seq ".to_string()
+                    },
+                    format!("f{}", size.to_bits()),
+                );
+                format!("{op} {lhs}, {rhs}, {dst}")
             }
 
             Inst::XmmRmRImm {
@@ -1188,23 +1134,22 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(*src1, 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!(
-                    "{} ${imm}, {src1}, {src2}, {dst}",
-                    ljustify(format!(
-                        "{}{}",
-                        op.to_string(),
-                        if *size == OperandSize::Size64 {
-                            ".w"
-                        } else {
-                            ""
-                        }
-                    )),
-                )
+                let op = ljustify(format!(
+                    "{}{}",
+                    op.to_string(),
+                    if *size == OperandSize::Size64 {
+                        ".w"
+                    } else {
+                        ""
+                    }
+                ));
+                format!("{op} ${imm}, {src1}, {src2}, {dst}")
             }
 
             Inst::XmmUninitializedValue { dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} {}", ljustify("uninit".into()), dst)
+                let op = ljustify("uninit".into());
+                format!("{op} {dst}")
             }
 
             Inst::XmmToGpr {
@@ -1216,7 +1161,8 @@ impl PrettyPrint for Inst {
                 let dst_size = dst_size.to_bytes();
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmToGprVex {
@@ -1228,19 +1174,22 @@ impl PrettyPrint for Inst {
                 let dst_size = dst_size.to_bytes();
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
-                format!("{} {src}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmToGprImm { op, src, dst, imm } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} ${imm}, {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmToGprImmVex { op, src, dst, imm } => {
                 let src = pretty_print_reg(src.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} ${imm}, {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::GprToXmm {
@@ -1251,7 +1200,8 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(src_size.to_bytes(), allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::GprToXmmVex {
@@ -1262,13 +1212,15 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(src_size.to_bytes(), allocs);
-                format!("{} {src}, {dst}", ljustify(op.to_string()))
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::XmmCmpRmR { op, src, dst } => {
                 let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
                 let src = src.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify(op.to_string()), src, dst)
+                let op = ljustify(op.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::CvtUint64ToFloatSeq {
@@ -1283,21 +1235,15 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
                 let tmp_gpr1 = pretty_print_reg(tmp_gpr1.to_reg().to_reg(), 8, allocs);
                 let tmp_gpr2 = pretty_print_reg(tmp_gpr2.to_reg().to_reg(), 8, allocs);
-                format!(
-                    "{} {}, {}, {}, {}",
-                    ljustify(format!(
-                        "u64_to_{}_seq",
-                        if *dst_size == OperandSize::Size64 {
-                            "f64"
-                        } else {
-                            "f32"
-                        }
-                    )),
-                    src,
-                    dst,
-                    tmp_gpr1,
-                    tmp_gpr2
-                )
+                let op = ljustify(format!(
+                    "u64_to_{}_seq",
+                    if *dst_size == OperandSize::Size64 {
+                        "f64"
+                    } else {
+                        "f32"
+                    }
+                ));
+                format!("{op} {src}, {dst}, {tmp_gpr1}, {tmp_gpr2}")
             }
 
             Inst::CvtFloatToSintSeq {
@@ -1313,19 +1259,13 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
                 let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8, allocs);
                 let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8, allocs);
-                format!(
-                    "{} {}, {}, {}, {}",
-                    ljustify(format!(
-                        "cvt_float{}_to_sint{}{}_seq",
-                        src_size.to_bits(),
-                        dst_size.to_bits(),
-                        if *is_saturating { "_sat" } else { "" },
-                    )),
-                    src,
-                    dst,
-                    tmp_gpr,
-                    tmp_xmm,
-                )
+                let op = ljustify(format!(
+                    "cvt_float{}_to_sint{}{}_seq",
+                    src_size.to_bits(),
+                    dst_size.to_bits(),
+                    if *is_saturating { "_sat" } else { "" },
+                ));
+                format!("{op} {src}, {dst}, {tmp_gpr}, {tmp_xmm}")
             }
 
             Inst::CvtFloatToUintSeq {
@@ -1343,20 +1283,13 @@ impl PrettyPrint for Inst {
                 let tmp_gpr = pretty_print_reg(tmp_gpr.to_reg().to_reg(), 8, allocs);
                 let tmp_xmm = pretty_print_reg(tmp_xmm.to_reg().to_reg(), 8, allocs);
                 let tmp_xmm2 = pretty_print_reg(tmp_xmm2.to_reg().to_reg(), 8, allocs);
-                format!(
-                    "{} {}, {}, {}, {}, {}",
-                    ljustify(format!(
-                        "cvt_float{}_to_uint{}{}_seq",
-                        src_size.to_bits(),
-                        dst_size.to_bits(),
-                        if *is_saturating { "_sat" } else { "" },
-                    )),
-                    src,
-                    dst,
-                    tmp_gpr,
-                    tmp_xmm,
-                    tmp_xmm2,
-                )
+                let op = ljustify(format!(
+                    "cvt_float{}_to_uint{}{}_seq",
+                    src_size.to_bits(),
+                    dst_size.to_bits(),
+                    if *is_saturating { "_sat" } else { "" },
+                ));
+                format!("{op} {src}, {dst}, {tmp_gpr}, {tmp_xmm}, {tmp_xmm2}")
             }
 
             Inst::Imm {
@@ -1366,50 +1299,34 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size.to_bytes(), allocs);
                 if *dst_size == OperandSize::Size64 {
-                    format!(
-                        "{} ${}, {}",
-                        ljustify("movabsq".to_string()),
-                        *simm64 as i64,
-                        dst,
-                    )
+                    let op = ljustify("movabsq".to_string());
+                    let imm = *simm64 as i64;
+                    format!("{op} ${imm}, {dst}")
                 } else {
-                    format!(
-                        "{} ${}, {}",
-                        ljustify("movl".to_string()),
-                        (*simm64 as u32) as i32,
-                        dst,
-                    )
+                    let op = ljustify("movl".to_string());
+                    let imm = (*simm64 as u32) as i32;
+                    format!("{op} ${imm}, {dst}")
                 }
             }
 
             Inst::MovImmM { size, simm64, dst } => {
                 let dst = dst.pretty_print(size.to_bytes(), allocs);
                 let suffix = suffix_bwlq(*size);
-                let instruction = ljustify2("mov".to_string(), suffix);
-
-                match *size {
-                    OperandSize::Size8 => {
-                        format!("{} ${}, {}", instruction, (*simm64 as u8) as i8, dst)
-                    }
-                    OperandSize::Size16 => {
-                        format!("{} ${}, {}", instruction, (*simm64 as u16) as i16, dst)
-                    }
-                    OperandSize::Size32 => {
-                        format!("{} ${}, {}", instruction, (*simm64 as u32) as i32, dst)
-                    }
-                    OperandSize::Size64 => format!("{} ${}, {}", instruction, *simm64 as i64, dst),
-                }
+                let imm = match *size {
+                    OperandSize::Size8 => ((*simm64 as u8) as i8).to_string(),
+                    OperandSize::Size16 => ((*simm64 as u16) as i16).to_string(),
+                    OperandSize::Size32 => ((*simm64 as u32) as i32).to_string(),
+                    OperandSize::Size64 => (*simm64 as i64).to_string(),
+                };
+                let op = ljustify2("mov".to_string(), suffix);
+                format!("{op} ${imm}, {dst}")
             }
 
             Inst::MovRR { size, src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("mov".to_string(), suffix_lq(*size)),
-                    src,
-                    dst
-                )
+                let op = ljustify2("mov".to_string(), suffix_lq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::MovFromPReg { src, dst } => {
@@ -1417,7 +1334,8 @@ impl PrettyPrint for Inst {
                 let src: Reg = (*src).into();
                 let src = regs::show_ireg_sized(src, 8);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} {}, {}", ljustify("movq".to_string()), src, dst)
+                let op = ljustify("movq".to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::MovToPReg { src, dst } => {
@@ -1425,7 +1343,8 @@ impl PrettyPrint for Inst {
                 allocs.next_fixed_nonallocatable(*dst);
                 let dst: Reg = (*dst).into();
                 let dst = regs::show_ireg_sized(dst, 8);
-                format!("{} {}, {}", ljustify("movq".to_string()), src, dst)
+                let op = ljustify("movq".to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::MovzxRmR {
@@ -1438,28 +1357,28 @@ impl PrettyPrint for Inst {
                 };
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), dst_size, allocs);
                 let src = src.pretty_print(ext_mode.src_size(), allocs);
+
                 if *ext_mode == ExtMode::LQ {
-                    format!("{} {}, {}", ljustify("movl".to_string()), src, dst)
+                    let op = ljustify("movl".to_string());
+                    format!("{op} {src}, {dst}")
                 } else {
-                    format!(
-                        "{} {}, {}",
-                        ljustify2("movz".to_string(), ext_mode.to_string()),
-                        src,
-                        dst,
-                    )
+                    let op = ljustify2("movz".to_string(), ext_mode.to_string());
+                    format!("{op} {src}, {dst}")
                 }
             }
 
             Inst::Mov64MR { src, dst, .. } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src = src.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify("movq".to_string()), src, dst)
+                let op = ljustify("movq".to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::LoadEffectiveAddress { addr, dst, size } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let addr = addr.pretty_print(8, allocs);
-                format!("{} {}, {}", ljustify("lea".to_string()), addr, dst)
+                let op = ljustify("lea".to_string());
+                format!("{op} {addr}, {dst}")
             }
 
             Inst::MovsxRmR {
@@ -1467,23 +1386,15 @@ impl PrettyPrint for Inst {
             } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), ext_mode.dst_size(), allocs);
                 let src = src.pretty_print(ext_mode.src_size(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("movs".to_string(), ext_mode.to_string()),
-                    src,
-                    dst
-                )
+                let op = ljustify2("movs".to_string(), ext_mode.to_string());
+                format!("{op} {src}, {dst}")
             }
 
             Inst::MovRM { size, src, dst, .. } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = dst.pretty_print(size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("mov".to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst
-                )
+                let op = ljustify2("mov".to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::ShiftR {
@@ -1499,22 +1410,14 @@ impl PrettyPrint for Inst {
                 match num_bits.clone().to_imm8_reg() {
                     Imm8Reg::Reg { reg } => {
                         let reg = pretty_print_reg(reg, 1, allocs);
-                        format!(
-                            "{} {}, {}, {}",
-                            ljustify2(kind.to_string(), suffix_bwlq(*size)),
-                            reg,
-                            src,
-                            dst,
-                        )
+                        let op = ljustify2(kind.to_string(), suffix_bwlq(*size));
+                        format!("{op} {reg}, {src}, {dst}")
                     }
 
-                    Imm8Reg::Imm8 { imm: num_bits } => format!(
-                        "{} ${}, {}, {}",
-                        ljustify2(kind.to_string(), suffix_bwlq(*size)),
-                        num_bits,
-                        src,
-                        dst,
-                    ),
+                    Imm8Reg::Imm8 { imm: num_bits } => {
+                        let op = ljustify2(kind.to_string(), suffix_bwlq(*size));
+                        format!("{op} ${num_bits}, {src}, {dst}")
+                    }
                 }
             }
 
@@ -1528,13 +1431,8 @@ impl PrettyPrint for Inst {
                 let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let src2 = src2.pretty_print(8, allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify(opcode.to_string()),
-                    src1,
-                    src2,
-                    dst,
-                )
+                let op = ljustify(opcode.to_string());
+                format!("{op} {src1}, {src2}, {dst}")
             }
 
             Inst::CmpRmiR {
@@ -1549,28 +1447,21 @@ impl PrettyPrint for Inst {
                     CmpOpcode::Cmp => "cmp",
                     CmpOpcode::Test => "test",
                 };
-                format!(
-                    "{} {}, {}",
-                    ljustify2(op.to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst,
-                )
+                let op = ljustify2(op.to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::Setcc { cc, dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 1, allocs);
-                format!("{} {}", ljustify2("set".to_string(), cc.to_string()), dst)
+                let op = ljustify2("set".to_string(), cc.to_string());
+                format!("{op} {dst}")
             }
 
             Inst::Bswap { size, src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}",
-                    ljustify2("bswap".to_string(), suffix_bwlq(*size)),
-                    src,
-                    dst
-                )
+                let op = ljustify2("bswap".to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
             }
 
             Inst::Cmove {
@@ -1583,13 +1474,8 @@ impl PrettyPrint for Inst {
                 let alternative = pretty_print_reg(alternative.to_reg(), size.to_bytes(), allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let consequent = consequent.pretty_print(size.to_bytes(), allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify(format!("cmov{}{}", cc.to_string(), suffix_bwlq(*size))),
-                    consequent,
-                    alternative,
-                    dst,
-                )
+                let op = ljustify(format!("cmov{}{}", cc.to_string(), suffix_bwlq(*size)));
+                format!("{op} {consequent}, {alternative}, {dst}")
             }
 
             Inst::XmmCmove {
@@ -1611,18 +1497,19 @@ impl PrettyPrint for Inst {
                     types::F64X2 => "apd",
                     _ => "dqa",
                 };
+                let cc = cc.invert();
                 format!(
                     "mov{suffix} {alternative}, {dst}; \
-                    j{} $next; \
+                    j{cc} $next; \
                     mov{suffix} {consequent}, {dst}; \
-                    $next:",
-                    cc.invert().to_string(),
+                    $next:"
                 )
             }
 
             Inst::Push64 { src } => {
                 let src = src.pretty_print(8, allocs);
-                format!("{} {}", ljustify("pushq".to_string()), src)
+                let op = ljustify("pushq".to_string());
+                format!("{op} {src}")
             }
 
             Inst::StackProbeLoop {
@@ -1631,27 +1518,25 @@ impl PrettyPrint for Inst {
                 guard_size,
             } => {
                 let tmp = pretty_print_reg(tmp.to_reg(), 8, allocs);
-                format!(
-                    "{} {}, frame_size={}, guard_size={}",
-                    ljustify("stack_probe_loop".to_string()),
-                    tmp,
-                    frame_size,
-                    guard_size
-                )
+                let op = ljustify("stack_probe_loop".to_string());
+                format!("{op} {tmp}, frame_size={frame_size}, guard_size={guard_size}")
             }
 
             Inst::Pop64 { dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} {}", ljustify("popq".to_string()), dst)
+                let op = ljustify("popq".to_string());
+                format!("{op} {dst}")
             }
 
             Inst::CallKnown { dest, .. } => {
-                format!("{} {:?}", ljustify("call".to_string()), dest)
+                let op = ljustify("call".to_string());
+                format!("{op} {dest:?}")
             }
 
             Inst::CallUnknown { dest, .. } => {
                 let dest = dest.pretty_print(8, allocs);
-                format!("{} *{}", ljustify("call".to_string()), dest)
+                let op = ljustify("call".to_string());
+                format!("{op} *{dest}")
             }
 
             Inst::Args { args } => {
@@ -1660,7 +1545,7 @@ impl PrettyPrint for Inst {
                     use std::fmt::Write;
                     let preg = regs::show_reg(arg.preg);
                     let def = pretty_print_reg(arg.vreg.to_reg(), 8, allocs);
-                    write!(&mut s, " {}={}", def, preg).unwrap();
+                    write!(&mut s, " {def}={preg}").unwrap();
                 }
                 s
             }
@@ -1671,31 +1556,33 @@ impl PrettyPrint for Inst {
                     use std::fmt::Write;
                     let preg = regs::show_reg(ret.preg);
                     let vreg = pretty_print_reg(ret.vreg, 8, allocs);
-                    write!(&mut s, " {}={}", vreg, preg).unwrap();
+                    write!(&mut s, " {vreg}={preg}").unwrap();
                 }
                 s
             }
 
             Inst::JmpKnown { dst } => {
-                format!("{} {}", ljustify("jmp".to_string()), dst.to_string())
+                let op = ljustify("jmp".to_string());
+                let dst = dst.to_string();
+                format!("{op} {dst}")
             }
 
-            Inst::JmpIf { cc, taken } => format!(
-                "{} {}",
-                ljustify2("j".to_string(), cc.to_string()),
-                taken.to_string(),
-            ),
+            Inst::JmpIf { cc, taken } => {
+                let taken = taken.to_string();
+                let op = ljustify2("j".to_string(), cc.to_string());
+                format!("{op} {taken}")
+            }
 
             Inst::JmpCond {
                 cc,
                 taken,
                 not_taken,
-            } => format!(
-                "{} {}; j {}",
-                ljustify2("j".to_string(), cc.to_string()),
-                taken.to_string(),
-                not_taken.to_string()
-            ),
+            } => {
+                let taken = taken.to_string();
+                let not_taken = not_taken.to_string();
+                let op = ljustify2("j".to_string(), cc.to_string());
+                format!("{op} {taken}; j {not_taken}")
+            }
 
             Inst::JmpTableSeq {
                 idx, tmp1, tmp2, ..
@@ -1703,18 +1590,14 @@ impl PrettyPrint for Inst {
                 let idx = pretty_print_reg(*idx, 8, allocs);
                 let tmp1 = pretty_print_reg(tmp1.to_reg(), 8, allocs);
                 let tmp2 = pretty_print_reg(tmp2.to_reg(), 8, allocs);
-                format!(
-                    "{} {}, {}, {}",
-                    ljustify("br_table".into()),
-                    idx,
-                    tmp1,
-                    tmp2
-                )
+                let op = ljustify("br_table".into());
+                format!("{op} {idx}, {tmp1}, {tmp2}")
             }
 
             Inst::JmpUnknown { target } => {
                 let target = target.pretty_print(8, allocs);
-                format!("{} *{}", ljustify("jmp".to_string()), target)
+                let op = ljustify("jmp".to_string());
+                format!("{op} *{target}")
             }
 
             Inst::TrapIf { cc, trap_code, .. } => {
@@ -1727,12 +1610,9 @@ impl PrettyPrint for Inst {
                 trap_code,
                 ..
             } => {
-                format!(
-                    "trap_if_and {}, {}, {}",
-                    cc1.invert().to_string(),
-                    cc2.invert().to_string(),
-                    trap_code
-                )
+                let cc1 = cc1.invert();
+                let cc2 = cc2.invert();
+                format!("trap_if_and {cc1}, {cc2}, {trap_code}")
             }
 
             Inst::TrapIfOr {
@@ -1741,25 +1621,17 @@ impl PrettyPrint for Inst {
                 trap_code,
                 ..
             } => {
-                format!(
-                    "trap_if_or {}, {}, {}",
-                    cc1.to_string(),
-                    cc2.invert().to_string(),
-                    trap_code
-                )
+                let cc2 = cc2.invert();
+                format!("trap_if_or {cc1}, {cc2}, {trap_code}")
             }
 
             Inst::LoadExtName {
                 dst, name, offset, ..
             } => {
                 let dst = pretty_print_reg(dst.to_reg(), 8, allocs);
-                format!(
-                    "{} {}+{}, {}",
-                    ljustify("load_ext_name".into()),
-                    name.display(None),
-                    offset,
-                    dst,
-                )
+                let name = name.display(None);
+                let op = ljustify("load_ext_name".into());
+                format!("{op} {name}+{offset}, {dst}")
             }
 
             Inst::LockCmpxchg {
@@ -1775,20 +1647,17 @@ impl PrettyPrint for Inst {
                 let expected = pretty_print_reg(*expected, size, allocs);
                 let dst_old = pretty_print_reg(dst_old.to_reg(), size, allocs);
                 let mem = mem.pretty_print(size, allocs);
+                let suffix = suffix_bwlq(OperandSize::from_bytes(size as u32));
                 format!(
-                    "lock cmpxchg{} {}, {}, expected={}, dst_old={}",
-                    suffix_bwlq(OperandSize::from_bytes(size as u32)),
-                    replacement,
-                    mem,
-                    expected,
-                    dst_old,
+                    "lock cmpxchg{suffix} {replacement}, {mem}, expected={expected}, dst_old={dst_old}"
                 )
             }
 
             Inst::AtomicRmwSeq { ty, op, .. } => {
+                let ty = ty.bits();
                 format!(
-                    "atomically {{ {}_bits_at_[%r9]) {:?}= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }}",
-                    ty.bits(), op)
+                    "atomically {{ {ty}_bits_at_[%r9]) {op:?}= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }}"
+                )
             }
 
             Inst::Fence { kind } => match kind {
@@ -1797,20 +1666,20 @@ impl PrettyPrint for Inst {
                 FenceKind::SFence => "sfence".to_string(),
             },
 
-            Inst::VirtualSPOffsetAdj { offset } => format!("virtual_sp_offset_adjust {}", offset),
+            Inst::VirtualSPOffsetAdj { offset } => format!("virtual_sp_offset_adjust {offset}"),
 
             Inst::Hlt => "hlt".into(),
 
-            Inst::Ud2 { trap_code } => format!("ud2 {}", trap_code),
+            Inst::Ud2 { trap_code } => format!("ud2 {trap_code}"),
 
             Inst::ElfTlsGetAddr { ref symbol, dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} = elf_tls_get_addr {:?}", dst, symbol)
+                format!("{dst} = elf_tls_get_addr {symbol:?}")
             }
 
             Inst::MachOTlsGetAddr { ref symbol, dst } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
-                format!("{} = macho_tls_get_addr {:?}", dst, symbol)
+                format!("{dst} = macho_tls_get_addr {symbol:?}")
             }
 
             Inst::CoffTlsGetAddr {
@@ -1823,21 +1692,20 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
                 let tmp = allocs.next(tmp.to_reg().to_reg());
 
-                let mut s = format!("{} = coff_tls_get_addr {:?}", dst, symbol);
+                let mut s = format!("{dst} = coff_tls_get_addr {symbol:?}");
                 if tmp.is_virtual() {
-                    write!(&mut s, ", {}", show_ireg_sized(tmp, 8)).unwrap();
+                    let tmp = show_ireg_sized(tmp, 8);
+                    write!(&mut s, ", {tmp}").unwrap();
                 };
 
                 s
             }
 
-            Inst::Unwind { inst } => {
-                format!("unwind {:?}", inst)
-            }
+            Inst::Unwind { inst } => format!("unwind {inst:?}"),
 
             Inst::DummyUse { reg } => {
                 let reg = pretty_print_reg(*reg, 8, allocs);
-                format!("dummy_use {}", reg)
+                format!("dummy_use {reg}")
             }
         }
     }


### PR DESCRIPTION
While working on #6461 I found it nice to have the format strings for the pretty-printer use variables inline rather than as arguments. This PR refactors all the format strings in the instruction pretty-printer to use inline variables uniformly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
