### PR TITLE
winch(x64) Add support for if/else

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -81,8 +81,10 @@ fn execute_one(data: &[u8]) -> Result<()> {
     // When fuzzing Winch, explicitly override the compiler strategy, which by
     // default its arbitrary implementation unconditionally returns
     // `Cranelift`.
+    // We also explicitly disable multi-value support.
     if fuzz_winch {
         config.wasmtime.compiler_strategy = CompilerStrategy::Winch;
+        config.module_config.config.multi_value_enabled = false;
     }
 
     // Choose an engine that Wasmtime will be differentially executed against.
@@ -352,7 +354,9 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | LocalSet { .. }
                         | Call { .. }
                         | Nop { .. }
-                        | End { .. } => {}
+                        | End { .. }
+                        | If { .. }
+                        | Else { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -156,6 +156,7 @@ impl ABIArg {
 }
 
 /// ABI-specific representation of the function result.
+#[derive(Copy, Clone)]
 pub(crate) enum ABIResult {
     Reg {
         /// Type of the result.

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -71,6 +71,10 @@ pub(crate) trait ABI {
     /// function type.
     fn sig(wasm_sig: &WasmFuncType, call_conv: &CallingConvention) -> ABISig;
 
+    /// Construct the ABI-specific result from a slice of
+    /// [`wasmtime_environ::WasmtType`].
+    fn result(returns: &[WasmType], call_conv: &CallingConvention) -> ABIResult;
+
     /// Returns the number of bits in a word.
     fn word_bits() -> u32;
 
@@ -178,6 +182,15 @@ impl ABIResult {
     pub fn is_void(&self) -> bool {
         match self {
             Self::Reg { ty, .. } => ty.is_none(),
+        }
+    }
+
+    /// Returns result's length.
+    pub fn len(&self) -> usize {
+        if self.is_void() {
+            0
+        } else {
+            1
         }
     }
 }

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -1,4 +1,5 @@
 use crate::{
+    abi::ABIResult,
     frame::Frame,
     masm::{MacroAssembler, OperandSize, RegImm},
     reg::Reg,
@@ -45,15 +46,16 @@ impl<'a> CodeGenContext<'a> {
     /// spilling if not available.
     pub fn gpr<M: MacroAssembler>(&mut self, named: Reg, masm: &mut M) -> Reg {
         self.regalloc.gpr(named, &mut |regalloc| {
-            Self::spill(&mut self.stack, regalloc, &self.frame, masm)
+            Self::spill_callback(&mut self.stack, regalloc, &self.frame, masm)
         })
     }
 
     /// Request the next avaiable general purpose register to the register allocator,
     /// spilling if no registers are available.
     pub fn any_gpr<M: MacroAssembler>(&mut self, masm: &mut M) -> Reg {
-        self.regalloc
-            .any_gpr(&mut |regalloc| Self::spill(&mut self.stack, regalloc, &self.frame, masm))
+        self.regalloc.any_gpr(&mut |regalloc| {
+            Self::spill_callback(&mut self.stack, regalloc, &self.frame, masm)
+        })
     }
 
     /// Free the given general purpose register.
@@ -128,7 +130,7 @@ impl<'a> CodeGenContext<'a> {
                 let addr = masm.address_from_sp(*offset);
                 masm.load(addr, dst, size);
             }
-        };
+        }
     }
 
     /// Prepares arguments for emitting a unary operation.
@@ -242,6 +244,43 @@ impl<'a> CodeGenContext<'a> {
         self.stack.inner_mut().truncate(truncate);
     }
 
+    /// Convenience wrapper around [`Self::spill_callback`].
+    ///
+    /// This function exists for cases in which triggering an unconditional
+    /// spill is needed, like before entering control flow.
+    pub fn spill<M: MacroAssembler>(&mut self, masm: &mut M) {
+        Self::spill_callback(&mut self.stack, &mut self.regalloc, &mut self.frame, masm);
+    }
+
+    /// Handles the emission of the ABI result. This function is used at the end
+    /// of a block or function to pop the results from the value stack into the
+    /// corresponding ABI result representation.
+    pub fn pop_abi_results<M: MacroAssembler>(&mut self, result: &ABIResult, masm: &mut M) {
+        if result.is_void() {
+            return;
+        }
+
+        let reg = self.pop_to_reg(masm, Some(result.result_reg()), OperandSize::S64);
+        self.regalloc.free_gpr(reg);
+    }
+
+    /// Push ABI results in to the value stack. This function is used at the end
+    /// of a block or after a function call to push the corresponding ABI
+    /// results into the value stack.
+    pub fn push_abi_results<M: MacroAssembler>(&mut self, result: &ABIResult, masm: &mut M) {
+        if result.is_void() {
+            return;
+        }
+
+        match result {
+            ABIResult::Reg { reg, .. } => {
+                assert!(self.regalloc.gpr_available(*reg));
+                let result_reg = Val::reg(self.gpr(*reg, masm));
+                self.stack.push(result_reg);
+            }
+        }
+    }
+
     /// Spill locals and registers to memory.
     // TODO optimize the spill range;
     //
@@ -250,7 +289,7 @@ impl<'a> CodeGenContext<'a> {
     // we could effectively ignore that range;
     // only focusing on the range that contains
     // spillable values.
-    fn spill<M: MacroAssembler>(
+    fn spill_callback<M: MacroAssembler>(
         stack: &mut Stack,
         regalloc: &mut RegAlloc,
         frame: &Frame,
@@ -269,9 +308,7 @@ impl<'a> CodeGenContext<'a> {
                 let offset = masm.push(regalloc.scratch);
                 *v = Val::Memory(offset);
             }
-            v => {
-                println!("trying to spill something unknown {:?}", v);
-            }
+            _ => {}
         });
     }
 }

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -1,0 +1,154 @@
+//! Data structures for control flow emission.
+//!
+//! As of the current implementation, Winch doesnt offer support for the
+//! multi-value proposal, which in the context of control flow constructs it
+//! means that blocks don't take any params and produce 0 or 1 return. The
+//! intention is to implement support for multi-value across the compiler, when
+//! that time comes, here are some general changes that will be needed for
+//! control flow:
+//!
+//! * Consider having a copy of the block params on the side, and push them when
+//! encountering an else or duplicate the block params upfront. If no else is
+//! present, clean the extra copies from the stack.
+//!
+//! * Eagerly load the block params. Params can flow "downward" as the block
+//! results in the case of an empty then or else block:
+//!   (module
+//!     (func (export "params") (param i32) (result i32)
+//!       (i32.const 2)
+//!       (if (param i32) (result i32) (local.get 0)
+//!       (then))
+//!     (i32.const 3)
+//!     (i32.add)
+//!   )
+//!
+//! As a future optimization, we could perform a look ahead to the next
+//! instruction when reaching any of the comparison instructions. If the next
+//! instruction is a control instruction, we could avoid emitting
+//! a [`crate::masm::MacroAssembler::cmp_with_set`] and instead emit
+//! a conditional jump inline when emitting the control flow instruction.
+
+use super::{CodeGenContext, MacroAssembler, OperandSize};
+use crate::{
+    abi::{ABIResult, ABI},
+    masm::CmpKind,
+    CallingConvention,
+};
+use cranelift_codegen::MachLabel;
+use wasmtime_environ::WasmType;
+
+/// Holds the necessary metdata to support the emission
+/// of control flow instructions.
+pub(crate) enum ControlStackFrame {
+    If {
+        /// The continuation label.
+        ///
+        /// This could be either the else branch if
+        /// the if instruction has an else or the end
+        /// label otherwise.
+        cont: MachLabel,
+        /// The exit label, only present if there's an else
+        /// branch.
+        end: Option<MachLabel>,
+        /// The return values of the block.
+        result: ABIResult,
+        /// The size of the value stack at the beginning of the If.
+        original_stack_size: usize,
+    },
+}
+
+impl ControlStackFrame {
+    /// Returns [`ControlStackFrame`] for an if.
+    pub fn if_<M: MacroAssembler>(
+        returns: &[WasmType],
+        masm: &mut M,
+        context: &mut CodeGenContext,
+    ) -> Self {
+        let result = <M::ABI as ABI>::result(&returns, &CallingConvention::Default);
+        let mut control = Self::If {
+            cont: masm.get_label(),
+            end: None,
+            result,
+            original_stack_size: 0,
+        };
+
+        control.emit(masm, context);
+        control
+    }
+
+    fn emit<M: MacroAssembler>(&mut self, masm: &mut M, context: &mut CodeGenContext) {
+        match self {
+            ControlStackFrame::If {
+                cont,
+                original_stack_size,
+                ..
+            } => {
+                // Pop the condition value.
+                let top = context.pop_to_reg(masm, None, OperandSize::S32);
+
+                // Unconditionall spill before emitting control flow.
+                context.spill(masm);
+
+                *original_stack_size = context.stack.len();
+                masm.branch(CmpKind::Eq, top.into(), top.into(), *cont, OperandSize::S32);
+                context.free_gpr(top);
+            }
+        }
+    }
+
+    /// Handles the else branch if the current control stack frame is
+    /// [`ControlStackFrame::If`].
+    pub fn emit_else<M: MacroAssembler>(&mut self, masm: &mut M, context: &mut CodeGenContext) {
+        match self {
+            ControlStackFrame::If {
+                cont,
+                end,
+                result,
+                original_stack_size,
+                ..
+            } => {
+                assert!((*original_stack_size + result.len()) == context.stack.len());
+                // Before emitting an unconditional jump to the end branch,
+                // we handle the result of the if-then block.
+                context.pop_abi_results(&result, masm);
+                // Before binding the else branch, we emit the jump to the end
+                // label.
+                let end_label = masm.get_label();
+                masm.jmp(end_label);
+                // Update the stack control frame with the
+                // end branch.
+                *end = Some(end_label);
+                // Bind the continuation branch.
+                masm.bind(*cont);
+            }
+        }
+    }
+
+    /// Handles the end of a control stack frame.
+    pub fn emit_end<M: MacroAssembler>(&mut self, masm: &mut M, context: &mut CodeGenContext) {
+        match self {
+            ControlStackFrame::If {
+                cont,
+                end,
+                result,
+                original_stack_size,
+                ..
+            } => {
+                assert!((*original_stack_size + result.len()) == context.stack.len());
+                // Before binding the exit label, we handle the block results.
+                context.pop_abi_results(&result, masm);
+                // Then we push the block results ino the value stack.
+                context.push_abi_results(&result, masm);
+                // If an end label is present, it means that
+                // there's an else branch present, and we bind the end
+                // label; else no else branch is present and
+                // we bind the if's exit label.
+                if let Some(end) = end {
+                    masm.bind(*end);
+                } else {
+                    masm.bind(*cont);
+                }
+            }
+        }
+    }
+}

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -36,9 +36,9 @@ where
     pub masm: &'a mut M,
 
     /// Stack frames for control flow.
-    // NB The 6 is set arbitrarily, we can adjust it as
+    // NB The 64 is set arbitrarily, we can adjust it as
     // we see fit.
-    pub control_frames: SmallVec<[ControlStackFrame; 6]>,
+    pub control_frames: SmallVec<[ControlStackFrame; 64]>,
 }
 
 impl<'a, M> CodeGen<'a, M>

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -9,7 +9,8 @@ use cranelift_codegen::{
         emit::{EmitInfo, EmitState},
         ALUOp, ALUOp3, AMode, ExtendOp, Imm12, Inst, PairAMode,
     },
-    settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, Writable,
+    settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, MachLabel,
+    Writable,
 };
 
 /// An Aarch64 instruction operand.
@@ -296,5 +297,10 @@ impl Assembler {
             rm: rm.into(),
             ra: ra.into(),
         });
