### PR TITLE
cranelift: Expose `MachLabel`

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -94,7 +94,7 @@ pub use crate::machinst::buffer::{
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
-    MachInstEmitState, Reg, TextSectionBuilder, Writable,
+    MachInstEmitState, MachLabel, Reg, TextSectionBuilder, Writable,
 };
 
 mod alias_analysis;


### PR DESCRIPTION
This is the first of a series of patches to support control flow in Winch.

This change exposes `MachLabel` from cranelift for it to be consumed by Winch's `MacroAssembler` and `Assembler`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
