### PR TITLE
x64: Don't require SSE4.1 for `enable_simd`

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -31,8 +31,7 @@ fn define_settings(shared: &SettingGroup) -> SettingGroup {
         "has_sse41",
         "Has support for SSE4.1.",
         "SSE4.1: CPUID.01H:ECX.SSE4_1[bit 19]",
-        // Needed for default `enable_simd` setting.
-        true,
+        false,
     );
     let has_sse42 = settings.add_bool(
         "has_sse42",

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -215,11 +215,11 @@ fn isa_constructor(
     let isa_flags = x64_settings::Flags::new(&shared_flags, builder);
 
     // Check for compatibility between flags and ISA level
-    // requested. In particular, SIMD support requires SSE4.2.
+    // requested. In particular, SIMD support requires SSSE3.
     if !cfg!(miri) && shared_flags.enable_simd() {
-        if !isa_flags.has_sse3() || !isa_flags.has_ssse3() || !isa_flags.has_sse41() {
+        if !isa_flags.has_sse3() || !isa_flags.has_ssse3() {
             return Err(CodegenError::Unsupported(
-                "SIMD support requires SSE3, SSSE3, and SSE4.1 on x86_64.".into(),
+                "SIMD support requires SSE3 and SSSE3 on x86_64.".into(),
             ));
         }
     }
@@ -243,7 +243,6 @@ mod test {
         let mut isa_builder = crate::isa::lookup_by_name("x86_64").unwrap();
         isa_builder.set("has_sse3", "false").unwrap();
         isa_builder.set("has_ssse3", "false").unwrap();
-        isa_builder.set("has_sse41", "false").unwrap();
         assert!(matches!(
             isa_builder.finish(shared_flags),
             Err(CodegenError::Unsupported(_)),

--- a/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-libcall.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=false
+target x86_64
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/ceil.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=true
+target x86_64 sse41
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %f1(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/extractlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function %f1(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function %f1(i8) -> f32 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x64/float-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %f32_add(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/floor-libcall.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=false
+target x86_64
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_avx=false has_fma=false
+target x86_64 sse41
 
 function %fma_f32(f32, f32, f32) -> f32 {
 block0(v0: f32, v1: f32, v2: f32):

--- a/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %insertlane_f64x2_zero(f64x2, f64) -> f64x2 {
 block0(v0: f64x2, v1: f64):

--- a/cranelift/filetests/filetests/isa/x64/insertlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %insertlane_f64x2_zero(f64x2, f64) -> f64x2 {
 block0(v0: f64x2, v1: f64):

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function %f1(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest-libcall.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=false
+target x86_64
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/nearest.clif
+++ b/cranelift/filetests/filetests/isa/x64/nearest.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=true
+target x86_64 sse41
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %punpckldq(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %punpcklbw(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %i8x16_add(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %mask_from_icmp(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %or_from_memory(f32x4, i64) -> f32x4 {
 block0(v0: f32x4, v1: i64):

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %icmp_ne_32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %sload8x8(i64) -> i16x8 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %uload8x8(i64) -> i16x8 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %bnot_i32x4(i32x4) -> i32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %splat_i8(i8) -> i8x16 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %splat_i8(i8) -> i8x16 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -1,8 +1,6 @@
-
-
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 sse41
 
 function %imul_swiden_hi_i8x16(i8x16, i8x16) -> i16x8 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/trunc-libcall.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64 has_sse41=false
+target x86_64
 
 function %f1(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function %f1(f64x2) -> i32x4 {
 block0(v0: f64x2):

--- a/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/widen-high-bug.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function u0:0(i64 vmctx, i8x16) -> i16x8 fast {
 block0(v0: i64, v2: i8x16):

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 sse41
 
 function %f1(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/ceil.clif
+++ b/cranelift/filetests/filetests/runtests/ceil.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
-target x86_64
-target x86_64 has_sse41=false
 set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/floor.clif
+++ b/cranelift/filetests/filetests/runtests/floor.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
-target x86_64
-target x86_64 has_sse41=false
 set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/nearest.clif
+++ b/cranelift/filetests/filetests/runtests/nearest.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
-target x86_64
-target x86_64 has_sse41=false
 set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse41
+target x86_64 sse42
+target x86_64 sse42 has_avx
 
 
 function %sadd_sat_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-conversion.clif
+++ b/cranelift/filetests/filetests/runtests/simd-conversion.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue.clif
@@ -1,11 +1,12 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target aarch64
 target s390x
+target x86_64
 target x86_64 sse41
-target x86_64 sse41 has_avx
+target x86_64 sse42
+target x86_64 sse42 has_avx
 
 function %vall_true_i8x16(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
@@ -1,9 +1,9 @@
 test interpret
 test run
-target x86_64 has_sse41=false
 set enable_simd
 target aarch64
 target s390x
+target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
 

--- a/cranelift/filetests/filetests/runtests/trunc.clif
+++ b/cranelift/filetests/filetests/runtests/trunc.clif
@@ -1,8 +1,9 @@
 test interpret
 test run
-target x86_64
-target x86_64 has_sse41=false
 set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse42
 target x86_64 sse42 has_avx
 target aarch64
 target s390x

--- a/cranelift/filetests/filetests/wasm/x64-relaxed-simd-deterministic.wat
+++ b/cranelift/filetests/filetests/wasm/x64-relaxed-simd-deterministic.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! compile = true
 ;;! relaxed_simd_deterministic = true
-;;! settings = ["enable_simd", "has_avx"]
+;;! settings = ["enable_simd", "sse42", "has_avx"]
 
 (module
   (func (param v128) (result v128)

--- a/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
+++ b/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
@@ -1,5 +1,6 @@
 ;;! target = "x86_64"
 ;;! compile = true
+;;! settings = ["enable_simd", "sse41"]
 
 (module
   (func (param v128) (result v128)

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -79,7 +79,6 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
         // if present.
         isa_builder.set("has_sse3", "false").unwrap();
         isa_builder.set("has_ssse3", "false").unwrap();
-        isa_builder.set("has_sse41", "false").unwrap();
 
         if std::is_x86_feature_detected!("sse3") {
             isa_builder.enable("has_sse3").unwrap();

--- a/cranelift/reader/src/isaspec.rs
+++ b/cranelift/reader/src/isaspec.rs
@@ -87,6 +87,8 @@ macro_rules! option_err {
 }
 
 /// Parse an iterator of command line options and apply them to `config`.
+///
+/// Note that parsing terminates after the first error is encountered.
 pub fn parse_options<'a, I>(
     iter: I,
     config: &mut dyn Configurable,
@@ -95,37 +97,40 @@ pub fn parse_options<'a, I>(
 where
     I: Iterator<Item = &'a str>,
 {
-    for opt in iter.map(TestOption::new) {
-        match opt {
-            TestOption::Flag(name) => match config.enable(name) {
-                Ok(_) => {}
-                Err(SetError::BadName(name)) => {
-                    return Err(ParseOptionError::UnknownFlag { loc, name })
-                }
-                Err(_) => return option_err!(loc, "not a boolean flag: '{}'", opt),
-            },
-            TestOption::Value(name, value) => match config.set(name, value) {
-                Ok(_) => {}
-                Err(SetError::BadName(name)) => {
-                    return Err(ParseOptionError::UnknownValue {
-                        loc,
-                        name,
-                        value: value.to_string(),
-                    })
-                }
-                Err(SetError::BadType) => {
-                    return option_err!(loc, "invalid setting type: '{}'", opt)
-                }
-                Err(SetError::BadValue(expected)) => {
-                    return option_err!(
-                        loc,
-                        "invalid setting value for '{}', expected {}",
-                        opt,
-                        expected
-                    );
-                }
-            },
-        }
+    for opt in iter {
+        parse_option(opt, config, loc)?;
     }
     Ok(())
+}
+
+/// Parse an single command line options and apply it to `config`.
+pub fn parse_option(
+    opt: &str,
+    config: &mut dyn Configurable,
+    loc: Location,
+) -> Result<(), ParseOptionError> {
+    match TestOption::new(opt) {
+        TestOption::Flag(name) => match config.enable(name) {
+            Ok(_) => Ok(()),
+            Err(SetError::BadName(name)) => Err(ParseOptionError::UnknownFlag { loc, name }),
+            Err(_) => option_err!(loc, "not a boolean flag: '{}'", opt),
+        },
+        TestOption::Value(name, value) => match config.set(name, value) {
+            Ok(_) => Ok(()),
+            Err(SetError::BadName(name)) => Err(ParseOptionError::UnknownValue {
+                loc,
+                name,
+                value: value.to_string(),
+            }),
+            Err(SetError::BadType) => option_err!(loc, "invalid setting type: '{}'", opt),
+            Err(SetError::BadValue(expected)) => {
+                option_err!(
+                    loc,
+                    "invalid setting value for '{}', expected {}",
+                    opt,
+                    expected
+                )
+            }
+        },
+    }
 }

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -57,7 +57,7 @@ impl CodegenSettings {
             // to have test case failures unrelated to codegen setting input
             // that fail on one architecture to fail on other architectures as
             // well.
-            let new_flags = ["has_sse3", "has_ssse3", "has_sse41"]
+            let new_flags = ["has_sse3", "has_ssse3"]
                 .into_iter()
                 .map(|name| Ok((name, u.arbitrary()?)))
                 .collect::<arbitrary::Result<HashMap<_, bool>>>()?;
@@ -146,8 +146,8 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                     // `maybe_disable_more_features`.
                     std:"sse3" => clif:"has_sse3" ratio: 1 in 1,
                     std:"ssse3" => clif:"has_ssse3" ratio: 1 in 1,
-                    std:"sse4.1" => clif:"has_sse41" ratio: 1 in 1,
 
+                    std:"sse4.1" => clif:"has_sse41",
                     std:"sse4.2" => clif:"has_sse42",
                     std:"popcnt" => clif:"has_popcnt",
                     std:"avx" => clif:"has_avx",


### PR DESCRIPTION
This commit removes the SSE4.1 requirement for the `enable_simd` CLIF feature. This means that the new baseline required is SSSE3 for the WebAssembly SIMD proposal. Many existing tests for codegen were all updated to explicitly enable `has_sse41` and runtests were updated to test with and without SSE 4.1.

Wasmtime's fuzzing is additionally updated to flip the SSE4.1 feature to enable fuzz-testing this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
