### PR TITLE
Add a `set_random` function to `WasiCtxBuilder`.

### DIFF
--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -116,7 +116,7 @@ impl WasiCtxBuilder {
     /// Set the generator for the secure random number generator.
     ///
     /// This initializes the random number generator using
-    /// [`rand::thread_rng`].
+    /// [`cap_rand::thread_rng`].
     pub fn set_secure_random(mut self) -> Self {
         self.random = Some(random::thread_rng());
         self
@@ -133,6 +133,8 @@ impl WasiCtxBuilder {
     /// unpredictable random data in order to maintain its security invariants,
     /// and ideally should use the insecure random API otherwise, so using any
     /// prerecorded or otherwise predictable data may compromise security.
+    ///
+    /// [`set_secure_random`]: Self::set_secure_random
     pub fn set_secure_random_to_custom_generator(
         mut self,
         random: impl RngCore + Send + Sync + 'static,

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -133,7 +133,10 @@ impl WasiCtxBuilder {
     /// unpredictable random data in order to maintain its security invariants,
     /// and ideally should use the insecure random API otherwise, so using any
     /// prerecorded or otherwise predictable data may compromise security.
-    pub fn set_secure_random_to_custom_generator(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
+    pub fn set_secure_random_to_custom_generator(
+        mut self,
+        random: impl RngCore + Send + Sync + 'static,
+    ) -> Self {
         self.random = Some(Box::new(random));
         self
     }

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -41,7 +41,7 @@ impl WasiCtxBuilder {
             .set_stdin(pipe::ReadPipe::new(std::io::empty()))
             .set_stdout(pipe::WritePipe::new(std::io::sink()))
             .set_stderr(pipe::WritePipe::new(std::io::sink()))
-            .set_random();
+            .set_secure_random();
         result
     }
 
@@ -117,16 +117,23 @@ impl WasiCtxBuilder {
     ///
     /// This initializes the random number generator using
     /// [`rand::thread_rng`].
-    pub fn set_random(mut self) -> Self {
+    pub fn set_secure_random(mut self) -> Self {
         self.random = Some(random::thread_rng());
         self
     }
 
-    /// Set the generator for the secure random number generator. This
-    /// is only avalabile under `cfg(test)` as it's only intended for use
-    /// by tests.
-    #[cfg(test)]
-    pub fn set_random_for_testing(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
+    /// Set the generator for the secure random number generator to a custom
+    /// generator.
+    ///
+    /// This function is usually not needed; use [`set_secure_random`] to
+    /// install the default generator, which is intended to be sufficient for
+    /// most use cases.
+    ///
+    /// Guest code may rely on this random number generator to produce fresh
+    /// unpredictable random data in order to maintain its security invariants,
+    /// and ideally should use the insecure random API otherwise, so using any
+    /// prerecorded or otherwise predictable data may compromise security.
+    pub fn set_secure_random_to_custom_generator(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
         self.random = Some(Box::new(random));
         self
     }

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -34,14 +34,14 @@ impl WasiCtxBuilder {
         let insecure_random_seed =
             cap_rand::thread_rng(cap_rand::ambient_authority()).gen::<u128>();
 
-        let mut result = Self::default()
+        let result = Self::default()
             .set_clocks(clocks::host::clocks_ctx())
             .set_insecure_random(insecure_random)
             .set_insecure_random_seed(insecure_random_seed)
             .set_stdin(pipe::ReadPipe::new(std::io::empty()))
             .set_stdout(pipe::WritePipe::new(std::io::sink()))
-            .set_stderr(pipe::WritePipe::new(std::io::sink()));
-        result.random = Some(random::thread_rng());
+            .set_stderr(pipe::WritePipe::new(std::io::sink()))
+            .set_random();
         result
     }
 
@@ -113,11 +113,20 @@ impl WasiCtxBuilder {
         self
     }
 
+    /// Set the generator for the secure random number generator.
+    ///
+    /// This initializes the random number generator using
+    /// [`rand::thread_rng`].
+    pub fn set_random(mut self) -> Self {
+        self.random = Some(random::thread_rng());
+        self
+    }
+
     /// Set the generator for the secure random number generator. This
     /// is only avalabile under `cfg(test)` as it's only intended for use
     /// by tests.
     #[cfg(test)]
-    pub fn set_random(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
+    pub fn set_random_for_testing(mut self, random: impl RngCore + Send + Sync + 'static) -> Self {
         self.random = Some(Box::new(random));
         self
     }


### PR DESCRIPTION
Add a `set_random` function to `WasiCtxBuilder`, allowing users that construct a default interface via `WasiCtxBuilder::default()` or `WasiCtx::builder()` to initialize the `random` state.

Fixes #6576.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
