### PR TITLE
x64: Avoid using `movddup` without SSSE3

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1663,6 +1663,9 @@
 (decl pure use_fma () bool)
 (extern constructor use_fma use_fma)
 
+(decl pure use_ssse3 () bool)
+(extern constructor use_ssse3 use_ssse3)
+
 (decl pure use_sse41 () bool)
 (extern constructor use_sse41 use_sse41)
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4318,14 +4318,15 @@
         (if-let $true (use_avx_simd))
         (x64_vbroadcastss addr))
 
-;; t64x2.splat - use `movddup` which is exactly what we want and there's a
-;; minor specialization for sinkable loads to avoid going through a gpr for i64
-;; splats
+;; t64x2.splat - use `pshufd` to broadcast the lower 64-bit lane to the upper
+;; lane. A minor specialization for sinkable loads to avoid going through a gpr
+;; for i64 splats is used as well when `movddup` is available.
 (rule 0 (lower (has_type $I64X2 (splat src)))
-        (x64_movddup (bitcast_gpr_to_xmm $I64 src)))
+        (x64_pshufd (bitcast_gpr_to_xmm $I64 src) 0b01_00_01_00))
 (rule 0 (lower (has_type $F64X2 (splat src)))
-        (x64_movddup src))
+        (x64_pshufd src 0b01_00_01_00))
 (rule 5 (lower (has_type (multi_lane 64 2) (splat (sinkable_load addr))))
+        (if-let $true (use_ssse3))
         (x64_movddup addr))
 
 ;; Rules for `vany_true` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -225,6 +225,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
+    fn use_ssse3(&mut self) -> bool {
+        self.backend.x64_flags.use_ssse3()
+    }
+
+    #[inline]
     fn use_sse41(&mut self) -> bool {
         self.backend.x64_flags.use_sse41()
     }

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -252,7 +252,7 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movddup %xmm0, %xmm0
+;   pshufd  $68, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -262,7 +262,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movddup %xmm0, %xmm0
+;   pshufd $0x44, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -99,7 +99,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovq   %rdi, %xmm2
-;   vmovddup %xmm2, %xmm0
+;   vpshufd $68, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -110,7 +110,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   vmovq %rdi, %xmm2
-;   vmovddup %xmm2, %xmm0
+;   vpshufd $0x44, %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -150,7 +150,7 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vmovddup %xmm0, %xmm0
+;   vpshufd $68, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -160,7 +160,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   vmovddup %xmm0, %xmm0
+;   vpshufd $0x44, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
@@ -94,7 +94,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   vmovq   %rdi, %xmm2
-;   vmovddup %xmm2, %xmm0
+;   vpshufd $68, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -105,7 +105,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   vmovq %rdi, %xmm2
-;   vmovddup %xmm2, %xmm0
+;   vpshufd $0x44, %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -145,7 +145,7 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vmovddup %xmm0, %xmm0
+;   vpshufd $68, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -155,7 +155,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   vmovddup %xmm0, %xmm0
+;   vpshufd $0x44, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -99,7 +99,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %xmm2
-;   movddup %xmm2, %xmm0
+;   pshufd  $68, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -110,7 +110,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdi, %xmm2
-;   movddup %xmm2, %xmm0
+;   pshufd $0x44, %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -150,7 +150,7 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movddup %xmm0, %xmm0
+;   pshufd  $68, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -160,7 +160,7 @@ block0(v0: f64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movddup %xmm0, %xmm0
+;   pshufd $0x44, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -2,10 +2,12 @@
 test run
 target aarch64
 target s390x
+target x86_64 has_ssse3=false
 set enable_simd
-target x86_64 has_sse3 has_ssse3 has_sse41
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx has_avx2
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target x86_64 sse41 has_avx has_avx2
 target riscv64 has_v
 
 function %splat_i8x16(i8) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -2,7 +2,6 @@
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
 target x86_64 sse41


### PR DESCRIPTION
Update the lowerings for 64-bit splats to use `pshufd` instead, as LLVM does.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
