### PR TITLE
Bump regalloc2 to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4befc14107257dcfe5bb704e1777a93490161dee55e2d331dd43920e0b3da5a"
+checksum = "12513beb38dd35aab3ac5f5b89fd0330159a0dc21d5309d75073011bbc8032b0"
 dependencies = [
  "hashbrown 0.13.2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.9.0"
+regalloc2 = "0.9.1"
 
 # cap-std family:
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -29,6 +29,13 @@ user-id = 187138
 user-login = "elliottt"
 user-name = "Trevor Elliott"
 
+[[publisher.regalloc2]]
+version = "0.9.1"
+when = "2023-05-31"
+user-id = 187138
+user-login = "elliottt"
+user-name = "Trevor Elliott"
+
 [[publisher.unicode-segmentation]]
 version = "1.10.1"
 when = "2023-01-31"


### PR DESCRIPTION
Pull in the [0.9.1](https://github.com/bytecodealliance/regalloc2/pull/139) release of regalloc2.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
