### PR TITLE
Remove trailing space in precise-output tests

### DIFF
--- a/cranelift/filetests/filetests/egraph/cprop-splat.clif
+++ b/cranelift/filetests/filetests/egraph/cprop-splat.clif
@@ -11,7 +11,7 @@ block0:
 
 ; function %i8x16_1() -> i8x16 fast {
 ;     const0 = 0x33333333333333333333333333333333
-; 
+;
 ; block0:
 ;     v3 = vconst.i8x16 const0
 ;     v4 -> v3
@@ -27,7 +27,7 @@ block0:
 
 ; function %i8x16_2() -> i8x16 fast {
 ;     const0 = 0x80808080808080808080808080808080
-; 
+;
 ; block0:
 ;     v3 = vconst.i8x16 const0
 ;     v4 -> v3
@@ -43,7 +43,7 @@ block0:
 
 ; function %i16x8_1() -> i16x8 fast {
 ;     const0 = 0x12341234123412341234123412341234
-; 
+;
 ; block0:
 ;     v3 = vconst.i16x8 const0
 ;     v4 -> v3
@@ -59,7 +59,7 @@ block0:
 
 ; function %i16x8_2() -> i16x8 fast {
 ;     const0 = 0x87658765876587658765876587658765
-; 
+;
 ; block0:
 ;     v3 = vconst.i16x8 const0
 ;     v4 -> v3
@@ -75,7 +75,7 @@ block0:
 
 ; function %i32x4_1() -> i32x4 fast {
 ;     const0 = 0x12345678123456781234567812345678
-; 
+;
 ; block0:
 ;     v3 = vconst.i32x4 const0
 ;     v4 -> v3
@@ -91,7 +91,7 @@ block0:
 
 ; function %i32x4_2() -> i32x4 fast {
 ;     const0 = 0x87654321876543218765432187654321
-; 
+;
 ; block0:
 ;     v3 = vconst.i32x4 const0
 ;     v4 -> v3
@@ -107,7 +107,7 @@ block0:
 
 ; function %i64x2_1() -> i64x2 fast {
 ;     const0 = 0x0123456789abcdef0123456789abcdef
-; 
+;
 ; block0:
 ;     v3 = vconst.i64x2 const0
 ;     v4 -> v3
@@ -123,7 +123,7 @@ block0:
 
 ; function %i64x2_2() -> i64x2 fast {
 ;     const0 = 0xfedcba9876543210fedcba9876543210
-; 
+;
 ; block0:
 ;     v3 = vconst.i64x2 const0
 ;     v4 -> v3
@@ -139,7 +139,7 @@ block0:
 
 ; function %i8x16_3() -> i8x16 fast {
 ;     const0 = 0xfefefefefefefefefefefefefefefefe
-; 
+;
 ; block0:
 ;     v3 = vconst.i8x16 const0
 ;     v4 -> v3
@@ -155,7 +155,7 @@ block0:
 
 ; function %f32x4() -> f32x4 fast {
 ;     const0 = 0x40400000404000004040000040400000
-; 
+;
 ; block0:
 ;     v3 = vconst.f32x4 const0
 ;     v4 -> v3
@@ -171,7 +171,7 @@ block0:
 
 ; function %f64x2() -> f64x2 fast {
 ;     const0 = 0x40100000000000004010000000000000
-; 
+;
 ; block0:
 ;     v3 = vconst.f64x2 const0
 ;     v4 -> v3

--- a/cranelift/filetests/filetests/egraph/multivalue.clif
+++ b/cranelift/filetests/filetests/egraph/multivalue.clif
@@ -23,7 +23,7 @@ function u0:359(i64) -> i8, i8 system_v {
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/egraph/not_a_load.clif
+++ b/cranelift/filetests/filetests/egraph/not_a_load.clif
@@ -21,7 +21,7 @@ function u0:1302(i64) -> i64 system_v {
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -14,7 +14,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldr w0, [x0, w1, SXTW]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr w0, [x0, w1, sxtw]
@@ -32,7 +32,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldr w0, [x0, w1, SXTW]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr w0, [x0, w1, sxtw]
@@ -52,7 +52,7 @@ block0(v0: i32, v1: i32):
 ;   mov w3, w0
 ;   ldr w0, [x3, w1, UXTW]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, w0
@@ -77,7 +77,7 @@ block0(v0: i64, v1: i32):
 ;   add x7, x5, x1, SXTW
 ;   ldr w0, [x7, w1, SXTW]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x3, x0, #0x44
@@ -102,7 +102,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   add x6, x4, x1
 ;   ldr w0, [x6, #48]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x4, x0, x2
@@ -127,7 +127,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   add x8, x5, x2
 ;   ldr w0, [x8, x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, #0x1004
@@ -148,7 +148,7 @@ block0:
 ;   movz x0, #1234
 ;   ldr w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0x4d2
@@ -168,7 +168,7 @@ block0(v0: i64):
 ;   add x2, x0, #8388608
 ;   ldr w0, [x2]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x2, x0, #0x800, lsl #12
@@ -188,7 +188,7 @@ block0(v0: i64):
 ;   sub x2, x0, #4
 ;   ldr w0, [x2]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub x2, x0, #4
@@ -210,7 +210,7 @@ block0(v0: i64):
 ;   add x4, x3, x0
 ;   ldr w0, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0xca00
@@ -231,7 +231,7 @@ block0(v0: i32):
 ;   sxtw x2, w0
 ;   ldr w0, [x2]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x2, w0
@@ -252,7 +252,7 @@ block0(v0: i32, v1: i32):
 ;   sxtw x3, w0
 ;   ldr w0, [x3, w1, SXTW]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x3, w0
@@ -272,7 +272,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movn w4, #4097
 ;   ldrsh x0, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w4, #-0x1002
@@ -292,7 +292,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movz x4, #4098
 ;   ldrsh x0, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x4, #0x1002
@@ -313,7 +313,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   sxtw x6, w4
 ;   ldrsh x0, [x6]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w4, #-0x1002
@@ -335,7 +335,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   sxtw x6, w4
 ;   ldrsh x0, [x6]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x4, #0x1002
@@ -356,7 +356,7 @@ block0(v0: i64):
 ;   ldp x0, x1, [x5]
 ;   stp x0, x1, [x5]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, x0
@@ -377,7 +377,7 @@ block0(v0: i64):
 ;   ldp x0, x1, [x5, #16]
 ;   stp x0, x1, [x5, #16]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, x0
@@ -398,7 +398,7 @@ block0(v0: i64):
 ;   ldp x0, x1, [x5, #504]
 ;   stp x0, x1, [x5, #504]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, x0
@@ -419,7 +419,7 @@ block0(v0: i64):
 ;   ldp x0, x1, [x5, #-512]
 ;   stp x0, x1, [x5, #-512]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, x0
@@ -441,7 +441,7 @@ block0(v0: i64):
 ;   ldp x0, x1, [x5, #32]
 ;   stp x0, x1, [x5, #32]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, x0
@@ -465,7 +465,7 @@ block0(v0: i32):
 ;   sxtw x4, w8
 ;   stp x0, x1, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x3, w0
@@ -494,7 +494,7 @@ block0(v0: i64, v1: i32):
 ;   add x5, x11, x9, SXTW
 ;   stp x0, x1, [x5, #24]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x4, x0, w1, sxtw

--- a/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/arithmetic.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   add x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, x1
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sub x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub x0, x0, x1
@@ -44,7 +44,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   madd x0, x0, x1, xzr
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul x0, x0, x1
@@ -60,7 +60,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   umulh x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umulh x0, x0, x1
@@ -76,7 +76,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   smulh x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smulh x0, x0, x1
@@ -96,7 +96,7 @@ block0(v0: i64, v1: i64):
 ;   b.vs #trap=int_ovf
 ;   sdiv x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cbz x1, #0x18
@@ -120,7 +120,7 @@ block0(v0: i64):
 ;   movz w2, #2
 ;   sdiv x0, x0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w2, #2
@@ -138,7 +138,7 @@ block0(v0: i64, v1: i64):
 ;   cbz x1, #trap=int_divz
 ;   udiv x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cbz x1, #0xc
@@ -158,7 +158,7 @@ block0(v0: i64):
 ;   movz x2, #2
 ;   udiv x0, x0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #2
@@ -177,7 +177,7 @@ block0(v0: i64, v1: i64):
 ;   sdiv x4, x0, x1
 ;   msub x0, x4, x1, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cbz x1, #0x10
@@ -198,7 +198,7 @@ block0(v0: i64, v1: i64):
 ;   udiv x4, x0, x1
 ;   msub x0, x4, x1, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cbz x1, #0x10
@@ -223,7 +223,7 @@ block0(v0: i32, v1: i32):
 ;   b.vs #trap=int_ovf
 ;   sdiv x0, x3, x5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x3, w0
@@ -250,7 +250,7 @@ block0(v0: i32):
 ;   movz w4, #2
 ;   sdiv x0, x2, x4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x2, w0
@@ -271,7 +271,7 @@ block0(v0: i32, v1: i32):
 ;   cbz x5, #trap=int_divz
 ;   udiv x0, x3, x5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, w0
@@ -294,7 +294,7 @@ block0(v0: i32):
 ;   movz w4, #2
 ;   udiv x0, x2, x4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w2, w0
@@ -316,7 +316,7 @@ block0(v0: i32, v1: i32):
 ;   sdiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x3, w0
@@ -341,7 +341,7 @@ block0(v0: i32, v1: i32):
 ;   udiv x8, x3, x5
 ;   msub x0, x8, x5, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, w0
@@ -362,7 +362,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, x1
@@ -378,7 +378,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orr x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, x1
@@ -394,7 +394,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eor x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, x1
@@ -410,7 +410,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   bic x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic x0, x0, x1
@@ -426,7 +426,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orn x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn x0, x0, x1
@@ -442,7 +442,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eon x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x0, x0, x1
@@ -458,7 +458,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orn x0, xzr, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn x0, x0
@@ -476,7 +476,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sub w0, w1, w0, LSL 21
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w1, w0, lsl #21
@@ -493,7 +493,7 @@ block0(v0: i32):
 ; block0:
 ;   sub w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w0, #1
@@ -510,7 +510,7 @@ block0(v0: i32):
 ; block0:
 ;   add w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, #1
@@ -527,7 +527,7 @@ block0(v0: i64):
 ; block0:
 ;   add x0, x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, #1
@@ -545,7 +545,7 @@ block0(v0: i64):
 ;   movz x3, #1
 ;   sub x0, xzr, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x3, #1
@@ -563,7 +563,7 @@ block0(v0: i8x16):
 ; block0:
 ;   ushr v0.16b, v0.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v0.16b, v0.16b, #1
@@ -580,7 +580,7 @@ block0(v0: i128, v1: i128):
 ;   adds x0, x0, x2
 ;   adc x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adds x0, x0, x2
@@ -598,7 +598,7 @@ block0(v0: i128, v1: i128):
 ;   subs x0, x0, x2
 ;   sbc x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   subs x0, x0, x2
@@ -618,7 +618,7 @@ block0(v0: i128, v1: i128):
 ;   madd x1, x1, x2, x7
 ;   madd x0, x0, x2, xzr
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umulh x5, x0, x2
@@ -638,7 +638,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ; block0:
 ;   madd w0, w1, w2, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   madd w0, w1, w2, w0
@@ -655,7 +655,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ; block0:
 ;   madd w0, w1, w2, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   madd w0, w1, w2, w0
@@ -672,7 +672,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ; block0:
 ;   msub w0, w1, w2, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msub w0, w1, w2, w0
@@ -689,7 +689,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ; block0:
 ;   msub x0, x1, x2, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msub x0, x1, x2, x0
@@ -707,7 +707,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   madd w5, w1, w2, wzr
 ;   sub w0, w5, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul w5, w1, w2
@@ -726,7 +726,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   madd x5, x1, x2, xzr
 ;   sub x0, x5, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul x5, x1, x2
@@ -746,7 +746,7 @@ block0(v0: i64):
 ;   sdiv x4, x0, x2
 ;   msub x0, x4, x2, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w2, #2
@@ -767,7 +767,7 @@ block0(v0: i64):
 ;   udiv x4, x0, x2
 ;   msub x0, x4, x2, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #2
@@ -790,7 +790,7 @@ block0(v0: i64):
 ;   b.vs #trap=int_ovf
 ;   sdiv x0, x0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #-1

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-cas.clif
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw-lse.clif
@@ -11,7 +11,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldaddal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldaddal x1, x3, [x0]
@@ -27,7 +27,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldaddal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldaddal w1, w3, [x0]
@@ -43,7 +43,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldaddalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldaddalh w1, w3, [x0]
@@ -59,7 +59,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldaddalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldaddalb w1, w3, [x0]
@@ -76,7 +76,7 @@ block0(v0: i64, v1: i64):
 ;   sub x3, xzr, x1
 ;   ldaddal x3, x5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg x3, x1
@@ -94,7 +94,7 @@ block0(v0: i64, v1: i32):
 ;   sub w3, wzr, w1
 ;   ldaddal w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -112,7 +112,7 @@ block0(v0: i64, v1: i16):
 ;   sub w3, wzr, w1
 ;   ldaddalh w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -130,7 +130,7 @@ block0(v0: i64, v1: i8):
 ;   sub w3, wzr, w1
 ;   ldaddalb w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -148,7 +148,7 @@ block0(v0: i64, v1: i64):
 ;   eon x3, x1, xzr
 ;   ldclral x3, x5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x3, x1, xzr
@@ -166,7 +166,7 @@ block0(v0: i64, v1: i32):
 ;   eon w3, w1, wzr
 ;   ldclral w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w3, w1, wzr
@@ -184,7 +184,7 @@ block0(v0: i64, v1: i16):
 ;   eon w3, w1, wzr
 ;   ldclralh w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w3, w1, wzr
@@ -202,7 +202,7 @@ block0(v0: i64, v1: i8):
 ;   eon w3, w1, wzr
 ;   ldclralb w3, w5, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w3, w1, wzr
@@ -230,7 +230,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -273,7 +273,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -316,7 +316,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -359,7 +359,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -391,7 +391,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldsetal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsetal x1, x3, [x0]
@@ -407,7 +407,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldsetal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsetal w1, w3, [x0]
@@ -423,7 +423,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldsetalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsetalh w1, w3, [x0]
@@ -439,7 +439,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldsetalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsetalb w1, w3, [x0]
@@ -455,7 +455,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldeoral x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldeoral x1, x3, [x0]
@@ -471,7 +471,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldeoral w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldeoral w1, w3, [x0]
@@ -487,7 +487,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldeoralh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldeoralh w1, w3, [x0]
@@ -503,7 +503,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldeoralb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldeoralb w1, w3, [x0]
@@ -519,7 +519,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldsmaxal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsmaxal x1, x3, [x0]
@@ -535,7 +535,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldsmaxal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsmaxal w1, w3, [x0]
@@ -551,7 +551,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldsmaxalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsmaxalh w1, w3, [x0]
@@ -567,7 +567,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldsmaxalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsmaxalb w1, w3, [x0]
@@ -583,7 +583,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldumaxal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldumaxal x1, x3, [x0]
@@ -599,7 +599,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldumaxal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldumaxal w1, w3, [x0]
@@ -615,7 +615,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldumaxalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldumaxalh w1, w3, [x0]
@@ -631,7 +631,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldumaxalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldumaxalb w1, w3, [x0]
@@ -647,7 +647,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ldsminal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsminal x1, x3, [x0]
@@ -663,7 +663,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   ldsminal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsminal w1, w3, [x0]
@@ -679,7 +679,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   ldsminalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsminalh w1, w3, [x0]
@@ -695,7 +695,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   ldsminalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldsminalb w1, w3, [x0]
@@ -711,7 +711,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lduminal x1, x3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lduminal x1, x3, [x0]
@@ -727,7 +727,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   lduminal w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lduminal w1, w3, [x0]
@@ -743,7 +743,7 @@ block0(v0: i64, v1: i16):
 ; block0:
 ;   lduminalh w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lduminalh w1, w3, [x0]
@@ -759,7 +759,7 @@ block0(v0: i64, v1: i8):
 ; block0:
 ;   lduminalb w1, w3, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lduminalb w1, w3, [x0]

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
@@ -22,7 +22,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -64,7 +64,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -106,7 +106,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -148,7 +148,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -190,7 +190,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -232,7 +232,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -274,7 +274,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -316,7 +316,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -358,7 +358,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -400,7 +400,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -442,7 +442,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -484,7 +484,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -526,7 +526,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -569,7 +569,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -612,7 +612,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -655,7 +655,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -698,7 +698,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -740,7 +740,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -782,7 +782,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -824,7 +824,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -866,7 +866,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -908,7 +908,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -950,7 +950,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -992,7 +992,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1034,7 +1034,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1077,7 +1077,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1120,7 +1120,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1164,7 +1164,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1208,7 +1208,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1251,7 +1251,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1294,7 +1294,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1337,7 +1337,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1380,7 +1380,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1423,7 +1423,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1466,7 +1466,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1510,7 +1510,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1554,7 +1554,7 @@ block0(v0: i64, v1: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1597,7 +1597,7 @@ block0(v0: i64, v1: i32):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1640,7 +1640,7 @@ block0(v0: i64, v1: i16):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -1683,7 +1683,7 @@ block0(v0: i64, v1: i8):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic_load.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   ldar x0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldar x0, [x0]
@@ -27,7 +27,7 @@ block0(v0: i64):
 ; block0:
 ;   ldar w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldar w0, [x0]
@@ -43,7 +43,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarh w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarh w0, [x0]
@@ -59,7 +59,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarb w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarb w0, [x0]
@@ -76,7 +76,7 @@ block0(v0: i64):
 ; block0:
 ;   ldar w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldar w0, [x0]
@@ -93,7 +93,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarh w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarh w0, [x0]
@@ -110,7 +110,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarb w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarb w0, [x0]
@@ -127,7 +127,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarh w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarh w0, [x0]
@@ -144,7 +144,7 @@ block0(v0: i64):
 ; block0:
 ;   ldarb w0, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldarb w0, [x0]

--- a/cranelift/filetests/filetests/isa/aarch64/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic_store.clif
@@ -11,7 +11,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stlr x0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlr x0, [x1]
@@ -27,7 +27,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   stlr w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlr w0, [x1]
@@ -43,7 +43,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   stlrh w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrh w0, [x1]
@@ -59,7 +59,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   stlrb w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrb w0, [x1]
@@ -76,7 +76,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stlr w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlr w0, [x1]
@@ -93,7 +93,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stlrh w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrh w0, [x1]
@@ -110,7 +110,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stlrb w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrb w0, [x1]
@@ -127,7 +127,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   stlrh w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrh w0, [x1]
@@ -144,7 +144,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   stlrb w0, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stlrb w0, [x1]

--- a/cranelift/filetests/filetests/isa/aarch64/basic1.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/basic1.clif
@@ -12,7 +12,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   add w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, w1

--- a/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitcast.clif
@@ -11,7 +11,7 @@ block0(v0: f32):
 ; block0:
 ;   mov w0, v0.s[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, v0.s[0]
@@ -27,7 +27,7 @@ block0(v0: i32):
 ; block0:
 ;   fmov s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s0, w0
@@ -43,7 +43,7 @@ block0(v0: f64):
 ; block0:
 ;   mov x0, v0.d[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, v0.d[0]
@@ -59,7 +59,7 @@ block0(v0: i64):
 ; block0:
 ;   fmov d0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d0, x0

--- a/cranelift/filetests/filetests/isa/aarch64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitops.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   rbit w2, w0
 ;   lsr w0, w2, #24
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w2, w0
@@ -31,7 +31,7 @@ block0(v0: i16):
 ;   rbit w2, w0
 ;   lsr w0, w2, #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w2, w0
@@ -48,7 +48,7 @@ block0(v0: i32):
 ; block0:
 ;   rbit w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w0, w0
@@ -64,7 +64,7 @@ block0(v0: i64):
 ; block0:
 ;   rbit x0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit x0, x0
@@ -82,7 +82,7 @@ block0(v0: i128):
 ;   rbit x1, x0
 ;   rbit x0, x6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x6, x1
@@ -102,7 +102,7 @@ block0(v0: i8):
 ;   clz w4, w2
 ;   sub w0, w4, #24
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w2, w0
@@ -122,7 +122,7 @@ block0(v0: i16):
 ;   clz w4, w2
 ;   sub w0, w4, #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w2, w0
@@ -140,7 +140,7 @@ block0(v0: i32):
 ; block0:
 ;   clz w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clz w0, w0
@@ -156,7 +156,7 @@ block0(v0: i64):
 ; block0:
 ;   clz x0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clz x0, x0
@@ -176,7 +176,7 @@ block0(v0: i128):
 ;   madd x0, x5, x7, x3
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clz x3, x1
@@ -198,7 +198,7 @@ block0(v0: i8):
 ;   cls w4, w2
 ;   sub w0, w4, #24
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w2, w0
@@ -218,7 +218,7 @@ block0(v0: i16):
 ;   cls w4, w2
 ;   sub w0, w4, #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w2, w0
@@ -236,7 +236,7 @@ block0(v0: i32):
 ; block0:
 ;   cls w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cls w0, w0
@@ -252,7 +252,7 @@ block0(v0: i64):
 ; block0:
 ;   cls x0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cls x0, x0
@@ -276,7 +276,7 @@ block0(v0: i128):
 ;   add x0, x14, x5
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cls x3, x0
@@ -302,7 +302,7 @@ block0(v0: i8):
 ;   orr w4, w2, #8388608
 ;   clz w0, w4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w2, w0
@@ -322,7 +322,7 @@ block0(v0: i16):
 ;   orr w4, w2, #32768
 ;   clz w0, w4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w2, w0
@@ -341,7 +341,7 @@ block0(v0: i32):
 ;   rbit w2, w0
 ;   clz w0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit w2, w0
@@ -359,7 +359,7 @@ block0(v0: i64):
 ;   rbit x2, x0
 ;   clz x0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit x2, x0
@@ -382,7 +382,7 @@ block0(v0: i128):
 ;   madd x0, x9, x11, x7
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rbit x3, x0
@@ -409,7 +409,7 @@ block0(v0: i128):
 ;   umov w0, v17.b[0]
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d4, x0
@@ -433,7 +433,7 @@ block0(v0: i64):
 ;   addv b6, v4.8b
 ;   umov w0, v6.b[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d2, x0
@@ -455,7 +455,7 @@ block0(v0: i32):
 ;   addv b6, v4.8b
 ;   umov w0, v6.b[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s2, w0
@@ -477,7 +477,7 @@ block0(v0: i16):
 ;   addp v6.8b, v4.8b, v4.8b
 ;   umov w0, v6.b[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s2, w0
@@ -498,7 +498,7 @@ block0(v0: i8):
 ;   cnt v4.8b, v2.8b
 ;   umov w0, v4.b[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s2, w0
@@ -518,7 +518,7 @@ block0:
 ;   movz w1, #255
 ;   sxtb w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w1, #0xff
@@ -537,7 +537,7 @@ block0:
 ;   movz w1, #255
 ;   sxtb w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w1, #0xff
@@ -554,7 +554,7 @@ block0(v0: i32):
 ; block0:
 ;   orn w0, wzr, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn w0, w0
@@ -570,7 +570,7 @@ block0(v0: i64):
 ; block0:
 ;   orn x0, xzr, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn x0, x0
@@ -588,7 +588,7 @@ block0(v0: i64):
 ; block0:
 ;   orn x0, xzr, x0, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn x0, x0, lsl #3
@@ -605,7 +605,7 @@ block0(v0: i128):
 ;   orn x0, xzr, x0
 ;   orn x1, xzr, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn x0, x0
@@ -622,7 +622,7 @@ block0(v0: i8x16):
 ; block0:
 ;   mvn v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn v0.16b, v0.16b
@@ -638,7 +638,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   and w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w0, w0, w1
@@ -654,7 +654,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, x1
@@ -671,7 +671,7 @@ block0(v0: i128, v1: i128):
 ;   and x0, x0, x2
 ;   and x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, x2
@@ -688,7 +688,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
@@ -705,7 +705,7 @@ block0(v0: i64):
 ; block0:
 ;   and x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, #3
@@ -722,7 +722,7 @@ block0(v0: i64):
 ; block0:
 ;   and x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, #3
@@ -740,7 +740,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, x1, lsl #3
@@ -758,7 +758,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, x1, lsl #3
@@ -774,7 +774,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   orr w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr w0, w0, w1
@@ -790,7 +790,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orr x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, x1
@@ -807,7 +807,7 @@ block0(v0: i128, v1: i128):
 ;   orr x0, x0, x2
 ;   orr x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, x2
@@ -824,7 +824,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
@@ -841,7 +841,7 @@ block0(v0: i64):
 ; block0:
 ;   orr x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, #3
@@ -858,7 +858,7 @@ block0(v0: i64):
 ; block0:
 ;   orr x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, #3
@@ -876,7 +876,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orr x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, x1, lsl #3
@@ -894,7 +894,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orr x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, x1, lsl #3
@@ -910,7 +910,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   eor w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor w0, w0, w1
@@ -926,7 +926,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eor x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, x1
@@ -943,7 +943,7 @@ block0(v0: i128, v1: i128):
 ;   eor x0, x0, x2
 ;   eor x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, x2
@@ -960,7 +960,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
@@ -977,7 +977,7 @@ block0(v0: i64):
 ; block0:
 ;   eor x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, #3
@@ -994,7 +994,7 @@ block0(v0: i64):
 ; block0:
 ;   eor x0, x0, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, #3
@@ -1012,7 +1012,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eor x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, x1, lsl #3
@@ -1030,7 +1030,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eor x0, x0, x1, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, x1, lsl #3
@@ -1046,7 +1046,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   bic w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic w0, w0, w1
@@ -1062,7 +1062,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   bic x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic x0, x0, x1
@@ -1079,7 +1079,7 @@ block0(v0: i128, v1: i128):
 ;   bic x0, x0, x2
 ;   bic x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic x0, x0, x2
@@ -1096,7 +1096,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   bic v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic v0.16b, v0.16b, v1.16b
@@ -1113,7 +1113,7 @@ block0(v0: i64):
 ; block0:
 ;   bic x0, x0, #4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and x0, x0, #0xfffffffffffffffb
@@ -1131,7 +1131,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   bic x0, x0, x1, LSL 4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic x0, x0, x1, lsl #4
@@ -1147,7 +1147,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   orn w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn w0, w0, w1
@@ -1163,7 +1163,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orn x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn x0, x0, x1
@@ -1180,7 +1180,7 @@ block0(v0: i128, v1: i128):
 ;   orn x0, x0, x2
 ;   orn x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn x0, x0, x2
@@ -1198,7 +1198,7 @@ block0(v0: i64):
 ; block0:
 ;   orn x0, x0, #4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x0, x0, #0xfffffffffffffffb
@@ -1216,7 +1216,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   orn x0, x0, x1, LSL 4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn x0, x0, x1, lsl #4
@@ -1232,7 +1232,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   eon w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w0, w0, w1
@@ -1248,7 +1248,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eon x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x0, x0, x1
@@ -1265,7 +1265,7 @@ block0(v0: i128, v1: i128):
 ;   eon x0, x0, x2
 ;   eon x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x0, x0, x2
@@ -1283,7 +1283,7 @@ block0(v0: i64):
 ; block0:
 ;   eon x0, x0, #4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor x0, x0, #0xfffffffffffffffb
@@ -1301,7 +1301,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eon x0, x0, x1, LSL 4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x0, x0, x1, lsl #4
@@ -1325,7 +1325,7 @@ block0(v0: i128, v1: i8):
 ;   csel x0, xzr, x4, ne
 ;   csel x1, x4, x14, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl x4, x0, x2
@@ -1357,7 +1357,7 @@ block0(v0: i128, v1: i128):
 ;   csel x0, xzr, x5, ne
 ;   csel x1, x5, x15, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl x5, x0, x2
@@ -1389,7 +1389,7 @@ block0(v0: i128, v1: i8):
 ;   csel x0, x6, x14, ne
 ;   csel x1, xzr, x6, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x4, x0, x2
@@ -1421,7 +1421,7 @@ block0(v0: i128, v1: i128):
 ;   csel x0, x7, x15, ne
 ;   csel x1, xzr, x7, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x5, x0, x2
@@ -1454,7 +1454,7 @@ block0(v0: i128, v1: i8):
 ;   csel x0, x6, x0, ne
 ;   csel x1, x14, x6, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x4, x0, x2
@@ -1488,7 +1488,7 @@ block0(v0: i128, v1: i128):
 ;   csel x0, x7, x1, ne
 ;   csel x1, x15, x7, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x5, x0, x2
@@ -1514,7 +1514,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   eon w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w0, w0, w1
@@ -1532,7 +1532,7 @@ block0(v0: i128, v1: i128):
 ;   eon x0, x0, x2
 ;   eon x1, x1, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon x0, x0, x2

--- a/cranelift/filetests/filetests/isa/aarch64/bitopts-optimized.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bitopts-optimized.clif
@@ -14,7 +14,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   bic w0, w1, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bic w0, w1, w0
@@ -31,7 +31,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   orn w0, w1, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orn w0, w1, w0
@@ -48,7 +48,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   eon w0, w1, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eon w0, w1, w0

--- a/cranelift/filetests/filetests/isa/aarch64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bmask.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ;   subs xzr, x0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -31,7 +31,7 @@ block0(v0: i64):
 ;   subs xzr, x0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -49,7 +49,7 @@ block0(v0: i64):
 ;   subs xzr, x0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -67,7 +67,7 @@ block0(v0: i64):
 ;   subs xzr, x0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -85,7 +85,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -103,7 +103,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -121,7 +121,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -139,7 +139,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -158,7 +158,7 @@ block0(v0: i16):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xffff
@@ -178,7 +178,7 @@ block0(v0: i16):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xffff
@@ -198,7 +198,7 @@ block0(v0: i16):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xffff
@@ -218,7 +218,7 @@ block0(v0: i16):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xffff
@@ -238,7 +238,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xff
@@ -258,7 +258,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xff
@@ -278,7 +278,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xff
@@ -298,7 +298,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xff
@@ -319,7 +319,7 @@ block0(v0: i128):
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -340,7 +340,7 @@ block0(v0: i128):
 ;   subs xzr, x3, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -360,7 +360,7 @@ block0(v0: i128):
 ;   subs xzr, x3, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -380,7 +380,7 @@ block0(v0: i128):
 ;   subs xzr, x3, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -400,7 +400,7 @@ block0(v0: i128):
 ;   subs xzr, x3, #0
 ;   csetm x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -420,7 +420,7 @@ block0(v0: i64):
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -440,7 +440,7 @@ block0(v0: i32):
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -461,7 +461,7 @@ block0(v0: i16):
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xffff
@@ -483,7 +483,7 @@ block0(v0: i8):
 ;   csetm x1, ne
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w2, w0, #0xff

--- a/cranelift/filetests/filetests/isa/aarch64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bswap.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ; block0:
 ;   rev64 x0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev x0, x0
@@ -28,7 +28,7 @@ block0(v0: i32):
 ; block0:
 ;   rev32 w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev w0, w0
@@ -44,7 +44,7 @@ block0(v0: i16):
 ; block0:
 ;   rev16 w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev16 w0, w0

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -51,7 +51,7 @@ block5(v5: i32):
 ; block5:
 ;   add w0, w0, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   hint #0x22
@@ -116,7 +116,7 @@ block2:
 ; block2:
 ;   mov x0, x8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   hint #0x22
@@ -158,7 +158,7 @@ block0(v0: i64):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   hint #0x22

--- a/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-indirect.clif
@@ -16,7 +16,7 @@ block0(v0: i64, v1: i64):
 ;   blr x1
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -19,7 +19,7 @@ block0(v0: i64):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   paciasp
@@ -45,7 +45,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   add x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, x1

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -19,7 +19,7 @@ block0(v0: i64):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -49,7 +49,7 @@ block0(v0: i32):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -71,7 +71,7 @@ block0(v0: i32):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -92,7 +92,7 @@ block0(v0: i32):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -114,7 +114,7 @@ block0(v0: i32):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -149,7 +149,7 @@ block0(v0: i8):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -192,7 +192,7 @@ block0(v0: i8):
 ;   mov x5, x7
 ;   mov x6, x7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w7, #0x2a
@@ -252,7 +252,7 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -348,7 +348,7 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -448,7 +448,7 @@ block0:
 ;   add sp, sp, #48
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -510,7 +510,7 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, x1
@@ -537,7 +537,7 @@ block0(v0: i64):
 ;   blr x4
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -564,7 +564,7 @@ block0(v0: i64, v1: i128):
 ; block0:
 ;   mov x0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, x2
@@ -591,7 +591,7 @@ block0(v0: i64):
 ;   blr x4
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -618,7 +618,7 @@ block0(v0: i64, v1: i128):
 ; block0:
 ;   mov x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, x1
@@ -645,7 +645,7 @@ block0(v0: i64):
 ;   blr x4
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -675,7 +675,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ldr x1, [fp, #24]
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -715,7 +715,7 @@ block0(v0: i128, v1: i64):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -753,7 +753,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ldr x1, [fp, #24]
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -793,7 +793,7 @@ block0(v0: i128, v1: i64):
 ;   virtual_sp_offset_adjust -16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -832,7 +832,7 @@ block0:
 ;   movz w3, #1
 ;   str w3, [x6]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x6, x0
@@ -853,7 +853,7 @@ block0(v0: i64):
 ;   movz x2, #42
 ;   str x2, [x8]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #0x2a
@@ -877,7 +877,7 @@ block0(v0: i64):
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -913,7 +913,7 @@ block0(v0: i64):
 ;   ldr x23, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -948,7 +948,7 @@ block0:
 ;   blr x0
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/cold-blocks.clif
@@ -25,7 +25,7 @@ block2:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w5, w0
@@ -58,7 +58,7 @@ block2 cold:
 ; block2:
 ;   movz w0, #97
 ;   b label3
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w5, w0

--- a/cranelift/filetests/filetests/isa/aarch64/compare_zero.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/compare_zero.clif
@@ -14,7 +14,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmeq v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v0.16b, v0.16b, #0
@@ -31,7 +31,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmeq v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v0.16b, v0.16b, #0
@@ -49,7 +49,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmeq v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v0.8h, v0.8h, #0
@@ -66,7 +66,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmeq v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v0.8h, v0.8h, #0
@@ -85,7 +85,7 @@ block0(v0: i32x4):
 ;   cmeq v2.4s, v0.4s, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.4s, v0.4s, #0
@@ -104,7 +104,7 @@ block0(v0: i32x4):
 ;   cmeq v2.4s, v0.4s, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.4s, v0.4s, #0
@@ -124,7 +124,7 @@ block0(v0: i64x2):
 ;   cmeq v2.2d, v0.2d, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
@@ -143,7 +143,7 @@ block0(v0: i64x2):
 ;   cmeq v2.2d, v0.2d, #0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0
@@ -162,7 +162,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmle v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmle v0.16b, v0.16b, #0
@@ -179,7 +179,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmle v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmle v0.16b, v0.16b, #0
@@ -197,7 +197,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmge v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, #0
@@ -214,7 +214,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmge v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, #0
@@ -232,7 +232,7 @@ block0(v0: i32x4):
 ; block0:
 ;   cmge v0.4s, v0.4s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmge v0.4s, v0.4s, #0
@@ -249,7 +249,7 @@ block0(v0: i32x4):
 ; block0:
 ;   cmge v0.4s, v0.4s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmge v0.4s, v0.4s, #0
@@ -267,7 +267,7 @@ block0(v0: i64x2):
 ; block0:
 ;   cmle v0.2d, v0.2d, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmle v0.2d, v0.2d, #0
@@ -284,7 +284,7 @@ block0(v0: i64x2):
 ; block0:
 ;   cmle v0.2d, v0.2d, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmle v0.2d, v0.2d, #0
@@ -302,7 +302,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmlt v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmlt v0.16b, v0.16b, #0
@@ -319,7 +319,7 @@ block0(v0: i8x16):
 ; block0:
 ;   cmlt v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmlt v0.16b, v0.16b, #0
@@ -337,7 +337,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmgt v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmgt v0.8h, v0.8h, #0
@@ -354,7 +354,7 @@ block0(v0: i16x8):
 ; block0:
 ;   cmgt v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmgt v0.8h, v0.8h, #0
@@ -372,7 +372,7 @@ block0(v0: i32x4):
 ; block0:
 ;   cmgt v0.4s, v0.4s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmgt v0.4s, v0.4s, #0
@@ -389,7 +389,7 @@ block0(v0: i32x4):
 ; block0:
 ;   cmgt v0.4s, v0.4s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmgt v0.4s, v0.4s, #0
@@ -407,7 +407,7 @@ block0(v0: i64x2):
 ; block0:
 ;   cmlt v0.2d, v0.2d, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmlt v0.2d, v0.2d, #0
@@ -424,7 +424,7 @@ block0(v0: i64x2):
 ; block0:
 ;   cmlt v0.2d, v0.2d, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmlt v0.2d, v0.2d, #0
@@ -442,7 +442,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmeq v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v0.4s, v0.4s, #0.0
@@ -459,7 +459,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmeq v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v0.4s, v0.4s, #0.0
@@ -477,7 +477,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmeq v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v0.2d, v0.2d, #0.0
@@ -494,7 +494,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmeq v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v0.2d, v0.2d, #0.0
@@ -513,7 +513,7 @@ block0(v0: f64x2):
 ;   fcmeq v2.2d, v0.2d, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v2.2d, v0.2d, #0.0
@@ -532,7 +532,7 @@ block0(v0: f64x2):
 ;   fcmeq v2.2d, v0.2d, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v2.2d, v0.2d, #0.0
@@ -552,7 +552,7 @@ block0(v0: f32x4):
 ;   fcmeq v2.4s, v0.4s, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v2.4s, v0.4s, #0.0
@@ -571,7 +571,7 @@ block0(v0: f32x4):
 ;   fcmeq v2.4s, v0.4s, #0.0
 ;   mvn v0.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmeq v2.4s, v0.4s, #0.0
@@ -590,7 +590,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
@@ -607,7 +607,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
@@ -625,7 +625,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
@@ -642,7 +642,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
@@ -660,7 +660,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
@@ -677,7 +677,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmge v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmge v0.2d, v0.2d, #0.0
@@ -695,7 +695,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
@@ -712,7 +712,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmle v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmle v0.4s, v0.4s, #0.0
@@ -730,7 +730,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
@@ -747,7 +747,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
@@ -765,7 +765,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
@@ -782,7 +782,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
@@ -800,7 +800,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
@@ -817,7 +817,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fcmgt v0.2d, v0.2d, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmgt v0.2d, v0.2d, #0.0
@@ -835,7 +835,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0
@@ -852,7 +852,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcmlt v0.4s, v0.4s, #0.0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmlt v0.4s, v0.4s, #0.0

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -13,7 +13,7 @@ block0(v0: i64, v1: i64):
 ;   subs xzr, x0, x1
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x1
@@ -32,7 +32,7 @@ block0(v0: i128, v1: i128):
 ;   ccmp x1, x3, #nzcv, eq
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -52,7 +52,7 @@ block0(v0: i128, v1: i128):
 ;   ccmp x1, x3, #nzcv, eq
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -74,7 +74,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, lt
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -98,7 +98,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, lo
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -122,7 +122,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, le
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -146,7 +146,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, ls
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -170,7 +170,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, gt
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -194,7 +194,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, hi
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -218,7 +218,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, ge
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -242,7 +242,7 @@ block0(v0: i128, v1: i128):
 ;   cset x9, hs
 ;   csel x0, x6, x9, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -277,7 +277,7 @@ block2:
 ; block2:
 ;   movz x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x1
@@ -311,7 +311,7 @@ block1:
 ; block3:
 ;   movz x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x1
@@ -338,7 +338,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -364,7 +364,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr x3, x0, x1
@@ -392,7 +392,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -421,7 +421,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -454,7 +454,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -491,7 +491,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -529,7 +529,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -568,7 +568,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -606,7 +606,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -643,7 +643,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -681,7 +681,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
@@ -720,7 +720,7 @@ block1:
 ;   b label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2

--- a/cranelift/filetests/filetests/isa/aarch64/condops.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condops.clif
@@ -16,7 +16,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -38,7 +38,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -60,7 +60,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -82,7 +82,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -105,7 +105,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w6, w0
@@ -128,7 +128,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -150,7 +150,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -172,7 +172,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -194,7 +194,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   subs wzr, w4, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -217,7 +217,7 @@ block0(v0: i16, v1: i128, v2: i128):
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w6, w0
@@ -239,7 +239,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   subs wzr, w0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -259,7 +259,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   subs wzr, w0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -279,7 +279,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   subs wzr, w0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -299,7 +299,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   subs wzr, w0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -320,7 +320,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -341,7 +341,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   subs xzr, x0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -361,7 +361,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   subs xzr, x0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -381,7 +381,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   subs xzr, x0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -401,7 +401,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   subs xzr, x0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -422,7 +422,7 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -447,7 +447,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   ccmp x1, x8, #nzcv, eq
 ;   csel x0, x2, x3, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -474,7 +474,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   ccmp x1, x8, #nzcv, eq
 ;   csel x0, x2, x3, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -501,7 +501,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   ccmp x1, x8, #nzcv, eq
 ;   csel x0, x2, x3, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -528,7 +528,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   ccmp x1, x8, #nzcv, eq
 ;   csel x0, x2, x3, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -556,7 +556,7 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   csel x0, x2, x4, eq
 ;   csel x1, x3, x5, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x10, #0x2a
@@ -582,7 +582,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -606,7 +606,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -630,7 +630,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -654,7 +654,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w4, w0
@@ -679,7 +679,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   csel x1, x3, x5, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w6, w0
@@ -704,7 +704,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -728,7 +728,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -752,7 +752,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -776,7 +776,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w4, w0
@@ -801,7 +801,7 @@ block0(v0: i16, v1: i128, v2: i128):
 ;   csel x1, x3, x5, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w6, w0
@@ -825,7 +825,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -847,7 +847,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -869,7 +869,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -891,7 +891,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -914,7 +914,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   csel x1, x3, x5, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -937,7 +937,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -959,7 +959,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -981,7 +981,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -1003,7 +1003,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   csel x0, x1, x2, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -1026,7 +1026,7 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   csel x1, x3, x5, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0x2a
@@ -1053,7 +1053,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -1082,7 +1082,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -1111,7 +1111,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -1140,7 +1140,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   csel x0, x2, x3, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x7, #0x2a
@@ -1170,7 +1170,7 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   csel x1, x3, x5, eq
 ;   csdb
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x10, #0x2a
@@ -1195,7 +1195,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #42
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w2, w0
@@ -1215,7 +1215,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   bic w6, w2, w0
 ;   orr w0, w4, w6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w4, w1, w0
@@ -1234,7 +1234,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   ands wzr, w0, #255
 ;   csel x0, x1, x2, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   tst w0, #0xff
@@ -1254,7 +1254,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   subs wzr, w0, #42
 ;   csel x0, x1, x2, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x2a
@@ -1273,7 +1273,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   csel x0, x2, x4, ne
 ;   csel x1, x3, x5, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   tst w0, #0xff

--- a/cranelift/filetests/filetests/isa/aarch64/constants.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/constants.clif
@@ -12,7 +12,7 @@ block0:
 ; block0:
 ;   movz w0, #255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #0xff
@@ -28,7 +28,7 @@ block0:
 ; block0:
 ;   movz w0, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #0
@@ -44,7 +44,7 @@ block0:
 ; block0:
 ;   movz x0, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0
@@ -60,7 +60,7 @@ block0:
 ; block0:
 ;   movz x0, #65535
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0xffff
@@ -76,7 +76,7 @@ block0:
 ; block0:
 ;   movz x0, #65535, LSL #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0xffff0000
@@ -92,7 +92,7 @@ block0:
 ; block0:
 ;   movz x0, #65535, LSL #32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0xffff00000000
@@ -108,7 +108,7 @@ block0:
 ; block0:
 ;   movz x0, #65535, LSL #48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-0x1000000000000
@@ -124,7 +124,7 @@ block0:
 ; block0:
 ;   movn x0, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-1
@@ -140,7 +140,7 @@ block0:
 ; block0:
 ;   movn x0, #65535
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-0x10000
@@ -156,7 +156,7 @@ block0:
 ; block0:
 ;   movn x0, #65535, LSL #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-0xffff0001
@@ -172,7 +172,7 @@ block0:
 ; block0:
 ;   movn x0, #65535, LSL #32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-0xffff00000001
@@ -188,7 +188,7 @@ block0:
 ; block0:
 ;   movn x0, #65535, LSL #48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0xffffffffffff
@@ -207,7 +207,7 @@ block0:
 ;   movk x0, x0, #61603, LSL #32
 ;   movk x0, x0, #62283, LSL #48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0x3a
@@ -227,7 +227,7 @@ block0:
 ;   movz x0, #7924, LSL #16
 ;   movk x0, x0, #4841, LSL #48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0x1ef40000
@@ -245,7 +245,7 @@ block0:
 ;   movn x0, #57611, LSL #16
 ;   movk x0, x0, #4841, LSL #48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-0xe10b0001
@@ -262,7 +262,7 @@ block0:
 ; block0:
 ;   movn w0, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #-1
@@ -278,7 +278,7 @@ block0:
 ; block0:
 ;   movn w0, #8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #-9
@@ -294,7 +294,7 @@ block0:
 ; block0:
 ;   movn w0, #8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #-9
@@ -310,7 +310,7 @@ block0:
 ; block0:
 ;   movn x0, #8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #-9
@@ -326,7 +326,7 @@ block0:
 ; block0:
 ;   fmov d0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d0, #1.00000000
@@ -342,7 +342,7 @@ block0:
 ; block0:
 ;   fmov s0, #5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s0, #5.00000000
@@ -359,7 +359,7 @@ block0:
 ;   movz x0, #16457, LSL #48
 ;   fmov d0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0x4049000000000000
@@ -377,7 +377,7 @@ block0:
 ;   movz w0, #16968, LSL #16
 ;   fmov s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, #0x42480000
@@ -394,7 +394,7 @@ block0:
 ; block0:
 ;   movi v0.2s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.2s, #0
@@ -410,7 +410,7 @@ block0:
 ; block0:
 ;   movi v0.2s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.2s, #0
@@ -426,7 +426,7 @@ block0:
 ; block0:
 ;   fmov d0, #-16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d0, #-16.00000000
@@ -442,7 +442,7 @@ block0:
 ; block0:
 ;   fmov s0, #-16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s0, #-16.00000000

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-narrow.clif
@@ -20,7 +20,7 @@ block0(v0: i16):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   sqxtn v0.8b, v2.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.4h, w0
@@ -47,7 +47,7 @@ block0(v0: i16):
 ;   sqxtn v0.8b, v4.8h
 ;   sqxtn2 v0.16b, v0.16b, v4.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.8h, w0
@@ -74,7 +74,7 @@ block0(v0: i32):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   sqxtn v0.4h, v2.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.2s, w0
@@ -101,7 +101,7 @@ block0(v0: i32):
 ;   sqxtn v0.4h, v4.4s
 ;   sqxtn2 v0.8h, v0.8h, v4.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.4s, w0
@@ -128,7 +128,7 @@ block0(v0: i64):
 ;   sqxtn v0.2s, v4.2d
 ;   sqxtn2 v0.4s, v0.4s, v4.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.2d, x0
@@ -155,7 +155,7 @@ block0(v0: i16):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   sqxtun v0.8b, v2.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.4h, w0
@@ -182,7 +182,7 @@ block0(v0: i16):
 ;   sqxtun v0.8b, v4.8h
 ;   sqxtun2 v0.16b, v0.16b, v4.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.8h, w0
@@ -209,7 +209,7 @@ block0(v0: i32):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   sqxtun v0.4h, v2.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.2s, w0
@@ -236,7 +236,7 @@ block0(v0: i32):
 ;   sqxtun v0.4h, v4.4s
 ;   sqxtun2 v0.8h, v0.8h, v4.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.4s, w0
@@ -263,7 +263,7 @@ block0(v0: i64):
 ;   sqxtun v0.2s, v4.2d
 ;   sqxtun2 v0.4s, v0.4s, v4.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.2d, x0
@@ -290,7 +290,7 @@ block0(v0: i16):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   uqxtn v0.8b, v2.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.4h, w0
@@ -317,7 +317,7 @@ block0(v0: i16):
 ;   uqxtn v0.8b, v4.8h
 ;   uqxtn2 v0.16b, v0.16b, v4.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.8h, w0
@@ -344,7 +344,7 @@ block0(v0: i32):
 ;   mov v2.d[1], v2.d[1], v2.d[0]
 ;   uqxtn v0.4h, v2.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v2.2s, w0
@@ -371,7 +371,7 @@ block0(v0: i32):
 ;   uqxtn v0.4h, v4.4s
 ;   uqxtn2 v0.8h, v0.8h, v4.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.4s, w0
@@ -398,7 +398,7 @@ block0(v0: i64):
 ;   uqxtn v0.2s, v4.2d
 ;   uqxtn2 v0.4s, v0.4s, v4.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v4.2d, x0

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-neon.clif
@@ -19,7 +19,7 @@ block0(v0: i8, v1: i8):
 ;   dup v6.16b, w1
 ;   add v0.16b, v5.16b, v6.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.16b, w0
@@ -45,7 +45,7 @@ block0(v0: i16, v1: i16):
 ;   dup v6.8h, w1
 ;   add v0.8h, v5.8h, v6.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.8h, w0
@@ -71,7 +71,7 @@ block0(v0: i32, v1: i32):
 ;   dup v6.4s, w1
 ;   mul v0.4s, v5.4s, v6.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.4s, w0
@@ -97,7 +97,7 @@ block0(v0: i64, v1: i64):
 ;   dup v6.2d, x1
 ;   sub v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, x0
@@ -123,7 +123,7 @@ block0(v0: f32, v1: f32):
 ;   dup v6.4s, v1.s[0]
 ;   fadd v0.4s, v5.4s, v6.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.4s, v0.s[0]
@@ -149,7 +149,7 @@ block0(v0: f64, v1: f64):
 ;   dup v6.2d, v1.d[0]
 ;   fsub v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, v0.d[0]
@@ -175,7 +175,7 @@ block0(v0: f64, v1: f64):
 ;   dup v6.2d, v1.d[0]
 ;   fmul v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, v0.d[0]
@@ -201,7 +201,7 @@ block0(v0: f64, v1: f64):
 ;   dup v6.2d, v1.d[0]
 ;   fdiv v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, v0.d[0]
@@ -227,7 +227,7 @@ block0(v0: f64, v1: f64):
 ;   dup v6.2d, v1.d[0]
 ;   fmin v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, v0.d[0]
@@ -253,7 +253,7 @@ block0(v0: f64, v1: f64):
 ;   dup v6.2d, v1.d[0]
 ;   fmax v0.2d, v5.2d, v6.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v5.2d, v0.d[0]
@@ -280,7 +280,7 @@ block0(v0: f64, v1: f64):
 ;   fcmgt v0.2d, v6.2d, v7.2d
 ;   bsl v0.16b, v0.16b, v7.16b, v6.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]
@@ -308,7 +308,7 @@ block0(v0: f64, v1: f64):
 ;   fcmgt v0.2d, v7.2d, v6.2d
 ;   bsl v0.16b, v0.16b, v7.16b, v6.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v6.2d, v0.d[0]

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-simd-widen.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ;   dup v3.16b, w0
 ;   sxtl2 v0.8h, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.16b, w0
@@ -44,7 +44,7 @@ block0(v0: i16):
 ;   dup v3.8h, w0
 ;   sxtl2 v0.4s, v3.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.8h, w0
@@ -69,7 +69,7 @@ block0(v0: i32):
 ;   dup v3.4s, w0
 ;   sxtl2 v0.2d, v3.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.4s, w0
@@ -94,7 +94,7 @@ block0(v0: i8):
 ;   dup v3.16b, w0
 ;   sxtl v0.8h, v3.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.16b, w0
@@ -119,7 +119,7 @@ block0(v0: i16):
 ;   dup v3.8h, w0
 ;   sxtl v0.4s, v3.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.8h, w0
@@ -144,7 +144,7 @@ block0(v0: i32):
 ;   dup v3.4s, w0
 ;   sxtl v0.2d, v3.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v3.4s, w0

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -22,7 +22,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -57,7 +57,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -93,7 +93,7 @@ block0(v0: i32):
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -128,7 +128,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -163,7 +163,7 @@ block0(v0: i32):
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -196,7 +196,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/extend-op.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/extend-op.clif
@@ -15,7 +15,7 @@ block0(v0: i8):
 ;   sxtb x3, w0
 ;   add x0, x3, #42
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb x3, w0
@@ -33,7 +33,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   add x0, x1, x0, SXTB
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x1, w0, sxtb
@@ -49,7 +49,7 @@ block0(v0: i64):
 ; block0:
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x1, #0
@@ -65,7 +65,7 @@ block0(v0: i64):
 ; block0:
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   asr x1, x0, #0x3f
@@ -82,7 +82,7 @@ block0(v0: i32):
 ;   mov w0, w0
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, w0
@@ -100,7 +100,7 @@ block0(v0: i32):
 ;   sxtw x0, w0
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x0, w0
@@ -118,7 +118,7 @@ block0(v0: i16):
 ;   uxth w0, w0
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w0, w0
@@ -136,7 +136,7 @@ block0(v0: i16):
 ;   sxth x0, w0
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth x0, w0
@@ -154,7 +154,7 @@ block0(v0: i8):
 ;   uxtb w0, w0
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w0, w0
@@ -172,7 +172,7 @@ block0(v0: i8):
 ;   sxtb x0, w0
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb x0, w0
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ; block0:
 ;   umov w0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
@@ -207,7 +207,7 @@ block0(v0: i8x16):
 ; block0:
 ;   umov w0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
@@ -224,7 +224,7 @@ block0(v0: i8x16):
 ; block0:
 ;   umov w0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
@@ -242,7 +242,7 @@ block0(v0: i8x16):
 ;   umov w0, v0.b[1]
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.b[1]
@@ -260,7 +260,7 @@ block0(v0: i8x16):
 ; block0:
 ;   smov w0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov w0, v0.b[1]
@@ -277,7 +277,7 @@ block0(v0: i8x16):
 ; block0:
 ;   smov w0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov w0, v0.b[1]
@@ -294,7 +294,7 @@ block0(v0: i8x16):
 ; block0:
 ;   smov x0, v0.b[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.b[1]
@@ -312,7 +312,7 @@ block0(v0: i8x16):
 ;   smov x0, v0.b[1]
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.b[1]
@@ -330,7 +330,7 @@ block0(v0: i16x8):
 ; block0:
 ;   umov w0, v0.h[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.h[1]
@@ -347,7 +347,7 @@ block0(v0: i16x8):
 ; block0:
 ;   umov w0, v0.h[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.h[1]
@@ -365,7 +365,7 @@ block0(v0: i16x8):
 ;   umov w0, v0.h[1]
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umov w0, v0.h[1]
@@ -383,7 +383,7 @@ block0(v0: i16x8):
 ; block0:
 ;   smov w0, v0.h[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov w0, v0.h[1]
@@ -400,7 +400,7 @@ block0(v0: i16x8):
 ; block0:
 ;   smov x0, v0.h[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.h[1]
@@ -418,7 +418,7 @@ block0(v0: i16x8):
 ;   smov x0, v0.h[1]
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.h[1]
@@ -436,7 +436,7 @@ block0(v0: i32x4):
 ; block0:
 ;   mov w0, v0.s[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, v0.s[1]
@@ -454,7 +454,7 @@ block0(v0: i32x4):
 ;   mov w0, v0.s[1]
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, v0.s[1]
@@ -472,7 +472,7 @@ block0(v0: i32x4):
 ; block0:
 ;   smov x0, v0.s[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.s[1]
@@ -490,7 +490,7 @@ block0(v0: i32x4):
 ;   smov x0, v0.s[1]
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smov x0, v0.s[1]
@@ -509,7 +509,7 @@ block0(v0: i64x2):
 ;   mov x0, v0.d[1]
 ;   movz x1, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, v0.d[1]
@@ -528,7 +528,7 @@ block0(v0: i64x2):
 ;   mov x0, v0.d[1]
 ;   asr x1, x0, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, v0.d[1]

--- a/cranelift/filetests/filetests/isa/aarch64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fcvt-small.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   uxtb w2, w0
 ;   ucvtf s0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w2, w0
@@ -31,7 +31,7 @@ block0(v0: i8):
 ;   uxtb w2, w0
 ;   ucvtf d0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w2, w0
@@ -49,7 +49,7 @@ block0(v0: i16):
 ;   uxth w2, w0
 ;   ucvtf s0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w2, w0
@@ -67,7 +67,7 @@ block0(v0: i16):
 ;   uxth w2, w0
 ;   ucvtf d0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w2, w0
@@ -93,7 +93,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -130,7 +130,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -167,7 +167,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -204,7 +204,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0

--- a/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fcvt.clif
@@ -12,7 +12,7 @@ block0(v0: i8):
 ;   sxtb w2, w0
 ;   scvtf s0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w2, w0
@@ -30,7 +30,7 @@ block0(v0: i16):
 ;   sxth w2, w0
 ;   scvtf s0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w2, w0
@@ -47,7 +47,7 @@ block0(v0: i32):
 ; block0:
 ;   scvtf s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf s0, w0
@@ -63,7 +63,7 @@ block0(v0: i64):
 ; block0:
 ;   scvtf s0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf s0, x0
@@ -80,7 +80,7 @@ block0(v0: i8):
 ;   sxtb w2, w0
 ;   scvtf d0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w2, w0
@@ -98,7 +98,7 @@ block0(v0: i16):
 ;   sxth w2, w0
 ;   scvtf d0, w2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w2, w0
@@ -115,7 +115,7 @@ block0(v0: i32):
 ; block0:
 ;   scvtf d0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf d0, w0
@@ -131,7 +131,7 @@ block0(v0: i64):
 ; block0:
 ;   scvtf d0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf d0, x0
@@ -148,7 +148,7 @@ block0(v0: i32x4):
 ;   sxtl v2.2d, v0.2s
 ;   scvtf v0.2d, v2.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshll v2.2d, v0.2s, #0
@@ -179,7 +179,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   fadd s21, s22, s21
 ;   fadd s0, s21, s24
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w12, w0
@@ -205,7 +205,7 @@ block0(v0: i32x4):
 ;   uxtl v3.2d, v0.2s
 ;   ucvtf v0.2d, v3.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushll v3.2d, v0.2s, #0
@@ -222,7 +222,7 @@ block0(v0: i32x4):
 ; block0:
 ;   ucvtf v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ucvtf v0.4s, v0.4s
@@ -247,7 +247,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -284,7 +284,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -321,7 +321,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -358,7 +358,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -386,7 +386,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvtzu w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w0, s0
@@ -402,7 +402,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvtzu x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu x0, s0
@@ -418,7 +418,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvtzu w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w0, d0
@@ -434,7 +434,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvtzu x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu x0, d0
@@ -460,7 +460,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -499,7 +499,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -537,7 +537,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -577,7 +577,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -606,7 +606,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvtzs w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w0, s0
@@ -622,7 +622,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvtzs x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs x0, s0
@@ -638,7 +638,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvtzs w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w0, d0
@@ -654,7 +654,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvtzs x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs x0, d0
@@ -670,7 +670,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcvtzu v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu v0.4s, v0.4s
@@ -686,7 +686,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fcvtzs v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs v0.4s, v0.4s
@@ -705,7 +705,7 @@ block0(v0: f32):
 ;   subs wzr, w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w2, s0
@@ -730,7 +730,7 @@ block0(v0: f32):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w2, s0
@@ -755,7 +755,7 @@ block0(v0: f32):
 ;   subs wzr, w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w2, s0
@@ -780,7 +780,7 @@ block0(v0: f32):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w2, s0
@@ -805,7 +805,7 @@ block0(v0: f64):
 ;   subs wzr, w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w2, d0
@@ -830,7 +830,7 @@ block0(v0: f64):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w2, d0
@@ -855,7 +855,7 @@ block0(v0: f64):
 ;   subs wzr, w2, w4
 ;   csel x0, x4, x2, hi
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzu w2, d0
@@ -880,7 +880,7 @@ block0(v0: f64):
 ;   subs wzr, w9, w6
 ;   csel x0, x6, x9, lt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvtzs w2, d0

--- a/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/floating-point.clif
@@ -12,7 +12,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fadd s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fadd s0, s0, s1
@@ -28,7 +28,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fadd d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fadd d0, d0, d1
@@ -44,7 +44,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fsub s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsub s0, s0, s1
@@ -60,7 +60,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fsub d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsub d0, d0, d1
@@ -76,7 +76,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fmul s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmul s0, s0, s1
@@ -92,7 +92,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fmul d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmul d0, d0, d1
@@ -108,7 +108,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fdiv s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fdiv s0, s0, s1
@@ -124,7 +124,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fdiv d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fdiv d0, d0, d1
@@ -140,7 +140,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fmin s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmin s0, s0, s1
@@ -156,7 +156,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fmin d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmin d0, d0, d1
@@ -172,7 +172,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fmax s0, s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmax s0, s0, s1
@@ -188,7 +188,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fmax d0, d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmax d0, d0, d1
@@ -204,7 +204,7 @@ block0(v0: f32):
 ; block0:
 ;   fsqrt s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt s0, s0
@@ -220,7 +220,7 @@ block0(v0: f64):
 ; block0:
 ;   fsqrt d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt d0, d0
@@ -236,7 +236,7 @@ block0(v0: f32):
 ; block0:
 ;   fabs s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs s0, s0
@@ -252,7 +252,7 @@ block0(v0: f64):
 ; block0:
 ;   fabs d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs d0, d0
@@ -268,7 +268,7 @@ block0(v0: f32):
 ; block0:
 ;   fneg s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg s0, s0
@@ -284,7 +284,7 @@ block0(v0: f64):
 ; block0:
 ;   fneg d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg d0, d0
@@ -300,7 +300,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt d0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt d0, s0
@@ -316,7 +316,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt s0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt s0, d0
@@ -332,7 +332,7 @@ block0(v0: f32):
 ; block0:
 ;   frintp s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintp s0, s0
@@ -348,7 +348,7 @@ block0(v0: f64):
 ; block0:
 ;   frintp d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintp d0, d0
@@ -364,7 +364,7 @@ block0(v0: f32):
 ; block0:
 ;   frintm s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintm s0, s0
@@ -380,7 +380,7 @@ block0(v0: f64):
 ; block0:
 ;   frintm d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintm d0, d0
@@ -396,7 +396,7 @@ block0(v0: f32):
 ; block0:
 ;   frintz s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintz s0, s0
@@ -412,7 +412,7 @@ block0(v0: f64):
 ; block0:
 ;   frintz d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintz d0, d0
@@ -428,7 +428,7 @@ block0(v0: f32):
 ; block0:
 ;   frintn s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintn s0, s0
@@ -444,7 +444,7 @@ block0(v0: f64):
 ; block0:
 ;   frintn d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintn d0, d0
@@ -460,7 +460,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ; block0:
 ;   fmadd s0, s0, s1, s2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd s0, s0, s1, s2
@@ -476,7 +476,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ; block0:
 ;   fmadd d0, d0, d1, d2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd d0, d0, d1, d2
@@ -493,7 +493,7 @@ block0(v0: f32, v1: f32):
 ;   ushr v4.2s, v1.2s, #31
 ;   sli v0.2s, v0.2s, v4.2s, #31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v4.2s, v1.2s, #0x1f
@@ -511,7 +511,7 @@ block0(v0: f64, v1: f64):
 ;   ushr d4, d1, #63
 ;   sli d0, d0, d4, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr d4, d1, #0x3f
@@ -537,7 +537,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -575,7 +575,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs w0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -613,7 +613,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -651,7 +651,7 @@ block0(v0: f32):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs x0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s0
@@ -689,7 +689,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -726,7 +726,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs w0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -765,7 +765,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzu x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -803,7 +803,7 @@ block0(v0: f64):
 ;   b.ge #trap=int_ovf
 ;   fcvtzs x0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp d0, d0
@@ -832,7 +832,7 @@ block0(v0: i32):
 ; block0:
 ;   ucvtf s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ucvtf s0, w0
@@ -848,7 +848,7 @@ block0(v0: i32):
 ; block0:
 ;   scvtf s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf s0, w0
@@ -864,7 +864,7 @@ block0(v0: i64):
 ; block0:
 ;   ucvtf s0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ucvtf s0, x0
@@ -880,7 +880,7 @@ block0(v0: i64):
 ; block0:
 ;   scvtf s0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf s0, x0
@@ -896,7 +896,7 @@ block0(v0: i32):
 ; block0:
 ;   ucvtf d0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ucvtf d0, w0
@@ -912,7 +912,7 @@ block0(v0: i32):
 ; block0:
 ;   scvtf d0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf d0, w0
@@ -928,7 +928,7 @@ block0(v0: i64):
 ; block0:
 ;   ucvtf d0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ucvtf d0, x0
@@ -944,7 +944,7 @@ block0(v0: i64):
 ; block0:
 ;   scvtf d0, x0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   scvtf d0, x0
@@ -960,7 +960,7 @@ block0(v0: f32x2):
 ; block0:
 ;   fsqrt v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt v0.2s, v0.2s
@@ -976,7 +976,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fsqrt v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt v0.4s, v0.4s
@@ -992,7 +992,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fsqrt v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt v0.2d, v0.2d
@@ -1008,7 +1008,7 @@ block0(v0: f32x2):
 ; block0:
 ;   fneg v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg v0.2s, v0.2s
@@ -1024,7 +1024,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fneg v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg v0.4s, v0.4s
@@ -1040,7 +1040,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fneg v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg v0.2d, v0.2d
@@ -1056,7 +1056,7 @@ block0(v0: f32x2):
 ; block0:
 ;   fabs v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs v0.2s, v0.2s
@@ -1072,7 +1072,7 @@ block0(v0: f32x4):
 ; block0:
 ;   fabs v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs v0.4s, v0.4s
@@ -1088,7 +1088,7 @@ block0(v0: f64x2):
 ; block0:
 ;   fabs v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs v0.2d, v0.2d
@@ -1104,7 +1104,7 @@ block0(v0: f32x2):
 ; block0:
 ;   frintp v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintp v0.2s, v0.2s
@@ -1120,7 +1120,7 @@ block0(v0: f32x4):
 ; block0:
 ;   frintp v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintp v0.4s, v0.4s
@@ -1136,7 +1136,7 @@ block0(v0: f64x2):
 ; block0:
 ;   frintp v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintp v0.2d, v0.2d
@@ -1152,7 +1152,7 @@ block0(v0: f32x2):
 ; block0:
 ;   frintm v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintm v0.2s, v0.2s
@@ -1168,7 +1168,7 @@ block0(v0: f32x4):
 ; block0:
 ;   frintm v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintm v0.4s, v0.4s
@@ -1184,7 +1184,7 @@ block0(v0: f64x2):
 ; block0:
 ;   frintm v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintm v0.2d, v0.2d
@@ -1200,7 +1200,7 @@ block0(v0: f32x2):
 ; block0:
 ;   frintz v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintz v0.2s, v0.2s
@@ -1216,7 +1216,7 @@ block0(v0: f32x4):
 ; block0:
 ;   frintz v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintz v0.4s, v0.4s
@@ -1232,7 +1232,7 @@ block0(v0: f64x2):
 ; block0:
 ;   frintz v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintz v0.2d, v0.2d
@@ -1248,7 +1248,7 @@ block0(v0: f32x2):
 ; block0:
 ;   frintn v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintn v0.2s, v0.2s
@@ -1264,7 +1264,7 @@ block0(v0: f32x4):
 ; block0:
 ;   frintn v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintn v0.4s, v0.4s
@@ -1280,7 +1280,7 @@ block0(v0: f64x2):
 ; block0:
 ;   frintn v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   frintn v0.2d, v0.2d
@@ -1298,7 +1298,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v5.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -1318,7 +1318,7 @@ block0(v0: f32x2, v1: f32x2, v2: f32x2):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.2s, v0.2s, v5.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -1338,7 +1338,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.2d, v0.2d, v5.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -1357,7 +1357,7 @@ block0(v0: f32x2, v1: f32x2):
 ;   ushr v4.2s, v1.2s, #31
 ;   sli v0.2s, v0.2s, v4.2s, #31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v4.2s, v1.2s, #0x1f
@@ -1375,7 +1375,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   ushr v4.4s, v1.4s, #31
 ;   sli v0.4s, v0.4s, v4.4s, #31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v4.4s, v1.4s, #0x1f
@@ -1393,7 +1393,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   ushr v4.2d, v1.2d, #63
 ;   sli v0.2d, v0.2d, v4.2d, #63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v4.2d, v1.2d, #0x3f

--- a/cranelift/filetests/filetests/isa/aarch64/fma.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fma.clif
@@ -11,7 +11,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ; block0:
 ;   fmadd s0, s0, s1, s2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd s0, s0, s1, s2
@@ -27,7 +27,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ; block0:
 ;   fmadd d0, d0, d1, d2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd d0, d0, d1, d2
@@ -45,7 +45,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v5.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -65,7 +65,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.2d, v0.2d, v5.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -86,7 +86,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.4s, v0.4s, v5.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -107,7 +107,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.2d, v0.2d, v5.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -128,7 +128,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.4s, v0.4s, v5.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -149,7 +149,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.2d, v0.2d, v5.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -170,7 +170,7 @@ block0(v0: f32, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v1.4s, v5.s[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -192,7 +192,7 @@ block0(v0: f32x4, v1: f32, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.4s, v0.4s, v5.4s, v1.s[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -215,7 +215,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v1.4s, v5.s[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -239,7 +239,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.4s, v0.4s, v5.4s, v1.s[3]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b
@@ -268,7 +268,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   mov v0.16b, v2.16b
 ;   fmla v0.4s, v0.4s, v23.4s, v19.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v31.16b, v1.16b
@@ -298,7 +298,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   mov v0.16b, v2.16b
 ;   fmls v0.2d, v0.2d, v5.2d, v1.d[1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v5.16b, v0.16b

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc-pauth.clif
@@ -16,7 +16,7 @@ block0:
 ;   mov x0, fp
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   paciasp
@@ -42,7 +42,7 @@ block0:
 ;   mov x0, sp
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   paciasp
@@ -70,7 +70,7 @@ block0:
 ;   mov x0, lr
 ;   ldp fp, lr, [sp], #16
 ;   autiasp ; ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   paciasp

--- a/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fp_sp_pc.clif
@@ -15,7 +15,7 @@ block0:
 ;   mov x0, fp
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -38,7 +38,7 @@ block0:
 ;   mov x0, sp
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -61,7 +61,7 @@ block0:
 ;   ldr x0, [fp, #8]
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iabs.clif
@@ -12,7 +12,7 @@ block0(v0: i8x16):
 ; block0:
 ;   abs v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.16b, v0.16b
@@ -28,7 +28,7 @@ block0(v0: i8x8):
 ; block0:
 ;   abs v0.8b, v0.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.8b, v0.8b
@@ -44,7 +44,7 @@ block0(v0: i16x8):
 ; block0:
 ;   abs v0.8h, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.8h, v0.8h
@@ -60,7 +60,7 @@ block0(v0: i16x4):
 ; block0:
 ;   abs v0.4h, v0.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.4h, v0.4h
@@ -76,7 +76,7 @@ block0(v0: i32x4):
 ; block0:
 ;   abs v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.4s, v0.4s
@@ -92,7 +92,7 @@ block0(v0: i32x2):
 ; block0:
 ;   abs v0.2s, v0.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.2s, v0.2s
@@ -108,7 +108,7 @@ block0(v0: i64x2):
 ; block0:
 ;   abs v0.2d, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   abs v0.2d, v0.2d
@@ -126,7 +126,7 @@ block0(v0: i8):
 ;   subs wzr, w2, #0
 ;   csneg x0, x2, x2, gt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w2, w0
@@ -146,7 +146,7 @@ block0(v0: i16):
 ;   subs wzr, w2, #0
 ;   csneg x0, x2, x2, gt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w2, w0
@@ -165,7 +165,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #0
 ;   csneg x0, x0, x0, gt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0
@@ -183,7 +183,7 @@ block0(v0: i64):
 ;   subs xzr, x0, #0
 ;   csneg x0, x0, x0, gt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0

--- a/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
@@ -17,7 +17,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #1118208
 ;   cset x0, hi
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x111, lsl #12
@@ -36,7 +36,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #1118208
 ;   cset x0, hs
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x111, lsl #12
@@ -57,7 +57,7 @@ block0(v0: i32):
 ;   subs wzr, w0, w3
 ;   cset x0, hs
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x1111
@@ -80,7 +80,7 @@ block0(v0: i32):
 ;   subs wzr, w0, w3
 ;   cset x0, hs
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x1110
@@ -101,7 +101,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #1118208
 ;   cset x0, gt
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x111, lsl #12
@@ -120,7 +120,7 @@ block0(v0: i32):
 ;   subs wzr, w0, #1118208
 ;   cset x0, ge
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #0x111, lsl #12
@@ -141,7 +141,7 @@ block0(v0: i32):
 ;   subs wzr, w0, w3
 ;   cset x0, ge
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x1111
@@ -164,7 +164,7 @@ block0(v0: i32):
 ;   subs wzr, w0, w3
 ;   cset x0, ge
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x1110

--- a/cranelift/filetests/filetests/isa/aarch64/iconst-icmp-small.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iconst-icmp-small.clif
@@ -20,7 +20,7 @@ block0:
 ;   subs wzr, w1, w2, UXTH
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w2, #0xddcc

--- a/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.clif
@@ -1,5 +1,5 @@
 ;; Test our lowerings that try to fit negated iconst values in immediates, like
-;; `x + -1 => sub x 0x1`. Currently, not working as expected for i32 and i16. 
+;; `x + -1 => sub x 0x1`. Currently, not working as expected for i32 and i16.
 
 test compile precise-output
 set unwind_info=false
@@ -26,7 +26,7 @@ block0(v0: i64):
 ;; 4294967295 is zero-extended i32 -1
 function %b(i32) -> i32 {
 block0(v0: i32):
-    v1 = iconst.i32 4294967295 
+    v1 = iconst.i32 4294967295
     v3 = iadd v0, v1
     return v3
 }
@@ -81,7 +81,7 @@ block0(v0: i64):
 ;; 4294967295 is zero-extended i32 -1
 function %b(i32) -> i32 {
 block0(v0: i32):
-    v1 = iconst.i32 4294967295 
+    v1 = iconst.i32 4294967295
     v3 = iadd v1, v0
     return v3
 }
@@ -137,7 +137,7 @@ block0(v0: i64):
 ;; 4294967295 is zero-extended i32 -1
 function %b(i32) -> i32 {
 block0(v0: i32):
-    v1 = iconst.i32 4294967295 
+    v1 = iconst.i32 4294967295
     v3 = isub v0, v1
     return v3
 }

--- a/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iconst-imm12_from_negated.clif
@@ -17,7 +17,7 @@ block0(v0: i64):
 ; block0:
 ;   sub x0, x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub x0, x0, #1
@@ -35,7 +35,7 @@ block0(v0: i32):
 ; block0:
 ;   sub w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w0, #1
@@ -53,7 +53,7 @@ block0(v0: i16):
 ; block0:
 ;   sub w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w0, #1
@@ -71,7 +71,7 @@ block0(v0: i64):
 ; block0:
 ;   sub x0, x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub x0, x0, #1
@@ -90,7 +90,7 @@ block0(v0: i32):
 ; block0:
 ;   sub w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w0, #1
@@ -109,7 +109,7 @@ block0(v0: i16):
 ; block0:
 ;   sub w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub w0, w0, #1
@@ -127,7 +127,7 @@ block0(v0: i64):
 ; block0:
 ;   add x0, x0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, #1
@@ -146,7 +146,7 @@ block0(v0: i32):
 ; block0:
 ;   add w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, #1
@@ -165,8 +165,9 @@ block0(v0: i16):
 ; block0:
 ;   add w0, w0, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, #1
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
@@ -24,7 +24,7 @@ block0:
 ;   add sp, sp, #2048
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -56,7 +56,7 @@ block0:
 ;   add sp, sp, #12288
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -99,7 +99,7 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/issue-5985.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/issue-5985.clif
@@ -12,7 +12,7 @@ block0:
 ; block0:
 ;   movi v0.2d, #72056494543077120
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.2d, #0xffff0000ffff00

--- a/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
@@ -47,7 +47,7 @@ block5(v5: i32):
 ; block5:
 ;   add w0, w0, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, #3

--- a/cranelift/filetests/filetests/isa/aarch64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf_with_preserve_frame_pointers.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ; block0:
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/multivalue-ret.clif
@@ -14,7 +14,7 @@ block1:
 ;   movz x0, #1
 ;   movz x1, #2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #1

--- a/cranelift/filetests/filetests/isa/aarch64/narrow-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/narrow-arithmetic.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   add w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, w1
@@ -28,7 +28,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   add w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, w1
@@ -44,7 +44,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   add w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, w1
@@ -61,7 +61,7 @@ block0(v0: i32, v1: i8):
 ; block0:
 ;   add w0, w0, w1, SXTB
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add w0, w0, w1, sxtb
@@ -78,7 +78,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   add x0, x0, x1, SXTW
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, w1, sxtw

--- a/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/pinned-reg.clif
@@ -16,7 +16,7 @@ block0:
 ;   add x1, x1, #1
 ;   mov x21, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x1, x21

--- a/cranelift/filetests/filetests/isa/aarch64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/prologue.clif
@@ -151,7 +151,7 @@ block0(v0: f64):
 ;   ldp d14, d15, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -322,7 +322,7 @@ block0(v0: i64):
 ;   ldr x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/reduce.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reduce.clif
@@ -11,7 +11,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -25,7 +25,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -39,7 +39,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -53,7 +53,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -10,7 +10,7 @@ block0(v0: r64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -26,7 +26,7 @@ block0(v0: r64):
 ;   subs xzr, x0, #0
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, #0
@@ -44,7 +44,7 @@ block0(v0: r64):
 ;   adds xzr, x0, #1
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmn x0, #1
@@ -61,7 +61,7 @@ block0:
 ; block0:
 ;   movz x0, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0
@@ -120,7 +120,7 @@ block3(v7: r64, v8: r64):
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/select.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/select.clif
@@ -14,7 +14,7 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;   subs wzr, w0, w1
 ;   csel x0, x2, x3, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, w1
@@ -34,7 +34,7 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   fcmp s0, s1
 ;   csel x0, x0, x1, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcmp s0, s1

--- a/cranelift/filetests/filetests/isa/aarch64/shift-op.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-op.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ; block0:
 ;   add x0, x0, x0, LSL 3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x0, x0, x0, lsl #3
@@ -31,7 +31,7 @@ block0(v0: i32):
 ; block0:
 ;   lsl w0, w0, #21
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl w0, w0, #0x15

--- a/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shift-rotate.clif
@@ -37,7 +37,7 @@ block0(v0: i128, v1: i128):
 ;   orr x1, x8, x9
 ;   orr x0, x6, x7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, #0x80
@@ -74,7 +74,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ror x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ror x0, x0, x1
@@ -90,7 +90,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ror w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ror w0, w0, w1
@@ -112,7 +112,7 @@ block0(v0: i16, v1: i16):
 ;   lsl w13, w3, w9
 ;   orr w0, w13, w11
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w3, w0
@@ -140,7 +140,7 @@ block0(v0: i8, v1: i8):
 ;   lsl w13, w3, w9
 ;   orr w0, w13, w11
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w3, w0
@@ -183,7 +183,7 @@ block0(v0: i128, v1: i128):
 ;   orr x0, x6, x7
 ;   orr x1, x8, x9
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x5, #0x80
@@ -221,7 +221,7 @@ block0(v0: i64, v1: i64):
 ;   sub x3, xzr, x1
 ;   ror x0, x0, x3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg x3, x1
@@ -239,7 +239,7 @@ block0(v0: i32, v1: i32):
 ;   sub w3, wzr, w1
 ;   ror w0, w0, w3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -263,7 +263,7 @@ block0(v0: i16, v1: i16):
 ;   lsl w15, w5, w11
 ;   orr w0, w15, w13
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -293,7 +293,7 @@ block0(v0: i8, v1: i8):
 ;   lsl w15, w5, w11
 ;   orr w0, w15, w13
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg w3, w1
@@ -316,7 +316,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lsr x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x0, x0, x1
@@ -332,7 +332,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lsr w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr w0, w0, w1
@@ -350,7 +350,7 @@ block0(v0: i16, v1: i16):
 ;   and w5, w1, #15
 ;   lsr w0, w3, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w3, w0
@@ -370,7 +370,7 @@ block0(v0: i8, v1: i8):
 ;   and w5, w1, #7
 ;   lsr w0, w3, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w3, w0
@@ -388,7 +388,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lsl x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl x0, x0, x1
@@ -404,7 +404,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lsl w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl w0, w0, w1
@@ -421,7 +421,7 @@ block0(v0: i16, v1: i16):
 ;   and w3, w1, #15
 ;   lsl w0, w0, w3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w3, w1, #0xf
@@ -439,7 +439,7 @@ block0(v0: i8, v1: i8):
 ;   and w3, w1, #7
 ;   lsl w0, w0, w3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w3, w1, #7
@@ -456,7 +456,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   asr x0, x0, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   asr x0, x0, x1
@@ -472,7 +472,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   asr w0, w0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   asr w0, w0, w1
@@ -490,7 +490,7 @@ block0(v0: i16, v1: i16):
 ;   and w5, w1, #15
 ;   asr w0, w3, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w3, w0
@@ -510,7 +510,7 @@ block0(v0: i8, v1: i8):
 ;   and w5, w1, #7
 ;   asr w0, w3, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w3, w0
@@ -529,7 +529,7 @@ block0(v0: i64):
 ; block0:
 ;   ror x0, x0, #17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ror x0, x0, #0x11
@@ -546,7 +546,7 @@ block0(v0: i64):
 ; block0:
 ;   ror x0, x0, #47
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ror x0, x0, #0x2f
@@ -563,7 +563,7 @@ block0(v0: i32):
 ; block0:
 ;   ror w0, w0, #15
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ror w0, w0, #0xf
@@ -583,7 +583,7 @@ block0(v0: i16):
 ;   lsl w6, w2, #10
 ;   orr w0, w6, w4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w2, w0
@@ -606,7 +606,7 @@ block0(v0: i8):
 ;   lsl w6, w2, #3
 ;   orr w0, w6, w4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w2, w0
@@ -626,7 +626,7 @@ block0(v0: i64):
 ; block0:
 ;   lsr x0, x0, #17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsr x0, x0, #0x11
@@ -643,7 +643,7 @@ block0(v0: i64):
 ; block0:
 ;   asr x0, x0, #17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   asr x0, x0, #0x11
@@ -660,7 +660,7 @@ block0(v0: i64):
 ; block0:
 ;   lsl x0, x0, #17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lsl x0, x0, #0x11

--- a/cranelift/filetests/filetests/isa/aarch64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/shuffle.clif
@@ -15,7 +15,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ldr q3, [const(0)]
 ;   tbl v0.16b, { v30.16b, v31.16b }, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v30.16b, v0.16b
@@ -41,7 +41,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   uzp1 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.16b, v0.16b, v1.16b
@@ -57,7 +57,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   uzp2 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.16b, v0.16b, v1.16b
@@ -76,7 +76,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   uzp1 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.8h, v0.8h, v1.8h
@@ -95,7 +95,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   uzp2 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.8h, v0.8h, v1.8h
@@ -114,7 +114,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   uzp1 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.4s, v0.4s, v1.4s
@@ -133,7 +133,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   uzp2 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.4s, v0.4s, v1.4s
@@ -152,7 +152,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp1 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.2d, v0.2d, v1.2d
@@ -171,7 +171,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp2 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.2d, v0.2d, v1.2d
@@ -187,7 +187,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   zip1 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip1 v0.16b, v0.16b, v1.16b
@@ -203,7 +203,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   zip2 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip2 v0.16b, v0.16b, v1.16b
@@ -222,7 +222,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   zip1 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip1 v0.8h, v0.8h, v1.8h
@@ -241,7 +241,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   zip2 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip2 v0.8h, v0.8h, v1.8h
@@ -260,7 +260,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   zip1 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip1 v0.4s, v0.4s, v1.4s
@@ -279,7 +279,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   zip2 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   zip2 v0.4s, v0.4s, v1.4s
@@ -298,7 +298,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp1 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.2d, v0.2d, v1.2d
@@ -317,7 +317,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp2 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.2d, v0.2d, v1.2d
@@ -333,7 +333,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   trn1 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn1 v0.16b, v0.16b, v1.16b
@@ -349,7 +349,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   trn2 v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn2 v0.16b, v0.16b, v1.16b
@@ -368,7 +368,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   trn1 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn1 v0.8h, v0.8h, v1.8h
@@ -387,7 +387,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   trn2 v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn2 v0.8h, v0.8h, v1.8h
@@ -406,7 +406,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   trn1 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn1 v0.4s, v0.4s, v1.4s
@@ -425,7 +425,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   trn2 v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   trn2 v0.4s, v0.4s, v1.4s
@@ -444,7 +444,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp1 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp1 v0.2d, v0.2d, v1.2d
@@ -463,7 +463,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   uzp2 v0.2d, v0.2d, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uzp2 v0.2d, v0.2d, v1.2d
@@ -479,7 +479,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   ext v0.16b, v0.16b, v1.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ext v0.16b, v0.16b, v1.16b, #0
@@ -495,7 +495,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   ext v0.16b, v0.16b, v1.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ext v0.16b, v0.16b, v1.16b, #1
@@ -511,7 +511,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   ext v0.16b, v0.16b, v1.16b, #5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ext v0.16b, v0.16b, v1.16b, #5
@@ -527,7 +527,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   ext v0.16b, v0.16b, v1.16b, #11
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ext v0.16b, v0.16b, v1.16b, #0xb
@@ -546,7 +546,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ldr q3, [const(0)]
 ;   tbl v0.16b, { v30.16b, v31.16b }, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v30.16b, v0.16b
@@ -572,7 +572,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   dup v0.16b, v0.b[5]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.16b, v0.b[5]
@@ -591,7 +591,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   dup v0.8h, v0.h[6]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.8h, v0.h[6]
@@ -610,7 +610,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   dup v0.4s, v0.s[3]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.4s, v0.s[3]
@@ -629,7 +629,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   dup v0.2d, v0.d[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.2d, v0.d[0]
@@ -648,7 +648,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   rev16 v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev16 v0.16b, v0.16b
@@ -667,7 +667,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   rev32 v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev32 v0.16b, v0.16b
@@ -686,7 +686,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   rev32 v0.8h, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev32 v0.8h, v0.8h
@@ -705,7 +705,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   rev64 v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev64 v0.16b, v0.16b
@@ -724,7 +724,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   rev64 v0.8h, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev64 v0.8h, v0.8h
@@ -743,7 +743,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   rev64 v0.4s, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rev64 v0.4s, v0.4s

--- a/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-arithmetic.clif
@@ -12,7 +12,7 @@ block0(v0: i8x8, v1: i8x8):
 ; block0:
 ;   urhadd v0.8b, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.8b, v0.8b, v1.8b
@@ -28,7 +28,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   urhadd v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.16b, v0.16b, v1.16b
@@ -44,7 +44,7 @@ block0(v0: i16x4, v1: i16x4):
 ; block0:
 ;   urhadd v0.4h, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.4h, v0.4h, v1.4h
@@ -60,7 +60,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   urhadd v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.8h, v0.8h, v1.8h
@@ -76,7 +76,7 @@ block0(v0: i32x2, v1: i32x2):
 ; block0:
 ;   urhadd v0.2s, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.2s, v0.2s, v1.2s
@@ -92,7 +92,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   urhadd v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   urhadd v0.4s, v0.4s, v1.4s
@@ -115,7 +115,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   add v23.2d, v19.2d, v21.2d
 ;   add v0.2d, v17.2d, v23.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x3, #1
@@ -139,7 +139,7 @@ block0(v0: i8x16):
 ; block0:
 ;   shl v0.16b, v0.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.16b, v0.16b, #1
@@ -156,7 +156,7 @@ block0(v0: i16x8):
 ; block0:
 ;   shl v0.8h, v0.8h, #15
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.8h, v0.8h, #0xf
@@ -173,7 +173,7 @@ block0(v0: i32x4):
 ; block0:
 ;   shl v0.4s, v0.4s, #22
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.4s, v0.4s, #0x16
@@ -190,7 +190,7 @@ block0(v0: i64x2):
 ; block0:
 ;   shl v0.2d, v0.2d, #55
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.2d, v0.2d, #0x37
@@ -207,7 +207,7 @@ block0(v0: i8x16):
 ; block0:
 ;   sshr v0.16b, v0.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v0.16b, v0.16b, #1
@@ -224,7 +224,7 @@ block0(v0: i16x8):
 ; block0:
 ;   sshr v0.8h, v0.8h, #15
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v0.8h, v0.8h, #0xf
@@ -241,7 +241,7 @@ block0(v0: i32x4):
 ; block0:
 ;   sshr v0.4s, v0.4s, #22
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v0.4s, v0.4s, #0x16
@@ -258,7 +258,7 @@ block0(v0: i64x2):
 ; block0:
 ;   sshr v0.2d, v0.2d, #55
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v0.2d, v0.2d, #0x37
@@ -275,7 +275,7 @@ block0(v0: i8x16):
 ; block0:
 ;   ushr v0.16b, v0.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v0.16b, v0.16b, #1
@@ -292,7 +292,7 @@ block0(v0: i16x8):
 ; block0:
 ;   ushr v0.8h, v0.8h, #15
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v0.8h, v0.8h, #0xf
@@ -309,7 +309,7 @@ block0(v0: i32x4):
 ; block0:
 ;   ushr v0.4s, v0.4s, #22
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v0.4s, v0.4s, #0x16
@@ -326,7 +326,7 @@ block0(v0: i64x2):
 ; block0:
 ;   ushr v0.2d, v0.2d, #55
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ushr v0.2d, v0.2d, #0x37
@@ -343,7 +343,7 @@ block0(v0: i8x16):
 ; block0:
 ;   shl v0.16b, v0.16b, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.16b, v0.16b, #0
@@ -360,7 +360,7 @@ block0(v0: i16x8):
 ; block0:
 ;   shl v0.8h, v0.8h, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.8h, v0.8h, #0
@@ -377,7 +377,7 @@ block0(v0: i32x4):
 ; block0:
 ;   shl v0.4s, v0.4s, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.4s, v0.4s, #0
@@ -394,7 +394,7 @@ block0(v0: i64x2):
 ; block0:
 ;   shl v0.2d, v0.2d, #0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shl v0.2d, v0.2d, #0
@@ -410,7 +410,7 @@ block0(v0: i8x16):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -425,7 +425,7 @@ block0(v0: i16x8):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -440,7 +440,7 @@ block0(v0: i32x4):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -455,7 +455,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -470,7 +470,7 @@ block0(v0: i8x16):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -485,7 +485,7 @@ block0(v0: i16x8):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -500,7 +500,7 @@ block0(v0: i32x4):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -515,7 +515,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
@@ -12,7 +12,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
@@ -28,7 +28,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
@@ -44,7 +44,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   and v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and v0.16b, v0.16b, v1.16b
@@ -60,7 +60,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
@@ -76,7 +76,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
@@ -92,7 +92,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   orr v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   orr v0.16b, v0.16b, v1.16b
@@ -108,7 +108,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
@@ -124,7 +124,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
@@ -140,7 +140,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   eor v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   eor v0.16b, v0.16b, v1.16b
@@ -162,7 +162,7 @@ block0:
 ;   movi v4.16b, #0
 ;   bsl v0.16b, v0.16b, v3.16b, v4.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.16b, #0
@@ -181,7 +181,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bsl v0.16b, v1.16b, v2.16b
@@ -197,7 +197,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bsl v0.16b, v1.16b, v2.16b
@@ -213,7 +213,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ; block0:
 ;   bsl v0.16b, v0.16b, v1.16b, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bsl v0.16b, v1.16b, v2.16b
@@ -233,7 +233,7 @@ block0(v0: i32):
 ;   dup v6.16b, w3
 ;   sshl v0.16b, v5.16b, v6.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr q5, #0x20
@@ -262,7 +262,7 @@ block0:
 ;   ldr q1, [const(0)]
 ;   ushr v0.16b, v1.16b, #1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr q1, #0x10
@@ -289,7 +289,7 @@ block0(v0: i32):
 ;   dup v7.16b, w5
 ;   sshl v0.16b, v6.16b, v7.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr q6, #0x20
@@ -315,7 +315,7 @@ block0(v0: i8x16, v1: i32):
 ; block0:
 ;   sshr v0.16b, v0.16b, #3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v0.16b, v0.16b, #3
@@ -334,7 +334,7 @@ block0(v0: i64x2, v1: i32):
 ;   dup v7.2d, x5
 ;   sshl v0.2d, v0.2d, v7.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and w3, w0, #0x3f

--- a/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
@@ -13,7 +13,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   cmeq v3.4s, v0.4s, v1.4s
 ;   mvn v0.16b, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v3.4s, v0.4s, v1.4s
@@ -30,7 +30,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   cmhi v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmhi v0.4s, v0.4s, v1.4s
@@ -46,7 +46,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   cmge v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmge v0.8h, v0.8h, v1.8h
@@ -62,7 +62,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   cmhs v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmhs v0.16b, v0.16b, v1.16b

--- a/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-extmul.clif
@@ -14,7 +14,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   smull v0.8h, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull v0.8h, v0.8b, v1.8b
@@ -32,7 +32,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   smull2 v0.8h, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull2 v0.8h, v0.16b, v1.16b
@@ -50,7 +50,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   smull v0.4s, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull v0.4s, v0.4h, v1.4h
@@ -68,7 +68,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   smull2 v0.4s, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull2 v0.4s, v0.8h, v1.8h
@@ -86,7 +86,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   smull v0.2d, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull v0.2d, v0.2s, v1.2s
@@ -104,7 +104,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   smull2 v0.2d, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smull2 v0.2d, v0.4s, v1.4s
@@ -122,7 +122,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   umull v0.8h, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull v0.8h, v0.8b, v1.8b
@@ -140,7 +140,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   umull2 v0.8h, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull2 v0.8h, v0.16b, v1.16b
@@ -158,7 +158,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   umull v0.4s, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull v0.4s, v0.4h, v1.4h
@@ -176,7 +176,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   umull2 v0.4s, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull2 v0.4s, v0.8h, v1.8h
@@ -194,7 +194,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   umull v0.2d, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull v0.2d, v0.2s, v1.2s
@@ -212,7 +212,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   umull2 v0.2d, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umull2 v0.2d, v0.4s, v1.4s

--- a/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
@@ -20,7 +20,7 @@ block0:
 ;   ldr q3, [const(0)]
 ;   tbl v0.16b, { v30.16b, v31.16b }, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v30.16b, #0
@@ -51,7 +51,7 @@ block0:
 ;   mov v30.16b, v31.16b
 ;   tbl v0.16b, { v30.16b, v31.16b }, v2.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w2, #1
@@ -81,7 +81,7 @@ block0:
 ;   ldr q3, [const(0)]
 ;   tbl v0.16b, { v2.16b }, v3.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr q2, #0x10
@@ -107,7 +107,7 @@ block0(v0: i8):
 ; block0:
 ;   dup v0.16b, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.16b, w0
@@ -124,7 +124,7 @@ block0:
 ; block0:
 ;   movi v0.16b, #255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.16b, #0xff
@@ -140,7 +140,7 @@ block0(v0: i32):
 ; block0:
 ;   dup v0.4s, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.4s, w0
@@ -156,7 +156,7 @@ block0(v0: f64):
 ; block0:
 ;   dup v0.2d, v0.d[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   dup v0.2d, v0.d[0]
@@ -174,7 +174,7 @@ block0(v0: i64):
 ;   ldr w3, [x0]
 ;   fmov s0, w3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr w3, [x0]
@@ -191,7 +191,7 @@ block0(v0: i32):
 ; block0:
 ;   fmov s0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s0, w0
@@ -207,7 +207,7 @@ block0(v0: f32):
 ; block0:
 ;   fmov s0, s0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s0, s0

--- a/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
@@ -12,7 +12,7 @@ block0(v0: i32x4):
 ; block0:
 ;   mvn v0.16b, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvn v0.16b, v0.16b
@@ -31,7 +31,7 @@ block0(v0: i32x4):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umaxp v2.4s, v0.4s, v0.4s
@@ -53,7 +53,7 @@ block0(v0: i64x2):
 ;   fcmp d4, d4
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0

--- a/cranelift/filetests/filetests/isa/aarch64/simd-min-max.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-min-max.clif
@@ -12,7 +12,7 @@ block0(v0: i8x8, v1: i8x8):
 ; block0:
 ;   smin v0.8b, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.8b, v0.8b, v1.8b
@@ -28,7 +28,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   smin v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.16b, v0.16b, v1.16b
@@ -44,7 +44,7 @@ block0(v0: i16x4, v1: i16x4):
 ; block0:
 ;   smin v0.4h, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.4h, v0.4h, v1.4h
@@ -60,7 +60,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   smin v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.8h, v0.8h, v1.8h
@@ -76,7 +76,7 @@ block0(v0: i32x2, v1: i32x2):
 ; block0:
 ;   smin v0.2s, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.2s, v0.2s, v1.2s
@@ -92,7 +92,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   smin v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smin v0.4s, v0.4s, v1.4s
@@ -108,7 +108,7 @@ block0(v0: i8x8, v1: i8x8):
 ; block0:
 ;   umin v0.8b, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.8b, v0.8b, v1.8b
@@ -124,7 +124,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   umin v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.16b, v0.16b, v1.16b
@@ -140,7 +140,7 @@ block0(v0: i16x4, v1: i16x4):
 ; block0:
 ;   umin v0.4h, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.4h, v0.4h, v1.4h
@@ -156,7 +156,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   umin v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.8h, v0.8h, v1.8h
@@ -172,7 +172,7 @@ block0(v0: i32x2, v1: i32x2):
 ; block0:
 ;   umin v0.2s, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.2s, v0.2s, v1.2s
@@ -188,7 +188,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   umin v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umin v0.4s, v0.4s, v1.4s
@@ -204,7 +204,7 @@ block0(v0: i8x8, v1: i8x8):
 ; block0:
 ;   smax v0.8b, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.8b, v0.8b, v1.8b
@@ -220,7 +220,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   smax v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.16b, v0.16b, v1.16b
@@ -236,7 +236,7 @@ block0(v0: i16x4, v1: i16x4):
 ; block0:
 ;   smax v0.4h, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.4h, v0.4h, v1.4h
@@ -252,7 +252,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   smax v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.8h, v0.8h, v1.8h
@@ -268,7 +268,7 @@ block0(v0: i32x2, v1: i32x2):
 ; block0:
 ;   smax v0.2s, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.2s, v0.2s, v1.2s
@@ -284,7 +284,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   smax v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   smax v0.4s, v0.4s, v1.4s
@@ -300,7 +300,7 @@ block0(v0: i8x8, v1: i8x8):
 ; block0:
 ;   umax v0.8b, v0.8b, v1.8b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.8b, v0.8b, v1.8b
@@ -316,7 +316,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   umax v0.16b, v0.16b, v1.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.16b, v0.16b, v1.16b
@@ -332,7 +332,7 @@ block0(v0: i16x4, v1: i16x4):
 ; block0:
 ;   umax v0.4h, v0.4h, v1.4h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.4h, v0.4h, v1.4h
@@ -348,7 +348,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   umax v0.8h, v0.8h, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.8h, v0.8h, v1.8h
@@ -364,7 +364,7 @@ block0(v0: i32x2, v1: i32x2):
 ; block0:
 ;   umax v0.2s, v0.2s, v1.2s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.2s, v0.2s, v1.2s
@@ -380,7 +380,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   umax v0.4s, v0.4s, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   umax v0.4s, v0.4s, v1.4s

--- a/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
@@ -14,7 +14,7 @@ block0(v0: i16x4, v1: i16x4):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   sqxtn v0.8b, v3.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -33,7 +33,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   sqxtn v0.8b, v0.8h
 ;   sqxtn2 v0.16b, v0.16b, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.8b, v0.8h
@@ -52,7 +52,7 @@ block0(v0: i32x2, v1: i32x2):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   sqxtn v0.4h, v3.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -71,7 +71,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   sqxtn v0.4h, v0.4s
 ;   sqxtn2 v0.8h, v0.8h, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.4h, v0.4s
@@ -89,7 +89,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   sqxtn v0.2s, v0.2d
 ;   sqxtn2 v0.4s, v0.4s, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.2s, v0.2d
@@ -108,7 +108,7 @@ block0(v0: i16x4, v1: i16x4):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   sqxtun v0.8b, v3.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -127,7 +127,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   sqxtun v0.8b, v0.8h
 ;   sqxtun2 v0.16b, v0.16b, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.8b, v0.8h
@@ -146,7 +146,7 @@ block0(v0: i32x2, v1: i32x2):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   sqxtun v0.4h, v3.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -165,7 +165,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   sqxtun v0.4h, v0.4s
 ;   sqxtun2 v0.8h, v0.8h, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.4h, v0.4s
@@ -183,7 +183,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   sqxtun v0.2s, v0.2d
 ;   sqxtun2 v0.4s, v0.4s, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.2s, v0.2d
@@ -202,7 +202,7 @@ block0(v0: i16x4, v1: i16x4):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   uqxtn v0.8b, v3.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -221,7 +221,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   uqxtn v0.8b, v0.8h
 ;   uqxtn2 v0.16b, v0.16b, v1.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.8b, v0.8h
@@ -240,7 +240,7 @@ block0(v0: i32x2, v1: i32x2):
 ;   mov v3.d[1], v3.d[1], v1.d[0]
 ;   uqxtn v0.4h, v3.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov v3.16b, v0.16b
@@ -259,7 +259,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   uqxtn v0.4h, v0.4s
 ;   uqxtn2 v0.8h, v0.8h, v1.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.4h, v0.4s
@@ -277,7 +277,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   uqxtn v0.2s, v0.2d
 ;   uqxtn2 v0.4s, v0.4s, v1.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.2s, v0.2d
@@ -295,7 +295,7 @@ block0(v0: i16x8):
 ; block0:
 ;   sqxtn v0.8b, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.8b, v0.8h
@@ -312,7 +312,7 @@ block0(v0: i32x4):
 ; block0:
 ;   sqxtn v0.4h, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.4h, v0.4s
@@ -329,7 +329,7 @@ block0(v0: i64x2):
 ; block0:
 ;   sqxtn v0.2s, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtn v0.2s, v0.2d
@@ -346,7 +346,7 @@ block0(v0: i16x8):
 ; block0:
 ;   sqxtun v0.8b, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.8b, v0.8h
@@ -363,7 +363,7 @@ block0(v0: i32x4):
 ; block0:
 ;   sqxtun v0.4h, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.4h, v0.4s
@@ -380,7 +380,7 @@ block0(v0: i64x2):
 ; block0:
 ;   sqxtun v0.2s, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqxtun v0.2s, v0.2d
@@ -397,7 +397,7 @@ block0(v0: i16x8):
 ; block0:
 ;   uqxtn v0.8b, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.8b, v0.8h
@@ -414,7 +414,7 @@ block0(v0: i32x4):
 ; block0:
 ;   uqxtn v0.4h, v0.4s
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.4h, v0.4s
@@ -431,7 +431,7 @@ block0(v0: i64x2):
 ; block0:
 ;   uqxtn v0.2s, v0.2d
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uqxtn v0.2s, v0.2d

--- a/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-pairwise-add.clif
@@ -13,7 +13,7 @@ block0(v0: i8x16):
 ; block0:
 ;   saddlp v0.8h, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   saddlp v0.8h, v0.16b
@@ -31,7 +31,7 @@ block0(v0: i16x8):
 ; block0:
 ;   saddlp v0.4s, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   saddlp v0.4s, v0.8h
@@ -49,7 +49,7 @@ block0(v0: i8x16):
 ; block0:
 ;   uaddlp v0.8h, v0.16b
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uaddlp v0.8h, v0.16b
@@ -67,7 +67,7 @@ block0(v0: i16x8):
 ; block0:
 ;   uaddlp v0.4s, v0.8h
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uaddlp v0.4s, v0.8h

--- a/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-splat.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ; block0:
 ;   ld1r { v0.2d }, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld1r {v0.2d}, [x0]
@@ -31,7 +31,7 @@ block0(v0: i64):
 ;   add x2, x0, #100
 ;   ld1r { v0.2d }, [x2]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x2, x0, #0x64
@@ -51,7 +51,7 @@ block0(v0: i64):
 ;   add x4, x0, x2
 ;   ld1r { v0.2d }, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #0xfff0000
@@ -72,7 +72,7 @@ block0(v0: i64, v1: i64):
 ;   add x4, x0, x1
 ;   ld1r { v0.2d }, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x4, x0, x1
@@ -93,7 +93,7 @@ block0(v0: i64, v1: i64):
 ;   add x4, x5, #100
 ;   ld1r { v0.2d }, [x4]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add x5, x0, x1
@@ -117,7 +117,7 @@ block0(v0: i64, v1: i64):
 ;   add x5, x6, #100
 ;   ld1r { v0.2d }, [x5]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x6, #2

--- a/cranelift/filetests/filetests/isa/aarch64/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-valltrue.clif
@@ -15,7 +15,7 @@ block0(v0: i8x8):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uminv b2, v0.8b
@@ -37,7 +37,7 @@ block0(v0: i8x16):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uminv b2, v0.16b
@@ -59,7 +59,7 @@ block0(v0: i16x4):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uminv h2, v0.4h
@@ -81,7 +81,7 @@ block0(v0: i16x8):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uminv h2, v0.8h
@@ -103,7 +103,7 @@ block0(v0: i32x2):
 ;   ccmp w2, #0, #nZcv, ne
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, v0.d[0]
@@ -125,7 +125,7 @@ block0(v0: i32x4):
 ;   subs xzr, x4, #0
 ;   cset x0, ne
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uminv s2, v0.4s
@@ -147,7 +147,7 @@ block0(v0: i64x2):
 ;   fcmp d4, d4
 ;   cset x0, eq
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmeq v2.2d, v0.2d, #0

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -15,7 +15,7 @@ block0:
 ;   movk x1, x1, #1, LSL #48
 ;   dup v0.2d, x1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x1, #1
@@ -36,7 +36,7 @@ block0:
 ;   movz x0, #42679
 ;   dup v0.8h, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x0, #0xa6b7
@@ -54,7 +54,7 @@ block0(v0: i32, v1: i8x16, v2: i8x16):
 ;   subs wzr, w0, wzr
 ;   vcsel v0.16b, v0.16b, v1.16b, ne (if-then-else diamond)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp w0, wzr
@@ -75,7 +75,7 @@ block0(v0: i64):
 ; block0:
 ;   ld1r { v0.16b }, [x0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld1r {v0.16b}, [x0]
@@ -95,7 +95,7 @@ block0(v0: i64, v1: i64):
 ;   ld1r { v0.16b }, [x0]
 ;   ld1r { v1.16b }, [x1]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld1r {v0.16b}, [x0]
@@ -117,7 +117,7 @@ block0(v0: i64, v1: i64):
 ;   ld1r { v0.16b }, [x1]
 ;   dup v1.16b, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldrb w5, [x0]
@@ -139,7 +139,7 @@ block0(v0: i64, v1: i64):
 ;   dup v0.16b, w5
 ;   dup v1.16b, w5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldrb w5, [x0]
@@ -159,7 +159,7 @@ block0:
 ;   movi v0.2d, #18374687579166474495
 ;   fmov d0, d0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   movi v0.2d, #0xff0000ffff0000ff
@@ -177,7 +177,7 @@ block0:
 ; block0:
 ;   mvni v0.4s, #15, MSL #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvni v0.4s, #0xf, msl #16
@@ -194,7 +194,7 @@ block0:
 ; block0:
 ;   fmov v0.4s, #1.3125
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov v0.4s, #1.31250000

--- a/cranelift/filetests/filetests/isa/aarch64/simd_load_zero.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd_load_zero.clif
@@ -15,7 +15,7 @@ block0:
 ;   movk x2, x2, #1, LSL #48
 ;   fmov d0, x2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, #1
@@ -35,7 +35,7 @@ block0:
 ;   movz w1, #42679
 ;   fmov s0, w1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w1, #0xa6b7
@@ -54,7 +54,7 @@ block0:
 ;   fmov s1, #1
 ;   fmov s0, s1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov s1, #1.00000000
@@ -73,7 +73,7 @@ block0:
 ;   fmov d1, #1
 ;   fmov d0, d1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmov d1, #1.00000000

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -10,7 +10,7 @@ block0:
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -23,7 +23,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -40,7 +40,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -62,7 +62,7 @@ block0(v0: i64):
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -102,7 +102,7 @@ block0(v0: i64):
 ;   blr x2
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -138,7 +138,7 @@ block0(v0: i64):
 ;   add sp, sp, #176
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -178,7 +178,7 @@ block0(v0: i64):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -225,7 +225,7 @@ block0(v0: i64):
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -273,7 +273,7 @@ block0(v0: i64):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -320,7 +320,7 @@ block0(v0: i64):
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -19,7 +19,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -53,7 +53,7 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -87,7 +87,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -123,7 +123,7 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -158,7 +158,7 @@ block0(v0: i64):
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -194,7 +194,7 @@ block0(v0: i64):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -538,7 +538,7 @@ block0(v0: i8):
 ;   ldp x27, x28, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -735,7 +735,7 @@ block0(v0: i128):
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -767,7 +767,7 @@ block0(v0: i128):
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -803,7 +803,7 @@ block0(v0: i128):
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -838,7 +838,7 @@ block0:
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -870,7 +870,7 @@ block0:
 ;   add sp, sp, #32
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
@@ -906,7 +906,7 @@ block0:
 ;   add sp, sp, x16, UXTX
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
@@ -15,7 +15,7 @@ block0:
 ; block0:
 ;   load_ext_name x0, TestCase(%my_global)+0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adrp x0, #0 ; reloc_external Aarch64AdrGotPage21 %my_global 0

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
@@ -14,7 +14,7 @@ block0:
 ; block0:
 ;   load_ext_name x0, TestCase(%my_global)+0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldr x0, #8

--- a/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-elf-gd.clif
@@ -30,7 +30,7 @@ block0(v0: i32):
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tls-macho.clif
@@ -30,7 +30,7 @@ block0(v0: i32):
 ;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!

--- a/cranelift/filetests/filetests/isa/aarch64/traps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/traps.clif
@@ -9,7 +9,7 @@ block0:
 ; VCode:
 ; block0:
 ;   udf #0xc11f
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user0
@@ -25,7 +25,7 @@ block0(v0: i64, v1: i64):
 ;   adds x3, x0, x1
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adds x3, x0, x1

--- a/cranelift/filetests/filetests/isa/aarch64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/uadd_overflow_trap.clif
@@ -14,7 +14,7 @@ block0(v0: i32):
 ;   adds w0, w0, w3
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x7f
@@ -36,7 +36,7 @@ block0(v0: i32):
 ;   adds w0, w3, w0
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w3, #0x7f
@@ -56,7 +56,7 @@ block0(v0: i32, v1: i32):
 ;   adds w0, w0, w1
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adds w0, w0, w1
@@ -77,7 +77,7 @@ block0(v0: i64):
 ;   adds x0, x0, x3
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x3, #0x7f
@@ -99,7 +99,7 @@ block0(v0: i64):
 ;   adds x0, x3, x0
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x3, #0x7f
@@ -119,7 +119,7 @@ block0(v0: i64, v1: i64):
 ;   adds x0, x0, x1
 ;   b.hs #trap=user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adds x0, x0, x1

--- a/cranelift/filetests/filetests/isa/aarch64/uextend-sextend.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/uextend-sextend.clif
@@ -12,7 +12,7 @@ block0(v0: i8):
 ; block0:
 ;   uxtb w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w0, w0
@@ -28,7 +28,7 @@ block0(v0: i8):
 ; block0:
 ;   uxtb w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w0, w0
@@ -44,7 +44,7 @@ block0(v0: i8):
 ; block0:
 ;   uxtb w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxtb w0, w0
@@ -60,7 +60,7 @@ block0(v0: i8):
 ; block0:
 ;   sxtb x0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb x0, w0
@@ -76,7 +76,7 @@ block0(v0: i8):
 ; block0:
 ;   sxtb w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w0, w0
@@ -92,7 +92,7 @@ block0(v0: i8):
 ; block0:
 ;   sxtb w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtb w0, w0
@@ -108,7 +108,7 @@ block0(v0: i16):
 ; block0:
 ;   uxth w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w0, w0
@@ -124,7 +124,7 @@ block0(v0: i16):
 ; block0:
 ;   uxth w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   uxth w0, w0
@@ -140,7 +140,7 @@ block0(v0: i16):
 ; block0:
 ;   sxth x0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth x0, w0
@@ -156,7 +156,7 @@ block0(v0: i16):
 ; block0:
 ;   sxth w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxth w0, w0
@@ -172,7 +172,7 @@ block0(v0: i32):
 ; block0:
 ;   mov w0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov w0, w0
@@ -188,7 +188,7 @@ block0(v0: i32):
 ; block0:
 ;   sxtw x0, w0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sxtw x0, w0

--- a/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/vhigh_bits.clif
@@ -21,7 +21,7 @@ block0(v0: i8x16):
 ;   addv h28, v26.8h
 ;   umov w0, v28.h[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v2.16b, v0.16b, #7
@@ -57,7 +57,7 @@ block0(v0: i8x16):
 ;   addv h28, v26.8h
 ;   umov w0, v28.h[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v2.16b, v0.16b, #7
@@ -87,7 +87,7 @@ block0(v0: i16x8):
 ;   addv h16, v6.8h
 ;   umov w0, v16.h[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v2.8h, v0.8h, #0xf
@@ -117,7 +117,7 @@ block0(v0: i32x4):
 ;   addv s16, v6.4s
 ;   mov w0, v16.s[0]
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sshr v2.4s, v0.4s, #0x1f
@@ -147,7 +147,7 @@ block0(v0: i64x2):
 ;   lsr x8, x4, #63
 ;   add x0, x8, x6, LSL 1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mov x2, v0.d[1]

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -16,7 +16,7 @@ block0(v0: i64, v1: i32):
 ;   add a2,a0,a2
 ;   lw a0,0(a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a2, a1
@@ -38,7 +38,7 @@ block0(v0: i64, v1: i32):
 ;   add a2,a2,a0
 ;   lw a0,0(a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a2, a1
@@ -64,7 +64,7 @@ block0(v0: i32, v1: i32):
 ;   add a5,a6,a7
 ;   lw a0,0(a5)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a4, a0, 0x20
@@ -94,7 +94,7 @@ block0(v0: i64, v1: i32):
 ;   add a4,a4,a4
 ;   lw a0,4(a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a4, a1
@@ -121,7 +121,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   addi a4,a4,48
 ;   lw a0,0(a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a4, a0, a1
@@ -149,7 +149,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   add a6,a7,a6
 ;   lw a0,0(a6)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a6, 1
@@ -172,7 +172,7 @@ block0:
 ;   li t1,1234
 ;   lw a0,0(t1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x4d2
@@ -193,7 +193,7 @@ block0(v0: i64):
 ;   add a1,a0,a1
 ;   lw a0,0(a1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a1, 0x800
@@ -214,7 +214,7 @@ block0(v0: i64):
 ;   addi a0,a0,-4
 ;   lw a0,0(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, a0, -4
@@ -236,7 +236,7 @@ block0(v0: i64):
 ;   add a2,a0,a2
 ;   lw a0,0(a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a2, 0x3b9ad
@@ -257,7 +257,7 @@ block0(v0: i32):
 ;   sext.w a0,a0
 ;   lw a0,0(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a0, a0
@@ -280,7 +280,7 @@ block0(v0: i32, v1: i32):
 ;   add a3,a3,a4
 ;   lw a0,0(a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a3, a0
@@ -305,7 +305,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   srli a6,a4,32
 ;   lh a0,0(a6)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a5, 0xfffff
@@ -331,7 +331,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   srli a6,a4,32
 ;   lh a0,0(a6)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a5, 1
@@ -356,7 +356,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   sext.w a4,a4
 ;   lh a0,0(a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a4, 0xfffff
@@ -380,7 +380,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   sext.w a4,a4
 ;   lh a0,0(a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a4, 1
@@ -406,7 +406,7 @@ block0(v0: i64):
 ;   sd a1,8(a0)
 ;   mv a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0(a0)
@@ -435,7 +435,7 @@ block0(v0: i64):
 ;   sd a1,24(a0)
 ;   mv a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0x10(a0)
@@ -464,7 +464,7 @@ block0(v0: i64):
 ;   sd a1,512(a0)
 ;   mv a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0x1f8(a0)
@@ -493,7 +493,7 @@ block0(v0: i64):
 ;   sd a1,-504(a0)
 ;   mv a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, -0x200(a0)
@@ -521,7 +521,7 @@ block0(v0: i64):
 ;   sd a0,0(a2)
 ;   sd a1,8(a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a2, a0, 0x20
@@ -547,7 +547,7 @@ block0(v0: i32):
 ;   sd a0,0(a2)
 ;   sd a1,8(a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a2, a0
@@ -577,7 +577,7 @@ block0(v0: i64, v1: i32):
 ;   sd a0,0(a4)
 ;   sd a1,8(a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a4, a1

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic-extends.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic-extends.clif
@@ -13,7 +13,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   addw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addw a0, a0, a1
@@ -30,7 +30,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   subw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   subw a0, a0, a1
@@ -47,7 +47,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sllw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllw a0, a0, a1
@@ -64,7 +64,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   srlw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srlw a0, a0, a1
@@ -81,7 +81,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sraw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sraw a0, a0, a1
@@ -99,7 +99,7 @@ block0(v0: i32):
 ; block0:
 ;   addiw a0,a0,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addiw a0, a0, -1
@@ -117,7 +117,7 @@ block0(v0: i32):
 ; block0:
 ;   slliw a0,a0,31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slliw a0, a0, 0x1f
@@ -135,7 +135,7 @@ block0(v0: i32):
 ; block0:
 ;   srliw a0,a0,31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srliw a0, a0, 0x1f
@@ -153,12 +153,11 @@ block0(v0: i32):
 ; block0:
 ;   sraiw a0,a0,31
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sraiw a0, a0, 0x1f
 ;   ret
-
 
 function %sext_sshr_i32_i128(i32, i128) -> i64 {
 block0(v0: i32, v1: i128):
@@ -171,7 +170,7 @@ block0(v0: i32, v1: i128):
 ; block0:
 ;   sraw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sraw a0, a0, a1

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic-zba.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic-zba.clif
@@ -14,7 +14,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   add.uw a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x85, 0xa5, 0x08
@@ -32,7 +32,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sh1add a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xa5, 0xa5, 0x20
@@ -51,7 +51,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   sh1add.uw a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0xa5, 0xa5, 0x20
@@ -69,7 +69,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sh2add a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xc5, 0xa5, 0x20
@@ -88,7 +88,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   sh2add.uw a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0xc5, 0xa5, 0x20
@@ -106,7 +106,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sh3add a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xe5, 0xa5, 0x20
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   sh3add.uw a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0xe5, 0xa5, 0x20
@@ -144,7 +144,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sh1add a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xa5, 0xa5, 0x20
@@ -164,7 +164,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sh1add a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xa5, 0xa5, 0x20
@@ -182,7 +182,7 @@ block0(v0: i32):
 ; block0:
 ;   slli.uw a0,a0,5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x1b, 0x15, 0x55, 0x08

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a0, a0, a1
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sub a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub a0, a0, a1
@@ -44,7 +44,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   mul a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul a0, a0, a1
@@ -60,7 +60,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   mulhu a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulhu a0, a0, a1
@@ -76,7 +76,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   mulh a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulh a0, a0, a1
@@ -100,7 +100,7 @@ block0(v0: i64, v1: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   div a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a2, zero, -1
@@ -142,7 +142,7 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a6)
 ;   div a0,a0,a6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 2
@@ -176,7 +176,7 @@ block0(v0: i64, v1: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   divu a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne zero, a1, 8
@@ -197,7 +197,7 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   divu a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 2
@@ -217,7 +217,7 @@ block0(v0: i64, v1: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   rem a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne zero, a1, 8
@@ -236,7 +236,7 @@ block0(v0: i64, v1: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remu a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne zero, a1, 8
@@ -265,7 +265,7 @@ block0(v0: i32, v1: i32):
 ;   trap_ifc int_divz##(zero eq a2)
 ;   divw a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a0, a0
@@ -313,7 +313,7 @@ block0(v0: i32):
 ;   trap_ifc int_divz##(zero eq a2)
 ;   divw a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 2
@@ -354,7 +354,7 @@ block0(v0: i32, v1: i32):
 ;   srli a7,a5,32
 ;   divuw a0,a7,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 0x20
@@ -383,7 +383,7 @@ block0(v0: i32):
 ;   srli a7,a5,32
 ;   divuw a0,a7,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 2
@@ -408,7 +408,7 @@ block0(v0: i32, v1: i32):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a1, a1
@@ -430,7 +430,7 @@ block0(v0: i32, v1: i32):
 ;   trap_ifc int_divz##(zero eq a2)
 ;   remuw a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 0x20
@@ -450,7 +450,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and a0, a0, a1
@@ -466,7 +466,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -482,7 +482,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xor a0, a0, a1
@@ -499,7 +499,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -517,7 +517,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -535,7 +535,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -552,7 +552,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   not a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a0, a0
@@ -571,7 +571,7 @@ block0(v0: i32, v1: i32):
 ;   slliw a2,a0,53
 ;   subw a0,a1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slliw a2, a0, 0x15
@@ -589,7 +589,7 @@ block0(v0: i32):
 ; block0:
 ;   addiw a0,a0,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addiw a0, a0, -1
@@ -607,7 +607,7 @@ block0(v0: i32):
 ;   li a1,-1
 ;   subw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, -1
@@ -626,7 +626,7 @@ block0(v0: i64):
 ;   li a1,-1
 ;   sub a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, -1
@@ -645,7 +645,7 @@ block0(v0: i64):
 ;   li a0,1
 ;   sub a0,zero,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, 1
@@ -665,7 +665,7 @@ block0(v0: i128, v1: i128):
 ;   add a6,a1,a3
 ;   add a1,a6,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a0, a0, a2
@@ -689,7 +689,7 @@ block0(v0: i128, v1: i128):
 ;   sub a6,a1,a3
 ;   sub a1,a6,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub a2, a0, a2
@@ -712,7 +712,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   mulw a2,a1,a2
 ;   add a0,a2,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulw a2, a1, a2
@@ -731,7 +731,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   mulw a2,a1,a2
 ;   subw a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulw a2, a1, a2
@@ -750,7 +750,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   mul a2,a1,a2
 ;   sub a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul a2, a1, a2
@@ -769,7 +769,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   mulw a2,a1,a2
 ;   subw a0,a2,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulw a2, a1, a2
@@ -788,7 +788,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   mul a2,a1,a2
 ;   sub a0,a2,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mul a2, a1, a2
@@ -808,7 +808,7 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   rem a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 2
@@ -830,7 +830,7 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a1)
 ;   remu a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 2
@@ -859,7 +859,7 @@ block0(v0: i64):
 ;   trap_ifc int_divz##(zero eq a6)
 ;   div a0,a0,a6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, -1

--- a/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amoadd.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoadd.d.aqrl a0, a1, (a0)
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amoadd.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoadd.w.aqrl a0, a1, (a0)
@@ -45,7 +45,7 @@ block0(v0: i64, v1: i64):
 ;   sub a1,zero,a1
 ;   amoadd.d.aqrl a2,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg a1, a1
@@ -63,7 +63,7 @@ block0(v0: i64, v1: i32):
 ;   sub a1,zero,a1
 ;   amoadd.w.aqrl a2,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg a1, a1
@@ -80,7 +80,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amoand.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoand.d.aqrl a0, a1, (a0)
@@ -96,7 +96,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amoand.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoand.w.aqrl a0, a1, (a0)
@@ -114,7 +114,7 @@ block0(v0: i64, v1: i64):
 ;   mv a2,a1
 ;   atomic_rmw.i64 nand a0,a2,(a3)##t0=a1 offset=zero
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a3, a0, 0
@@ -138,7 +138,7 @@ block0(v0: i64, v1: i32):
 ;   mv a2,a1
 ;   atomic_rmw.i32 nand a0,a2,(a3)##t0=a1 offset=zero
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a3, a0, 0
@@ -160,7 +160,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amoor.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoor.d.aqrl a0, a1, (a0)
@@ -176,7 +176,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amoor.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoor.w.aqrl a0, a1, (a0)
@@ -192,7 +192,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amoxor.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoxor.d.aqrl a0, a1, (a0)
@@ -208,7 +208,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amoxor.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amoxor.w.aqrl a0, a1, (a0)
@@ -224,7 +224,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amomax.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomax.d.aqrl a0, a1, (a0)
@@ -240,7 +240,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amomax.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomax.w.aqrl a0, a1, (a0)
@@ -256,7 +256,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amomaxu.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomaxu.d.aqrl a0, a1, (a0)
@@ -272,7 +272,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amomaxu.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomaxu.w.aqrl a0, a1, (a0)
@@ -288,7 +288,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amomin.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomin.d.aqrl a0, a1, (a0)
@@ -304,7 +304,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amomin.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amomin.w.aqrl a0, a1, (a0)
@@ -320,7 +320,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   amominu.d.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amominu.d.aqrl a0, a1, (a0)
@@ -336,7 +336,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   amominu.w.aqrl a0,a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   amominu.w.aqrl a0, a1, (a0)

--- a/cranelift/filetests/filetests/isa/riscv64/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic_load.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ; block0:
 ;   atomic_load.i64 a0,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fence rw, rw
@@ -30,7 +30,7 @@ block0(v0: i64):
 ; block0:
 ;   atomic_load.i32 a0,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fence rw, rw
@@ -51,7 +51,7 @@ block0(v0: i64):
 ;   slli a0,a1,32
 ;   srli a0,a0,32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fence rw, rw

--- a/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   atomic_store.i64 a0,(a1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fence rw, w
@@ -32,7 +32,7 @@ block0(v0: i64):
 ;   load_sym t2,%sym+0
 ;   atomic_store.i64 a0,(t2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t2, 0
@@ -57,7 +57,7 @@ block0(v0: i64):
 ;   addi a1,a1,57
 ;   atomic_store.i64 a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a1, 3
@@ -76,7 +76,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   atomic_store.i32 a0,(a1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fence rw, w
@@ -96,7 +96,7 @@ block0(v0: i32):
 ;   load_sym t2,%sym+0
 ;   atomic_store.i32 a0,(t2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t2, 0
@@ -121,7 +121,7 @@ block0(v0: i64):
 ;   addi a1,a1,57
 ;   atomic_store.i32 a1,(a0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a1, 3

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
@@ -11,7 +11,7 @@ function %or_not_optimization_float() -> i32 system_v {
 block0:
     v0 = iconst.i32 0
     v1 = f32const 0.0
-    v2 = bnot v1 
+    v2 = bnot v1
     v3 = bor v2, v2
     br_table v0, block1(v3), [block1(v1)]
 

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
@@ -39,7 +39,7 @@ block1(v4: f32):
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-optimized.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-optimized.clif
@@ -12,7 +12,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   andn a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0x75, 0xb5, 0x40
@@ -29,7 +29,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   andn a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xf5, 0xa5, 0x40
@@ -45,7 +45,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   orn a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0x65, 0xb5, 0x40
@@ -62,7 +62,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   orn a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0xe5, 0xa5, 0x40

--- a/cranelift/filetests/filetests/isa/riscv64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   mv a3,a0
 ;   brev8 a0,a3##tmp=t2 tmp2=a2 step=a1 ty=i8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a3, a0, 0
@@ -51,7 +51,7 @@ block0(v0: i16):
 ;   rev8 a4,a2##step=a6 tmp=a5
 ;   srli a0,a4,48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a7, a0, 0
@@ -100,7 +100,7 @@ block0(v0: i32):
 ;   rev8 a4,a2##step=a6 tmp=a5
 ;   srli a0,a4,32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a7, a0, 0
@@ -148,7 +148,7 @@ block0(v0: i64):
 ;   rev8 t2,a6##step=a1 tmp=a0
 ;   brev8 a0,t2##tmp=a3 tmp2=a4 step=a5 ty=i64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a6, a0, 0
@@ -199,7 +199,7 @@ block0(v0: i128):
 ;   rev8 t4,a3##step=t1 tmp=t0
 ;   brev8 a0,t4##tmp=a4 tmp2=a3 step=a2 ty=i64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a3, a0, 0
@@ -276,7 +276,7 @@ block0(v0: i8):
 ;   mv a2,a0
 ;   clz a0,a2##ty=i8 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -304,7 +304,7 @@ block0(v0: i16):
 ;   mv a2,a0
 ;   clz a0,a2##ty=i16 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -332,7 +332,7 @@ block0(v0: i32):
 ;   mv a2,a0
 ;   clz a0,a2##ty=i32 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -360,7 +360,7 @@ block0(v0: i64):
 ;   mv a2,a0
 ;   clz a0,a2##ty=i64 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -391,7 +391,7 @@ block0(v0: i128):
 ;   add a0,a2,t3
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, zero, 0
@@ -439,7 +439,7 @@ block0(v0: i8):
 ;   clz t4,a5##ty=i8 tmp=a7 step=t3
 ;   addi a0,t4,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38
@@ -478,7 +478,7 @@ block0(v0: i16):
 ;   clz t4,a5##ty=i16 tmp=a7 step=t3
 ;   addi a0,t4,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -516,7 +516,7 @@ block0(v0: i32):
 ;   clz a7,a3##ty=i32 tmp=a5 step=a6
 ;   addi a0,a7,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w t2, a0
@@ -552,7 +552,7 @@ block0(v0: i64):
 ;   clz a5,a1##ty=i64 tmp=a3 step=a4
 ;   addi a0,a5,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not t2, a0
@@ -594,7 +594,7 @@ block0(v0: i128):
 ;   addi a0,a5,-1
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a2, a0
@@ -648,7 +648,7 @@ block0(v0: i8):
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i8 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -675,7 +675,7 @@ block0(v0: i16):
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i16 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -702,7 +702,7 @@ block0(v0: i32):
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i32 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -729,7 +729,7 @@ block0(v0: i64):
 ;   mv a2,a0
 ;   ctz a0,a2##ty=i64 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -760,7 +760,7 @@ block0(v0: i128):
 ;   add a0,a6,t3
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori t4, a1, 0
@@ -806,7 +806,7 @@ block0(v0: i128):
 ;   add a0,a2,a6
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori t3, a0, 0
@@ -847,7 +847,7 @@ block0(v0: i64):
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i64 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -875,7 +875,7 @@ block0(v0: i32):
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i32 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -903,7 +903,7 @@ block0(v0: i16):
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i16 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -931,7 +931,7 @@ block0(v0: i8):
 ;   mv a2,a0
 ;   popcnt a0,a2##ty=i8 tmp=t2 step=a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a0, 0
@@ -958,7 +958,7 @@ block0(v0: i32):
 ; block0:
 ;   not a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a0, a0
@@ -974,7 +974,7 @@ block0(v0: i64):
 ; block0:
 ;   not a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a0, a0
@@ -993,7 +993,7 @@ block0(v0: i64):
 ;   slli a0,a0,3
 ;   not a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 3
@@ -1011,7 +1011,7 @@ block0(v0: i128):
 ;   not a0,a0
 ;   not a1,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a0, a0
@@ -1028,7 +1028,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and a0, a0, a1
@@ -1044,7 +1044,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and a0, a0, a1
@@ -1061,7 +1061,7 @@ block0(v0: i128, v1: i128):
 ;   and a0,a0,a2
 ;   and a1,a1,a3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and a0, a0, a2
@@ -1079,7 +1079,7 @@ block0(v0: i64):
 ; block0:
 ;   andi a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 3
@@ -1096,7 +1096,7 @@ block0(v0: i64):
 ; block0:
 ;   andi a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 3
@@ -1115,7 +1115,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1135,7 +1135,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   and a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1152,7 +1152,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -1168,7 +1168,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -1185,7 +1185,7 @@ block0(v0: i128, v1: i128):
 ;   or a0,a0,a2
 ;   or a1,a1,a3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a2
@@ -1203,7 +1203,7 @@ block0(v0: i64):
 ; block0:
 ;   ori a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a0, 3
@@ -1220,7 +1220,7 @@ block0(v0: i64):
 ; block0:
 ;   ori a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a0, 3
@@ -1239,7 +1239,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1259,7 +1259,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   or a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1276,7 +1276,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xor a0, a0, a1
@@ -1292,7 +1292,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xor a0, a0, a1
@@ -1309,7 +1309,7 @@ block0(v0: i128, v1: i128):
 ;   xor a0,a0,a2
 ;   xor a1,a1,a3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xor a0, a0, a2
@@ -1327,7 +1327,7 @@ block0(v0: i64):
 ; block0:
 ;   xori a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xori a0, a0, 3
@@ -1344,7 +1344,7 @@ block0(v0: i64):
 ; block0:
 ;   xori a0,a0,3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xori a0, a0, 3
@@ -1363,7 +1363,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1383,7 +1383,7 @@ block0(v0: i64, v1: i64):
 ;   slli a1,a1,3
 ;   xor a0,a1,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 3
@@ -1401,7 +1401,7 @@ block0(v0: i32, v1: i32):
 ;   not a1,a1
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1419,7 +1419,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1439,7 +1439,7 @@ block0(v0: i128, v1: i128):
 ;   and a0,a0,a4
 ;   and a1,a1,a6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a4, a2
@@ -1461,7 +1461,7 @@ block0(v0: i64):
 ;   not a1,a1
 ;   and a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 4
@@ -1483,7 +1483,7 @@ block0(v0: i64, v1: i64):
 ;   not a2,a2
 ;   and a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a1, 4
@@ -1502,7 +1502,7 @@ block0(v0: i32, v1: i32):
 ;   not a1,a1
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1520,7 +1520,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1540,7 +1540,7 @@ block0(v0: i128, v1: i128):
 ;   or a0,a0,a4
 ;   or a1,a1,a6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a4, a2
@@ -1562,7 +1562,7 @@ block0(v0: i64):
 ;   not a1,a1
 ;   or a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 4
@@ -1584,7 +1584,7 @@ block0(v0: i64, v1: i64):
 ;   not a2,a2
 ;   or a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a1, 4
@@ -1603,7 +1603,7 @@ block0(v0: i32, v1: i32):
 ;   not a1,a1
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1621,7 +1621,7 @@ block0(v0: i64, v1: i64):
 ;   not a1,a1
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a1, a1
@@ -1641,7 +1641,7 @@ block0(v0: i128, v1: i128):
 ;   xor a0,a0,a4
 ;   xor a1,a1,a6
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a4, a2
@@ -1663,7 +1663,7 @@ block0(v0: i64):
 ;   not a1,a1
 ;   xor a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 4
@@ -1685,7 +1685,7 @@ block0(v0: i64, v1: i64):
 ;   not a2,a2
 ;   xor a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a1, 4
@@ -1714,7 +1714,7 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,zero,a7##condition=(a6 uge a4)
 ;   select_reg a1,a7,a3##condition=(a6 uge a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -1761,7 +1761,7 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,zero,t3##condition=(a7 uge a5)
 ;   select_reg a1,t3,a3##condition=(a7 uge a5)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -1808,7 +1808,7 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,a5,a0##condition=(a6 uge a4)
 ;   select_reg a1,zero,a5##condition=(a6 uge a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -1854,7 +1854,7 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,a6,a5##condition=(a7 uge a4)
 ;   select_reg a1,zero,a6##condition=(a7 uge a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -1904,7 +1904,7 @@ block0(v0: i128, v1: i8):
 ;   select_reg a0,a4,a0##condition=(t2 uge t0)
 ;   select_reg a1,t3,a4##condition=(t2 uge t0)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -1959,7 +1959,7 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,a5,a4##condition=(a1 uge t1)
 ;   select_reg a1,t4,a5##condition=(a1 uge t1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f

--- a/cranelift/filetests/filetests/isa/riscv64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/br_table.clif
@@ -49,7 +49,7 @@ block5(v5: i32):
 ; block7:
 ;   add a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t6, a0, 0x20

--- a/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
@@ -20,7 +20,7 @@ block0(v0: i64, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -22,7 +22,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -62,7 +62,7 @@ block0(v0: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -92,7 +92,7 @@ block0(v0: i32):
 ; block0:
 ;   slli a0,a0,32; srli a0,a0,32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x20
@@ -120,7 +120,7 @@ block0(v0: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -150,7 +150,7 @@ block0(v0: i32):
 ; block0:
 ;   slli a0,a0,32; srai a0,a0,32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x20
@@ -192,7 +192,7 @@ block0(v0: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -245,7 +245,7 @@ block0(v0: i8):
 ;   sd a0,48(a3)
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a2, a1, 0
@@ -319,7 +319,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -398,7 +398,7 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a1, 0
@@ -429,7 +429,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -461,7 +461,7 @@ block0(v0: i64, v1: i128):
 ; block0:
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a1, 0
@@ -492,7 +492,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -524,7 +524,7 @@ block0(v0: i64, v1: i128):
 ; block0:
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a0, a1, 0
@@ -555,7 +555,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -594,7 +594,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -642,7 +642,7 @@ block0(v0: i128, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -689,7 +689,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -737,7 +737,7 @@ block0(v0: i128, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -779,14 +779,12 @@ block0:
 ;   li a0,0
 ;   li a1,1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
 ;   addi a1, zero, 1
 ;   ret
-
-
 
 function %call_colocated(i16) -> i16 {
     sig0 = () system_v
@@ -814,7 +812,7 @@ block0(v0: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -42,7 +42,7 @@ block0(v0: i64):
 ;   ret
 
 function %f2(i32) -> i64 {
-    fn0 = %g(i32 uext) -> i64 
+    fn0 = %g(i32 uext) -> i64
 
 block0(v0: i32):
     v1 = call fn0(v0)
@@ -100,7 +100,7 @@ block0(v0: i32):
 ;   ret
 
 function %f4(i32) -> i64 {
-    fn0 = %g(i32 sext) -> i64 
+    fn0 = %g(i32 sext) -> i64
 
 block0(v0: i32):
     v1 = call fn0(v0)

--- a/cranelift/filetests/filetests/isa/riscv64/cls-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/cls-zbb.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ;   addi t4,a7,-56
 ;   addi a0,t4,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x45, 0x60
@@ -50,7 +50,7 @@ block0(v0: i16):
 ;   addi t4,a7,-48
 ;   addi a0,t4,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x55, 0x60
@@ -79,7 +79,7 @@ block0(v0: i32):
 ;   clzw a5,a3
 ;   addi a0,a5,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w t2, a0
@@ -105,7 +105,7 @@ block0(v0: i64):
 ;   clz a3,a1
 ;   addi a0,a3,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not t2, a0
@@ -137,7 +137,7 @@ block0(v0: i128):
 ;   addi a0,a1,-1
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   not a2, a0

--- a/cranelift/filetests/filetests/isa/riscv64/clz-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/clz-zbb.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   clz a1,t2
 ;   addi a0,a1,-56
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi t2, a0, 0xff
@@ -34,7 +34,7 @@ block0(v0: i16):
 ;   clz a1,t2
 ;   addi a0,a1,-48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xbb, 0x43, 0x05, 0x08
@@ -52,7 +52,7 @@ block0(v0: i32):
 ; block0:
 ;   clzw a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x1b, 0x15, 0x05, 0x60
@@ -68,7 +68,7 @@ block0(v0: i64):
 ; block0:
 ;   clz a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x05, 0x60
@@ -88,7 +88,7 @@ block0(v0: i128):
 ;   add a0,a2,a4
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x96, 0x05, 0x60

--- a/cranelift/filetests/filetests/isa/riscv64/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/cold-blocks.clif
@@ -26,7 +26,7 @@ block2:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a0, 0x20
@@ -61,7 +61,7 @@ block2 cold:
 ; block2:
 ;   li a0,97
 ;   j label3
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a0, 0x20

--- a/cranelift/filetests/filetests/isa/riscv64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condbr.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   eq a0,a0,a1##ty=i64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a0, a1, 0xc
@@ -31,7 +31,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   eq a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a1, a3, 0x10
@@ -51,7 +51,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   ne a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a1, a3, 8
@@ -71,7 +71,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   slt a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a1, a3, 0xc
@@ -92,7 +92,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   ult a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a1, a3, 0xc
@@ -113,7 +113,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   sle a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a1, a3, 0xc
@@ -134,7 +134,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   ule a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a1, a3, 0xc
@@ -155,7 +155,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   sgt a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a3, a1, 0xc
@@ -176,7 +176,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   ugt a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a3, a1, 0xc
@@ -197,7 +197,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   sge a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a3, a1, 0xc
@@ -218,7 +218,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   uge a0,[a0,a1],[a2,a3]##ty=i128
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a3, a1, 0xc
@@ -253,7 +253,7 @@ block2:
 ; block2:
 ;   li a0,1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a0, a1, 0xc
@@ -289,7 +289,7 @@ block1:
 ; block3:
 ;   li a0,1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a0, a1, 0xc
@@ -319,7 +319,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bnez a1, 8
@@ -349,7 +349,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a1, a3, 0x10
@@ -379,7 +379,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bne a1, a3, 8
@@ -409,7 +409,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a1, a3, 0xc
@@ -440,7 +440,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a1, a3, 0xc
@@ -471,7 +471,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a1, a3, 0xc
@@ -502,7 +502,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a1, a3, 0xc
@@ -533,7 +533,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a3, a1, 0xc
@@ -564,7 +564,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a3, a1, 0xc
@@ -595,7 +595,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   blt a3, a1, 0xc
@@ -626,7 +626,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bltu a3, a1, 0xc
@@ -657,7 +657,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi t2, a0, 0xff
@@ -684,7 +684,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -712,7 +712,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x20
@@ -738,7 +738,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/condops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condops.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   andi a4,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -43,7 +43,7 @@ block0(v0: i8):
 ;   andi a2,a2,255
 ;   eq a0,a0,a2##ty=i8
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a2, zero, 0x2a
@@ -68,7 +68,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   and a5,a3,a2
 ;   or a0,a1,a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   and a1, a0, a1
@@ -88,7 +88,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   andi a3,a0,255
 ;   select_i8 a0,a1,a2##condition=a3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a0, 0xff
@@ -115,7 +115,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   srli t3,a6,32
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -141,7 +141,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   andi a5,a0,255
 ;   select_i128 [a0,a1],[a7,a2],[a3,a4]##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a7, a1, 0

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -12,7 +12,7 @@ block0:
 ; block0:
 ;   li a0,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, -1
@@ -28,7 +28,7 @@ block0:
 ; block0:
 ;   li a0,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
@@ -44,7 +44,7 @@ block0:
 ; block0:
 ;   li a0,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
@@ -61,7 +61,7 @@ block0:
 ;   lui t1,16
 ;   addi a0,t1,4095
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui t1, 0x10
@@ -78,7 +78,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -98,7 +98,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff00000000
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -118,7 +118,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff000000000000
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -138,7 +138,7 @@ block0:
 ; block0:
 ;   li a0,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, -1
@@ -154,7 +154,7 @@ block0:
 ; block0:
 ;   lui a0,1048560
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a0, 0xffff0
@@ -170,7 +170,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffffffff0000ffff
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -190,7 +190,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffff0000ffffffff
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -210,7 +210,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xffffffffffff
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -230,7 +230,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xf34bf0a31212003a
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -250,7 +250,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0x12e900001ef40000
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -270,7 +270,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0x12e9ffff1ef4ffff
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -290,7 +290,7 @@ block0:
 ; block0:
 ;   li a0,-1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, -1
@@ -306,7 +306,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xfffffff7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -326,7 +326,7 @@ block0:
 ; block0:
 ;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xfffffff7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0
@@ -346,7 +346,7 @@ block0:
 ; block0:
 ;   li a0,-9
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, -9
@@ -363,7 +363,7 @@ block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x3ff0000000000000
 ;   fmv.d.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t1, 0
@@ -385,7 +385,7 @@ block0:
 ;   lui t1,264704
 ;   fmv.w.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui t1, 0x40a00
@@ -403,7 +403,7 @@ block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x4049000000000000
 ;   fmv.d.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t1, 0
@@ -425,7 +425,7 @@ block0:
 ;   lui t1,271488
 ;   fmv.w.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui t1, 0x42480
@@ -443,7 +443,7 @@ block0:
 ;   li t1,0
 ;   fmv.d.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv t1, zero
@@ -461,7 +461,7 @@ block0:
 ;   li t1,0
 ;   fmv.w.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv t1, zero
@@ -479,7 +479,7 @@ block0:
 ;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xc030000000000000
 ;   fmv.d.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t1, 0
@@ -501,7 +501,7 @@ block0:
 ;   auipc t1,0; ld t1,12(t1); j 8; .4byte 0xc1800000
 ;   fmv.w.x fa0,t1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc t1, 0

--- a/cranelift/filetests/filetests/isa/riscv64/ctz-zbb-zbs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ctz-zbb-zbs.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   bseti t2,a0,8
 ;   ctzw a0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x85, 0x28
@@ -31,7 +31,7 @@ block0(v0: i16):
 ;   bseti t2,a0,16
 ;   ctzw a0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x05, 0x29
@@ -48,7 +48,7 @@ block0(v0: i32):
 ; block0:
 ;   ctzw a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x1b, 0x15, 0x15, 0x60
@@ -64,8 +64,9 @@ block0(v0: i64):
 ; block0:
 ;   ctz a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x15, 0x60
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/ctz-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ctz-zbb.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   ori t2,a0,256
 ;   ctzw a0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori t2, a0, 0x100
@@ -33,7 +33,7 @@ block0(v0: i16):
 ;   or a1,a0,t2
 ;   ctzw a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui t2, 0x10
@@ -51,7 +51,7 @@ block0(v0: i32):
 ; block0:
 ;   ctzw a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x1b, 0x15, 0x15, 0x60
@@ -67,7 +67,7 @@ block0(v0: i64):
 ; block0:
 ;   ctz a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x15, 0x60
@@ -87,7 +87,7 @@ block0(v0: i128):
 ;   add a0,a2,a4
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x95, 0x15, 0x60

--- a/cranelift/filetests/filetests/isa/riscv64/extend-i128.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend-i128.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ; block0:
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a1, zero
@@ -30,7 +30,7 @@ block0(v0: i32):
 ;   srli a0,t2,32
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x20
@@ -50,7 +50,7 @@ block0(v0: i16):
 ;   srli a0,t2,48
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -69,7 +69,7 @@ block0(v0: i8):
 ;   andi a0,a0,255
 ;   li a1,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -86,7 +86,7 @@ block0(v0: i64):
 ; block0:
 ;   srai a1,a0,63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srai a1, a0, 0x3f
@@ -103,7 +103,7 @@ block0(v0: i32):
 ;   sext.w a0,a0
 ;   srai a1,a0,63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a0, a0
@@ -122,7 +122,7 @@ block0(v0: i16):
 ;   srai a0,t2,48
 ;   srai a1,a0,63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -142,7 +142,7 @@ block0(v0: i8):
 ;   srai a0,t2,56
 ;   srai a1,a0,63
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38

--- a/cranelift/filetests/filetests/isa/riscv64/extend-zba.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend-zba.clif
@@ -12,7 +12,7 @@ block0(v0: i32):
 ; block0:
 ;   zext.w a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x05, 0x05, 0x08

--- a/cranelift/filetests/filetests/isa/riscv64/extend-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend-zbb.clif
@@ -15,7 +15,7 @@ block0(v0: i16):
 ; block0:
 ;   zext.h a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x45, 0x05, 0x08
@@ -31,7 +31,7 @@ block0(v0: i8):
 ; block0:
 ;   andi a0,a0,255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -47,7 +47,7 @@ block0(v0: i16):
 ; block0:
 ;   zext.h a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x45, 0x05, 0x08
@@ -65,7 +65,7 @@ block0(v0: i8):
 ; block0:
 ;   sext.b a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x45, 0x60
@@ -81,7 +81,7 @@ block0(v0: i8):
 ; block0:
 ;   sext.b a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x45, 0x60
@@ -97,7 +97,7 @@ block0(v0: i16):
 ; block0:
 ;   sext.h a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x55, 0x60
@@ -113,7 +113,7 @@ block0(v0: i8):
 ; block0:
 ;   sext.b a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x45, 0x60
@@ -129,8 +129,9 @@ block0(v0: i16):
 ; block0:
 ;   sext.h a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x13, 0x15, 0x55, 0x60
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/extend-zbkb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend-zbkb.clif
@@ -13,7 +13,7 @@ block0(v0: i16):
 ; block0:
 ;   packw a0,a0,zero
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x45, 0x05, 0x08
@@ -29,7 +29,7 @@ block0(v0: i16):
 ; block0:
 ;   packw a0,a0,zero
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x3b, 0x45, 0x05, 0x08
@@ -45,7 +45,7 @@ block0(v0: i32):
 ; block0:
 ;   pack a0,a0,zero
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x33, 0x45, 0x05, 0x08

--- a/cranelift/filetests/filetests/isa/riscv64/extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend.clif
@@ -15,7 +15,7 @@ block0(v0: i8):
 ; block0:
 ;   andi a0,a0,255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -31,7 +31,7 @@ block0(v0: i8):
 ; block0:
 ;   andi a0,a0,255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -48,7 +48,7 @@ block0(v0: i16):
 ;   slli t2,a0,48
 ;   srli a0,t2,48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -65,7 +65,7 @@ block0(v0: i8):
 ; block0:
 ;   andi a0,a0,255
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -82,7 +82,7 @@ block0(v0: i16):
 ;   slli t2,a0,48
 ;   srli a0,t2,48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -100,7 +100,7 @@ block0(v0: i32):
 ;   slli t2,a0,32
 ;   srli a0,t2,32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x20
@@ -120,7 +120,7 @@ block0(v0: i8):
 ;   slli t2,a0,56
 ;   srai a0,t2,56
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38
@@ -138,7 +138,7 @@ block0(v0: i8):
 ;   slli t2,a0,56
 ;   srai a0,t2,56
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38
@@ -156,7 +156,7 @@ block0(v0: i16):
 ;   slli t2,a0,48
 ;   srai a0,t2,48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -174,7 +174,7 @@ block0(v0: i8):
 ;   slli t2,a0,56
 ;   srai a0,t2,56
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38
@@ -192,7 +192,7 @@ block0(v0: i16):
 ;   slli t2,a0,48
 ;   srai a0,t2,48
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -209,7 +209,7 @@ block0(v0: i32):
 ; block0:
 ;   sext.w a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a0, a0
@@ -229,7 +229,7 @@ block0(v0: i8):
 ;   srai a2,a0,56
 ;   addi a0,a2,42
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x38
@@ -250,7 +250,7 @@ block0(v0: i8, v1: i64):
 ;   srai a3,a2,56
 ;   add a0,a3,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a2, a0, 0x38

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -24,7 +24,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv t2, zero
@@ -55,7 +55,7 @@ block1:
 ;   j label3
 ; block3:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv t2, zero

--- a/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   andi t2,a0,255
 ;   fcvt.s.lu fa0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi t2, a0, 0xff
@@ -31,7 +31,7 @@ block0(v0: i8):
 ;   andi t2,a0,255
 ;   fcvt.d.lu fa0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi t2, a0, 0xff
@@ -50,7 +50,7 @@ block0(v0: i16):
 ;   srli a1,t2,48
 ;   fcvt.s.lu fa0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -70,7 +70,7 @@ block0(v0: i16):
 ;   srli a1,t2,48
 ;   fcvt.d.lu fa0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -88,7 +88,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint.i8 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -121,7 +121,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint.i8 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -159,7 +159,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint.i16 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -192,7 +192,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint.i16 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -12,7 +12,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fadd.s fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fadd.s fa0, fa0, fa1
@@ -28,7 +28,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fadd.d fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fadd.d fa0, fa0, fa1
@@ -44,7 +44,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fsub.s fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsub.s fa0, fa0, fa1
@@ -60,7 +60,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fsub.d fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsub.d fa0, fa0, fa1
@@ -76,7 +76,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fmul.s fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmul.s fa0, fa0, fa1
@@ -92,7 +92,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fmul.d fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmul.d fa0, fa0, fa1
@@ -108,7 +108,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fdiv.s fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fdiv.s fa0, fa0, fa1
@@ -124,7 +124,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fdiv.d fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fdiv.d fa0, fa0, fa1
@@ -141,7 +141,7 @@ block0(v0: f32, v1: f32):
 ;   fmv.d ft5,fa0
 ;   fmin.s fa0,ft5,fa1##tmp=a1 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -178,7 +178,7 @@ block0(v0: f64, v1: f64):
 ;   fmv.d ft5,fa0
 ;   fmin.d fa0,ft5,fa1##tmp=a1 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -215,7 +215,7 @@ block0(v0: f32, v1: f32):
 ;   fmv.d ft5,fa0
 ;   fmax.s fa0,ft5,fa1##tmp=a1 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -252,7 +252,7 @@ block0(v0: f64, v1: f64):
 ;   fmv.d ft5,fa0
 ;   fmax.d fa0,ft5,fa1##tmp=a1 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -288,7 +288,7 @@ block0(v0: f32):
 ; block0:
 ;   fsqrt.s fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt.s fa0, fa0
@@ -304,7 +304,7 @@ block0(v0: f64):
 ; block0:
 ;   fsqrt.d fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsqrt.d fa0, fa0
@@ -320,7 +320,7 @@ block0(v0: f32):
 ; block0:
 ;   fabs.s fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs.s fa0, fa0
@@ -336,7 +336,7 @@ block0(v0: f64):
 ; block0:
 ;   fabs.d fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fabs.d fa0, fa0
@@ -352,7 +352,7 @@ block0(v0: f32):
 ; block0:
 ;   fneg.s fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg.s fa0, fa0
@@ -368,7 +368,7 @@ block0(v0: f64):
 ; block0:
 ;   fneg.d fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fneg.d fa0, fa0
@@ -384,7 +384,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt.d.s fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x53, 0x75, 0x05, 0x42
@@ -400,7 +400,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt.s.d fa0,fa0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.s.d fa0, fa0
@@ -417,7 +417,7 @@ block0(v0: f32):
 ;   fmv.d ft5,fa0
 ;   ceil fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -448,7 +448,7 @@ block0(v0: f64):
 ;   fmv.d ft5,fa0
 ;   ceil fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -483,7 +483,7 @@ block0(v0: f32):
 ;   fmv.d ft5,fa0
 ;   floor fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -514,7 +514,7 @@ block0(v0: f64):
 ;   fmv.d ft5,fa0
 ;   floor fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -549,7 +549,7 @@ block0(v0: f32):
 ;   fmv.d ft5,fa0
 ;   trunc fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -580,7 +580,7 @@ block0(v0: f64):
 ;   fmv.d ft5,fa0
 ;   trunc fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -615,7 +615,7 @@ block0(v0: f32):
 ;   fmv.d ft5,fa0
 ;   nearest fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f32
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -646,7 +646,7 @@ block0(v0: f64):
 ;   fmv.d ft5,fa0
 ;   nearest fa0,ft5##int_tmp=a0 f_tmp=ft4 ty=f64
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d ft5, fa0
@@ -680,7 +680,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ; block0:
 ;   fmadd.s fa0,fa0,fa1,fa2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd.s fa0, fa0, fa1, fa2
@@ -696,7 +696,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ; block0:
 ;   fmadd.d fa0,fa0,fa1,fa2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmadd.d fa0, fa0, fa1, fa2
@@ -712,7 +712,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   fsgnj.s fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsgnj.s fa0, fa0, fa1
@@ -728,7 +728,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   fsgnj.d fa0,fa0,fa1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fsgnj.d fa0, fa0, fa1
@@ -744,7 +744,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint.i32 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -777,7 +777,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_sint.i32 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -810,7 +810,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint.i64 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -843,7 +843,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_sint.i64 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -876,7 +876,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint.i32 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -914,7 +914,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_sint.i32 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -952,7 +952,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint.i64 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -990,7 +990,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_sint.i64 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -1028,7 +1028,7 @@ block0(v0: i32):
 ; block0:
 ;   fcvt.s.wu fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.s.wu fa0, a0
@@ -1044,7 +1044,7 @@ block0(v0: i32):
 ; block0:
 ;   fcvt.s.w fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.s.w fa0, a0
@@ -1060,7 +1060,7 @@ block0(v0: i64):
 ; block0:
 ;   fcvt.s.lu fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.s.lu fa0, a0
@@ -1076,7 +1076,7 @@ block0(v0: i64):
 ; block0:
 ;   fcvt.s.l fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.s.l fa0, a0
@@ -1092,7 +1092,7 @@ block0(v0: i32):
 ; block0:
 ;   fcvt.d.wu fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.d.wu fa0, a0
@@ -1108,7 +1108,7 @@ block0(v0: i32):
 ; block0:
 ;   fcvt.d.w fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x53, 0x75, 0x05, 0xd2
@@ -1124,7 +1124,7 @@ block0(v0: i64):
 ; block0:
 ;   fcvt.d.lu fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.d.lu fa0, a0
@@ -1140,7 +1140,7 @@ block0(v0: i64):
 ; block0:
 ;   fcvt.d.l fa0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fcvt.d.l fa0, a0
@@ -1156,7 +1156,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint_sat.i32 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -1176,7 +1176,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_sint_sat.i32 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -1196,7 +1196,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_uint_sat.i64 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -1216,7 +1216,7 @@ block0(v0: f32):
 ; block0:
 ;   fcvt_to_sint_sat.i64 a0,fa0##in_ty=f32 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
@@ -1236,7 +1236,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint_sat.i32 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -1256,7 +1256,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_sint_sat.i32 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -1276,7 +1276,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_uint_sat.i64 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
@@ -1296,7 +1296,7 @@ block0(v0: f64):
 ; block0:
 ;   fcvt_to_sint_sat.i64 a0,fa0##in_ty=f64 tmp=ft3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0

--- a/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
@@ -15,7 +15,7 @@ block0(v0: i128):
 ;   sub a1,zero,a2
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -36,7 +36,7 @@ block0(v0: i128):
 ;   sltu a2,zero,a0
 ;   sub a0,zero,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -56,7 +56,7 @@ block0(v0: i128):
 ;   sltu a2,zero,a0
 ;   sub a0,zero,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -76,7 +76,7 @@ block0(v0: i128):
 ;   sltu a2,zero,a0
 ;   sub a0,zero,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -96,7 +96,7 @@ block0(v0: i128):
 ;   sltu a2,zero,a0
 ;   sub a0,zero,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a0, a1
@@ -116,7 +116,7 @@ block0(v0: i64):
 ;   sub a1,zero,t2
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   snez t2, a0
@@ -138,7 +138,7 @@ block0(v0: i32):
 ;   sub a1,zero,a3
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x20
@@ -162,7 +162,7 @@ block0(v0: i16):
 ;   sub a1,zero,a3
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -185,7 +185,7 @@ block0(v0: i8):
 ;   sub a1,zero,a1
 ;   mv a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi t2, a0, 0xff

--- a/cranelift/filetests/filetests/isa/riscv64/iabs-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iabs-zbb.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x45, 0x60
@@ -33,7 +33,7 @@ block0(v0: i16):
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x13, 0x55, 0x60
@@ -53,7 +53,7 @@ block0(v0: i32):
 ;   sub a1,zero,t2
 ;   max a0,t2,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w t2, a0
@@ -72,7 +72,7 @@ block0(v0: i64):
 ;   sub t2,zero,a0
 ;   max a0,a0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg t2, a0

--- a/cranelift/filetests/filetests/isa/riscv64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iabs.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   sub a3,zero,a1
 ;   select_reg a0,a1,a3##condition=(a1 sgt a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x38
@@ -39,7 +39,7 @@ block0(v0: i16):
 ;   sub a3,zero,a1
 ;   select_reg a0,a1,a3##condition=(a1 sgt a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli t2, a0, 0x30
@@ -63,7 +63,7 @@ block0(v0: i32):
 ;   sub a1,zero,t2
 ;   select_reg a0,t2,a1##condition=(t2 sgt a1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w t2, a0
@@ -85,7 +85,7 @@ block0(v0: i64):
 ;   sub t2,zero,a0
 ;   select_reg a0,a0,t2##condition=(a0 sgt t2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   neg t2, a0

--- a/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
@@ -20,7 +20,7 @@ block0:
 ;   srli a5,a3,48
 ;   ne a0,a1,a5##ty=i16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lui a3, 0xe

--- a/cranelift/filetests/filetests/isa/riscv64/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/multivalue-ret.clif
@@ -15,7 +15,7 @@ block1:
 ;   li a0,1
 ;   li a1,2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a0, zero, 1

--- a/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
@@ -12,7 +12,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a0, a0, a1
@@ -28,7 +28,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a0, a0, a1
@@ -44,7 +44,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a0, a0, a1
@@ -63,7 +63,7 @@ block0(v0: i32, v1: i8):
 ;   srai a3,a1,56
 ;   add a0,a0,a3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a1, 0x38
@@ -83,7 +83,7 @@ block0(v0: i64, v1: i32):
 ;   sext.w a1,a1
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a1, a1

--- a/cranelift/filetests/filetests/isa/riscv64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/prologue.clif
@@ -171,7 +171,7 @@ block0(v0: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -376,7 +376,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/reduce.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reduce.clif
@@ -11,7 +11,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -25,7 +25,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -39,7 +39,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -53,7 +53,7 @@ block0(v0: i128):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -10,7 +10,7 @@ block0(v0: r64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -25,7 +25,7 @@ block0(v0: r64):
 ; block0:
 ;   seqz a0,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   seqz a0, a0
@@ -42,7 +42,7 @@ block0(v0: r64):
 ;   addi t2,a0,1
 ;   seqz a0,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t2, a0, 1
@@ -59,7 +59,7 @@ block0:
 ; block0:
 ;   li a0,0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
@@ -127,7 +127,7 @@ block3(v7: r64, v8: r64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/select-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select-float.clif
@@ -18,7 +18,7 @@ block0(v0: i8, v1: f32, v2: f32):
 ;   andi a4,a4,255
 ;   select_reg fa0,fa0,fa1##condition=(a2 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -43,7 +43,7 @@ block0(v0: i8, v1: f64, v2: f64):
 ;   andi a4,a4,255
 ;   select_reg fa0,fa0,fa1##condition=(a2 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -70,7 +70,7 @@ block0(v0: i16, v1: f32, v2: f32):
 ;   srli t3,a6,48
 ;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -99,7 +99,7 @@ block0(v0: i16, v1: f64, v2: f64):
 ;   srli t3,a6,48
 ;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -128,7 +128,7 @@ block0(v0: i32, v1: f32, v2: f32):
 ;   srli t3,a6,32
 ;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -157,7 +157,7 @@ block0(v0: i32, v1: f64, v2: f64):
 ;   srli t3,a6,32
 ;   select_reg fa0,fa0,fa1##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -182,7 +182,7 @@ block0(v0: i64, v1: f32, v2: f32):
 ;   li a2,42
 ;   select_reg fa0,fa0,fa1##condition=(a0 eq a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a2, zero, 0x2a
@@ -203,7 +203,7 @@ block0(v0: i64, v1: f64, v2: f64):
 ;   li a2,42
 ;   select_reg fa0,fa0,fa1##condition=(a0 eq a2)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a2, zero, 0x2a
@@ -229,7 +229,7 @@ block0(v0: i128, v1: f32, v2: f32):
 ;   andi a5,a6,255
 ;   select_f32 fa0,fa6,fa1##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d fa6, fa0
@@ -265,7 +265,7 @@ block0(v0: i128, v1: f64, v2: f64):
 ;   andi a5,a6,255
 ;   select_f64 fa0,fa6,fa1##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fmv.d fa6, fa0

--- a/cranelift/filetests/filetests/isa/riscv64/select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   andi a4,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -44,7 +44,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   andi a4,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -71,7 +71,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   andi a4,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -98,7 +98,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   andi a4,a4,255
 ;   select_reg a0,a1,a2##condition=(a3 eq a4)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a4, zero, 0x2a
@@ -128,7 +128,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   andi a7,t1,255
 ;   select_i128 [a0,a1],[a5,a2],[a3,a4]##condition=a7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a5, a1, 0
@@ -165,7 +165,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   srli t3,a6,48
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -196,7 +196,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   srli t3,a6,48
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -227,7 +227,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   srli t3,a6,48
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -258,7 +258,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   srli t3,a6,48
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -292,7 +292,7 @@ block0(v0: i16, v1: i128, v2: i128):
 ;   andi t4,a5,255
 ;   select_i128 [a0,a1],[a6,a2],[a3,a4]##condition=t4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a6, a1, 0
@@ -331,7 +331,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   srli t3,a6,32
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -362,7 +362,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   srli t3,a6,32
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -393,7 +393,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   srli t3,a6,32
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -424,7 +424,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   srli t3,a6,32
 ;   select_reg a0,a1,a2##condition=(a4 eq t3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -458,7 +458,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   andi t4,a5,255
 ;   select_i128 [a0,a1],[a6,a2],[a3,a4]##condition=t4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a6, a1, 0
@@ -493,7 +493,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   li a3,42
 ;   select_reg a0,a1,a2##condition=(a0 eq a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -516,7 +516,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   li a3,42
 ;   select_reg a0,a1,a2##condition=(a0 eq a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -539,7 +539,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   li a3,42
 ;   select_reg a0,a1,a2##condition=(a0 eq a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -562,7 +562,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   li a3,42
 ;   select_reg a0,a1,a2##condition=(a0 eq a3)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -588,7 +588,7 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   andi a5,a7,255
 ;   select_i128 [a0,a1],[t1,a2],[a3,a4]##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori t1, a1, 0
@@ -623,7 +623,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   andi a5,a6,255
 ;   select_i8 a0,a2,a3##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -657,7 +657,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   andi a5,a6,255
 ;   select_i16 a0,a2,a3##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -691,7 +691,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   andi a5,a6,255
 ;   select_i32 a0,a2,a3##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -725,7 +725,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   andi a5,a6,255
 ;   select_i64 a0,a2,a3##condition=a5
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -759,7 +759,7 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   andi a7,t4,255
 ;   select_i128 [a0,a1],[a2,a3],[a4,a5]##condition=a7
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 0x2a

--- a/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
@@ -24,7 +24,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   and a2,a2,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -65,7 +65,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   and a2,a2,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -106,7 +106,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   and a2,a2,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -147,7 +147,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   and a2,a2,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -192,7 +192,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   or a0,a0,t3
 ;   or a1,a2,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a5, zero, 0x2a
@@ -239,7 +239,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -284,7 +284,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -329,7 +329,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -374,7 +374,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -423,7 +423,7 @@ block0(v0: i16, v1: i128, v2: i128):
 ;   or a0,a6,t0
 ;   or a1,a5,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -472,7 +472,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -517,7 +517,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -562,7 +562,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -607,7 +607,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   and a4,a2,a3
 ;   or a0,a0,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
@@ -656,7 +656,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   or a0,a6,t0
 ;   or a1,a5,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a
@@ -701,7 +701,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   and a0,a2,t1
 ;   or a0,t4,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 0x2a
@@ -738,7 +738,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   and a0,a2,t1
 ;   or a0,t4,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 0x2a
@@ -775,7 +775,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   and a0,a2,t1
 ;   or a0,t4,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 0x2a
@@ -812,7 +812,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   and a0,a2,t1
 ;   or a0,t4,a0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t4, zero, 0x2a
@@ -853,7 +853,7 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   or a0,t1,a6
 ;   or a1,a1,t3
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a5, zero, 0x2a
@@ -896,7 +896,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   and a2,a3,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -937,7 +937,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   and a2,a3,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -978,7 +978,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   and a2,a3,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -1019,7 +1019,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   and a2,a3,a0
 ;   or a0,t1,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t1, zero, 0x2a
@@ -1064,7 +1064,7 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   or a0,a0,t3
 ;   or a1,a2,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x2a

--- a/cranelift/filetests/filetests/isa/riscv64/shift-op.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/shift-op.clif
@@ -15,7 +15,7 @@ block0(v0: i64):
 ;   slli a1,a0,3
 ;   add a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a1, a0, 3
@@ -33,7 +33,7 @@ block0(v0: i32):
 ; block0:
 ;   slliw a0,a0,53
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slliw a0, a0, 0x15

--- a/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/shift-rotate.clif
@@ -31,7 +31,7 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,t4,a1##condition=(a2 uge t1)
 ;   select_reg a1,a1,t4##condition=(a2 uge t1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -80,7 +80,7 @@ block0(v0: i64, v1: i64):
 ;   select_reg t0,zero,t3##condition=(a0 eq zero)
 ;   or a0,a6,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a7, a0, 0
@@ -115,7 +115,7 @@ block0(v0: i32, v1: i32):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x20
@@ -150,7 +150,7 @@ block0(v0: i16, v1: i16):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x30
@@ -184,7 +184,7 @@ block0(v0: i8, v1: i8):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -225,7 +225,7 @@ block0(v0: i128, v1: i128):
 ;   select_reg a0,t4,a1##condition=(a2 uge t1)
 ;   select_reg a1,a1,t4##condition=(a2 uge t1)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a3, a2, 0x3f
@@ -274,7 +274,7 @@ block0(v0: i64, v1: i64):
 ;   select_reg t0,zero,t3##condition=(a0 eq zero)
 ;   or a0,a6,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a7, a0, 0
@@ -309,7 +309,7 @@ block0(v0: i32, v1: i32):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x20
@@ -344,7 +344,7 @@ block0(v0: i16, v1: i16):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x30
@@ -378,7 +378,7 @@ block0(v0: i8, v1: i8):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -404,7 +404,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   srl a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srl a0, a0, a1
@@ -420,7 +420,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   srlw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srlw a0, a0, a1
@@ -439,7 +439,7 @@ block0(v0: i16, v1: i16):
 ;   andi a4,a1,15
 ;   srlw a0,a2,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x30
@@ -460,7 +460,7 @@ block0(v0: i8, v1: i8):
 ;   andi a2,a1,7
 ;   srlw a0,a0,a2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a0, a0, 0xff
@@ -478,7 +478,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sll a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sll a0, a0, a1
@@ -494,7 +494,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sllw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllw a0, a0, a1
@@ -511,7 +511,7 @@ block0(v0: i16, v1: i16):
 ;   andi a1,a1,15
 ;   sllw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a1, a1, 0xf
@@ -529,7 +529,7 @@ block0(v0: i8, v1: i8):
 ;   andi a1,a1,7
 ;   sllw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   andi a1, a1, 7
@@ -546,7 +546,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sra a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sra a0, a0, a1
@@ -562,7 +562,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sraw a0,a0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sraw a0, a0, a1
@@ -581,7 +581,7 @@ block0(v0: i16, v1: i16):
 ;   andi a4,a1,15
 ;   sra a0,a2,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x30
@@ -603,7 +603,7 @@ block0(v0: i8, v1: i8):
 ;   andi a4,a1,7
 ;   sra a0,a2,a4
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x38
@@ -630,7 +630,7 @@ block0(v0: i64):
 ;   select_reg t0,zero,t3##condition=(a1 eq zero)
 ;   or a0,a6,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x11
@@ -664,7 +664,7 @@ block0(v0: i64):
 ;   select_reg t0,zero,t3##condition=(a1 eq zero)
 ;   or a0,a6,t0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a6, zero, 0x11
@@ -700,7 +700,7 @@ block0(v0: i32):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t3, zero, 0x11
@@ -738,7 +738,7 @@ block0(v0: i16):
 ;   select_reg a1,zero,t2##condition=(a4 eq zero)
 ;   or a0,t0,a1
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi t3, zero, 0xa
@@ -775,7 +775,7 @@ block0(v0: i8):
 ;   select_reg t2,zero,t0##condition=(a2 eq zero)
 ;   or a0,t3,t2
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a7, zero, 3
@@ -803,7 +803,7 @@ block0(v0: i64):
 ; block0:
 ;   srli a0,a0,17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srli a0, a0, 0x11
@@ -820,7 +820,7 @@ block0(v0: i64):
 ; block0:
 ;   srai a0,a0,17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srai a0, a0, 0x11
@@ -837,7 +837,7 @@ block0(v0: i64):
 ; block0:
 ;   slli a0,a0,17
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x11

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
@@ -36,7 +36,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
@@ -116,7 +116,7 @@ block0(
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -512,7 +512,7 @@ block0(v0: f32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -557,7 +557,7 @@ block0(v0: f64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
@@ -26,7 +26,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -77,7 +77,7 @@ block0(v0: i32x4, v1: i32x4, v2: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -128,7 +128,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -179,7 +179,7 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
@@ -22,7 +22,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -59,7 +59,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -98,7 +98,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -137,7 +137,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -512,7 +512,7 @@ block0(v0: f32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -557,7 +557,7 @@ block0(v0: f64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -512,7 +512,7 @@ block0(v0: f32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -557,7 +557,7 @@ block0(v0: f64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
@@ -20,7 +20,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -55,7 +55,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -91,7 +91,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -127,7 +127,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -163,7 +163,7 @@ block0(v0: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -199,7 +199,7 @@ block0(v0: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -236,7 +236,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -273,7 +273,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -349,7 +349,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -387,7 +387,7 @@ block0(v0: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -425,7 +425,7 @@ block0(v0: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
@@ -23,7 +23,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -65,7 +65,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -145,7 +145,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -187,7 +187,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -227,7 +227,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
@@ -23,7 +23,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -65,7 +65,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -145,7 +145,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -187,7 +187,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -227,7 +227,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
@@ -23,7 +23,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -65,7 +65,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -145,7 +145,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -187,7 +187,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -227,7 +227,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
@@ -22,7 +22,7 @@ block0(v0: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -61,7 +61,7 @@ block0(v0: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
@@ -23,7 +23,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -65,7 +65,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -145,7 +145,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -187,7 +187,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -227,7 +227,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
@@ -24,7 +24,7 @@ block0(v0:i64x4, v1:i64x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -66,7 +66,7 @@ block0(v0:i64x8, v1:i64x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
@@ -23,7 +23,7 @@ block0(v0:i8x8, v1:i8x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0:i16x4, v1:i16x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0:i32x2, v1:i32x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
@@ -22,7 +22,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -59,7 +59,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -98,7 +98,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -137,7 +137,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -66,7 +66,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -110,7 +110,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -154,7 +154,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -197,7 +197,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -240,7 +240,7 @@ block0(v0: f64x2, v1: f64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -283,7 +283,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -327,7 +327,7 @@ block0(v0: f32x4, v1: f32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -372,7 +372,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -416,7 +416,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -461,7 +461,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -506,7 +506,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -189,7 +189,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-loads.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   vle8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -33,7 +33,7 @@ block0(v0: i64):
 ;   vle16.v v3,0(a0) #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
@@ -53,7 +53,7 @@ block0(v0: i64):
 ;   vle32.v v3,0(a0) #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
@@ -73,7 +73,7 @@ block0(v0: i64):
 ;   vle64.v v3,0(a0) #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd

--- a/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -477,7 +477,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -477,7 +477,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-splat.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ;   vmv.v.x v3,a0 #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -32,7 +32,7 @@ block0(v0: i16):
 ;   vmv.v.x v3,a0 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
@@ -52,7 +52,7 @@ block0(v0: i32):
 ;   vmv.v.x v3,a0 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
@@ -72,7 +72,7 @@ block0(v0: i64):
 ;   vmv.v.x v3,a0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v3,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd
@@ -93,7 +93,7 @@ block0:
 ;   vmv.v.i v2,2 #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -113,7 +113,7 @@ block0:
 ;   vmv.v.i v2,2 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
@@ -134,7 +134,7 @@ block0:
 ;   vmv.v.i v2,2 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
@@ -155,7 +155,7 @@ block0:
 ;   vmv.v.i v2,2 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd
@@ -175,7 +175,7 @@ block0(v0: f32):
 ;   vfmv.v.f v3,fa0 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
@@ -195,7 +195,7 @@ block0(v0: f64):
 ;   vfmv.v.f v3,fa0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v3,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
@@ -22,7 +22,7 @@ block0(v0: f32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -61,7 +61,7 @@ block0(v0: f64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -478,7 +478,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
@@ -21,7 +21,7 @@ block0(v0: i64, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -56,7 +56,7 @@ block0(v0: i64, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -92,7 +92,7 @@ block0(v0: i64, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -128,7 +128,7 @@ block0(v0: i64, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -190,7 +190,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -229,7 +229,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -270,7 +270,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -311,7 +311,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -351,7 +351,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -389,7 +389,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -429,7 +429,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -469,7 +469,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -477,7 +477,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -477,7 +477,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -63,7 +63,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -191,7 +191,7 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -232,7 +232,7 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -275,7 +275,7 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -318,7 +318,7 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -359,7 +359,7 @@ block0(v0: i8x16, v1: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -397,7 +397,7 @@ block0(v0: i16x8, v1: i16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -437,7 +437,7 @@ block0(v0: i32x4, v1: i32):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -478,7 +478,7 @@ block0(v0: i64x2, v1: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vconst-64bit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vconst-64bit.clif
@@ -13,7 +13,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=8, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x04, 0xcc
@@ -36,7 +36,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=8, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x04, 0xcc
@@ -59,7 +59,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=8, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x04, 0xcc
@@ -82,7 +82,7 @@ block0:
 ;   vle16.v v2,[const(0)] #avl=4, #vtype=(e16, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x82, 0xcc
@@ -107,7 +107,7 @@ block0:
 ;   vle32.v v2,[const(0)] #avl=2, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=8, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x01, 0xcd

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vconst.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vconst.clif
@@ -13,7 +13,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -40,7 +40,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -67,7 +67,7 @@ block0:
 ;   vle8.v v2,[const(0)] #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x08, 0xcc
@@ -94,7 +94,7 @@ block0:
 ;   vle16.v v2,[const(0)] #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
@@ -121,7 +121,7 @@ block0:
 ;   vle32.v v2,[const(0)] #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x02, 0xcd
@@ -148,7 +148,7 @@ block0:
 ;   vle64.v v2,[const(0)] #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v2,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x57, 0x70, 0x81, 0xcd

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -90,7 +90,7 @@ block2(v6: i8x16, v7: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -24,7 +24,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -41,7 +41,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ret
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -113,7 +113,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -156,7 +156,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -200,7 +200,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -260,7 +260,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -312,7 +312,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -372,7 +372,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -24,7 +24,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -65,7 +65,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -115,7 +115,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -158,7 +158,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -209,7 +209,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -252,7 +252,7 @@ block0(v0: i64):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -636,7 +636,7 @@ block0(v0: i8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -867,7 +867,7 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -911,7 +911,7 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -958,7 +958,7 @@ block0(v0: i128):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -1012,7 +1012,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -1054,7 +1054,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
@@ -1099,7 +1099,7 @@ block0:
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10

--- a/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
@@ -14,7 +14,7 @@ block0:
 ; block0:
 ;   load_sym a0,%my_global+0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   auipc a0, 0

--- a/cranelift/filetests/filetests/isa/riscv64/traps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/traps.clif
@@ -10,7 +10,7 @@ block0:
 ; VCode:
 ; block0:
 ;   udf##trap_code=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
@@ -32,7 +32,7 @@ block0(v0: i64):
 ;   ret
 ; block2:
 ;   udf##trap_code=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 0x2a
@@ -56,7 +56,7 @@ block0:
 ; block0:
 ;   ebreak
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ebreak

--- a/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
@@ -19,7 +19,7 @@ block0(v0: i32):
 ;   srli t0,a0,32
 ;   trap_if t0,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a5, zero, 0x7f
@@ -51,7 +51,7 @@ block0(v0: i32):
 ;   srli t0,a0,32
 ;   trap_if t0,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a5, zero, 0x7f
@@ -81,7 +81,7 @@ block0(v0: i32, v1: i32):
 ;   srli t0,a0,32
 ;   trap_if t0,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a0, a0, 0x20
@@ -109,7 +109,7 @@ block0(v0: i64):
 ;   ult a2,a0,a4##ty=i64
 ;   trap_if a2,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ori a4, a0, 0
@@ -137,7 +137,7 @@ block0(v0: i64):
 ;   ult a2,a0,a1##ty=i64
 ;   trap_if a2,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 0x7f
@@ -164,7 +164,7 @@ block0(v0: i64, v1: i64):
 ;   mv a0,a3
 ;   trap_if a2,user0
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a1, a0, a1

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic.clif
@@ -14,7 +14,7 @@ block0(v0: i128, v1: i128):
 ;   vaq %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -33,7 +33,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   agr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agr %r2, %r3
@@ -50,7 +50,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   agfr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfr %r2, %r3
@@ -67,7 +67,7 @@ block0(v0: i64):
 ; block0:
 ;   aghi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aghi %r2, 1
@@ -84,7 +84,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r2, 32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfi %r2, 0x8000
@@ -101,7 +101,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ag %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ag %r2, 0(%r3)
@@ -118,7 +118,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   agh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agh %r2, 0(%r3)
@@ -135,7 +135,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   agf %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agf %r2, 0(%r3)
@@ -151,7 +151,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ar %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ar %r2, %r3
@@ -168,7 +168,7 @@ block0(v0: i32):
 ; block0:
 ;   ahi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, 1
@@ -185,7 +185,7 @@ block0(v0: i32):
 ; block0:
 ;   afi %r2, 32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   afi %r2, 0x8000
@@ -202,7 +202,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   a %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   a %r2, 0(%r3)
@@ -219,7 +219,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   ay %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ay %r2, 0x1000(%r3)
@@ -236,7 +236,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   ah %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ah %r2, 0(%r3)
@@ -253,7 +253,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   ahy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahy %r2, 0x1000(%r3)
@@ -269,7 +269,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   ar %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ar %r2, %r3
@@ -286,7 +286,7 @@ block0(v0: i16):
 ; block0:
 ;   ahi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, 1
@@ -303,7 +303,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   ah %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ah %r2, 0(%r3)
@@ -319,7 +319,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   ar %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ar %r2, %r3
@@ -336,7 +336,7 @@ block0(v0: i8):
 ; block0:
 ;   ahi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, 1
@@ -354,7 +354,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   ar %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -374,7 +374,7 @@ block0(v0: i128, v1: i128):
 ;   vsq %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -393,7 +393,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sgr %r2, %r3
@@ -410,7 +410,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   sgfr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sgfr %r2, %r3
@@ -427,7 +427,7 @@ block0(v0: i64):
 ; block0:
 ;   aghi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aghi %r2, -1
@@ -444,7 +444,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r2, -32769
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfi %r2, -0x8001
@@ -461,7 +461,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sg %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sg %r2, 0(%r3)
@@ -478,7 +478,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sgh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sgh %r2, 0(%r3)
@@ -495,7 +495,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sgf %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sgf %r2, 0(%r3)
@@ -511,7 +511,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sr %r2, %r3
@@ -528,7 +528,7 @@ block0(v0: i32):
 ; block0:
 ;   ahi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, -1
@@ -545,7 +545,7 @@ block0(v0: i32):
 ; block0:
 ;   afi %r2, -32769
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   afi %r2, -0x8001
@@ -562,7 +562,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   s %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   s %r2, 0(%r3)
@@ -579,7 +579,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   sy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sy %r2, 0x1000(%r3)
@@ -596,7 +596,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   sh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sh %r2, 0(%r3)
@@ -613,7 +613,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   shy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   shy %r2, 0x1000(%r3)
@@ -629,7 +629,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   sr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sr %r2, %r3
@@ -646,7 +646,7 @@ block0(v0: i16):
 ; block0:
 ;   ahi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, -1
@@ -663,7 +663,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   sh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sh %r2, 0(%r3)
@@ -679,7 +679,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   sr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sr %r2, %r3
@@ -696,7 +696,7 @@ block0(v0: i8):
 ; block0:
 ;   ahi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ahi %r2, -1
@@ -714,7 +714,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   sr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -737,7 +737,7 @@ block0(v0: i128):
 ;   vsel %v20, %v6, %v1, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -759,7 +759,7 @@ block0(v0: i64):
 ; block0:
 ;   lpgr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lpgr %r2, %r2
@@ -776,7 +776,7 @@ block0(v0: i32):
 ; block0:
 ;   lpgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lpgfr %r2, %r2
@@ -792,7 +792,7 @@ block0(v0: i32):
 ; block0:
 ;   lpr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lpr %r2, %r2
@@ -809,7 +809,7 @@ block0(v0: i16):
 ;   lhr %r4, %r2
 ;   lpr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r4, %r2
@@ -827,7 +827,7 @@ block0(v0: i8):
 ;   lbr %r4, %r2
 ;   lpr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r4, %r2
@@ -847,7 +847,7 @@ block0(v0: i128):
 ;   vsq %v6, %v4, %v1
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -866,7 +866,7 @@ block0(v0: i64):
 ; block0:
 ;   lcgr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcgr %r2, %r2
@@ -883,7 +883,7 @@ block0(v0: i32):
 ; block0:
 ;   lcgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcgfr %r2, %r2
@@ -899,7 +899,7 @@ block0(v0: i32):
 ; block0:
 ;   lcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r2, %r2
@@ -915,7 +915,7 @@ block0(v0: i16):
 ; block0:
 ;   lcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r2, %r2
@@ -931,7 +931,7 @@ block0(v0: i8):
 ; block0:
 ;   lcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r2, %r2
@@ -964,7 +964,7 @@ block0(v0: i128, v1: i128):
 ;   vst %v1, 0(%r2)
 ;   lmg %r6, %r15, 48(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r6, %r15, 0x30(%r15)
@@ -998,7 +998,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   msgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msgr %r2, %r3
@@ -1015,7 +1015,7 @@ block0(v0: i64):
 ; block0:
 ;   mghi %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mghi %r2, 3
@@ -1032,7 +1032,7 @@ block0(v0: i64):
 ; block0:
 ;   msgfi %r2, 32769
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msgfi %r2, 0x8001
@@ -1049,7 +1049,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   msg %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msg %r2, 0(%r3)
@@ -1066,7 +1066,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   mgh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mgh %r2, 0(%r3)
@@ -1083,7 +1083,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   msgf %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msgf %r2, 0(%r3)
@@ -1099,7 +1099,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   msr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msr %r2, %r3
@@ -1116,7 +1116,7 @@ block0(v0: i32):
 ; block0:
 ;   mhi %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mhi %r2, 3
@@ -1133,7 +1133,7 @@ block0(v0: i32):
 ; block0:
 ;   msfi %r2, 32769
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msfi %r2, 0x8001
@@ -1150,7 +1150,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   ms %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ms %r2, 0(%r3)
@@ -1167,7 +1167,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   msy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msy %r2, 0x1000(%r3)
@@ -1184,7 +1184,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   mh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mh %r2, 0(%r3)
@@ -1201,7 +1201,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   mhy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mhy %r2, 0x1000(%r3)
@@ -1217,7 +1217,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   msr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msr %r2, %r3
@@ -1234,7 +1234,7 @@ block0(v0: i16):
 ; block0:
 ;   mhi %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mhi %r2, 3
@@ -1251,7 +1251,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   mh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mh %r2, 0(%r3)
@@ -1267,7 +1267,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   msr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   msr %r2, %r3
@@ -1284,7 +1284,7 @@ block0(v0: i8):
 ; block0:
 ;   mhi %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mhi %r2, 3
@@ -1302,7 +1302,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   msr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -1321,7 +1321,7 @@ block0(v0: i64, v1: i64):
 ;   lgr %r3, %r2
 ;   mlgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r3
@@ -1342,7 +1342,7 @@ block0(v0: i32, v1: i32):
 ;   msgr %r5, %r3
 ;   srlg %r2, %r5, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r5, %r2
@@ -1364,7 +1364,7 @@ block0(v0: i16, v1: i16):
 ;   msr %r5, %r3
 ;   srlk %r2, %r5, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -1386,7 +1386,7 @@ block0(v0: i8, v1: i8):
 ;   msr %r5, %r3
 ;   srlk %r2, %r5, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2
@@ -1405,7 +1405,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   mgrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mgrk %r2, %r2, %r3
@@ -1424,7 +1424,7 @@ block0(v0: i32, v1: i32):
 ;   msgr %r5, %r3
 ;   srag %r2, %r5, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r5, %r2
@@ -1446,7 +1446,7 @@ block0(v0: i16, v1: i16):
 ;   msr %r5, %r3
 ;   srak %r2, %r5, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r2
@@ -1468,7 +1468,7 @@ block0(v0: i8, v1: i8):
 ;   msr %r5, %r3
 ;   srak %r2, %r5, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r2
@@ -1495,7 +1495,7 @@ block0(v0: i64, v1: i64):
 ;   dsgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llihf %r4, 0x7fffffff
@@ -1523,7 +1523,7 @@ block0(v0: i64):
 ;   dsgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r3, %r2
@@ -1552,7 +1552,7 @@ block0(v0: i32, v1: i32):
 ;   lgr %r2, %r3
 ;   lmg %r6, %r15, 48(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r6, %r15, 0x30(%r15)
@@ -1583,7 +1583,7 @@ block0(v0: i32):
 ;   dsgfr %r2, %r2
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r3, %r2
@@ -1611,7 +1611,7 @@ block0(v0: i16, v1: i16):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r5, %r2
@@ -1640,7 +1640,7 @@ block0(v0: i16):
 ;   dsgfr %r2, %r2
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r3, %r2
@@ -1668,7 +1668,7 @@ block0(v0: i8, v1: i8):
 ;   dsgfr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r5, %r2
@@ -1697,7 +1697,7 @@ block0(v0: i8):
 ;   dsgfr %r2, %r2
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r3, %r2
@@ -1720,7 +1720,7 @@ block0(v0: i64, v1: i64):
 ;   dlgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r3
@@ -1745,7 +1745,7 @@ block0(v0: i64):
 ;   dlgr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r3, %r2
@@ -1769,7 +1769,7 @@ block0(v0: i32, v1: i32):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r3
@@ -1794,7 +1794,7 @@ block0(v0: i32):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r3, %r2
@@ -1823,7 +1823,7 @@ block0(v0: i16, v1: i16):
 ;   lgr %r2, %r3
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
@@ -1856,7 +1856,7 @@ block0(v0: i16):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, 0
@@ -1887,7 +1887,7 @@ block0(v0: i8, v1: i8):
 ;   lgr %r2, %r3
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
@@ -1920,7 +1920,7 @@ block0(v0: i8):
 ;   dlr %r2, %r4
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, 0
@@ -1947,7 +1947,7 @@ block0(v0: i64, v1: i64):
 ;   lgr %r2, %r4
 ;   dsgr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r3, -1
@@ -1970,7 +1970,7 @@ block0(v0: i32, v1: i32):
 ;   lgfr %r3, %r2
 ;   dsgfr %r2, %r5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -1992,7 +1992,7 @@ block0(v0: i16, v1: i16):
 ;   lhr %r4, %r2
 ;   dsgfr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -2016,7 +2016,7 @@ block0(v0: i8, v1: i8):
 ;   lbr %r4, %r2
 ;   dsgfr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -2039,7 +2039,7 @@ block0(v0: i64, v1: i64):
 ;   lghi %r2, 0
 ;   dlgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r3
@@ -2061,7 +2061,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   dlr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r3
@@ -2088,7 +2088,7 @@ block0(v0: i16, v1: i16):
 ;   dlr %r2, %r5
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)
@@ -2121,7 +2121,7 @@ block0(v0: i8, v1: i8):
 ;   dlr %r2, %r5
 ;   lmg %r7, %r15, 56(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
@@ -18,7 +18,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   csg %r5, %r2, 0(%r4)
 ;   lrvgr %r2, %r5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r5, %r2
@@ -40,7 +40,7 @@ block0(v0: i32, v1: i32, v2: i64):
 ;   cs %r5, %r2, 0(%r4)
 ;   lrvr %r2, %r5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r5, %r2
@@ -68,7 +68,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   lrvr %r2, %r5
 ;   lmg %r11, %r15, 88(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r11, %r15, 0x58(%r15)
@@ -108,7 +108,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   rll %r2, %r0, 8(%r3)
 ;   lmg %r10, %r15, 80(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r10, %r15, 0x50(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
@@ -15,7 +15,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ; block0:
 ;   csg %r2, %r3, 0(%r4)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   csg %r2, %r3, 0(%r4)
@@ -31,7 +31,7 @@ block0(v0: i32, v1: i32, v2: i64):
 ; block0:
 ;   cs %r2, %r3, 0(%r4)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cs %r2, %r3, 0(%r4)
@@ -52,7 +52,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   0: rll %r1, %r0, 0(%r3) ; rxsbg %r1, %r2, 160, 48, 16 ; jglh 1f ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -87,7 +87,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   rll %r2, %r0, 8(%r3)
 ;   lmg %r10, %r15, 80(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r10, %r15, 0x50(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_load-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_load-little.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   lrvg %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r2, 0(%r2)
@@ -29,7 +29,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvg %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -46,7 +46,7 @@ block0(v0: i64):
 ; block0:
 ;   lrv %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r2, 0(%r2)
@@ -64,7 +64,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -81,7 +81,7 @@ block0(v0: i64):
 ; block0:
 ;   lrvh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r2, 0(%r2)
@@ -99,7 +99,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -116,7 +116,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_load.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_load.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   lg %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r2, 0(%r2)
@@ -29,7 +29,7 @@ block0:
 ; block0:
 ;   lgrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -45,7 +45,7 @@ block0(v0: i64):
 ; block0:
 ;   l %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r2, 0(%r2)
@@ -63,7 +63,7 @@ block0:
 ; block0:
 ;   lrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -79,7 +79,7 @@ block0(v0: i64):
 ; block0:
 ;   llh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
@@ -97,7 +97,7 @@ block0:
 ; block0:
 ;   llhrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -113,7 +113,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
@@ -13,7 +13,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: nngrk %r1, %r0, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -37,7 +37,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: nnrk %r1, %r0, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -63,7 +63,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -95,7 +95,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: nngrk %r1, %r0, %r2 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -150,7 +150,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: nnrk %r1, %r0, %r2 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -180,7 +180,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -215,7 +215,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
@@ -18,7 +18,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: csg %r0, %r2, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -41,7 +41,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: cs %r0, %r2, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -69,7 +69,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -103,7 +103,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -131,7 +131,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; agr %r1, %r4 ; lrvgr %r1, %r1 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -155,7 +155,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; ar %r1, %r4 ; lrvr %r1, %r1 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -185,7 +185,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -222,7 +222,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -251,7 +251,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; sgr %r1, %r4 ; lrvgr %r1, %r1 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -275,7 +275,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; sr %r1, %r4 ; lrvr %r1, %r1 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -305,7 +305,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -342,7 +342,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -371,7 +371,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   lang %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -391,7 +391,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   lan %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -417,7 +417,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -451,7 +451,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -479,7 +479,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   laog %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -499,7 +499,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   lao %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -525,7 +525,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -559,7 +559,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -587,7 +587,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   laxg %r4, %r2, 0(%r3)
 ;   lrvgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -607,7 +607,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   lax %r4, %r2, 0(%r3)
 ;   lrvr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -633,7 +633,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -667,7 +667,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -696,7 +696,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: ngrk %r1, %r0, %r2 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r4
@@ -722,7 +722,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: nrk %r1, %r0, %r2 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r4
@@ -752,7 +752,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -787,7 +787,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -816,7 +816,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; cgr %r4, %r1 ; jgnl 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -841,7 +841,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; cr %r4, %r1 ; jgnl 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -872,7 +872,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -911,7 +911,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -942,7 +942,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; cgr %r4, %r1 ; jgnh 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -967,7 +967,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; cr %r4, %r1 ; jgnh 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -998,7 +998,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -1037,7 +1037,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -1068,7 +1068,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; clgr %r4, %r1 ; jgnl 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -1093,7 +1093,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; clr %r4, %r1 ; jgnl 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -1124,7 +1124,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -1163,7 +1163,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -1194,7 +1194,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: lrvgr %r1, %r0 ; clgr %r4, %r1 ; jgnh 1f ; lrvgr %r1, %r4 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -1219,7 +1219,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: lrvr %r1, %r0 ; clr %r4, %r1 ; jgnh 1f ; lrvr %r1, %r4 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lrvr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -1250,7 +1250,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -1289,7 +1289,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
@@ -17,7 +17,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -38,7 +38,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -62,7 +62,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -93,7 +93,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -119,7 +119,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   laag %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   laag %r2, %r3, 0(%r2)
@@ -135,7 +135,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   laa %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   laa %r2, %r3, 0(%r2)
@@ -158,7 +158,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -192,7 +192,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -220,7 +220,7 @@ block0(v0: i64, v1: i64):
 ;   lcgr %r5, %r3
 ;   laag %r2, %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcgr %r5, %r3
@@ -238,7 +238,7 @@ block0(v0: i64, v1: i32):
 ;   lcr %r5, %r3
 ;   laa %r2, %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r3
@@ -262,7 +262,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -296,7 +296,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -323,7 +323,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lang %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lang %r2, %r3, 0(%r2)
@@ -339,7 +339,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   lan %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lan %r2, %r3, 0(%r2)
@@ -360,7 +360,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -391,7 +391,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -417,7 +417,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   laog %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   laog %r2, %r3, 0(%r2)
@@ -433,7 +433,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   lao %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lao %r2, %r3, 0(%r2)
@@ -454,7 +454,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -485,7 +485,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -511,7 +511,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   laxg %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   laxg %r2, %r3, 0(%r2)
@@ -527,7 +527,7 @@ block0(v0: i64, v1: i32):
 ; block0:
 ;   lax %r2, %r3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lax %r2, %r3, 0(%r2)
@@ -548,7 +548,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -579,7 +579,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -607,7 +607,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: ngrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; xihf %r1, 4294967295 ; csg %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -631,7 +631,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: nrk %r1, %r0, %r4 ; xilf %r1, 4294967295 ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -657,7 +657,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -689,7 +689,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -718,7 +718,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: cgr %r4, %r0 ; jgnl 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -741,7 +741,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: cr %r4, %r0 ; jgnl 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -769,7 +769,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -805,7 +805,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -836,7 +836,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: cgr %r4, %r0 ; jgnh 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -859,7 +859,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: cr %r4, %r0 ; jgnh 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -887,7 +887,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -923,7 +923,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -954,7 +954,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: clgr %r4, %r0 ; jgnl 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -977,7 +977,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: clr %r4, %r0 ; jgnl 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -1005,7 +1005,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -1041,7 +1041,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
@@ -1072,7 +1072,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   0: clgr %r4, %r0 ; jgnh 1f ; csg %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r0, 0(%r3)
@@ -1095,7 +1095,7 @@ block0(v0: i64, v1: i64, v2: i32):
 ;   0: clr %r4, %r0 ; jgnh 1f ; cs %r0, %r4, 0(%r3) ; jglh 0b ; 1:
 ;   lgr %r2, %r0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r0, 0(%r3)
@@ -1123,7 +1123,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r4
@@ -1159,7 +1159,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3

--- a/cranelift/filetests/filetests/isa/s390x/atomic_store-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_store-little.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ;   strvg %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvg %r2, 0(%r3)
@@ -32,7 +32,7 @@ block0(v0: i64):
 ;   larl %r1, %sym + 0 ; strvg %r2, 0(%r1)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -53,7 +53,7 @@ block0(v0: i64):
 ;   strvg %r4, 0(%r2)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r4, 0x3039
@@ -72,7 +72,7 @@ block0(v0: i32, v1: i64):
 ;   strv %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strv %r2, 0(%r3)
@@ -92,7 +92,7 @@ block0(v0: i32):
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -113,7 +113,7 @@ block0(v0: i64):
 ;   strv %r4, 0(%r2)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, 0x3039
@@ -132,7 +132,7 @@ block0(v0: i16, v1: i64):
 ;   strvh %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
@@ -152,7 +152,7 @@ block0(v0: i16):
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -172,7 +172,7 @@ block0(v0: i64):
 ;   mvhhi 0(%r2), 14640
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3930
@@ -190,7 +190,7 @@ block0(v0: i8, v1: i64):
 ;   stc %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -209,7 +209,7 @@ block0(v0: i64):
 ;   mvi 0(%r2), 123
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b

--- a/cranelift/filetests/filetests/isa/s390x/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_store.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ;   stg %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stg %r2, 0(%r3)
@@ -32,7 +32,7 @@ block0(v0: i64):
 ;   stgrl %r2, %sym + 0
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -51,7 +51,7 @@ block0(v0: i64):
 ;   mvghi 0(%r2), 12345
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvghi 0(%r2), 0x3039
@@ -69,7 +69,7 @@ block0(v0: i32, v1: i64):
 ;   st %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   st %r2, 0(%r3)
@@ -89,7 +89,7 @@ block0(v0: i32):
 ;   strl %r2, %sym + 0
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -108,7 +108,7 @@ block0(v0: i64):
 ;   mvhi 0(%r2), 12345
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhi 0(%r2), 0x3039
@@ -126,7 +126,7 @@ block0(v0: i16, v1: i64):
 ;   sth %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
@@ -146,7 +146,7 @@ block0(v0: i16):
 ;   sthrl %r2, %sym + 0
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -165,7 +165,7 @@ block0(v0: i64):
 ;   mvhhi 0(%r2), 12345
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3039
@@ -183,7 +183,7 @@ block0(v0: i8, v1: i64):
 ;   stc %r2, 0(%r3)
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -202,7 +202,7 @@ block0(v0: i64):
 ;   mvi 0(%r2), 123
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b

--- a/cranelift/filetests/filetests/isa/s390x/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitcast.clif
@@ -12,7 +12,7 @@ block0(v0: i8):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -26,7 +26,7 @@ block0(v0: i16):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -40,7 +40,7 @@ block0(v0: i32):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -54,7 +54,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -70,7 +70,7 @@ block0(v0: i128):
 ;   vl %v1, 0(%r3)
 ;   vst %v1, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -86,7 +86,7 @@ block0(v0: r64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -100,7 +100,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -114,7 +114,7 @@ block0(v0: r64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/bitops-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops-arch13.clif
@@ -15,7 +15,7 @@ block0(v0: i64):
 ; block0:
 ;   popcnt %r2, %r2, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xe1
@@ -33,7 +33,7 @@ block0(v0: i32):
 ;   llgfr %r4, %r2
 ;   popcnt %r2, %r4, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r4, %r2
@@ -52,7 +52,7 @@ block0(v0: i16):
 ;   llghr %r4, %r2
 ;   popcnt %r2, %r4, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r4, %r2
@@ -70,7 +70,7 @@ block0(v0: i8):
 ; block0:
 ;   popcnt %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   popcnt %r2, %r2

--- a/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
@@ -12,7 +12,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ncrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xf5
@@ -30,7 +30,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ncrk %r2, %r3, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xf5
@@ -47,7 +47,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ocrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x75
@@ -65,7 +65,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ocrk %r2, %r3, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x75
@@ -82,7 +82,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77
@@ -100,7 +100,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   nxrk %r2, %r3, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77
@@ -118,7 +118,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -29,7 +29,7 @@ block0(v0: i128):
 ;   vperm %v20, %v16, %v16, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -101,7 +101,7 @@ block0(v0: i64):
 ;   ogr %r4, %r2
 ;   lrvgr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r2
@@ -167,7 +167,7 @@ block0(v0: i32):
 ;   ork %r4, %r2, %r3
 ;   lrvr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   iilf %r4, 0xaaaaaaaa
@@ -226,7 +226,7 @@ block0(v0: i16):
 ;   lrvr %r2, %r4
 ;   srlk %r2, %r2, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, -0x5556
@@ -284,7 +284,7 @@ block0(v0: i8):
 ;   nrk %r3, %r5, %r4
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, -0x5556
@@ -329,7 +329,7 @@ block0(v0: i128):
 ;   vsel %v26, %v20, %v16, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -354,7 +354,7 @@ block0(v0: i64):
 ; block0:
 ;   flogr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   flogr %r2, %r2
@@ -372,7 +372,7 @@ block0(v0: i32):
 ;   flogr %r2, %r4
 ;   ahi %r2, -32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r4, %r2
@@ -392,7 +392,7 @@ block0(v0: i16):
 ;   flogr %r2, %r4
 ;   ahi %r2, -48
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r4, %r2
@@ -412,7 +412,7 @@ block0(v0: i8):
 ;   flogr %r2, %r4
 ;   ahi %r2, -56
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgcr %r4, %r2
@@ -444,7 +444,7 @@ block0(v0: i128):
 ;   vaq %v4, %v2, %v4
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -477,7 +477,7 @@ block0(v0: i64):
 ;   flogr %r2, %r2
 ;   aghi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srag %r4, %r2, 0x3f
@@ -500,7 +500,7 @@ block0(v0: i32):
 ;   flogr %r2, %r4
 ;   ahi %r2, -33
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r4, %r2
@@ -524,7 +524,7 @@ block0(v0: i16):
 ;   flogr %r2, %r4
 ;   ahi %r2, -49
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r4, %r2
@@ -548,7 +548,7 @@ block0(v0: i8):
 ;   flogr %r2, %r4
 ;   ahi %r2, -57
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r4, %r2
@@ -577,7 +577,7 @@ block0(v0: i128):
 ;   vsel %v26, %v20, %v18, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -608,7 +608,7 @@ block0(v0: i64):
 ;   lghi %r5, 63
 ;   sgrk %r2, %r5, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcgr %r4, %r2
@@ -636,7 +636,7 @@ block0(v0: i32):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r2
@@ -664,7 +664,7 @@ block0(v0: i16):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r2
@@ -692,7 +692,7 @@ block0(v0: i8):
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r4, %r2
@@ -720,7 +720,7 @@ block0(v0: i128):
 ;   vag %v20, %v16, %v18
 ;   vst %v20, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -749,7 +749,7 @@ block0(v0: i64):
 ;   agr %r4, %r2
 ;   srlg %r2, %r4, 56
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   popcnt %r4, %r2
@@ -777,7 +777,7 @@ block0(v0: i32):
 ;   ar %r4, %r2
 ;   srlk %r2, %r4, 24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   popcnt %r4, %r2
@@ -801,7 +801,7 @@ block0(v0: i16):
 ;   ark %r2, %r4, %r2
 ;   nill %r2, 255
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   popcnt %r4, %r2
@@ -820,7 +820,7 @@ block0(v0: i8):
 ; block0:
 ;   popcnt %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   popcnt %r2, %r2

--- a/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise-arch13.clif
@@ -16,7 +16,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ncgrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xe5
@@ -33,7 +33,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ncrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xf5
@@ -50,7 +50,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   ncrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xf5
@@ -67,7 +67,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   ncrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0xf5
@@ -84,7 +84,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ocgrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x65
@@ -101,7 +101,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   ocrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x75
@@ -118,7 +118,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   ocrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x75
@@ -135,7 +135,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   ocrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x75
@@ -152,7 +152,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   nxgrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x67
@@ -169,7 +169,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77
@@ -186,7 +186,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77
@@ -203,7 +203,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   nxrk %r2, %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x77
@@ -220,7 +220,7 @@ block0(v0: i64):
 ; block0:
 ;   nogrk %r2, %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x66
@@ -237,7 +237,7 @@ block0(v0: i32):
 ; block0:
 ;   nork %r2, %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x76
@@ -254,7 +254,7 @@ block0(v0: i16):
 ; block0:
 ;   nork %r2, %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x76
@@ -271,7 +271,7 @@ block0(v0: i8):
 ; block0:
 ;   nork %r2, %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xb9, 0x76
@@ -290,7 +290,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   ncgrk %r4, %r4, %r2
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ngr %r3, %r2
@@ -311,7 +311,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   ncrk %r4, %r4, %r2
 ;   ork %r2, %r4, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
@@ -332,7 +332,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   ncrk %r4, %r4, %r2
 ;   ork %r2, %r4, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
@@ -353,7 +353,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   ncrk %r4, %r4, %r2
 ;   ork %r2, %r4, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -17,7 +17,7 @@ block0(v0: i128, v1: i128):
 ;   vn %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -36,7 +36,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ngr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ngr %r2, %r3
@@ -53,7 +53,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ng %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ng %r2, 0(%r3)
@@ -69,7 +69,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r2, %r3
@@ -86,7 +86,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   n %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   n %r2, 0(%r3)
@@ -103,7 +103,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   ny %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ny %r2, 0x1000(%r3)
@@ -119,7 +119,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r2, %r3
@@ -137,7 +137,7 @@ block0(v0: i16, v1: i64):
 ;   llh %r3, 0(%r3)
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
@@ -154,7 +154,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r2, %r3
@@ -172,7 +172,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -192,7 +192,7 @@ block0(v0: i128, v1: i128):
 ;   vo %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -211,7 +211,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   ogr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ogr %r2, %r3
@@ -228,7 +228,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   og %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   og %r2, 0(%r3)
@@ -244,7 +244,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or %r2, %r3
@@ -261,7 +261,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   o %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   o %r2, 0(%r3)
@@ -278,7 +278,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   oy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   oy %r2, 0x1000(%r3)
@@ -294,7 +294,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or %r2, %r3
@@ -312,7 +312,7 @@ block0(v0: i16, v1: i64):
 ;   llh %r3, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
@@ -329,7 +329,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or %r2, %r3
@@ -347,7 +347,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -367,7 +367,7 @@ block0(v0: i128, v1: i128):
 ;   vx %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -386,7 +386,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xgr %r2, %r3
@@ -403,7 +403,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   xg %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xg %r2, 0(%r3)
@@ -419,7 +419,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xr %r2, %r3
@@ -436,7 +436,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   x %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   x %r2, 0(%r3)
@@ -453,7 +453,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   xy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xy %r2, 0x1000(%r3)
@@ -469,7 +469,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xr %r2, %r3
@@ -487,7 +487,7 @@ block0(v0: i16, v1: i64):
 ;   llh %r3, 0(%r3)
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
@@ -504,7 +504,7 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xr %r2, %r3
@@ -522,7 +522,7 @@ block0(v0: i8, v1: i64):
 ;   llc %r3, 0(%r3)
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -542,7 +542,7 @@ block0(v0: i128, v1: i128):
 ;   vnc %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -563,7 +563,7 @@ block0(v0: i64, v1: i64):
 ;   xihf %r3, 4294967295
 ;   ngr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -582,7 +582,7 @@ block0(v0: i32, v1: i32):
 ;   xilf %r3, 4294967295
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -600,7 +600,7 @@ block0(v0: i16, v1: i16):
 ;   xilf %r3, 4294967295
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -618,7 +618,7 @@ block0(v0: i8, v1: i8):
 ;   xilf %r3, 4294967295
 ;   nr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -638,7 +638,7 @@ block0(v0: i128, v1: i128):
 ;   voc %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -659,7 +659,7 @@ block0(v0: i64, v1: i64):
 ;   xihf %r3, 4294967295
 ;   ogr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -678,7 +678,7 @@ block0(v0: i32, v1: i32):
 ;   xilf %r3, 4294967295
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -696,7 +696,7 @@ block0(v0: i16, v1: i16):
 ;   xilf %r3, 4294967295
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -714,7 +714,7 @@ block0(v0: i8, v1: i8):
 ;   xilf %r3, 4294967295
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -734,7 +734,7 @@ block0(v0: i128, v1: i128):
 ;   vnx %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -755,7 +755,7 @@ block0(v0: i64, v1: i64):
 ;   xihf %r3, 4294967295
 ;   xgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -774,7 +774,7 @@ block0(v0: i32, v1: i32):
 ;   xilf %r3, 4294967295
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -792,7 +792,7 @@ block0(v0: i16, v1: i16):
 ;   xilf %r3, 4294967295
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -810,7 +810,7 @@ block0(v0: i8, v1: i8):
 ;   xilf %r3, 4294967295
 ;   xr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r3, 0xffffffff
@@ -829,7 +829,7 @@ block0(v0: i128):
 ;   vno %v4, %v1, %v1
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -848,7 +848,7 @@ block0(v0: i64):
 ;   xilf %r2, 4294967295
 ;   xihf %r2, 4294967295
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r2, 0xffffffff
@@ -865,7 +865,7 @@ block0(v0: i32):
 ; block0:
 ;   xilf %r2, 4294967295
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r2, 0xffffffff
@@ -881,7 +881,7 @@ block0(v0: i16):
 ; block0:
 ;   xilf %r2, 4294967295
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r2, 0xffffffff
@@ -897,7 +897,7 @@ block0(v0: i8):
 ; block0:
 ;   xilf %r2, 4294967295
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xilf %r2, 0xffffffff
@@ -917,7 +917,7 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   vsel %v16, %v3, %v5, %v1
 ;   vst %v16, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -942,7 +942,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   ngr %r4, %r5
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ngr %r3, %r2
@@ -967,7 +967,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
@@ -991,7 +991,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
@@ -1015,7 +1015,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   nrk %r2, %r4, %r5
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
@@ -1037,7 +1037,7 @@ block0(v0: i32, v1: i32):
 ;   xr %r2, %r3
 ;   xilf %r2, 4294967295
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   xr %r2, %r3
@@ -1058,7 +1058,7 @@ block0(v0: i128, v1: i128):
 ;   vnx %v6, %v1, %v3
 ;   vst %v6, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1078,7 +1078,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vnx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25

--- a/cranelift/filetests/filetests/isa/s390x/bswap.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bswap.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   lrvgr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvgr %r2, %r2
@@ -27,7 +27,7 @@ block0(v0: i32):
 ; block0:
 ;   lrvr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r2, %r2
@@ -44,7 +44,7 @@ block0(v0: i16):
 ;   lrvr %r4, %r2
 ;   srlk %r2, %r4, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvr %r4, %r2

--- a/cranelift/filetests/filetests/isa/s390x/call.clif
+++ b/cranelift/filetests/filetests/isa/s390x/call.clif
@@ -22,7 +22,7 @@ block0(v0: i64):
 ;   basr %r14, %r5
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -56,7 +56,7 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -82,7 +82,7 @@ block0(v0: i32):
 ; block0:
 ;   llgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r2, %r2
@@ -106,7 +106,7 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -132,7 +132,7 @@ block0(v0: i32):
 ; block0:
 ;   lgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r2, %r2
@@ -154,7 +154,7 @@ block0(v0: i64):
 ;   brasl %r14, %g
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -182,7 +182,7 @@ block0(v0: i32):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -214,7 +214,7 @@ block0(v0: i64, v1: i64):
 ;   basr %r14, %r3
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -275,7 +275,7 @@ block0(v0: i64, v1: i32, v2: i32, v3: i32, v4: i16, v5: i16, v6: i16, v7: i8, v8
 ;   agrk %r2, %r4, %r3
 ;   lmg %r6, %r15, 48(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r6, %r15, 0x30(%r15)
@@ -341,7 +341,7 @@ block0(v0: i128, v1: i128, v2: i128, v3: i128, v4: i128, v5: i128, v6: i128, v7:
 ;   vaq %v16, %v16, %v17
 ;   vst %v16, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -383,7 +383,7 @@ block0:
 ;   lghi %r2, 0
 ;   brasl %r14, %g
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/s390x/cold-blocks.clif
@@ -25,7 +25,7 @@ block2:
 ;   jg label3
 ; block3:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r2, 0
@@ -58,7 +58,7 @@ block2 cold:
 ; block2:
 ;   lhi %r2, 97
 ;   jg label3
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r2, 0

--- a/cranelift/filetests/filetests/isa/s390x/concat-split.clif
+++ b/cranelift/filetests/filetests/isa/s390x/concat-split.clif
@@ -12,7 +12,7 @@ block0(v0: i64, v1: i64):
 ;   vlvgp %v4, %r4, %r3
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgp %v4, %r4, %r3
@@ -31,7 +31,7 @@ block0(v0: i128):
 ;   lgdr %r3, %f1
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/condbr.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condbr.clif
@@ -13,7 +13,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
@@ -45,7 +45,7 @@ block2:
 ; block2:
 ;   lghi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
@@ -78,7 +78,7 @@ block1:
 ; block3:
 ;   lghi %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3

--- a/cranelift/filetests/filetests/isa/s390x/condops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/condops.clif
@@ -16,7 +16,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   lgr %r2, %r4
 ;   locgre %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r2, %r2
@@ -38,7 +38,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   lgr %r2, %r4
 ;   locrlh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r2, %r2
@@ -61,7 +61,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   lgr %r2, %r4
 ;   locre %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clfi %r2, 0x2a
@@ -84,7 +84,7 @@ block0(v0: i32, v1: i8x16, v2: i8x16):
 ;   vlr %v24, %v25
 ;   jne 10 ; vlr %v24, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clfi %r2, 0x2a

--- a/cranelift/filetests/filetests/isa/s390x/constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/constants.clif
@@ -11,7 +11,7 @@ block0:
 ; block0:
 ;   lhi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r2, -1
@@ -27,7 +27,7 @@ block0:
 ; block0:
 ;   lhi %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r2, 0
@@ -43,7 +43,7 @@ block0:
 ; block0:
 ;   lghi %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r2, 0
@@ -59,7 +59,7 @@ block0:
 ; block0:
 ;   lgfi %r2, 65535
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfi %r2, 0xffff
@@ -75,7 +75,7 @@ block0:
 ; block0:
 ;   llilh %r2, 65535
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llilh %r2, 0xffff
@@ -91,7 +91,7 @@ block0:
 ; block0:
 ;   llihl %r2, 65535
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llihl %r2, 0xffff
@@ -107,7 +107,7 @@ block0:
 ; block0:
 ;   llihh %r2, 65535
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llihh %r2, 0xffff
@@ -123,7 +123,7 @@ block0:
 ; block0:
 ;   lghi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r2, -1
@@ -139,7 +139,7 @@ block0:
 ; block0:
 ;   lgfi %r2, -65536
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfi %r2, -0x10000
@@ -156,7 +156,7 @@ block0:
 ;   llihf %r2, 4081840291
 ;   iilf %r2, 303169594
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llihf %r2, 0xf34bf0a3
@@ -174,7 +174,7 @@ block0:
 ;   llihh %r2, 4841
 ;   iilh %r2, 7924
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llihh %r2, 0x12e9
@@ -191,7 +191,7 @@ block0:
 ; block0:
 ;   lhi %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r2, -1

--- a/cranelift/filetests/filetests/isa/s390x/conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/conversions.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ;   vlvgg %v4, %r3, 1
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v4
@@ -33,7 +33,7 @@ block0(v0: i32):
 ;   vlvgf %v4, %r3, 3
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v4
@@ -51,7 +51,7 @@ block0(v0: i32):
 ; block0:
 ;   llgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r2, %r2
@@ -69,7 +69,7 @@ block0(v0: i16):
 ;   vlvgh %v4, %r3, 7
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v4
@@ -87,7 +87,7 @@ block0(v0: i16):
 ; block0:
 ;   llghr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r2, %r2
@@ -103,7 +103,7 @@ block0(v0: i16):
 ; block0:
 ;   llhr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r2, %r2
@@ -121,7 +121,7 @@ block0(v0: i8):
 ;   vlvgb %v4, %r3, 15
 ;   vst %v4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v4
@@ -139,7 +139,7 @@ block0(v0: i8):
 ; block0:
 ;   llgcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgcr %r2, %r2
@@ -155,7 +155,7 @@ block0(v0: i8):
 ; block0:
 ;   llcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r2, %r2
@@ -171,7 +171,7 @@ block0(v0: i8):
 ; block0:
 ;   llcr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r2, %r2
@@ -189,7 +189,7 @@ block0(v0: i64):
 ;   vlvgp %v5, %r5, %r3
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srag %r5, %r3, 0x3f
@@ -210,7 +210,7 @@ block0(v0: i32):
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r5, %r3
@@ -229,7 +229,7 @@ block0(v0: i32):
 ; block0:
 ;   lgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r2, %r2
@@ -248,7 +248,7 @@ block0(v0: i16):
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r5, %r3
@@ -267,7 +267,7 @@ block0(v0: i16):
 ; block0:
 ;   lghr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r2, %r2
@@ -283,7 +283,7 @@ block0(v0: i16):
 ; block0:
 ;   lhr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r2, %r2
@@ -302,7 +302,7 @@ block0(v0: i8):
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r5, %r3
@@ -321,7 +321,7 @@ block0(v0: i8):
 ; block0:
 ;   lgbr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r2, %r2
@@ -337,7 +337,7 @@ block0(v0: i8):
 ; block0:
 ;   lbr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r2, %r2
@@ -353,7 +353,7 @@ block0(v0: i8):
 ; block0:
 ;   lbr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r2, %r2
@@ -370,7 +370,7 @@ block0(v0: i128):
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -388,7 +388,7 @@ block0(v0: i128):
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -406,7 +406,7 @@ block0(v0: i128):
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -424,7 +424,7 @@ block0(v0: i128):
 ;   vl %v1, 0(%r2)
 ;   vlgvg %r2, %v1, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -441,7 +441,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -457,7 +457,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -473,7 +473,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -489,7 +489,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -505,7 +505,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -521,7 +521,7 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -543,7 +543,7 @@ block0(v0: i128):
 ;   vlvgp %v20, %r3, %r3
 ;   vst %v20, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -569,7 +569,7 @@ block0(v0: i128):
 ;   lghi %r2, 0
 ;   locghine %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -593,7 +593,7 @@ block0(v0: i128):
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -617,7 +617,7 @@ block0(v0: i128):
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -641,7 +641,7 @@ block0(v0: i128):
 ;   lhi %r2, 0
 ;   lochine %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -665,7 +665,7 @@ block0(v0: i64, v1: i64):
 ;   vlvgp %v17, %r4, %r4
 ;   vst %v17, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r4, 0
@@ -687,7 +687,7 @@ block0(v0: i64, v1: i64):
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r3, 0
@@ -707,7 +707,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r3, 0
@@ -727,7 +727,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r3, 0
@@ -747,7 +747,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r3, 0
@@ -769,7 +769,7 @@ block0(v0: i32, v1: i32):
 ;   vlvgp %v17, %r4, %r4
 ;   vst %v17, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r4, 0
@@ -791,7 +791,7 @@ block0(v0: i32, v1: i32):
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r3, 0
@@ -811,7 +811,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r3, 0
@@ -831,7 +831,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r3, 0
@@ -851,7 +851,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r3, 0
@@ -874,7 +874,7 @@ block0(v0: i16, v1: i16):
 ;   vlvgp %v19, %r3, %r3
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r3, %r4
@@ -898,7 +898,7 @@ block0(v0: i16, v1: i16):
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r3
@@ -920,7 +920,7 @@ block0(v0: i16, v1: i16):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r3
@@ -942,7 +942,7 @@ block0(v0: i16, v1: i16):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r3
@@ -964,7 +964,7 @@ block0(v0: i16, v1: i16):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r3
@@ -988,7 +988,7 @@ block0(v0: i8, v1: i8):
 ;   vlvgp %v19, %r3, %r3
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r3, %r4
@@ -1012,7 +1012,7 @@ block0(v0: i8, v1: i8):
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1034,7 +1034,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1056,7 +1056,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1078,7 +1078,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1102,7 +1102,7 @@ block0(v0: i8, v1: i8):
 ;   vlvgp %v19, %r3, %r3
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r3, %r4
@@ -1126,7 +1126,7 @@ block0(v0: i8, v1: i8):
 ;   lghi %r2, 0
 ;   locghilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1148,7 +1148,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1170,7 +1170,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3
@@ -1192,7 +1192,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochilh %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r3

--- a/cranelift/filetests/filetests/isa/s390x/fence.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fence.clif
@@ -15,7 +15,7 @@ block0:
 ; block0:
 ;   bcr 14, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bnor %r0

--- a/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point-arch13.clif
@@ -20,7 +20,7 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -58,7 +58,7 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -97,7 +97,7 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -135,7 +135,7 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -174,7 +174,7 @@ block0(v0: f32):
 ;   wclfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -212,7 +212,7 @@ block0(v0: f32):
 ;   wcfeb %v20, %f0, 0, 5
 ;   vlgvf %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -252,7 +252,7 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -292,7 +292,7 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -332,7 +332,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -374,7 +374,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -415,7 +415,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -457,7 +457,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -498,7 +498,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -540,7 +540,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -583,7 +583,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -625,7 +625,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -661,7 +661,7 @@ block0(v0: i8):
 ;   vlvgf %v4, %r4, 0
 ;   wcelfb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r4, %r2
@@ -681,7 +681,7 @@ block0(v0: i8):
 ;   vlvgf %v4, %r4, 0
 ;   wcefb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r4, %r2
@@ -701,7 +701,7 @@ block0(v0: i16):
 ;   vlvgf %v4, %r4, 0
 ;   wcelfb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -721,7 +721,7 @@ block0(v0: i16):
 ;   vlvgf %v4, %r4, 0
 ;   wcefb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r4, %r2
@@ -740,7 +740,7 @@ block0(v0: i32):
 ;   vlvgf %v2, %r2, 0
 ;   wcelfb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
@@ -758,7 +758,7 @@ block0(v0: i32):
 ;   vlvgf %v2, %r2, 0
 ;   wcefb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
@@ -777,7 +777,7 @@ block0(v0: i64):
 ;   wcdlgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -797,7 +797,7 @@ block0(v0: i64):
 ;   wcdgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -817,7 +817,7 @@ block0(v0: i8):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgcr %r4, %r2
@@ -837,7 +837,7 @@ block0(v0: i8):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r4, %r2
@@ -857,7 +857,7 @@ block0(v0: i16):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r4, %r2
@@ -877,7 +877,7 @@ block0(v0: i16):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r4, %r2
@@ -897,7 +897,7 @@ block0(v0: i32):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r4, %r2
@@ -917,7 +917,7 @@ block0(v0: i32):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r4, %r2
@@ -936,7 +936,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   wcdlgb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -954,7 +954,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   wcdgb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -974,7 +974,7 @@ block0(v0: f32):
 ;   clfi %r2, 256
 ;   lochih %r2, 255
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgd %v2, %v0, 2, 8, 5
@@ -1000,7 +1000,7 @@ block0(v0: f32):
 ;   chi %r2, -128
 ;   lochil %r2, -128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgd %v2, %v0, 2, 8, 5
@@ -1026,7 +1026,7 @@ block0(v0: f32):
 ;   clfi %r2, 65535
 ;   lochih %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgd %v2, %v0, 2, 8, 5
@@ -1052,7 +1052,7 @@ block0(v0: f32):
 ;   chi %r2, -32768
 ;   lochil %r2, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgd %v2, %v0, 2, 8, 5
@@ -1076,7 +1076,7 @@ block0(v0: f32):
 ;   wclfeb %f2, %f0, 0, 5
 ;   vlgvf %r2, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgd %v2, %v0, 2, 8, 5
@@ -1096,7 +1096,7 @@ block0(v0: f32):
 ;   cebr %f0, %f0
 ;   lochio %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgd %v2, %v0, 2, 8, 5
@@ -1117,7 +1117,7 @@ block0(v0: f32):
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1139,7 +1139,7 @@ block0(v0: f32):
 ;   cebr %f0, %f0
 ;   locghio %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1162,7 +1162,7 @@ block0(v0: f64):
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1188,7 +1188,7 @@ block0(v0: f64):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -1214,7 +1214,7 @@ block0(v0: f64):
 ;   clgfi %r2, 65535
 ;   locghih %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1240,7 +1240,7 @@ block0(v0: f64):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -1267,7 +1267,7 @@ block0(v0: f64):
 ;   clgr %r2, %r4
 ;   locgrh %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1296,7 +1296,7 @@ block0(v0: f64):
 ;   cgr %r2, %r4
 ;   locgrl %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -1322,7 +1322,7 @@ block0(v0: f64):
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1342,7 +1342,7 @@ block0(v0: f64):
 ;   cdbr %f0, %f0
 ;   locghio %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5

--- a/cranelift/filetests/filetests/isa/s390x/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/s390x/floating-point.clif
@@ -18,7 +18,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.f32 0 ; le %f0, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -37,7 +37,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.f64 0 ; ld %f0, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -58,7 +58,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.f32 1 ; le %f0, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -77,7 +77,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.f64 1 ; ld %f0, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -98,7 +98,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   aebr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aebr %f0, %f2
@@ -114,7 +114,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   adbr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   adbr %f0, %f2
@@ -130,7 +130,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   sebr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sebr %f0, %f2
@@ -146,7 +146,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   sdbr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sdbr %f0, %f2
@@ -162,7 +162,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   meebr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   meebr %f0, %f2
@@ -178,7 +178,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   mdbr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mdbr %f0, %f2
@@ -194,7 +194,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   debr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   debr %f0, %f2
@@ -210,7 +210,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   ddbr %f0, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ddbr %f0, %f2
@@ -226,7 +226,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   wfminsb %f0, %f0, %f2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfminsb %f0, %f0, %f2, 1
@@ -242,7 +242,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   wfmindb %f0, %f0, %f2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmindb %f0, %f0, %f2, 1
@@ -258,7 +258,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   wfmaxsb %f0, %f0, %f2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmaxsb %f0, %f0, %f2, 1
@@ -274,7 +274,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   wfmaxdb %f0, %f0, %f2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmaxdb %f0, %f0, %f2, 1
@@ -290,7 +290,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   wfminsb %f0, %f0, %f2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfminsb %f0, %f0, %f2, 3
@@ -306,7 +306,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   wfmindb %f0, %f0, %f2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmindb %f0, %f0, %f2, 3
@@ -322,7 +322,7 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   wfmaxsb %f0, %f0, %f2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmaxsb %f0, %f0, %f2, 3
@@ -338,7 +338,7 @@ block0(v0: f64, v1: f64):
 ; block0:
 ;   wfmaxdb %f0, %f0, %f2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmaxdb %f0, %f0, %f2, 3
@@ -354,7 +354,7 @@ block0(v0: f32):
 ; block0:
 ;   sqebr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqebr %f0, %f0
@@ -370,7 +370,7 @@ block0(v0: f64):
 ; block0:
 ;   sqdbr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sqdbr %f0, %f0
@@ -386,7 +386,7 @@ block0(v0: f32):
 ; block0:
 ;   lpebr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lpebr %f0, %f0
@@ -402,7 +402,7 @@ block0(v0: f64):
 ; block0:
 ;   lpdbr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lpdbr %f0, %f0
@@ -418,7 +418,7 @@ block0(v0: f32):
 ; block0:
 ;   lcebr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcebr %f0, %f0
@@ -434,7 +434,7 @@ block0(v0: f64):
 ; block0:
 ;   lcdbr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcdbr %f0, %f0
@@ -450,7 +450,7 @@ block0(v0: f32):
 ; block0:
 ;   ldebr %f0, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f0, %f0
@@ -466,7 +466,7 @@ block0(v0: f64):
 ; block0:
 ;   ledbra %f0, 0, %f0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ledbr %f0, %f0
@@ -482,7 +482,7 @@ block0(v0: f32):
 ; block0:
 ;   fiebr %f0, 6, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fiebr %f0, 6, %f0
@@ -498,7 +498,7 @@ block0(v0: f64):
 ; block0:
 ;   fidbr %f0, 6, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fidbr %f0, 6, %f0
@@ -514,7 +514,7 @@ block0(v0: f32):
 ; block0:
 ;   fiebr %f0, 7, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fiebr %f0, 7, %f0
@@ -530,7 +530,7 @@ block0(v0: f64):
 ; block0:
 ;   fidbr %f0, 7, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fidbr %f0, 7, %f0
@@ -546,7 +546,7 @@ block0(v0: f32):
 ; block0:
 ;   fiebr %f0, 5, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fiebr %f0, 5, %f0
@@ -562,7 +562,7 @@ block0(v0: f64):
 ; block0:
 ;   fidbr %f0, 5, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fidbr %f0, 5, %f0
@@ -578,7 +578,7 @@ block0(v0: f32):
 ; block0:
 ;   fiebr %f0, 4, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fiebr %f0, 4, %f0
@@ -594,7 +594,7 @@ block0(v0: f64):
 ; block0:
 ;   fidbr %f0, 4, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   fidbr %f0, 4, %f0
@@ -610,7 +610,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ; block0:
 ;   wfmasb %f0, %f0, %f2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmasb %f0, %f0, %f2, %f4
@@ -626,7 +626,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ; block0:
 ;   wfmadb %f0, %f0, %f2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wfmadb %f0, %f0, %f2, %f4
@@ -643,7 +643,7 @@ block0(v0: f32, v1: f32):
 ;   bras %r1, 8 ; data.f32 NaN ; le %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -663,7 +663,7 @@ block0(v0: f64, v1: f64):
 ;   bras %r1, 12 ; data.f64 NaN ; ld %f3, 0(%r1)
 ;   vsel %v0, %v0, %v2, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -694,7 +694,7 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -734,7 +734,7 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -775,7 +775,7 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -815,7 +815,7 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -856,7 +856,7 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -896,7 +896,7 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -937,7 +937,7 @@ block0(v0: f32):
 ;   wclgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -977,7 +977,7 @@ block0(v0: f32):
 ;   wcgdb %v22, %v20, 0, 5
 ;   vlgvg %r2, %v22, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cebr %f0, %f0
@@ -1017,7 +1017,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1059,7 +1059,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1100,7 +1100,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1142,7 +1142,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1183,7 +1183,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1225,7 +1225,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1268,7 +1268,7 @@ block0(v0: f64):
 ;   wclgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1310,7 +1310,7 @@ block0(v0: f64):
 ;   wcgdb %v20, %f0, 0, 5
 ;   vlgvg %r2, %v20, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cdbr %f0, %f0
@@ -1347,7 +1347,7 @@ block0(v0: i8):
 ;   wcdlgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgcr %r4, %r2
@@ -1369,7 +1369,7 @@ block0(v0: i8):
 ;   wcdgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r4, %r2
@@ -1391,7 +1391,7 @@ block0(v0: i16):
 ;   wcdlgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r4, %r2
@@ -1413,7 +1413,7 @@ block0(v0: i16):
 ;   wcdgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r4, %r2
@@ -1435,7 +1435,7 @@ block0(v0: i32):
 ;   wcdlgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r4, %r2
@@ -1457,7 +1457,7 @@ block0(v0: i32):
 ;   wcdgb %f6, %f4, 0, 3
 ;   ledbra %f0, 4, %f6, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r4, %r2
@@ -1478,7 +1478,7 @@ block0(v0: i64):
 ;   wcdlgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1498,7 +1498,7 @@ block0(v0: i64):
 ;   wcdgb %f4, %f2, 0, 3
 ;   ledbra %f0, 4, %f4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1518,7 +1518,7 @@ block0(v0: i8):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgcr %r4, %r2
@@ -1538,7 +1538,7 @@ block0(v0: i8):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgbr %r4, %r2
@@ -1558,7 +1558,7 @@ block0(v0: i16):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghr %r4, %r2
@@ -1578,7 +1578,7 @@ block0(v0: i16):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghr %r4, %r2
@@ -1598,7 +1598,7 @@ block0(v0: i32):
 ;   ldgr %f4, %r4
 ;   wcdlgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r4, %r2
@@ -1618,7 +1618,7 @@ block0(v0: i32):
 ;   ldgr %f4, %r4
 ;   wcdgb %f0, %f4, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfr %r4, %r2
@@ -1637,7 +1637,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   wcdlgb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1655,7 +1655,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   wcdgb %f0, %f2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1676,7 +1676,7 @@ block0(v0: f32):
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1704,7 +1704,7 @@ block0(v0: f32):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1732,7 +1732,7 @@ block0(v0: f32):
 ;   clgfi %r2, 65535
 ;   locghih %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1760,7 +1760,7 @@ block0(v0: f32):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1789,7 +1789,7 @@ block0(v0: f32):
 ;   clgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1820,7 +1820,7 @@ block0(v0: f32):
 ;   cgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1848,7 +1848,7 @@ block0(v0: f32):
 ;   wclgdb %f4, %f2, 0, 5
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1870,7 +1870,7 @@ block0(v0: f32):
 ;   cebr %f0, %f0
 ;   locghio %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldebr %f2, %f0
@@ -1893,7 +1893,7 @@ block0(v0: f64):
 ;   clgfi %r2, 256
 ;   locghih %r2, 255
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1919,7 +1919,7 @@ block0(v0: f64):
 ;   cghi %r2, -128
 ;   locghil %r2, -128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -1945,7 +1945,7 @@ block0(v0: f64):
 ;   clgfi %r2, 65535
 ;   locghih %r2, -1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -1971,7 +1971,7 @@ block0(v0: f64):
 ;   cghi %r2, -32768
 ;   locghil %r2, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -1998,7 +1998,7 @@ block0(v0: f64):
 ;   clgr %r2, %r4
 ;   locgrh %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -2027,7 +2027,7 @@ block0(v0: f64):
 ;   cgr %r2, %r4
 ;   locgrl %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -2053,7 +2053,7 @@ block0(v0: f64):
 ;   wclgdb %f2, %f0, 0, 5
 ;   lgdr %r2, %f2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wclgdb %f2, %f0, 0, 5
@@ -2073,7 +2073,7 @@ block0(v0: f64):
 ;   cdbr %f0, %f0
 ;   locghio %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   wcgdb %f2, %f0, 0, 5
@@ -2092,7 +2092,7 @@ block0(v0: i64):
 ; block0:
 ;   ldgr %f0, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f0, %r2
@@ -2108,7 +2108,7 @@ block0(v0: f64):
 ; block0:
 ;   lgdr %r2, %f0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgdr %r2, %f0
@@ -2124,7 +2124,7 @@ block0(v0: i32):
 ; block0:
 ;   vlvgf %v0, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v0, %r2, 0
@@ -2140,7 +2140,7 @@ block0(v0: f32):
 ; block0:
 ;   vlgvf %r2, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r2, %v0, 0
@@ -2155,7 +2155,7 @@ block0(v0: f32):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -2169,7 +2169,7 @@ block0(v0: f64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fp_sp_pc.clif
@@ -18,7 +18,7 @@ block0:
 ;   lg %r2, 0(%r15)
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -46,7 +46,7 @@ block0:
 ;   lgr %r2, %r15
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -74,7 +74,7 @@ block0:
 ;   lg %r2, 272(%r15)
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/fpmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem-arch13.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   vlebrg %v0, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x00
@@ -29,7 +29,7 @@ block0(v0: i64):
 ; block0:
 ;   vlebrf %v0, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x00
@@ -47,7 +47,7 @@ block0(v0: f64, v1: i64):
 ; block0:
 ;   vstebrg %v0, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x00
@@ -65,7 +65,7 @@ block0(v0: f32, v1: i64):
 ; block0:
 ;   vstebrf %v0, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x00

--- a/cranelift/filetests/filetests/isa/s390x/fpmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/fpmem.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   ld %f0, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f0, 0(%r2)
@@ -27,7 +27,7 @@ block0(v0: i64):
 ; block0:
 ;   le %f0, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   le %f0, 0(%r2)
@@ -44,7 +44,7 @@ block0(v0: i64):
 ;   lrvg %r4, 0(%r2)
 ;   ldgr %f0, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -62,7 +62,7 @@ block0(v0: i64):
 ;   lrv %r4, 0(%r2)
 ;   vlvgf %v0, %r4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -79,7 +79,7 @@ block0(v0: f64, v1: i64):
 ; block0:
 ;   std %f0, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   std %f0, 0(%r2)
@@ -95,7 +95,7 @@ block0(v0: f32, v1: i64):
 ; block0:
 ;   ste %f0, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ste %f0, 0(%r2)
@@ -112,7 +112,7 @@ block0(v0: f64, v1: i64):
 ;   lgdr %r5, %f0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgdr %r5, %f0
@@ -130,7 +130,7 @@ block0(v0: f32, v1: i64):
 ;   vlgvf %r5, %v0, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v0, 0

--- a/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp-i128.clif
@@ -15,7 +15,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -39,7 +39,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -63,7 +63,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -89,7 +89,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -115,7 +115,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -141,7 +141,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -167,7 +167,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -193,7 +193,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -219,7 +219,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -245,7 +245,7 @@ block0(v0: i128, v1: i128):
 ;   lhi %r2, 0
 ;   lochinl %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/icmp.clif
@@ -13,7 +13,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgr %r2, %r3
@@ -34,7 +34,7 @@ block0(v0: i64, v1: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgfr %r2, %r3
@@ -55,7 +55,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r2, 1
@@ -76,7 +76,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgfi %r2, 0x8000
@@ -97,7 +97,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cg %r2, 0(%r3)
@@ -120,7 +120,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -141,7 +141,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgh %r2, 0(%r3)
@@ -164,7 +164,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -185,7 +185,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgf %r2, 0(%r3)
@@ -208,7 +208,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -228,7 +228,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cr %r2, %r3
@@ -249,7 +249,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chi %r2, 1
@@ -270,7 +270,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cfi %r2, 0x8000
@@ -291,7 +291,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c %r2, 0(%r3)
@@ -312,7 +312,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cy %r2, 0x1000(%r3)
@@ -335,7 +335,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   crl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -356,7 +356,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ch %r2, 0(%r3)
@@ -377,7 +377,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chy %r2, 0x1000(%r3)
@@ -400,7 +400,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   chrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -422,7 +422,7 @@ block0(v0: i16, v1: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r2
@@ -446,7 +446,7 @@ block0(v0: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r4, %r2
@@ -469,7 +469,7 @@ block0(v0: i16, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r2
@@ -494,7 +494,7 @@ block0(v0: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r4, %r2
@@ -517,7 +517,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r2
@@ -541,7 +541,7 @@ block0(v0: i8):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r4, %r2
@@ -565,7 +565,7 @@ block0(v0: i8, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r2
@@ -587,7 +587,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
@@ -608,7 +608,7 @@ block0(v0: i64, v1: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfr %r2, %r3
@@ -629,7 +629,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfi %r2, 1
@@ -650,7 +650,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clg %r2, 0(%r3)
@@ -673,7 +673,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -694,7 +694,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgf %r2, 0(%r3)
@@ -717,7 +717,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -739,7 +739,7 @@ block0(v0: i64, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgh %r3, 0(%r3)
@@ -763,7 +763,7 @@ block0(v0: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -783,7 +783,7 @@ block0(v0: i32, v1: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clr %r2, %r3
@@ -804,7 +804,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clfi %r2, 1
@@ -825,7 +825,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cl %r2, 0(%r3)
@@ -846,7 +846,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cly %r2, 0x1000(%r3)
@@ -869,7 +869,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -891,7 +891,7 @@ block0(v0: i32, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r3, 0(%r3)
@@ -915,7 +915,7 @@ block0(v0: i32):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -937,7 +937,7 @@ block0(v0: i16, v1: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -961,7 +961,7 @@ block0(v0: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -985,7 +985,7 @@ block0(v0: i16, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -1011,7 +1011,7 @@ block0(v0: i16):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -1034,7 +1034,7 @@ block0(v0: i8, v1: i8):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2
@@ -1058,7 +1058,7 @@ block0(v0: i8):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r4, %r2
@@ -1082,7 +1082,7 @@ block0(v0: i8, v1: i64):
 ;   lhi %r2, 0
 ;   lochil %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2

--- a/cranelift/filetests/filetests/isa/s390x/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/s390x/jumptable.clif
@@ -48,7 +48,7 @@ block5(v5: i32):
 ; block5:
 ;   ar %r2, %r5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfr %r3, %r2

--- a/cranelift/filetests/filetests/isa/s390x/leaf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf_with_preserve_frame_pointers.clif
@@ -19,7 +19,7 @@ block0(v0: i64):
 ; block0:
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/load-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/load-little.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   lrvg %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r2, 0(%r2)
@@ -29,7 +29,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvg %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -46,7 +46,7 @@ block0(v0: i64):
 ; block0:
 ;   llgc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgc %r2, 0(%r2)
@@ -62,7 +62,7 @@ block0(v0: i64):
 ; block0:
 ;   lgb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgb %r2, 0(%r2)
@@ -79,7 +79,7 @@ block0(v0: i64):
 ;   lrvh %r4, 0(%r2)
 ;   llghr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -99,7 +99,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   llghr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -118,7 +118,7 @@ block0(v0: i64):
 ;   lrvh %r4, 0(%r2)
 ;   lghr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -138,7 +138,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   lghr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -157,7 +157,7 @@ block0(v0: i64):
 ;   lrv %r4, 0(%r2)
 ;   llgfr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -177,7 +177,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
 ;   llgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -196,7 +196,7 @@ block0(v0: i64):
 ;   lrv %r4, 0(%r2)
 ;   lgfr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -216,7 +216,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
 ;   lgfr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -234,7 +234,7 @@ block0(v0: i64):
 ; block0:
 ;   lrv %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r2, 0(%r2)
@@ -252,7 +252,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrv %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -269,7 +269,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
@@ -285,7 +285,7 @@ block0(v0: i64):
 ; block0:
 ;   lb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
@@ -302,7 +302,7 @@ block0(v0: i64):
 ;   lrvh %r4, 0(%r2)
 ;   llhr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -322,7 +322,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   llhr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -341,7 +341,7 @@ block0(v0: i64):
 ;   lrvh %r4, 0(%r2)
 ;   lhr %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -361,7 +361,7 @@ block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   lhr %r2, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -379,7 +379,7 @@ block0(v0: i64):
 ; block0:
 ;   lrvh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r2, 0(%r2)
@@ -397,7 +397,7 @@ block0:
 ; block0:
 ;   larl %r1, %sym + 0 ; lrvh %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -414,7 +414,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
@@ -430,7 +430,7 @@ block0(v0: i64):
 ; block0:
 ;   lb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
@@ -446,7 +446,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/load.clif
+++ b/cranelift/filetests/filetests/isa/s390x/load.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   lg %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r2, 0(%r2)
@@ -29,7 +29,7 @@ block0:
 ; block0:
 ;   lgrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -45,7 +45,7 @@ block0(v0: i64):
 ; block0:
 ;   llgc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgc %r2, 0(%r2)
@@ -61,7 +61,7 @@ block0(v0: i64):
 ; block0:
 ;   lgb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgb %r2, 0(%r2)
@@ -77,7 +77,7 @@ block0(v0: i64):
 ; block0:
 ;   llgh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgh %r2, 0(%r2)
@@ -95,7 +95,7 @@ block0:
 ; block0:
 ;   llghrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -111,7 +111,7 @@ block0(v0: i64):
 ; block0:
 ;   lgh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgh %r2, 0(%r2)
@@ -129,7 +129,7 @@ block0:
 ; block0:
 ;   lghrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -145,7 +145,7 @@ block0(v0: i64):
 ; block0:
 ;   llgf %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgf %r2, 0(%r2)
@@ -163,7 +163,7 @@ block0:
 ; block0:
 ;   llgfrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -179,7 +179,7 @@ block0(v0: i64):
 ; block0:
 ;   lgf %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgf %r2, 0(%r2)
@@ -197,7 +197,7 @@ block0:
 ; block0:
 ;   lgfrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -213,7 +213,7 @@ block0(v0: i64):
 ; block0:
 ;   l %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   l %r2, 0(%r2)
@@ -231,7 +231,7 @@ block0:
 ; block0:
 ;   lrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -247,7 +247,7 @@ block0(v0: i64):
 ; block0:
 ;   ly %r2, 4096(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ly %r2, 0x1000(%r2)
@@ -263,7 +263,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
@@ -279,7 +279,7 @@ block0(v0: i64):
 ; block0:
 ;   lb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
@@ -295,7 +295,7 @@ block0(v0: i64):
 ; block0:
 ;   llh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
@@ -313,7 +313,7 @@ block0:
 ; block0:
 ;   llhrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -329,7 +329,7 @@ block0(v0: i64):
 ; block0:
 ;   lh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lh %r2, 0(%r2)
@@ -345,7 +345,7 @@ block0(v0: i64):
 ; block0:
 ;   lhy %r2, 4096(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhy %r2, 0x1000(%r2)
@@ -363,7 +363,7 @@ block0:
 ; block0:
 ;   lhrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -379,7 +379,7 @@ block0(v0: i64):
 ; block0:
 ;   llh %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llh %r2, 0(%r2)
@@ -397,7 +397,7 @@ block0:
 ; block0:
 ;   llhrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -413,7 +413,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
@@ -429,7 +429,7 @@ block0(v0: i64):
 ; block0:
 ;   lb %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lb %r2, 0(%r2)
@@ -445,7 +445,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)

--- a/cranelift/filetests/filetests/isa/s390x/minmax.clif
+++ b/cranelift/filetests/filetests/isa/s390x/minmax.clif
@@ -15,7 +15,7 @@ block0(v0: i128, v1: i128):
 ;   jnl 10 ; vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v5, 0(%r3)
@@ -39,7 +39,7 @@ block0(v0: i64, v1: i64):
 ;   clgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
@@ -57,7 +57,7 @@ block0(v0: i32, v1: i32):
 ;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clr %r2, %r3
@@ -77,7 +77,7 @@ block0(v0: i16, v1: i16):
 ;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r2, %r2
@@ -99,7 +99,7 @@ block0(v0: i8, v1: i8):
 ;   clr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r2, %r2
@@ -122,7 +122,7 @@ block0(v0: i128, v1: i128):
 ;   jnl 10 ; vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v5, 0(%r3)
@@ -146,7 +146,7 @@ block0(v0: i64, v1: i64):
 ;   clgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgr %r2, %r3
@@ -164,7 +164,7 @@ block0(v0: i32, v1: i32):
 ;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clr %r2, %r3
@@ -184,7 +184,7 @@ block0(v0: i16, v1: i16):
 ;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r2, %r2
@@ -206,7 +206,7 @@ block0(v0: i8, v1: i8):
 ;   clr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r2, %r2
@@ -229,7 +229,7 @@ block0(v0: i128, v1: i128):
 ;   jnl 10 ; vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v5, 0(%r3)
@@ -253,7 +253,7 @@ block0(v0: i64, v1: i64):
 ;   cgr %r2, %r3
 ;   locgrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgr %r2, %r3
@@ -271,7 +271,7 @@ block0(v0: i32, v1: i32):
 ;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cr %r2, %r3
@@ -291,7 +291,7 @@ block0(v0: i16, v1: i16):
 ;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r2, %r2
@@ -313,7 +313,7 @@ block0(v0: i8, v1: i8):
 ;   cr %r2, %r3
 ;   locrl %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r2, %r2
@@ -336,7 +336,7 @@ block0(v0: i128, v1: i128):
 ;   jnl 10 ; vlr %v5, %v3
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v5, 0(%r3)
@@ -360,7 +360,7 @@ block0(v0: i64, v1: i64):
 ;   cgr %r2, %r3
 ;   locgrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cgr %r2, %r3
@@ -378,7 +378,7 @@ block0(v0: i32, v1: i32):
 ;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cr %r2, %r3
@@ -398,7 +398,7 @@ block0(v0: i16, v1: i16):
 ;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r2, %r2
@@ -420,7 +420,7 @@ block0(v0: i8, v1: i8):
 ;   cr %r2, %r3
 ;   locrh %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r2, %r2

--- a/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
+++ b/cranelift/filetests/filetests/isa/s390x/multivalue-ret.clif
@@ -17,7 +17,7 @@ block1:
 ;   lghi %r4, 3
 ;   lghi %r5, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r2, 1
@@ -52,7 +52,7 @@ block1:
 ;   lgr %r2, %r6
 ;   lmg %r6, %r15, 48(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r6, %r15, 0x30(%r15)
@@ -86,7 +86,7 @@ block1:
 ;   bras %r1, 12 ; data.f64 2 ; ld %f4, 0(%r1)
 ;   bras %r1, 12 ; data.f64 3 ; ld %f6, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -135,7 +135,7 @@ block1:
 ;   std %f7, 0(%r2)
 ;   vsteg %v16, 8(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -10,7 +10,7 @@ block0(v0: r64, v1: r64):
 ; block0:
 ;   lgr %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r2, %r3
@@ -28,7 +28,7 @@ block0(v0: r64):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r2, 0
@@ -48,7 +48,7 @@ block0(v0: r64):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cghi %r2, -1
@@ -66,7 +66,7 @@ block0:
 ; block0:
 ;   lghi %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r2, 0
@@ -123,7 +123,7 @@ block3(v7: r64, v8: r64):
 ;   lg %r4, 0(%r4)
 ;   lmg %r11, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r11, %r15, 0x58(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/saturating-ops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/saturating-ops.clif
@@ -14,7 +14,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   lghi %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r2, 0

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -20,7 +20,7 @@ block0(v0: i128, v1: i128):
 ;   vo %v26, %v20, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -54,7 +54,7 @@ block0(v0: i128, v1: i64):
 ;   vo %v27, %v21, %v25
 ;   vst %v27, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -88,7 +88,7 @@ block0(v0: i128):
 ;   vo %v24, %v18, %v22
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -115,7 +115,7 @@ block0(v0: i64, v1: i128):
 ;   lcr %r4, %r3
 ;   rllg %r2, %r2, 0(%r4)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -135,7 +135,7 @@ block0(v0: i64, v1: i64):
 ;   lcr %r5, %r3
 ;   rllg %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r3
@@ -153,7 +153,7 @@ block0(v0: i64):
 ; block0:
 ;   rllg %r2, %r2, 47
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rllg %r2, %r2, 0x2f
@@ -172,7 +172,7 @@ block0(v0: i32, v1: i128):
 ;   lcr %r4, %r3
 ;   rll %r2, %r2, 0(%r4)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -192,7 +192,7 @@ block0(v0: i32, v1: i32):
 ;   lcr %r5, %r3
 ;   rll %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r3
@@ -210,7 +210,7 @@ block0(v0: i32):
 ; block0:
 ;   rll %r2, %r2, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rll %r2, %r2, 0xf
@@ -234,7 +234,7 @@ block0(v0: i16, v1: i128):
 ;   srlk %r2, %r2, 0(%r3)
 ;   ork %r2, %r4, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -264,7 +264,7 @@ block0(v0: i16, v1: i16):
 ;   srlk %r3, %r5, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -290,7 +290,7 @@ block0(v0: i16):
 ;   srlk %r4, %r4, 10
 ;   or %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -317,7 +317,7 @@ block0(v0: i8, v1: i128):
 ;   srlk %r2, %r2, 0(%r3)
 ;   ork %r2, %r4, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -347,7 +347,7 @@ block0(v0: i8, v1: i8):
 ;   srlk %r3, %r5, 0(%r3)
 ;   or %r2, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2
@@ -373,7 +373,7 @@ block0(v0: i8):
 ;   srlk %r4, %r4, 3
 ;   or %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r4, %r2
@@ -401,7 +401,7 @@ block0(v0: i128, v1: i128):
 ;   vo %v26, %v20, %v24
 ;   vst %v26, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -435,7 +435,7 @@ block0(v0: i128, v1: i64):
 ;   vo %v27, %v21, %v25
 ;   vst %v27, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -469,7 +469,7 @@ block0(v0: i128):
 ;   vo %v24, %v18, %v22
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -495,7 +495,7 @@ block0(v0: i64, v1: i128):
 ;   vlgvg %r3, %v2, 1
 ;   rllg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -513,7 +513,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   rllg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rllg %r2, %r2, 0(%r3)
@@ -530,7 +530,7 @@ block0(v0: i64):
 ; block0:
 ;   rllg %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rllg %r2, %r2, 0x11
@@ -548,7 +548,7 @@ block0(v0: i32, v1: i128):
 ;   vlgvg %r3, %v2, 1
 ;   rll %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -566,7 +566,7 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   rll %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rll %r2, %r2, 0(%r3)
@@ -583,7 +583,7 @@ block0(v0: i32):
 ; block0:
 ;   rll %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   rll %r2, %r2, 0x11
@@ -607,7 +607,7 @@ block0(v0: i16, v1: i128):
 ;   srlk %r2, %r2, 0(%r4)
 ;   ork %r2, %r5, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -637,7 +637,7 @@ block0(v0: i16, v1: i16):
 ;   srlk %r4, %r5, 0(%r2)
 ;   ork %r2, %r3, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -663,7 +663,7 @@ block0(v0: i16):
 ;   srlk %r4, %r4, 6
 ;   or %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -690,7 +690,7 @@ block0(v0: i8, v1: i128):
 ;   srlk %r2, %r2, 0(%r4)
 ;   ork %r2, %r5, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -720,7 +720,7 @@ block0(v0: i8, v1: i8):
 ;   srlk %r4, %r5, 0(%r2)
 ;   ork %r2, %r3, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2
@@ -746,7 +746,7 @@ block0(v0: i8):
 ;   srlk %r4, %r4, 5
 ;   or %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r4, %r2
@@ -770,7 +770,7 @@ block0(v0: i128, v1: i128):
 ;   vsrl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -796,7 +796,7 @@ block0(v0: i128, v1: i64):
 ;   vsrl %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -822,7 +822,7 @@ block0(v0: i128):
 ;   vsrl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -844,7 +844,7 @@ block0(v0: i64, v1: i128):
 ;   vlgvg %r3, %v2, 1
 ;   srlg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -862,7 +862,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   srlg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srlg %r2, %r2, 0(%r3)
@@ -879,7 +879,7 @@ block0(v0: i64):
 ; block0:
 ;   srlg %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srlg %r2, %r2, 0x11
@@ -898,7 +898,7 @@ block0(v0: i32, v1: i128):
 ;   nill %r3, 31
 ;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -919,7 +919,7 @@ block0(v0: i32, v1: i32):
 ;   nill %r5, 31
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -938,7 +938,7 @@ block0(v0: i32):
 ; block0:
 ;   srlk %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srlk %r2, %r2, 0x11
@@ -958,7 +958,7 @@ block0(v0: i16, v1: i128):
 ;   nill %r5, 15
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -980,7 +980,7 @@ block0(v0: i16, v1: i16):
 ;   nill %r3, 15
 ;   srlk %r2, %r5, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r5, %r2
@@ -1000,7 +1000,7 @@ block0(v0: i16):
 ;   llhr %r4, %r2
 ;   srlk %r2, %r4, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llhr %r4, %r2
@@ -1021,7 +1021,7 @@ block0(v0: i8, v1: i128):
 ;   nill %r5, 7
 ;   srlk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1043,7 +1043,7 @@ block0(v0: i8, v1: i8):
 ;   nill %r3, 7
 ;   srlk %r2, %r5, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r5, %r2
@@ -1063,7 +1063,7 @@ block0(v0: i8):
 ;   llcr %r4, %r2
 ;   srlk %r2, %r4, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llcr %r4, %r2
@@ -1085,7 +1085,7 @@ block0(v0: i128, v1: i128):
 ;   vsl %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1111,7 +1111,7 @@ block0(v0: i128, v1: i64):
 ;   vsl %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1137,7 +1137,7 @@ block0(v0: i128):
 ;   vsl %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1159,7 +1159,7 @@ block0(v0: i64, v1: i128):
 ;   vlgvg %r3, %v2, 1
 ;   sllg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1177,7 +1177,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sllg %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllg %r2, %r2, 0(%r3)
@@ -1194,7 +1194,7 @@ block0(v0: i64):
 ; block0:
 ;   sllg %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllg %r2, %r2, 0x11
@@ -1213,7 +1213,7 @@ block0(v0: i32, v1: i128):
 ;   nill %r3, 31
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1234,7 +1234,7 @@ block0(v0: i32, v1: i32):
 ;   nill %r5, 31
 ;   sllk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -1253,7 +1253,7 @@ block0(v0: i32):
 ; block0:
 ;   sllk %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r2, 0x11
@@ -1272,7 +1272,7 @@ block0(v0: i16, v1: i128):
 ;   nill %r3, 15
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1293,7 +1293,7 @@ block0(v0: i16, v1: i16):
 ;   nill %r5, 15
 ;   sllk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -1312,7 +1312,7 @@ block0(v0: i16):
 ; block0:
 ;   sllk %r2, %r2, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r2, 0xa
@@ -1331,7 +1331,7 @@ block0(v0: i8, v1: i128):
 ;   nill %r3, 7
 ;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1352,7 +1352,7 @@ block0(v0: i8, v1: i8):
 ;   nill %r5, 7
 ;   sllk %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -1371,7 +1371,7 @@ block0(v0: i8):
 ; block0:
 ;   sllk %r2, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r2, 3
@@ -1392,7 +1392,7 @@ block0(v0: i128, v1: i128):
 ;   vsra %v18, %v16, %v6
 ;   vst %v18, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1418,7 +1418,7 @@ block0(v0: i128, v1: i64):
 ;   vsra %v19, %v17, %v7
 ;   vst %v19, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1444,7 +1444,7 @@ block0(v0: i128):
 ;   vsra %v16, %v6, %v4
 ;   vst %v16, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r3)
@@ -1466,7 +1466,7 @@ block0(v0: i64, v1: i128):
 ;   vlgvg %r3, %v2, 1
 ;   srag %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1484,7 +1484,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   srag %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srag %r2, %r2, 0(%r3)
@@ -1501,7 +1501,7 @@ block0(v0: i64):
 ; block0:
 ;   srag %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srag %r2, %r2, 0x11
@@ -1520,7 +1520,7 @@ block0(v0: i32, v1: i128):
 ;   nill %r3, 31
 ;   srak %r2, %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1541,7 +1541,7 @@ block0(v0: i32, v1: i32):
 ;   nill %r5, 31
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -1560,7 +1560,7 @@ block0(v0: i32):
 ; block0:
 ;   srak %r2, %r2, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   srak %r2, %r2, 0x11
@@ -1580,7 +1580,7 @@ block0(v0: i16, v1: i128):
 ;   nill %r5, 15
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1602,7 +1602,7 @@ block0(v0: i16, v1: i16):
 ;   nill %r3, 15
 ;   srak %r2, %r5, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r5, %r2
@@ -1622,7 +1622,7 @@ block0(v0: i16):
 ;   lhr %r4, %r2
 ;   srak %r2, %r4, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhr %r4, %r2
@@ -1643,7 +1643,7 @@ block0(v0: i8, v1: i128):
 ;   nill %r5, 7
 ;   srak %r2, %r2, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r3)
@@ -1665,7 +1665,7 @@ block0(v0: i8, v1: i8):
 ;   nill %r3, 7
 ;   srak %r2, %r5, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r5, %r2
@@ -1685,7 +1685,7 @@ block0(v0: i8):
 ;   lbr %r4, %r2
 ;   srak %r2, %r4, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lbr %r4, %r2

--- a/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
@@ -9,7 +9,7 @@ block0:
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -22,7 +22,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -39,7 +39,7 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -61,7 +61,7 @@ block0(v0: i64):
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
@@ -101,7 +101,7 @@ block0(v0: i64):
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
@@ -133,7 +133,7 @@ block0(v0: i64):
 ; block0:
 ;   aghi %r15, 168
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   la %r1, 0xa8(%r2)
@@ -157,7 +157,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r15, 400000
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
@@ -183,7 +183,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r15, 4000000
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgrtle %r15, %r2 ; trap: stk_ovf
@@ -214,7 +214,7 @@ block0(v0: i64):
 ; block0:
 ;   aghi %r15, 24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
@@ -246,7 +246,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r15, 400000
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
@@ -279,7 +279,7 @@ block0(v0: i64):
 ; block0:
 ;   agfi %r15, 4000000
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
@@ -309,7 +309,7 @@ block0(v0: i64):
 ; block0:
 ;   aghi %r15, 24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgfi %r1, 0xf4240

--- a/cranelift/filetests/filetests/isa/s390x/stack.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack.clif
@@ -17,7 +17,7 @@ block0:
 ;   la %r2, 0(%r15)
 ;   aghi %r15, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aghi %r15, -8
@@ -41,7 +41,7 @@ block0:
 ;   la %r2, 0(%r15)
 ;   agfi %r15, 100008
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8
@@ -65,7 +65,7 @@ block0:
 ;   lg %r2, 0(%r3)
 ;   aghi %r15, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aghi %r15, -8
@@ -91,7 +91,7 @@ block0:
 ;   lg %r2, 0(%r3)
 ;   agfi %r15, 100008
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8
@@ -116,7 +116,7 @@ block0(v0: i64):
 ;   stg %r2, 0(%r4)
 ;   aghi %r15, 8
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   aghi %r15, -8
@@ -142,7 +142,7 @@ block0(v0: i64):
 ;   stg %r2, 0(%r4)
 ;   agfi %r15, 100008
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   agfi %r15, -0x186a8

--- a/cranelift/filetests/filetests/isa/s390x/store-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/store-little.clif
@@ -11,7 +11,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   strvg %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvg %r2, 0(%r3)
@@ -29,7 +29,7 @@ block0(v0: i64):
 ; block0:
 ;   larl %r1, %sym + 0 ; strvg %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -48,7 +48,7 @@ block0(v0: i64):
 ;   lghi %r4, 12345
 ;   strvg %r4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r4, 0x3039
@@ -65,7 +65,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -82,7 +82,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -98,7 +98,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   strvh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
@@ -116,7 +116,7 @@ block0(v0: i64):
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -134,7 +134,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 14640
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3930
@@ -150,7 +150,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   strv %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strv %r2, 0(%r3)
@@ -168,7 +168,7 @@ block0(v0: i64):
 ; block0:
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -187,7 +187,7 @@ block0(v0: i64):
 ;   lghi %r4, 12345
 ;   strv %r4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lghi %r4, 0x3039
@@ -204,7 +204,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   strv %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strv %r2, 0(%r3)
@@ -222,7 +222,7 @@ block0(v0: i32):
 ; block0:
 ;   larl %r1, %sym + 0 ; strv %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -241,7 +241,7 @@ block0(v0: i64):
 ;   lhi %r4, 12345
 ;   strv %r4, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lhi %r4, 0x3039
@@ -258,7 +258,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -275,7 +275,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -291,7 +291,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   strvh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
@@ -309,7 +309,7 @@ block0(v0: i32):
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -327,7 +327,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 14640
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3930
@@ -343,7 +343,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   strvh %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strvh %r2, 0(%r3)
@@ -361,7 +361,7 @@ block0(v0: i16):
 ; block0:
 ;   larl %r1, %sym + 0 ; strvh %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r1, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -379,7 +379,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 14640
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3930
@@ -395,7 +395,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -412,7 +412,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -428,7 +428,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -444,7 +444,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   stcy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stcy %r2, 0x1000(%r3)
@@ -461,7 +461,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -478,7 +478,7 @@ block0(v0: i64):
 ; block0:
 ;   mviy 4096(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mviy 0x1000(%r2), 0x7b

--- a/cranelift/filetests/filetests/isa/s390x/store.clif
+++ b/cranelift/filetests/filetests/isa/s390x/store.clif
@@ -11,7 +11,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stg %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stg %r2, 0(%r3)
@@ -29,7 +29,7 @@ block0(v0: i64):
 ; block0:
 ;   stgrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stgrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -46,7 +46,7 @@ block0(v0: i64):
 ; block0:
 ;   mvghi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvghi 0(%r2), 0x3039
@@ -62,7 +62,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -79,7 +79,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -95,7 +95,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   sth %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
@@ -113,7 +113,7 @@ block0(v0: i64):
 ; block0:
 ;   sthrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -130,7 +130,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3039
@@ -146,7 +146,7 @@ block0(v0: i64, v1: i64):
 ; block0:
 ;   st %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   st %r2, 0(%r3)
@@ -164,7 +164,7 @@ block0(v0: i64):
 ; block0:
 ;   strl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -181,7 +181,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhi 0(%r2), 0x3039
@@ -197,7 +197,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   st %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   st %r2, 0(%r3)
@@ -215,7 +215,7 @@ block0(v0: i32):
 ; block0:
 ;   strl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   strl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -231,7 +231,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   sty %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sty %r2, 0x1000(%r3)
@@ -248,7 +248,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhi 0(%r2), 0x3039
@@ -264,7 +264,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -281,7 +281,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -297,7 +297,7 @@ block0(v0: i32, v1: i64):
 ; block0:
 ;   sth %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
@@ -315,7 +315,7 @@ block0(v0: i32):
 ; block0:
 ;   sthrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -332,7 +332,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3039
@@ -348,7 +348,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   sth %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sth %r2, 0(%r3)
@@ -366,7 +366,7 @@ block0(v0: i16):
 ; block0:
 ;   sthrl %r2, %sym + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sthrl %r2, 0 ; reloc_external PCRel32Dbl %sym 2
@@ -382,7 +382,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   sthy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sthy %r2, 0x1000(%r3)
@@ -399,7 +399,7 @@ block0(v0: i64):
 ; block0:
 ;   mvhhi 0(%r2), 12345
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvhhi 0(%r2), 0x3039
@@ -415,7 +415,7 @@ block0(v0: i16, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -432,7 +432,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -448,7 +448,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   stc %r2, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stc %r2, 0(%r3)
@@ -464,7 +464,7 @@ block0(v0: i8, v1: i64):
 ; block0:
 ;   stcy %r2, 4096(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stcy %r2, 0x1000(%r3)
@@ -481,7 +481,7 @@ block0(v0: i64):
 ; block0:
 ;   mvi 0(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mvi 0(%r2), 0x7b
@@ -498,7 +498,7 @@ block0(v0: i64):
 ; block0:
 ;   mviy 4096(%r2), 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mviy 0x1000(%r2), 0x7b

--- a/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/s390x/struct-arg.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ; block0:
 ;   llc %r2, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r2, 0(%r2)
@@ -31,7 +31,7 @@ block0(v0: i64, v1: i64):
 ;   llc %r4, 0(%r2)
 ;   ark %r2, %r3, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   llc %r3, 0(%r3)
@@ -57,7 +57,7 @@ block0(v0: i64):
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -87,7 +87,7 @@ block0(v0: i64, v1: i64):
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -114,7 +114,7 @@ block0(v0: i64, v1: i64):
 ;   llc %r4, 0(%r5)
 ;   ark %r2, %r3, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lgr %r5, %r3
@@ -143,7 +143,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   brasl %r14, userextname0
 ;   lmg %r14, %r15, 592(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -184,7 +184,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   brasl %r14, userextname0
 ;   lmg %r7, %r15, 1304(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r7, %r15, 0x38(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/symbols.clif
+++ b/cranelift/filetests/filetests/isa/s390x/symbols.clif
@@ -17,7 +17,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data %my_global + 0 ; lg %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -40,7 +40,7 @@ block0:
 ; block0:
 ;   larl %r2, %my_global_colo + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r2, 0 ; reloc_external PCRel32Dbl %my_global_colo 2
@@ -58,7 +58,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data %my_func + 0 ; lg %r2, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -81,7 +81,7 @@ block0:
 ; block0:
 ;   larl %r2, %my_func_colo + 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   larl %r2, 0 ; reloc_external PCRel32Dbl %my_func_colo 2

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -24,7 +24,7 @@ block0(v0: i32):
 ;   agr %r2, %r5
 ;   lmg %r12, %r15, 256(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r12, %r15, 0x60(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/traps.clif
+++ b/cranelift/filetests/filetests/isa/s390x/traps.clif
@@ -13,7 +13,7 @@ block0:
 ; VCode:
 ; block0:
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x00, 0x00 ; trap: user0
@@ -26,7 +26,7 @@ block0:
 ; VCode:
 ; block0:
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x00, 0x00 ; trap: user0
@@ -47,7 +47,7 @@ block0(v0: i64):
 ;   br %r14
 ; block1:
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfi %r2, 0x2a
@@ -73,7 +73,7 @@ block0(v0: i64):
 ;   br %r14
 ; block2:
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfi %r2, 0x2a
@@ -99,7 +99,7 @@ block0(v0: i64):
 ;   br %r14
 ; block2:
 ;   .word 0x0000 # trap=user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   clgfi %r2, 0x2a
@@ -119,7 +119,7 @@ block0:
 ; block0:
 ;   .word 0x0001 # debugtrap
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x00, 0x01

--- a/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/s390x/uadd_overflow_trap.clif
@@ -13,7 +13,7 @@ block0(v0: i32):
 ;   alfi %r2, 127
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alfi %r2, 0x7f
@@ -32,7 +32,7 @@ block0(v0: i32):
 ;   alfi %r2, 127
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alfi %r2, 0x7f
@@ -50,7 +50,7 @@ block0(v0: i32, v1: i32):
 ;   alr %r2, %r3
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   alr %r2, %r3
@@ -69,7 +69,7 @@ block0(v0: i64):
 ;   algfi %r2, 127
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfi %r2, 0x7f
@@ -88,7 +88,7 @@ block0(v0: i64):
 ;   algfi %r2, 127
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfi %r2, 0x7f
@@ -106,7 +106,7 @@ block0(v0: i64, v1: i64):
 ;   algr %r2, %r3
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algr %r2, %r3
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i32):
 ;   algfr %r2, %r3
 ;   jgnle .+2 # trap=user0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   algfr %r2, %r3

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -18,7 +18,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -79,7 +79,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -168,7 +168,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
@@ -229,7 +229,7 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ;   basr %r14, %r4
 ;   lmg %r14, %r15, 272(%r15)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)

--- a/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-arithmetic.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vag %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vag %v24, %v24, %v25
@@ -27,7 +27,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vaf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vaf %v24, %v24, %v25
@@ -43,7 +43,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vah %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vah %v24, %v24, %v25
@@ -59,7 +59,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vab %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vab %v24, %v24, %v25
@@ -75,7 +75,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vsg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsg %v24, %v24, %v25
@@ -91,7 +91,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vsf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsf %v24, %v24, %v25
@@ -107,7 +107,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vsh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsh %v24, %v24, %v25
@@ -123,7 +123,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vsb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsb %v24, %v24, %v25
@@ -139,7 +139,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlpg %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlpg %v24, %v24
@@ -155,7 +155,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlpf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlpf %v24, %v24
@@ -171,7 +171,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlph %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlph %v24, %v24
@@ -187,7 +187,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlpb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlpb %v24, %v24
@@ -203,7 +203,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlcg %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlcg %v24, %v24
@@ -219,7 +219,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlcf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlcf %v24, %v24
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlch %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlch %v24, %v24
@@ -251,7 +251,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlcb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlcb %v24, %v24
@@ -267,7 +267,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vmxlg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxlg %v24, %v24, %v25
@@ -283,7 +283,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmxlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxlf %v24, %v24, %v25
@@ -299,7 +299,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmxlh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxlh %v24, %v24, %v25
@@ -315,7 +315,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmxlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxlb %v24, %v24, %v25
@@ -331,7 +331,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vmnlg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnlg %v24, %v24, %v25
@@ -347,7 +347,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmnlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnlf %v24, %v24, %v25
@@ -363,7 +363,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmnlh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnlh %v24, %v24, %v25
@@ -379,7 +379,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmnlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnlb %v24, %v24, %v25
@@ -395,7 +395,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vmxg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxg %v24, %v24, %v25
@@ -411,7 +411,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmxf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxf %v24, %v24, %v25
@@ -427,7 +427,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmxh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxh %v24, %v24, %v25
@@ -443,7 +443,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmxb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmxb %v24, %v24, %v25
@@ -459,7 +459,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vmng %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmng %v24, %v24, %v25
@@ -475,7 +475,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmnf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnf %v24, %v24, %v25
@@ -491,7 +491,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmnh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnh %v24, %v24, %v25
@@ -507,7 +507,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmnb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmnb %v24, %v24, %v25
@@ -523,7 +523,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vavglg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vavglg %v24, %v24, %v25
@@ -539,7 +539,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vavglf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vavglf %v24, %v24, %v25
@@ -555,7 +555,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vavglh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vavglh %v24, %v24, %v25
@@ -571,7 +571,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vavglb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vavglb %v24, %v24, %v25
@@ -589,7 +589,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchlg %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vag %v3, %v24, %v25
@@ -609,7 +609,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchlf %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vaf %v3, %v24, %v25
@@ -629,7 +629,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchlh %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vah %v3, %v24, %v25
@@ -649,7 +649,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchlb %v5, %v24, %v3
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vab %v3, %v24, %v25
@@ -673,7 +673,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vag %v21, %v17, %v19
 ;   vpksg %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v3, %v24
@@ -701,7 +701,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vaf %v21, %v17, %v19
 ;   vpksf %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphh %v3, %v24
@@ -729,7 +729,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vah %v21, %v17, %v19
 ;   vpksh %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphb %v3, %v24
@@ -753,7 +753,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchlg %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsg %v3, %v24, %v25
@@ -773,7 +773,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchlf %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsf %v3, %v24, %v25
@@ -793,7 +793,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchlh %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsh %v3, %v24, %v25
@@ -813,7 +813,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchlb %v5, %v24, %v25
 ;   vn %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsb %v3, %v24, %v25
@@ -837,7 +837,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vsg %v21, %v17, %v19
 ;   vpksg %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v3, %v24
@@ -865,7 +865,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vsf %v21, %v17, %v19
 ;   vpksf %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphh %v3, %v24
@@ -893,7 +893,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vsh %v21, %v17, %v19
 ;   vpksh %v24, %v7, %v21
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphb %v3, %v24
@@ -920,7 +920,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vaf %v19, %v25, %v17
 ;   vpkg %v24, %v7, %v19
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 0x20
@@ -946,7 +946,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vah %v19, %v25, %v17
 ;   vpkf %v24, %v7, %v19
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 0x10
@@ -972,7 +972,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vab %v19, %v25, %v17
 ;   vpkh %v24, %v7, %v19
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 8
@@ -998,7 +998,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vaf %v19, %v25, %v17
 ;   vpkg %v24, %v19, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 0x20
@@ -1024,7 +1024,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vah %v19, %v25, %v17
 ;   vpkf %v24, %v19, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 0x10
@@ -1050,7 +1050,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vab %v19, %v25, %v17
 ;   vpkh %v24, %v19, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 8
@@ -1077,7 +1077,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   msgr %r3, %r2
 ;   vlvgp %v24, %r5, %r3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1099,7 +1099,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlf %v24, %v24, %v25
@@ -1115,7 +1115,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmlhw %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlhw %v24, %v24, %v25
@@ -1131,7 +1131,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlb %v24, %v24, %v25
@@ -1154,7 +1154,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   mlgr %r2, %r2
 ;   vlvgp %v24, %r4, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r3, %v24, 0
@@ -1177,7 +1177,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmlhf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlhf %v24, %v24, %v25
@@ -1193,7 +1193,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmlhh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlhh %v24, %v24, %v25
@@ -1209,7 +1209,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmlhb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmlhb %v24, %v24, %v25
@@ -1232,7 +1232,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   mgrk %r2, %r2, %r5
 ;   vlvgp %v24, %r4, %r2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1255,7 +1255,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vmhf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmhf %v24, %v24, %v25
@@ -1271,7 +1271,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vmhh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmhh %v24, %v24, %v25
@@ -1287,7 +1287,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmhb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmhb %v24, %v24, %v25
@@ -1311,7 +1311,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vmoh %v5, %v24, %v25
 ;   vaf %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmeh %v3, %v24, %v25
@@ -1341,7 +1341,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vesraf %v1, %v31, 15
 ;   vpksf %v24, %v21, %v1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphh %v3, %v24
@@ -1393,7 +1393,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vesrag %v2, %v31, 31
 ;   vpksg %v24, %v1, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v3, %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitcast.clif
@@ -14,7 +14,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -31,7 +31,7 @@ block0(v0: i64x2):
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v2, %v24, %v24, 4
@@ -51,7 +51,7 @@ block0(v0: i64x2):
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v2, %v24, %v24, 4
@@ -68,7 +68,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -82,7 +82,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -96,7 +96,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14
@@ -110,7 +110,7 @@ block0(v0: i64x2):
 ; VCode:
 ; block0:
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitops.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vpopctg %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpopctg %v24, %v24
@@ -27,7 +27,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vpopctf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpopctf %v24, %v24
@@ -43,7 +43,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vpopcth %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpopcth %v24, %v24
@@ -59,7 +59,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vpopctb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpopctb %v24, %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-bitwise.clif
@@ -12,7 +12,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vn %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
@@ -28,7 +28,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vn %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
@@ -44,7 +44,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vn %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
@@ -60,7 +60,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vn %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vn %v24, %v24, %v25
@@ -76,7 +76,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vo %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
@@ -92,7 +92,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vo %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
@@ -108,7 +108,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vo %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
@@ -124,7 +124,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vo %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vo %v24, %v24, %v25
@@ -140,7 +140,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
@@ -156,7 +156,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
@@ -172,7 +172,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
@@ -188,7 +188,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vx %v24, %v24, %v25
@@ -204,7 +204,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vnc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
@@ -220,7 +220,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vnc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
@@ -236,7 +236,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vnc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
@@ -252,7 +252,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vnc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnc %v24, %v24, %v25
@@ -268,7 +268,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   voc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
@@ -284,7 +284,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   voc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
@@ -300,7 +300,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   voc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
@@ -316,7 +316,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   voc %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   voc %v24, %v24, %v25
@@ -332,7 +332,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vnx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
@@ -348,7 +348,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vnx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
@@ -364,7 +364,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vnx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
@@ -380,7 +380,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vnx %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vnx %v24, %v24, %v25
@@ -396,7 +396,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vno %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
@@ -412,7 +412,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vno %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
@@ -428,7 +428,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vno %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
@@ -444,7 +444,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vno %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vno %v24, %v24, %v24
@@ -460,7 +460,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ; block0:
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
@@ -476,7 +476,7 @@ block0(v0: i32x4, v1: i32x4, v2: i32x4):
 ; block0:
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
@@ -492,7 +492,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ; block0:
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24
@@ -508,7 +508,7 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
 ; block0:
 ;   vsel %v24, %v25, %v26, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsel %v24, %v25, %v26, %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants-le-lane.clif
@@ -11,7 +11,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -27,7 +27,7 @@ block0:
 ; block0:
 ;   vrepig %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, 0x7fff
@@ -43,7 +43,7 @@ block0:
 ; block0:
 ;   vrepig %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, -0x8000
@@ -59,7 +59,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -81,7 +81,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -103,7 +103,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000000000000020000000000000001 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -128,7 +128,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -144,7 +144,7 @@ block0:
 ; block0:
 ;   vrepif %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, 0x7fff
@@ -160,7 +160,7 @@ block0:
 ; block0:
 ;   vrepif %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, -0x8000
@@ -176,7 +176,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -196,7 +196,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -216,7 +216,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000200000001 ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -237,7 +237,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000004000000030000000200000001 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -262,7 +262,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -278,7 +278,7 @@ block0:
 ; block0:
 ;   vrepih %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, 0x7fff
@@ -294,7 +294,7 @@ block0:
 ; block0:
 ;   vrepih %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, -0x8000
@@ -310,7 +310,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00080007000600050004000300020001 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -335,7 +335,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -351,7 +351,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 127
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x7f
@@ -367,7 +367,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x80
@@ -383,7 +383,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x100f0e0d0c0b0a090807060504030201 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14

--- a/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-constants.clif
@@ -11,7 +11,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -27,7 +27,7 @@ block0:
 ; block0:
 ;   vrepig %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, 0x7fff
@@ -43,7 +43,7 @@ block0:
 ; block0:
 ;   vrepig %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, -0x8000
@@ -59,7 +59,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000000008000 ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -81,7 +81,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0xffffffffffff7fff ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -103,7 +103,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000000000000010000000000000002 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -128,7 +128,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -144,7 +144,7 @@ block0:
 ; block0:
 ;   vrepif %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, 0x7fff
@@ -160,7 +160,7 @@ block0:
 ; block0:
 ;   vrepif %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, -0x8000
@@ -176,7 +176,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0x00008000 ; vlrepf %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -196,7 +196,7 @@ block0:
 ; block0:
 ;   bras %r1, 8 ; data.u32 0xffff7fff ; vlrepf %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 8
@@ -216,7 +216,7 @@ block0:
 ; block0:
 ;   bras %r1, 12 ; data.u64 0x0000000100000002 ; vlrepg %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0xc
@@ -237,7 +237,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00000001000000020000000300000004 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -262,7 +262,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -278,7 +278,7 @@ block0:
 ; block0:
 ;   vrepih %v24, 32767
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, 0x7fff
@@ -294,7 +294,7 @@ block0:
 ; block0:
 ;   vrepih %v24, -32768
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, -0x8000
@@ -310,7 +310,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x00010002000300040005000600070008 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -335,7 +335,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -351,7 +351,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 127
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x7f
@@ -367,7 +367,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 128
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x80
@@ -383,7 +383,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x0102030405060708090a0b0c0d0e0f10 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions-le-lane.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpksg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksg %v24, %v25, %v24
@@ -27,7 +27,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vpksf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksf %v24, %v25, %v24
@@ -43,7 +43,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vpksh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksh %v24, %v25, %v24
@@ -62,7 +62,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vmxg %v7, %v25, %v3
 ;   vpklsg %v24, %v7, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -84,7 +84,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vmxf %v7, %v25, %v3
 ;   vpklsf %v24, %v7, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -106,7 +106,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vmxh %v7, %v25, %v3
 ;   vpklsh %v24, %v7, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -125,7 +125,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpklsg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsg %v24, %v25, %v24
@@ -141,7 +141,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vpklsf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsf %v24, %v25, %v24
@@ -157,7 +157,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vpklsh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsh %v24, %v25, %v24
@@ -173,7 +173,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuplf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplf %v24, %v24
@@ -189,7 +189,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuplh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhw %v24, %v24
@@ -205,7 +205,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuplb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplb %v24, %v24
@@ -221,7 +221,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuphf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v24, %v24
@@ -237,7 +237,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuphh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphh %v24, %v24
@@ -253,7 +253,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuphb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphb %v24, %v24
@@ -269,7 +269,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vupllf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllf %v24, %v24
@@ -285,7 +285,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vupllh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllh %v24, %v24
@@ -301,7 +301,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vupllb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllb %v24, %v24
@@ -317,7 +317,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuplhf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhf %v24, %v24
@@ -333,7 +333,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuplhh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhh %v24, %v24
@@ -349,7 +349,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuplhb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhb %v24, %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-conversions.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpksg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksg %v24, %v24, %v25
@@ -27,7 +27,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vpksf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksf %v24, %v24, %v25
@@ -43,7 +43,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vpksh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpksh %v24, %v24, %v25
@@ -62,7 +62,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vmxg %v7, %v25, %v3
 ;   vpklsg %v24, %v5, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -84,7 +84,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vmxf %v7, %v25, %v3
 ;   vpklsf %v24, %v5, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -106,7 +106,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vmxh %v7, %v25, %v3
 ;   vpklsh %v24, %v5, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -125,7 +125,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpklsg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsg %v24, %v24, %v25
@@ -141,7 +141,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vpklsf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsf %v24, %v24, %v25
@@ -157,7 +157,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vpklsh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpklsh %v24, %v24, %v25
@@ -173,7 +173,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuphf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v24, %v24
@@ -189,7 +189,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuphh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphh %v24, %v24
@@ -205,7 +205,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuphb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphb %v24, %v24
@@ -221,7 +221,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuplf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplf %v24, %v24
@@ -237,7 +237,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuplh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhw %v24, %v24
@@ -253,7 +253,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuplb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplb %v24, %v24
@@ -269,7 +269,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vuplhf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhf %v24, %v24
@@ -285,7 +285,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vuplhh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhh %v24, %v24
@@ -301,7 +301,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vuplhb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhb %v24, %v24
@@ -317,7 +317,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vupllf %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllf %v24, %v24
@@ -333,7 +333,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vupllh %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllh %v24, %v24
@@ -349,7 +349,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vupllb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vupllb %v24, %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fcmp.clif
@@ -11,7 +11,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfcedb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedb %v24, %v24, %v25
@@ -28,7 +28,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfcedb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedb %v3, %v24, %v25
@@ -45,7 +45,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfchdb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v24, %v24, %v25
@@ -61,7 +61,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfchdb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v24, %v25, %v24
@@ -77,7 +77,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfchedb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v24, %v24, %v25
@@ -93,7 +93,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfchedb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v24, %v25, %v24
@@ -111,7 +111,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchdb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
@@ -131,7 +131,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchdb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
@@ -150,7 +150,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchedb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v3, %v25, %v24
@@ -168,7 +168,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchedb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
@@ -186,7 +186,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchdb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v3, %v25, %v24
@@ -204,7 +204,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchdb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdb %v3, %v24, %v25
@@ -223,7 +223,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchedb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
@@ -243,7 +243,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vfchedb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedb %v3, %v24, %v25
@@ -261,7 +261,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfcesb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcesb %v24, %v24, %v25
@@ -278,7 +278,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfcesb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcesb %v3, %v24, %v25
@@ -295,7 +295,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfchsb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v24, %v24, %v25
@@ -311,7 +311,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfchsb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v24, %v25, %v24
@@ -327,7 +327,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfchesb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v24, %v24, %v25
@@ -343,7 +343,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfchesb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v24, %v25, %v24
@@ -361,7 +361,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchsb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
@@ -381,7 +381,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchsb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
@@ -400,7 +400,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchesb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v3, %v25, %v24
@@ -418,7 +418,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchesb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25
@@ -436,7 +436,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchsb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v3, %v25, %v24
@@ -454,7 +454,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchsb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchsb %v3, %v24, %v25
@@ -473,7 +473,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchesb %v5, %v25, %v24
 ;   vo %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25
@@ -493,7 +493,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vfchesb %v5, %v25, %v24
 ;   vno %v24, %v3, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchesb %v3, %v24, %v25

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp-arch13.clif
@@ -11,7 +11,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vcelfb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdlg %v24, %v24, 2, 0, 4
@@ -27,7 +27,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vcefb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdg %v24, %v24, 2, 0, 4
@@ -43,7 +43,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vcdlgb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdlgb %v24, %v24, 0, 4
@@ -59,7 +59,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vcdgb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdgb %v24, %v24, 0, 4
@@ -75,7 +75,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vclfeb %v24, %v24, 0, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgd %v24, %v24, 2, 0, 5
@@ -94,7 +94,7 @@ block0(v0: f32x4):
 ;   vfcesb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgd %v2, %v24, 2, 0, 5
@@ -113,7 +113,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vclgdb %v24, %v24, 0, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgdb %v24, %v24, 0, 5
@@ -132,7 +132,7 @@ block0(v0: f64x2):
 ;   vfcedb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgdb %v2, %v24, 0, 5

--- a/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-fp.clif
@@ -11,7 +11,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -27,7 +27,7 @@ block0:
 ; block0:
 ;   vgbm %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -43,7 +43,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x3f800000400000004040000040800000 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -65,7 +65,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x4080000040400000400000003f800000 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -87,7 +87,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x3ff00000000000004000000000000000 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -111,7 +111,7 @@ block0:
 ; block0:
 ;   bras %r1, 20 ; data.u128 0x40000000000000003ff0000000000000 ; vl %v24, 0(%r1)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -135,7 +135,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfasb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfasb %v24, %v24, %v25
@@ -151,7 +151,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfadb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfadb %v24, %v24, %v25
@@ -167,7 +167,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfssb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfssb %v24, %v24, %v25
@@ -183,7 +183,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfsdb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfsdb %v24, %v24, %v25
@@ -199,7 +199,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfmsb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmsb %v24, %v24, %v25
@@ -215,7 +215,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfmdb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmdb %v24, %v24, %v25
@@ -231,7 +231,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfdsb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfdsb %v24, %v24, %v25
@@ -247,7 +247,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfddb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfddb %v24, %v24, %v25
@@ -263,7 +263,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfminsb %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfminsb %v24, %v24, %v25, 1
@@ -279,7 +279,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfmindb %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmindb %v24, %v24, %v25, 1
@@ -295,7 +295,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfmaxsb %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmaxsb %v24, %v24, %v25, 1
@@ -311,7 +311,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfmaxdb %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmaxdb %v24, %v24, %v25, 1
@@ -327,7 +327,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfminsb %v24, %v24, %v25, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfminsb %v24, %v24, %v25, 3
@@ -343,7 +343,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfmindb %v24, %v24, %v25, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmindb %v24, %v24, %v25, 3
@@ -359,7 +359,7 @@ block0(v0: f32x4, v1: f32x4):
 ; block0:
 ;   vfmaxsb %v24, %v24, %v25, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmaxsb %v24, %v24, %v25, 3
@@ -375,7 +375,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vfmaxdb %v24, %v24, %v25, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmaxdb %v24, %v24, %v25, 3
@@ -391,7 +391,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vfsqsb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfsqsb %v24, %v24
@@ -407,7 +407,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vfsqdb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfsqdb %v24, %v24
@@ -423,7 +423,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vflpsb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vflpsb %v24, %v24
@@ -439,7 +439,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vflpdb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vflpdb %v24, %v24
@@ -455,7 +455,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vflcsb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vflcsb %v24, %v24
@@ -471,7 +471,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vflcdb %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vflcdb %v24, %v24
@@ -488,7 +488,7 @@ block0(v0: f32x4):
 ;   vmrhf %v2, %v24, %v24
 ;   vldeb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v2, %v24, %v24
@@ -506,7 +506,7 @@ block0(v0: f32x4):
 ;   vmrlf %v2, %v24, %v24
 ;   vldeb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v2, %v24, %v24
@@ -526,7 +526,7 @@ block0(v0: f64x2):
 ;   vgbm %v6, 0
 ;   vpkg %v24, %v4, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vledb %v2, %v24, 0, 0
@@ -548,7 +548,7 @@ block0(v0: f64x2):
 ;   vgbm %v6, 0
 ;   vpkg %v24, %v6, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vledb %v2, %v24, 0, 0
@@ -567,7 +567,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vfisb %v24, %v24, 0, 6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 6
@@ -583,7 +583,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vfidb %v24, %v24, 0, 6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 6
@@ -599,7 +599,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vfisb %v24, %v24, 0, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 7
@@ -615,7 +615,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vfidb %v24, %v24, 0, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 7
@@ -631,7 +631,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vfisb %v24, %v24, 0, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 5
@@ -647,7 +647,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vfidb %v24, %v24, 0, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 5
@@ -663,7 +663,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vfisb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfisb %v24, %v24, 0, 4
@@ -679,7 +679,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vfidb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfidb %v24, %v24, 0, 4
@@ -695,7 +695,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ; block0:
 ;   vfmasb %v24, %v24, %v25, %v26
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmasb %v24, %v24, %v25, %v26
@@ -711,7 +711,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ; block0:
 ;   vfmadb %v24, %v24, %v25, %v26
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfmadb %v24, %v24, %v25, %v26
@@ -728,7 +728,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgmf %v3, 1, 31
 ;   vsel %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgmf %v3, 1, 0x1f
@@ -746,7 +746,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   vgmg %v3, 1, 63
 ;   vsel %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgmg %v3, 1, 0x3f
@@ -770,7 +770,7 @@ block0(v0: i32x4):
 ;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplhf %v2, %v24
@@ -809,7 +809,7 @@ block0(v0: i32x4):
 ;   bras %r1, 20 ; data.u128 0x0001020308090a0b1011121318191a1b ; vl %v22, 0(%r1)
 ;   vperm %v24, %v6, %v20, %v22
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v2, %v24
@@ -841,7 +841,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vcdlgb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdlgb %v24, %v24, 0, 4
@@ -857,7 +857,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vcdgb %v24, %v24, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcdgb %v24, %v24, 0, 4
@@ -874,7 +874,7 @@ block0(v0: i32x4):
 ;   vuphf %v2, %v24
 ;   vcdgb %v24, %v2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuphf %v2, %v24
@@ -892,7 +892,7 @@ block0(v0: i32x4):
 ;   vuplf %v2, %v24
 ;   vcdgb %v24, %v2, 0, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vuplf %v2, %v24
@@ -915,7 +915,7 @@ block0(v0: f32x4):
 ;   vclgdb %v20, %v18, 0, 5
 ;   vpklsg %v24, %v6, %v20
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v2, %v24, %v24
@@ -946,7 +946,7 @@ block0(v0: f32x4):
 ;   vfcesb %v26, %v24, %v24
 ;   vsel %v24, %v22, %v25, %v26
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v2, %v24, %v24
@@ -971,7 +971,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vclgdb %v24, %v24, 0, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vclgdb %v24, %v24, 0, 5
@@ -990,7 +990,7 @@ block0(v0: f64x2):
 ;   vfcedb %v6, %v24, %v24
 ;   vsel %v24, %v2, %v4, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vcgdb %v2, %v24, 0, 5

--- a/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-icmp.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vceqg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqg %v24, %v24, %v25
@@ -28,7 +28,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vceqg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqg %v3, %v24, %v25
@@ -45,7 +45,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vchg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchg %v24, %v24, %v25
@@ -61,7 +61,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vchg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchg %v24, %v25, %v24
@@ -78,7 +78,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchg %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchg %v3, %v25, %v24
@@ -96,7 +96,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchg %v3, %v24, %v25
@@ -113,7 +113,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vchlg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlg %v24, %v24, %v25
@@ -129,7 +129,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vchlg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlg %v24, %v25, %v24
@@ -146,7 +146,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchlg %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlg %v3, %v25, %v24
@@ -164,7 +164,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   vchlg %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlg %v3, %v24, %v25
@@ -181,7 +181,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vceqf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqf %v24, %v24, %v25
@@ -198,7 +198,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vceqf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqf %v3, %v24, %v25
@@ -215,7 +215,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vchf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchf %v24, %v24, %v25
@@ -231,7 +231,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vchf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchf %v24, %v25, %v24
@@ -248,7 +248,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchf %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchf %v3, %v25, %v24
@@ -266,7 +266,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchf %v3, %v24, %v25
@@ -283,7 +283,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vchlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlf %v24, %v24, %v25
@@ -299,7 +299,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   vchlf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlf %v24, %v25, %v24
@@ -316,7 +316,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchlf %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlf %v3, %v25, %v24
@@ -334,7 +334,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vchlf %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlf %v3, %v24, %v25
@@ -351,7 +351,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vceqh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqh %v24, %v24, %v25
@@ -368,7 +368,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vceqh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqh %v3, %v24, %v25
@@ -385,7 +385,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vchh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchh %v24, %v24, %v25
@@ -401,7 +401,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vchh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchh %v24, %v25, %v24
@@ -418,7 +418,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchh %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchh %v3, %v25, %v24
@@ -436,7 +436,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchh %v3, %v24, %v25
@@ -453,7 +453,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vchlh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlh %v24, %v24, %v25
@@ -469,7 +469,7 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   vchlh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlh %v24, %v25, %v24
@@ -486,7 +486,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchlh %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlh %v3, %v25, %v24
@@ -504,7 +504,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vchlh %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlh %v3, %v24, %v25
@@ -521,7 +521,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vceqb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqb %v24, %v24, %v25
@@ -538,7 +538,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vceqb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqb %v3, %v24, %v25
@@ -555,7 +555,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vchb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchb %v24, %v24, %v25
@@ -571,7 +571,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vchb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchb %v24, %v25, %v24
@@ -588,7 +588,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchb %v3, %v25, %v24
@@ -606,7 +606,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchb %v3, %v24, %v25
@@ -623,7 +623,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vchlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlb %v24, %v24, %v25
@@ -639,7 +639,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vchlb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlb %v24, %v25, %v24
@@ -656,7 +656,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchlb %v3, %v25, %v24
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlb %v3, %v25, %v24
@@ -674,7 +674,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vchlb %v3, %v24, %v25
 ;   vno %v24, %v3, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlb %v3, %v24, %v25

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-arch13.clif
@@ -12,7 +12,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -29,7 +29,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -46,7 +46,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -65,7 +65,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -84,7 +84,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -101,7 +101,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -118,7 +118,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -137,7 +137,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -156,7 +156,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
@@ -173,7 +173,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
@@ -190,7 +190,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vlebrh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -209,7 +209,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -227,7 +227,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -244,7 +244,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -261,7 +261,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -278,7 +278,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -295,7 +295,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -312,7 +312,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -329,7 +329,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -348,7 +348,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -367,7 +367,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -384,7 +384,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -401,7 +401,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -420,7 +420,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -439,7 +439,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -456,7 +456,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -473,7 +473,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -492,7 +492,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -511,7 +511,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -528,7 +528,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -545,7 +545,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -564,7 +564,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -583,7 +583,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
@@ -600,7 +600,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
@@ -617,7 +617,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstebrh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -636,7 +636,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstebrh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -654,7 +654,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -671,7 +671,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -688,7 +688,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -705,7 +705,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -722,7 +722,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -739,7 +739,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -756,7 +756,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -775,7 +775,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -794,7 +794,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -811,7 +811,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -828,7 +828,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -847,7 +847,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -866,7 +866,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -883,7 +883,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -902,7 +902,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -919,7 +919,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -938,7 +938,7 @@ block0(v0: i64):
 ; block0:
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
@@ -955,7 +955,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -974,7 +974,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -991,7 +991,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -1008,7 +1008,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -1025,7 +1025,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -1044,7 +1044,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -1061,7 +1061,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -1081,7 +1081,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1100,7 +1100,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1121,7 +1121,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1140,7 +1140,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1161,7 +1161,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1180,7 +1180,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1201,7 +1201,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1220,7 +1220,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1239,7 +1239,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1258,7 +1258,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1279,7 +1279,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1298,7 +1298,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane-arch13.clif
@@ -12,7 +12,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -29,7 +29,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -46,7 +46,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -65,7 +65,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -84,7 +84,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -101,7 +101,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -118,7 +118,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -137,7 +137,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -156,7 +156,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
@@ -173,7 +173,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
@@ -190,7 +190,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -208,7 +208,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vlebrh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -227,7 +227,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -244,7 +244,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -261,7 +261,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -278,7 +278,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -295,7 +295,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -312,7 +312,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -329,7 +329,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -348,7 +348,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vlebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -367,7 +367,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -384,7 +384,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -401,7 +401,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -420,7 +420,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -439,7 +439,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -456,7 +456,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -473,7 +473,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -492,7 +492,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -511,7 +511,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -528,7 +528,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -545,7 +545,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -564,7 +564,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -583,7 +583,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
@@ -600,7 +600,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
@@ -617,7 +617,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstebrh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -635,7 +635,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstebrh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -654,7 +654,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -671,7 +671,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -688,7 +688,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -705,7 +705,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -722,7 +722,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -739,7 +739,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -756,7 +756,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -775,7 +775,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstebrg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -794,7 +794,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -811,7 +811,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -828,7 +828,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -847,7 +847,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstebrf %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -866,7 +866,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -883,7 +883,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -902,7 +902,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -919,7 +919,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -938,7 +938,7 @@ block0(v0: i64):
 ; block0:
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
@@ -955,7 +955,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -974,7 +974,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -991,7 +991,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -1008,7 +1008,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -1025,7 +1025,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -1044,7 +1044,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -1061,7 +1061,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -1081,7 +1081,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1100,7 +1100,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1121,7 +1121,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1140,7 +1140,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1161,7 +1161,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1180,7 +1180,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1200,7 +1200,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1219,7 +1219,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1238,7 +1238,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1257,7 +1257,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1278,7 +1278,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -1297,7 +1297,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlebrf %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane-le-lane.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 1
@@ -27,7 +27,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 0
@@ -44,7 +44,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vleig %v24, 123, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleig %v24, 0x7b, 1
@@ -61,7 +61,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vleig %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleig %v24, 0x7b, 0
@@ -78,7 +78,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
@@ -95,7 +95,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
@@ -112,7 +112,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
@@ -129,7 +129,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
@@ -146,7 +146,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -163,7 +163,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -181,7 +181,7 @@ block0(v0: i64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -200,7 +200,7 @@ block0(v0: i64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -217,7 +217,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 3
@@ -233,7 +233,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 0
@@ -250,7 +250,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vleif %v24, 123, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleif %v24, 0x7b, 3
@@ -267,7 +267,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vleif %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleif %v24, 0x7b, 0
@@ -285,7 +285,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v3, 15
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf
@@ -305,7 +305,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v5, 61440
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 3
@@ -326,7 +326,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 0
@@ -346,7 +346,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -364,7 +364,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -381,7 +381,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -399,7 +399,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -418,7 +418,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -435,7 +435,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 7
@@ -451,7 +451,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 0
@@ -468,7 +468,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vleih %v24, 123, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleih %v24, 0x7b, 7
@@ -485,7 +485,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vleih %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleih %v24, 0x7b, 0
@@ -503,7 +503,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v3, 3
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 3
@@ -523,7 +523,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v5, 49152
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v3, %v25, 7
@@ -544,7 +544,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v5, 3
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v3, %v25, 0
@@ -564,7 +564,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v3, 49152
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xc000
@@ -582,7 +582,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
@@ -599,7 +599,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
@@ -617,7 +617,7 @@ block0(v0: i16x8, v1: i64):
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
@@ -636,7 +636,7 @@ block0(v0: i16x8, v1: i64):
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
@@ -653,7 +653,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vlvgb %v24, %r2, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0xf
@@ -669,7 +669,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0
@@ -686,7 +686,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vleib %v24, 123, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleib %v24, 0x7b, 0xf
@@ -703,7 +703,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vleib %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleib %v24, 0x7b, 0
@@ -721,7 +721,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v3, 1
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 1
@@ -741,7 +741,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v5, 32768
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0xf
@@ -762,7 +762,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v5, 1
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0
@@ -782,7 +782,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v3, 32768
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0x8000
@@ -800,7 +800,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -817,7 +817,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -834,7 +834,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -851,7 +851,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -867,7 +867,7 @@ block0(v0: f64x2, v1: f64):
 ; block0:
 ;   vpdi %v24, %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v0, 0
@@ -883,7 +883,7 @@ block0(v0: f64x2, v1: f64):
 ; block0:
 ;   vpdi %v24, %v0, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v0, %v24, 1
@@ -900,7 +900,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
@@ -917,7 +917,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
@@ -934,7 +934,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
@@ -951,7 +951,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
@@ -968,7 +968,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -985,7 +985,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -1003,7 +1003,7 @@ block0(v0: f64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -1022,7 +1022,7 @@ block0(v0: f64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -1041,7 +1041,7 @@ block0(v0: f32x4, v1: f32):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v0, 0
@@ -1060,7 +1060,7 @@ block0(v0: f32x4, v1: f32):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v0, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -1079,7 +1079,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v3, 15
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf
@@ -1099,7 +1099,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v5, 61440
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 3
@@ -1120,7 +1120,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 0
@@ -1140,7 +1140,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -1158,7 +1158,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -1175,7 +1175,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -1193,7 +1193,7 @@ block0(v0: f32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -1212,7 +1212,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -1229,7 +1229,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlgvg %r2, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 1
@@ -1245,7 +1245,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlgvg %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 0
@@ -1262,7 +1262,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -1279,7 +1279,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -1297,7 +1297,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -1316,7 +1316,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1333,7 +1333,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlgvf %r2, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 3
@@ -1349,7 +1349,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlgvf %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 0
@@ -1366,7 +1366,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -1383,7 +1383,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -1401,7 +1401,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
@@ -1420,7 +1420,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
@@ -1437,7 +1437,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlgvh %r2, %v24, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 7
@@ -1453,7 +1453,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlgvh %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 0
@@ -1470,7 +1470,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
@@ -1487,7 +1487,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
@@ -1505,7 +1505,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlgvh %r5, %v24, 7
 ;   strvh %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 7
@@ -1524,7 +1524,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlgvh %r5, %v24, 0
 ;   strvh %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 0
@@ -1541,7 +1541,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlgvb %r2, %v24, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0xf
@@ -1557,7 +1557,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlgvb %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0
@@ -1574,7 +1574,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -1591,7 +1591,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -1608,7 +1608,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -1625,7 +1625,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -1641,7 +1641,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v0, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 1
@@ -1657,7 +1657,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v0, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 0
@@ -1674,7 +1674,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -1691,7 +1691,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -1709,7 +1709,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -1728,7 +1728,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1745,7 +1745,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v0, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 3
@@ -1761,7 +1761,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v0, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 0
@@ -1778,7 +1778,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -1795,7 +1795,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -1813,7 +1813,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
@@ -1832,7 +1832,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
@@ -1850,7 +1850,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   vrepg %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1868,7 +1868,7 @@ block0:
 ; block0:
 ;   vrepig %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, 0x7b
@@ -1885,7 +1885,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vrepg %v24, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
@@ -1902,7 +1902,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vrepg %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
@@ -1919,7 +1919,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -1938,7 +1938,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -1957,7 +1957,7 @@ block0(v0: i32):
 ;   vlvgf %v2, %r2, 0
 ;   vrepf %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
@@ -1975,7 +1975,7 @@ block0:
 ; block0:
 ;   vrepif %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, 0x7b
@@ -1992,7 +1992,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
@@ -2009,7 +2009,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
@@ -2026,7 +2026,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -2045,7 +2045,7 @@ block0(v0: i64):
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -2064,7 +2064,7 @@ block0(v0: i16):
 ;   vlvgh %v2, %r2, 0
 ;   vreph %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v2, %r2, 0
@@ -2082,7 +2082,7 @@ block0:
 ; block0:
 ;   vrepih %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, 0x7b
@@ -2099,7 +2099,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vreph %v24, %v24, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v24, %v24, 7
@@ -2116,7 +2116,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vreph %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v24, %v24, 0
@@ -2133,7 +2133,7 @@ block0(v0: i64):
 ; block0:
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
@@ -2152,7 +2152,7 @@ block0(v0: i64):
 ;   vlvgh %v4, %r4, 0
 ;   vreph %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -2171,7 +2171,7 @@ block0(v0: i8):
 ;   vlvgb %v2, %r2, 0
 ;   vrepb %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v2, %r2, 0
@@ -2189,7 +2189,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x7b
@@ -2206,7 +2206,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vrepb %v24, %v24, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0xf
@@ -2223,7 +2223,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vrepb %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0
@@ -2240,7 +2240,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -2257,7 +2257,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -2273,7 +2273,7 @@ block0(v0: f64):
 ; block0:
 ;   vrepg %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v0, 0
@@ -2290,7 +2290,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v24, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
@@ -2307,7 +2307,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
@@ -2324,7 +2324,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -2343,7 +2343,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -2361,7 +2361,7 @@ block0(v0: f32):
 ; block0:
 ;   vrepf %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v0, 0
@@ -2378,7 +2378,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
@@ -2395,7 +2395,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
@@ -2412,7 +2412,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -2431,7 +2431,7 @@ block0(v0: i64):
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -2450,7 +2450,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2469,7 +2469,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleig %v24, 123, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2488,7 +2488,7 @@ block0(v0: i64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2507,7 +2507,7 @@ block0(v0: i64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2526,7 +2526,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2546,7 +2546,7 @@ block0(v0: i64):
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2565,7 +2565,7 @@ block0(v0: i32):
 ;   vgbm %v24, 0
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2584,7 +2584,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleif %v24, 123, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2603,7 +2603,7 @@ block0(v0: i32x4):
 ;   vgbm %v2, 15
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xf
@@ -2623,7 +2623,7 @@ block0(v0: i32x4):
 ;   vgbm %v4, 15
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v2, %v24, 0
@@ -2643,7 +2643,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2663,7 +2663,7 @@ block0(v0: i64):
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2682,7 +2682,7 @@ block0(v0: i16):
 ;   vgbm %v24, 0
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2701,7 +2701,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleih %v24, 123, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2720,7 +2720,7 @@ block0(v0: i16x8):
 ;   vgbm %v2, 3
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 3
@@ -2740,7 +2740,7 @@ block0(v0: i16x8):
 ;   vgbm %v4, 3
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v2, %v24, 0
@@ -2760,7 +2760,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2780,7 +2780,7 @@ block0(v0: i64):
 ;   lrvh %r2, 0(%r2)
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2799,7 +2799,7 @@ block0(v0: i8):
 ;   vgbm %v24, 0
 ;   vlvgb %v24, %r2, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2818,7 +2818,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleib %v24, 123, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2837,7 +2837,7 @@ block0(v0: i8x16):
 ;   vgbm %v2, 1
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 1
@@ -2857,7 +2857,7 @@ block0(v0: i8x16):
 ;   vgbm %v4, 1
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v2, %v24, 0
@@ -2877,7 +2877,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2896,7 +2896,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2914,7 +2914,7 @@ block0(v0: f64):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v2, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2933,7 +2933,7 @@ block0(v0: f64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v2, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2952,7 +2952,7 @@ block0(v0: f64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2971,7 +2971,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2991,7 +2991,7 @@ block0(v0: i64):
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -3011,7 +3011,7 @@ block0(v0: f32):
 ;   vgbm %v4, 15
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v2, %v0, 0
@@ -3031,7 +3031,7 @@ block0(v0: f32x4):
 ;   vgbm %v2, 15
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xf
@@ -3051,7 +3051,7 @@ block0(v0: f32x4):
 ;   vgbm %v4, 15
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v2, %v24, 0
@@ -3071,7 +3071,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -3091,7 +3091,7 @@ block0(v0: i64):
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-lane.clif
@@ -11,7 +11,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 0
@@ -27,7 +27,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vlvgg %v24, %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgg %v24, %r2, 1
@@ -44,7 +44,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vleig %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleig %v24, 0x7b, 0
@@ -61,7 +61,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vleig %v24, 123, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleig %v24, 0x7b, 1
@@ -78,7 +78,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
@@ -95,7 +95,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
@@ -112,7 +112,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
@@ -129,7 +129,7 @@ block0(v0: i64x2, v1: i64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
@@ -146,7 +146,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -163,7 +163,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -181,7 +181,7 @@ block0(v0: i64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -200,7 +200,7 @@ block0(v0: i64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -217,7 +217,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 0
@@ -233,7 +233,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vlvgf %v24, %r2, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v24, %r2, 3
@@ -250,7 +250,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vleif %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleif %v24, 0x7b, 0
@@ -267,7 +267,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vleif %v24, 123, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleif %v24, 0x7b, 3
@@ -285,7 +285,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -305,7 +305,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 0
@@ -326,7 +326,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v5, 61440
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 3
@@ -346,7 +346,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   vgbm %v3, 15
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf
@@ -364,7 +364,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -381,7 +381,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -399,7 +399,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -418,7 +418,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -435,7 +435,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 0
@@ -451,7 +451,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vlvgh %v24, %r2, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v24, %r2, 7
@@ -468,7 +468,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vleih %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleih %v24, 0x7b, 0
@@ -485,7 +485,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vleih %v24, 123, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleih %v24, 0x7b, 7
@@ -503,7 +503,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v3, 49152
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xc000
@@ -523,7 +523,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v5, 3
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v3, %v25, 0
@@ -544,7 +544,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v5, 49152
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v3, %v25, 7
@@ -564,7 +564,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   vgbm %v3, 3
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 3
@@ -582,7 +582,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 0
@@ -599,7 +599,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vleh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleh %v24, 0(%r2), 7
@@ -617,7 +617,7 @@ block0(v0: i16x8, v1: i64):
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
@@ -636,7 +636,7 @@ block0(v0: i16x8, v1: i64):
 ;   lrvh %r5, 0(%r2)
 ;   vlvgh %v24, %r5, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r5, 0(%r2)
@@ -653,7 +653,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0
@@ -669,7 +669,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vlvgb %v24, %r2, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v24, %r2, 0xf
@@ -686,7 +686,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vleib %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleib %v24, 0x7b, 0
@@ -703,7 +703,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vleib %v24, 123, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleib %v24, 0x7b, 0xf
@@ -721,7 +721,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v3, 32768
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0x8000
@@ -741,7 +741,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v5, 1
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0
@@ -762,7 +762,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v5, 32768
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v3, %v25, 0xf
@@ -782,7 +782,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v3, 1
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 1
@@ -800,7 +800,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -817,7 +817,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -834,7 +834,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0
@@ -851,7 +851,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vleb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleb %v24, 0(%r2), 0xf
@@ -867,7 +867,7 @@ block0(v0: f64x2, v1: f64):
 ; block0:
 ;   vpdi %v24, %v0, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v0, %v24, 1
@@ -883,7 +883,7 @@ block0(v0: f64x2, v1: f64):
 ; block0:
 ;   vpdi %v24, %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v0, 0
@@ -900,7 +900,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 1
@@ -917,7 +917,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 0
@@ -934,7 +934,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v25, %v24, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v25, %v24, 5
@@ -951,7 +951,7 @@ block0(v0: f64x2, v1: f64x2):
 ; block0:
 ;   vpdi %v24, %v24, %v25, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v24, %v24, %v25, 1
@@ -968,7 +968,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 0
@@ -985,7 +985,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vleg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vleg %v24, 0(%r2), 1
@@ -1003,7 +1003,7 @@ block0(v0: f64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -1022,7 +1022,7 @@ block0(v0: f64x2, v1: i64):
 ;   lrvg %r5, 0(%r2)
 ;   vlvgg %v24, %r5, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r2)
@@ -1040,7 +1040,7 @@ block0(v0: f32x4, v1: f32):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v0, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -1059,7 +1059,7 @@ block0(v0: f32x4, v1: f32):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v0, 0
@@ -1079,7 +1079,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v3, 61440
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf000
@@ -1099,7 +1099,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v5, 15
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 0
@@ -1120,7 +1120,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v5, 61440
 ;   vsel %v24, %v3, %v24, %v5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v3, %v25, 3
@@ -1140,7 +1140,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   vgbm %v3, 15
 ;   vsel %v24, %v25, %v24, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v3, 0xf
@@ -1158,7 +1158,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 0
@@ -1175,7 +1175,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vlef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlef %v24, 0(%r2), 3
@@ -1193,7 +1193,7 @@ block0(v0: f32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -1212,7 +1212,7 @@ block0(v0: i32x4, v1: i64):
 ;   lrv %r5, 0(%r2)
 ;   vlvgf %v24, %r5, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r5, 0(%r2)
@@ -1229,7 +1229,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlgvg %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 0
@@ -1245,7 +1245,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vlgvg %r2, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r2, %v24, 1
@@ -1262,7 +1262,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -1279,7 +1279,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -1297,7 +1297,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1316,7 +1316,7 @@ block0(v0: i64x2, v1: i64):
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -1333,7 +1333,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlgvf %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 0
@@ -1349,7 +1349,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vlgvf %r2, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r2, %v24, 3
@@ -1366,7 +1366,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -1383,7 +1383,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -1401,7 +1401,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
@@ -1420,7 +1420,7 @@ block0(v0: i32x4, v1: i64):
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
@@ -1437,7 +1437,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlgvh %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 0
@@ -1453,7 +1453,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vlgvh %r2, %v24, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r2, %v24, 7
@@ -1470,7 +1470,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 0
@@ -1487,7 +1487,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsteh %v24, 0(%r2), 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteh %v24, 0(%r2), 7
@@ -1505,7 +1505,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlgvh %r5, %v24, 0
 ;   strvh %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 0
@@ -1524,7 +1524,7 @@ block0(v0: i16x8, v1: i64):
 ;   vlgvh %r5, %v24, 7
 ;   strvh %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvh %r5, %v24, 7
@@ -1541,7 +1541,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlgvb %r2, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0
@@ -1557,7 +1557,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vlgvb %r2, %v24, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvb %r2, %v24, 0xf
@@ -1574,7 +1574,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -1591,7 +1591,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -1608,7 +1608,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0
@@ -1625,7 +1625,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vsteb %v24, 0(%r2), 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteb %v24, 0(%r2), 0xf
@@ -1641,7 +1641,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v0, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 0
@@ -1657,7 +1657,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v0, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v0, %v24, 1
@@ -1674,7 +1674,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 0
@@ -1691,7 +1691,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsteg %v24, 0(%r2), 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vsteg %v24, 0(%r2), 1
@@ -1709,7 +1709,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlgvg %r5, %v24, 0
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 0
@@ -1728,7 +1728,7 @@ block0(v0: f64x2, v1: i64):
 ;   vlgvg %r5, %v24, 1
 ;   strvg %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -1745,7 +1745,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v0, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 0
@@ -1761,7 +1761,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v0, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v0, %v24, 3
@@ -1778,7 +1778,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 0
@@ -1795,7 +1795,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstef %v24, 0(%r2), 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vstef %v24, 0(%r2), 3
@@ -1813,7 +1813,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlgvf %r5, %v24, 0
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 0
@@ -1832,7 +1832,7 @@ block0(v0: f32x4, v1: i64):
 ;   vlgvf %r5, %v24, 3
 ;   strv %r5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvf %r5, %v24, 3
@@ -1850,7 +1850,7 @@ block0(v0: i64):
 ;   ldgr %f2, %r2
 ;   vrepg %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ldgr %f2, %r2
@@ -1868,7 +1868,7 @@ block0:
 ; block0:
 ;   vrepig %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepig %v24, 0x7b
@@ -1885,7 +1885,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vrepg %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
@@ -1902,7 +1902,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vrepg %v24, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
@@ -1919,7 +1919,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -1938,7 +1938,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -1957,7 +1957,7 @@ block0(v0: i32):
 ;   vlvgf %v2, %r2, 0
 ;   vrepf %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgf %v2, %r2, 0
@@ -1975,7 +1975,7 @@ block0:
 ; block0:
 ;   vrepif %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepif %v24, 0x7b
@@ -1992,7 +1992,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
@@ -2009,7 +2009,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
@@ -2026,7 +2026,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -2045,7 +2045,7 @@ block0(v0: i64):
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -2064,7 +2064,7 @@ block0(v0: i16):
 ;   vlvgh %v2, %r2, 0
 ;   vreph %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgh %v2, %r2, 0
@@ -2082,7 +2082,7 @@ block0:
 ; block0:
 ;   vrepih %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepih %v24, 0x7b
@@ -2099,7 +2099,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vreph %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v24, %v24, 0
@@ -2116,7 +2116,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vreph %v24, %v24, 7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v24, %v24, 7
@@ -2133,7 +2133,7 @@ block0(v0: i64):
 ; block0:
 ;   vlreph %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlreph %v24, 0(%r2)
@@ -2152,7 +2152,7 @@ block0(v0: i64):
 ;   vlvgh %v4, %r4, 0
 ;   vreph %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvh %r4, 0(%r2)
@@ -2171,7 +2171,7 @@ block0(v0: i8):
 ;   vlvgb %v2, %r2, 0
 ;   vrepb %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlvgb %v2, %r2, 0
@@ -2189,7 +2189,7 @@ block0:
 ; block0:
 ;   vrepib %v24, 123
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v24, 0x7b
@@ -2206,7 +2206,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vrepb %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0
@@ -2223,7 +2223,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vrepb %v24, %v24, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v24, %v24, 0xf
@@ -2240,7 +2240,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -2257,7 +2257,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepb %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepb %v24, 0(%r2)
@@ -2273,7 +2273,7 @@ block0(v0: f64):
 ; block0:
 ;   vrepg %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v0, 0
@@ -2290,7 +2290,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 0
@@ -2307,7 +2307,7 @@ block0(v0: f64x2):
 ; block0:
 ;   vrepg %v24, %v24, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepg %v24, %v24, 1
@@ -2324,7 +2324,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepg %v24, 0(%r2)
@@ -2343,7 +2343,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vrepg %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -2361,7 +2361,7 @@ block0(v0: f32):
 ; block0:
 ;   vrepf %v24, %v0, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v0, 0
@@ -2378,7 +2378,7 @@ block0(v0: f32x4):
 ; block0:
 ;   vrepf %v24, %v24, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 0
@@ -2395,7 +2395,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vrepf %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v24, %v24, 3
@@ -2412,7 +2412,7 @@ block0(v0: i64):
 ; block0:
 ;   vlrepf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlrepf %v24, 0(%r2)
@@ -2431,7 +2431,7 @@ block0(v0: i64):
 ;   vlvgf %v4, %r4, 0
 ;   vrepf %v24, %v4, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrv %r4, 0(%r2)
@@ -2450,7 +2450,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2469,7 +2469,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleig %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2488,7 +2488,7 @@ block0(v0: i64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2507,7 +2507,7 @@ block0(v0: i64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v24, %v2, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2526,7 +2526,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2546,7 +2546,7 @@ block0(v0: i64):
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2565,7 +2565,7 @@ block0(v0: i32):
 ;   vgbm %v24, 0
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2584,7 +2584,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleif %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2603,7 +2603,7 @@ block0(v0: i32x4):
 ;   vgbm %v2, 61440
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xf000
@@ -2623,7 +2623,7 @@ block0(v0: i32x4):
 ;   vgbm %v4, 61440
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v2, %v24, 3
@@ -2643,7 +2643,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2663,7 +2663,7 @@ block0(v0: i64):
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2682,7 +2682,7 @@ block0(v0: i16):
 ;   vgbm %v24, 0
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2701,7 +2701,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleih %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2720,7 +2720,7 @@ block0(v0: i16x8):
 ;   vgbm %v2, 49152
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xc000
@@ -2740,7 +2740,7 @@ block0(v0: i16x8):
 ;   vgbm %v4, 49152
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vreph %v2, %v24, 7
@@ -2760,7 +2760,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleh %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2780,7 +2780,7 @@ block0(v0: i64):
 ;   lrvh %r2, 0(%r2)
 ;   vlvgh %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2799,7 +2799,7 @@ block0(v0: i8):
 ;   vgbm %v24, 0
 ;   vlvgb %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2818,7 +2818,7 @@ block0:
 ;   vgbm %v24, 0
 ;   vleib %v24, 123, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2837,7 +2837,7 @@ block0(v0: i8x16):
 ;   vgbm %v2, 32768
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0x8000
@@ -2857,7 +2857,7 @@ block0(v0: i8x16):
 ;   vgbm %v4, 32768
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepb %v2, %v24, 0xf
@@ -2877,7 +2877,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2896,7 +2896,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleb %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2914,7 +2914,7 @@ block0(v0: f64):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v0, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2933,7 +2933,7 @@ block0(v0: f64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v24, %v2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2952,7 +2952,7 @@ block0(v0: f64x2):
 ;   vgbm %v2, 0
 ;   vpdi %v24, %v24, %v2, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -2971,7 +2971,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vleg %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -2991,7 +2991,7 @@ block0(v0: i64):
 ;   lrvg %r2, 0(%r2)
 ;   vlvgg %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -3010,7 +3010,7 @@ block0(v0: f32):
 ;   vgbm %v2, 61440
 ;   vn %v24, %v0, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xf000
@@ -3029,7 +3029,7 @@ block0(v0: f32x4):
 ;   vgbm %v2, 61440
 ;   vn %v24, %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vgbm %v2, 0xf000
@@ -3049,7 +3049,7 @@ block0(v0: f32x4):
 ;   vgbm %v4, 61440
 ;   vn %v24, %v2, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepf %v2, %v24, 3
@@ -3069,7 +3069,7 @@ block0(v0: i64):
 ;   vgbm %v24, 0
 ;   vlef %v24, 0(%r2), 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24
@@ -3089,7 +3089,7 @@ block0(v0: i64):
 ;   lrv %r2, 0(%r2)
 ;   vlvgf %v24, %r2, 0
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v24

--- a/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-logical.clif
@@ -14,7 +14,7 @@ block0(v0: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -36,7 +36,7 @@ block0(v0: i32x4):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -58,7 +58,7 @@ block0(v0: i16x8):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -80,7 +80,7 @@ block0(v0: i8x16):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -102,7 +102,7 @@ block0(v0: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -124,7 +124,7 @@ block0(v0: i32x4):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -146,7 +146,7 @@ block0(v0: i16x8):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -168,7 +168,7 @@ block0(v0: i8x16):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v2
@@ -190,7 +190,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
@@ -211,7 +211,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
@@ -232,7 +232,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
@@ -253,7 +253,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
@@ -274,7 +274,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
@@ -295,7 +295,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
@@ -316,7 +316,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
@@ -337,7 +337,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
@@ -358,7 +358,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
@@ -379,7 +379,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
@@ -400,7 +400,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
@@ -421,7 +421,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
@@ -442,7 +442,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
@@ -463,7 +463,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
@@ -484,7 +484,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
@@ -505,7 +505,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
@@ -526,7 +526,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
@@ -547,7 +547,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
@@ -568,7 +568,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochino %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
@@ -589,7 +589,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochine %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
@@ -610,7 +610,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
@@ -631,7 +631,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vceqgs %v3, %v24, %v25
@@ -652,7 +652,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
@@ -673,7 +673,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v24, %v25
@@ -694,7 +694,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
@@ -715,7 +715,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchgs %v3, %v25, %v24
@@ -736,7 +736,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
@@ -757,7 +757,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v24, %v25
@@ -778,7 +778,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
@@ -799,7 +799,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vchlgs %v3, %v25, %v24
@@ -820,7 +820,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
@@ -841,7 +841,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfcedbs %v3, %v24, %v25
@@ -862,7 +862,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
@@ -883,7 +883,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v24, %v25
@@ -904,7 +904,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
@@ -925,7 +925,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v24, %v25
@@ -946,7 +946,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
@@ -967,7 +967,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchdbs %v3, %v25, %v24
@@ -988,7 +988,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochie %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
@@ -1009,7 +1009,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   lhi %r2, 0
 ;   lochio %r2, 1
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vfchedbs %v3, %v25, %v24
@@ -1029,7 +1029,7 @@ block0(v0: i64x2):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1059,7 +1059,7 @@ block0(v0: i32x4):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1087,7 +1087,7 @@ block0(v0: i16x8):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1115,7 +1115,7 @@ block0(v0: i8x16):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1142,7 +1142,7 @@ block0(v0: i64x2):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1171,7 +1171,7 @@ block0(v0: i32x4):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1201,7 +1201,7 @@ block0(v0: i16x8):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -1229,7 +1229,7 @@ block0(v0: i8x16):
 ;   vbperm %v4, %v24, %v2
 ;   lgdr %r2, %f4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute-le-lane.clif
@@ -15,7 +15,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmxlb %v17, %v5, %v7
 ;   vperm %v24, %v3, %v24, %v17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -36,7 +36,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vrepib %v3, 15
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vrepib %v3, 0xf
@@ -54,7 +54,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   bras %r1, 20 ; data.u128 0x0a1e000d0b1702180403090b15100f0c ; vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -80,7 +80,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v25
@@ -96,7 +96,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v25
@@ -112,7 +112,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v25
@@ -128,7 +128,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v25
@@ -144,7 +144,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v24
@@ -160,7 +160,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v24
@@ -176,7 +176,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v24
@@ -192,7 +192,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v24
@@ -208,7 +208,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v24
@@ -224,7 +224,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v24
@@ -240,7 +240,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v24
@@ -256,7 +256,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v24
@@ -272,7 +272,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v25
@@ -288,7 +288,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v25
@@ -304,7 +304,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v25
@@ -320,7 +320,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v25
@@ -336,7 +336,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v25
@@ -352,7 +352,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v25
@@ -368,7 +368,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v25
@@ -384,7 +384,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v25
@@ -400,7 +400,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v24
@@ -416,7 +416,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v24
@@ -432,7 +432,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v24
@@ -448,7 +448,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v24
@@ -464,7 +464,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v24
@@ -480,7 +480,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v24
@@ -496,7 +496,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v24
@@ -512,7 +512,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v24
@@ -528,7 +528,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v25
@@ -544,7 +544,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v25
@@ -560,7 +560,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v25
@@ -576,7 +576,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v25
@@ -593,7 +593,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v25
@@ -609,7 +609,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v25
@@ -625,7 +625,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v25
@@ -641,7 +641,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v24
@@ -657,7 +657,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v24
@@ -673,7 +673,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v24
@@ -689,7 +689,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v24
@@ -705,7 +705,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v24
@@ -721,7 +721,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v24
@@ -737,7 +737,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v25
@@ -753,7 +753,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v25
@@ -769,7 +769,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v25

--- a/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-permute.clif
@@ -14,7 +14,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vmnlb %v7, %v5, %v25
 ;   vperm %v24, %v24, %v3, %v7
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -34,7 +34,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   vgbm %v3, 0
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vzero %v3
@@ -52,7 +52,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   bras %r1, 20 ; data.u128 0x03001f1a04060c0b170d1804020f1105 ; vl %v3, 0(%r1)
 ;   vperm %v24, %v24, %v25, %v3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   bras %r1, 0x14
@@ -78,7 +78,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v25
@@ -94,7 +94,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v25
@@ -110,7 +110,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v25
@@ -126,7 +126,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v25
@@ -142,7 +142,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v24
@@ -158,7 +158,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v24
@@ -174,7 +174,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v24
@@ -190,7 +190,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v24
@@ -206,7 +206,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v24, %v24
@@ -222,7 +222,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v24, %v24
@@ -238,7 +238,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v24, %v24
@@ -254,7 +254,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v24, %v24
@@ -270,7 +270,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhg %v24, %v25, %v25
@@ -286,7 +286,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhf %v24, %v25, %v25
@@ -302,7 +302,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhh %v24, %v25, %v25
@@ -318,7 +318,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrhb %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrhb %v24, %v25, %v25
@@ -334,7 +334,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v25
@@ -350,7 +350,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v25
@@ -366,7 +366,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v25
@@ -382,7 +382,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v25
@@ -398,7 +398,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v24
@@ -414,7 +414,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v24
@@ -430,7 +430,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v24
@@ -446,7 +446,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v24
@@ -462,7 +462,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v24, %v24
@@ -478,7 +478,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v24, %v24
@@ -494,7 +494,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v24, %v24
@@ -510,7 +510,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v24, %v24
@@ -526,7 +526,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlg %v24, %v25, %v25
@@ -542,7 +542,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlf %v24, %v25, %v25
@@ -558,7 +558,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlh %v24, %v25, %v25
@@ -574,7 +574,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vmrlb %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vmrlb %v24, %v25, %v25
@@ -591,7 +591,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v25
@@ -607,7 +607,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v25
@@ -623,7 +623,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v24, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v25
@@ -639,7 +639,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v24
@@ -655,7 +655,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v24
@@ -671,7 +671,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v25, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v24
@@ -687,7 +687,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v24, %v24
@@ -703,7 +703,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v24, %v24
@@ -719,7 +719,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v24, %v24
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v24, %v24
@@ -735,7 +735,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkg %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkg %v24, %v25, %v25
@@ -751,7 +751,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkf %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkf %v24, %v25, %v25
@@ -767,7 +767,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   vpkh %v24, %v25, %v25
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpkh %v24, %v25, %v25

--- a/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-shift-rotate.clif
@@ -12,7 +12,7 @@ block0(v0: i64x2, v1: i64):
 ;   lcr %r5, %r2
 ;   verllg %v24, %v24, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r2
@@ -30,7 +30,7 @@ block0(v0: i64x2):
 ; block0:
 ;   verllg %v24, %v24, 47
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllg %v24, %v24, 0x2f
@@ -47,7 +47,7 @@ block0(v0: i32x4, v1: i32):
 ;   lcr %r5, %r2
 ;   verllf %v24, %v24, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r2
@@ -65,7 +65,7 @@ block0(v0: i32x4):
 ; block0:
 ;   verllf %v24, %v24, 15
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllf %v24, %v24, 0xf
@@ -82,7 +82,7 @@ block0(v0: i16x8, v1: i16):
 ;   lcr %r5, %r2
 ;   verllh %v24, %v24, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r2
@@ -100,7 +100,7 @@ block0(v0: i16x8):
 ; block0:
 ;   verllh %v24, %v24, 6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllh %v24, %v24, 6
@@ -117,7 +117,7 @@ block0(v0: i8x16, v1: i8):
 ;   lcr %r5, %r2
 ;   verllb %v24, %v24, 0(%r5)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lcr %r5, %r2
@@ -135,7 +135,7 @@ block0(v0: i8x16):
 ; block0:
 ;   verllb %v24, %v24, 5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllb %v24, %v24, 5
@@ -151,7 +151,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   verllg %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllg %v24, %v24, 0(%r2)
@@ -168,7 +168,7 @@ block0(v0: i64x2):
 ; block0:
 ;   verllg %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllg %v24, %v24, 0x11
@@ -184,7 +184,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   verllf %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllf %v24, %v24, 0(%r2)
@@ -201,7 +201,7 @@ block0(v0: i32x4):
 ; block0:
 ;   verllf %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllf %v24, %v24, 0x11
@@ -217,7 +217,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   verllh %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllh %v24, %v24, 0(%r2)
@@ -234,7 +234,7 @@ block0(v0: i16x8):
 ; block0:
 ;   verllh %v24, %v24, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllh %v24, %v24, 0xa
@@ -250,7 +250,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   verllb %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllb %v24, %v24, 0(%r2)
@@ -267,7 +267,7 @@ block0(v0: i8x16):
 ; block0:
 ;   verllb %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   verllb %v24, %v24, 3
@@ -283,7 +283,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vesrlg %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlg %v24, %v24, 0(%r2)
@@ -300,7 +300,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vesrlg %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlg %v24, %v24, 0x11
@@ -316,7 +316,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vesrlf %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlf %v24, %v24, 0(%r2)
@@ -333,7 +333,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vesrlf %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlf %v24, %v24, 0x11
@@ -349,7 +349,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vesrlh %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlh %v24, %v24, 0(%r2)
@@ -366,7 +366,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vesrlh %v24, %v24, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlh %v24, %v24, 0xa
@@ -382,7 +382,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vesrlb %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlb %v24, %v24, 0(%r2)
@@ -399,7 +399,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vesrlb %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrlb %v24, %v24, 3
@@ -415,7 +415,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   veslg %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslg %v24, %v24, 0(%r2)
@@ -432,7 +432,7 @@ block0(v0: i64x2):
 ; block0:
 ;   veslg %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslg %v24, %v24, 0x11
@@ -448,7 +448,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   veslf %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslf %v24, %v24, 0(%r2)
@@ -465,7 +465,7 @@ block0(v0: i32x4):
 ; block0:
 ;   veslf %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslf %v24, %v24, 0x11
@@ -481,7 +481,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   veslh %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslh %v24, %v24, 0(%r2)
@@ -498,7 +498,7 @@ block0(v0: i16x8):
 ; block0:
 ;   veslh %v24, %v24, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslh %v24, %v24, 0xa
@@ -514,7 +514,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   veslb %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslb %v24, %v24, 0(%r2)
@@ -531,7 +531,7 @@ block0(v0: i8x16):
 ; block0:
 ;   veslb %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   veslb %v24, %v24, 3
@@ -547,7 +547,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vesrag %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrag %v24, %v24, 0(%r2)
@@ -564,7 +564,7 @@ block0(v0: i64x2):
 ; block0:
 ;   vesrag %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrag %v24, %v24, 0x11
@@ -580,7 +580,7 @@ block0(v0: i32x4, v1: i32):
 ; block0:
 ;   vesraf %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesraf %v24, %v24, 0(%r2)
@@ -597,7 +597,7 @@ block0(v0: i32x4):
 ; block0:
 ;   vesraf %v24, %v24, 17
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesraf %v24, %v24, 0x11
@@ -613,7 +613,7 @@ block0(v0: i16x8, v1: i16):
 ; block0:
 ;   vesrah %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrah %v24, %v24, 0(%r2)
@@ -630,7 +630,7 @@ block0(v0: i16x8):
 ; block0:
 ;   vesrah %v24, %v24, 10
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrah %v24, %v24, 0xa
@@ -646,7 +646,7 @@ block0(v0: i8x16, v1: i8):
 ; block0:
 ;   vesrab %v24, %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrab %v24, %v24, 0(%r2)
@@ -663,7 +663,7 @@ block0(v0: i8x16):
 ; block0:
 ;   vesrab %v24, %v24, 3
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vesrab %v24, %v24, 3

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-arch13.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -30,7 +30,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -48,7 +48,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -84,7 +84,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -102,7 +102,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -119,7 +119,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -135,7 +135,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -151,7 +151,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -167,7 +167,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -184,7 +184,7 @@ block0(v0: i64):
 ;   vl %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v3, 0(%r3)
@@ -201,7 +201,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -217,7 +217,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -233,7 +233,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -249,7 +249,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -265,7 +265,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -281,7 +281,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -298,7 +298,7 @@ block0(v0: i128, v1: i64):
 ;   vl %v1, 0(%r2)
 ;   vst %v1, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -315,7 +315,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -331,7 +331,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -348,7 +348,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -367,7 +367,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -387,7 +387,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuplhf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -408,7 +408,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -427,7 +427,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -447,7 +447,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuphf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -467,7 +467,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -483,7 +483,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrh %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -501,7 +501,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -519,7 +519,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -538,7 +538,7 @@ block0(v0: i64):
 ;   vlbrq %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x30
@@ -558,7 +558,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -576,7 +576,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -594,7 +594,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -610,7 +610,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstbrh %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -628,7 +628,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstbrf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -646,7 +646,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstbrg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -665,7 +665,7 @@ block0(v0: i128, v1: i64):
 ;   vl %v1, 0(%r2)
 ;   vstbrq %v1, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -683,7 +683,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstbrf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -701,7 +701,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstbrg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane-arch13.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -33,7 +33,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -55,7 +55,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuplhf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -74,7 +74,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -95,7 +95,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -117,7 +117,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuphf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -135,7 +135,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -152,7 +152,7 @@ block0(v0: i64):
 ; block0:
 ;   vlerh %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -170,7 +170,7 @@ block0(v0: i64):
 ; block0:
 ;   vlerf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -188,7 +188,7 @@ block0(v0: i64):
 ; block0:
 ;   vlerg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -206,7 +206,7 @@ block0(v0: i64):
 ; block0:
 ;   vlerf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -224,7 +224,7 @@ block0(v0: i64):
 ; block0:
 ;   vlerg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -242,7 +242,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -259,7 +259,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vsterh %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -277,7 +277,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vsterf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -295,7 +295,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vsterg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -313,7 +313,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vsterf %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -331,7 +331,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vsterg %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -350,7 +350,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -370,7 +370,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuplhh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -390,7 +390,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuplhf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -410,7 +410,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -430,7 +430,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuphh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -450,7 +450,7 @@ block0(v0: i64):
 ;   vlebrg %v2, 0(%r2), 0
 ;   vuphf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x20
@@ -469,7 +469,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -486,7 +486,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -503,7 +503,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -520,7 +520,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -537,7 +537,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -554,7 +554,7 @@ block0(v0: i64):
 ; block0:
 ;   vlbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -571,7 +571,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -588,7 +588,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -605,7 +605,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -622,7 +622,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -639,7 +639,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80
@@ -656,7 +656,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vstbrq %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0xe6, 0x80

--- a/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem-le-lane.clif
@@ -13,7 +13,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuplhb %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -34,7 +34,7 @@ block0(v0: i64):
 ;   verllh %v6, %v4, 8
 ;   vuplhh %v24, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -55,7 +55,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuplhf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -75,7 +75,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuphb %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -96,7 +96,7 @@ block0(v0: i64):
 ;   verllh %v6, %v4, 8
 ;   vuphh %v24, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -117,7 +117,7 @@ block0(v0: i64):
 ;   verllg %v4, %v2, 32
 ;   vuphf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -137,7 +137,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -158,7 +158,7 @@ block0(v0: i64):
 ;   verllg %v6, %v4, 32
 ;   verllf %v24, %v6, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
@@ -179,7 +179,7 @@ block0(v0: i64):
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
@@ -198,7 +198,7 @@ block0(v0: i64):
 ;   vl %v2, 0(%r2)
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
@@ -217,7 +217,7 @@ block0(v0: i64):
 ;   vpdi %v4, %v2, %v2, 4
 ;   verllg %v24, %v4, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
@@ -236,7 +236,7 @@ block0(v0: i64):
 ;   vl %v2, 0(%r2)
 ;   vpdi %v24, %v2, %v2, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v2, 0(%r2)
@@ -256,7 +256,7 @@ block0(v0: i8x16, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -278,7 +278,7 @@ block0(v0: i16x8, v1: i64):
 ;   verllf %v7, %v5, 16
 ;   vst %v7, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -299,7 +299,7 @@ block0(v0: i32x4, v1: i64):
 ;   verllg %v5, %v3, 32
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -318,7 +318,7 @@ block0(v0: i64x2, v1: i64):
 ;   vpdi %v3, %v24, %v24, 4
 ;   vst %v3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -337,7 +337,7 @@ block0(v0: f32x4, v1: i64):
 ;   verllg %v5, %v3, 32
 ;   vst %v5, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -356,7 +356,7 @@ block0(v0: f64x2, v1: i64):
 ;   vpdi %v3, %v24, %v24, 4
 ;   vst %v3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -375,7 +375,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuplhb %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -395,7 +395,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuplhh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -415,7 +415,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuplhf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -435,7 +435,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuphb %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -455,7 +455,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuphh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -475,7 +475,7 @@ block0(v0: i64):
 ;   ldgr %f4, %r4
 ;   vuphf %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -495,7 +495,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -515,7 +515,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -535,7 +535,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -555,7 +555,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -575,7 +575,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -595,7 +595,7 @@ block0(v0: i64):
 ;   lrvg %r2, 8(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -616,7 +616,7 @@ block0(v0: i64, v1: i64):
 ;   lrvg %r3, 8(%r3,%r2)
 ;   vlvgp %v24, %r3, %r5
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r3, %r2)
@@ -636,7 +636,7 @@ block0(v0: i64):
 ;   lrvg %r2, 136(%r2)
 ;   vlvgp %v24, %r2, %r4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0x80(%r2)
@@ -657,7 +657,7 @@ block0(v0: i8x16, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -679,7 +679,7 @@ block0(v0: i16x8, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -701,7 +701,7 @@ block0(v0: i32x4, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -723,7 +723,7 @@ block0(v0: i64x2, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -745,7 +745,7 @@ block0(v0: f32x4, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -767,7 +767,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -790,7 +790,7 @@ block0(v0: f64x2, v1: i64, v2: i64):
 ;   strvg %r5, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1
@@ -812,7 +812,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r5, 128(%r2)
 ;   strvg %r3, 136(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vlgvg %r5, %v24, 1

--- a/cranelift/filetests/filetests/isa/s390x/vecmem.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vecmem.clif
@@ -12,7 +12,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -30,7 +30,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -48,7 +48,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -84,7 +84,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphh %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -102,7 +102,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphf %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -119,7 +119,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -135,7 +135,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -151,7 +151,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -167,7 +167,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -184,7 +184,7 @@ block0(v0: i64):
 ;   vl %v3, 0(%r3)
 ;   vst %v3, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v3, 0(%r3)
@@ -201,7 +201,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -217,7 +217,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -233,7 +233,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -249,7 +249,7 @@ block0(v0: i16x8, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -265,7 +265,7 @@ block0(v0: i32x4, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -281,7 +281,7 @@ block0(v0: i64x2, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -298,7 +298,7 @@ block0(v0: i128, v1: i64):
 ;   vl %v1, 0(%r2)
 ;   vst %v1, 0(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -315,7 +315,7 @@ block0(v0: f32x4, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -331,7 +331,7 @@ block0(v0: f64x2, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -348,7 +348,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuplhb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -367,7 +367,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuplhh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -388,7 +388,7 @@ block0(v0: i64):
 ;   verllg %v6, %v4, 32
 ;   vuplhf %v24, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -408,7 +408,7 @@ block0(v0: i64):
 ;   ld %f2, 0(%r2)
 ;   vuphb %v24, %v2
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -427,7 +427,7 @@ block0(v0: i64):
 ;   verllh %v4, %v2, 8
 ;   vuphh %v24, %v4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld %f2, 0(%r2)
@@ -448,7 +448,7 @@ block0(v0: i64):
 ;   verllg %v6, %v4, 32
 ;   vuphf %v24, %v6
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -467,7 +467,7 @@ block0(v0: i64):
 ; block0:
 ;   vl %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v24, 0(%r2)
@@ -488,7 +488,7 @@ block0(v0: i64):
 ;   verllg %v18, %v16, 32
 ;   verllf %v24, %v18, 16
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -513,7 +513,7 @@ block0(v0: i64):
 ;   vpdi %v16, %v6, %v6, 4
 ;   verllg %v24, %v16, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -536,7 +536,7 @@ block0(v0: i64):
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v24, %v6, %v6, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -558,7 +558,7 @@ block0(v0: i64):
 ;   vlvgp %v7, %r3, %r5
 ;   vst %v7, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r3)
@@ -581,7 +581,7 @@ block0(v0: i64):
 ;   vpdi %v16, %v6, %v6, 4
 ;   verllg %v24, %v16, 32
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -604,7 +604,7 @@ block0(v0: i64):
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v24, %v6, %v6, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0(%r2)
@@ -627,7 +627,7 @@ block0(v0: i64, v1: i64):
 ;   vlvgp %v7, %r3, %r5
 ;   vpdi %v24, %v7, %v7, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r5, 0(%r3, %r2)
@@ -649,7 +649,7 @@ block0(v0: i64):
 ;   vlvgp %v6, %r2, %r4
 ;   vpdi %v24, %v6, %v6, 4
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lrvg %r4, 0x80(%r2)
@@ -668,7 +668,7 @@ block0(v0: i8x16, v1: i64):
 ; block0:
 ;   vst %v24, 0(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vst %v24, 0(%r2)
@@ -690,7 +690,7 @@ block0(v0: i16x8, v1: i64):
 ;   strvg %r3, 0(%r2)
 ;   strvg %r5, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -717,7 +717,7 @@ block0(v0: i32x4, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -742,7 +742,7 @@ block0(v0: i64x2, v1: i64):
 ;   strvg %r3, 0(%r2)
 ;   strvg %r5, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -766,7 +766,7 @@ block0(v0: i128, v1: i64):
 ;   strvg %r2, 0(%r3)
 ;   strvg %r4, 8(%r3)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vl %v1, 0(%r2)
@@ -791,7 +791,7 @@ block0(v0: f32x4, v1: i64):
 ;   strvg %r5, 0(%r2)
 ;   strvg %r3, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -816,7 +816,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r3, 0(%r2)
 ;   strvg %r5, 8(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4
@@ -841,7 +841,7 @@ block0(v0: f64x2, v1: i64, v2: i64):
 ;   strvg %r5, 0(%r3,%r2)
 ;   strvg %r4, 8(%r3,%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v4, %v24, %v24, 4
@@ -865,7 +865,7 @@ block0(v0: f64x2, v1: i64):
 ;   strvg %r3, 128(%r2)
 ;   strvg %r5, 136(%r2)
 ;   br %r14
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   vpdi %v3, %v24, %v24, 4

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -17,7 +17,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -71,7 +71,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -99,7 +99,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -127,7 +127,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -155,7 +155,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -184,7 +184,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -216,7 +216,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -251,7 +251,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/band_not_bmi1.clif
@@ -16,7 +16,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -42,7 +42,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/basic.clif
+++ b/cranelift/filetests/filetests/isa/x64/basic.clif
@@ -15,7 +15,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/bitcast.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -20,7 +20,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -51,7 +51,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -82,7 +82,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -113,7 +113,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -144,7 +144,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -175,7 +175,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -206,7 +206,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -237,7 +237,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -268,7 +268,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -299,7 +299,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -330,7 +330,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -361,7 +361,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -392,7 +392,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -423,7 +423,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -454,7 +454,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -485,7 +485,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -518,7 +518,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -552,7 +552,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -585,7 +585,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -618,7 +618,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -651,7 +651,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -684,7 +684,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -717,7 +717,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -750,7 +750,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -783,7 +783,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -31,7 +31,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -80,7 +80,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -129,7 +129,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -179,7 +179,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -228,7 +228,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -277,7 +277,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -333,7 +333,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -395,7 +395,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -443,7 +443,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -491,7 +491,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -539,7 +539,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -587,7 +587,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -648,7 +648,7 @@ block202:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -700,7 +700,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -751,7 +751,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -802,7 +802,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -853,7 +853,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -928,7 +928,7 @@ block5(v5: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1012,7 +1012,7 @@ block1(v5: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/x64/bswap.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -70,7 +70,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -22,7 +22,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -63,7 +63,7 @@ block0(v0: i32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -124,7 +124,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -229,7 +229,7 @@ block0(
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -298,7 +298,7 @@ block0(v0: i64, v1:i64, v2:i64, v3:i64, v4:i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -350,7 +350,7 @@ block0(v0: i32, v1: f32, v2: i64, v3: f64, v4: i32, v5: i32, v6: i32, v7: f32, v
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -392,7 +392,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -418,7 +418,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -452,7 +452,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -492,7 +492,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -542,7 +542,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -592,7 +592,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -639,7 +639,7 @@ block0(v0: f32, v1: i64, v2: i32, v3: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -15,7 +15,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -24,7 +24,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -67,7 +67,7 @@ block0(v0: f64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/x64/cold-blocks.clif
@@ -30,7 +30,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block2 cold:
 ; block2:
 ;   movl    $97, %eax
 ;   jmp     label3
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -57,7 +57,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -103,7 +103,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -153,7 +153,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -204,7 +204,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -240,7 +240,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -268,7 +268,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -296,7 +296,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -324,7 +324,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -353,7 +353,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -383,7 +383,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -413,7 +413,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -443,7 +443,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -15,7 +15,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -23,7 +23,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -59,7 +59,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -95,7 +95,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -131,7 +131,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -167,7 +167,7 @@ block0(v0: i8x16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -193,7 +193,7 @@ block0(v0: i16x8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -219,7 +219,7 @@ block0(v0: i32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -245,7 +245,7 @@ block0(v0: f32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -271,7 +271,7 @@ block0(v0: i64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -297,7 +297,7 @@ block0(v0: f64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -15,7 +15,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -115,7 +115,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -140,7 +140,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: i8x16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -192,7 +192,7 @@ block0(v0: i16x8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -218,7 +218,7 @@ block0(v0: i32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -244,7 +244,7 @@ block0(v0: f32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -270,7 +270,7 @@ block0(v0: i64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -296,7 +296,7 @@ block0(v0: f64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/fabs.clif
@@ -17,7 +17,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -46,7 +46,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -106,7 +106,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -18,7 +18,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -70,7 +70,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -96,7 +96,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -122,7 +122,7 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -148,7 +148,7 @@ block0(v0: i64, v1: i64, v2: f64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -185,7 +185,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -214,7 +214,7 @@ block0(v0: i128, v1: i64, v2: i128, v3: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -258,7 +258,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -415,7 +415,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcopysign.clif
@@ -21,7 +21,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -58,7 +58,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -16,7 +16,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -16,7 +16,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -69,7 +69,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -94,7 +94,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -120,7 +120,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -147,7 +147,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -173,7 +173,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -198,7 +198,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -223,7 +223,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -263,7 +263,7 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -309,7 +309,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -362,7 +362,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -396,7 +396,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -437,7 +437,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -479,7 +479,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -520,7 +520,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -562,7 +562,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -606,7 +606,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -651,7 +651,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -695,7 +695,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -740,7 +740,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -779,7 +779,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -818,7 +818,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -857,7 +857,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -896,7 +896,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -931,7 +931,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -966,7 +966,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1001,7 +1001,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1051,7 +1051,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1098,7 +1098,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/float-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-avx.clif
@@ -16,7 +16,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -191,7 +191,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -216,7 +216,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -241,7 +241,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -266,7 +266,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -291,7 +291,7 @@ block0(v0: f64, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -316,7 +316,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -341,7 +341,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -366,7 +366,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -391,7 +391,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -416,7 +416,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -448,7 +448,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -480,7 +480,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -505,7 +505,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -536,7 +536,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -572,7 +572,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -605,7 +605,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -633,7 +633,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/float-bitcast-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-bitcast-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/float-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-bitcast.clif
@@ -16,7 +16,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/floating-point.clif
+++ b/cranelift/filetests/filetests/isa/x64/floating-point.clif
@@ -17,7 +17,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -48,7 +48,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/floor.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -16,7 +16,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -113,7 +113,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -203,7 +203,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fma-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-inst.clif
@@ -15,7 +15,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64, v1: f64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -117,7 +117,7 @@ block0(v0: f32, v1: i64, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -143,7 +143,7 @@ block0(v0: i64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -169,7 +169,7 @@ block0(v0: f32x4, v1: i64, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -195,7 +195,7 @@ block0(v0: i64, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -221,7 +221,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -247,7 +247,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -274,7 +274,7 @@ block0(v0: f32x4, v1: f32x4, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -301,7 +301,7 @@ block0(v0: f64x2, v1: f64x2, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -328,7 +328,7 @@ block0(v0: f32, v1: i64, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -355,7 +355,7 @@ block0(v0: i64, v1: f64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -382,7 +382,7 @@ block0(v0: i64, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -409,7 +409,7 @@ block0(v0: f64x2, v1: i64, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fneg.clif
+++ b/cranelift/filetests/filetests/isa/x64/fneg.clif
@@ -17,7 +17,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -46,7 +46,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -106,7 +106,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
+++ b/cranelift/filetests/filetests/isa/x64/fp_sp_pc.clif
@@ -16,7 +16,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -67,7 +67,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -50,7 +50,7 @@ block0(v1: i64, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -79,7 +79,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -113,7 +113,7 @@ block0(v1: i64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -50,7 +50,7 @@ block0(v1: i64, v2: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -79,7 +79,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -113,7 +113,7 @@ block0(v1: i64, v2: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fsqrt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fsqrt-avx.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fsqrt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fsqrt.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -19,7 +19,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -50,7 +50,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -81,7 +81,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -112,7 +112,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -143,7 +143,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -174,7 +174,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -214,7 +214,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -252,7 +252,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -279,7 +279,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -431,7 +431,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -583,7 +583,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -639,7 +639,7 @@ block2:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -677,7 +677,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -705,7 +705,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -734,7 +734,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -762,7 +762,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -788,7 +788,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -813,7 +813,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -839,7 +839,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -906,7 +906,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1055,7 +1055,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1164,7 +1164,7 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1191,7 +1191,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1249,7 +1249,7 @@ block2(v8: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1332,7 +1332,7 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1400,7 +1400,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1452,7 +1452,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1505,7 +1505,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1553,7 +1553,7 @@ block0(v0: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1590,7 +1590,7 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1636,7 +1636,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1698,7 +1698,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1763,7 +1763,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1851,7 +1851,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1960,7 +1960,7 @@ block0(v0: i128, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/iabs.clif
@@ -17,7 +17,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -46,7 +46,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -75,7 +75,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -104,7 +104,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
@@ -16,7 +16,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/immediates.clif
+++ b/cranelift/filetests/filetests/isa/x64/immediates.clif
@@ -33,7 +33,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -26,7 +26,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -60,7 +60,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -95,7 +95,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -25,7 +25,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -59,7 +59,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -94,7 +94,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
@@ -16,7 +16,7 @@ block0(v0: f64x2, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64x2, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -68,7 +68,7 @@ block0(v0: f64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -96,7 +96,7 @@ block0(v0: i8x16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -124,7 +124,7 @@ block0(v0: i16x8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -151,7 +151,7 @@ block0(v0: i32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -177,7 +177,7 @@ block0(v0: i64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/insertlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane.clif
@@ -16,7 +16,7 @@ block0(v0: f64x2, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64x2, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -68,7 +68,7 @@ block0(v0: f64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -96,7 +96,7 @@ block0(v0: i8x16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -124,7 +124,7 @@ block0(v0: i16x8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -151,7 +151,7 @@ block0(v0: i32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -177,7 +177,7 @@ block0(v0: i64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -39,7 +39,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -99,7 +99,7 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -160,7 +160,7 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -221,7 +221,7 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -282,7 +282,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -327,7 +327,7 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -356,7 +356,7 @@ block0(v0: i32, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -386,7 +386,7 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -417,7 +417,7 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -447,7 +447,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -476,7 +476,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -505,7 +505,7 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -534,7 +534,7 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -563,7 +563,7 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -592,7 +592,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -621,7 +621,7 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -650,7 +650,7 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -680,7 +680,7 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -711,7 +711,7 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -742,7 +742,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -773,7 +773,7 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -804,7 +804,7 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -835,7 +835,7 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -866,7 +866,7 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -897,7 +897,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -926,7 +926,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -953,7 +953,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -980,7 +980,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1007,7 +1007,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/lea.clif
+++ b/cranelift/filetests/filetests/isa/x64/lea.clif
@@ -15,7 +15,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -92,7 +92,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -119,7 +119,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -146,7 +146,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -175,7 +175,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -204,7 +204,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -231,7 +231,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -258,7 +258,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/leaf.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf.clif
@@ -18,7 +18,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf_with_preserve_frame_pointers.clif
@@ -18,7 +18,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/load-op-store.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op-store.clif
@@ -17,7 +17,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -71,7 +71,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -98,7 +98,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -125,7 +125,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -152,7 +152,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -179,7 +179,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -206,7 +206,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -233,7 +233,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/load-op.clif
+++ b/cranelift/filetests/filetests/isa/x64/load-op.clif
@@ -17,7 +17,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -45,7 +45,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -73,7 +73,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -101,7 +101,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -129,7 +129,7 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -161,7 +161,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -195,7 +195,7 @@ block1:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -225,7 +225,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -255,7 +255,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -20,7 +20,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -15,7 +15,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -72,7 +72,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -109,7 +109,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -134,7 +134,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
+++ b/cranelift/filetests/filetests/isa/x64/pinned-reg.clif
@@ -20,7 +20,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -55,7 +55,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt-use-popcnt.clif
@@ -15,7 +15,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -34,7 +34,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -98,7 +98,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -159,7 +159,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -219,7 +219,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/probestack.clif
@@ -22,7 +22,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/sdiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/sdiv.clif
@@ -19,7 +19,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -53,7 +53,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -87,7 +87,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -121,7 +121,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -23,7 +23,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -60,7 +60,7 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
@@ -23,7 +23,7 @@ block0(v0: f32, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -19,7 +19,7 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -51,7 +51,7 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/sextend.clif
+++ b/cranelift/filetests/filetests/isa/x64/sextend.clif
@@ -15,7 +15,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/shift-to-extend.clif
+++ b/cranelift/filetests/filetests/isa/x64/shift-to-extend.clif
@@ -18,7 +18,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -70,7 +70,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -96,7 +96,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -122,7 +122,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -148,7 +148,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -174,7 +174,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -200,7 +200,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -226,7 +226,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -252,7 +252,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
@@ -19,7 +19,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -47,7 +47,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -75,7 +75,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -103,7 +103,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -131,7 +131,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -20,7 +20,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -59,7 +59,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -97,7 +97,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -125,7 +125,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -153,7 +153,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -181,7 +181,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -209,7 +209,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -237,7 +237,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -265,7 +265,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -293,7 +293,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -321,7 +321,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -349,7 +349,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -379,7 +379,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -409,7 +409,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -437,7 +437,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -465,7 +465,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -493,7 +493,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -521,7 +521,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -549,7 +549,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -577,7 +577,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -605,7 +605,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -632,7 +632,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -658,7 +658,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -685,7 +685,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -714,7 +714,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -743,7 +743,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -770,7 +770,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -798,7 +798,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
@@ -17,7 +17,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -191,7 +191,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -216,7 +216,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -241,7 +241,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -266,7 +266,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -291,7 +291,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -316,7 +316,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -341,7 +341,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -366,7 +366,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -391,7 +391,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -416,7 +416,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -441,7 +441,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -466,7 +466,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -491,7 +491,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -520,7 +520,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -551,7 +551,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -580,7 +580,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -616,7 +616,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -647,7 +647,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -676,7 +676,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -719,7 +719,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -744,7 +744,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -769,7 +769,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -794,7 +794,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -819,7 +819,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -844,7 +844,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -869,7 +869,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -894,7 +894,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -927,7 +927,7 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -965,7 +965,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -997,7 +997,7 @@ block0(v0: i16x8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1026,7 +1026,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1054,7 +1054,7 @@ block0(v0: i32x4, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1083,7 +1083,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1108,7 +1108,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1133,7 +1133,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1158,7 +1158,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1183,7 +1183,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1210,7 +1210,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1239,7 +1239,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1280,7 +1280,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1323,7 +1323,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1358,7 +1358,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1399,7 +1399,7 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1435,7 +1435,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1468,7 +1468,7 @@ block0(v0: i16x8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1497,7 +1497,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1525,7 +1525,7 @@ block0(v0: i32x4, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1554,7 +1554,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1582,7 +1582,7 @@ block0(v0: i64x2, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1611,7 +1611,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1642,7 +1642,7 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1678,7 +1678,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1720,7 +1720,7 @@ block0(v0: i16x8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1749,7 +1749,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1777,7 +1777,7 @@ block0(v0: i32x4, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1806,7 +1806,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1834,7 +1834,7 @@ block0(v0: i64x2, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1863,7 +1863,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1888,7 +1888,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1913,7 +1913,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1938,7 +1938,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1963,7 +1963,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -23,7 +23,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -58,7 +58,7 @@ block0(v0: f32x4, v1: f32x4, v2: i32x4, v3: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -126,7 +126,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -175,7 +175,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -221,7 +221,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
@@ -17,7 +17,7 @@ block0(v0: f32x4, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -48,7 +48,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -194,7 +194,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -221,7 +221,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -246,7 +246,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -271,7 +271,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -296,7 +296,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -321,7 +321,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -346,7 +346,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -371,7 +371,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -396,7 +396,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -421,7 +421,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -448,7 +448,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -477,7 +477,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -506,7 +506,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -533,7 +533,7 @@ block0(v0: f32x4, v1: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -558,7 +558,7 @@ block0(v0: f64x2, v1: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -583,7 +583,7 @@ block0(v0: i8x16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -608,7 +608,7 @@ block0(v0: i16x8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -633,7 +633,7 @@ block0(v0: i32x4, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -658,7 +658,7 @@ block0(v0: i64x2, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -16,7 +16,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -191,7 +191,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -216,7 +216,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -244,7 +244,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -275,7 +275,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -306,7 +306,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -343,7 +343,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -388,7 +388,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -419,7 +419,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -445,7 +445,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -471,7 +471,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -500,7 +500,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -532,7 +532,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -558,7 +558,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -584,7 +584,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -620,7 +620,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -666,7 +666,7 @@ block0(v0: i8x16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -700,7 +700,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -726,7 +726,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -758,7 +758,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -795,7 +795,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -832,7 +832,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -870,7 +870,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -910,7 +910,7 @@ block0(v0: i64x2, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-cmp-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-cmp-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -191,7 +191,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -222,7 +222,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -259,7 +259,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -297,7 +297,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -336,7 +336,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -368,7 +368,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -393,7 +393,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -418,7 +418,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -443,7 +443,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -468,7 +468,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -493,7 +493,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -518,7 +518,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -543,7 +543,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -568,7 +568,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -593,7 +593,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -618,7 +618,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -643,7 +643,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -19,7 +19,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -50,7 +50,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -80,7 +80,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -109,7 +109,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -24,7 +24,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -81,7 +81,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -131,7 +131,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -170,7 +170,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -201,7 +201,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -230,7 +230,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -256,7 +256,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -282,7 +282,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -307,7 +307,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -331,7 +331,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -168,7 +168,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -196,7 +196,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -224,7 +224,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -91,7 +91,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -116,7 +116,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -18,7 +18,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -45,7 +45,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -20,7 +20,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -59,7 +59,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -101,7 +101,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -145,7 +145,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -48,7 +48,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -103,7 +103,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -129,7 +129,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -154,7 +154,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -184,7 +184,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -215,7 +215,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -243,7 +243,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -269,7 +269,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -295,7 +295,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -321,7 +321,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
@@ -17,7 +17,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -71,7 +71,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -98,7 +98,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -124,7 +124,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -149,7 +149,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -175,7 +175,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -201,7 +201,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -227,7 +227,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -253,7 +253,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -279,7 +279,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -305,7 +305,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -48,7 +48,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -76,7 +76,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -103,7 +103,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -129,7 +129,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -154,7 +154,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -184,7 +184,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -215,7 +215,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -244,7 +244,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -271,7 +271,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -298,7 +298,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -325,7 +325,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -26,7 +26,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -100,7 +100,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -131,7 +131,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -166,7 +166,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -201,7 +201,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -237,7 +237,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -275,7 +275,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -310,7 +310,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -341,7 +341,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -376,7 +376,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -411,7 +411,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/smulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/smulhi.clif
@@ -17,7 +17,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -46,7 +46,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -75,7 +75,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -18,7 +18,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -18,7 +18,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -53,7 +53,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -88,7 +88,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -123,7 +123,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -160,7 +160,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -194,7 +194,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -228,7 +228,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -262,7 +262,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -41,7 +41,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -107,7 +107,7 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -174,7 +174,7 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -241,7 +241,7 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -308,7 +308,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -356,7 +356,7 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -385,7 +385,7 @@ block0(v0: i32, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -415,7 +415,7 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -446,7 +446,7 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -476,7 +476,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -505,7 +505,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -534,7 +534,7 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -563,7 +563,7 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -592,7 +592,7 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -621,7 +621,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -650,7 +650,7 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -679,7 +679,7 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -709,7 +709,7 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -740,7 +740,7 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -771,7 +771,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -802,7 +802,7 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -833,7 +833,7 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -864,7 +864,7 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -895,7 +895,7 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -926,7 +926,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -955,7 +955,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -982,7 +982,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1009,7 +1009,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1036,7 +1036,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -16,7 +16,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -47,7 +47,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -86,7 +86,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -134,7 +134,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -177,7 +177,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -230,7 +230,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-ret.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-ret.clif
@@ -18,7 +18,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -50,7 +50,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -88,7 +88,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -17,7 +17,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -71,7 +71,7 @@ block0:
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/table.clif
+++ b/cranelift/filetests/filetests/isa/x64/table.clif
@@ -35,7 +35,7 @@ block0(v0: i32, v1: r64, v2: i64):
 ;   ret
 ; block2:
 ;   ud2 table_oob
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/tls_coff.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_coff.clif
@@ -19,7 +19,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/x64/tls_elf.clif
@@ -18,7 +18,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -11,7 +11,7 @@ block0:
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ud2 user0
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -35,7 +35,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -16,7 +16,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/trunc.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc.clif
@@ -15,7 +15,7 @@ block0(v0: f32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: f64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: f32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -90,7 +90,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_trap.clif
@@ -18,7 +18,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -49,7 +49,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -79,7 +79,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -110,7 +110,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -141,7 +141,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -171,7 +171,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/udiv.clif
+++ b/cranelift/filetests/filetests/isa/x64/udiv.clif
@@ -16,7 +16,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -44,7 +44,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -73,7 +73,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -102,7 +102,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/udivrem.clif
+++ b/cranelift/filetests/filetests/isa/x64/udivrem.clif
@@ -25,7 +25,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -105,7 +105,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -145,7 +145,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -1,8 +1,8 @@
 test compile precise-output
 target x86_64
 
-function u0:0(i32, i64) -> i32 fast { 
-block0(v1: i32, v2: i64): 
+function u0:0(i32, i64) -> i32 fast {
+block0(v1: i32, v2: i64):
     v3 = load.i32 notrap aligned v2
     v4 = umax v1, v3
     return v4

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -19,7 +19,7 @@ block0(v1: i32, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/umulhi.clif
+++ b/cranelift/filetests/filetests/isa/x64/umulhi.clif
@@ -17,7 +17,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -46,7 +46,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -75,7 +75,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/urem.clif
+++ b/cranelift/filetests/filetests/isa/x64/urem.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -47,7 +47,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -78,7 +78,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -109,7 +109,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -38,7 +38,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -100,7 +100,7 @@ block0(v0: i128, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -163,7 +163,7 @@ block0(v0: i128, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -226,7 +226,7 @@ block0(v0: i128, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -289,7 +289,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -335,7 +335,7 @@ block0(v0: i64, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -365,7 +365,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -395,7 +395,7 @@ block0(v0: i16, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -426,7 +426,7 @@ block0(v0: i8, v1: i128):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -456,7 +456,7 @@ block0(v0: i64, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -485,7 +485,7 @@ block0(v0: i64, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -514,7 +514,7 @@ block0(v0: i64, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -543,7 +543,7 @@ block0(v0: i64, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -572,7 +572,7 @@ block0(v0: i32, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -601,7 +601,7 @@ block0(v0: i32, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -630,7 +630,7 @@ block0(v0: i32, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -659,7 +659,7 @@ block0(v0: i32, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -689,7 +689,7 @@ block0(v0: i16, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -720,7 +720,7 @@ block0(v0: i16, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -751,7 +751,7 @@ block0(v0: i16, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -782,7 +782,7 @@ block0(v0: i16, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -813,7 +813,7 @@ block0(v0: i8, v1: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -844,7 +844,7 @@ block0(v0: i8, v1: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -875,7 +875,7 @@ block0(v0: i8, v1: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -906,7 +906,7 @@ block0(v0: i8, v1: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -935,7 +935,7 @@ block0(v0: i64):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -962,7 +962,7 @@ block0(v0: i32):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -989,7 +989,7 @@ block0(v0: i16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -1016,7 +1016,7 @@ block0(v0: i8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -24,7 +24,7 @@ block0(v0: f64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits-avx.clif
@@ -16,7 +16,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -43,7 +43,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -70,7 +70,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -95,7 +95,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
@@ -15,7 +15,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -68,7 +68,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -96,7 +96,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -121,7 +121,7 @@ block0(v0: i64x2):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -19,7 +19,7 @@ block0(v0: i64, v2: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -15,7 +15,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -40,7 +40,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -65,7 +65,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -92,7 +92,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -121,7 +121,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -149,7 +149,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -175,7 +175,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -200,7 +200,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -225,7 +225,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -252,7 +252,7 @@ block0(v0: i8x16):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -280,7 +280,7 @@ block0(v0: i16x8):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
@@ -308,7 +308,7 @@ block0(v0: i32x4):
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp

--- a/cranelift/filetests/filetests/parser/branch.clif
+++ b/cranelift/filetests/filetests/parser/branch.clif
@@ -91,7 +91,7 @@ block30:
 block40:
     trap user4
 block50:
-    trap user1    
+    trap user1
 }
 ; sameln: function %jumptable(i32) fast {
 ; check:  block10(v3: i32):

--- a/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
@@ -1,7 +1,7 @@
 test interpret
 test run
 target s390x
-target riscv64 has_a 
+target riscv64 has_a
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-cas.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas.clif
@@ -2,7 +2,7 @@ test run
 target aarch64
 target aarch64 has_lse
 target x86_64
-target s390x 
+target s390x
 target riscv64 has_a
 
 ; We can't test that these instructions are right regarding atomicity, but we can

--- a/cranelift/filetests/filetests/runtests/icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq.clif
@@ -2,7 +2,7 @@ test interpret
 test run
 target aarch64
 target x86_64
-target riscv64 
+target riscv64
 target s390x
 
 function %icmp_eq_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/src/subtest.rs
+++ b/cranelift/filetests/src/subtest.rs
@@ -160,7 +160,12 @@ pub fn check_precise_output(actual: &[&str], context: &Context) -> Result<()> {
         .comments
         .iter()
         .filter(|c| !c.text.starts_with(";;"))
-        .map(|c| c.text.strip_prefix("; ").unwrap_or(c.text))
+        .map(|c| {
+            c.text
+                .strip_prefix("; ")
+                .or_else(|| c.text.strip_prefix(";"))
+                .unwrap_or(c.text)
+        })
         .collect::<Vec<_>>();
 
     // If the expectation matches what we got, then there's nothing to do.
@@ -199,8 +204,11 @@ fn update_test(output: &[&str], context: &Context) -> Result<()> {
 
             // Splice in the test output
             for output in output {
-                new_test.push_str("; ");
-                new_test.push_str(output);
+                new_test.push(';');
+                if !output.is_empty() {
+                    new_test.push(' ');
+                    new_test.push_str(output);
+                }
                 new_test.push_str("\n");
             }
 


### PR DESCRIPTION
Avoid generating lines with trailing space when updating precise-output compilation tests. This came up as a [comment](https://github.com/bytecodealliance/wasmtime/pull/6461#issuecomment-1564639750) on #6461.

I'd recommend reviewing by commit. The first commit in the series is the change that avoids emitting `; ` lines in the precise-output tests, the second removes some miscellaneous trailing whitespace from tests, and the last commit is the bulk update of all precise-output tests to no longer emit lines with trailing whitespace.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
