### PR TITLE
x64: Move some constants directly in-line with ISLE

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -4250,12 +4250,6 @@
         (if-let $true (use_avx_simd))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvttpd2dq) x))
 
-(decl fcvt_uint_mask_const () VCodeConstant)
-(extern constructor fcvt_uint_mask_const fcvt_uint_mask_const)
-
-(decl fcvt_uint_mask_high_const () VCodeConstant)
-(extern constructor fcvt_uint_mask_high_const fcvt_uint_mask_high_const)
-
 ;; Helpers for creating `pcmpeq*` instructions.
 (decl x64_pcmpeq (Type Xmm XmmMem) Xmm)
 (rule (x64_pcmpeq $I8X16 x y) (x64_pcmpeqb x y))
@@ -4512,25 +4506,6 @@
 
           (SideEffectNoResult.Inst
             (MInst.JmpTableSeq idx tmp1 tmp2 default_target jt_targets))))
-
-;;;; iadd_pairwise constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl iadd_pairwise_mul_const_16 () VCodeConstant)
-(extern constructor iadd_pairwise_mul_const_16 iadd_pairwise_mul_const_16)
-
-(decl iadd_pairwise_mul_const_32 () VCodeConstant)
-(extern constructor iadd_pairwise_mul_const_32 iadd_pairwise_mul_const_32)
-
-(decl iadd_pairwise_xor_const_32 () VCodeConstant)
-(extern constructor iadd_pairwise_xor_const_32 iadd_pairwise_xor_const_32)
-
-(decl iadd_pairwise_addd_const_32 () VCodeConstant)
-(extern constructor iadd_pairwise_addd_const_32 iadd_pairwise_addd_const_32)
-
-;;;; snarrow constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl snarrow_umax_mask () VCodeConstant)
-(extern constructor snarrow_umax_mask snarrow_umax_mask)
 
 ;;;; Comparisons ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -4890,12 +4865,6 @@
 (decl perm_from_mask_with_zeros (VCodeConstant VCodeConstant) VecMask)
 (extern extractor perm_from_mask_with_zeros perm_from_mask_with_zeros)
 
-;;;; Swizzle ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; Create a mask for zeroing out-of-bounds lanes of the swizzle mask.
-(decl swizzle_zero_mask () VCodeConstant)
-(extern constructor swizzle_zero_mask swizzle_zero_mask)
-
 ;;;; TLS Values ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Helper for emitting ElfTlsGetAddr.
@@ -4919,19 +4888,6 @@
             (tmp WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.CoffTlsGetAddr name dst tmp))))
         dst))
-
-;;;; sqmul_round_sat ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl sqmul_round_sat_mask () VCodeConstant)
-(extern constructor sqmul_round_sat_mask sqmul_round_sat_mask)
-
-;;;; uunarrow ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl uunarrow_umax_mask () VCodeConstant)
-(extern constructor uunarrow_umax_mask uunarrow_umax_mask)
-
-(decl uunarrow_uint_mask () VCodeConstant)
-(extern constructor uunarrow_uint_mask uunarrow_uint_mask)
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2183,23 +2183,18 @@
 ;;
 ;; __m128i lookup = _mm_setr_epi8(0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4);
 
