### PR TITLE
Add clz and ctz instructions to Winch

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -344,6 +344,10 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | I64Rotl { .. }
                         | I32Rotr { .. }
                         | I64Rotr { .. }
+                        | I32Clz { .. }
+                        | I64Clz { .. }
+                        | I32Ctz { .. }
+                        | I64Ctz { .. }
                         | LocalGet { .. }
                         | LocalSet { .. }
                         | Call { .. }

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -134,11 +134,11 @@ impl<'a> CodeGenContext<'a> {
     /// Prepares arguments for emitting a unary operation.
     pub fn unop<F, M>(&mut self, masm: &mut M, size: OperandSize, emit: &mut F)
     where
-        F: FnMut(&mut M, RegImm, OperandSize),
+        F: FnMut(&mut M, Reg, OperandSize),
         M: MacroAssembler,
     {
         let reg = self.pop_to_reg(masm, None, size);
-        emit(masm, reg.into(), size);
+        emit(masm, reg, size);
         self.stack.push(Val::reg(reg));
     }
 

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -226,6 +226,14 @@ impl Masm for MacroAssembler {
     fn cmp_with_set(&mut self, _src: RegImm, _dst: RegImm, _kind: CmpKind, _size: OperandSize) {
         todo!()
     }
+
+    fn clz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {
+        todo!()
+    }
+
+    fn ctz(&mut self, _src: Reg, _dst: Reg, _size: OperandSize) {
+        todo!()
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -41,6 +41,12 @@ impl From<Reg> for RegMemImm {
     }
 }
 
+impl From<Reg> for RegMem {
+    fn from(value: Reg) -> Self {
+        RegMem::Reg { reg: value.into() }
+    }
+}
+
 impl From<Reg> for WritableGpr {
     fn from(reg: Reg) -> Self {
         let writable = Writable::from_reg(reg.into());
@@ -51,6 +57,12 @@ impl From<Reg> for WritableGpr {
 impl From<Reg> for Gpr {
     fn from(reg: Reg) -> Self {
         Gpr::new(reg.into()).expect("valid gpr")
+    }
+}
+
+impl From<Reg> for GprMem {
+    fn from(value: Reg) -> Self {
+        GprMem::new(value.into()).expect("valid gpr")
     }
 }
 
@@ -121,6 +133,8 @@ pub(crate) struct Assembler {
     emit_info: EmitInfo,
     /// Emission state.
     emit_state: EmitState,
+    /// x64 flags.
+    isa_flags: x64_settings::Flags,
 }
 
 impl Assembler {
@@ -129,7 +143,8 @@ impl Assembler {
         Self {
             buffer: MachBuffer::<Inst>::new(),
             emit_state: Default::default(),
-            emit_info: EmitInfo::new(shared_flags, isa_flags),
+            emit_info: EmitInfo::new(shared_flags, isa_flags.clone()),
+            isa_flags,
         }
     }
 
@@ -684,6 +699,61 @@ impl Assembler {
         // Copy correct bit from status register into dst register.
         self.emit(Inst::Setcc {
             cc: kind.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Store the count of leading zeroes in src in dst.
+    /// Requires `has_lzcnt` flag.
+    pub fn lzcnt(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        assert!(self.isa_flags.has_lzcnt(), "Requires has_lzcnt flag");
+        self.emit(Inst::UnaryRmR {
+            size: size.into(),
+            op: args::UnaryRmROpcode::Lzcnt,
+            src: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Store the count of trailing zeroes in src in dst.
+    /// Requires `has_bmi1` flag.
+    pub fn tzcnt(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        assert!(self.isa_flags.has_bmi1(), "Requires has_bmi1 flag");
+        self.emit(Inst::UnaryRmR {
+            size: size.into(),
+            op: args::UnaryRmROpcode::Tzcnt,
+            src: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Stores position of the most significant bit set in src in dst.
+    /// Zero flag is set if src is equal to 0.
+    pub fn bsr(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::UnaryRmR {
+            size: size.into(),
+            op: args::UnaryRmROpcode::Bsr,
+            src: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Performs integer negation on src and places result in dst.
+    pub fn neg(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::Neg {
+            size: size.into(),
+            src: src.into(),
+            dst: dst.into(),
+        });
+    }
+
+    /// Stores position of the least significant bit set in src in dst.
+    /// Zero flag is set if src is equal to 0.
+    pub fn bsf(&mut self, src: Reg, dst: Reg, size: OperandSize) {
+        self.emit(Inst::UnaryRmR {
+            size: size.into(),
+            op: args::UnaryRmROpcode::Bsf,
+            src: src.into(),
             dst: dst.into(),
         });
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -74,6 +74,24 @@ pub(crate) enum OperandSize {
     S64,
 }
 
+impl OperandSize {
+    /// The number of bits in the operand.
+    pub fn num_bits(&self) -> i32 {
+        match self {
+            OperandSize::S32 => 32,
+            OperandSize::S64 => 64,
+        }
+    }
+
+    /// The binary logarithm of the number of bits in the operand.
+    pub fn log2(&self) -> u8 {
+        match self {
+            OperandSize::S32 => 5,
+            OperandSize::S64 => 6,
+        }
+    }
+}
+
 /// An abstraction over a register or immediate.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RegImm {
@@ -228,6 +246,16 @@ pub(crate) trait MacroAssembler {
     /// Compare src and dst and put the result in dst.
     /// This function will potentially emit a series of instructions.
     fn cmp_with_set(&mut self, src: RegImm, dst: RegImm, kind: CmpKind, size: OperandSize);
+
+    /// Count the number of leading zeroes in src and put the result in dst.
+    /// In x64, this will emit multiple instructions if the `has_lzcnt` flag is
+    /// false.
+    fn clz(&mut self, src: Reg, dst: Reg, size: OperandSize);
+
+    /// Count the number of trailing zeroes in src and put the result in dst.
+    /// In x64, this will emit multiple instructions if the `has_tzcnt` flag is
+    /// false.
+    fn ctz(&mut self, src: Reg, dst: Reg, size: OperandSize);
 
     /// Push the register to the stack, returning the offset.
     fn push(&mut self, src: Reg) -> u32;

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -85,6 +85,10 @@ macro_rules! def_unsupported {
     (emit I64Rotl $($rest:tt)*) => {};
     (emit I32Rotr $($rest:tt)*) => {};
     (emit I64Rotr $($rest:tt)*) => {};
+    (emit I32Clz $($rest:tt)*) => {};
+    (emit I64Clz $($rest:tt)*) => {};
+    (emit I32Ctz $($rest:tt)*) => {};
+    (emit I64Ctz $($rest:tt)*) => {};
     (emit LocalGet $($rest:tt)*) => {};
     (emit LocalSet $($rest:tt)*) => {};
     (emit Call $($rest:tt)*) => {};
@@ -284,7 +288,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::imm(0), reg, CmpKind::Eq, size);
+            masm.cmp_with_set(RegImm::imm(0), reg.into(), CmpKind::Eq, size);
         });
     }
 
@@ -292,7 +296,39 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::imm(0), reg, CmpKind::Eq, size);
+            masm.cmp_with_set(RegImm::imm(0), reg.into(), CmpKind::Eq, size);
+        });
+    }
+
+    fn visit_i32_clz(&mut self) {
+        use OperandSize::*;
+
+        self.context.unop(self.masm, S32, &mut |masm, reg, size| {
+            masm.clz(reg, reg, size);
+        });
+    }
+
+    fn visit_i64_clz(&mut self) {
+        use OperandSize::*;
+
+        self.context.unop(self.masm, S64, &mut |masm, reg, size| {
+            masm.clz(reg, reg, size);
+        });
+    }
+
+    fn visit_i32_ctz(&mut self) {
+        use OperandSize::*;
+
+        self.context.unop(self.masm, S32, &mut |masm, reg, size| {
+            masm.ctz(reg, reg, size);
+        });
+    }
+
+    fn visit_i64_ctz(&mut self) {
+        use OperandSize::*;
+
+        self.context.unop(self.masm, S64, &mut |masm, reg, size| {
+            masm.ctz(reg, reg, size);
         });
     }
 

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 f30fbdc0             	lzcnt	eax, eax
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 5d                   	pop	rbp
+;;   1a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (result i32)
+        (local $foo i32)
+
+        (i32.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b802000000           	mov	eax, 2
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 f30fbdc0             	lzcnt	eax, eax
+;;   27:	 4883c410             	add	rsp, 0x10
+;;   2b:	 5d                   	pop	rbp
+;;   2c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (param i32) (result i32)
+        (local.get 0)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 f30fbdc0             	lzcnt	eax, eax
+;;   19:	 4883c410             	add	rsp, 0x10
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 0fbdc0               	bsr	eax, eax
+;;   14:	 41bb00000000         	mov	r11d, 0
+;;   1a:	 410f95c3             	setne	r11b
+;;   1e:	 f7d8                 	neg	eax
+;;   20:	 83c020               	add	eax, 0x20
+;;   23:	 4429d8               	sub	eax, r11d
+;;   26:	 4883c408             	add	rsp, 8
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+
+        (i32.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b802000000           	mov	eax, 2
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 0fbdc0               	bsr	eax, eax
+;;   26:	 41bb00000000         	mov	r11d, 0
+;;   2c:	 410f95c3             	setne	r11b
+;;   30:	 f7d8                 	neg	eax
+;;   32:	 83c020               	add	eax, 0x20
+;;   35:	 4429d8               	sub	eax, r11d
+;;   38:	 4883c410             	add	rsp, 0x10
+;;   3c:	 5d                   	pop	rbp
+;;   3d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (result i32)
+        (local.get 0)
+        (i32.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 0fbdc0               	bsr	eax, eax
+;;   18:	 41bb00000000         	mov	r11d, 0
+;;   1e:	 410f95c3             	setne	r11b
+;;   22:	 f7d8                 	neg	eax
+;;   24:	 83c020               	add	eax, 0x20
+;;   27:	 4429d8               	sub	eax, r11d
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 f30fbcc0             	tzcnt	eax, eax
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 5d                   	pop	rbp
+;;   1a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (result i32)
+        (local $foo i32)
+
+        (i32.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i32.ctz)
+    )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b802000000           	mov	eax, 2
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 f30fbcc0             	tzcnt	eax, eax
+;;   27:	 4883c410             	add	rsp, 0x10
+;;   2b:	 5d                   	pop	rbp
+;;   2c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (param i32) (result i32)
+        (local.get 0)
+        (i32.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 f30fbcc0             	tzcnt	eax, eax
+;;   19:	 4883c410             	add	rsp, 0x10
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (i32.const 1)
+        (i32.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 0fbcc0               	bsf	eax, eax
+;;   14:	 41bb00000000         	mov	r11d, 0
+;;   1a:	 410f94c3             	sete	r11b
+;;   1e:	 41c1e305             	shl	r11d, 5
+;;   22:	 4401d8               	add	eax, r11d
+;;   25:	 4883c408             	add	rsp, 8
+;;   29:	 5d                   	pop	rbp
+;;   2a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        (local $foo i32)
+
+        (i32.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i32.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b802000000           	mov	eax, 2
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 0fbcc0               	bsf	eax, eax
+;;   26:	 41bb00000000         	mov	r11d, 0
+;;   2c:	 410f94c3             	sete	r11b
+;;   30:	 41c1e305             	shl	r11d, 5
+;;   34:	 4401d8               	add	eax, r11d
+;;   37:	 4883c410             	add	rsp, 0x10
+;;   3b:	 5d                   	pop	rbp
+;;   3c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i32) (result i32)
+        (local.get 0)
+        (i32.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 0fbcc0               	bsf	eax, eax
+;;   18:	 41bb00000000         	mov	r11d, 0
+;;   1e:	 410f94c3             	sete	r11b
+;;   22:	 41c1e305             	shl	r11d, 5
+;;   26:	 4401d8               	add	eax, r11d
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 f3480fbdc0           	lzcnt	rax, rax
+;;   18:	 4883c408             	add	rsp, 8
+;;   1c:	 5d                   	pop	rbp
+;;   1d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (result i64)
+        (local $foo i64)
+
+        (i64.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 48c7c002000000       	mov	rax, 2
+;;   1c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   21:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   26:	 f3480fbdc0           	lzcnt	rax, rax
+;;   2b:	 4883c410             	add	rsp, 0x10
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+;;! flags = ["has_lzcnt"]
+
+(module
+    (func (param i64) (result i64)
+        (local.get 0)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;    d:	 4c893424             	mov	qword ptr [rsp], r14
+;;   11:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   16:	 f3480fbdc0           	lzcnt	rax, rax
+;;   1b:	 4883c410             	add	rsp, 0x10
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 480fbdc0             	bsr	rax, rax
+;;   17:	 41bb00000000         	mov	r11d, 0
+;;   1d:	 410f95c3             	setne	r11b
+;;   21:	 48f7d8               	neg	rax
+;;   24:	 4883c040             	add	rax, 0x40
+;;   28:	 4c29d8               	sub	rax, r11
+;;   2b:	 4883c408             	add	rsp, 8
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+
+        (i64.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 48c7c002000000       	mov	rax, 2
+;;   1c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   21:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   26:	 480fbdc0             	bsr	rax, rax
+;;   2a:	 41bb00000000         	mov	r11d, 0
+;;   30:	 410f95c3             	setne	r11b
+;;   34:	 48f7d8               	neg	rax
+;;   37:	 4883c040             	add	rax, 0x40
+;;   3b:	 4c29d8               	sub	rax, r11
+;;   3e:	 4883c410             	add	rsp, 0x10
+;;   42:	 5d                   	pop	rbp
+;;   43:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (result i64)
+        (local.get 0)
+        (i64.clz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;    d:	 4c893424             	mov	qword ptr [rsp], r14
+;;   11:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   16:	 480fbdc0             	bsr	rax, rax
+;;   1a:	 41bb00000000         	mov	r11d, 0
+;;   20:	 410f95c3             	setne	r11b
+;;   24:	 48f7d8               	neg	rax
+;;   27:	 4883c040             	add	rax, 0x40
+;;   2b:	 4c29d8               	sub	rax, r11
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 f3480fbcc0           	tzcnt	rax, rax
+;;   18:	 4883c408             	add	rsp, 8
+;;   1c:	 5d                   	pop	rbp
+;;   1d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (result i64)
+        (local $foo i64)
+
+        (i64.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 48c7c002000000       	mov	rax, 2
+;;   1c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   21:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   26:	 f3480fbcc0           	tzcnt	rax, rax
+;;   2b:	 4883c410             	add	rsp, 0x10
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+;;! flags = ["has_bmi1"]
+
+(module
+    (func (param i64) (result i64)
+        (local.get 0)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;    d:	 4c893424             	mov	qword ptr [rsp], r14
+;;   11:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   16:	 f3480fbcc0           	tzcnt	rax, rax
+;;   1b:	 4883c410             	add	rsp, 0x10
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (i64.const 1)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 480fbcc0             	bsf	rax, rax
+;;   17:	 41bb00000000         	mov	r11d, 0
+;;   1d:	 410f94c3             	sete	r11b
+;;   21:	 49c1e306             	shl	r11, 6
+;;   25:	 4c01d8               	add	rax, r11
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i64)
+        (local $foo i64)
+
+        (i64.const 2)
+        (local.set $foo)
+
+        (local.get $foo)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c893424             	mov	qword ptr [rsp], r14
+;;   15:	 48c7c002000000       	mov	rax, 2
+;;   1c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   21:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   26:	 480fbcc0             	bsf	rax, rax
+;;   2a:	 41bb00000000         	mov	r11d, 0
+;;   30:	 410f94c3             	sete	r11b
+;;   34:	 49c1e306             	shl	r11, 6
+;;   38:	 4c01d8               	add	rax, r11
+;;   3b:	 4883c410             	add	rsp, 0x10
+;;   3f:	 5d                   	pop	rbp
+;;   40:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+    (func (param i64) (result i64)
+        (local.get 0)
+        (i64.ctz)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;    d:	 4c893424             	mov	qword ptr [rsp], r14
+;;   11:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   16:	 480fbcc0             	bsf	rax, rax
+;;   1a:	 41bb00000000         	mov	r11d, 0
+;;   20:	 410f94c3             	sete	r11b
+;;   24:	 49c1e306             	shl	r11, 6
+;;   28:	 4c01d8               	add	rax, r11
+;;   2b:	 4883c410             	add	rsp, 0x10
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Add support for `clz` and `ctz` instructions to Winch. Also adds passing CPU flags to filetests.