### PR TITLE
riscv64: Implement Integer Narrowing SIMD Instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -542,6 +542,8 @@ impl VecAluOpRRImm5 {
             VecAluOpRRImm5::VsaddVI => 0b100001,
             VecAluOpRRImm5::VrgatherVI => 0b001100,
             VecAluOpRRImm5::VmvrV => 0b100111,
+            VecAluOpRRImm5::VnclipWI => 0b101111,
+            VecAluOpRRImm5::VnclipuWI => 0b101110,
             VecAluOpRRImm5::VmseqVI => 0b011000,
             VecAluOpRRImm5::VmsneVI => 0b011001,
             VecAluOpRRImm5::VmsleuVI => 0b011100,
@@ -568,6 +570,8 @@ impl VecAluOpRRImm5 {
             | VecAluOpRRImm5::VsaddVI
             | VecAluOpRRImm5::VrgatherVI
             | VecAluOpRRImm5::VmvrV
+            | VecAluOpRRImm5::VnclipWI
+            | VecAluOpRRImm5::VnclipuWI
             | VecAluOpRRImm5::VmseqVI
             | VecAluOpRRImm5::VmsneVI
             | VecAluOpRRImm5::VmsleuVI
@@ -585,7 +589,9 @@ impl VecAluOpRRImm5 {
             | VecAluOpRRImm5::VsraVI
             | VecAluOpRRImm5::VslidedownVI
             | VecAluOpRRImm5::VrgatherVI
-            | VecAluOpRRImm5::VmvrV => true,
+            | VecAluOpRRImm5::VmvrV
+            | VecAluOpRRImm5::VnclipWI
+            | VecAluOpRRImm5::VnclipuWI => true,
             VecAluOpRRImm5::VaddVI
             | VecAluOpRRImm5::VrsubVI
             | VecAluOpRRImm5::VandVI

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -213,6 +213,8 @@
   ;; This opcode represents multiple instructions `vmv1r`/`vmv2r`/`vmv4r`/etc...
   ;; The immediate field specifies how many registers should be copied.
   (VmvrV)
+  (VnclipWI)
+  (VnclipuWI)
   (VmseqVI)
   (VmsneVI)
   (VmsleuVI)
@@ -1144,6 +1146,21 @@
 (decl rv_vsext_vf8 (VReg VecOpMasking VState) VReg)
 (rule (rv_vsext_vf8 vs mask vstate)
   (vec_alu_rr (VecAluOpRR.VsextVF8) vs mask vstate))
+
+;; Helper for emitting the `vnclip.wi` instruction.
+;;
+;; vd[i] = clip(roundoff_signed(vs2[i], uimm))
+(decl rv_vnclip_wi (VReg UImm5 VecOpMasking VState) VReg)
+(rule (rv_vnclip_wi vs2 imm mask vstate)
+  (vec_alu_rr_uimm5 (VecAluOpRRImm5.VnclipWI) vs2 imm mask vstate))
+
+;; Helper for emitting the `vnclipu.wi` instruction.
+;;
+;; vd[i] = clip(roundoff_unsigned(vs2[i], uimm))
+(decl rv_vnclipu_wi (VReg UImm5 VecOpMasking VState) VReg)
+(rule (rv_vnclipu_wi vs2 imm mask vstate)
+  (vec_alu_rr_uimm5 (VecAluOpRRImm5.VnclipuWI) vs2 imm mask vstate))
+
 
 ;;;; Multi-Instruction Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1903,3 +1903,36 @@
 
 (rule 2 (lower (has_type (ty_vec_fits_in_register ty) (sqmul_round_sat (splat x) y)))
   (rv_vsmul_vx y x (unmasked) ty))
+
+;;;; Rules for `snarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (ty_vec_fits_in_register out_ty) (snarrow x @ (value_type in_ty) y)))
+  (if-let lane_diff (u64_to_uimm5 (u64_udiv (ty_lane_count out_ty) 2)))
+  (if-let zero (u64_to_uimm5 0))
+  (let ((x_clip VReg (rv_vnclip_wi x zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty))))
+        (y_clip VReg (rv_vnclip_wi y zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty)))))
+    (rv_vslideup_vvi x_clip y_clip lane_diff (unmasked) out_ty)))
+
+;;;; Rules for `uunarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (has_type (ty_vec_fits_in_register out_ty) (uunarrow x @ (value_type in_ty) y)))
+  (if-let lane_diff (u64_to_uimm5 (u64_udiv (ty_lane_count out_ty) 2)))
+  (if-let zero (u64_to_uimm5 0))
+  (let ((x_clip VReg (rv_vnclipu_wi x zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty))))
+        (y_clip VReg (rv_vnclipu_wi y zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty)))))
+    (rv_vslideup_vvi x_clip y_clip lane_diff (unmasked) out_ty)))
+
+;;;; Rules for `unarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; We don't have a instruction that saturates a signed source into an unsigned destination.
+;; To correct for this we just remove negative values using `vmax` and then use the normal
+;; unsigned to unsigned narrowing instruction.
+
+(rule (lower (has_type (ty_vec_fits_in_register out_ty) (unarrow x @ (value_type in_ty) y)))
+  (if-let lane_diff (u64_to_uimm5 (u64_udiv (ty_lane_count out_ty) 2)))
+  (if-let zero (u64_to_uimm5 0))
+  (let ((x_pos VReg (rv_vmax_vx x (zero_reg) (unmasked) in_ty))
+        (y_pos VReg (rv_vmax_vx y (zero_reg) (unmasked) in_ty))
+        (x_clip VReg (rv_vnclipu_wi x_pos zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty))))
+        (y_clip VReg (rv_vnclipu_wi y_pos zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty)))))
+    (rv_vslideup_vvi x_clip y_clip lane_diff (unmasked) out_ty)))

--- a/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
@@ -1,0 +1,144 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = snarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclip.wi v8,v1,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vnclip.wi v9,v3,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vslideup.vi v8,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x34, 0x10, 0xbe
+;   .byte 0xd7, 0x34, 0x30, 0xbe
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x57, 0x34, 0x94, 0x3a
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %snarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = snarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclip.wi v8,v1,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vnclip.wi v9,v3,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vslideup.vi v8,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x34, 0x10, 0xbe
+;   .byte 0xd7, 0x34, 0x30, 0xbe
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x34, 0x92, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %snarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = snarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclip.wi v8,v1,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vnclip.wi v9,v3,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vslideup.vi v8,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x34, 0x10, 0xbe
+;   .byte 0xd7, 0x34, 0x30, 0xbe
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x34, 0x91, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
@@ -1,0 +1,159 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = unarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v6,v1,zero #avl=8, #vtype=(e16, m1, ta, ma)
+;   vmax.vx v8,v3,zero #avl=8, #vtype=(e16, m1, ta, ma)
+;   vnclipu.wi v12,v6,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vnclipu.wi v13,v8,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vslideup.vi v12,v13,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x43, 0x10, 0x1e
+;   .byte 0x57, 0x44, 0x30, 0x1e
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x36, 0x60, 0xba
+;   .byte 0xd7, 0x36, 0x80, 0xba
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x57, 0x36, 0xd4, 0x3a
+;   .byte 0x27, 0x06, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %unarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = unarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v6,v1,zero #avl=4, #vtype=(e32, m1, ta, ma)
+;   vmax.vx v8,v3,zero #avl=4, #vtype=(e32, m1, ta, ma)
+;   vnclipu.wi v12,v6,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vnclipu.wi v13,v8,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vslideup.vi v12,v13,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x43, 0x10, 0x1e
+;   .byte 0x57, 0x44, 0x30, 0x1e
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x36, 0x60, 0xba
+;   .byte 0xd7, 0x36, 0x80, 0xba
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x36, 0xd2, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x06, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %unarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = unarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmax.vx v6,v1,zero #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmax.vx v8,v3,zero #avl=2, #vtype=(e64, m1, ta, ma)
+;   vnclipu.wi v12,v6,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vnclipu.wi v13,v8,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vslideup.vi v12,v13,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0x43, 0x10, 0x1e
+;   .byte 0x57, 0x44, 0x30, 0x1e
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x36, 0x60, 0xba
+;   .byte 0xd7, 0x36, 0x80, 0xba
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x36, 0xd1, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x06, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
@@ -1,0 +1,144 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+function %uunarrow_i16x8(i16x8, i16x8) -> i8x16 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = uunarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclipu.wi v8,v1,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vnclipu.wi v9,v3,0 #avl=8, #vtype=(e8, mf2, ta, ma)
+;   vslideup.vi v8,v9,8 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x74, 0xcc
+;   .byte 0x57, 0x34, 0x10, 0xba
+;   .byte 0xd7, 0x34, 0x30, 0xba
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x57, 0x34, 0x94, 0x3a
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %uunarrow_i32x4(i32x4, i32x4) -> i16x8 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = uunarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclipu.wi v8,v1,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vnclipu.wi v9,v3,0 #avl=4, #vtype=(e16, mf2, ta, ma)
+;   vslideup.vi v8,v9,4 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0xf2, 0xcc
+;   .byte 0x57, 0x34, 0x10, 0xba
+;   .byte 0xd7, 0x34, 0x30, 0xba
+;   .byte 0x57, 0x70, 0x84, 0xcc
+;   .byte 0x57, 0x34, 0x92, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %uunarrow_i64x2(i64x2, i64x2) -> i32x4 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = uunarrow v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnclipu.wi v8,v1,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vnclipu.wi v9,v3,0 #avl=2, #vtype=(e32, mf2, ta, ma)
+;   vslideup.vi v8,v9,2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x71, 0xcd
+;   .byte 0x57, 0x34, 0x10, 0xba
+;   .byte 0xd7, 0x34, 0x30, 0xba
+;   .byte 0x57, 0x70, 0x02, 0xcd
+;   .byte 0x57, 0x34, 0x91, 0x3a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 ; x86_64 considers the case `i64x2` -> `i32x4` to be 'unreachable'
+target riscv64 has_v
 
 function %snarrow_i64x2(i64x2, i64x2) -> i32x4 {
 block0(v0: i64x2, v1: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -5,6 +5,7 @@ target s390x
 set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target riscv64 has_v
 
 function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 ; x86_64 considers the case `i64x2 -> i32x4` to be 'unreachable'
+target riscv64 has_v
 
 function %unarrow_i64x2(i64x2, i64x2) -> i32x4 {
 block0(v0: i64x2, v1: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -7,6 +7,7 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+target riscv64 has_v
 
 function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 ; x86_64 panics: `Did not match fcvt input!
 ; thread 'worker #0' panicked at 'register allocation: Analysis(EntryLiveinValues([v2V]))', cranelift/codegen/src/machinst/compile.rs:96:10`
+target riscv64 has_v
 
 function %uunarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):


### PR DESCRIPTION
👋 Hey,

This PR implements some of the integer narrowing instructions (`{s,u,uu}narrow`). We don't have an exact native instruction for this, so the general strategy is to narrow each input individually and then merge them together.