### PR TITLE
riscv64: Implement `iadd` Widening Instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -297,6 +297,10 @@ impl VecAluOpRRR {
             VecAluOpRRR::VssubVV | VecAluOpRRR::VssubVX => 0b100011,
             VecAluOpRRR::VfsgnjnVV => 0b001001,
             VecAluOpRRR::VrgatherVV | VecAluOpRRR::VrgatherVX => 0b001100,
+            VecAluOpRRR::VwadduVV | VecAluOpRRR::VwadduVX => 0b110000,
+            VecAluOpRRR::VwaddVV | VecAluOpRRR::VwaddVX => 0b110001,
+            VecAluOpRRR::VwadduWV | VecAluOpRRR::VwadduWX => 0b110100,
+            VecAluOpRRR::VwaddWV | VecAluOpRRR::VwaddWX => 0b110101,
             VecAluOpRRR::VmsltVX => 0b011011,
         }
     }
@@ -321,11 +325,19 @@ impl VecAluOpRRR {
             | VecAluOpRRR::VmaxVV
             | VecAluOpRRR::VmergeVVM
             | VecAluOpRRR::VrgatherVV => VecOpCategory::OPIVV,
-            VecAluOpRRR::VmulVV
+            VecAluOpRRR::VwaddVV
+            | VecAluOpRRR::VwaddWV
+            | VecAluOpRRR::VwadduVV
+            | VecAluOpRRR::VwadduWV
+            | VecAluOpRRR::VmulVV
             | VecAluOpRRR::VmulhVV
             | VecAluOpRRR::VmulhuVV
             | VecAluOpRRR::VredmaxuVS
             | VecAluOpRRR::VredminuVS => VecOpCategory::OPMVV,
+            VecAluOpRRR::VwaddVX
+            | VecAluOpRRR::VwadduVX
+            | VecAluOpRRR::VwadduWX
+            | VecAluOpRRR::VwaddWX => VecOpCategory::OPMVX,
             VecAluOpRRR::VaddVX
             | VecAluOpRRR::VsaddVX
             | VecAluOpRRR::VsadduVX
@@ -375,7 +387,16 @@ impl VecAluOpRRR {
     /// Some instructions do not allow the source and destination registers to overlap.
     pub fn forbids_src_dst_overlaps(&self) -> bool {
         match self {
-            VecAluOpRRR::VrgatherVV | VecAluOpRRR::VrgatherVX => true,
+            VecAluOpRRR::VrgatherVV
+            | VecAluOpRRR::VrgatherVX
+            | VecAluOpRRR::VwadduVV
+            | VecAluOpRRR::VwadduVX
+            | VecAluOpRRR::VwaddVV
+            | VecAluOpRRR::VwaddVX
+            | VecAluOpRRR::VwadduWV
+            | VecAluOpRRR::VwadduWX
+            | VecAluOpRRR::VwaddWV
+            | VecAluOpRRR::VwaddWX => true,
             _ => false,
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -93,6 +93,10 @@
   (VaddVV)
   (VsaddVV)
   (VsadduVV)
+  (VwaddVV)
+  (VwaddWV)
+  (VwadduVV)
+  (VwadduWV)
   (VsubVV)
   (VssubVV)
   (VssubuVV)
@@ -123,6 +127,10 @@
   (VaddVX)
   (VsaddVX)
   (VsadduVX)
+  (VwaddVX)
+  (VwaddWX)
+  (VwadduVX)
+  (VwadduWX)
   (VsubVX)
   (VrsubVX)
   (VssubVX)
@@ -219,6 +227,10 @@
 (decl pure vstate_from_type (Type) VState)
 (extern constructor vstate_from_type vstate_from_type)
 (convert Type VState vstate_from_type)
+
+;; Alters the LMUL of a VState to mf2
+(decl pure vstate_mf2 (VState) VState)
+(extern constructor vstate_mf2 vstate_mf2)
 
 ;; Extracts an element width from a SIMD type.
 (decl pure element_width_from_type (Type) VecElementWidth)
@@ -348,6 +360,62 @@
 (decl rv_vsaddu_vi (VReg Imm5 VecOpMasking VState) VReg)
 (rule (rv_vsaddu_vi vs2 imm mask vstate)
   (vec_alu_rr_imm5 (VecAluOpRRImm5.VsadduVI) vs2 imm mask vstate))
+
+;; Helper for emitting the `vwadd.vv` instruction.
+;;
+;;  Widening integer add, 2*SEW = SEW + SEW
+(decl rv_vwadd_vv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwadd_vv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwaddVV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwadd.vx` instruction.
+;;
+;;  Widening integer add, 2*SEW = SEW + SEW
+(decl rv_vwadd_vx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwadd_vx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwaddVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwadd.wv` instruction.
+;;
+;;  Widening integer add, 2*SEW = 2*SEW + SEW
+(decl rv_vwadd_wv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwadd_wv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwaddWV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwadd.wx` instruction.
+;;
+;;  Widening integer add, 2*SEW = 2*SEW + SEW
+(decl rv_vwadd_wx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwadd_wx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwaddWX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwaddu.vv` instruction.
+;;
+;; Widening unsigned integer add, 2*SEW = SEW + SEW
+(decl rv_vwaddu_vv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwaddu_vv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwadduVV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwaddu.vv` instruction.
+;;
+;; Widening unsigned integer add, 2*SEW = SEW + SEW
+(decl rv_vwaddu_vx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwaddu_vx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwadduVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwaddu.wv` instruction.
+;;
+;;  Widening integer add, 2*SEW = 2*SEW + SEW
+(decl rv_vwaddu_wv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwaddu_wv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwadduWV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwaddu.wx` instruction.
+;;
+;;  Widening integer add, 2*SEW = 2*SEW + SEW
+(decl rv_vwaddu_wx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwaddu_wx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwadduWX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vsub.vv` instruction.
 (decl rv_vsub_vv (VReg VReg VecOpMasking VState) VReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -109,14 +109,146 @@
 (rule 9 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (splat y))))
   (rv_vadd_vx x y (unmasked) ty))
 
-(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd (splat x) y)))
-  (rv_vadd_vx y x (unmasked) ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (splat (sextend y @ (value_type sext_ty))))))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) sext_ty))
+  (rv_vwadd_wx x y (unmasked) (vstate_mf2 half_ty)))
+
+(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (splat (uextend y @ (value_type uext_ty))))))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) uext_ty))
+  (rv_vwaddu_wx x y (unmasked) (vstate_mf2 half_ty)))
 
 (rule 11 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (replicated_imm5 y))))
   (rv_vadd_vi x y (unmasked) ty))
 
