### PR TITLE
winch(x64): Add support for `loop`, `br` and `br_if`

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -359,7 +359,10 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | End { .. }
                         | If { .. }
                         | Else { .. }
-                        | Block { .. } => {}
+                        | Block { .. }
+                        | Loop { .. }
+                        | Br { .. }
+                        | BrIf { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -156,7 +156,7 @@ impl ABIArg {
 }
 
 /// ABI-specific representation of the function result.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum ABIResult {
     Reg {
         /// Type of the result.

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -30,6 +30,8 @@ pub(crate) struct CodeGenContext<'a> {
     pub stack: Stack,
     /// The current function's frame.
     pub frame: &'a Frame,
+    /// Reachability state.
+    pub reachable: bool,
 }
 
 impl<'a> CodeGenContext<'a> {
@@ -39,6 +41,7 @@ impl<'a> CodeGenContext<'a> {
             regalloc,
             stack,
             frame,
+            reachable: true,
         }
     }
 
@@ -241,6 +244,18 @@ impl<'a> CodeGenContext<'a> {
             }
         });
         self.stack.inner_mut().truncate(truncate);
+    }
+
+    /// Reset value and stack pointer to the given length
+    /// and stack pointer offset respectively.
+    pub fn reset_stack<M: MacroAssembler>(
+        &mut self,
+        masm: &mut M,
+        stack_len: usize,
+        sp_offset: u32,
+    ) {
+        masm.reset_stack_pointer(sp_offset);
+        self.drop_last(self.stack.len() - stack_len);
     }
 
     /// Convenience wrapper around [`Self::spill_callback`].

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -39,6 +39,7 @@ use wasmtime_environ::WasmType;
 
 /// Holds the necessary metdata to support the emission
 /// of control flow instructions.