-(decl popcount_4bit_table () VCodeConstant)  ;; bits-per-nibble table `lookup` above
-(extern constructor popcount_4bit_table popcount_4bit_table)
-
-(decl popcount_low_mask () VCodeConstant)    ;; mask for low nibbles: 0x0f * 16
-(extern constructor popcount_low_mask popcount_low_mask)
 
 (rule (lower (has_type $I8X16
                        (popcnt src)))
-      (let ((nibble_table_const VCodeConstant (popcount_4bit_table))
-            (low_mask XmmMem (popcount_low_mask))
+      (let ((low_mask XmmMem (emit_u128_le_const 0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f))
             (low_nibbles Xmm (sse_and $I8X16 src low_mask))
             ;; Note that this is a 16x8 shift, but that's OK; we mask
             ;; off anything that traverses from one byte to the next
             ;; with the low_mask below.
             (shifted_src Xmm (x64_psrlw src (xmi_imm 4)))
             (high_nibbles Xmm (sse_and $I8X16 shifted_src low_mask))
-            (lookup Xmm (x64_xmm_load_const $I8X16 (popcount_4bit_table)))
+            (lookup Xmm (x64_xmm_load_const $I8X16
+              (emit_u128_le_const 0x04030302_03020201_03020201_02010100)))
             (bit_counts_low Xmm (x64_pshufb lookup low_nibbles))
             (bit_counts_high Xmm (x64_pshufb lookup high_nibbles)))
         (x64_paddb bit_counts_low bit_counts_high)))
@@ -3274,9 +3269,9 @@
 ;; every value of the mantissa represents a corresponding uint32 number.
 ;; When we subtract 0x1.0p52 we are left with double(src).
 (rule 1 (lower (has_type $F64X2 (fcvt_from_uint (uwiden_low val @ (value_type $I32X4)))))
-      (let ((uint_mask XmmMem (fcvt_uint_mask_const))
+      (let ((uint_mask XmmMem (emit_u128_le_const 0x43300000_43300000))
             (res Xmm (x64_unpcklps val uint_mask))
-            (uint_mask_high XmmMem (fcvt_uint_mask_high_const)))
+            (uint_mask_high XmmMem (emit_u128_le_const 0x4330000000000000_4330000000000000)))
         (x64_subpd res uint_mask_high)))
 
 ;; When AVX512VL and AVX512F are available,
@@ -3480,7 +3475,8 @@
         (has_type $I16X8 (iadd_pairwise
                            (swiden_low val @ (value_type $I8X16))
                            (swiden_high val))))
-      (let ((mul_const Xmm (x64_xmm_load_const $I8X16 (iadd_pairwise_mul_const_16))))
+      (let ((mul_const Xmm (x64_xmm_load_const $I8X16
+              (emit_u128_le_const 0x01010101010101010101010101010101))))
         (x64_pmaddubsw mul_const val)))
 
 ;; special case for the `i32x4.extadd_pairwise_i16x8_s` wasm instruction
@@ -3488,7 +3484,7 @@
         (has_type $I32X4 (iadd_pairwise
                            (swiden_low val @ (value_type $I16X8))
                            (swiden_high val))))
-      (let ((mul_const XmmMem (iadd_pairwise_mul_const_32)))
+      (let ((mul_const XmmMem (emit_u128_le_const 0x0001_0001_0001_0001_0001_0001_0001_0001)))
         (x64_pmaddwd val mul_const)))
 
 ;; special case for the `i16x8.extadd_pairwise_i8x16_u` wasm instruction
@@ -3496,7 +3492,7 @@
         (has_type $I16X8 (iadd_pairwise
                            (uwiden_low val @ (value_type $I8X16))
                            (uwiden_high val))))
-      (let ((mul_const XmmMem (iadd_pairwise_mul_const_16)))
+      (let ((mul_const XmmMem (emit_u128_le_const 0x01010101010101010101010101010101)))
         (x64_pmaddubsw val mul_const)))
 
 ;; special case for the `i32x4.extadd_pairwise_i16x8_u` wasm instruction
@@ -3504,13 +3500,13 @@
         (has_type $I32X4 (iadd_pairwise
                            (uwiden_low val @ (value_type $I16X8))
                            (uwiden_high val))))
-      (let ((xor_const XmmMem (iadd_pairwise_xor_const_32))
+      (let ((xor_const XmmMem (emit_u128_le_const 0x8000_8000_8000_8000_8000_8000_8000_8000))
             (dst Xmm (x64_pxor val xor_const))
 
-            (madd_const XmmMem (iadd_pairwise_mul_const_32))
+            (madd_const XmmMem (emit_u128_le_const 0x0001_0001_0001_0001_0001_0001_0001_0001))
             (dst Xmm (x64_pmaddwd dst madd_const))
 
-            (addd_const XmmMem (iadd_pairwise_addd_const_32)))
+            (addd_const XmmMem (emit_u128_le_const 0x00010000_00010000_00010000_00010000)))
         (x64_paddd dst addd_const)))
 
 ;; special case for the `i32x4.dot_i16x8_s` wasm instruction
