### PR TITLE
Bump cargo-vet to 0.7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     if: needs.determine.outputs.audit
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.6.1
+      CARGO_VET_VERSION: 0.7.0
     steps:
     - uses: actions/checkout@v3
       with:

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4,7 +4,7 @@
 [[wildcard-audits.arbitrary]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2020-01-14"
 end = "2024-04-21"
 notes = "I am an author of this crate."
@@ -12,14 +12,14 @@ notes = "I am an author of this crate."
 [[wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2024-03-10"
 
 [[wildcard-audits.derive_arbitrary]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2020-01-14"
 end = "2024-04-27"
 notes = "I am an author of this crate"
@@ -35,7 +35,7 @@ notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-deve
 [[wildcard-audits.regalloc2]]
 who = "Trevor Elliott <telliott@fastly.com>"
 criteria = "safe-to-deploy"
-user-id = 187138
+user-id = 187138 # Trevor Elliott (elliottt)
 start = "2022-11-29"
 end = "2024-05-02"
 notes = """
@@ -48,7 +48,7 @@ actively maintain this crate over time.
 [[wildcard-audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -61,7 +61,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wasm-metadata]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -74,14 +74,14 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wasm-mutate]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2022-02-17"
 end = "2024-03-10"
 
 [[wildcard-audits.wasm-mutate]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2022-01-05"
 end = "2024-04-14"
 notes = """
@@ -94,7 +94,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wasm-smith]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-09-03"
 end = "2024-04-14"
 notes = """
@@ -107,7 +107,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wasmparser]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-07-13"
 end = "2024-04-14"
 notes = """
@@ -120,14 +120,14 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wasmprinter]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2021-04-28"
 end = "2024-03-10"
 
 [[wildcard-audits.wasmprinter]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-11-18"
 end = "2024-04-14"
 notes = """
@@ -140,7 +140,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wast]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-10-16"
 end = "2024-04-14"
 notes = """
@@ -153,7 +153,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-10-18"
 end = "2024-04-14"
 notes = """
@@ -166,7 +166,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-bindgen]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -179,7 +179,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-bindgen-core]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -192,7 +192,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-bindgen-rust]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -205,7 +205,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-bindgen-rust-lib]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -218,7 +218,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-bindgen-rust-macro]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -231,7 +231,7 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-component]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
 end = "2024-04-14"
 notes = """
@@ -244,14 +244,14 @@ so and will actively maintain this crate over time.
 [[wildcard-audits.wit-component]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 696
+user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2024-03-10"
 
 [[wildcard-audits.wit-parser]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 1
+user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-12-02"
 end = "2024-04-14"
 notes = """

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -529,14 +529,6 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.ittapi]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.ittapi-sys]]
-version = "0.3.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.jobserver]]
 version = "0.1.24"
 criteria = "safe-to-deploy"
@@ -980,10 +972,6 @@ criteria = "safe-to-deploy"
 [[exemptions.v8]]
 version = "0.44.3"
 criteria = "safe-to-run"
-
-[[exemptions.valuable]]
-version = "0.1.0"
-criteria = "safe-to-deploy"
 
 [[exemptions.wait-timeout]]
 version = "0.2.0"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -7,6 +7,9 @@ version = "0.7"
 [imports.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
 
+[imports.fermyon]
+url = "https://raw.githubusercontent.com/fermyon/spin/main/supply-chain/audits.toml"
+
 [imports.google]
 url = [
     "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT",
@@ -618,10 +621,6 @@ criteria = "safe-to-run"
 [[exemptions.once_cell]]
 version = "1.12.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.oorandom]]
-version = "11.1.3"
-criteria = "safe-to-run"
 
 [[exemptions.openvino-finder]]
 version = "0.4.1"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.6"
+version = "0.7"
 
 [imports.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"
@@ -19,20 +19,170 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
+[policy.cranelift]
+audit-as-crates-io = false
+
+[policy.cranelift-bforest]
+audit-as-crates-io = false
+
+[policy.cranelift-codegen]
+audit-as-crates-io = false
+
+[policy.cranelift-codegen-meta]
+audit-as-crates-io = false
+
+[policy.cranelift-codegen-shared]
+audit-as-crates-io = false
+
+[policy.cranelift-control]
+audit-as-crates-io = false
+
+[policy.cranelift-entity]
+audit-as-crates-io = false
+
+[policy.cranelift-frontend]
+audit-as-crates-io = false
+
+[policy.cranelift-interpreter]
+audit-as-crates-io = false
+
+[policy.cranelift-isle]
+audit-as-crates-io = false
+
+[policy.cranelift-jit]
+audit-as-crates-io = false
+
+[policy.cranelift-module]
+audit-as-crates-io = false
+
+[policy.cranelift-native]
+audit-as-crates-io = false
+
+[policy.cranelift-object]
+audit-as-crates-io = false
+
+[policy.cranelift-reader]
+audit-as-crates-io = false
+
+[policy.cranelift-serde]
+audit-as-crates-io = false
+
+[policy.cranelift-wasm]
+audit-as-crates-io = false
+
 [policy.isle-fuzz]
 criteria = "safe-to-run"
+
+[policy.wasi-cap-std-sync]
+audit-as-crates-io = false
+
+[policy.wasi-common]
+audit-as-crates-io = false
 
 [policy.wasi-crypto]
 audit-as-crates-io = false
 
+[policy.wasi-tokio]
+audit-as-crates-io = false
+
+[policy.wasmtime]
+audit-as-crates-io = false
+
+[policy.wasmtime-asm-macros]
+audit-as-crates-io = false
+
+[policy.wasmtime-cache]
+audit-as-crates-io = false
+
+[policy.wasmtime-cli]
+audit-as-crates-io = false
+
+[policy.wasmtime-cli-flags]
+audit-as-crates-io = false
+
+[policy.wasmtime-component-macro]
+audit-as-crates-io = false
+
+[policy.wasmtime-component-util]
+audit-as-crates-io = false
+
+[policy.wasmtime-cranelift]
+audit-as-crates-io = false
+
+[policy.wasmtime-cranelift-shared]
+audit-as-crates-io = false
+
+[policy.wasmtime-environ]
+audit-as-crates-io = false
+
 [policy.wasmtime-environ-fuzz]
 criteria = "safe-to-run"
+
+[policy.wasmtime-explorer]
+audit-as-crates-io = false
+
+[policy.wasmtime-fiber]
+audit-as-crates-io = false
 
 [policy.wasmtime-fuzz]
 criteria = "safe-to-run"
 
 [policy.wasmtime-fuzzing]
 criteria = "safe-to-run"
+
+[policy.wasmtime-jit]
+audit-as-crates-io = false
+
+[policy.wasmtime-jit-debug]
+audit-as-crates-io = false
+
+[policy.wasmtime-jit-icache-coherence]
+audit-as-crates-io = false
+
+[policy.wasmtime-runtime]
+audit-as-crates-io = false
+
+[policy.wasmtime-types]
+audit-as-crates-io = false
+
+[policy.wasmtime-wasi]
+audit-as-crates-io = false
+
+[policy.wasmtime-wasi-crypto]
+audit-as-crates-io = false
+
+[policy.wasmtime-wasi-http]
+audit-as-crates-io = false
+
+[policy.wasmtime-wasi-nn]
+audit-as-crates-io = false
+
+[policy.wasmtime-wasi-threads]
+audit-as-crates-io = false
+
+[policy.wasmtime-wast]
+audit-as-crates-io = false
+
+[policy.wasmtime-winch]
+audit-as-crates-io = false
+
+[policy.wasmtime-wit-bindgen]
+audit-as-crates-io = false
+
+[policy.wiggle]
+audit-as-crates-io = false
+
+[policy.wiggle-generate]
+audit-as-crates-io = false
+
+[policy.wiggle-macro]
+audit-as-crates-io = false
+
+[policy.wiggle-test]
+audit-as-crates-io = false
+
+[policy.winch-codegen]
+audit-as-crates-io = false
 
 [policy.witx]
 audit-as-crates-io = false

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -357,7 +357,7 @@ version = "0.2.83"
 [[audits.mozilla.wildcard-audits.unicode-segmentation]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-05-15"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
@@ -366,7 +366,7 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 [[audits.mozilla.wildcard-audits.unicode-width]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-12-05"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"
@@ -375,7 +375,7 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 [[audits.mozilla.wildcard-audits.unicode-xid]]
 who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
-user-id = 1139
+user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
 end = "2024-05-03"
 notes = "All code written or reviewed by Manish"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -23,13 +23,6 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.regalloc2]]
-version = "0.9.0"
-when = "2023-05-17"
-user-id = 187138
-user-login = "elliottt"
-user-name = "Trevor Elliott"
-
-[[publisher.regalloc2]]
 version = "0.9.1"
 when = "2023-05-31"
 user-id = 187138
@@ -58,36 +51,8 @@ user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
 [[publisher.wasm-encoder]]
-version = "0.26.0"
-when = "2023-04-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-encoder]]
-version = "0.27.0"
-when = "2023-05-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-encoder]]
 version = "0.29.0"
 when = "2023-05-26"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-metadata]]
-version = "0.5.0"
-when = "2023-04-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-metadata]]
-version = "0.6.0"
-when = "2023-05-15"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -100,22 +65,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-mutate]]
-version = "0.2.25"
-when = "2023-05-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-mutate]]
 version = "0.2.27"
 when = "2023-05-26"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-smith]]
-version = "0.12.8"
-when = "2023-05-15"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -128,29 +79,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmparser]]
-version = "0.104.0"
-when = "2023-04-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmparser]]
-version = "0.105.0"
-when = "2023-05-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmparser]]
 version = "0.107.0"
 when = "2023-05-26"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmprinter]]
-version = "0.2.57"
-when = "2023-05-15"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -163,22 +93,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wast]]
-version = "58.0.0"
-when = "2023-05-15"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wast]]
 version = "60.0.0"
 when = "2023-05-26"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wat]]
-version = "1.0.64"
-when = "2023-05-15"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -226,29 +142,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wit-component]]
-version = "0.8.2"
-when = "2023-04-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-component]]
-version = "0.9.0"
-when = "2023-05-16"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-component]]
 version = "0.11.0"
 when = "2023-05-26"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-parser]]
-version = "0.7.1"
-when = "2023-04-27"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -276,6 +171,28 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 violation = "<0.20.0"
 notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
+
+[[audits.embark-studios.audits.ittapi]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.3.3"
+notes = "Lots of unsafe code for calling into C FFI functions, looks pretty simple and sound though. No ambient capabilities"
+
+[[audits.embark-studios.audits.ittapi-sys]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.3.3"
+notes = """
+Builds C/asm dependency which this review has not audited in detail, but is well established from Intel. 
+Exposes FFI types & functions generated through bindgen. No other logic.
+No ambient capabilities
+"""
+
+[[audits.embark-studios.audits.valuable]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = "No unsafe usage or ambient capabilities, sane build script"
 
 [[audits.embark-studios.audits.webpki-roots]]
 who = "Johan Andersson <opensource@embark-studios.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -200,6 +200,11 @@ criteria = "safe-to-deploy"
 version = "0.22.4"
 notes = "Inspected it to confirm that it only contains data definitions and no runtime code"
 
+[[audits.fermyon.audits.oorandom]]
+who = "Radu Matei <radu.matei@fermyon.com>"
+criteria = "safe-to-run"
+version = "11.1.3"
+
 [[audits.google.audits.fastrand]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Note that we need these audits-as-crates-io entries because the new version has improved heuristics to detect matches on crates.io. @alexcrichton and I discussed this and some potential future improvements to the ergonomics.