### PR TITLE
Wasi: preview2 poll-oneoff returns list<bool>

### DIFF
--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1695,7 +1695,7 @@ pub unsafe extern "C" fn poll_oneoff(
         );
 
         assert_eq!(vec.len(), nsubscriptions);
-        assert_eq!(vec.as_ptr(), results);
+        assert_eq!(vec.as_ptr(), results as *const bool);
         forget(vec);
 
         drop(pollables);

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -34,8 +34,12 @@ pub mod bindings {
         world: "wasi:preview/command",
         std_feature,
         raw_strings,
-        // The generated definition of command will pull in std, so we are defining it
-        // manually below instead
+        // Automatically generated bindings for these functions will allocate
+        // Vecs, which in turn pulls in the panic machinery from std, which
+        // creates vtables that end up in the wasm elem section, which we
+        // can't support in these special core-wasm adapters.
+        // Instead, we manually define the bindings for these functions in
+        // terms of raw pointers.
         skip: ["run", "get-environment", "poll-oneoff"],
     });
 
@@ -45,6 +49,12 @@ pub mod bindings {
         world: "wasi:preview/reactor",
         std_feature,
         raw_strings,
+        // Automatically generated bindings for these functions will allocate
+        // Vecs, which in turn pulls in the panic machinery from std, which
+        // creates vtables that end up in the wasm elem section, which we
+        // can't support in these special core-wasm adapters.
+        // Instead, we manually define the bindings for these functions in
+        // terms of raw pointers.
         skip: ["get-environment", "poll-oneoff"],
     });
 }

--- a/crates/wasi/src/preview2/preview2/poll.rs
+++ b/crates/wasi/src/preview2/preview2/poll.rs
@@ -34,7 +34,7 @@ impl<T: WasiView> poll::Host for T {
         Ok(())
     }
 
-    async fn poll_oneoff(&mut self, futures: Vec<Pollable>) -> anyhow::Result<Vec<u8>> {
+    async fn poll_oneoff(&mut self, futures: Vec<Pollable>) -> anyhow::Result<Vec<bool>> {
         use crate::preview2::sched::{sync::SyncSched, Poll, Userdata, WasiSched};
 
         // Convert `futures` into `Poll` subscriptions.
@@ -74,10 +74,9 @@ impl<T: WasiView> poll::Host for T {
         // Do the poll.
         SyncSched.poll_oneoff(&mut poll).await?;
 
-        // Convert the results into a list of `u8` to return.
-        let mut results = vec![0_u8; len];
+        let mut results = vec![false; len];
         for (_result, data) in poll.results() {
-            results[u64::from(data) as usize] = u8::from(true);
+            results[u64::from(data) as usize] = true;
         }
         Ok(results)
     }

--- a/crates/wasi/wit/deps/poll/poll.wit
+++ b/crates/wasi/wit/deps/poll/poll.wit
@@ -32,10 +32,8 @@ interface poll {
     /// component model async proposal, which will include a scalable waiting
     /// facility.
     ///
-    /// Note that the return type would ideally be `list<bool>`, but that would
-    /// be more difficult to polyfill given the current state of `wit-bindgen`.
-    /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
-    /// for details.  For now, we use zero to mean "not ready" and non-zero to
-    /// mean "ready".
-    poll-oneoff: func(in: list<pollable>) -> list<u8>
+    /// The result list<bool> is the same length as the argument
+    /// list<pollable>, and indicates the readiness of each corresponding
+    /// element in that / list, with true indicating ready.
+    poll-oneoff: func(in: list<pollable>) -> list<bool>
 }


### PR DESCRIPTION
In the early days of the preview2 prototype, there was some trouble with wit-bindgen that made it impossible to return a `list<bool>` from the `poll-oneoff` function.

This bug has since been resolved. The poll-oneoff definition in wit has been modified to return `list<bool>` and minor tweaks have been made at use sites to use the boolean.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
