### PR TITLE
Update adapter build

### DIFF
--- a/ci/build-wasi-preview1-component-adapter.sh
+++ b/ci/build-wasi-preview1-component-adapter.sh
@@ -4,8 +4,8 @@ set -ex
 build_adapter="cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown"
 verify="cargo run -p verify-component-adapter --"
 
-debug="target/wasm32-unknown-unknown/debug/wasi_preview1_component_adapter.wasm"
-release="target/wasm32-unknown-unknown/release/wasi_preview1_component_adapter.wasm"
+debug="target/wasm32-unknown-unknown/debug/wasi_snapshot_preview1.wasm"
+release="target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm"
 
 # Debug build, default features (reactor)
 $build_adapter

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -145,12 +145,12 @@ fn build_adapter(out_dir: &PathBuf, name: &str, features: &[&str]) -> Vec<u8> {
     let status = cmd.status().unwrap();
     assert!(status.success());
 
-    let adapter = out_dir.join(format!("wasi_preview1_component_adapter.{name}.wasm"));
+    let adapter = out_dir.join(format!("wasi_snapshot_preview1.{name}.wasm"));
     std::fs::copy(
         out_dir
             .join("wasm32-unknown-unknown")
             .join("release")
-            .join("wasi_preview1_component_adapter.wasm"),
+            .join("wasi_snapshot_preview1.wasm"),
         &adapter,
     )
     .unwrap();

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -17,6 +17,7 @@ object = { version = "0.30.0", default-features = false, features = ["archive"] 
 [lib]
 test = false
 crate-type = ["cdylib"]
+name = "wasi_snapshot_preview1"
 
 [features]
 default = ["reactor"]

--- a/crates/wasi-preview1-component-adapter/README.md
+++ b/crates/wasi-preview1-component-adapter/README.md
@@ -17,13 +17,20 @@ instead.
 This adapter can be built with:
 
 ```sh
-$ cargo build --target wasm32-unknown-unknown --release
+$ cargo build -p wasi-preview1-component-adapter --target wasm32-unknown-unknown --release
 ```
 
 And the artifact will be located at
 `target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm`.
-Alternatively the latest copy of this can be [downloaded from the `dev` tag
-assets ][dev-tag]
+
+This by default builds a "reactor" adapter which means that it only provides
+adaptation from preview1 to preview2. Alternatively you can also build a
+"command" adapter by passing `--features command --no-default-features` which
+will additionally export a `run` function entrypoint. This is suitable for use
+with preview1 binaries that export a `_start` function.
+
+Alternatively the latest copy of the command and reactor adapters can be
+[downloaded from the `dev` tag assets][dev-tag]
 
 [dev-tag]: https://github.com/bytecodealliance/wasmtime/releases/tag/dev
 


### PR DESCRIPTION
* Rename the binary artifact to `wasi_snapshot_preview1.wasm` and update build scripts to account for this.
* Update documentation to mention difference between reactor/command builds.

Closes #6569

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
