### PR TITLE
Fix some beta warnings in the C API

### DIFF
--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -106,7 +106,7 @@ pub unsafe extern "C" fn wasm_func_new_with_env(
 ) -> Box<wasm_func_t> {
     let finalizer = crate::ForeignData { data, finalizer };
     create_function(store, ty, move |params, results| {
-        drop(&finalizer); // move entire finalizer into this closure
+        let _ = &finalizer; // move entire finalizer into this closure
         callback(finalizer.data, params, results)
     })
 }
@@ -241,7 +241,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
 ) -> impl Fn(Caller<'_, crate::StoreData>, &[Val], &mut [Val]) -> Result<()> {
     let foreign = crate::ForeignData { data, finalizer };
     move |mut caller, params, results| {
-        drop(&foreign); // move entire foreign into this closure
+        let _ = &foreign; // move entire foreign into this closure
 
         // Convert `params/results` to `wasmtime_val_t`. Use the previous
         // storage in `hostcall_val_storage` to help avoid allocations all the
@@ -305,7 +305,7 @@ pub(crate) unsafe fn c_unchecked_callback_to_rust_fn(
 ) -> impl Fn(Caller<'_, crate::StoreData>, &mut [ValRaw]) -> Result<()> {
     let foreign = crate::ForeignData { data, finalizer };
     move |caller, values| {
-        drop(&foreign); // move entire foreign into this closure
+        let _ = &foreign; // move entire foreign into this closure
         let mut caller = wasmtime_caller_t { caller };
         match callback(foreign.data, &mut caller, values.as_mut_ptr(), values.len()) {
             None => Ok(()),


### PR DESCRIPTION
This'll make the future upgrade to Rust 1.71 that much more smoother.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
