### PR TITLE
Fix inconsistent deadlines for monotonic clock timeouts

### DIFF
--- a/crates/test-programs/tests/wasi-preview2-components.rs
+++ b/crates/test-programs/tests/wasi-preview2-components.rs
@@ -256,6 +256,8 @@ async fn poll_oneoff_files() {
     run("poll_oneoff_files", false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+// This is a known bug with the preview 2 implementation on Windows:
+#[cfg_attr(windows, should_panic)]
 async fn poll_oneoff_stdio() {
     run("poll_oneoff_stdio", true).await.unwrap()
 }

--- a/crates/test-programs/tests/wasi-preview2-components.rs
+++ b/crates/test-programs/tests/wasi-preview2-components.rs
@@ -256,8 +256,6 @@ async fn poll_oneoff_files() {
     run("poll_oneoff_files", false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-// This is a known bug with the preview 2 implementation:
-#[should_panic]
 async fn poll_oneoff_stdio() {
     run("poll_oneoff_stdio", true).await.unwrap()
 }

--- a/crates/wasi/src/preview2/sched/subscription.rs
+++ b/crates/wasi/src/preview2/sched/subscription.rs
@@ -62,7 +62,7 @@ impl<'a> RwSubscription<'a> {
 
 pub struct MonotonicClockSubscription<'a> {
     pub clock: &'a dyn WasiMonotonicClock,
-    pub deadline: u64,
+    pub absolute_deadline: u64,
 }
 
 impl<'a> MonotonicClockSubscription<'a> {
@@ -70,10 +70,10 @@ impl<'a> MonotonicClockSubscription<'a> {
         self.clock.now()
     }
     pub fn duration_until(&self) -> Option<u64> {
-        self.deadline.checked_sub(self.now())
+        self.absolute_deadline.checked_sub(self.now())
     }
     pub fn result(&self) -> Option<Result<(), Error>> {
-        if self.now().checked_sub(self.deadline).is_some() {
+        if self.now() >= self.absolute_deadline {
             Some(Ok(()))
         } else {
             None

--- a/crates/wasi/src/preview2/sched/sync.rs
+++ b/crates/wasi/src/preview2/sched/sync.rs
@@ -84,7 +84,7 @@ pub(crate) async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                 //
                 // TODO: On Linux and FreeBSD, we could use `ppoll` instead
                 // which takes a `timespec.`
-                ((t.deadline + 999_999) / 1_000_000)
+                ((t.absolute_deadline.saturating_sub(t.clock.now()) + 999_999) / 1_000_000)
                     .try_into()
                     .map_err(|_| anyhow::anyhow!("overflow: poll timeout"))?
             } else {


### PR DESCRIPTION
Rename `MonotonicClockSubscription`'s `deadline` field to `absolute_deadline` and change the code that computes the value to compute an absolute time rather than a relative time, so that it's interpreted consistently everywhere.

Fixes #6588.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
