### PR TITLE
backport "cranelift: don't enable trace-log feature by default" (#6549)

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -44,7 +44,7 @@ cranelift-codegen-meta = { path = "meta", version = "0.97.0" }
 cranelift-isle = { path = "../isle/isle", version = "=0.97.0" }
 
 [features]
-default = ["std", "unwind", "trace-log"]
+default = ["std", "unwind"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two


### PR DESCRIPTION
In #5382 ("egraph support: rewrite to work in terms of CLIF data structures"), we added the `trace-log` feature to the set of default features for `cranelift-codegen`. I think this was an accident, probably added while debugging and overlooked when cleaning up to merge.

So let's undo that change.

This is a backport to the upcoming Wasmtime 10.0 release.