### PR TITLE
Add integer binary instructions to Winch

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -328,6 +328,22 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | I64GeU { .. }
                         | I32Eqz { .. }
                         | I64Eqz { .. }
+                        | I32And { .. }
+                        | I64And { .. }
+                        | I32Or { .. }
+                        | I64Or { .. }
+                        | I32Xor { .. }
+                        | I64Xor { .. }
+                        | I32Shl { .. }
+                        | I64Shl { .. }
+                        | I32ShrS { .. }
+                        | I64ShrS { .. }
+                        | I32ShrU { .. }
+                        | I64ShrU { .. }
+                        | I32Rotl { .. }
+                        | I64Rotl { .. }
+                        | I32Rotr { .. }
+                        | I64Rotr { .. }
                         | LocalGet { .. }
                         | LocalSet { .. }
                         | Call { .. }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -8,7 +8,10 @@ use crate::{
     abi::{self, local::LocalSlot},
     codegen::CodeGenContext,
     isa::reg::Reg,
-    masm::{CalleeKind, CmpKind, DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind},
+    masm::{
+        CalleeKind, CmpKind, DivKind, MacroAssembler as Masm, OperandSize, RegImm, RemKind,
+        ShiftKind,
+    },
 };
 use cranelift_codegen::{settings, Final, MachBufferFinalized};
 
