### PR TITLE
Fix a soundness issue with the component model and async

### DIFF
--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::cell::Cell;
 use std::io;
 use std::marker::PhantomData;
+use std::ops::Range;
 use std::panic::{self, AssertUnwindSafe};
 
 cfg_if::cfg_if! {
@@ -26,23 +27,34 @@ impl FiberStack {
         Ok(Self(imp::FiberStack::new(size)?))
     }
 
-    /// Creates a new fiber stack with the given pointer to the top of the stack.
+    /// Creates a new fiber stack with the given pointer to the bottom of the
+    /// stack plus the byte length of the stack.
+    ///
+    /// The `bottom` pointer should be addressable for `len` bytes. The page
+    /// beneath `bottom` should be unmapped as a guard page.
     ///
     /// # Safety
     ///
-    /// This is unsafe because there is no validation of the given stack pointer.
+    /// This is unsafe because there is no validation of the given pointer.
     ///
     /// The caller must properly allocate the stack space with a guard page and
     /// make the pages accessible for correct behavior.
-    pub unsafe fn from_top_ptr(top: *mut u8) -> io::Result<Self> {
-        Ok(Self(imp::FiberStack::from_top_ptr(top)?))
+    pub unsafe fn from_raw_parts(bottom: *mut u8, len: usize) -> io::Result<Self> {
+        Ok(Self(imp::FiberStack::from_raw_parts(bottom, len)?))
     }
 
     /// Gets the top of the stack.
     ///
-    /// Returns `None` if the platform does not support getting the top of the stack.
+    /// Returns `None` if the platform does not support getting the top of the
+    /// stack.
     pub fn top(&self) -> Option<*mut u8> {
         self.0.top()
+    }
+
+    /// Returns the range of where this stack resides in memory if the platform
+    /// supports it.
+    pub fn range(&self) -> Option<Range<usize>> {
+        self.0.range()
     }
 }
 

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -2,6 +2,7 @@ use crate::RunResult;
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::io;
+use std::ops::Range;
 use std::ptr;
 use windows_sys::Win32::Foundation::*;
 use windows_sys::Win32::System::Threading::*;
@@ -14,11 +15,15 @@ impl FiberStack {
         Ok(Self(size))
     }
 
-    pub unsafe fn from_top_ptr(_top: *mut u8) -> io::Result<Self> {
+    pub unsafe fn from_raw_parts(_base: *mut u8, _len: usize) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 
     pub fn top(&self) -> Option<*mut u8> {
+        None
+    }
+
+    pub fn range(&self) -> Option<Range<usize>> {
         None
     }
 }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -462,7 +462,7 @@ impl StackPool {
             commit_stack_pages(bottom_of_stack, size_without_guard)?;
 
             let stack =
-                wasmtime_fiber::FiberStack::from_top_ptr(bottom_of_stack.add(size_without_guard))?;
+                wasmtime_fiber::FiberStack::from_raw_parts(bottom_of_stack, size_without_guard)?;
             Ok(stack)
         }
     }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -70,8 +70,9 @@ pub use crate::mmap_vec::MmapVec;
 pub use crate::store_box::*;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
-    catch_traps, init_traps, raise_lib_trap, raise_user_trap, resume_panic, tls_eager_initialize,
-    Backtrace, Frame, SignalHandler, TlsRestore, Trap, TrapReason,
+    assert_tls_not_in_range, catch_traps, init_traps, raise_lib_trap, raise_user_trap,
+    resume_panic, tls_eager_initialize, Backtrace, Frame, SignalHandler, TlsRestore, Trap,
+    TrapReason,
 };
 pub use crate::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -69,11 +69,7 @@ pub use crate::mmap::Mmap;
 pub use crate::mmap_vec::MmapVec;
 pub use crate::store_box::*;
 pub use crate::table::{Table, TableElement};
