### PR TITLE
backport "cranelift: don't enable trace-log feature by default" (#6549)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,15 @@
 --------------------------------------------------------------------------------
+## 9.0.4
+
+Released 2023-06-12.
+
+### Fixed
+
+* Remove the `trace-log` feature from cranelift-codegen's default features, to
+  fix a performance regression when compiling large WebAssembly modules.
+  [#6553](https://github.com/bytecodealliance/wasmtime/pull/6553)
+
+--------------------------------------------------------------------------------
 ## 9.0.3
 
 Released 2023-05-31.

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -44,7 +44,7 @@ cranelift-codegen-meta = { path = "meta", version = "0.96.3" }
 cranelift-isle = { path = "../isle/isle", version = "=0.96.3" }
 
 [features]
-default = ["std", "unwind", "trace-log"]
+default = ["std", "unwind"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two


### PR DESCRIPTION
In #5382 ("egraph support: rewrite to work in terms of CLIF data structures"), we added the `trace-log` feature to the set of default features for `cranelift-codegen`. I think this was an accident, probably added while debugging and overlooked when cleaning up to merge.

So let's undo that change.

This is a backport to the recent Wasmtime 9.0 release.