### PR TITLE
aarch64: Use Imm12 in more cases

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -279,17 +279,12 @@ pub struct Imm12 {
 impl Imm12 {
     /// Compute a Imm12 from raw bits, if possible.
     pub fn maybe_from_u64(val: u64) -> Option<Imm12> {
-        if val == 0 {
-            Some(Imm12 {
-                bits: 0,
-                shift12: false,
-            })
-        } else if val < 0xfff {
+        if val & !0xfff == 0 {
             Some(Imm12 {
                 bits: val as u16,
                 shift12: false,
             })
-        } else if val < 0xfff_000 && (val & 0xfff == 0) {
+        } else if val & !(0xfff << 12) == 0 {
             Some(Imm12 {
                 bits: (val >> 12) as u16,
                 shift12: true,

--- a/cranelift/filetests/filetests/isa/aarch64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/amodes.clif
@@ -175,6 +175,26 @@ block0(v0: i64):
 ;   ldr w0, [x2]
 ;   ret
 
+function %add_imm12_max_shifted(i64) -> i32 {
+block0(v0: i64):
+  v1 = iconst.i64 0xFFF000
+  v2 = iadd.i64 v0, v1
+  v3 = load.i32 v2
+  return v3
+}
+
+; VCode:
+; block0:
+;   add x2, x0, #16773120
+;   ldr w0, [x2]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x2, x0, #0xfff, lsl #12
+;   ldr w0, [x2]
+;   ret
+
 function %f12(i64) -> i32 {
 block0(v0: i64):
   v1 = iconst.i64 -4


### PR DESCRIPTION
The previous implementation of Imm12::maybe_from_u64 did not match the constant values 0xfff or 0xfff000, even though those are expressible in the aarch64 12-bit immediate format.

Also the explicit test for 0 was unnecessary; it's a valid example of all bits outside the least-significant 12 bits being 0.