### PR TITLE
winch: Fix `CodeGenContext::pop_to_reg`

### DIFF
--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -65,6 +65,9 @@ impl<'a> CodeGenContext<'a> {
     /// it isn't already one; spilling if there are no registers
     /// available.  Optionally the caller may specify a specific
     /// destination register.
+    /// When a named register is requested and it's not at the top of the
+    /// stack a move from register to register might happen, in which case
+    /// the source register will be freed.
     pub fn pop_to_reg<M: MacroAssembler>(
         &mut self,
         masm: &mut M,
@@ -92,6 +95,10 @@ impl<'a> CodeGenContext<'a> {
             masm.pop(dst);
         } else {
             self.move_val_to_reg(&val, dst, masm, size);
+            // Free the source value if it is a register.
+            if val.is_reg() {
+                self.regalloc.free_gpr(val.get_reg());
+            }
         }
 
         dst


### PR DESCRIPTION
This commit fixes the implementation of `pop_to_reg`. In the previous implementation, whenever a specific register was requested as the destination register and a register-to-register moved happened the source register was never marked as free.

This issue became more evident with more complex programs involving control flow and division for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
