### PR TITLE
Add support to Winch for integer comparisons

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -306,6 +306,26 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | I32RemS { .. }
                         | I64Mul { .. }
                         | I64Sub { .. }
+                        | I32Eq { .. }
+                        | I64Eq { .. }
+                        | I32Ne { .. }
+                        | I64Ne { .. }
+                        | I32LtS { .. }
+                        | I64LtS { .. }
+                        | I32LtU { .. }
+                        | I64LtU { .. }
+                        | I32LeS { .. }
+                        | I64LeS { .. }
+                        | I32LeU { .. }
+                        | I64LeU { .. }
+                        | I32GtS { .. }
+                        | I64GtS { .. }
+                        | I32GtU { .. }
+                        | I64GtU { .. }
+                        | I32GeS { .. }
+                        | I64GeS { .. }
+                        | I32GeU { .. }
+                        | I64GeU { .. }
                         | LocalGet { .. }
                         | LocalSet { .. }
                         | Call { .. }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -8,7 +8,7 @@ use crate::{
     abi::{self, local::LocalSlot},
     codegen::CodeGenContext,
     isa::reg::Reg,
-    masm::{CalleeKind, DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind},
+    masm::{CalleeKind, CmpKind, DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind},
 };
 use cranelift_codegen::{settings, Final, MachBufferFinalized};
 
@@ -202,6 +202,17 @@ impl Masm for MacroAssembler {
 
     fn address_at_reg(&self, reg: Reg, offset: u32) -> Self::Address {
         Address::offset(reg, offset as i64)
+    }
+
+    fn cmp_with_set(
+        &mut self,
+        _dst: RegImm,
+        _lhs: RegImm,
+        _rhs: RegImm,
+        _kind: CmpKind,
+        _size: OperandSize,
+    ) {
+        todo!()
     }
 }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -4,7 +4,7 @@ use super::{
     asm::{Assembler, Operand},
     regs::{self, rbp, rsp},
 };