+    }
+
+    /// Get a label from the underlying machine code buffer.
+    pub fn get_label(&mut self) -> MachLabel {
+        self.buffer.get_label()
     }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -13,7 +13,7 @@ use crate::{
         ShiftKind,
     },
 };
-use cranelift_codegen::{settings, Final, MachBufferFinalized};
+use cranelift_codegen::{settings, Final, MachBufferFinalized, MachLabel};
 
 /// Aarch64 MacroAssembler.
 pub(crate) struct MacroAssembler {
@@ -226,12 +226,36 @@ impl Masm for MacroAssembler {
     fn cmp_with_set(&mut self, _src: RegImm, _dst: RegImm, _kind: CmpKind, _size: OperandSize) {
         todo!()
     }
+<<<<<<< HEAD
 
     fn clz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {
         todo!()
     }
 
     fn ctz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {
+        todo!()
+    }
+
+    fn get_label(&mut self) -> MachLabel {
+        self.asm.get_label()
+    }
+
+    fn bind(&mut self, _label: MachLabel) {
+        todo!()
+    }
+
+    fn branch(
+        &mut self,
+        _kind: CmpKind,
+        _lhs: RegImm,
+        _rhs: RegImm,
+        _taken: MachLabel,
+        _size: OperandSize,
+    ) {
+        todo!()
+    }
+
+    fn jmp(&mut self, _target: MachLabel) {
         todo!()
     }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -226,7 +226,6 @@ impl Masm for MacroAssembler {
     fn cmp_with_set(&mut self, _src: RegImm, _dst: RegImm, _kind: CmpKind, _size: OperandSize) {
         todo!()
     }
-<<<<<<< HEAD
 
     fn clz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {
         todo!()

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -16,7 +16,8 @@ use cranelift_codegen::{
         },
         settings as x64_settings, CallInfo, EmitInfo, EmitState, Inst,
     },
-    settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, Writable,
+    settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, MachLabel,
+    Writable,
 };
 
 use super::{address::Address, regs};
@@ -146,6 +147,12 @@ impl Assembler {
             emit_info: EmitInfo::new(shared_flags, isa_flags.clone()),
             isa_flags,
         }
+    }
+
+    /// Get a mutable reference to underlying
+    /// machine buffer.
+    pub fn buffer_mut(&mut self) -> &mut MachBuffer<Inst> {
+        &mut self.buffer
     }
 
     /// Return the emitted code.
@@ -682,6 +689,16 @@ impl Assembler {
         });
     }
 
