### PR TITLE
egraphs: Lift `splat` outside of int-to-float conversions

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -229,6 +229,7 @@ fn get_isle_compilations(
                     src_opts.join("remat.isle"),
                     src_opts.join("selects.isle"),
                     src_opts.join("shifts.isle"),
+                    src_opts.join("vector.isle"),
                 ],
                 untracked_inputs: vec![clif_opt_isle],
             },

--- a/cranelift/codegen/src/opts/vector.isle
+++ b/cranelift/codegen/src/opts/vector.isle
@@ -1,0 +1,8 @@
+;; Lift a splat outside of an int-to-float conversion to try to open up
+;; optimization opportunities with scalars.
+;;
+;; NB: this is also required for correctness at this time due to #6562
+(rule (simplify (fcvt_from_uint float_vector_ty (splat _ x)))
+      (splat float_vector_ty (fcvt_from_uint (lane_type float_vector_ty) x)))
+(rule (simplify (fcvt_from_sint float_vector_ty (splat _ x)))
+      (splat float_vector_ty (fcvt_from_sint (lane_type float_vector_ty) x)))

--- a/cranelift/filetests/filetests/egraph/vector.clif
+++ b/cranelift/filetests/filetests/egraph/vector.clif
@@ -1,0 +1,35 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %f1(i32) -> f64x2 {
+block0(v0: i32):
+  v1 = splat.i32x2 v0
+  v2 = fcvt_from_uint.f64x2 v1
+  return v2
+  ; check: v3 = fcvt_from_uint.f64 v0
+  ; check: v4 = splat.f64x2 v3
+  ; check: return v4
+}
+
+function %f2(i32) -> f64x2 {
+block0(v0: i32):
+  v1 = uextend.i64 v0
+  v2 = splat.i64x2 v1
+  v3 = fcvt_from_uint.f64x2 v2
+  return v3
+  ; check: v1 = uextend.i64 v0
+  ; check: v4 = fcvt_from_uint.f64 v1
+  ; check: v5 = splat.f64x2 v4
+  ; check: return v5
+}
+
+function %f3(i32) -> f64x2 {
+block0(v0: i32):
+  v1 = splat.i32x2 v0
+  v2 = fcvt_from_sint.f64x2 v1
+  return v2
+  ; check: v3 = fcvt_from_sint.f64 v0
+  ; check: v4 = splat.f64x2 v3
+  ; check: return v4
+}

--- a/tests/misc_testsuite/issue6562.wast
+++ b/tests/misc_testsuite/issue6562.wast
@@ -1,0 +1,8 @@
+(module
+  (func (result v128)
+    i32.const 0
+    v128.load32_splat align=1
+    f64x2.convert_low_i32x4_u
+  )
+  (memory 0 1)
+)


### PR DESCRIPTION
This commit adds a targeted optimization aimed at fixing #6562 as a temporary measure for now. The "real" fix for #6562 is to add a full lowering of `fcvt_from_uint` to the x64 backend, but for now adding this rule should fix the specific issue cropping up.

Closes #6562

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