@@ -177,6 +180,22 @@ impl Masm for MacroAssembler {
 
     fn mul(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize) {
         self.asm.mul(rhs.into(), lhs.into(), dst.into(), size);
+    }
+
+    fn and(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+        todo!()
+    }
+
+    fn or(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+        todo!()
+    }
+
+    fn xor(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+        todo!()
+    }
+
+    fn shift(&mut self, _context: &mut CodeGenContext, _kind: ShiftKind, _size: OperandSize) {
+        todo!()
     }
 
     fn div(&mut self, _context: &mut CodeGenContext, _kind: DivKind, _size: OperandSize) {

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     isa::reg::Reg,
-    masm::{CalleeKind, CmpKind, DivKind, OperandSize, RemKind},
+    masm::{CalleeKind, CmpKind, DivKind, OperandSize, RemKind, ShiftKind},
 };
 use cranelift_codegen::{
     entity::EntityRef,
@@ -11,7 +11,8 @@ use cranelift_codegen::{
     isa::x64::{
         args::{
             self, AluRmiROpcode, Amode, CmpOpcode, DivSignedness, ExtMode, FromWritableReg, Gpr,
-            GprMem, GprMemImm, RegMem, RegMemImm, SyntheticAmode, WritableGpr, CC,
+            GprMem, GprMemImm, Imm8Gpr, Imm8Reg, RegMem, RegMemImm,
+            ShiftKind as CraneliftShiftKind, SyntheticAmode, WritableGpr, CC,
         },
         settings as x64_settings, CallInfo, EmitInfo, EmitState, Inst,
     },
@@ -59,6 +60,12 @@ impl From<Reg> for GprMemImm {
     }
 }
 
+impl From<Reg> for Imm8Gpr {
+    fn from(value: Reg) -> Self {
+        Imm8Gpr::new(Imm8Reg::Reg { reg: value.into() }).expect("valid Imm8Gpr")
+    }
+}
+
 impl From<OperandSize> for args::OperandSize {
     fn from(size: OperandSize) -> Self {
         match size {
@@ -90,6 +97,18 @@ impl From<CmpKind> for CC {
             CmpKind::LeU => CC::BE,
             CmpKind::GeS => CC::NL,
             CmpKind::GeU => CC::NB,
+        }
+    }
+}
+
+impl From<ShiftKind> for CraneliftShiftKind {
+    fn from(value: ShiftKind) -> Self {
+        match value {
+            ShiftKind::Shl => CraneliftShiftKind::ShiftLeft,
+            ShiftKind::ShrS => CraneliftShiftKind::ShiftRightArithmetic,
+            ShiftKind::ShrU => CraneliftShiftKind::ShiftRightLogical,
+            ShiftKind::Rotl => CraneliftShiftKind::RotateLeft,
+            ShiftKind::Rotr => CraneliftShiftKind::RotateRight,
         }
     }
 }
@@ -292,6 +311,157 @@ impl Assembler {
         }
     }
 
+    /// Logical and instruction variants.
+    pub fn and(&mut self, src: Operand, dst: Operand, size: OperandSize) {
+        match &(src, dst) {
+            (Operand::Imm(imm), Operand::Reg(dst)) => {
+                if let Ok(val) = i32::try_from(*imm) {
+                    self.and_ir(val, *dst, size);
+                } else {
+                    let scratch = regs::scratch();
+                    self.mov_ir(*imm as u64, scratch, size);
+                    self.and_rr(scratch, *dst, size);
+                }
+            }
+            (Operand::Reg(src), Operand::Reg(dst)) => self.and_rr(*src, *dst, size),
+            _ => panic!(
+                "Invalid operand combination for and; src = {:?} dst = {:?}",
+                src, dst
+            ),
+        }
+    }
+
+    fn and_rr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::And,
+            src1: dst.into(),
+            src2: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    fn and_ir(&mut self, imm: i32, dst: Reg, size: OperandSize) {
+        let imm = RegMemImm::imm(imm as u32);
+
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::And,
+            src1: dst.into(),
+            src2: GprMemImm::new(imm).expect("valid immediate"),
+            dst: dst.into(),
+        });
+    }
+
+    /// Logical or instruction variants.
+    pub fn or(&mut self, src: Operand, dst: Operand, size: OperandSize) {
+        match &(src, dst) {
+            (Operand::Imm(imm), Operand::Reg(dst)) => {
+                if let Ok(val) = i32::try_from(*imm) {
+                    self.or_ir(val, *dst, size);
+                } else {
+                    let scratch = regs::scratch();
+                    self.mov_ir(*imm as u64, scratch, size);
+                    self.or_rr(scratch, *dst, size);
+                }
+            }
+            (Operand::Reg(src), Operand::Reg(dst)) => self.or_rr(*src, *dst, size),
+            _ => panic!(
+                "Invalid operand combination for or; src = {:?} dst = {:?}",
+                src, dst
+            ),
+        }
+    }
+
+    fn or_rr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Or,
+            src1: dst.into(),
+            src2: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    fn or_ir(&mut self, imm: i32, dst: Reg, size: OperandSize) {
+        let imm = RegMemImm::imm(imm as u32);
+
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Or,
+            src1: dst.into(),
+            src2: GprMemImm::new(imm).expect("valid immediate"),
+            dst: dst.into(),
+        });
+    }
+
+    /// Logical exclusive or instruction variants.
+    pub fn xor(&mut self, src: Operand, dst: Operand, size: OperandSize) {
+        match &(src, dst) {
+            (Operand::Imm(imm), Operand::Reg(dst)) => {
+                if let Ok(val) = i32::try_from(*imm) {
+                    self.xor_ir(val, *dst, size);
+                } else {
+                    let scratch = regs::scratch();
+                    self.mov_ir(*imm as u64, scratch, size);
+                    self.xor_rr(scratch, *dst, size);
+                }
+            }
+            (Operand::Reg(src), Operand::Reg(dst)) => self.xor_rr(*src, *dst, size),
+            _ => panic!(
+                "Invalid operand combination for xor; src = {:?} dst = {:?}",
+                src, dst
+            ),
+        }
+    }
+
+    /// Logical exclusive or with registers.
+    pub fn xor_rr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Xor,
+            src1: dst.into(),
+            src2: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    fn xor_ir(&mut self, imm: i32, dst: Reg, size: OperandSize) {
+        let imm = RegMemImm::imm(imm as u32);
+
+        self.emit(Inst::AluRmiR {
+            size: size.into(),
+            op: AluRmiROpcode::Xor,
+            src1: dst.into(),
+            src2: GprMemImm::new(imm).expect("valid immediate"),
+            dst: dst.into(),
+        });
+    }
+
+    /// Shift with register and register.
+    pub fn shift_rr(&mut self, src: Reg, dst: Reg, kind: ShiftKind, size: OperandSize) {
+        self.emit(Inst::ShiftR {
+            size: size.into(),
+            kind: kind.into(),
+            src: dst.into(),
+            num_bits: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Shift with immediate and register.
+    pub fn shift_ir(&mut self, imm: u8, dst: Reg, kind: ShiftKind, size: OperandSize) {
+        let imm = imm.into();
+
+        self.emit(Inst::ShiftR {
+            size: size.into(),
+            kind: kind.into(),
+            src: dst.into(),
+            num_bits: Imm8Gpr::new(imm).expect("valid immediate"),
+            dst: dst.into(),
+        });
+    }
+
     /// Signed/unsigned division.
     ///
     /// Emits a sequence of instructions to ensure the correctness of
@@ -463,17 +633,6 @@ impl Assembler {
         self.emit(Inst::AluRmiR {
             size: size.into(),
             op: AluRmiROpcode::Add,
-            src1: dst.into(),
-            src2: src.into(),
-            dst: dst.into(),
-        });
-    }
-
-    /// Logical exclusive or with registers.
-    pub fn xor_rr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
-        self.emit(Inst::AluRmiR {
-            size: size.into(),
-            op: AluRmiROpcode::Xor,
             src1: dst.into(),
             src2: src.into(),
             dst: dst.into(),

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -319,15 +319,12 @@ impl Assembler {
                     self.and_ir(val, *dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.mov_ir(*imm as u64, scratch, size);
+                    self.load_constant(imm, scratch, size);
                     self.and_rr(scratch, *dst, size);
                 }
             }
             (Operand::Reg(src), Operand::Reg(dst)) => self.and_rr(*src, *dst, size),
-            _ => panic!(
-                "Invalid operand combination for and; src = {:?} dst = {:?}",
-                src, dst
-            ),
+            _ => Self::handle_invalid_operand_combination(src, dst),
         }
     }
 
@@ -361,15 +358,12 @@ impl Assembler {
                     self.or_ir(val, *dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.mov_ir(*imm as u64, scratch, size);
+                    self.load_constant(imm, scratch, size);
                     self.or_rr(scratch, *dst, size);
                 }
             }
             (Operand::Reg(src), Operand::Reg(dst)) => self.or_rr(*src, *dst, size),
-            _ => panic!(
-                "Invalid operand combination for or; src = {:?} dst = {:?}",
-                src, dst
-            ),
+            _ => Self::handle_invalid_operand_combination(src, dst),
         }
     }
 
@@ -403,15 +397,12 @@ impl Assembler {
                     self.xor_ir(val, *dst, size);
                 } else {
                     let scratch = regs::scratch();
-                    self.mov_ir(*imm as u64, scratch, size);
+                    self.load_constant(imm, scratch, size);
                     self.xor_rr(scratch, *dst, size);
                 }
             }
             (Operand::Reg(src), Operand::Reg(dst)) => self.xor_rr(*src, *dst, size),
