### PR TITLE
egraphs: Transform `{u,s}widen_{low,high}+splat` into `splat+{u,s}extend`

### DIFF
--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -32,3 +32,10 @@
 ;; actually doing the extend in the first place.
 (rule (simplify (ireduce ty (sextend _ x @ (value_type ty)))) x)
 (rule (simplify (ireduce ty (uextend _ x @ (value_type ty)))) x)
+
+;; {u,s}widen_{low,high}+splat is the same as splat+{u,s}extend
+(rule (simplify (swiden_high wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
+(rule (simplify (swiden_low wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
+
+(rule (simplify (uwiden_high wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))
+(rule (simplify (uwiden_low wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))

--- a/cranelift/filetests/filetests/egraph/simd-splat-widen.clif
+++ b/cranelift/filetests/filetests/egraph/simd-splat-widen.clif
@@ -1,0 +1,43 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %swiden_high_splat_i8x16(i8) -> i16x8 {
+block0(v0: i8):
+    v1 = splat.i8x16 v0
+    v2 = swiden_high v1
+    return v2
+    ; check: v3 = sextend.i16 v0
+    ; check: v4 = splat.i16x8 v3
+    ; check: return v4
+}
+
+function %swiden_low_splat_i8x16(i8) -> i16x8 {
+block0(v0: i8):
+    v1 = splat.i8x16 v0
+    v2 = swiden_low v1
+    return v2
+    ; check: v3 = sextend.i16 v0
+    ; check: v4 = splat.i16x8 v3
+    ; check: return v4
+}
+
+function %uwiden_high_splat_i8x16(i8) -> i16x8 {
+block0(v0: i8):
+    v1 = splat.i8x16 v0
+    v2 = uwiden_high v1
+    return v2
+    ; check: v3 = uextend.i16 v0
+    ; check: v4 = splat.i16x8 v3
+    ; check: return v4
+}
+
+function %uwiden_low_splat_i8x16(i8) -> i16x8 {
+block0(v0: i8):
+    v1 = splat.i8x16 v0
+    v2 = uwiden_low v1
+    return v2
+    ; check: v3 = uextend.i16 v0
+    ; check: v4 = splat.i16x8 v3
+    ; check: return v4
+}


### PR DESCRIPTION
👋 Hey,

This PR adds an egraph optimization that transforms `swiden_low+splat` into `splat+sextend` (and similar variations).

The primary motivation for this is that I'm working on SIMD widening arithmetic instructions in the RISC-V backend, and would like to match all of those patterns with just `splat+extend`. That being said, It is also probably beneficial to do these transforms (at least for RISC-V) since we have a bunch of scalar instructions that `sextend` the result.