### PR TITLE
wasi-threads: check module shape at spawn time

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -528,3 +528,26 @@ fn run_threads() -> Result<()> {
     );
     Ok(())
 }
+
+#[cfg(feature = "wasi-threads")]
+#[test]
+fn run_simple_with_wasi_threads() -> Result<()> {
+    // We expect to be able to run Wasm modules that do not have correct
+    // wasi-thread entry points or imported shared memory as long as no threads
+    // are spawned.
+    let wasm = build_wasm("tests/all/cli_tests/simple.wat")?;
+    let stdout = run_wasmtime(&[
+        "run",
+        wasm.path().to_str().unwrap(),
+        "--wasi-modules",
+        "experimental-wasi-threads",
+        "--wasm-features",
+        "threads",
+        "--disable-cache",
+        "--invoke",
+        "simple",
+        "4",
+    ])?;
+    assert_eq!(stdout, "4\n");
+    Ok(())
+}


### PR DESCRIPTION
This change relaxes what kinds of modules can be run when wasi-threads is enabled via `--wasi-modules experimental-wasi-threads`. Previously, as reported in #6153, simple modules that made no use of thread spawning or shared memories were preemptively rejected when the wasi-threads context was created. This is too restrictive.

Instead, this change does the following:
- it moves the check for whether a module is valid according to the wasi-threads specification to the point a new thread is spawned; this resolves #6153
- as noted in #6153, this change also adds a better error message indicating that wasi-threads expects a shared memory import
- the way this is implemented also improves the module instantiation: by constructing an `InstancePre` once when the `WasiThreadsCtx` is built, we might shave off a bit of time from the "spawn a thread" call; this supercedes a similar effort in #5741

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
