### PR TITLE
riscv64: Fix wrong move instruction in `select`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1705,11 +1705,13 @@ impl MachInstEmit for Inst {
                 let rd = allocs.next_writable(rd);
                 let label_true = sink.get_label();
                 let label_jump_over = sink.get_label();
+                let ty = Inst::canonical_type_for_rc(rs1.class());
+
                 sink.use_label_at_offset(sink.cur_offset(), label_true, LabelUse::B12);
                 let x = condition.emit();
                 sink.put4(x);
                 // here is false , use rs2
-                Inst::gen_move(rd, rs2, I64).emit(&[], sink, emit_info, state);
+                Inst::gen_move(rd, rs2, ty).emit(&[], sink, emit_info, state);
                 // and jump over
                 Inst::Jal {
                     dest: BranchTarget::Label(label_jump_over),
@@ -1717,7 +1719,7 @@ impl MachInstEmit for Inst {
                 .emit(&[], sink, emit_info, state);
                 // here condition is true , use rs1
                 sink.bind_label(label_true, &mut state.ctrl_plane);
-                Inst::gen_move(rd, rs1, I64).emit(&[], sink, emit_info, state);
+                Inst::gen_move(rd, rs1, ty).emit(&[], sink, emit_info, state);
                 sink.bind_label(label_jump_over, &mut state.ctrl_plane);
             }
             &Inst::FcvtToInt {

--- a/cranelift/filetests/filetests/isa/riscv64/select-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select-float.clif
@@ -25,7 +25,7 @@ block0(v0: i8, v1: f32, v2: f32):
 ;   andi a2, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a2, a4, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i8_f64(i8, f64, f64) -> f64 {
@@ -50,7 +50,7 @@ block0(v0: i8, v1: f64, v2: f64):
 ;   andi a2, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a2, a4, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i16_f32(i16, f32, f32) -> f32 {
@@ -79,7 +79,7 @@ block0(v0: i16, v1: f32, v2: f32):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i16_f64(i16, f64, f64) -> f64 {
@@ -108,7 +108,7 @@ block0(v0: i16, v1: f64, v2: f64):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i32_f32(i32, f32, f32) -> f32 {
@@ -137,7 +137,7 @@ block0(v0: i32, v1: f32, v2: f32):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i32_f64(i32, f64, f64) -> f64 {
@@ -166,7 +166,7 @@ block0(v0: i32, v1: f64, v2: f64):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i64_f32(i64, f32, f32) -> f32 {
@@ -187,7 +187,7 @@ block0(v0: i64, v1: f32, v2: f32):
 ; block0: ; offset 0x0
 ;   addi a2, zero, 0x2a
 ;   beq a0, a2, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i64_f64(i64, f64, f64) -> f64 {
@@ -208,7 +208,7 @@ block0(v0: i64, v1: f64, v2: f64):
 ; block0: ; offset 0x0
 ;   addi a2, zero, 0x2a
 ;   beq a0, a2, 8
-;   ori a0, a1, 0
+;   fmv.d fa0, fa1
 ;   ret
 
 function %select_icmp_i128_f32(i128, f32, f32) -> f32 {

--- a/cranelift/filetests/filetests/runtests/i128-select-float.clif
+++ b/cranelift/filetests/filetests/runtests/i128-select-float.clif
@@ -1,0 +1,43 @@
+test interpret
+test run
+set enable_llvm_abi_extensions=true
+target aarch64
+target s390x
+target x86_64
+target riscv64
+
+function %select_icmp_i128_f32(i128, f32, f32) -> f32 {
+block0(v0: i128, v1: f32, v2: f32):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.f32 v5, v1, v2
+  return v6
+}
+; run: %select_icmp_i128_f32(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i128_f32(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i128_f32(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i128_f32(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i128_f32(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i128_f32(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i128_f32(42, 0x0.800000p-126, -0x0.800000p-126) == 0x0.800000p-126
+; run: %select_icmp_i128_f32(10, 0x0.800000p-126, -0x0.800000p-126) == -0x0.800000p-126
+
+
+
+function %select_icmp_i128_f64(i128, f64, f64) -> f64 {
+block0(v0: i128, v1: f64, v2: f64):
+  v3 = iconst.i64 42
+  v4 = uextend.i128 v3
+  v5 = icmp eq v0, v4
+  v6 = select.f64 v5, v1, v2
+  return v6
+}
+; run: %select_icmp_i128_f64(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i128_f64(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i128_f64(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i128_f64(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i128_f64(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i128_f64(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i128_f64(42, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == 0x0.8000000000000p-1022
+; run: %select_icmp_i128_f64(10, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == -0x0.8000000000002p-1022

--- a/cranelift/filetests/filetests/runtests/select-float.clif
+++ b/cranelift/filetests/filetests/runtests/select-float.clif
@@ -1,0 +1,141 @@
+test interpret
+test run
+target aarch64
+target s390x
+target x86_64
+target riscv64
+
+function %select_icmp_i8_f32(i8, f32, f32) -> f32 {
+block0(v0: i8, v1: f32, v2: f32):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i8_f32(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i8_f32(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i8_f32(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i8_f32(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i8_f32(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i8_f32(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i8_f32(42, 0x0.800000p-126, -0x0.800000p-126) == 0x0.800000p-126
+; run: %select_icmp_i8_f32(10, 0x0.800000p-126, -0x0.800000p-126) == -0x0.800000p-126
+
+
+function %select_icmp_i8_f64(i8, f64, f64) -> f64 {
+block0(v0: i8, v1: f64, v2: f64):
+  v3 = iconst.i8 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i8_f64(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i8_f64(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i8_f64(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i8_f64(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i8_f64(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i8_f64(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i8_f64(42, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == 0x0.8000000000000p-1022
+; run: %select_icmp_i8_f64(10, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == -0x0.8000000000002p-1022
+
+
+function %select_icmp_i16_f32(i16, f32, f32) -> f32 {
+block0(v0: i16, v1: f32, v2: f32):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i16_f32(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i16_f32(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i16_f32(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i16_f32(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i16_f32(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i16_f32(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i16_f32(42, 0x0.800000p-126, -0x0.800000p-126) == 0x0.800000p-126
+; run: %select_icmp_i16_f32(10, 0x0.800000p-126, -0x0.800000p-126) == -0x0.800000p-126
+
+
+function %select_icmp_i16_f64(i16, f64, f64) -> f64 {
+block0(v0: i16, v1: f64, v2: f64):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i16_f64(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i16_f64(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i16_f64(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i16_f64(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i16_f64(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i16_f64(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i16_f64(42, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == 0x0.8000000000000p-1022
+; run: %select_icmp_i16_f64(10, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == -0x0.8000000000002p-1022
+
+
+function %select_icmp_i32_f32(i32, f32, f32) -> f32 {
+block0(v0: i32, v1: f32, v2: f32):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i32_f32(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i32_f32(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i32_f32(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i32_f32(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i32_f32(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i32_f32(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i32_f32(42, 0x0.800000p-126, -0x0.800000p-126) == 0x0.800000p-126
+; run: %select_icmp_i32_f32(10, 0x0.800000p-126, -0x0.800000p-126) == -0x0.800000p-126
+
+
+function %select_icmp_i32_f64(i32, f64, f64) -> f64 {
+block0(v0: i32, v1: f64, v2: f64):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i32_f64(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i32_f64(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i32_f64(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i32_f64(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i32_f64(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i32_f64(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i32_f64(42, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == 0x0.8000000000000p-1022
+; run: %select_icmp_i32_f64(10, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == -0x0.8000000000002p-1022
+
+
+function %select_icmp_i64_f32(i64, f32, f32) -> f32 {
+block0(v0: i64, v1: f32, v2: f32):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.f32 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i64_f32(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i64_f32(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i64_f32(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i64_f32(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i64_f32(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i64_f32(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i64_f32(42, 0x0.800000p-126, -0x0.800000p-126) == 0x0.800000p-126
+; run: %select_icmp_i64_f32(10, 0x0.800000p-126, -0x0.800000p-126) == -0x0.800000p-126
+
+
+function %select_icmp_i64_f64(i64, f64, f64) -> f64 {
+block0(v0: i64, v1: f64, v2: f64):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select.f64 v4, v1, v2
+  return v5
+}
+; run: %select_icmp_i64_f64(42, 0x0.0, 0x1.0) == 0x0.0
+; run: %select_icmp_i64_f64(10, 0x0.0, 0x1.0) == 0x1.0
+; run: %select_icmp_i64_f64(42, +Inf, -Inf) == +Inf
+; run: %select_icmp_i64_f64(10, +Inf, -Inf) == -Inf
+; run: %select_icmp_i64_f64(42, +NaN, -NaN) == +NaN
+; run: %select_icmp_i64_f64(10, +NaN, -NaN) == -NaN
+; run: %select_icmp_i64_f64(42, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == 0x0.8000000000000p-1022
+; run: %select_icmp_i64_f64(10, 0x0.8000000000000p-1022, -0x0.8000000000002p-1022) == -0x0.8000000000002p-1022


### PR DESCRIPTION
👋 Hey,

This PR fixes an issue with `select` when used with float registers. We always emit an integer move, but `gen_select_reg` is sometimes used with float arguments. When this happens, emit instead a float move.