### PR TITLE
x64: Add support for `vpsraq`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -348,6 +348,12 @@
                    (src2 XmmMem)
                    (dst WritableXmm))
 
+       ;; Same as `XmmRmREvex` but for unary operations.
+       (XmmUnaryRmRImmEvex (op Avx512Opcode)
+                           (src XmmMem)
+                           (dst WritableXmm)
+                           (imm u8))
+
        ;; XMM (scalar or vector) binary op that relies on the EVEX
        ;; prefix. Takes three inputs.
        (XmmRmREvex3 (op Avx512Opcode)
@@ -1317,12 +1323,14 @@
             Vroundsd
           ))
 
-(type Avx512Opcode extern
+(type Avx512Opcode
       (enum Vcvtudq2ps
             Vpabsq
             Vpermi2b
             Vpmullq
-            Vpopcntb))
+            Vpopcntb
+            Vpsraq
+            VpsraqImm))
 
 (type FcmpImm extern
       (enum Equal
@@ -1669,11 +1677,11 @@
 (extern constructor const_to_type_masked_imm8 const_to_type_masked_imm8)
 
 ;; Generate a mask for the bit-width of the given type
-(decl shift_mask (Type) u32)
+(decl shift_mask (Type) u8)
 (extern constructor shift_mask shift_mask)
 
 ;; Mask a constant with the type's shift mask
-(decl shift_amount_masked (Type Imm64) u32)
+(decl shift_amount_masked (Type Imm64) u8)
 (extern constructor shift_amount_masked shift_amount_masked)
 
 ;; Extract a constant `GprMemImm.Imm` from a value operand.
@@ -1871,6 +1879,13 @@
                                             src1
                                             src2
                                             dst))))
+        dst))
+
+;; Helper for creating `MInst.XmmUnaryRmRImmEvex` instructions.
+(decl xmm_unary_rm_r_imm_evex (Avx512Opcode XmmMem u8) Xmm)
+(rule (xmm_unary_rm_r_imm_evex op src imm)
+      (let ((dst WritableXmm (temp_writable_xmm))
+            (_ Unit (emit (MInst.XmmUnaryRmRImmEvex op src dst imm))))
         dst))
 
 ;; Helper for creating `MInst.XmmRmiXmm` instructions.
@@ -3814,6 +3829,16 @@
 (rule 1 (x64_psrad src1 src2)
       (if-let $true (use_avx_simd))
       (xmm_rmir_vex (AvxOpcode.Vpsrad) src1 src2))
+
+;; Helper for creating `vpsraq` instructions.
+(decl x64_vpsraq (Xmm XmmMem) Xmm)
+(rule (x64_vpsraq src1 src2)
+      (xmm_rm_r_evex (Avx512Opcode.Vpsraq) src1 src2))
+
+;; Helper for creating `vpsraq` instructions.
+(decl x64_vpsraq_imm (XmmMem u8) Xmm)
+(rule (x64_vpsraq_imm src imm)
+      (xmm_unary_rm_r_imm_evex (Avx512Opcode.VpsraqImm) src imm))
 
 ;; Helper for creating `pextrb` instructions.
 (decl x64_pextrb (Xmm u8) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1749,31 +1749,26 @@ impl fmt::Display for AvxOpcode {
     }
 }
 
-#[derive(Clone, PartialEq)]
-#[allow(missing_docs)]
-pub enum Avx512Opcode {
-    Vcvtudq2ps,
-    Vpabsq,
-    Vpermi2b,
-    Vpmullq,
-    Vpopcntb,
-}
-
 #[derive(Copy, Clone, PartialEq)]
 #[allow(missing_docs)]
 pub enum Avx512TupleType {
     Full,
     FullMem,
+    Mem128,
 }
+
+pub use crate::isa::x64::lower::isle::generated_code::Avx512Opcode;
 
 impl Avx512Opcode {
     /// Which `InstructionSet`s support the opcode?
     pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
         match self {
-            Avx512Opcode::Vcvtudq2ps => {
+            Avx512Opcode::Vcvtudq2ps
+            | Avx512Opcode::Vpabsq
+            | Avx512Opcode::Vpsraq
+            | Avx512Opcode::VpsraqImm => {
                 smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL]
             }
-            Avx512Opcode::Vpabsq => smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL],
             Avx512Opcode::Vpermi2b => {
                 smallvec![InstructionSet::AVX512VL, InstructionSet::AVX512VBMI]
             }
@@ -1795,28 +1790,17 @@ impl Avx512Opcode {
         use Avx512TupleType::*;
 
         match self {
-            Vcvtudq2ps | Vpabsq | Vpmullq => Full,
+            Vcvtudq2ps | Vpabsq | Vpmullq | VpsraqImm => Full,
             Vpermi2b | Vpopcntb => FullMem,
+            Vpsraq => Mem128,
         }
-    }
-}
-
-impl fmt::Debug for Avx512Opcode {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let name = match self {
-            Avx512Opcode::Vcvtudq2ps => "vcvtudq2ps",
-            Avx512Opcode::Vpabsq => "vpabsq",
-            Avx512Opcode::Vpermi2b => "vpermi2b",
-            Avx512Opcode::Vpmullq => "vpmullq",
-            Avx512Opcode::Vpopcntb => "vpopcntb",
-        };
-        write!(fmt, "{}", name)
     }
 }
 
 impl fmt::Display for Avx512Opcode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self, f)