@@ -3645,7 +3641,9 @@
             ;; CVTTPD2DQ xmm_y, xmm_y
 
             (tmp1 Xmm (x64_cmppd a a (FcmpImm.Equal)))
-            (umax_mask XmmMem (snarrow_umax_mask))
+
+            ;; 2147483647.0 is equivalent to 0x41DFFFFFFFC00000
+            (umax_mask XmmMem (emit_u128_le_const 0x41DFFFFFFFC00000_41DFFFFFFFC00000))
 
             ;; ANDPD xmm_y, [wasm_f64x2_splat(2147483647.0)]
             (tmp1 Xmm (x64_andps tmp1 umax_mask))
@@ -4155,7 +4153,7 @@
 ;; Wasm SIMD semantics for this instruction. The instruction format maps to
 ;; variables like: %dst = swizzle %src, %mask
 (rule (lower (swizzle src mask))
-      (let ((mask Xmm (x64_paddusb mask (swizzle_zero_mask))))
+      (let ((mask Xmm (x64_paddusb mask (emit_u128_le_const 0x70707070707070707070707070707070))))
         (x64_pshufb src mask)))
 
 ;; Rules for `x86_pshufb` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -4428,7 +4426,7 @@
       (let ((src1 Xmm qx)
             (src2 Xmm qy)
 
-            (mask XmmMem (sqmul_round_sat_mask))
+            (mask XmmMem (emit_u128_le_const 0x8000_8000_8000_8000_8000_8000_8000_8000))
             (dst Xmm (x64_pmulhrsw src1 src2))
             (cmp Xmm (x64_pcmpeqw dst mask)))
         (x64_pxor dst cmp)))
@@ -4461,7 +4459,8 @@
             (zeros Xmm (xmm_zero $F64X2))
             (dst Xmm (x64_maxpd src zeros))
 
-            (umax_mask XmmMem (uunarrow_umax_mask))
+            ;; 4294967295.0 is equivalent to 0x41EFFFFFFFE00000
+            (umax_mask XmmMem (emit_u128_le_const 0x41EFFFFFFFE00000_41EFFFFFFFE00000))
 
             ;; MINPD xmm_y, [wasm_f64x2_splat(4294967295.0)]
             (dst Xmm (x64_minpd dst umax_mask))
@@ -4470,7 +4469,8 @@
             (dst Xmm (x64_round $F64X2 dst (RoundImm.RoundZero)))
 
             ;; ADDPD xmm_y, [wasm_f64x2_splat(0x1.0p+52)]
-            (uint_mask XmmMem (uunarrow_uint_mask))
+            (uint_mask XmmMem (emit_u128_le_const 0x4330000000000000_4330000000000000))
+
             (dst Xmm (x64_addpd dst uint_mask)))
 
         ;; SHUFPS xmm_y, xmm_xmp, 0x88

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -404,16 +404,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         SyntheticAmode::ConstantOffset(mask_table)
     }
 
