### PR TITLE
[9.0.0] Use Rust 1.69.0 instead of 1.70.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: 'Default toolchan to install'
     required: false
-    default: 'stable'
+    default: '1.69.0'
   lockfiles:
     description: 'Path glob for Cargo.lock files to use as cache keys'
     required: false


### PR DESCRIPTION
* Use Rust 1.69.0 instead of 1.70.0

Try to fix some recent CI breakage

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