+        let s = format!("{self:?}");
+        f.write_str(&s.to_lowercase())
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1935,6 +1935,33 @@ pub(crate) fn emit(
                 .encode(sink);
         }
 
+        Inst::XmmUnaryRmRImmEvex { op, src, dst, imm } => {
+            let dst = allocs.next(dst.to_reg().to_reg());
+            let src = match src.clone().to_reg_mem().with_allocs(allocs) {
+                RegMem::Reg { reg } => {
+                    RegisterOrAmode::Register(reg.to_real_reg().unwrap().hw_enc().into())
+                }
+                RegMem::Mem { addr } => RegisterOrAmode::Amode(addr.finalize(state, sink)),
+            };
+
+            let (opcode, opcode_ext, w) = match op {
+                Avx512Opcode::VpsraqImm => (0x72, 4, true),
+                _ => unimplemented!("Opcode {:?} not implemented", op),
+            };
+            EvexInstruction::new()
+                .length(EvexVectorLength::V128)
+                .prefix(LegacyPrefixes::_66)
+                .map(OpcodeMap::_0F)
+                .w(w)
+                .opcode(opcode)
+                .reg(opcode_ext)
+                .vvvvv(dst.to_real_reg().unwrap().hw_enc())
+                .tuple_type(op.tuple_type())
+                .rm(src)
+                .imm(*imm)
+                .encode(sink);
+        }
+
         Inst::XmmRmR {
             op,
             src1,
@@ -2756,15 +2783,16 @@ pub(crate) fn emit(
                 debug_assert_eq!(src1, dst);
             }
 
-            let (w, opcode) = match op {
-                Avx512Opcode::Vpermi2b => (false, 0x75),
-                Avx512Opcode::Vpmullq => (true, 0x40),
+            let (w, opcode, map) = match op {
+                Avx512Opcode::Vpermi2b => (false, 0x75, OpcodeMap::_0F38),
+                Avx512Opcode::Vpmullq => (true, 0x40, OpcodeMap::_0F38),
+                Avx512Opcode::Vpsraq => (true, 0xE2, OpcodeMap::_0F),
                 _ => unimplemented!("Opcode {:?} not implemented", op),
             };
             EvexInstruction::new()
                 .length(EvexVectorLength::V128)
                 .prefix(LegacyPrefixes::_66)
-                .map(OpcodeMap::_0F38)
+                .map(map)
                 .w(w)
                 .opcode(opcode)
                 .tuple_type(op.tuple_type())

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -149,7 +149,8 @@ impl Inst {
 
             Inst::XmmUnaryRmREvex { op, .. }
             | Inst::XmmRmREvex { op, .. }
-            | Inst::XmmRmREvex3 { op, .. } => op.available_from(),
+            | Inst::XmmRmREvex3 { op, .. }
+            | Inst::XmmUnaryRmRImmEvex { op, .. } => op.available_from(),
 
             Inst::XmmRmiRVex { op, .. }
             | Inst::XmmRmRVex3 { op, .. }
@@ -912,6 +913,15 @@ impl PrettyPrint for Inst {
                 let src = src.pretty_print(8, allocs);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
+            }
+
+            Inst::XmmUnaryRmRImmEvex {
+                op, src, dst, imm, ..
+            } => {
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8, allocs);
+                let src = src.pretty_print(8, allocs);
+                let op = ljustify(op.to_string());
+                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmMovRM { op, src, dst, .. } => {
@@ -1858,6 +1868,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             src.get_operands(collector);
         }
         Inst::XmmUnaryRmREvex { src, dst, .. }
+        | Inst::XmmUnaryRmRImmEvex { src, dst, .. }
         | Inst::XmmUnaryRmRUnaligned { src, dst, .. }
         | Inst::XmmUnaryRmRVex { src, dst, .. }
         | Inst::XmmUnaryRmRImmVex { src, dst, .. } => {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -757,10 +757,20 @@
 ;; The `sshr.i64x2` CLIF instruction has no single x86 instruction in the older
 ;; feature sets. To remedy this, a small dance is done with an unsigned right
 ;; shift plus some extra ops.
-;;
-;; TODO: add a lowering for `vpsraq` with AVX512{VL,F}
+(rule 3 (lower (has_type ty @ $I64X2 (sshr src (iconst n))))
+        (if-let $true (use_avx512vl_simd))
+        (if-let $true (use_avx512f_simd))
+        (x64_vpsraq_imm src (shift_amount_masked ty n)))
+
+(rule 2 (lower (has_type ty @ $I64X2 (sshr src amt)))
+        (if-let $true (use_avx512vl_simd))
+        (if-let $true (use_avx512f_simd))
+        (let ((masked Gpr (x64_and $I64 amt (RegMemImm.Imm (shift_mask ty)))))
+          (x64_vpsraq src (x64_movd_to_xmm masked))))
+
 (rule 1 (lower (has_type $I64X2 (sshr src (iconst (u64_from_imm64 (u64_as_u32 amt))))))
         (lower_i64x2_sshr_imm src (u32_and amt 63)))
+
 (rule (lower (has_type $I64X2 (sshr src amt)))
       (lower_i64x2_sshr_gpr src (x64_and $I64 amt (RegMemImm.Imm 63))))
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -252,14 +252,14 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn shift_mask(&mut self, ty: Type) -> u32 {
+    fn shift_mask(&mut self, ty: Type) -> u8 {
         debug_assert!(ty.lane_bits().is_power_of_two());
 
-        ty.lane_bits() - 1
+        (ty.lane_bits() - 1) as u8
     }
 
-    fn shift_amount_masked(&mut self, ty: Type, val: Imm64) -> u32 {
-        (val.bits() as u32) & self.shift_mask(ty)
+    fn shift_amount_masked(&mut self, ty: Type, val: Imm64) -> u8 {
+        (val.bits() as u8) & self.shift_mask(ty)
     }
 
     #[inline]

--- a/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
@@ -1,0 +1,140 @@
+test compile precise-output
+set enable_simd
+target x86_64 sse42 has_avx has_avx2 has_avx512f has_avx512vl
+
+function %sshr(i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64):
+  v2 = sshr v0, v1
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rcx
+;   andq    %rcx, $63, %rcx
+;   vmovd   %ecx, %xmm5
+;   vpsraq  %xmm5, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rcx
+;   andq $0x3f, %rcx
+;   vmovd %ecx, %xmm5
+;   vpsraq %xmm5, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sshr_imm(i64x2) -> i64x2 {
+block0(v0: i64x2):
+  v1 = sshr_imm v0, 31
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpsraqimm $31, %xmm0, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpsraq $0x1f, %xmm0, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %sshr_load_imm(i64) -> i64x2 {
+block0(v0: i64):
+  v1 = load.i64x2 v0
+  v2 = sshr_imm v1, 31
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpsraqimm $31, 0(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpsraq $0x1f, (%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %sshr_load2_imm(i64) -> i64x2 {
+block0(v0: i64):
+  v1 = load.i64x2 v0+7
+  v2 = sshr_imm v1, 31
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpsraqimm $31, 7(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpsraq $0x1f, 7(%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %sshr_load3_imm(i64) -> i64x2 {
+block0(v0: i64):
+  v1 = load.i64x2 v0+16
+  v2 = sshr_imm v1, 31
+  return v2
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpsraqimm $31, 16(%rdi), %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpsraq $0x1f, 0x10(%rdi), %xmm0 ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -6,7 +6,9 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse42
-target x86_64 skylake
+target x86_64 sse42 has_avx
+target x86_64 sse42 has_avx has_avx2
+target x86_64 sse42 has_avx has_avx2 has_avx512f has_avx512vl
 
 
 function %sshr_i8x16(i8x16, i32) -> i8x16 {


### PR DESCRIPTION
This commit adds support for the AVX-512 instruction `vpsraq` which is used to implement the `sshr` operation for the `i64x2` type. This instruction does not fit into any previous shape of supported AVX-512 instruction so new encoding support was added.

Additionally the instruction helpers for this differ from `psra{w,d}` where those two instructions are encoded with the second operand as `XmmMemImm`. The reason for this is that `psra{w,d}` are based on SSE encodings where a second argument of `XmmMemImm` reflects what the instruction can do, but `vpsraq` has two variants which subtly differ:

    (decl x64_vpsraq (Xmm XmmMem) Xmm)
    (decl x64_vpsraq_imm (XmmMem u8) Xmm)

Notably the `*_imm` variant can take a memory-based operand of what-to-shift unlike the SSE variant. Note that `vpsra{w,d}` are additionally supported with AVX-512 encodings but support is not added for those in this commit (left for a future PR to do so). Additionally the two encodings of `vpsraq` have a different `TupleType` which at least necessitates different opcodes and naturally extends it self to different instruction helpers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