-(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (iadd (replicated_imm5 x) y)))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (iadd (splat x) y)))
+  (rv_vadd_vx y x (unmasked) ty))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register ty) (iadd (splat (sextend x @ (value_type sext_ty))) y)))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) sext_ty))
+  (rv_vwadd_wx y x (unmasked) (vstate_mf2 half_ty)))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register ty) (iadd (splat (uextend x @ (value_type uext_ty))) y)))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) uext_ty))
+  (rv_vwaddu_wx y x (unmasked) (vstate_mf2 half_ty)))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register ty) (iadd (replicated_imm5 x) y)))
   (rv_vadd_vi y x (unmasked) ty))
+
+;; Signed Widening Low Additions
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register _) (iadd x (swiden_low y @ (value_type in_ty)))))
+  (rv_vwadd_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_low x @ (value_type in_ty)) y)))
+  (rv_vwadd_wv y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_low x @ (value_type in_ty))
+                                                            (swiden_low y))))
+  (rv_vwadd_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_low x @ (value_type in_ty))
+                                                            (splat (sextend y @ (value_type sext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwadd_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
+                                                            (swiden_low y @ (value_type in_ty)))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwadd_vx y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Signed Widening High Additions
+;; These are the same as the low additions, but we first slide down the inputs.
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register _) (iadd x (swiden_high y @ (value_type in_ty)))))
+  (rv_vwadd_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_high x @ (value_type in_ty)) y)))
+  (rv_vwadd_wv y (gen_slidedown_half in_ty x) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_high x @ (value_type in_ty))
+                                                            (swiden_high y))))
+  (rv_vwadd_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_high x @ (value_type in_ty))
+                                                            (splat (sextend y @ (value_type sext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwadd_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
+                                                            (swiden_high y @ (value_type in_ty)))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwadd_vx (gen_slidedown_half in_ty y) x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening Low Additions
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register _) (iadd x (uwiden_low y @ (value_type in_ty)))))
+  (rv_vwaddu_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_low x @ (value_type in_ty)) y)))
+  (rv_vwaddu_wv y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_low x @ (value_type in_ty))
+                                                            (uwiden_low y))))
+  (rv_vwaddu_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_low x @ (value_type in_ty))
+                                                            (splat (uextend y @ (value_type uext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwaddu_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend x @ (value_type uext_ty)))
+                                                            (uwiden_low y @ (value_type in_ty)))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwaddu_vx y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening High Additions
+;; These are the same as the low additions, but we first slide down the inputs.
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register _) (iadd x (uwiden_high y @ (value_type in_ty)))))
+  (rv_vwaddu_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_high x @ (value_type in_ty)) y)))
+  (rv_vwaddu_wv y (gen_slidedown_half in_ty x) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_high x @ (value_type in_ty))
+                                                            (uwiden_high y))))
+  (rv_vwaddu_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_high x @ (value_type in_ty))
+                                                            (splat (uextend y @ (value_type uext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwaddu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend y @ (value_type uext_ty)))
+                                                            (uwiden_high x @ (value_type in_ty)))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwaddu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Signed Widening Mixed High/Low Additions
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_low x @ (value_type in_ty))
+                                                            (swiden_high y))))
+  (rv_vwadd_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (swiden_high x @ (value_type in_ty))
+                                                            (swiden_low y))))
+  (rv_vwadd_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening Mixed High/Low Additions
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_low x @ (value_type in_ty))
+                                                            (uwiden_high y))))
+  (rv_vwaddu_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register _) (iadd (uwiden_high x @ (value_type in_ty))
+                                                            (uwiden_low y))))
+  (rv_vwaddu_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
 
 ;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -6,7 +6,7 @@ pub mod generated_code;
 use generated_code::{Context, ExtendOp, MInst};
 
 // Types that the generated ISLE code uses via `use super::*`.
-use self::generated_code::VecAluOpRR;
+use self::generated_code::{VecAluOpRR, VecLmul};
 use super::{writable_zero_reg, zero_reg};
 use crate::isa::riscv64::abi::Riscv64ABICallSite;
 use crate::isa::riscv64::lower::args::{
@@ -507,6 +507,17 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     #[inline]
     fn vstate_from_type(&mut self, ty: Type) -> VState {
         VState::from_type(ty)
+    }
+
+    #[inline]
+    fn vstate_mf2(&mut self, vs: VState) -> VState {
+        VState {
+            vtype: VType {
+                lmul: VecLmul::LmulF2,
+                ..vs.vtype
+            },
+            ..vs
+        }
     }
 
     fn min_vec_reg_size(&mut self) -> u64 {

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -740,6 +740,33 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn ty_half_lanes(&mut self, ty: Type) -> Option<Type> {
+            if ty.lane_count() == 1 {
+                None
+            } else {
+                ty.lane_type().by(ty.lane_count() / 2)
+            }
+        }
+
+        #[inline]
+        fn ty_half_width(&mut self, ty: Type) -> Option<Type> {
+            let new_lane = match ty.lane_type() {
+                I16 => I8,
+                I32 => I16,
+                I64 => I32,
+                F64 => F32,
+                _ => return None,
+            };
+
+            new_lane.by(ty.lane_count())
+        }
+
+        #[inline]
+        fn ty_equal(&mut self, lhs: Type, rhs: Type) -> bool {
+            lhs == rhs
+        }
+
+        #[inline]
         fn offset32_to_u32(&mut self, offset: Offset32) -> u32 {
             let offset: i32 = offset.into();
             offset as u32

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -277,6 +277,18 @@
 (decl pure lane_type (Type) Type)
 (extern constructor lane_type lane_type)
 
+;; Get a type with the same element type, but half the number of lanes.
+(decl pure partial ty_half_lanes (Type) Type)
+(extern constructor ty_half_lanes ty_half_lanes)
+
+;; Get a type with the same number of lanes but a lane type that is half as small.
+(decl pure partial ty_half_width (Type) Type)
+(extern constructor ty_half_width ty_half_width)
+
+;; Compare two types for equality.
+(decl pure ty_equal (Type Type) bool)
+(extern constructor ty_equal ty_equal)
+
 ;;;; `cranelift_codegen::ir::MemFlags ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `MemFlags::trusted`

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
@@ -1,0 +1,250 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %iadd_splat_sextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = sextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_splat_sextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = sextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_splat_sextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = sextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_splat_uextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = uextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_splat_uextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = uextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_splat_uextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = iadd v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
@@ -1,0 +1,421 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %iadd_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vslidedown.vi v8,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwadd.vv v10,v6,v8 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x34, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x25, 0x64, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vslidedown.vi v8,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwadd.vv v10,v6,v8 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x34, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v8,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v10,v6,v8 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x34, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_high v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwadd.vx v7,v5,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x32, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x63, 0x55, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_high v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwadd.vx v7,v5,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x32, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_high v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v7,v5,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x32, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwadd.wv v8,v3,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x33, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwadd.wv v8,v3,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wv v8,v3,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
@@ -1,0 +1,434 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %iadd_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v6,v1,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x11, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v6,v1,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v6,v1,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_low v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_low v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_low v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wv v6,v3,v1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x30, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wv v6,v3,v1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wv v6,v3,v1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.wv v6,v3,v1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xd6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
@@ -1,0 +1,284 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %iadd_swiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwadd.vv v8,v6,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa4, 0x61, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swiden_high_low_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwadd.vv v8,v6,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa4, 0x61, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swiden_high_low_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v8,v6,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa4, 0x61, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swiden_low_high_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwadd.vv v8,v1,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x13, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swiden_low_high_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1:i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwadd.vv v8,v1,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x13, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_swiden_low_high_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1:i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwadd.vv v8,v1,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x13, 0xc6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
@@ -1,0 +1,422 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+
+function %iadd_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vslidedown.vi v8,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwaddu.vv v10,v6,v8 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x34, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x25, 0x64, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vslidedown.vi v8,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwaddu.vv v10,v6,v8 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x34, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v8,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v10,v6,v8 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x34, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_high v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwaddu.vx v7,v5,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x32, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x63, 0x55, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_high v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwaddu.vx v7,v5,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x32, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_high v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v7,v5,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x32, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwaddu.wv v8,v3,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x33, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwaddu.wv v8,v3,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wv v8,v3,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
@@ -1,0 +1,391 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+
+function %iadd_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v6,v1,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x11, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v6,v1,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v6,v1,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_low v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_low v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_low v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wv v6,v3,v1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x30, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wv v6,v3,v1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.wv v6,v3,v1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xd2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
@@ -1,0 +1,286 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+
+
+function %iadd_uwiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwaddu.vv v8,v6,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa4, 0x61, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwiden_high_low_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwaddu.vv v8,v6,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa4, 0x61, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwiden_high_low_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v8,v6,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa4, 0x61, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwiden_low_high_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwaddu.vv v8,v1,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x13, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwiden_low_high_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1:i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwaddu.vv v8,v1,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x13, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_uwiden_low_high_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1:i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwaddu.vv v8,v1,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x13, 0xc2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -76,3 +76,62 @@ block0(v0: i64x2, v1: i64):
     return v3
 }
 ; run: %iadd_splat_i64x2([1 2], 10) == [11 12]
+
+
+function %iadd_splat_sextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = sextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_sextend_i16x8([1 -2 3 4 5 6 7 8], -10) == [-9 -12 -7 -6 -5 -4 -3 -2]
+
+function %iadd_splat_sextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = sextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_sextend_i32x4([1 -2 3 4], -10) == [-9 -12 -7 -6]
+
+function %iadd_splat_sextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = sextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_sextend_i64x2([1 -2], 10) == [11 8]
+
+
+function %iadd_splat_uextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = uextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_uextend_i16x8([1 -2 3 4 5 6 7 8], 10) == [11 8 13 14 15 16 17 18]
+; run: %iadd_splat_uextend_i16x8([1 -2 3 4 5 6 7 8], -10) == [0xf7 0xf4 0xf9 0xfa 0xfb 0xfc 0xfd 0xfe]
+
+function %iadd_splat_uextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = uextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_uextend_i32x4([1 -2 3 4], 10) == [11 8 13 14]
+; run: %iadd_splat_uextend_i32x4([1 -2 3 4], -10) == [0xfff7 0xfff4 0xfff9 0xfffa]
+
+function %iadd_splat_uextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = iadd v0, v3
+    return v4
+}
+; run: %iadd_splat_uextend_i64x2([1 -2], 10) == [11 8]
+; run: %iadd_splat_uextend_i64x2([1 -2], -10) == [0xfffffff7 0xfffffff4]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenhigh_i32x4([1 2 3 4], [-1 2 -3 4]) == [0 8]
+
+function %iadd_swidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenhigh_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 -5 6 7 8]) == [0 12 14 16]
+
+function %iadd_swidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenhigh_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 -9 10 11 12 13 14 15 16]) == [0 20 22 24 26 28 30 32]
+
+function %iadd_swidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_high v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenhigh_splat_i32x4([1 2 3 4], -1) == [2 3]
+; run: %iadd_swidenhigh_splat_i32x4([1 2 3 4], 10) == [13 14]
+
+function %iadd_swidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_high v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [4 5 6 7]
+; run: %iadd_swidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [15 16 17 18]
+
+function %iadd_swidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_high v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [8 9 10 11 12 13 14 15]
+; run: %iadd_swidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [19 20 21 22 23 24 25 26]
+
+function %iadd_swidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenhigh_lhs_i32x4([1 2 3 4], [-1 2]) == [2 6]
+
+function %iadd_swidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenhigh_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [4 8 10 12]
+
+function %iadd_swidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenhigh_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [8 12 14 16 18 20 22 24]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenlow_i32x4([1 2 3 4], [-1 2 3 4]) == [0 4]
+
+function %iadd_swidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenlow_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [0 4 6 8]
+
+function %iadd_swidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swidenlow_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [0 4 6 8 10 12 14 16]
+
+function %iadd_swidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_low v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenlow_splat_i32x4([1 2 3 4], -1) == [0 1]
+; run: %iadd_swidenlow_splat_i32x4([1 2 3 4], 10) == [11 12]
+
+function %iadd_swidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_low v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenlow_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [0 1 2 3]
+; run: %iadd_swidenlow_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [11 12 13 14]
+
+function %iadd_swidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_low v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_swidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [0 1 2 3 4 5 6 7]
+; run: %iadd_swidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [11 12 13 14 15 16 17 18]
+
+function %iadd_swidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenlow_lhs_i32x4([1 2 3 4], [-1 2]) == [0 4]
+
+function %iadd_swidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenlow_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [0 4 6 8]
+
+function %iadd_swidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_swidenlow_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [0 4 6 8 10 12 14 16]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
@@ -1,0 +1,65 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_swiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_high_low_i32x4([1 2 3 4], [-1 2 3 4]) == [2 6]
+
+function %iadd_swiden_high_low_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_high_low_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [4 8 10 12]
+
+function %iadd_swiden_high_low_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_high_low_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [8 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [17 12 14 16 18 20 22 24]
+
+
+function %iadd_swiden_low_high_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_low_high_i32x4([-1 2 3 4], [1 2 3 4]) == [2 6]
+
+function %iadd_swiden_low_high_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1:i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_low_high_i16x8([-1 2 3 4 5 6 7 8], [1 2 3 4 5 6 7 8]) == [4 8 10 12]
+
+function %iadd_swiden_low_high_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1:i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_swiden_low_high_i8x16([-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [8 12 14 16 18 20 22 24]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenhigh_i32x4([1 2 3 4], [-1 2 -3 4]) == [0x100000000 8]
+
+function %iadd_uwidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenhigh_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 -5 6 7 8]) == [0x10000 12 14 16]
+
+function %iadd_uwidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenhigh_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 -9 10 11 12 13 14 15 16]) == [0x100 20 22 24 26 28 30 32]
+
+function %iadd_uwidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_high v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenhigh_splat_i32x4([1 2 3 4], -1) == [0x100000002 0x100000003]
+; run: %iadd_uwidenhigh_splat_i32x4([1 2 3 4], 10) == [13 14]
+
+function %iadd_uwidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_high v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [0x10004 0x10005 0x10006 0x10007]
+; run: %iadd_uwidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [15 16 17 18]
+
+function %iadd_uwidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_high v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [0x108 0x109 0x10A 0x10B 0x10C 0x10D 0x10E 0x10F]
+; run: %iadd_uwidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [19 20 21 22 23 24 25 26]
+
+function %iadd_uwidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenhigh_lhs_i32x4([1 2 3 4], [-1 2]) == [2 6]
+
+function %iadd_uwidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenhigh_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [4 8 10 12]
+
+function %iadd_uwidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenhigh_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [8 12 14 16 18 20 22 24]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
@@ -1,0 +1,95 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenlow_i32x4([1 2 3 4], [-1 2 3 4]) == [0x100000000 4]
+
+function %iadd_uwidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenlow_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [0x10000 4 6 8]
+
+function %iadd_uwidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwidenlow_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [0x100 4 6 8 10 12 14 16]
+
+function %iadd_uwidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_low v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenlow_splat_i32x4([1 2 3 4], -1) == [0x100000000 0x100000001]
+; run: %iadd_uwidenlow_splat_i32x4([1 2 3 4], 10) == [11 12]
+
+function %iadd_uwidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_low v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenlow_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [0x10000 0x10001 0x10002 0x10003]
+; run: %iadd_uwidenlow_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [11 12 13 14]
+
+function %iadd_uwidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_low v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_uwidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [0x100 0x101 0x102 0x103 0x104 0x105 0x106 0x107]
+; run: %iadd_uwidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [11 12 13 14 15 16 17 18]
+
+
+function %iadd_uwidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenlow_lhs_i32x4([1 2 3 4], [-1 2]) == [0 4]
+
+function %iadd_uwidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenlow_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [0 4 6 8]
+
+function %iadd_uwidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = iadd v2, v1
+    return v3
+}
+; run: %iadd_uwidenlow_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [0 4 6 8 10 12 14 16]

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
@@ -1,0 +1,65 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %iadd_uwiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_high_low_i32x4([1 2 3 4], [-1 2 3 4]) == [0x100000002 6]
+
+function %iadd_uwiden_high_low_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_high_low_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [0x10004 8 10 12]
+
+function %iadd_uwiden_high_low_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_low v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_high_low_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [0x108 12 14 16 18 20 22 24]
+
+
+function %iadd_uwiden_low_high_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_low_high_i32x4([-1 2 3 4], [1 2 3 4]) == [0x100000002 6]
+
+function %iadd_uwiden_low_high_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1:i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_low_high_i16x8([-1 2 3 4 5 6 7 8], [1 2 3 4 5 6 7 8]) == [0x10004 8 10 12]
+
+function %iadd_uwiden_low_high_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1:i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_high v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_uwiden_low_high_i8x16([-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [0x108 12 14 16 18 20 22 24]


### PR DESCRIPTION
👋 Hey,

This PR adds the widening add instructions from the V spec. These are `vwadd{u,}.{w,v}{v,x}`.

This also adds a bunch of rules to try to match these instructions. And some of these end up being quite complex.

Rules that match `{u,s}widen_high` are the same as their `{u,s}widen_low` counterparts but they first do a `vslidedown` of half the vector, to bring the top lanes down.

`uwiden_low` rules are the same as the `swiden_low` rules, but they use `vwaddu.*` instead of `vwadd.*` which is the unsigned version of the instruction.

Now, in each of these groups of rules we have a few different instructions.

`vwadd.wv` does a 2 * SEW = 2 * SEW + SEW, this just means that the elements in the RHS vector are first sign extended before doing the addition. The only trick here is that since the result is 2*SEW we must use a vstate type that has half the element size as the type that we want to end up with. So to end up with a i32x4 `iadd` we need to pass in a i16x4 type as a vstate type.

`vwadd.vv` does 2 * SEW = SEW + SEW, so as long as both sides are extended we can use this instruction. We must set the vstate with a type that has half the element size and half the lanes of the final type.

`vwadd.wx` and `vwadd.vx` do the same thing, but the RHS is expected to be a extended and splatted X register, so we try to match exactly that. To make these rules more applicable I've previously added some egraph rules (#6533) that convert `{u,s}widen_{low,high}` into `splat+{u,s}extend`, this way we only have to try to match the splat version, which reduces the number of rules.

All of these rules use `vstate_mf2`. This is sets the LMUL setting to 1/2, meaning that at most we will read half of the source vector registers, and the result is guaranteed to fit in a single destination register. Otherwise we could have to write the result into multiple registers, which is something that the ISA supports, but adds a bunch of constraints that we don't need here.

---

I would really appreciate if we could find a way to reduce the number of rules here. I couldn't really come up with anything, but maybe someone does. We have equivalents to all of these for `isub` and `imul` so finding  a good reduction here, will hopefully make implementing those easier.