### PR TITLE
fuzzgen: Generate Random Calling Convetions

### DIFF
--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -12,7 +12,7 @@ use target_lexicon::Architecture;
 /// A trait for generating random Cranelift datastructures.
 pub trait CraneliftArbitrary {
     fn _type(&mut self, architecture: Architecture) -> Result<Type>;
-    fn callconv(&mut self) -> Result<CallConv>;
+    fn callconv(&mut self, architecture: Architecture) -> Result<CallConv>;
     fn abi_param(&mut self, architecture: Architecture) -> Result<AbiParam>;
     fn signature(
         &mut self,
@@ -45,9 +45,30 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
         Ok(*self.choose(types_for_architecture(architecture))?)
     }
 
-    fn callconv(&mut self) -> Result<CallConv> {
-        // TODO: Generate random CallConvs per target
-        Ok(CallConv::SystemV)
+    fn callconv(&mut self, architecture: Architecture) -> Result<CallConv> {
+        // These are implemented and should work on all backends
+        let mut allowed_callconvs = vec![CallConv::Fast, CallConv::Cold, CallConv::SystemV];
+
+        // Tailcalls work everywhere except on s390x (See: #6530)
+        if architecture != Architecture::S390x {
+            allowed_callconvs.push(CallConv::Tail);
+        }
+
+        // Fastcall is suposed to work on x86 and aarch64
+        if matches!(
+            architecture,
+            Architecture::X86_64 | Architecture::Aarch64(_)
+        ) {
+            allowed_callconvs.push(CallConv::WindowsFastcall);
+        }
+
+        // AArch64 has a few Apple specific calling conventions
+        if matches!(architecture, Architecture::Aarch64(_)) {
+            allowed_callconvs.push(CallConv::AppleAarch64);
+        }
+
+        // We are missing Wasmtime* calling conventions since they do not support i128 values.
+        Ok(*self.choose(&allowed_callconvs[..])?)
     }
 
     fn abi_param(&mut self, architecture: Architecture) -> Result<AbiParam> {
@@ -77,7 +98,7 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
         max_params: usize,
         max_rets: usize,
     ) -> Result<Signature> {
-        let callconv = self.callconv()?;
+        let callconv = self.callconv(architecture)?;
         let mut sig = Signature::new(callconv);
 
         for _ in 0..max_params {

--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -46,13 +46,11 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
     }
 
     fn callconv(&mut self, architecture: Architecture) -> Result<CallConv> {
+        // We are missing Wasmtime* calling conventions since they do not support i128 values.
+        // TODO: Enable Tail Calls
+
         // These are implemented and should work on all backends
         let mut allowed_callconvs = vec![CallConv::Fast, CallConv::Cold, CallConv::SystemV];
-
-        // Tailcalls work everywhere except on s390x (See: #6530)
-        if architecture != Architecture::S390x {
-            allowed_callconvs.push(CallConv::Tail);
-        }
 
         // Fastcall is suposed to work on x86 and aarch64
         if matches!(
@@ -67,7 +65,6 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
             allowed_callconvs.push(CallConv::AppleAarch64);
         }
 
-        // We are missing Wasmtime* calling conventions since they do not support i128 values.
         Ok(*self.choose(&allowed_callconvs[..])?)
     }
 


### PR DESCRIPTION
👋 Hey,

This PR allows fuzzgen to start using different calling conventions in the functions it generates.

I've disabled the `tail` calling convention for now since it's causing segfaults on x86 and wrong results on AArch64. (I'm also not sure if I should report that or if that's still expected? cc: @fitzgen )

Wasmtime calling conventions are also disabled since they don't support `i128` values, and avoiding generating those is a bit difficult for now.

I've fuzzed this under fuzzgen on both x86 and AArch64 for around an hour and it seems stable.