### PR TITLE
winch(x64): Add support for `block`

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -356,7 +356,8 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | Nop { .. }
                         | End { .. }
                         | If { .. }
-                        | Else { .. } => {}
+                        | Else { .. }
+                        | Block { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -1,5 +1,7 @@
+use smallvec::{smallvec, SmallVec};
+use wasmparser::BlockType;
 use wasmtime_environ::{
-    FuncIndex, ModuleTranslation, PtrSize, TypeConvert, VMOffsets, WasmFuncType,
+    FuncIndex, ModuleTranslation, PtrSize, TypeConvert, VMOffsets, WasmFuncType, WasmType,
 };
 
 /// The function environment.
@@ -36,6 +38,16 @@ impl<'a, P: PtrSize> FuncEnv<'a, P> {
             ty,
             import,
             index: idx,
+        }
+    }
+
+    /// Resolves the type of the block in terms of [`wastime_environ::WasmType`].
+    pub fn resolve_block_type(&self, blockty: BlockType) -> SmallVec<[WasmType; 1]> {
+        use BlockType::*;
+        match blockty {
+            Empty => smallvec![],
+            Type(ty) => smallvec![self.translation.module.convert_valtype(ty)],
+            _ => unimplemented!("multi-value"),
         }
     }
 }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -41,7 +41,7 @@ impl<'a, P: PtrSize> FuncEnv<'a, P> {
         }
     }
 
-    /// Resolves the type of the block in terms of [`wastime_environ::WasmType`].
+    /// Resolves the type of the block in terms of [`wasmtime_environ::WasmType`].
     pub fn resolve_block_type(&self, blockty: BlockType) -> SmallVec<[WasmType; 1]> {
         use BlockType::*;
         match blockty {

--- a/winch/filetests/filetests/x64/block/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/block/as_if_cond.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-if-condition")
+   (block (result i32) (i32.const 1)) (if (then (call $dummy)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 85c0                 	test	eax, eax
+;;   15:	 0f840d000000         	je	0x28
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;   1f:	 e800000000           	call	0x24
+;;   24:	 4883c408             	add	rsp, 8
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/as_if_else.wat
+++ b/winch/filetests/filetests/x64/block/as_if_else.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-else") (result i32)
+      (if (result i32) (i32.const 1) (then (i32.const 2)) (else (block (result i32) (i32.const 1))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840c000000         	je	0x25
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 e907000000           	jmp	0x2c
+;;   25:	 48c7c001000000       	mov	rax, 1
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/as_if_then.wat
+++ b/winch/filetests/filetests/x64/block/as_if_then.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+ (module
+   (func (export "as-if-then") (result i32)
+      (if (result i32) (i32.const 1) (then (block (result i32) (i32.const 1))) (else (i32.const 2)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840c000000         	je	0x25
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 e907000000           	jmp	0x2c
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/deep.wat
+++ b/winch/filetests/filetests/x64/block/deep.wat
@@ -1,0 +1,65 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "deep") (result i32)
+    (block (result i32) (block (result i32)
+      (block (result i32) (block (result i32)
+        (block (result i32) (block (result i32)
+          (block (result i32) (block (result i32)
+            (block (result i32) (block (result i32)
+              (block (result i32) (block (result i32)
+                (block (result i32) (block (result i32)
+                  (block (result i32) (block (result i32)
+                    (block (result i32) (block (result i32)
+                      (block (result i32) (block (result i32)
+                        (block (result i32) (block (result i32)
+                          (block (result i32) (block (result i32)
+                            (block (result i32) (block (result i32)
+                              (block (result i32) (block (result i32)
+                                (block (result i32) (block (result i32)
+                                  (block (result i32) (block (result i32)
+                                    (block (result i32) (block (result i32)
+                                      (block (result i32) (block (result i32)
+                                        (block (result i32) (block (result i32)
+                                          (call $dummy) (i32.const 150)
+                                        ))
+                                      ))
+                                    ))
+                                  ))
+                                ))
+                              ))
+                            ))
+                          ))
+                        ))
+                      ))
+                    ))
+                  ))
+                ))
+              ))
+            ))
+          ))
+        ))
+      ))
+    ))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c096000000       	mov	rax, 0x96
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/empty.wat
+++ b/winch/filetests/filetests/x64/block/empty.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+
+  (func (export "empty")
+    (block)
+    (block $l)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/nested.wat
+++ b/winch/filetests/filetests/x64/block/nested.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+
+  (func (export "nested") (result i32)
+    (block (result i32)
+      (block (call $dummy) (block) (nop))
+      (block (result i32) (call $dummy) (i32.const 9))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 48c7c009000000       	mov	rax, 9
+;;   2d:	 4883c408             	add	rsp, 8
+;;   31:	 5d                   	pop	rbp
+;;   32:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/singular.wat
+++ b/winch/filetests/filetests/x64/block/singular.wat
@@ -1,0 +1,16 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "singular") (result i32)
+    (block (nop))
+    (block (result i32) (i32.const 7))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c007000000       	mov	rax, 7
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	


### PR DESCRIPTION
This commit is a follow-up to
https://github.com/bytecodealliance/wasmtime/pull/6550.

This change implements support for blocks.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
