### PR TITLE
fuzzgen: Add `bb_padding_log2` option

### DIFF
--- a/cranelift/fuzzgen/src/config.rs
+++ b/cranelift/fuzzgen/src/config.rs
@@ -63,6 +63,10 @@ pub struct Config {
     /// them, but probably at a lower rate, so that overall execution time isn't
     /// impacted as much
     pub compile_flag_ratio: HashMap<&'static str, (usize, usize)>,
+
+    /// Range of values for the padding between basic blocks. Larger values will
+    /// generate larger functions.
+    pub bb_padding_log2_size: RangeInclusive<usize>,
 }
 
 impl Default for Config {
@@ -101,6 +105,11 @@ impl Default for Config {
             allowed_int_divz_ratio: (1, 1_000_000),
             allowed_fcvt_traps_ratio: (1, 1_000_000),
             compile_flag_ratio: [("regalloc_checker", (1usize, 1000))].into_iter().collect(),
+            // Generate up to 4KiB of padding between basic blocks. Although we only
+            // explicitly generate up to 16 blocks, after SSA construction we can
+            // end up with way more blocks than that (Seeing 400 blocks is not uncommon).
+            // At 4KiB we end up at around 1.5MiB of padding per function, which seems reasonable.
+            bb_padding_log2_size: 0..=12,
         }
     }
 }

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -215,6 +215,12 @@ where
             builder.set("probestack_size_log2", &format!("{}", size))?;
         }
 
+        // Generate random basic block padding
+        let bb_padding = self
+            .u
+            .int_in_range(self.config.bb_padding_log2_size.clone())?;
+        builder.set("bb_padding_log2_minus_one", &format!("{}", bb_padding))?;
+
         // Fixed settings
 
         // We need llvm ABI extensions for i128 values on x86, so enable it regardless of


### PR DESCRIPTION
👋 Hey,

This is a follow up PR to #6384, that allows fuzzgen to generate padding between basic blocks using the new `bb_padding_log2_size` cranelift setting.

I've fuzzed this with `icache` and `fuzzgen` for around an hour and it seems to be stable.