### PR TITLE
Trim the size of the gh-pages branch

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -35,6 +35,8 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: ./gh-pages/gh-pages
+        single-commit: true
+        clean: true
       if: github.ref == 'refs/heads/main'
 
     - run: npm install --production


### PR DESCRIPTION
No need to retain a full history of this branch as it's purely a function of the latest commit, so configure some options to throw away its history.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