-            _ => panic!(
-                "Invalid operand combination for xor; src = {:?} dst = {:?}",
-                src, dst
-            ),
+            _ => Self::handle_invalid_operand_combination(src, dst),
         }
     }
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -49,6 +49,22 @@ pub(crate) enum CmpKind {
     GeU,
 }
 
+/// Kinds of shifts in WebAssembly.The [`masm`] implementation for each ISA is
+/// responsible for emitting the correct sequence of instructions when
+/// lowering to machine code.
+pub(crate) enum ShiftKind {
+    /// Left shift.
+    Shl,
+    /// Signed right shift.
+    ShrS,
+    /// Unsigned right shift.
+    ShrU,
+    /// Left rotate.
+    Rotl,
+    /// Right rotate.
+    Rotr,
+}
+
 /// Operand size, in bits.
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
 pub(crate) enum OperandSize {
@@ -175,6 +191,23 @@ pub(crate) trait MacroAssembler {
 
     /// Perform multiplication operation.
     fn mul(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+
+    /// Perform logical and operation.
+    fn and(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+
+    /// Perform logical or operation.
+    fn or(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+
+    /// Perform logical exclusive or operation.
+    fn xor(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+
+    /// Perform a shift operation.
+    /// Shift is special in that some architectures have specific expectations
+    /// regarding the location of the instruction arguments. To free the
+    /// caller from having to deal with the architecture specific constraints
+    /// we give this function access to the code generation context, allowing
+    /// each implementation to decide the lowering path.
+    fn shift(&mut self, context: &mut CodeGenContext, kind: ShiftKind, size: OperandSize);
 
     /// Perform division operation.
     /// Division is special in that some architectures have specific

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -5,7 +5,7 @@
 //! machine code emitter.
 
 use crate::codegen::CodeGen;
-use crate::masm::{CmpKind, DivKind, MacroAssembler, OperandSize, RegImm, RemKind};
+use crate::masm::{CmpKind, DivKind, MacroAssembler, OperandSize, RegImm, RemKind, ShiftKind};
 use crate::stack::Val;
 use wasmparser::VisitOperator;
 use wasmtime_environ::{FuncIndex, WasmType};
@@ -69,6 +69,22 @@ macro_rules! def_unsupported {
     (emit I64GeU $($rest:tt)*) => {};
     (emit I32Eqz $($rest:tt)*) => {};
     (emit I64Eqz $($rest:tt)*) => {};
+    (emit I32And $($rest:tt)*) => {};
+    (emit I64And $($rest:tt)*) => {};
+    (emit I32Or $($rest:tt)*) => {};
+    (emit I64Or $($rest:tt)*) => {};
+    (emit I32Xor $($rest:tt)*) => {};
+    (emit I64Xor $($rest:tt)*) => {};
+    (emit I32Shl $($rest:tt)*) => {};
+    (emit I64Shl $($rest:tt)*) => {};
+    (emit I32ShrS $($rest:tt)*) => {};
+    (emit I64ShrS $($rest:tt)*) => {};
+    (emit I32ShrU $($rest:tt)*) => {};
+    (emit I64ShrU $($rest:tt)*) => {};
+    (emit I32Rotl $($rest:tt)*) => {};
+    (emit I64Rotl $($rest:tt)*) => {};
+    (emit I32Rotr $($rest:tt)*) => {};
+    (emit I64Rotr $($rest:tt)*) => {};
     (emit LocalGet $($rest:tt)*) => {};
     (emit LocalSet $($rest:tt)*) => {};
     (emit Call $($rest:tt)*) => {};
@@ -278,6 +294,112 @@ where
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
             masm.cmp_with_set(RegImm::imm(0), reg, CmpKind::Eq, size);
         });
+    }
+
+    fn visit_i32_and(&mut self) {
+        self.context.i32_binop(self.masm, |masm, dst, src, size| {
+            masm.and(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i64_and(&mut self) {
+        self.context.i64_binop(self.masm, |masm, dst, src, size| {
+            masm.and(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i32_or(&mut self) {
+        self.context.i32_binop(self.masm, |masm, dst, src, size| {
+            masm.or(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i64_or(&mut self) {
+        self.context.i64_binop(self.masm, |masm, dst, src, size| {
+            masm.or(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i32_xor(&mut self) {
+        self.context.i32_binop(self.masm, |masm, dst, src, size| {
+            masm.xor(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i64_xor(&mut self) {
+        self.context.i64_binop(self.masm, |masm, dst, src, size| {
+            masm.xor(dst, dst, src, size);
+        });
+    }
+
+    fn visit_i32_shl(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Shl, S32);
+    }
+
+    fn visit_i64_shl(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Shl, S64);
+    }
+
+    fn visit_i32_shr_s(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, ShrS, S32);
+    }
+
+    fn visit_i64_shr_s(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, ShrS, S64);
+    }
+
+    fn visit_i32_shr_u(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, ShrU, S32);
+    }
+
+    fn visit_i64_shr_u(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, ShrU, S64);
+    }
+
+    fn visit_i32_rotl(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Rotl, S32);
+    }
+
+    fn visit_i64_rotl(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Rotl, S64);
+    }
+
+    fn visit_i32_rotr(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Rotr, S32);
+    }
+
+    fn visit_i64_rotr(&mut self) {
+        use OperandSize::*;
+        use ShiftKind::*;
+
+        self.masm.shift(&mut self.context, Rotr, S64);
     }
 
     fn visit_end(&mut self) {}

--- a/winch/filetests/filetests/x64/i32_and/const.wat
+++ b/winch/filetests/filetests/x64/i32_and/const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 83e002               	and	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_and/locals.wat
+++ b/winch/filetests/filetests/x64/i32_and/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 21c1                 	and	ecx, eax
+;;   31:	 4889c8               	mov	rax, rcx
+;;   34:	 4883c410             	add	rsp, 0x10
+;;   38:	 5d                   	pop	rbp
+;;   39:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_and/params.wat
+++ b/winch/filetests/filetests/x64/i32_and/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 21c1                 	and	ecx, eax
+;;   1e:	 4889c8               	mov	rax, rcx
+;;   21:	 4883c410             	add	rsp, 0x10
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_or/const.wat
+++ b/winch/filetests/filetests/x64/i32_or/const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 83c802               	or	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_or/locals.wat
+++ b/winch/filetests/filetests/x64/i32_or/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 09c1                 	or	ecx, eax
+;;   31:	 4889c8               	mov	rax, rcx
+;;   34:	 4883c410             	add	rsp, 0x10
+;;   38:	 5d                   	pop	rbp
+;;   39:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_or/params.wat
+++ b/winch/filetests/filetests/x64/i32_or/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 09c1                 	or	ecx, eax
+;;   1e:	 4889c8               	mov	rax, rcx
+;;   21:	 4883c410             	add	rsp, 0x10
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1c000               	rol	eax, 0
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1c002               	rol	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/locals.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2b:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2f:	 d3c0                 	rol	eax, cl
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1c:	 d3c0                 	rol	eax, cl
+;;   1e:	 4883c410             	add	rsp, 0x10
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1c800               	ror	eax, 0
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1c802               	ror	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/locals.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2b:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2f:	 d3c8                 	ror	eax, cl
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1c:	 d3c8                 	ror	eax, cl
+;;   1e:	 4883c410             	add	rsp, 0x10
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/16_const.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shl)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1e000               	shl	eax, 0
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/8_const.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shl)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1e002               	shl	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shl/locals.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2b:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2f:	 d3e0                 	shl	eax, cl
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shl/params.wat
+++ b/winch/filetests/filetests/x64/i32_shl/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1c:	 d3e0                 	shl	eax, cl
+;;   1e:	 4883c410             	add	rsp, 0x10
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1f800               	sar	eax, 0
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1f802               	sar	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/locals.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2b:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2f:	 d3f8                 	sar	eax, cl
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1c:	 d3f8                 	sar	eax, cl
+;;   1e:	 4883c410             	add	rsp, 0x10
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 512)
+        (i32.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1e800               	shr	eax, 0
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 c1e802               	shr	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/locals.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2b:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2f:	 d3e8                 	shr	eax, cl
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1c:	 d3e8                 	shr	eax, cl
+;;   1e:	 4883c410             	add	rsp, 0x10
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_xor/const.wat
+++ b/winch/filetests/filetests/x64/i32_xor/const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.const 2)
+        (i32.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 83f002               	xor	eax, 2
+;;   14:	 4883c408             	add	rsp, 8
+;;   18:	 5d                   	pop	rbp
+;;   19:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i32_xor/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)  
+        (local $bar i32)
+
+        (i32.const 1)
+        (local.set $foo)
+
+        (i32.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i32.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1e:	 b802000000           	mov	eax, 2
+;;   23:	 89442408             	mov	dword ptr [rsp + 8], eax
+;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   2f:	 31c1                 	xor	ecx, eax
+;;   31:	 4889c8               	mov	rax, rcx
+;;   34:	 4883c410             	add	rsp, 0x10
+;;   38:	 5d                   	pop	rbp
+;;   39:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_xor/params.wat
+++ b/winch/filetests/filetests/x64/i32_xor/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (param i32) (result i32)
+        (local.get 0)
+        (local.get 1)
+        (i32.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1c:	 31c1                 	xor	ecx, eax
+;;   1e:	 4889c8               	mov	rax, rcx
+;;   21:	 4883c410             	add	rsp, 0x10
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_and/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/32_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883e003             	and	rax, 3
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_and/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/64_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c21d8               	and	rax, r11
+;;   23:	 4883c408             	add	rsp, 8
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_and/locals.wat
+++ b/winch/filetests/filetests/x64/i64_and/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4821c1               	and	rcx, rax
+;;   3e:	 4889c8               	mov	rax, rcx
+;;   41:	 4883c418             	add	rsp, 0x18
+;;   45:	 5d                   	pop	rbp
+;;   46:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_and/params.wat
+++ b/winch/filetests/filetests/x64/i64_and/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.and)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4821c1               	and	rcx, rax
+;;   23:	 4889c8               	mov	rax, rcx
+;;   26:	 4883c418             	add	rsp, 0x18
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_or/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/32_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883c803             	or	rax, 3
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_or/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/64_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c09d8               	or	rax, r11
+;;   23:	 4883c408             	add	rsp, 8
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_or/locals.wat
+++ b/winch/filetests/filetests/x64/i64_or/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4809c1               	or	rcx, rax
+;;   3e:	 4889c8               	mov	rax, rcx
+;;   41:	 4883c418             	add	rsp, 0x18
+;;   45:	 5d                   	pop	rbp
+;;   46:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_or/params.wat
+++ b/winch/filetests/filetests/x64/i64_or/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.or)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4809c1               	or	rcx, rax
+;;   23:	 4889c8               	mov	rax, rcx
+;;   26:	 4883c418             	add	rsp, 0x18
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1c000             	rol	rax, 0
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1c002             	rol	rax, 2
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   36:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   3b:	 48d3c0               	rol	rax, cl
+;;   3e:	 4883c418             	add	rsp, 0x18
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.rotl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   1b:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   20:	 48d3c0               	rol	rax, cl
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1c800             	ror	rax, 0
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1c802             	ror	rax, 2
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   36:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   3b:	 48d3c8               	ror	rax, cl
+;;   3e:	 4883c418             	add	rsp, 0x18
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.rotr)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   1b:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   20:	 48d3c8               	ror	rax, cl
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1e000             	shl	rax, 0
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1e002             	shl	rax, 2
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shl/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   36:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   3b:	 48d3e0               	shl	rax, cl
+;;   3e:	 4883c418             	add	rsp, 0x18
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shl/params.wat
+++ b/winch/filetests/filetests/x64/i64_shl/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shl)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   1b:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   20:	 48d3e0               	shl	rax, cl
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1f800             	sar	rax, 0
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1f802             	sar	rax, 2
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   36:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   3b:	 48d3f8               	sar	rax, cl
+;;   3e:	 4883c418             	add	rsp, 0x18
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shr_s)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   1b:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   20:	 48d3f8               	sar	rax, cl
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 512)
+        (i64.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1e800             	shr	rax, 0
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.const 2)
+        (i64.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 48c1e802             	shr	rax, 2
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)  
+        (local $bar i64)
+
+        (i64.const 1)
+        (local.set $foo)
+
+        (i64.const 2)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   36:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   3b:	 48d3e8               	shr	rax, cl
+;;   3e:	 4883c418             	add	rsp, 0x18
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/params.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.shr_u)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   1b:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   20:	 48d3e8               	shr	rax, cl
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_xor/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/32_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 2)
+        (i64.const 3)
+        (i64.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883f003             	xor	rax, 3
+;;   17:	 4883c408             	add	rsp, 8
+;;   1b:	 5d                   	pop	rbp
+;;   1c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_xor/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/64_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 9223372036854775806)
+        (i64.const 9223372036854775807)
+        (i64.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48b8feffffffffffff7f 	
+;; 				movabs	rax, 0x7ffffffffffffffe
+;;   16:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   20:	 4c31d8               	xor	rax, r11
+;;   23:	 4883c408             	add	rsp, 8
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i64_xor/locals.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+        (local $bar i64)
+
+        (i64.const 2)
+        (local.set $foo)
+        (i64.const 3)
+        (local.set $bar)
+
+        (local.get $foo)
+        (local.get $bar)
+        (i64.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 4531db               	xor	r11d, r11d
+;;    b:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   10:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   15:	 4c893424             	mov	qword ptr [rsp], r14
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   31:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   36:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   3b:	 4831c1               	xor	rcx, rax
+;;   3e:	 4889c8               	mov	rax, rcx
+;;   41:	 4883c418             	add	rsp, 0x18
+;;   45:	 5d                   	pop	rbp
+;;   46:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_xor/params.wat
+++ b/winch/filetests/filetests/x64/i64_xor/params.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (param i64) (result i64)
+        (local.get 0)
+        (local.get 1)
+        (i64.xor)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4889742408           	mov	qword ptr [rsp + 8], rsi
+;;   12:	 4c893424             	mov	qword ptr [rsp], r14
+;;   16:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   1b:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   20:	 4831c1               	xor	rcx, rax
+;;   23:	 4889c8               	mov	rax, rcx
+;;   26:	 4883c418             	add	rsp, 0x18
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Part of #6528. Adds x86 support for a number of integer binary instructions to Winch.