+#[derive(Debug)]
 pub(crate) enum ControlStackFrame {
     If {
         /// The if continuation label.
@@ -46,21 +47,47 @@ pub(crate) enum ControlStackFrame {
         /// The return values of the block.
         result: ABIResult,
         /// The size of the value stack at the beginning of the If.
-        original_stack_size: usize,
+        original_stack_len: usize,
+        /// The stack pointer offset at the beginning of the If.
+        original_sp_offset: u32,
+        /// Local reachability state when entering the block.
+        reachable: bool,
     },
     Else {
         /// The else continuation label.
         cont: MachLabel,
         /// The return values of the block.
         result: ABIResult,
-        /// The size of the value stack at the beginning of the If.
-        original_stack_size: usize,
+        /// The size of the value stack at the beginning of the Else.
+        original_stack_len: usize,
+        /// The stack pointer offset at the beginning of the Else.
+        original_sp_offset: u32,
+        /// Local reachability state when entering the block.
+        reachable: bool,
     },
     Block {
         /// The block exit label.
         exit: MachLabel,
         /// The size of the value stack at the beginning of the block.
-        original_stack_size: usize,
+        original_stack_len: usize,
+        /// The return values of the block.
+        result: ABIResult,
+        /// The stack pointer offset at the beginning of the Block.
+        original_sp_offset: u32,
+        /// Exit state of the block.
+        ///
+        /// This flag is used to dertermine if a block is a branch
+        /// target. By default, this is false, and it's updated when
+        /// emitting a `br` or `br_if`.
+        is_branch_target: bool,
+    },
+    Loop {
+        /// The start of the loop.
+        head: MachLabel,
+        /// The size of the value stack at the beginning of the block.
+        original_stack_len: usize,
+        /// The stack pointer offset at the beginning of the Block.
+        original_sp_offset: u32,
         /// The return values of the block.
         result: ABIResult,
     },
@@ -77,11 +104,29 @@ impl ControlStackFrame {
         let mut control = Self::If {
             cont: masm.get_label(),
             result,
-            original_stack_size: 0,
+            reachable: context.reachable,
+            original_stack_len: 0,
+            original_sp_offset: 0,
         };
 
         control.emit(masm, context);
         control
+    }
+
+    /// Creates a block that represents the base
+    /// block for the function body.
+    pub fn function_body_block<M: MacroAssembler>(
+        result: ABIResult,
+        masm: &mut M,
+        context: &mut CodeGenContext,
+    ) -> Self {
+        Self::Block {
+            original_stack_len: context.stack.len(),
+            result,
+            is_branch_target: false,
+            exit: masm.get_label(),
+            original_sp_offset: masm.sp_offset(),
+        }
     }
 
     /// Returns [`ControlStackFrame`] for a block.
@@ -92,9 +137,29 @@ impl ControlStackFrame {
     ) -> Self {
         let result = <M::ABI as ABI>::result(&returns, &CallingConvention::Default);
         let mut control = Self::Block {
-            original_stack_size: 0,
+            original_stack_len: 0,
             result,
+            is_branch_target: false,
             exit: masm.get_label(),
+            original_sp_offset: 0,
+        };
+
+        control.emit(masm, context);
+        control
+    }
+
+    /// Returns [`ControlStackFrame`] for a loop.
+    pub fn loop_<M: MacroAssembler>(
+        returns: &[WasmType],
+        masm: &mut M,
+        context: &mut CodeGenContext,
+    ) -> Self {
+        let result = <M::ABI as ABI>::result(&returns, &CallingConvention::Default);
+        let mut control = Self::Loop {
+            original_stack_len: 0,
+            result,
+            head: masm.get_label(),
+            original_sp_offset: 0,
         };
 
         control.emit(masm, context);
@@ -103,10 +168,17 @@ impl ControlStackFrame {
 
     fn emit<M: MacroAssembler>(&mut self, masm: &mut M, context: &mut CodeGenContext) {
         use ControlStackFrame::*;
+
+        // Do not perform any emissions if we are in an unreachable state.
+        if !context.reachable {
+            return;
+        }
+
         match self {
             If {
                 cont,
-                original_stack_size,
+                original_stack_len,
+                original_sp_offset,
                 ..
             } => {
                 // Pop the condition value.
@@ -115,19 +187,34 @@ impl ControlStackFrame {
                 // Unconditionall spill before emitting control flow.
                 context.spill(masm);
 
-                *original_stack_size = context.stack.len();
+                *original_stack_len = context.stack.len();
+                *original_sp_offset = masm.sp_offset();
                 masm.branch(CmpKind::Eq, top.into(), top.into(), *cont, OperandSize::S32);
                 context.free_gpr(top);
             }
             Block {
-                original_stack_size,
+                original_stack_len,
+                original_sp_offset,
                 ..
             } => {
                 // Unconditional spill before entering the block.
                 // We assume that there are no live registers when
                 // exiting the block.
                 context.spill(masm);
-                *original_stack_size = context.stack.len();
+                *original_stack_len = context.stack.len();
+                *original_sp_offset = masm.sp_offset();
+            }
+            Loop {
+                original_stack_len,
+                original_sp_offset,
+                head,
+                ..
+            } => {
+                // Unconditional spill before entering the loop block.
+                context.spill(masm);
+                *original_stack_len = context.stack.len();
+                *original_sp_offset = masm.sp_offset();
+                masm.bind(*head);
             }
             _ => unreachable!(),
         }
@@ -139,12 +226,11 @@ impl ControlStackFrame {
         use ControlStackFrame::*;
         match self {
             If {
-                cont,
                 result,
-                original_stack_size,
+                original_stack_len,
                 ..
             } => {
-                assert!((*original_stack_size + result.len()) == context.stack.len());
+                assert!((*original_stack_len + result.len()) == context.stack.len());
                 // Before emitting an unconditional jump to the exit branch,
                 // we handle the result of the if-then block.
                 context.pop_abi_results(&result, masm);
@@ -153,13 +239,45 @@ impl ControlStackFrame {
                 let exit_label = masm.get_label();
                 masm.jmp(exit_label);
                 // Bind the else branch.
+                self.bind_else(masm, Some(exit_label), context.reachable);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Binds the else branch label and converts `self` to
+    /// [`ControlStackFrame::Else`].
+    pub fn bind_else<M: MacroAssembler>(
+        &mut self,
+        masm: &mut M,
+        exit: Option<MachLabel>,
+        reachable: bool,
+    ) {
+        use ControlStackFrame::*;
+        match self {
+            If {
+                cont,
+                result,
+                original_stack_len,
+                original_sp_offset,
+                ..
+            } => {
+                // Bind the else branch.
                 masm.bind(*cont);
+
+                let label = if let Some(cont) = exit {
+                    cont
+                } else {
+                    masm.get_label()
+                };
 
                 // Update the stack control frame with an else control frame.
                 *self = ControlStackFrame::Else {
-                    cont: exit_label,
-                    original_stack_size: *original_stack_size,
+                    cont: label,
+                    original_stack_len: *original_stack_len,
                     result: *result,
+                    reachable,
+                    original_sp_offset: *original_sp_offset,
                 };
             }
             _ => unreachable!(),
@@ -171,37 +289,149 @@ impl ControlStackFrame {
         use ControlStackFrame::*;
         match self {
             If {
-                cont,
                 result,
-                original_stack_size,
+                original_stack_len,
                 ..
             }
             | Else {
-                cont,
                 result,
-                original_stack_size,
+                original_stack_len,
                 ..
             } => {
-                assert!((*original_stack_size + result.len()) == context.stack.len());
+                assert!((*original_stack_len + result.len()) == context.stack.len());
                 // Before binding the exit label, we handle the block results.
                 context.pop_abi_results(&result, masm);
-                // Then we push the block results ino the value stack.
-                context.push_abi_results(&result, masm);
-                // Bind the exit label.
-                masm.bind(*cont)
+                self.bind_end(masm, context);
             }
             Block {
-                original_stack_size,
+                original_stack_len,
                 result,
-                exit,
+                ..
             } => {
-                assert!((*original_stack_size + result.len()) == context.stack.len());
-                // Before exiting, handle block results.
+                assert!((*original_stack_len + result.len()) == context.stack.len());
                 context.pop_abi_results(&result, masm);
-                // Then, push the results to the value stack.
-                context.push_abi_results(&result, masm);
-                masm.bind(*exit);
+                self.bind_end(masm, context);
             }
+            Loop {
+                result,
+                original_stack_len,
+                ..
+            } => {
+                assert!((*original_stack_len + result.len()) == context.stack.len());
+            }
+        }
+    }
+
+    /// Binds the exit label of the current control stack frame and pushes the
+    /// ABI results to the value stack.
+    pub fn bind_end<M: MacroAssembler>(&self, masm: &mut M, context: &mut CodeGenContext) {
+        // Push the results to the value stack.
+        context.push_abi_results(self.result(), masm);
+        self.bind_exit_label(masm);
+    }
+
+    /// Binds the exit label of the control stack frame.
+    pub fn bind_exit_label<M: MacroAssembler>(&self, masm: &mut M) {
+        if let Some(label) = self.exit_label() {
+            masm.bind(*label);
+        }
+    }
+
+    /// Returns the continuation label of the current control stack frame.
+    pub fn label(&self) -> &MachLabel {
+        use ControlStackFrame::*;
+
+        match self {
+            If { cont, .. } | Else { cont, .. } => cont,
+            Block { exit, .. } => exit,
+            Loop { head, .. } => head,
+        }
+    }
+
+    /// Returns the exit label of the current control stack frame. Note that
+    /// this is similar to [`ControlStackFrame::label`], with the only difference that it
+    /// returns `None` for `Loop` since its label doesn't represent an exit.
+    fn exit_label(&self) -> Option<&MachLabel> {
+        use ControlStackFrame::*;
+
+        match self {
+            If { cont, .. } | Else { cont, .. } => Some(cont),
+            Block { exit, .. } => Some(exit),
+            Loop { .. } => None,
+        }
+    }
+
+    /// Set the current control stack frame as a branch target.
+    pub fn set_as_target(&mut self) {
+        match self {
+            ControlStackFrame::Block {
+                is_branch_target, ..
+            } => {
+                *is_branch_target = true;
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns [`crate::abi::ABIResult`] of the control stack frame
+    /// block.
+    pub fn result(&self) -> &ABIResult {
+        use ControlStackFrame::*;
+
+        match self {
+            If { result, .. }
+            | Else { result, .. }
+            | Block { result, .. }
+            | Loop { result, .. } => result,
+        }
+    }
+
+    /// This function is used at the end of unreachable code handling
+    /// to determine if the reachability status should be updated.
+    pub fn is_next_sequence_reachable(&self) -> bool {
+        use ControlStackFrame::*;
+
+        match self {
+            // For if/else, the reachability of the next sequence is determined
+            // by the reachability state at the start of the block. An else
+            // block will be reachable if the if block is also reachable at
+            // entry.
+            If { reachable, .. } | Else { reachable, .. } => *reachable,
+            // For blocks, the reachability of the next sequence is determined
+            // if they're a branch target.
+            Block {
+                is_branch_target, ..
+            } => *is_branch_target,
+            // Loops are not used for reachability analysis,
+            // given that they don't have exit branches.
+            Loop { .. } => false,
+        }
+    }
+
+    // TODO document.
+    pub fn original_stack_len_and_sp_offset(&self) -> (usize, u32) {
+        use ControlStackFrame::*;
+        match self {
+            If {
+                original_stack_len,
+                original_sp_offset,
+                ..
+            }
+            | Else {
+                original_stack_len,
+                original_sp_offset,
+                ..
+            }
+            | Block {
+                original_stack_len,
+                original_sp_offset,
+                ..
+            }
+            | Loop {
+                original_stack_len,
+                original_sp_offset,
+                ..
+            } => (*original_stack_len, *original_sp_offset),
         }
     }
 }

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -303,4 +303,10 @@ impl Assembler {
     pub fn get_label(&mut self) -> MachLabel {
         self.buffer.get_label()
     }
+
+    /// Get a mutable reference to underlying
+    /// machine buffer.
+    pub fn buffer_mut(&mut self) -> &mut MachBuffer<Inst> {
+        &mut self.buffer
+    }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -106,6 +106,10 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
+    fn reset_stack_pointer(&mut self, offset: u32) {
+        self.sp_offset = offset;
+    }
+
     fn local_address(&mut self, local: &LocalSlot) -> Address {
         let (reg, offset) = local
             .addressed_from_sp()
@@ -243,8 +247,9 @@ impl Masm for MacroAssembler {
         self.asm.get_label()
     }
 
-    fn bind(&mut self, _label: MachLabel) {
-        todo!()
+    fn bind(&mut self, label: MachLabel) {
+        let buffer = self.asm.buffer_mut();
+        buffer.bind_label(label, &mut Default::default());
     }
 
     fn branch(

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -88,6 +88,10 @@ impl Masm for MacroAssembler {
         self.decrement_sp(bytes);
     }
 
+    fn reset_stack_pointer(&mut self, offset: u32) {
+        self.sp_offset = offset;
+    }
+
     fn local_address(&mut self, local: &LocalSlot) -> Address {
         let (reg, offset) = local
             .addressed_from_sp()

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -167,6 +167,12 @@ pub(crate) trait MacroAssembler {
     /// Free stack space.
     fn free_stack(&mut self, bytes: u32);
 
+    /// Reset the stack pointer to the given offset;
+    ///
+    /// Used to reset the stack pointer to a given offset
+    /// when dealing with unreachable code.
+    fn reset_stack_pointer(&mut self, offset: u32);
+
     /// Get the address of a local slot.
     fn local_address(&mut self, local: &LocalSlot) -> Self::Address;
 

--- a/winch/filetests/filetests/x64/br/as_block_first.wat
+++ b/winch/filetests/filetests/x64/br/as_block_first.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-block-first")
+    (block (br 0) (call $dummy))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br/as_block_last.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-block-last")
+    (block (nop) (call $dummy) (br 0))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883c408             	add	rsp, 8
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_block_mid.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-block-mid")
+    (block (call $dummy) (br 0) (call $dummy))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883c408             	add	rsp, 8
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_block_value.wat
+++ b/winch/filetests/filetests/x64/br/as_block_value.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-block-value") (result i32)
+    (block (result i32) (nop) (call $dummy) (br 0 (i32.const 2)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_br_if_cond.wat
@@ -1,0 +1,13 @@
+;;! target = "x86_64"
+(module
+    (func (export "as-br_if-cond")
+    (block (br_if 0 (br 0)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br/as_br_value.wat
@@ -1,0 +1,14 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (br 0 (i32.const 9))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c009000000       	mov	rax, 9
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_all.wat
+++ b/winch/filetests/filetests/x64/br/as_call_all.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-all") (result i32)
+    (block (result i32) (call $f (br 0 (i32.const 15))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00f000000       	mov	rax, 0xf
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br/as_call_first.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-first") (result i32)
+    (block (result i32)
+      (call $f (br 0 (i32.const 12)) (i32.const 2) (i32.const 3))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00c000000       	mov	rax, 0xc
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br/as_call_last.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-last") (result i32)
+    (block (result i32)
+      (call $f (i32.const 1) (i32.const 2) (br 0 (i32.const 14)))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00e000000       	mov	rax, 0xe
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_call_mid.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-mid") (result i32)
+    (block (result i32)
+      (call $f (i32.const 1) (br 0 (i32.const 13)) (i32.const 3))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00d000000       	mov	rax, 0xd
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_if_cond.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-cond") (result i32)
+    (block (result i32)
+      (if (result i32) (br 0 (i32.const 2))
+        (then (i32.const 0))
+        (else (i32.const 1))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br/as_if_else.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-else") (param i32 i32) (result i32)
+    (block (result i32)
+      (if (result i32) (local.get 0)
+        (then (local.get 1))
+        (else (br 1 (i32.const 4)))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8409000000         	je	0x29
+;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   24:	 e907000000           	jmp	0x30
+;;   29:	 48c7c004000000       	mov	rax, 4
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br/as_if_then.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-then") (param i32 i32) (result i32)
+    (block (result i32)
+      (if (result i32) (local.get 0)
+        (then (br 1 (i32.const 3)))
+        (else (local.get 1))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f840c000000         	je	0x2c
+;;   20:	 48c7c003000000       	mov	rax, 3
+;;   27:	 e904000000           	jmp	0x30
+;;   2c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_first.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-loop-first") (result i32)
+    (block (result i32) (loop (result i32) (br 1 (i32.const 3)) (i32.const 2)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c003000000       	mov	rax, 3
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_last.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-loop-last") (result i32)
+    (block (result i32)
+      (loop (result i32) (nop) (call $dummy) (br 1 (i32.const 5)))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c005000000       	mov	rax, 5
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_mid.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-loop-mid") (result i32)
+    (block (result i32)
+      (loop (result i32) (call $dummy) (br 1 (i32.const 4)) (i32.const 2))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c004000000       	mov	rax, 4
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-last") (param i32)
+    (block (call $dummy) (call $dummy) (br_if 0 (local.get 0)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 e800000000           	call	0x16
+;;   16:	 e800000000           	call	0x1b
+;;   1b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1f:	 85c9                 	test	ecx, ecx
+;;   21:	 0f8500000000         	jne	0x27
+;;   27:	 4883c410             	add	rsp, 0x10
+;;   2b:	 5d                   	pop	rbp
+;;   2c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-last-value") (param i32) (result i32)
+    (block (result i32)
+      (call $dummy) (call $dummy) (br_if 0 (i32.const 11) (local.get 0))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 e800000000           	call	0x16
+;;   16:	 e800000000           	call	0x1b
+;;   1b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1f:	 48c7c00b000000       	mov	rax, 0xb
+;;   26:	 85c9                 	test	ecx, ecx
+;;   28:	 0f8500000000         	jne	0x2e
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-if-cond")
+    (block (br_if 0 (br_if 0 (i32.const 1) (i32.const 1))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b901000000           	mov	ecx, 1
+;;   11:	 85c9                 	test	ecx, ecx
+;;   13:	 0f850d000000         	jne	0x26
+;;   19:	 b901000000           	mov	ecx, 1
+;;   1e:	 85c9                 	test	ecx, ecx
+;;   20:	 0f8500000000         	jne	0x26
+;;   26:	 4883c408             	add	rsp, 8
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_value.wat
@@ -1,0 +1,17 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (br_if 0 (i32.const 1) (i32.const 2))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b902000000           	mov	ecx, 2
+;;   11:	 48c7c001000000       	mov	rax, 1
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8500000000         	jne	0x20
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_first.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-first") (result i32)
+    (block (result i32)
+      (call $f
+        (br_if 0 (i32.const 12) (i32.const 1)) (i32.const 2) (i32.const 3)
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b901000000           	mov	ecx, 1
+;;   11:	 48c7c00c000000       	mov	rax, 0xc
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8517000000         	jne	0x37
+;;   20:	 50                   	push	rax
+;;   21:	 8b3c24               	mov	edi, dword ptr [rsp]
+;;   24:	 be02000000           	mov	esi, 2
+;;   29:	 ba03000000           	mov	edx, 3
+;;   2e:	 e800000000           	call	0x33
+;;   33:	 4883c408             	add	rsp, 8
+;;   37:	 4883c408             	add	rsp, 8
+;;   3b:	 5d                   	pop	rbp
+;;   3c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_last.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-last") (result i32)
+    (block (result i32)
+      (call $f
+        (i32.const 1) (i32.const 2) (br_if 0 (i32.const 14) (i32.const 1))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b901000000           	mov	ecx, 1
+;;   11:	 48c7c00e000000       	mov	rax, 0xe
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8517000000         	jne	0x37
+;;   20:	 50                   	push	rax
+;;   21:	 bf01000000           	mov	edi, 1
+;;   26:	 be02000000           	mov	esi, 2
+;;   2b:	 8b1424               	mov	edx, dword ptr [rsp]
+;;   2e:	 e800000000           	call	0x33
+;;   33:	 4883c408             	add	rsp, 8
+;;   37:	 4883c408             	add	rsp, 8
+;;   3b:	 5d                   	pop	rbp
+;;   3c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_mid.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1)) 
+  (func (export "as-call-mid") (result i32)
+    (block (result i32)
+      (call $f
+        (i32.const 1) (br_if 0 (i32.const 13) (i32.const 1)) (i32.const 3)
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b901000000           	mov	ecx, 1
+;;   11:	 48c7c00d000000       	mov	rax, 0xd
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8517000000         	jne	0x37
+;;   20:	 50                   	push	rax
+;;   21:	 bf01000000           	mov	edi, 1
+;;   26:	 8b3424               	mov	esi, dword ptr [rsp]
+;;   29:	 ba03000000           	mov	edx, 3
+;;   2e:	 e800000000           	call	0x33
+;;   33:	 4883c408             	add	rsp, 8
+;;   37:	 4883c408             	add	rsp, 8
+;;   3b:	 5d                   	pop	rbp
+;;   3c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_cond.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-cond") (param i32) (result i32)
+    (block (result i32)
+      (if (result i32)
+        (br_if 0 (i32.const 1) (local.get 0))
+        (then (i32.const 2))
+        (else (i32.const 3))
+      )
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   15:	 48c7c001000000       	mov	rax, 1
+;;   1c:	 85c9                 	test	ecx, ecx
+;;   1e:	 0f851b000000         	jne	0x3f
+;;   24:	 85c0                 	test	eax, eax
+;;   26:	 0f840c000000         	je	0x38
+;;   2c:	 48c7c002000000       	mov	rax, 2
+;;   33:	 e907000000           	jmp	0x3f
+;;   38:	 48c7c003000000       	mov	rax, 3
+;;   3f:	 4883c410             	add	rsp, 0x10
+;;   43:	 5d                   	pop	rbp
+;;   44:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_else.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-if-else") (param i32 i32)
+    (block
+      (if (local.get 0) (then (call $dummy)) (else (br_if 1 (local.get 1))))
+    )
+  )
+)
+
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f840a000000         	je	0x2a
+;;   20:	 e800000000           	call	0x25
+;;   25:	 e90c000000           	jmp	0x36
+;;   2a:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   2e:	 85c9                 	test	ecx, ecx
+;;   30:	 0f8500000000         	jne	0x36
+;;   36:	 4883c410             	add	rsp, 0x10
+;;   3a:	 5d                   	pop	rbp
+;;   3b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_then.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-if-then") (param i32 i32)
+    (block
+      (if (local.get 0) (then (br_if 1 (local.get 1))) (else (call $dummy)))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8411000000         	je	0x31
+;;   20:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   24:	 85c9                 	test	ecx, ecx
+;;   26:	 0f850a000000         	jne	0x36
+;;   2c:	 e905000000           	jmp	0x36
+;;   31:	 e800000000           	call	0x36
+;;   36:	 4883c410             	add	rsp, 0x10
+;;   3a:	 5d                   	pop	rbp
+;;   3b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-local-set-value") (param i32) (result i32)
+    (local i32)
+    (block (result i32)
+      (local.set 0 (br_if 0 (i32.const 17) (local.get 0)))
+      (i32.const -1)
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c893424             	mov	qword ptr [rsp], r14
+;;   10:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   14:	 48c7c011000000       	mov	rax, 0x11
+;;   1b:	 85c9                 	test	ecx, ecx
+;;   1d:	 0f850b000000         	jne	0x2e
+;;   23:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   27:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_loop_last.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-loop-last") (param i32)
+    (loop (call $dummy) (br_if 1 (local.get 0)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 e800000000           	call	0x16
+;;   16:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1a:	 85c9                 	test	ecx, ecx
+;;   1c:	 0f8500000000         	jne	0x22
+;;   22:	 4883c410             	add	rsp, 0x10
+;;   26:	 5d                   	pop	rbp
+;;   27:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_binary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_binary_operand.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-binary-operand") (result i32)
+    (i32.mul
+      (loop (result i32) (call $dummy) (i32.const 3))
+      (loop (result i32) (call $dummy) (i32.const 4))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 b803000000           	mov	eax, 3
+;;   2b:	 6bc004               	imul	eax, eax, 4
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_if_first.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_first.wat
@@ -1,0 +1,17 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-if-first") (result i32)
+    (block (result i32) (br_if 0 (loop (result i32) (i32.const 1)) (i32.const 2)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b902000000           	mov	ecx, 2
+;;   11:	 48c7c001000000       	mov	rax, 1
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8500000000         	jne	0x20
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_last.wat
@@ -1,0 +1,17 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-if-last") (result i32)
+    (block (result i32) (br_if 0 (i32.const 2) (loop (result i32) (i32.const 1))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b901000000           	mov	ecx, 1
+;;   11:	 48c7c002000000       	mov	rax, 2
+;;   18:	 85c9                 	test	ecx, ecx
+;;   1a:	 0f8500000000         	jne	0x20
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_value.wat
@@ -1,0 +1,14 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (loop (result i32) (i32.const 1))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_call_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_call_value.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32) (result i32) (local.get 0))
+  (func (export "as-call-value") (result i32)
+    (call $f (loop (result i32) (i32.const 1)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 4883c410             	add	rsp, 0x10
+;;   19:	 5d                   	pop	rbp
+;;   1a:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 bf01000000           	mov	edi, 1
+;;   15:	 e800000000           	call	0x1a
+;;   1a:	 4883c408             	add	rsp, 8
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_if_condition.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_condition.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-if-condition")
+    (loop (result i32) (i32.const 1)) (if (then (call $dummy)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840d000000         	je	0x26
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 4883c408             	add	rsp, 8
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_if_else.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_else.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-else") (result i32)
+    (if (result i32) (i32.const 1) (then (i32.const 2)) (else (loop (result i32) (i32.const 1))))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840c000000         	je	0x25
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 e907000000           	jmp	0x2c
+;;   25:	 48c7c001000000       	mov	rax, 1
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_if_then.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_then.wat
@@ -1,0 +1,19 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-if-then") (result i32)
+    (if (result i32) (i32.const 1) (then (loop (result i32) (i32.const 1))) (else (i32.const 2)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840c000000         	je	0x25
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 e907000000           	jmp	0x2c
+;;   25:	 48c7c002000000       	mov	rax, 2
+;;   2c:	 4883c408             	add	rsp, 8
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_local_set_value.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-local-set-value") (result i32)
+    (local i32) (local.set 0 (loop (result i32) (i32.const 1))) (local.get 0)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b801000000           	mov	eax, 1
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 4883c410             	add	rsp, 0x10
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_test_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_test_operand.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-test-operand") (result i32)
+    (i32.eqz (loop (result i32) (call $dummy) (i32.const 13)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 b80d000000           	mov	eax, 0xd
+;;   1e:	 83f800               	cmp	eax, 0
+;;   21:	 b800000000           	mov	eax, 0
+;;   26:	 400f94c0             	sete	al
+;;   2a:	 4883c408             	add	rsp, 8
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_unary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_unary_operand.wat
@@ -1,0 +1,31 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-unary-operand") (result i32)
+    (i32.ctz (loop (result i32) (call $dummy) (i32.const 13)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 b80d000000           	mov	eax, 0xd
+;;   1e:	 0fbcc0               	bsf	eax, eax
+;;   21:	 41bb00000000         	mov	r11d, 0
+;;   27:	 410f94c3             	sete	r11b
+;;   2b:	 41c1e305             	shl	r11d, 5
+;;   2f:	 4401d8               	add	eax, r11d
+;;   32:	 4883c408             	add	rsp, 8
+;;   36:	 5d                   	pop	rbp
+;;   37:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/break_inner.wat
+++ b/winch/filetests/filetests/x64/loop/break_inner.wat
@@ -1,0 +1,55 @@
+;;! target = "x86_64"
+(module
+  (func (export "break-inner") (result i32)
+    (local i32)
+    (local.set 0 (i32.const 0))
+    (local.set 0 (i32.add (local.get 0) (block (result i32) (loop (result i32) (block (result i32) (br 2 (i32.const 0x1)))))))
+    (local.set 0 (i32.add (local.get 0) (block (result i32) (loop (result i32) (loop (result i32) (br 2 (i32.const 0x2)))))))
+    (local.set 0 (i32.add (local.get 0) (block (result i32) (loop (result i32) (block (result i32) (loop (result i32) (br 1 (i32.const 0x4))))))))
+    (local.set 0 (i32.add (local.get 0) (block (result i32) (loop (result i32) (i32.ctz (br 1 (i32.const 0x8)))))))
+    (local.set 0 (i32.add (local.get 0) (block (result i32) (loop (result i32) (i32.ctz (loop (result i32) (br 2 (i32.const 0x10))))))))
+    (local.get 0)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b800000000           	mov	eax, 0
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   24:	 4153                 	push	r11
+;;   26:	 48c7c001000000       	mov	rax, 1
+;;   2d:	 59                   	pop	rcx
+;;   2e:	 01c1                 	add	ecx, eax
+;;   30:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   34:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   39:	 4153                 	push	r11
+;;   3b:	 48c7c002000000       	mov	rax, 2
+;;   42:	 59                   	pop	rcx
+;;   43:	 01c1                 	add	ecx, eax
+;;   45:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   49:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   4e:	 4153                 	push	r11
+;;   50:	 48c7c004000000       	mov	rax, 4
+;;   57:	 59                   	pop	rcx
+;;   58:	 01c1                 	add	ecx, eax
+;;   5a:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   5e:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   63:	 4153                 	push	r11
+;;   65:	 48c7c008000000       	mov	rax, 8
+;;   6c:	 59                   	pop	rcx
+;;   6d:	 01c1                 	add	ecx, eax
+;;   6f:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   73:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   78:	 4153                 	push	r11
+;;   7a:	 48c7c010000000       	mov	rax, 0x10
+;;   81:	 59                   	pop	rcx
+;;   82:	 01c1                 	add	ecx, eax
+;;   84:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   88:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   8c:	 4883c410             	add	rsp, 0x10
+;;   90:	 5d                   	pop	rbp
+;;   91:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/cont_inner.wat
+++ b/winch/filetests/filetests/x64/loop/cont_inner.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func (export "cont-inner") (result i32)
+    (local i32)
+    (local.set 0 (i32.const 0))
+    (local.set 0 (i32.add (local.get 0) (loop (result i32) (loop (result i32) (br 1)))))
+    (local.set 0 (i32.add (local.get 0) (loop (result i32) (i32.ctz (br 0)))))
+    (local.set 0 (i32.add (local.get 0) (loop (result i32) (i32.ctz (loop (result i32) (br 1))))))
+    (local.get 0)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b800000000           	mov	eax, 0
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   24:	 4153                 	push	r11
+;;   26:	 58                   	pop	rax
+;;   27:	 e9faffffff           	jmp	0x26
+;;   2c:	 4883c410             	add	rsp, 0x10
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/deep.wat
+++ b/winch/filetests/filetests/x64/loop/deep.wat
@@ -1,0 +1,67 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "deep") (result i32)
+    (loop (result i32) (block (result i32)
+      (loop (result i32) (block (result i32)
+        (loop (result i32) (block (result i32)
+          (loop (result i32) (block (result i32)
+            (loop (result i32) (block (result i32)
+              (loop (result i32) (block (result i32)
+                (loop (result i32) (block (result i32)
+                  (loop (result i32) (block (result i32)
+                    (loop (result i32) (block (result i32)
+                      (loop (result i32) (block (result i32)
+                        (loop (result i32) (block (result i32)
+                          (loop (result i32) (block (result i32)
+                            (loop (result i32) (block (result i32)
+                              (loop (result i32) (block (result i32)
+                                (loop (result i32) (block (result i32)
+                                  (loop (result i32) (block (result i32)
+                                    (loop (result i32) (block (result i32)
+                                      (loop (result i32) (block (result i32)
+                                        (loop (result i32) (block (result i32)
+                                          (loop (result i32) (block (result i32)
+                                            (call $dummy) (i32.const 150)
+                                          ))
+                                        ))
+                                      ))
+                                    ))
+                                  ))
+                                ))
+                              ))
+                            ))
+                          ))
+                        ))
+                      ))
+                    ))
+                  ))
+                ))
+              ))
+            ))
+          ))
+        ))
+      ))
+    ))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c096000000       	mov	rax, 0x96
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/effects.wat
+++ b/winch/filetests/filetests/x64/loop/effects.wat
@@ -1,0 +1,41 @@
+;;! target = "x86_64"
+(module
+  (func $fx (export "effects") (result i32)
+    (local i32)
+    (block
+      (loop
+        (local.set 0 (i32.const 1))
+        (local.set 0 (i32.mul (local.get 0) (i32.const 3)))
+        (local.set 0 (i32.sub (local.get 0) (i32.const 5)))
+        (local.set 0 (i32.mul (local.get 0) (i32.const 7)))
+        (br 1)
+        (local.set 0 (i32.mul (local.get 0) (i32.const 100)))
+      )
+    )
+    (i32.eq (local.get 0) (i32.const -14))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 b801000000           	mov	eax, 1
+;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   23:	 6bc003               	imul	eax, eax, 3
+;;   26:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   2a:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   2e:	 83e805               	sub	eax, 5
+;;   31:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   35:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   39:	 6bc007               	imul	eax, eax, 7
+;;   3c:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   40:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   44:	 83f8f2               	cmp	eax, -0xe
+;;   47:	 b800000000           	mov	eax, 0
+;;   4c:	 400f94c0             	sete	al
+;;   50:	 4883c410             	add	rsp, 0x10
+;;   54:	 5d                   	pop	rbp
+;;   55:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/empty.wat
+++ b/winch/filetests/filetests/x64/loop/empty.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "empty")
+    (loop)
+    (loop $l)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/for.wat
+++ b/winch/filetests/filetests/x64/loop/for.wat
@@ -1,0 +1,47 @@
+;;! target = "x86_64"
+(module
+  (func (export "for-") (param i64) (result i64)
+    (local i64 i64)
+    (local.set 1 (i64.const 1))
+    (local.set 2 (i64.const 2))
+    (block
+      (loop
+        (br_if 1 (i64.gt_u (local.get 2) (local.get 0)))
+        (local.set 1 (i64.mul (local.get 1) (local.get 2)))
+        (local.set 2 (i64.add (local.get 2) (i64.const 1)))
+        (br 0)
+      )
+    )
+    (local.get 1)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec20             	sub	rsp, 0x20
+;;    8:	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
+;;    d:	 48c744241000000000   	
+;; 				mov	qword ptr [rsp + 0x10], 0
+;;   16:	 4c893424             	mov	qword ptr [rsp], r14
+;;   1a:	 48c7c001000000       	mov	rax, 1
+;;   21:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   26:	 48c7c002000000       	mov	rax, 2
+;;   2d:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   32:	 488b442418           	mov	rax, qword ptr [rsp + 0x18]
+;;   37:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   3c:	 4839c1               	cmp	rcx, rax
+;;   3f:	 b900000000           	mov	ecx, 0
+;;   44:	 400f97c1             	seta	cl
+;;   48:	 85c9                 	test	ecx, ecx
+;;   4a:	 0f8526000000         	jne	0x76
+;;   50:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   55:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   5a:	 480fafc8             	imul	rcx, rax
+;;   5e:	 48894c2410           	mov	qword ptr [rsp + 0x10], rcx
+;;   63:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   68:	 4883c001             	add	rax, 1
+;;   6c:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   71:	 e9bcffffff           	jmp	0x32
+;;   76:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   7b:	 4883c420             	add	rsp, 0x20
+;;   7f:	 5d                   	pop	rbp
+;;   80:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/multi.wat
+++ b/winch/filetests/filetests/x64/loop/multi.wat
@@ -1,0 +1,46 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "multi") (result i32)
+    (loop (call $dummy) (call $dummy) (call $dummy) (call $dummy))
+    (loop (result i32) (call $dummy) (call $dummy) (i32.const 8) (call $dummy))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 4883ec08             	sub	rsp, 8
+;;   2a:	 e800000000           	call	0x2f
+;;   2f:	 4883c408             	add	rsp, 8
+;;   33:	 4883ec08             	sub	rsp, 8
+;;   37:	 e800000000           	call	0x3c
+;;   3c:	 4883c408             	add	rsp, 8
+;;   40:	 4883ec08             	sub	rsp, 8
+;;   44:	 e800000000           	call	0x49
+;;   49:	 4883c408             	add	rsp, 8
+;;   4d:	 4883ec08             	sub	rsp, 8
+;;   51:	 e800000000           	call	0x56
+;;   56:	 4883c408             	add	rsp, 8
+;;   5a:	 4883ec08             	sub	rsp, 8
+;;   5e:	 e800000000           	call	0x63
+;;   63:	 4883c408             	add	rsp, 8
+;;   67:	 48c7c008000000       	mov	rax, 8
+;;   6e:	 4883c408             	add	rsp, 8
+;;   72:	 5d                   	pop	rbp
+;;   73:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/nested.wat
+++ b/winch/filetests/filetests/x64/loop/nested.wat
@@ -1,0 +1,32 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "nested") (result i32)
+    (loop (result i32)
+      (loop (call $dummy) (block) (nop))
+      (loop (result i32) (call $dummy) (i32.const 9))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 48c7c009000000       	mov	rax, 9
+;;   2d:	 4883c408             	add	rsp, 8
+;;   31:	 5d                   	pop	rbp
+;;   32:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/singular.wat
+++ b/winch/filetests/filetests/x64/loop/singular.wat
@@ -1,0 +1,16 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "singular") (result i32)
+    (loop (nop))
+    (loop (result i32) (i32.const 7))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c007000000       	mov	rax, 7
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/while.wat
+++ b/winch/filetests/filetests/x64/loop/while.wat
@@ -1,0 +1,43 @@
+;;! target = "x86_64"
+(module
+  (func (export "while-") (param i64) (result i64)
+    (local i64)
+    (local.set 1 (i64.const 1))
+    (block
+      (loop
+        (br_if 1 (i64.eqz (local.get 0)))
+        (local.set 1 (i64.mul (local.get 0) (local.get 1)))
+        (local.set 0 (i64.sub (local.get 0) (i64.const 1)))
+        (br 0)
+      )
+    )
+    (local.get 1)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;    d:	 4c893424             	mov	qword ptr [rsp], r14
+;;   11:	 48c7c001000000       	mov	rax, 1
+;;   18:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   1d:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   22:	 4883f800             	cmp	rax, 0
+;;   26:	 b800000000           	mov	eax, 0
+;;   2b:	 400f94c0             	sete	al
+;;   2f:	 50                   	push	rax
+;;   30:	 59                   	pop	rcx
+;;   31:	 85c9                 	test	ecx, ecx
+;;   33:	 0f8526000000         	jne	0x5f
+;;   39:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   3e:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   43:	 480fafc8             	imul	rcx, rax
+;;   47:	 48894c2408           	mov	qword ptr [rsp + 8], rcx
+;;   4c:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   51:	 4883e801             	sub	rax, 1
+;;   55:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   5a:	 e9beffffff           	jmp	0x1d
+;;   5f:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   64:	 4883c418             	add	rsp, 0x18
+;;   68:	 5d                   	pop	rbp
+;;   69:	 c3                   	ret	


### PR DESCRIPTION
Part of https://github.com/bytecodealliance/wasmtime/issues/6528

This change adds support for the `loop`, `br` and `br_if` instructions as well as unreachable code handling. Whenever an instruction that affects reachability is emitted (`br` in the case of this PR), the compiler will enter into an unreachable code state, essentially ignoring most of the subsequent instructions. When handling the unreachable code state some instructions are still observed, in order to determine if reachability should be restored.

This change, particulary the handling of unreachable code, adds all the necessary building blocks to the compiler to emit other instructions that affect reachability (e.g `unreachable`, `return`).

I decided to bundle these instructions together to be able to test more complex scenarios with `loop`, but I'm happy to split this change into two (or more). 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
