### PR TITLE
x64: Gate usages of `palignr` on SSSE3

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3641,10 +3641,12 @@
 ;; to the lower lanes first.
 (rule 1 (lower (has_type $I16X8 (swiden_high val @ (value_type $I8X16))))
         (if-let $true (use_sse41))
+        (if-let $true (use_ssse3))
         (let ((x Xmm val))
           (x64_pmovsxbw (x64_palignr x x 8))))
 (rule 1 (lower (has_type $I32X4 (swiden_high val @ (value_type $I16X8))))
         (if-let $true (use_sse41))
+        (if-let $true (use_ssse3))
         (let ((x Xmm val))
           (x64_pmovsxwd (x64_palignr x x 8))))
 (rule 1 (lower (has_type $I64X2 (swiden_high val @ (value_type $I32X4))))
@@ -4105,6 +4107,7 @@
 ;; operand as the low-order bytes and the first operand as high-order bytes,
 ;; so put `a` second.
 (rule 13 (lower (shuffle a b (palignr_imm_from_immediate n)))
+         (if-let $true (use_ssse3))
          (x64_palignr b a n))
 (decl palignr_imm_from_immediate (u8) Immediate)
 (extern extractor palignr_imm_from_immediate palignr_imm_from_immediate)

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target s390x
+target x86_64 sse41 has_ssse3=false
 set enable_simd
 target x86_64
 target x86_64 sse41


### PR DESCRIPTION
A `shuffle` specialization can fall-back to the default implementation and otherwise two other rules already gated on SSE4.1 for other instructions needs a second clause for SSSE3 as well.

Note that the `shuffle` variant will get tested in a subsequent commit that adds a `pshufb` fallback.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
