### PR TITLE
Fix a flaky poll_oneoff test

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_stdio.rs
@@ -103,15 +103,17 @@ unsafe fn test_stdout_stderr_write() {
             },
         },
     };
+    let mut timed_out = false;
     while !writable.is_empty() {
+        if timed_out {
+            panic!("timed out with the following pending subs: {:?}", writable)
+        }
         let mut subs = writable_subs(&writable);
         subs.push(clock.clone());
         let out = poll_oneoff_impl(&subs).unwrap();
         for event in out {
             match event.userdata {
-                CLOCK_ID => {
-                    panic!("timed out with the following pending subs: {:?}", writable)
-                }
+                CLOCK_ID => timed_out = true,
                 ud => {
                     if let Some(_) = writable.remove(&ud) {
                         assert_eq!(event.type_, wasi::EVENTTYPE_FD_WRITE);


### PR DESCRIPTION
This commit fixes a test that has failed on CI and seems flaky. This test asserts that stderr/stdout are writable and that a 200ms timeout does not elapse when calculating this. The implementation, on Windows at least, of `poll_oneoff` always reports stdout/stderr as "ready for write" meaning that this test should trivially pass. The flakiness comes from the timeout parameter where apparently sometimes on CI the determination of this takes more than 200ms. This means that the timer subscription may or may not fire depending on the timing of the test, and currently the test always fails if the timeout subscription fires.

This commit updates the test to store whether a timeout has passed and only fail if `poll_oneoff` is attempted when the timeout has already elapsed. This will allow the timeout to fire so long as the two streams are considered writable at the same time, achieving the desired result of the test to assert that, without timing out both stdout and stderr are considered writable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
