### PR TITLE
x64: Add support for more BMI1 instructions

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -47,6 +47,12 @@
                  (src GprMem)
                  (dst WritableGpr))
 
+       ;; Same as `UnaryRmR` but with the VEX prefix for BMI1 instructions.
+       (UnaryRmRVex (size OperandSize)
+                    (op UnaryRmRVexOpcode)
+                    (src GprMem)
+                    (dst WritableGpr))
+
        ;; Bitwise not.
        (Not (size OperandSize) ;; 1, 2, 4, or 8
             (src Gpr)
@@ -733,6 +739,11 @@
             Lzcnt
             Tzcnt
             Popcnt))
+
+(type UnaryRmRVexOpcode
+      (enum Blsi
+            Blsmsk
+            Blsr))
 
 (type SseOpcode extern
       (enum Addps
@@ -1975,6 +1986,13 @@
 (rule (unary_rm_r op src size)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.UnaryRmR size op src dst))))
+        dst))
+
+;; Helper for creating `MInst.UnaryRmRVex` instructions.
+(decl unary_rm_r_vex (UnaryRmRVexOpcode GprMem OperandSize) Gpr)
+(rule (unary_rm_r_vex op src size)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.UnaryRmRVex size op src dst))))
         dst))
 
 (decl cvt_u64_to_float_seq (Type Gpr) Xmm)
@@ -3988,6 +4006,21 @@
             (bsf_result Gpr (produces_flags_get_reg bsf))
             (cmove ConsumesFlags (cmove ty (CC.Z) alt bsf_result)))
         (with_flags_reg (produces_flags_ignore bsf) cmove)))
+
+;; Helper for creating `blsi` instructions.
+(decl x64_blsi (Type GprMem) Gpr)
+(rule (x64_blsi ty src)
+      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsi) src (operand_size_of_type_32_64 ty)))
+
+;; Helper for creating `blsmsk` instructions.
+(decl x64_blsmsk (Type GprMem) Gpr)
+(rule (x64_blsmsk ty src)
+      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsmsk) src (operand_size_of_type_32_64 ty)))
+
+;; Helper for creating `blsr` instructions.
+(decl x64_blsr (Type GprMem) Gpr)
+(rule (x64_blsr ty src)
+      (unary_rm_r_vex (UnaryRmRVexOpcode.Blsr) src (operand_size_of_type_32_64 ty)))
 
 ;; Helper for creating `popcnt` instructions.
 (decl x64_popcnt (Type Gpr) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -905,6 +905,24 @@ impl fmt::Display for UnaryRmROpcode {
     }
 }
 
+pub use crate::isa::x64::lower::isle::generated_code::UnaryRmRVexOpcode;
+
+impl UnaryRmRVexOpcode {
+    pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
+        match self {
+            UnaryRmRVexOpcode::Blsi | UnaryRmRVexOpcode::Blsmsk | UnaryRmRVexOpcode::Blsr => {
+                smallvec![InstructionSet::BMI1]
+            }
+        }
+    }
+}
+
+impl fmt::Display for UnaryRmRVexOpcode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&format!("{self:?}").to_lowercase())
+    }
+}
+
 #[derive(Clone, Copy, PartialEq)]
 /// Comparison operations.
 pub enum CmpOpcode {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -131,6 +131,7 @@ impl Inst {
 
             Inst::AluRmRVex { op, .. } => op.available_from(),
             Inst::UnaryRmR { op, .. } => op.available_from(),
+            Inst::UnaryRmRVex { op, .. } => op.available_from(),
 
             // These use dynamic SSE opcodes.
             Inst::GprToXmm { op, .. }
@@ -728,6 +729,13 @@ impl PrettyPrint for Inst {
                 format!("{op} {src2}, {src1}, {dst}")
             }
             Inst::UnaryRmR { src, dst, op, size } => {
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
+                let src = src.pretty_print(size.to_bytes(), allocs);
+                let op = ljustify2(op.to_string(), suffix_bwlq(*size));
+                format!("{op} {src}, {dst}")
+            }
+
+            Inst::UnaryRmRVex { src, dst, op, size } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes(), allocs);
                 let src = src.pretty_print(size.to_bytes(), allocs);
                 let op = ljustify2(op.to_string(), suffix_bwlq(*size));
@@ -1849,7 +1857,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
                 }
             }
         }
-        Inst::UnaryRmR { src, dst, .. } => {
+        Inst::UnaryRmR { src, dst, .. } | Inst::UnaryRmRVex { src, dst, .. } => {
             collector.reg_def(dst.to_writable_reg());
             src.get_operands(collector);
         }

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -341,6 +341,23 @@
       (if-let $true (use_bmi1))
       (x64_andn ty y x))
 