-    fn popcount_4bit_table(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&POPCOUNT_4BIT_TABLE))
-    }
-
-    fn popcount_low_mask(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&POPCOUNT_LOW_MASK))
-    }
-
     #[inline]
     fn writable_reg_to_xmm(&mut self, r: WritableReg) -> WritableXmm {
         Writable::from_reg(Xmm::new(r.to_reg()).unwrap())
@@ -720,53 +710,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn fcvt_uint_mask_const(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&UINT_MASK))
-    }
-
-    #[inline]
-    fn fcvt_uint_mask_high_const(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&UINT_MASK_HIGH))
-    }
-
-    #[inline]
-    fn iadd_pairwise_mul_const_16(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&IADD_PAIRWISE_MUL_CONST_16))
-    }
-
-    #[inline]
-    fn iadd_pairwise_mul_const_32(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&IADD_PAIRWISE_MUL_CONST_32))
-    }
-
-    #[inline]
-    fn iadd_pairwise_xor_const_32(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&IADD_PAIRWISE_XOR_CONST_32))
-    }
-
-    #[inline]
-    fn iadd_pairwise_addd_const_32(&mut self) -> VCodeConstant {
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&IADD_PAIRWISE_ADDD_CONST_32))
-    }
-
-    #[inline]
-    fn snarrow_umax_mask(&mut self) -> VCodeConstant {
-        // 2147483647.0 is equivalent to 0x41DFFFFFFFC00000
-        static UMAX_MASK: [u8; 16] = [
-            0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF, 0xDF, 0x41, 0x00, 0x00, 0xC0, 0xFF, 0xFF, 0xFF,
-            0xDF, 0x41,
-        ];
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&UMAX_MASK))
-    }
-
-    #[inline]
     fn shuffle_0_31_mask(&mut self, mask: &VecMask) -> VCodeConstant {
         let mask = mask
             .iter()
@@ -824,46 +767,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         let mask = mask.iter().cloned().collect();
         self.lower_ctx
             .use_constant(VCodeConstantData::Generated(mask))
-    }
-
-    #[inline]
-    fn swizzle_zero_mask(&mut self) -> VCodeConstant {
-        static ZERO_MASK_VALUE: [u8; 16] = [0x70; 16];
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&ZERO_MASK_VALUE))
-    }
-
-    #[inline]
-    fn sqmul_round_sat_mask(&mut self) -> VCodeConstant {
-        static SAT_MASK: [u8; 16] = [
-            0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80,
-            0x00, 0x80,
-        ];
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&SAT_MASK))
-    }
-
-    #[inline]
-    fn uunarrow_umax_mask(&mut self) -> VCodeConstant {
-        // 4294967295.0 is equivalent to 0x41EFFFFFFFE00000
-        static UMAX_MASK: [u8; 16] = [
-            0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF, 0xEF, 0x41, 0x00, 0x00, 0xE0, 0xFF, 0xFF, 0xFF,
-            0xEF, 0x41,
-        ];
-
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&UMAX_MASK))
-    }
-
-    #[inline]
-    fn uunarrow_uint_mask(&mut self) -> VCodeConstant {
-        static UINT_MASK: [u8; 16] = [
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x30, 0x43,
-        ];
-
-        self.lower_ctx
-            .use_constant(VCodeConstantData::WellKnown(&UINT_MASK))
     }
 
     fn xmm_mem_to_xmm_mem_aligned(&mut self, arg: &XmmMem) -> XmmMemAligned {
@@ -1104,18 +1007,6 @@ const I8X16_USHR_MASKS: [u8; 128] = [
     0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
 ];
 
-/// Number of bits set in a given nibble (4-bit value). Used in the
-/// vector implementation of popcount.
-#[rustfmt::skip] // Preserve 4x4 layout.
-const POPCOUNT_4BIT_TABLE: [u8; 16] = [
-    0x00, 0x01, 0x01, 0x02,
-    0x01, 0x02, 0x02, 0x03,
-    0x01, 0x02, 0x02, 0x03,
-    0x02, 0x03, 0x03, 0x04,
-];
-
-const POPCOUNT_LOW_MASK: [u8; 16] = [0x0f; 16];
-
 #[inline]
 fn to_simm32(constant: i64) -> Option<GprMemImm> {
     if constant == ((constant << 32) >> 32) {
@@ -1129,25 +1020,3 @@ fn to_simm32(constant: i64) -> Option<GprMemImm> {
         None
     }
 }
-
-const UINT_MASK: [u8; 16] = [
-    0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-];
-
-const UINT_MASK_HIGH: [u8; 16] = [
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x43,
-];
-
-const IADD_PAIRWISE_MUL_CONST_16: [u8; 16] = [0x01; 16];
-
-const IADD_PAIRWISE_MUL_CONST_32: [u8; 16] = [
-    0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00,
-];
-
-const IADD_PAIRWISE_XOR_CONST_32: [u8; 16] = [
-    0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0x80,
-];
-
-const IADD_PAIRWISE_ADDD_CONST_32: [u8; 16] = [
-    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00,
-];


### PR DESCRIPTION
I believe that historically it was difficult to write a 128-bit constant in ISLE but nowadays ISLE supports `u128` integer literals so it's now possible to do that. This commit moves some existing constants in `x64/lower/isle.rs` into `lower.isle` directly to more easily understand them when reading over instruction lowerings by avoiding having to context switch between ISLE and Rust to understand the value of a constant.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