+    /// Emit a test instruction with two register operands.
+    pub fn test_rr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::CmpRmiR {
+            size: size.into(),
+            opcode: CmpOpcode::Test,
+            src: src.into(),
+            dst: dst.into(),
+        })
+    }
+
     /// Set value in dst to `0` or `1` based on flags in status register and
     /// [`CmpKind`].
     pub fn setcc(&mut self, kind: CmpKind, dst: Operand) {
@@ -758,6 +775,11 @@ impl Assembler {
         });
     }
 
+    /// Emit a function call to a known or unknown location.
+    ///
+    /// A known location is a locally defined function index.
+    /// An unknown location is an address whose value is located
+    /// ina register.
     pub fn call(&mut self, callee: CalleeKind) {
         match callee {
             CalleeKind::Indirect(reg) => {
@@ -792,5 +814,18 @@ impl Assembler {
 
     fn handle_invalid_operand_combination(src: Operand, dst: Operand) {
         panic!("Invalid operand combination; src={:?}, dst={:?}", src, dst);
+    }
+
+    /// Emits a conditional jump to the given label.
+    pub fn jmp_if(&mut self, cc: impl Into<CC>, taken: MachLabel) {
+        self.emit(Inst::JmpIf {
+            cc: cc.into(),
+            taken,
+        });
+    }
+
+    /// Performs an unconditional jump to the given label.
+    pub fn jmp(&mut self, target: MachLabel) {
+        self.emit(Inst::JmpKnown { dst: target });
     }
 }

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -2,7 +2,7 @@ use crate::isa::reg::Reg;
 use std::collections::VecDeque;
 
 /// Value definition to be used within the shadow stack.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub(crate) enum Val {
     /// I32 Constant.
     I32(i32),

--- a/winch/filetests/filetests/x64/if/as_binop.wat
+++ b/winch/filetests/filetests/x64/if/as_binop.wat
@@ -1,0 +1,58 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-binary-operand") (param i32 i32) (result i32)
+    (i32.mul
+      (if (result i32) (local.get 0)
+        (then (call $dummy) (i32.const 3))
+        (else (call $dummy) (i32.const -3))
+      )
+      (if (result i32) (local.get 1)
+        (then (call $dummy) (i32.const 4))
+        (else (call $dummy) (i32.const -5))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8411000000         	je	0x31
+;;   20:	 e800000000           	call	0x25
+;;   25:	 48c7c003000000       	mov	rax, 3
+;;   2c:	 e90c000000           	jmp	0x3d
+;;   31:	 e800000000           	call	0x36
+;;   36:	 48c7c0fdffffff       	mov	rax, 0xfffffffffffffffd
+;;   3d:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   41:	 50                   	push	rax
+;;   42:	 85c9                 	test	ecx, ecx
+;;   44:	 0f8419000000         	je	0x63
+;;   4a:	 4883ec08             	sub	rsp, 8
+;;   4e:	 e800000000           	call	0x53
+;;   53:	 4883c408             	add	rsp, 8
+;;   57:	 48c7c004000000       	mov	rax, 4
+;;   5e:	 e914000000           	jmp	0x77
+;;   63:	 4883ec08             	sub	rsp, 8
+;;   67:	 e800000000           	call	0x6c
+;;   6c:	 4883c408             	add	rsp, 8
+;;   70:	 48c7c0fbffffff       	mov	rax, 0xfffffffffffffffb
+;;   77:	 59                   	pop	rcx
+;;   78:	 0fafc8               	imul	ecx, eax
+;;   7b:	 4889c8               	mov	rax, rcx
+;;   7e:	 4883c410             	add	rsp, 0x10
+;;   82:	 5d                   	pop	rbp
+;;   83:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/if/as_if_cond.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-if-condition") (param i32) (result i32)
+    (if (result i32)
+      (if (result i32) (local.get 0)
+        (then (i32.const 1)) (else (i32.const 0))
+      )
+      (then (call $dummy) (i32.const 2))
+      (else (call $dummy) (i32.const 3))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 85c0                 	test	eax, eax
+;;   17:	 0f840c000000         	je	0x29
+;;   1d:	 48c7c001000000       	mov	rax, 1
+;;   24:	 e907000000           	jmp	0x30
+;;   29:	 48c7c000000000       	mov	rax, 0
+;;   30:	 85c0                 	test	eax, eax
+;;   32:	 0f8411000000         	je	0x49
+;;   38:	 e800000000           	call	0x3d
+;;   3d:	 48c7c002000000       	mov	rax, 2
+;;   44:	 e90c000000           	jmp	0x55
+;;   49:	 e800000000           	call	0x4e
+;;   4e:	 48c7c003000000       	mov	rax, 3
+;;   55:	 4883c410             	add	rsp, 0x10
+;;   59:	 5d                   	pop	rbp
+;;   5a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_testop.wat
+++ b/winch/filetests/filetests/x64/if/as_testop.wat
@@ -1,0 +1,39 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-test-operand") (param i32) (result i32)
+    (i32.eqz
+      (if (result i32) (local.get 0)
+        (then (call $dummy) (i32.const 13))
+        (else (call $dummy) (i32.const 0))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 85c0                 	test	eax, eax
+;;   17:	 0f8411000000         	je	0x2e
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 48c7c00d000000       	mov	rax, 0xd
+;;   29:	 e90c000000           	jmp	0x3a
+;;   2e:	 e800000000           	call	0x33
+;;   33:	 48c7c000000000       	mov	rax, 0
+;;   3a:	 83f800               	cmp	eax, 0
+;;   3d:	 b800000000           	mov	eax, 0
+;;   42:	 400f94c0             	sete	al
+;;   46:	 4883c410             	add	rsp, 0x10
+;;   4a:	 5d                   	pop	rbp
+;;   4b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/nested.wat
+++ b/winch/filetests/filetests/x64/if/nested.wat
@@ -1,0 +1,79 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "nested") (param i32 i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then
+        (if (local.get 1) (then (call $dummy) (nop)))
+        (if (local.get 1) (then) (else (call $dummy) (nop)))
+        (if (result i32) (local.get 1)
+          (then (call $dummy) (i32.const 9))
+          (else (call $dummy) (i32.const 10))
+        )
+      )
+      (else
+        (if (local.get 1) (then (call $dummy) (nop)))
+        (if (local.get 1) (then) (else (call $dummy) (nop)))
+        (if (result i32) (local.get 1)
+          (then (call $dummy) (i32.const 10))
+          (else (call $dummy) (i32.const 11))
+        )
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8455000000         	je	0x75
+;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   24:	 85c0                 	test	eax, eax
+;;   26:	 0f8405000000         	je	0x31
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   35:	 85c0                 	test	eax, eax
+;;   37:	 0f8405000000         	je	0x42
+;;   3d:	 e905000000           	jmp	0x47
+;;   42:	 e800000000           	call	0x47
+;;   47:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   4b:	 85c0                 	test	eax, eax
+;;   4d:	 0f8411000000         	je	0x64
+;;   53:	 e800000000           	call	0x58
+;;   58:	 48c7c009000000       	mov	rax, 9
+;;   5f:	 e961000000           	jmp	0xc5
+;;   64:	 e800000000           	call	0x69
+;;   69:	 48c7c00a000000       	mov	rax, 0xa
+;;   70:	 e950000000           	jmp	0xc5
+;;   75:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   79:	 85c0                 	test	eax, eax
+;;   7b:	 0f8405000000         	je	0x86
+;;   81:	 e800000000           	call	0x86
+;;   86:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   8a:	 85c0                 	test	eax, eax
+;;   8c:	 0f8405000000         	je	0x97
+;;   92:	 e905000000           	jmp	0x9c
+;;   97:	 e800000000           	call	0x9c
+;;   9c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   a0:	 85c0                 	test	eax, eax
+;;   a2:	 0f8411000000         	je	0xb9
+;;   a8:	 e800000000           	call	0xad
+;;   ad:	 48c7c00a000000       	mov	rax, 0xa
+;;   b4:	 e90c000000           	jmp	0xc5
+;;   b9:	 e800000000           	call	0xbe
+;;   be:	 48c7c00b000000       	mov	rax, 0xb
+;;   c5:	 4883c410             	add	rsp, 0x10
+;;   c9:	 5d                   	pop	rbp
+;;   ca:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/singular.wat
+++ b/winch/filetests/filetests/x64/if/singular.wat
@@ -1,0 +1,38 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "singular") (param i32) (result i32)
+    (if (local.get 0) (then (nop)))
+    (if (local.get 0) (then (nop)) (else (nop)))
+    (if (result i32) (local.get 0) (then (i32.const 7)) (else (i32.const 8)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 85c0                 	test	eax, eax
+;;   17:	 0f8400000000         	je	0x1d
+;;   1d:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   21:	 85c0                 	test	eax, eax
+;;   23:	 0f8400000000         	je	0x29
+;;   29:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2d:	 85c0                 	test	eax, eax
+;;   2f:	 0f840c000000         	je	0x41
+;;   35:	 48c7c007000000       	mov	rax, 7
+;;   3c:	 e907000000           	jmp	0x48
+;;   41:	 48c7c008000000       	mov	rax, 8
+;;   48:	 4883c410             	add	rsp, 0x10
+;;   4c:	 5d                   	pop	rbp
+;;   4d:	 c3                   	ret	


### PR DESCRIPTION
This change adds the necessary building blocks to support control flow; this change also adds support for the `If` / `Else` operators.

This change does not include multi-value support. The idea is to add support for multi-value across the compiler (functions and blocks) as a separate future change.

The general gist of the change is to track the presence of control flow frames as part of the code generation context and emit the corresponding labels as and instructions as control flow blocks are found.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