-pub use crate::traphandlers::{
-    assert_tls_not_in_range, catch_traps, init_traps, raise_lib_trap, raise_user_trap,
-    resume_panic, tls_eager_initialize, Backtrace, Frame, SignalHandler, TlsState, Trap,
-    TrapReason,
-};
+pub use crate::traphandlers::*;
 pub use crate::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMInvokeArgument, VMMemoryDefinition,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub use crate::store_box::*;
 pub use crate::table::{Table, TableElement};
 pub use crate::traphandlers::{
     assert_tls_not_in_range, catch_traps, init_traps, raise_lib_trap, raise_user_trap,
-    resume_panic, tls_eager_initialize, Backtrace, Frame, SignalHandler, TlsRestore, Trap,
+    resume_panic, tls_eager_initialize, Backtrace, Frame, SignalHandler, TlsState, Trap,
     TrapReason,
 };
 pub use crate::vmcontext::{

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -1,8 +1,10 @@
 #![cfg(not(miri))]
 
+use crate::async_functions::{execute_across_threads, PollOnce};
 use anyhow::Result;
 use wasmtime::component::*;
-use wasmtime::{Store, StoreContextMut, Trap};
+use wasmtime::{Engine, Store, StoreContextMut, Trap};
+use wasmtime_component_util::REALLOC_AND_FREE;
 
 /// This is super::func::thunks, except with an async store.
 #[tokio::test]
@@ -86,5 +88,156 @@ async fn smoke_func_wrap() -> Result<()> {
     thunk.call_async(&mut store, ()).await?;
     thunk.post_return_async(&mut store).await?;
 
+    Ok(())
+}
+
+// This test stresses TLS management in combination with the `realloc` option
+// for imported functions. This will create an async computation which invokes a
+// component that invokes an imported function. The imported function returns a
+// list which will require invoking malloc.
+//
+// As an added stressor all polls are sprinkled across threads through
+// `execute_across_threads`. Yields are injected liberally by configuring 1
+// fuel consumption to trigger a yield.
+//
+// Overall a yield should happen during malloc which should be an "interesting
+// situation" with respect to the runtime.
+#[tokio::test]
+async fn resume_separate_thread() -> Result<()> {
+    let mut config = component_test_util::config();
+    config.async_support(true);
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
+    let component = format!(
+        r#"
+            (component
+                (import "yield" (func $yield (result (list u8))))
+                (core module $libc
+                    (memory (export "memory") 1)
+                    {REALLOC_AND_FREE}
+                )
+                (core instance $libc (instantiate $libc))
+
+                (core func $yield
+                    (canon lower
+                        (func $yield)
+                        (memory $libc "memory")
+                        (realloc (func $libc "realloc"))
+                    )
+                )
+
+                (core module $m
+                    (import "" "yield" (func $yield (param i32)))
+                    (import "libc" "memory" (memory 0))
+                    (func $start
+                        i32.const 8
+                        call $yield
+                    )
+                    (start $start)
+                )
+                (core instance (instantiate $m
+                    (with "" (instance (export "yield" (func $yield))))
+                    (with "libc" (instance $libc))
+                ))
+            )
+        "#
+    );
+    let component = Component::new(&engine, component)?;
+    let mut linker = Linker::new(&engine);
+    linker
+        .root()
+        .func_wrap_async("yield", |_: StoreContextMut<()>, _: ()| {
+            Box::new(async {
+                tokio::task::yield_now().await;
+                Ok((vec![1u8, 2u8],))
+            })
+        })?;
+
+    execute_across_threads(async move {
+        let mut store = Store::new(&engine, ());
+        store.out_of_fuel_async_yield(u64::MAX, 1);
+        linker.instantiate_async(&mut store, &component).await?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?;
+    Ok(())
+}
+
+// This test is intended to stress TLS management in the component model around
+// the management of the `realloc` function. This creates an async computation
+// representing the execution of a component model function where entry into the
+// component uses `realloc` and then the component runs. This async computation
+// is then polled iteratively with another "wasm activation" (in this case a
+// core wasm function) on the stack. The poll-per-call should work and nothing
+// should in theory have problems here.
+//
+// As an added stressor all polls are sprinkled across threads through
+// `execute_across_threads`. Yields are injected liberally by configuring 1
+// fuel consumption to trigger a yield.
+//
+// Overall a yield should happen during malloc which should be an "interesting
+// situation" with respect to the runtime.
+#[tokio::test]
+async fn poll_through_wasm_activation() -> Result<()> {
+    let mut config = component_test_util::config();
+    config.async_support(true);
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
+    let component = format!(
+        r#"
+            (component
+                (core module $m
+                    {REALLOC_AND_FREE}
+                    (memory (export "memory") 1)
+                    (func (export "run") (param i32 i32)
+                    )
+                )
+                (core instance $i (instantiate $m))
+                (func (export "run") (param "x" (list u8))
+                    (canon lift (core func $i "run")
+                                (memory $i "memory")
+                                (realloc (func $i "realloc"))))
+            )
+        "#
+    );
+    let component = Component::new(&engine, component)?;
+    let linker = Linker::new(&engine);
+
+    let invoke_component = {
+        let engine = engine.clone();
+        async move {
+            let mut store = Store::new(&engine, ());
+            store.out_of_fuel_async_yield(u64::MAX, 1);
+            let instance = linker.instantiate_async(&mut store, &component).await?;
+            let func = instance.get_typed_func::<(Vec<u8>,), ()>(&mut store, "run")?;
+            func.call_async(&mut store, (vec![1, 2, 3],)).await?;
+            Ok::<_, anyhow::Error>(())
+        }
+    };
+
+    execute_across_threads(async move {
+        let mut store = Store::new(&engine, Some(Box::pin(invoke_component)));
+        let poll_once = wasmtime::Func::wrap0_async(&mut store, |mut cx| {
+            let invoke_component = cx.data_mut().take().unwrap();
+            Box::new(async move {
+                match PollOnce::new(invoke_component).await {
+                    Ok(result) => {
+                        result?;
+                        Ok(1)
+                    }
+                    Err(future) => {
+                        *cx.data_mut() = Some(future);
+                        Ok(0)
+                    }
+                }
+            })
+        });
+        let poll_once = poll_once.typed::<(), i32>(&mut store)?;
+        while poll_once.call_async(&mut store, ()).await? != 1 {
+            // loop around to call again
+        }
+        Ok::<_, anyhow::Error>(())
+    })
+    .await?;
     Ok(())
 }

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -419,7 +419,7 @@ async fn drop_future_on_epoch_yield() {
 
     let instance = linker.instantiate_async(&mut store, &module).await.unwrap();
     let f = instance.get_func(&mut store, "run").unwrap();
-    PollOnce::new(Box::pin(f.call_async(&mut store, &[], &mut []))).await;
+    let _ = PollOnce::new(Box::pin(f.call_async(&mut store, &[], &mut []))).await;
 
     assert_eq!(true, alive_flag.load(Ordering::Acquire));
 }


### PR DESCRIPTION
This commit addresses https://github.com/bytecodealliance/wasmtime/issues/6493 by fixing a soundness issue with the async
implementation of the component model. This issue has been presence
since the inception of the addition of async support to the component
model and doesn't represent a recent regression. The underlying problem
is that one of the base assumptions of the trap handling code is that
there's only one single activation in TLS that needs to be pushed/popped
when a stack is switched (e.g. a fiber is switched to or from). In the
case of the component model there might be two activations: one for an
invocation of a component function and then a second for an invocation
of a `realloc` function to return results back to wasm (e.g. in the case
an imported function returns a list).

This problem is fixed by changing how TLS is managed in the presence of
fibers. Previously when a fiber was suspended it would pop a single
activation from the top of the stack and save that to get pushed when
the fiber was resumed. This has the benefit of maintaining an entire
linked list of activations for the current thread but has the problem
above where it doesn't handle a fiber with multiple activations on it.
Instead now TLS management is done when a fiber is resumed instead of
suspended. Instead of pushing/popping a single activation the entire
linked list of activations is tracked for a particular fiber and stored
within the fiber itself. In this manner resuming a fiber will push
all activations onto the current thread and suspending a fiber will pop
all activations for the fiber (and store them as a new linked list in
the fiber's state itself).

This end result is that all activations on a fiber should now be managed
correctly, regardless of how many there are. The main downside of this
commit is that fiber suspension and resumption is more complicated, but
the hope there is that fiber suspension typically corresponds with I/O
not being ready or similar so the order of magnitude of TLS operations
isn't too significant compared to the I/O overhead.