### PR TITLE
fix the link to the published binaries of the component adapter

### DIFF
--- a/crates/wasi-preview1-component-adapter/README.md
+++ b/crates/wasi-preview1-component-adapter/README.md
@@ -22,10 +22,10 @@ $ cargo build --target wasm32-unknown-unknown --release
 
 And the artifact will be located at
 `target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm`.
-Alternatively the latest copy of this can be [downloaded from the releases
-page][latest-release]
+Alternatively the latest copy of this can be [downloaded from the `dev` tag
+assets ][dev-tag]
 
-[latest-release]: https://github.com/bytecodealliance/preview2-prototyping/releases/tag/latest
+[dev-tag]: https://github.com/bytecodealliance/wasmtime/releases/tag/dev
 
 ## Using
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