+;; Specialization of `blsr` for BMI1
+
+(rule 12 (lower (has_type (ty_32_or_64 ty) (band (isub x (iconst (u64_from_imm64 1))) x)))
+         (if-let $true (use_bmi1))
+         (x64_blsr ty x))
+(rule 13 (lower (has_type (ty_32_or_64 ty) (band x (isub x (iconst (u64_from_imm64 1))))))
+         (if-let $true (use_bmi1))
+         (x64_blsr ty x))
+
+;; Specialization of `blsi` for BMI1
+
+(rule 12 (lower (has_type (ty_32_or_64 ty) (band (ineg x) x)))
+         (if-let $true (use_bmi1))
+         (x64_blsi ty x))
+(rule 13 (lower (has_type (ty_32_or_64 ty) (band x (ineg x))))
+         (if-let $true (use_bmi1))
+         (x64_blsi ty x))
 
 ;;;; Rules for `bor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -435,6 +452,15 @@
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
         (value_gprs (x64_xor $I64 x_lo y_lo)
                     (x64_xor $I64 x_hi y_hi))))
+
+;; Specialization of `blsmsk` for BMI1
+
+(rule 8 (lower (has_type (ty_32_or_64 ty) (bxor (isub x (iconst (u64_from_imm64 1))) x)))
+        (if-let $true (use_bmi1))
+        (x64_blsmsk ty x))
+(rule 9 (lower (has_type (ty_32_or_64 ty) (bxor x (isub x (iconst (u64_from_imm64 1))))))
+        (if-let $true (use_bmi1))
+        (x64_blsmsk ty x))
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi1.clif
@@ -1,0 +1,323 @@
+test compile precise-output
+target x86_64 has_bmi1
+
+function %blsr_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 1
+  v2 = isub v0, v1
+  v3 = band v0, v2
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsrl   %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsrl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsr_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = iconst.i64 1
+  v2 = isub v0, v1
+  v3 = band v0, v2
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsrq   %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsrq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsr_alt_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 1
+  v2 = isub v0, v1
+  v3 = band v2, v0
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsrl   %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsrl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsr_alt_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = iconst.i64 1
+  v2 = isub v0, v1
+  v3 = band v2, v0
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsrq   %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsrq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsi_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = ineg v0
+  v2 = band v0, v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsil   %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsil %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsi_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = ineg v0
+  v2 = band v0, v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsiq   %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsiq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsi_alt_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = ineg v0
+  v2 = band v1, v0
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsil   %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsil %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsi_alt_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = ineg v0
+  v2 = band v1, v0
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsiq   %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsiq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsmsk_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 1
+  v2 = isub v0, v1
+  v3 = bxor v0, v2
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsmskl %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsmskl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsmsk_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = iconst.i64 1
+  v2 = isub v0, v1
+  v3 = bxor v0, v2
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsmskq %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsmskq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsmsk_alt_i32(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 1
+  v2 = isub v0, v1
+  v3 = bxor v2, v0
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsmskl %edi, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsmskl %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %blsmsk_alt_i64(i64) -> i64 {
+block0(v0: i64):
+  v1 = iconst.i64 1
+  v2 = isub v0, v1
+  v3 = bxor v2, v0
+  return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   blsmskq %rdi, %rax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   blsmskq %rdi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/x64-bmi1.clif
+++ b/cranelift/filetests/filetests/runtests/x64-bmi1.clif
@@ -1,0 +1,86 @@
+test interpret
+test run
+target aarch64
+target s390x
+target x86_64
+target x86_64 has_bmi1
+target riscv64
+
+function %blsi32(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = band v0, v1
+    return v2
+}
+; run: %blsi32(0) == 0
+; run: %blsi32(1) == 1
+; run: %blsi32(0x80) == 0x80
+; run: %blsi32(0xf80) == 0x80
+; run: %blsi32(0xffff0000) == 0x10000
+
+function %blsi64(i64) -> i64 {
+block0(v0: i64):
+    v1 = ineg v0
+    v2 = band v0, v1
+    return v2
+}
+; run: %blsi64(0) == 0
+; run: %blsi64(1) == 1
+; run: %blsi64(0x80) == 0x80
+; run: %blsi64(0xf80) == 0x80
+; run: %blsi64(0xffff0000) == 0x10000
+; run: %blsi64(0xffff000000000000) == 0x1000000000000
+
+function %blsr32(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 1
+    v2 = isub v0, v1
+    v3 = band v0, v2
+    return v3
+}
+; run: %blsr32(0) == 0
+; run: %blsr32(1) == 0
+; run: %blsr32(0x3) == 0x2
+; run: %blsr32(0xff) == 0xfe
+; run: %blsr32(0x10001000) == 0x10000000
+
+function %blsr64(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 1
+    v2 = isub v0, v1
+    v3 = band v0, v2
+    return v3
+}
+; run: %blsr64(0) == 0
+; run: %blsr64(1) == 0
+; run: %blsr64(0x3) == 0x2
+; run: %blsr64(0xff) == 0xfe
+; run: %blsr64(0x10001000) == 0x10000000
+; run: %blsr64(0x1000100010001000) == 0x1000100010000000
+
+function %blsmsk32(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 1
+    v2 = isub v0, v1
+    v3 = bxor v0, v2
+    return v3
+}
+; run: %blsmsk32(0) == -1
+; run: %blsmsk32(1) == 1
+; run: %blsmsk32(0x80) == 0xff
+; run: %blsmsk32(0x8080) == 0xff
+; run: %blsmsk32(0xffffffff) == 1
+
+function %blsmsk64(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 1
+    v2 = isub v0, v1
+    v3 = bxor v0, v2
+    return v3
+}
+; run: %blsmsk64(0) == -1
+; run: %blsmsk64(1) == 1
+; run: %blsmsk64(0x80) == 0xff
+; run: %blsmsk64(0x8080) == 0xff
+; run: %blsmsk64(0xffffffff) == 1
+; run: %blsmsk64(0xffffffff00000000) == 0x1ffffffff


### PR DESCRIPTION
This commit fills out more support for the BMI1 instruction set with `blsi`, `blsr`, and `blsmsk`. These are all relatively simple pattern matches in ISLE and then various other infrastructure was added for testing, runtime testing, and encoding.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
