### PR TITLE
riscv64: Implement SIMD `popcnt`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -272,7 +272,7 @@ impl VecAluOpRRR {
             | VecAluOpRRR::VfsubVV
             | VecAluOpRRR::VfsubVF => 0b000010,
             VecAluOpRRR::VrsubVX => 0b000011,
-            VecAluOpRRR::VmulVV => 0b100101,
+            VecAluOpRRR::VmulVV | VecAluOpRRR::VmulVX => 0b100101,
             VecAluOpRRR::VmulhVV => 0b100111,
             VecAluOpRRR::VmulhuVV | VecAluOpRRR::VfmulVV | VecAluOpRRR::VfmulVF => 0b100100,
             VecAluOpRRR::VsllVV | VecAluOpRRR::VsllVX => 0b100101,
@@ -349,7 +349,8 @@ impl VecAluOpRRR {
             | VecAluOpRRR::VwsubVX
             | VecAluOpRRR::VwsubuVX
             | VecAluOpRRR::VwsubuWX
-            | VecAluOpRRR::VwsubWX => VecOpCategory::OPMVX,
+            | VecAluOpRRR::VwsubWX
+            | VecAluOpRRR::VmulVX => VecOpCategory::OPMVX,
             VecAluOpRRR::VaddVX
             | VecAluOpRRR::VsaddVX
             | VecAluOpRRR::VsadduVX

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -143,6 +143,7 @@
   (VwsubuWX)
   (VssubVX)
   (VssubuVX)
+  (VmulVX)
   (VsllVX)
   (VsrlVX)
   (VsraVX)
@@ -530,6 +531,11 @@
 (decl rv_vmul_vv (VReg VReg VecOpMasking VState) VReg)
 (rule (rv_vmul_vv vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VmulVV) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vmul.vx` instruction.
+(decl rv_vmul_vx (VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vmul_vx vs2 vs1 mask vstate)
+  (vec_alu_rrr (VecAluOpRRR.VmulVX) vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `vmulh.vv` instruction.
 (decl rv_vmulh_vv (VReg VReg VecOpMasking VState) VReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -725,10 +725,55 @@
   (rv_sraiw x y))
 
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule (lower (has_type (fits_in_64 ty) (popcnt x)))
+
+(rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (popcnt x)))
   (lower_popcnt x ty))
+
 (rule 1 (lower (has_type $I128 (popcnt x)))
   (lower_popcnt_i128 x))
+
+;; Popcount using multiply.
+;; This is popcount64c() from
+;; http://en.wikipedia.org/wiki/Hamming_weight
+;;
+;; Here's the C version for 32 bits:
+;;  x = x - ((x>> 1) & 0x55555555);
+;;  x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+;;  x = ((x + (x >> 4)) & 0x0F0F0F0F);
+;;  return (x * 0x01010101) >> 24; // Here 24 is the type width - 8.
+;;
+;; TODO: LLVM generates a much better implementation for I8X16. See: https://godbolt.org/z/qr6vf9Gr3
+;; For the other types it seems to be largely the same.
+(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (popcnt x)))
+  (if-let one (u64_to_uimm5 1))
+  (if-let two (u64_to_uimm5 2))
+  (if-let four (u64_to_uimm5 4))
+
+  (let (;; x = x - ((x >> 1) & 0x55555555);
+        (mask_55 XReg (imm (lane_type ty) (u64_and 0x5555555555555555 (ty_mask (lane_type ty)))))
+        (count2_shr VReg (rv_vsrl_vi x one (unmasked) ty))
+        (count2_and VReg (rv_vand_vx count2_shr mask_55 (unmasked) ty))
+        (count2 VReg (rv_vsub_vv x count2_and (unmasked) ty))
+
+        ;; x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+        (mask_33 XReg (imm (lane_type ty) (u64_and 0x3333333333333333 (ty_mask (lane_type ty)))))
+        (count4_shr VReg (rv_vsrl_vi count2 two (unmasked) ty))
+        (count4_and VReg (rv_vand_vx count4_shr mask_33 (unmasked) ty))
+        (count4_lhs VReg (rv_vand_vx count2 mask_33 (unmasked) ty))
+        (count4 VReg (rv_vadd_vv count4_lhs count4_and (unmasked) ty))
+
+        ;; x = (x + (x >> 4)) & 0x0F0F0F0F;
+        (mask_0f XReg (imm (lane_type ty) (u64_and 0x0f0f0f0f0f0f0f0f (ty_mask (lane_type ty)))))
+        (count8_shr VReg (rv_vsrl_vi count4 four (unmasked) ty))
+        (count8_add VReg (rv_vadd_vv count4 count8_shr (unmasked) ty))
+        (count8 VReg (rv_vand_vx count8_add mask_0f (unmasked) ty))
+
+        ;; (x * 0x01010101) >> (<ty_width> - 8)
+        (mask_01 XReg (imm (lane_type ty) (u64_and 0x0101010101010101 (ty_mask (lane_type ty)))))
+        (mul VReg (rv_vmul_vx count8 mask_01 (unmasked) ty))
+        (shift XReg (imm $I64 (u64_sub (ty_bits (lane_type ty)) 8)))
+        (res VReg (rv_vsrl_vx mul shift (unmasked) ty)))
+    res))
 
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
@@ -1,0 +1,316 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %popcnt_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = popcnt v0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a1,85
+;   vsrl.vi v6,v1,1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v8,v6,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vsub.vv v10,v1,v8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   li t4,51
+;   vsrl.vi v14,v10,2 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v16,v14,t4 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v18,v10,t4 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vv v20,v18,v16 #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a6,15
+;   vsrl.vi v24,v20,4 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vv v26,v20,v24 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vand.vx v28,v26,a6 #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a1,1
+;   vmul.vx v0,v28,a1 #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a5,0
+;   vsrl.vx v4,v0,a5 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a1, zero, 0x55
+;   .byte 0x57, 0xb3, 0x10, 0xa2
+;   .byte 0x57, 0xc4, 0x65, 0x26
+;   .byte 0x57, 0x05, 0x14, 0x0a
+;   addi t4, zero, 0x33
+;   .byte 0x57, 0x37, 0xa1, 0xa2
+;   .byte 0x57, 0xc8, 0xee, 0x26
+;   .byte 0x57, 0xc9, 0xae, 0x26
+;   .byte 0x57, 0x0a, 0x28, 0x03
+;   addi a6, zero, 0xf
+;   .byte 0x57, 0x3c, 0x42, 0xa3
+;   .byte 0x57, 0x0d, 0x4c, 0x03
+;   .byte 0x57, 0x4e, 0xa8, 0x27
+;   addi a1, zero, 1
+;   .byte 0x57, 0xe0, 0xc5, 0x97
+;   mv a5, zero
+;   .byte 0x57, 0xc2, 0x07, 0xa2
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %popcnt_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = popcnt v0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   lui a2,5
+;   addi a2,a2,1365
+;   vsrl.vi v8,v1,1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v10,v8,a2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vsub.vv v12,v1,v10 #avl=8, #vtype=(e16, m1, ta, ma)
+;   lui t2,3
+;   addi t2,t2,819
+;   vsrl.vi v18,v12,2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v20,v18,t2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v22,v12,t2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vadd.vv v24,v22,v20 #avl=8, #vtype=(e16, m1, ta, ma)
+;   lui t1,1
+;   addi t1,t1,3855
+;   vsrl.vi v30,v24,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vadd.vv v0,v24,v30 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v2,v0,t1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   li a7,257
+;   vmul.vx v6,v2,a7 #avl=8, #vtype=(e16, m1, ta, ma)
+;   li t1,8
+;   vsrl.vx v10,v6,t1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v10,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   lui a2, 5
+;   addi a2, a2, 0x555
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0xb4, 0x10, 0xa2
+;   .byte 0x57, 0x45, 0x86, 0x26
+;   .byte 0x57, 0x06, 0x15, 0x0a
+;   lui t2, 3
+;   addi t2, t2, 0x333
+;   .byte 0x57, 0x39, 0xc1, 0xa2
+;   .byte 0x57, 0xca, 0x23, 0x27
+;   .byte 0x57, 0xcb, 0xc3, 0x26
+;   .byte 0x57, 0x0c, 0x6a, 0x03
+;   lui t1, 1
+;   addi t1, t1, -0xf1
+;   .byte 0x57, 0x3f, 0x82, 0xa3
+;   .byte 0x57, 0x00, 0x8f, 0x03
+;   .byte 0x57, 0x41, 0x03, 0x26
+;   addi a7, zero, 0x101
+;   .byte 0x57, 0xe3, 0x28, 0x96
+;   addi t1, zero, 8
+;   .byte 0x57, 0x45, 0x63, 0xa2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x05, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %popcnt_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = popcnt v0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   lui a2,349525
+;   addi a2,a2,1365
+;   vsrl.vi v8,v1,1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v10,v8,a2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vsub.vv v12,v1,v10 #avl=4, #vtype=(e32, m1, ta, ma)
+;   lui t2,209715
+;   addi t2,t2,819
+;   vsrl.vi v18,v12,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v20,v18,t2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v22,v12,t2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vadd.vv v24,v22,v20 #avl=4, #vtype=(e32, m1, ta, ma)
+;   lui t1,61681
+;   addi t1,t1,3855
+;   vsrl.vi v30,v24,4 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vadd.vv v0,v24,v30 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v2,v0,t1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   lui t3,4112
+;   addi t3,t3,257
+;   vmul.vx v8,v2,t3 #avl=4, #vtype=(e32, m1, ta, ma)
+;   li a1,24
+;   vsrl.vx v12,v8,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   lui a2, 0x55555
+;   addi a2, a2, 0x555
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0xb4, 0x10, 0xa2
+;   .byte 0x57, 0x45, 0x86, 0x26
+;   .byte 0x57, 0x06, 0x15, 0x0a
+;   lui t2, 0x33333
+;   addi t2, t2, 0x333
+;   .byte 0x57, 0x39, 0xc1, 0xa2
+;   .byte 0x57, 0xca, 0x23, 0x27
+;   .byte 0x57, 0xcb, 0xc3, 0x26
+;   .byte 0x57, 0x0c, 0x6a, 0x03
+;   lui t1, 0xf0f1
+;   addi t1, t1, -0xf1
+;   .byte 0x57, 0x3f, 0x82, 0xa3
+;   .byte 0x57, 0x00, 0x8f, 0x03
+;   .byte 0x57, 0x41, 0x03, 0x26
+;   lui t3, 0x1010
+;   addi t3, t3, 0x101
+;   .byte 0x57, 0x64, 0x2e, 0x96
+;   addi a1, zero, 0x18
+;   .byte 0x57, 0xc6, 0x85, 0xa2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x06, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %popcnt_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = popcnt v0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   auipc a1,0; ld a1,12(a1); j 12; .8byte 0x5555555555555555
+;   vsrl.vi v6,v1,1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vand.vx v8,v6,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vsub.vv v10,v1,v8 #avl=2, #vtype=(e64, m1, ta, ma)
+;   auipc t4,0; ld t4,12(t4); j 12; .8byte 0x3333333333333333
+;   vsrl.vi v14,v10,2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vand.vx v16,v14,t4 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vand.vx v18,v10,t4 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vadd.vv v20,v18,v16 #avl=2, #vtype=(e64, m1, ta, ma)
+;   auipc a6,0; ld a6,12(a6); j 12; .8byte 0xf0f0f0f0f0f0f0f
+;   vsrl.vi v24,v20,4 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vadd.vv v26,v20,v24 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vand.vx v28,v26,a6 #avl=2, #vtype=(e64, m1, ta, ma)
+;   auipc a1,0; ld a1,12(a1); j 12; .8byte 0x101010101010101
+;   vmul.vx v0,v28,a1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a5,56
+;   vsrl.vx v4,v0,a5 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v4,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   auipc a1, 0
+;   ld a1, 0xc(a1)
+;   j 0xc
+;   .byte 0x55, 0x55, 0x55, 0x55
+;   .byte 0x55, 0x55, 0x55, 0x55
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xb3, 0x10, 0xa2
+;   .byte 0x57, 0xc4, 0x65, 0x26
+;   .byte 0x57, 0x05, 0x14, 0x0a
+;   auipc t4, 0
+;   ld t4, 0xc(t4)
+;   j 0xc
+;   .byte 0x33, 0x33, 0x33, 0x33
+;   .byte 0x33, 0x33, 0x33, 0x33
+;   .byte 0x57, 0x37, 0xa1, 0xa2
+;   .byte 0x57, 0xc8, 0xee, 0x26
+;   .byte 0x57, 0xc9, 0xae, 0x26
+;   .byte 0x57, 0x0a, 0x28, 0x03
+;   auipc a6, 0
+;   ld a6, 0xc(a6)
+;   j 0xc
+;   .byte 0x0f, 0x0f, 0x0f, 0x0f
+;   .byte 0x0f, 0x0f, 0x0f, 0x0f
+;   .byte 0x57, 0x3c, 0x42, 0xa3
+;   .byte 0x57, 0x0d, 0x4c, 0x03
+;   .byte 0x57, 0x4e, 0xa8, 0x27
+;   auipc a1, 0
+;   ld a1, 0xc(a1)
+;   j 0xc
+;   .byte 0x01, 0x01, 0x01, 0x01
+;   .byte 0x01, 0x01, 0x01, 0x01
+;   .byte 0x57, 0xe0, 0xc5, 0x97
+;   addi a5, zero, 0x38
+;   .byte 0x57, 0xc2, 0x07, 0xa2
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x02, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
@@ -1,0 +1,38 @@
+test interpret
+test run
+target aarch64
+target s390x
+target riscv64 has_v
+
+;; This file contains tests for the popcnt instruction with element sizes larger than i8.
+;; X86 does not support these yet, but we should merge this with the main file once it does.
+
+function %popcnt_i16x8(i16x8) -> i16x8 {
+block0(v0: i16x8):
+    v1 = popcnt v0
+    return v1
+}
+; run: %popcnt_i16x8([1 1 1 1 1 1 1 1]) == [1 1 1 1 1 1 1 1]
+; run: %popcnt_i16x8([0x4000 0x4000 0x4000 0x4000 0x4000 0x4000 0x4000 0x4000]) == [1 1 1 1 1 1 1 1]
+; run: %popcnt_i16x8([-1 -1 -1 -1 -1 -1 -1 -1]) == [16 16 16 16 16 16 16 16]
+; run: %popcnt_i16x8([0 0 0 0 0 0 0 0]) == [0 0 0 0 0 0 0 0]
+
+function %popcnt_i32x4(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = popcnt v0
+    return v1
+}
+; run: %popcnt_i32x4([1 1 1 1]) == [1 1 1 1]
+; run: %popcnt_i32x4([0x40000000 0x40000000 0x40000000 0x40000000]) == [1 1 1 1]
+; run: %popcnt_i32x4([-1 -1 -1 -1]) == [32 32 32 32]
+; run: %popcnt_i32x4([0 0 0 0]) == [0 0 0 0]
+
+function %popcnt_i64x2(i64x2) -> i64x2 {
+block0(v0: i64x2):
+    v1 = popcnt v0
+    return v1
+}
+; run: %popcnt_i64x2([1 1]) == [1 1]
+; run: %popcnt_i64x2([0x4000000000000000 0x4000000000000000]) == [1 1]
+; run: %popcnt_i64x2([-1 -1]) == [64 64]
+; run: %popcnt_i64x2([0 0]) == [0 0]

--- a/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-target aarch64
 target s390x
 target riscv64 has_v
 

--- a/cranelift/filetests/filetests/runtests/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt.clif
@@ -1,0 +1,18 @@
+test interpret
+test run
+target aarch64
+target s390x
+set enable_simd
+target x86_64 sse42
+target x86_64 sse42 has_avx has_avx512vl has_avx512bitalg
+target riscv64 has_v
+
+function %popcnt_i8x16(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = popcnt v0
+    return v1
+}
+; run: %popcnt_i8x16([1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]) == [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+; run: %popcnt_i8x16([0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40 0x40]) == [1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1]
+; run: %popcnt_i8x16([-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]) == [8 8 8 8 8 8 8 8 8 8 8 8 8 8 8 8]
+; run: %popcnt_i8x16([0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]) == [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]


### PR DESCRIPTION
👋 Hey,

This PR Implements the SIMD `popcnt` instruction for RISC-V.  We don't have a native version of this, so we need to use one of the popular algorithms that normally replaces the native instruction. This is the variant that [LLVM uses](https://godbolt.org/z/qr6vf9Gr3) for element types larger than `i8`, they also have a shorter implementation for `i8x16`, but I didn't implement it here.

I also checked what V8 produces and they do a loop that sums each bit. In our case that would involve having a custom instruction and I didn't really want to do that.