### PR TITLE
riscv64: Add SIMD `isub` Widening Instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -299,8 +299,12 @@ impl VecAluOpRRR {
             VecAluOpRRR::VrgatherVV | VecAluOpRRR::VrgatherVX => 0b001100,
             VecAluOpRRR::VwadduVV | VecAluOpRRR::VwadduVX => 0b110000,
             VecAluOpRRR::VwaddVV | VecAluOpRRR::VwaddVX => 0b110001,
+            VecAluOpRRR::VwsubuVV | VecAluOpRRR::VwsubuVX => 0b110010,
+            VecAluOpRRR::VwsubVV | VecAluOpRRR::VwsubVX => 0b110011,
             VecAluOpRRR::VwadduWV | VecAluOpRRR::VwadduWX => 0b110100,
             VecAluOpRRR::VwaddWV | VecAluOpRRR::VwaddWX => 0b110101,
+            VecAluOpRRR::VwsubuWV | VecAluOpRRR::VwsubuWX => 0b110110,
+            VecAluOpRRR::VwsubWV | VecAluOpRRR::VwsubWX => 0b110111,
             VecAluOpRRR::VmsltVX => 0b011011,
         }
     }
@@ -329,6 +333,10 @@ impl VecAluOpRRR {
             | VecAluOpRRR::VwaddWV
             | VecAluOpRRR::VwadduVV
             | VecAluOpRRR::VwadduWV
+            | VecAluOpRRR::VwsubVV
+            | VecAluOpRRR::VwsubWV
+            | VecAluOpRRR::VwsubuVV
+            | VecAluOpRRR::VwsubuWV
             | VecAluOpRRR::VmulVV
             | VecAluOpRRR::VmulhVV
             | VecAluOpRRR::VmulhuVV
@@ -337,7 +345,11 @@ impl VecAluOpRRR {
             VecAluOpRRR::VwaddVX
             | VecAluOpRRR::VwadduVX
             | VecAluOpRRR::VwadduWX
-            | VecAluOpRRR::VwaddWX => VecOpCategory::OPMVX,
+            | VecAluOpRRR::VwaddWX
+            | VecAluOpRRR::VwsubVX
+            | VecAluOpRRR::VwsubuVX
+            | VecAluOpRRR::VwsubuWX
+            | VecAluOpRRR::VwsubWX => VecOpCategory::OPMVX,
             VecAluOpRRR::VaddVX
             | VecAluOpRRR::VsaddVX
             | VecAluOpRRR::VsadduVX
@@ -396,7 +408,15 @@ impl VecAluOpRRR {
             | VecAluOpRRR::VwadduWV
             | VecAluOpRRR::VwadduWX
             | VecAluOpRRR::VwaddWV
-            | VecAluOpRRR::VwaddWX => true,
+            | VecAluOpRRR::VwaddWX
+            | VecAluOpRRR::VwsubuVV
+            | VecAluOpRRR::VwsubuVX
+            | VecAluOpRRR::VwsubVV
+            | VecAluOpRRR::VwsubVX
+            | VecAluOpRRR::VwsubuWV
+            | VecAluOpRRR::VwsubuWX
+            | VecAluOpRRR::VwsubWV
+            | VecAluOpRRR::VwsubWX => true,
             _ => false,
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -98,6 +98,10 @@
   (VwadduVV)
   (VwadduWV)
   (VsubVV)
+  (VwsubVV)
+  (VwsubWV)
+  (VwsubuVV)
+  (VwsubuWV)
   (VssubVV)
   (VssubuVV)
   (VmulVV)
@@ -133,6 +137,10 @@
   (VwadduWX)
   (VsubVX)
   (VrsubVX)
+  (VwsubVX)
+  (VwsubWX)
+  (VwsubuVX)
+  (VwsubuWX)
   (VssubVX)
   (VssubuVX)
   (VsllVX)
@@ -431,6 +439,62 @@
 (decl rv_vrsub_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vrsub_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VrsubVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsub.vv` instruction.
+;;
+;;  Widening integer sub, 2*SEW = SEW + SEW
+(decl rv_vwsub_vv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwsub_vv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubVV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsub.vx` instruction.
+;;
+;;  Widening integer sub, 2*SEW = SEW + SEW
+(decl rv_vwsub_vx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwsub_vx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsub.wv` instruction.
+;;
+;;  Widening integer sub, 2*SEW = 2*SEW + SEW
+(decl rv_vwsub_wv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwsub_wv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubWV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsub.wx` instruction.
+;;
+;;  Widening integer sub, 2*SEW = 2*SEW + SEW
+(decl rv_vwsub_wx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwsub_wx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubWX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsubu.vv` instruction.
+;;
+;; Widening unsigned integer sub, 2*SEW = SEW + SEW
+(decl rv_vwsubu_vv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwsubu_vv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubuVV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsubu.vv` instruction.
+;;
+;; Widening unsigned integer sub, 2*SEW = SEW + SEW
+(decl rv_vwsubu_vx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwsubu_vx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubuVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsubu.wv` instruction.
+;;
+;;  Widening integer sub, 2*SEW = 2*SEW + SEW
+(decl rv_vwsubu_wv (VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vwsubu_wv vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubuWV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vwsubu.wx` instruction.
+;;
+;;  Widening integer sub, 2*SEW = 2*SEW + SEW
+(decl rv_vwsubu_wx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vwsubu_wx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VwsubuWX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vssub.vv` instruction.
 (decl rv_vssub_vv (VReg VReg VecOpMasking VState) VReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -277,11 +277,100 @@
 (rule 4 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat y))))
   (rv_vsub_vx x y (unmasked) ty))
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub (splat x) y)))
+(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (sextend y @ (value_type sext_ty))))))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) sext_ty))
+  (rv_vwsub_wx x y (unmasked) (vstate_mf2 half_ty)))
+
+(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (uextend y @ (value_type uext_ty))))))
+  (if-let half_ty (ty_half_width ty))
+  (if-let $true (ty_equal (lane_type half_ty) uext_ty))
+  (rv_vwsubu_wx x y (unmasked) (vstate_mf2 half_ty)))
+
+(rule 6 (lower (has_type (ty_vec_fits_in_register ty) (isub (splat x) y)))
   (rv_vrsub_vx y x (unmasked) ty))
 
-(rule 6 (lower (has_type (ty_vec_fits_in_register ty) (isub (replicated_imm5 x) y)))
+(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub (replicated_imm5 x) y)))
   (rv_vrsub_vi y x (unmasked) ty))
+
+
+;; Signed Widening Low Subtractions
+
+(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_low y @ (value_type in_ty)))))
+  (rv_vwsub_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                           (swiden_low y))))
+  (rv_vwsub_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                           (splat (sextend y @ (value_type sext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwsub_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Signed Widening High Subtractions
+;; These are the same as the low widenings, but we first slide down the inputs.
+
+(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_high y @ (value_type in_ty)))))
+  (rv_vwsub_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                           (swiden_high y))))
+  (rv_vwsub_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                           (splat (sextend y @ (value_type sext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) sext_ty))
+  (rv_vwsub_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening Low Subtractions
+
+(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_low y @ (value_type in_ty)))))
+  (rv_vwsubu_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                           (uwiden_low y))))
+  (rv_vwsubu_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                           (splat (uextend y @ (value_type uext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwsubu_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening High Subtractions
+;; These are the same as the low widenings, but we first slide down the inputs.
+
+(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_high y @ (value_type in_ty)))))
+  (rv_vwsubu_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                           (uwiden_high y))))
+  (rv_vwsubu_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                           (splat (uextend y @ (value_type uext_ty))))))
+  (if-let $true (ty_equal (lane_type in_ty) uext_ty))
+  (rv_vwsubu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Signed Widening Mixed High/Low Subtractions
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                           (swiden_high y))))
+  (rv_vwsub_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                           (swiden_low y))))
+  (rv_vwsub_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+;; Unsigned Widening Mixed High/Low Subtractions
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                           (uwiden_high y))))
+  (rv_vwsubu_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
+
+(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                           (uwiden_low y))))
+  (rv_vwsubu_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 
 ;;;; Rules for `ineg` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
@@ -1,0 +1,899 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+
+function %isub_splat_reverse_i8x16(i8x16, i8) -> i8x16 {
+block0(v0: i8x16, v1: i8):
+    v2 = splat.i8x16 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v5,v1,a0 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x42, 0x15, 0x0e
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_reverse_i16x8(i16x8, i16) -> i16x8 {
+block0(v0: i16x8, v1: i16):
+    v2 = splat.i16x8 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v5,v1,a0 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x42, 0x15, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_reverse_i32x4(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v5,v1,a0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x42, 0x15, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_reverse_i64x2(i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64):
+    v2 = splat.i64x2 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vx v5,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x42, 0x15, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_i8x16(i8x16, i8) -> i8x16 {
+block0(v0: i8x16, v1: i8):
+    v2 = splat.i8x16 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v5,v1,a0 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x42, 0x15, 0x0a
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_i16x8(i16x8, i16) -> i16x8 {
+block0(v0: i16x8, v1: i16):
+    v2 = splat.i16x8 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v5,v1,a0 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x42, 0x15, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_i32x4(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v5,v1,a0 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x42, 0x15, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_i64x2(i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64):
+    v2 = splat.i64x2 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vx v5,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x42, 0x15, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = iconst.i8 5
+    v2 = splat.i8x16 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a2,5
+;   vsub.vx v5,v1,a2 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v5,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a2, zero, 5
+;   .byte 0xd7, 0x42, 0x16, 0x0a
+;   .byte 0xa7, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = iconst.i16 -16
+    v2 = splat.i16x8 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a2,-16
+;   vsub.vx v5,v1,a2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v5,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a2, zero, -0x10
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x42, 0x16, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 15
+    v2 = splat.i32x4 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a2,15
+;   vsub.vx v5,v1,a2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v5,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a2, zero, 0xf
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x42, 0x16, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i64 -5
+    v2 = splat.i64x2 v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a2,-5
+;   vsub.vx v5,v1,a2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v5,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a2, zero, -5
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x42, 0x16, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_reverse_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = iconst.i8 5
+    v2 = splat.i8x16 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vi v4,v1,5 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0xb2, 0x12, 0x0e
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_reverse_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = iconst.i16 -16
+    v2 = splat.i16x8 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vi v4,v1,-16 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x32, 0x18, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_reverse_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 15
+    v2 = splat.i32x4 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vi v4,v1,15 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0xb2, 0x17, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_const_reverse_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = iconst.i64 -5
+    v2 = splat.i64x2 v1
+    v3 = isub v2, v0
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vrsub.vi v4,v1,-5 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xb2, 0x1d, 0x0e
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_sextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = sextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_sextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = sextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_sextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = sextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_uextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = uextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_uextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = uextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_splat_uextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = isub v0, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
@@ -1,0 +1,421 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %isub_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vslidedown.vi v8,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsub.vv v10,v6,v8 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x34, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x25, 0x64, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vslidedown.vi v8,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsub.vv v10,v6,v8 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x34, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v8,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vv v10,v6,v8 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x34, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_high v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsub.vx v7,v5,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x32, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x63, 0x55, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_high v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsub.vx v7,v5,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x32, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_high v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v7,v5,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x32, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsub.wv v8,v3,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x33, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsub.wv v8,v3,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wv v8,v3,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
@@ -1,0 +1,391 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %isub_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vv v6,v1,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x11, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vv v6,v1,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vv v6,v1,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_low v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_low v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_low v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.vx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xce
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wv v6,v3,v1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x30, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wv v6,v3,v1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_swidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsub.wv v6,v3,v1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xde
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
@@ -1,0 +1,421 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %isub_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vslidedown.vi v8,v3,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsubu.vv v10,v6,v8 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x34, 0x31, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x25, 0x64, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vslidedown.vi v8,v3,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsubu.vv v10,v6,v8 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x34, 0x32, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v8,v3,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vv v10,v6,v8 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x34, 0x34, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x25, 0x64, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_high v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsubu.vx v7,v5,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0xd7, 0x32, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x63, 0x55, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_high v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsubu.vx v7,v5,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0xd7, 0x32, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_high v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v5,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v7,v5,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0xd7, 0x32, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x63, 0x55, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vwsubu.wv v8,v3,v6 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x33, 0x11, 0x3e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x24, 0x33, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vwsubu.wv v8,v3,v6 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x33, 0x12, 0x3e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vslidedown.vi v6,v1,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wv v8,v3,v6 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x33, 0x14, 0x3e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x24, 0x33, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
@@ -1,0 +1,391 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %isub_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vv v6,v1,v3 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x11, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vv v6,v1,v3 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vv v6,v1,v3 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x11, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_low v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v5,v1,a0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0xd7, 0x62, 0x15, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_low v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v5,v1,a0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_low v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.vx v5,v1,a0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v5,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0xd7, 0x62, 0x15, 0xca
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x82, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wv v6,v3,v1 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0xa3, 0x30, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wv v6,v3,v1 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_uwidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vwsubu.wv v6,v3,v1 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vse8.v v6,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0xa3, 0x30, 0xda
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
@@ -151,3 +151,61 @@ block0(v0: i64x2):
 }
 ; run: %isub_splat_const_reverse_i64x2([1 2]) == [-6 -7]
 
+
+function %isub_splat_sextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = sextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_sextend_i16x8([1 -2 3 4 5 6 7 8], -10) == [11 8 13 14 15 16 17 18]
+
+function %isub_splat_sextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = sextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_sextend_i32x4([1 -2 3 4], -10) == [11 8 13 14]
+
+function %isub_splat_sextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = sextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_sextend_i64x2([1 -2], 10) == [-9 -12]
+
+
+function %isub_splat_uextend_i16x8(i16x8, i8) -> i16x8 {
+block0(v0: i16x8, v1: i8):
+    v2 = uextend.i16 v1
+    v3 = splat.i16x8 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_uextend_i16x8([1 -2 3 4 5 6 7 8], 10) == [0xfff7 0xfff4 0xfff9 0xfffa 0xfffb 0xfffc 0xfffd 0xfffe]
+; run: %isub_splat_uextend_i16x8([1 -2 3 4 5 6 7 8], -10) == [0xff0b 0xff08 0xff0d 0xff0e 0xff0f 0xff10 0xff11 0xff12]
+
+function %isub_splat_uextend_i32x4(i32x4, i16) -> i32x4 {
+block0(v0: i32x4, v1: i16):
+    v2 = uextend.i32 v1
+    v3 = splat.i32x4 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_uextend_i32x4([1 -2 3 4], 10) == [0xfffffff7 0xfffffff4 0xfffffff9 0xfffffffa]
+; run: %isub_splat_uextend_i32x4([1 -2 3 4], -10) == [0xffff000b 0xffff0008 0xffff000d 0xffff000e]
+
+function %isub_splat_uextend_i64x2(i64x2, i32) -> i64x2 {
+block0(v0: i64x2, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = splat.i64x2 v2
+    v4 = isub v0, v3
+    return v4
+}
+; run: %isub_splat_uextend_i64x2([1 -2], 10) == [0xfffffffffffffff7 0xfffffffffffffff4]
+; run: %isub_splat_uextend_i64x2([1 -2], -10) == [0xffffffff0000000b 0xffffffff00000008]

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %isub_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenhigh_i32x4([1 2 3 4], [-1 2 -3 4]) == [6 0]
+
+function %isub_swidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenhigh_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 -5 6 7 8]) == [10 0 0 0]
+
+function %isub_swidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_high v0
+    v3 = swiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenhigh_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 -9 10 11 12 13 14 15 16]) == [18 0 0 0 0 0 0 0]
+
+function %isub_swidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_high v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenhigh_splat_i32x4([1 2 3 4], -1) == [4 5]
+; run: %isub_swidenhigh_splat_i32x4([1 2 3 4], 10) == [-7 -6]
+
+function %isub_swidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_high v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [6 7 8 9]
+; run: %isub_swidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [-5 -4 -3 -2]
+
+function %isub_swidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_high v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [10 11 12 13 14 15 16 17]
+; run: %isub_swidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [-1 0 1 2 3 4 5 6]
+
+function %isub_swidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenhigh_lhs_i32x4([1 2 3 4], [-1 2]) == [-4 -2]
+
+function %isub_swidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenhigh_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [-6 -4 -4 -4]
+
+function %isub_swidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenhigh_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [-10 -8 -8 -8 -8 -8 -8 -8]

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %isub_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenlow_i32x4([1 2 3 4], [-1 2 3 4]) == [2 0]
+
+function %isub_swidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenlow_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [2 0 0 0]
+
+function %isub_swidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = swiden_low v0
+    v3 = swiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_swidenlow_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [2 0 0 0 0 0 0 0]
+
+function %isub_swidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = swiden_low v0
+    v3 = sextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenlow_splat_i32x4([1 2 3 4], -1) == [2 3]
+; run: %isub_swidenlow_splat_i32x4([1 2 3 4], 10) == [-9 -8]
+
+function %isub_swidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = swiden_low v0
+    v3 = sextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenlow_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [2 3 4 5]
+; run: %isub_swidenlow_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [-9 -8 -7 -6]
+
+function %isub_swidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = swiden_low v0
+    v3 = sextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_swidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [2 3 4 5 6 7 8 9]
+; run: %isub_swidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [-9 -8 -7 -6 -5 -4 -3 -2]
+
+function %isub_swidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenlow_lhs_i32x4([1 2 3 4], [-1 2]) == [-2 0]
+
+function %isub_swidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenlow_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [-2 0 0 0]
+
+function %isub_swidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = swiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_swidenlow_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [-2 0 0 0 0 0 0 0]

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
@@ -1,0 +1,94 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %isub_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenhigh_i32x4([1 2 3 4], [-1 2 -3 4]) == [0xffffffff00000006 0]
+
+function %isub_uwidenhigh_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenhigh_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 -5 6 7 8]) == [0xffff000a 0 0 0]
+
+function %isub_uwidenhigh_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_high v0
+    v3 = uwiden_high v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenhigh_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 -9 10 11 12 13 14 15 16]) == [0xff12 0 0 0 0 0 0 0]
+
+function %isub_uwidenhigh_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_high v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenhigh_splat_i32x4([1 2 3 4], -1) == [0xffffffff00000004 0xffffffff00000005]
+; run: %isub_uwidenhigh_splat_i32x4([1 2 3 4], 10) == [-7 -6]
+
+function %isub_uwidenhigh_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_high v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [0xffff0006 0xffff0007 0xffff0008 0xffff0009]
+; run: %isub_uwidenhigh_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [-5 -4 -3 -2]
+
+function %isub_uwidenhigh_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_high v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [0xff0a 0xff0b 0xff0c 0xff0d 0xff0e 0xff0f 0xff10 0xff11]
+; run: %isub_uwidenhigh_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [-1 0 1 2 3 4 5 6]
+
+function %isub_uwidenhigh_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenhigh_lhs_i32x4([1 2 3 4], [-1 2]) == [-4 -2]
+
+function %isub_uwidenhigh_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenhigh_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [-6 -4 -4 -4]
+
+function %isub_uwidenhigh_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_high v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenhigh_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [-10 -8 -8 -8 -8 -8 -8 -8]

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
@@ -1,0 +1,95 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
+target riscv64gc has_v
+
+
+function %isub_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenlow_i32x4([1 2 3 4], [-1 2 3 4]) == [0xffffffff00000002 0]
+
+function %isub_uwidenlow_i16x8(i16x8, i16x8) -> i32x4 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenlow_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4 5 6 7 8]) == [0xffff0002 0 0 0]
+
+function %isub_uwidenlow_i8x16(i8x16, i8x16) -> i16x8 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = uwiden_low v0
+    v3 = uwiden_low v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_uwidenlow_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16]) == [0xff02 0 0 0 0 0 0 0]
+
+function %isub_uwidenlow_splat_i32x4(i32x4, i32) -> i64x2 {
+block0(v0: i32x4, v1: i32):
+    v2 = uwiden_low v0
+    v3 = uextend.i64 v1
+    v4 = splat.i64x2 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenlow_splat_i32x4([1 2 3 4], -1) == [0xffffffff00000002 0xffffffff00000003]
+; run: %isub_uwidenlow_splat_i32x4([1 2 3 4], 10) == [-9 -8]
+
+function %isub_uwidenlow_splat_i16x8(i16x8, i16) -> i32x4 {
+block0(v0: i16x8, v1: i16):
+    v2 = uwiden_low v0
+    v3 = uextend.i32 v1
+    v4 = splat.i32x4 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenlow_splat_i16x8([1 2 3 4 5 6 7 8], -1) == [0xffff0002 0xffff0003 0xffff0004 0xffff0005]
+; run: %isub_uwidenlow_splat_i16x8([1 2 3 4 5 6 7 8], 10) == [-9 -8 -7 -6]
+
+function %isub_uwidenlow_splat_i8x16(i8x16, i8) -> i16x8 {
+block0(v0: i8x16, v1: i8):
+    v2 = uwiden_low v0
+    v3 = uextend.i16 v1
+    v4 = splat.i16x8 v3
+    v5 = isub v2, v4
+    return v5
+}
+; run: %isub_uwidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], -1) == [0xff02 0xff03 0xff04 0xff05 0xff06 0xff07 0xff08 0xff09]
+; run: %isub_uwidenlow_splat_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], 10) == [-9 -8 -7 -6 -5 -4 -3 -2]
+
+
+function %isub_uwidenlow_lhs_i32x4(i32x4, i64x2) -> i64x2 {
+block0(v0: i32x4, v1: i64x2):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenlow_lhs_i32x4([1 2 3 4], [-1 2]) == [-2 0]
+
+function %isub_uwidenlow_lhs_i16x8(i16x8, i32x4) -> i32x4 {
+block0(v0: i16x8, v1: i32x4):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenlow_lhs_i16x8([1 2 3 4 5 6 7 8], [-1 2 3 4]) == [-2 0 0 0]
+
+function %isub_uwidenlow_lhs_i8x16(i8x16, i16x8) -> i16x8 {
+block0(v0: i8x16, v1: i16x8):
+    v2 = uwiden_low v0
+    v3 = isub v1, v2
+    return v3
+}
+; run: %isub_uwidenlow_lhs_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [-1 2 3 4 5 6 7 8]) == [-2 0 0 0 0 0 0 0]


### PR DESCRIPTION
👋 Hey,

This PR adds the widening `sub` instructions. These are similar to the instructions added in #6542. The only difference is that the rules are not commutative so we have slightly fewer of them.

That PR explains how these instructions work in a slightly more detailed way. We have the exact same instructions for both `add` and `sub`.