-use crate::masm::{DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind};
+use crate::masm::{CmpKind, DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind};
 use crate::{
     abi::{self, align_to, calculate_frame_adjustment, LocalSlot},
     codegen::CodeGenContext,
@@ -254,6 +254,27 @@ impl Masm for MacroAssembler {
 
     fn address_at_reg(&self, reg: Reg, offset: u32) -> Self::Address {
         Address::offset(reg, offset)
+    }
+
+    fn cmp_with_set(
+        &mut self,
+        dst: RegImm,
+        lhs: RegImm,
+        rhs: RegImm,
+        kind: CmpKind,
+        size: OperandSize,
+    ) {
+        let (src, dst): (Operand, Operand) = if dst == lhs {
+            (rhs.into(), dst.into())
+        } else {
+            panic!(
+                "the destination and first source argument must be the same, dst={:?}, lhs={:?}",
+                dst, lhs
+            );
+        };
+
+        self.asm.cmp(src, dst, size);
+        self.asm.setcc(kind, dst);
     }
 }
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -193,6 +193,7 @@ pub(crate) trait MacroAssembler {
     fn rem(&mut self, context: &mut CodeGenContext, kind: RemKind, size: OperandSize);
 
     /// Compare two operands and put the result in dst.
+    /// This function will potentially emit a series of instructions.
     fn cmp_with_set(
         &mut self,
         dst: RegImm,

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -22,6 +22,33 @@ pub(crate) enum RemKind {
     Unsigned,
 }
 
+/// Kinds of binary comparison in WebAssembly. The [`masm`] implementation for
+/// each ISA is responsible for emitting the correct sequence of instructions
+/// when lowering to machine code.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CmpKind {
+    /// Equal.
+    Eq,
+    /// Not equal.
+    Ne,
+    /// Signed less than.
+    LtS,
+    /// Unsigned less than.
+    LtU,
+    /// Signed greater than.
+    GtS,
+    /// Unsigned greater than.
+    GtU,
+    /// Signed less than or equal.
+    LeS,
+    /// Unsigned less than or equal.
+    LeU,
+    /// Signed greater than or equal.
+    GeS,
+    /// Unsigned greater than or equal.
+    GeU,
+}
+
 /// Operand size, in bits.
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub(crate) enum OperandSize {
@@ -164,6 +191,16 @@ pub(crate) trait MacroAssembler {
 
     /// Calculate remainder.
     fn rem(&mut self, context: &mut CodeGenContext, kind: RemKind, size: OperandSize);
+
+    /// Compare two numbers and put result in dst.
+    fn cmp_with_set(
+        &mut self,
+        dst: RegImm,
+        lhs: RegImm,
+        rhs: RegImm,
+        kind: CmpKind,
+        size: OperandSize,
+    );
 
     /// Push the register to the stack, returning the offset.
     fn push(&mut self, src: Reg) -> u32;

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -192,7 +192,7 @@ pub(crate) trait MacroAssembler {
     /// Calculate remainder.
     fn rem(&mut self, context: &mut CodeGenContext, kind: RemKind, size: OperandSize);
 
-    /// Compare two numbers and put result in dst.
+    /// Compare two operands and put the result in dst.
     fn cmp_with_set(
         &mut self,
         dst: RegImm,

--- a/winch/filetests/filetests/x64/i32_eq/const.wat
+++ b/winch/filetests/filetests/x64/i32_eq/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f94c0             	sete	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i32_eq/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f94c1             	sete	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_eq/params.wat
+++ b/winch/filetests/filetests/x64/i32_eq/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f94c1             	sete	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f9dc0             	setge	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f9dc1             	setge	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f9dc1             	setge	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f93c0             	setae	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f93c1             	setae	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f93c1             	setae	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f9fc0             	setg	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f9fc1             	setg	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f9fc1             	setg	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f97c0             	seta	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f97c1             	seta	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f97c1             	seta	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f9ec0             	setle	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f9ec1             	setle	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f9ec1             	setle	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.le_u)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f96c0             	setbe	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.le_u)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f96c1             	setbe	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.le_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f96c1             	setbe	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.lt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f9cc0             	setl	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.lt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f9cc1             	setl	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.lt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f9cc1             	setl	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f92c0             	setb	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.lt_u)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f92c1             	setb	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f92c1             	setb	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ne/const.wat
+++ b/winch/filetests/filetests/x64/i32_ne/const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 2)
+        (i32.const 3)
+        (i32.ne)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 83f803               	cmp	eax, 3
+;;   14:	 b800000000           	mov	eax, 0
+;;   19:	 400f95c0             	setne	al
+;;   1d:	 4883c408             	add	rsp, 8
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ne/locals.wat
@@ -1,0 +1,36 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+        (local $bar i32)
+
+        (i32.const 2)
+        (local.set $foo)
+        (i32.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.ne)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b802000000           	mov	eax, 2
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b803000000           	mov	eax, 3
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 39c1                 	cmp	ecx, eax
+;;   31:	 b900000000           	mov	ecx, 0
+;;   36:	 400f95c1             	setne	cl
+;;   3a:	 4889c8               	mov	rax, rcx
+;;   3d:	 4883c410             	add	rsp, 0x10
+;;   41:	 5d                   	pop	rbp
+;;   42:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ne/params.wat
+++ b/winch/filetests/filetests/x64/i32_ne/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.ne)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 39c1                 	cmp	ecx, eax
+;;   1e:	 b900000000           	mov	ecx, 0
+;;   23:	 400f95c1             	setne	cl
+;;   27:	 4889c8               	mov	rax, rcx
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eq/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f94c0             	sete	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eq/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f94c0             	sete	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i64_eq/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f94c1             	sete	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eq/params.wat
+++ b/winch/filetests/filetests/x64/i64_eq/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.eq)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f94c1             	sete	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f9dc0             	setge	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f9dc0             	setge	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f9dc1             	setge	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ge_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f9dc1             	setge	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f93c0             	setae	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f93c0             	setae	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f93c1             	setae	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ge_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f93c1             	setae	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f9fc0             	setg	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f9fc0             	setg	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f9fc1             	setg	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.gt_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f9fc1             	setg	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f97c0             	seta	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f97c0             	seta	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f97c1             	seta	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.gt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f97c1             	seta	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f9ec0             	setle	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f9ec0             	setle	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f9ec1             	setle	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.le_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f9ec1             	setle	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.le_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f96c0             	setbe	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.le_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f96c0             	setbe	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.le_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f96c1             	setbe	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.le_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f96c1             	setbe	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.lt_s)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f9cc0             	setl	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.lt_s)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f9cc0             	setl	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/locals.wat
@@ -1,0 +1,38 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.lt_s)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f9cc1             	setl	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/params.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.lt_s)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f9cc1             	setl	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f92c0             	setb	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f92c0             	setb	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/locals.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f92c1             	setb	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/params.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.lt_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f92c1             	setb	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/32_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.ne)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f803             	cmp	rax, 3
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f95c0             	setne	al
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/64_const.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.ne)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c39d8               	cmp	rax, r11
+;;   23:	 b800000000           	mov	eax, 0
+;;   28:	 400f95c0             	setne	al
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ne/locals.wat
@@ -1,0 +1,38 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.ne)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4839c1               	cmp	rcx, rax
+;;   3e:	 b900000000           	mov	ecx, 0
+;;   43:	 400f95c1             	setne	cl
+;;   47:	 4889c8               	mov	rax, rcx
+;;   4a:	 4883c418             	add	rsp, 0x18
+;;   4e:	 5d                   	pop	rbp
+;;   4f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/params.wat
+++ b/winch/filetests/filetests/x64/i64_ne/params.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i64.ne)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4839c1               	cmp	rcx, rax
+;;   23:	 b900000000           	mov	ecx, 0
+;;   28:	 400f95c1             	setne	cl
+;;   2c:	 4889c8               	mov	rax, rcx
+;;   2f:	 4883c418             	add	rsp, 0x18
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
This change introduces support for binary comparison instructions for `i32`s and `i64`s to Winch.

To accomplish this, I introduce a `cmp_with_set` method on the macro assembler that emits a `cmp` instruction or equivalent, emits an instruction to clear the destination register, and emits an instruction to set the destination register to `0` or `1` depending on the kind of comparison.