### PR TITLE
x64: Add non-SSSE3 lowering for `sqmul_round_sat`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -215,6 +215,10 @@ impl TargetIsa for AArch64Backend {
     fn has_x86_pshufb_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmulhrsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for AArch64Backend {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -348,6 +348,10 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Returns whether the CLIF `x86_pshufb` instruction is implemented for
     /// this ISA.
     fn has_x86_pshufb_lowering(&self) -> bool;
+
+    /// Returns whether the CLIF `x86_pmulhrsw` instruction is implemented for
+    /// this ISA.
+    fn has_x86_pmulhrsw_lowering(&self) -> bool;
 }
 
 /// Function alignment specifications as required by an ISA, returned by

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -190,6 +190,10 @@ impl TargetIsa for Riscv64Backend {
     fn has_x86_pshufb_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmulhrsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for Riscv64Backend {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -190,6 +190,10 @@ impl TargetIsa for S390xBackend {
     fn has_x86_pshufb_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmulhrsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for S390xBackend {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4546,18 +4546,50 @@
 
 ;; Rules for `sqmul_round_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (sqmul_round_sat qx @ (value_type $I16X8) qy))
-      (let ((src1 Xmm qx)
-            (src2 Xmm qy)
+(rule 1 (lower (sqmul_round_sat qx @ (value_type $I16X8) qy))
+        (if-let $true (use_ssse3))
+        (let ((src1 Xmm qx)
+              (src2 Xmm qy)
 
-            (mask XmmMem (emit_u128_le_const 0x8000_8000_8000_8000_8000_8000_8000_8000))
-            (dst Xmm (x64_pmulhrsw src1 src2))
-            (cmp Xmm (x64_pcmpeqw dst mask)))
-        (x64_pxor dst cmp)))
+              (mask XmmMem (emit_u128_le_const 0x8000_8000_8000_8000_8000_8000_8000_8000))
+              (dst Xmm (x64_pmulhrsw src1 src2))
+              (cmp Xmm (x64_pcmpeqw dst mask)))
+          (x64_pxor dst cmp)))
+
+;; This operation is defined in wasm as:
+;;
+;;    S.SignedSaturate((x * y + 0x4000) >> 15)
+;;
+;; so perform all those operations here manually with a lack of the native
+;; instruction.
+(rule (lower (sqmul_round_sat qx @ (value_type $I16X8) qy))
+      (let (
+          (qx Xmm qx)
+          (qy Xmm qy)
+          ;; Multiply `qx` and `qy` generating 32-bit intermediate results. The
+          ;; 32-bit results have their low-halves stored in `mul_lsb` and the
+          ;; high halves are stored in `mul_msb`. These are then shuffled into
+          ;; `mul_lo` and `mul_hi` which represent the low 4 multiplications
+          ;; and the upper 4 multiplications.
+          (mul_lsb Xmm (x64_pmullw qx qy))
+          (mul_msb Xmm (x64_pmulhw qx qy))
+          (mul_lo Xmm (x64_punpcklwd mul_lsb mul_msb))
+          (mul_hi Xmm (x64_punpckhwd mul_lsb mul_msb))
+          ;; Add the 0x4000 constant to all multiplications
+          (val Xmm (x64_movdqu_load (emit_u128_le_const 0x00004000_00004000_00004000_00004000)))
+          (mul_lo Xmm (x64_paddd mul_lo val))
+          (mul_hi Xmm (x64_paddd mul_hi val))
+          ;; Perform the right-shift by 15 to all multiplications
+          (lo Xmm (x64_psrad mul_lo (xmi_imm 15)))
+          (hi Xmm (x64_psrad mul_hi (xmi_imm 15)))
+        )
+        ;; And finally perform a saturating 32-to-16-bit conversion.
+        (x64_packssdw lo hi)))
 
 ;; Rules for `x86_pmulhrsw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (x86_pmulhrsw qx @ (value_type $I16X8) qy))
+      (if-let $true (use_ssse3))
       (x64_pmulhrsw qx qy))
 
 ;; Rules for `uunarrow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -190,6 +190,10 @@ impl TargetIsa for X64Backend {
     fn has_x86_pshufb_lowering(&self) -> bool {
         self.x64_flags.use_ssse3()
     }
+
+    fn has_x86_pmulhrsw_lowering(&self) -> bool {
+        self.x64_flags.use_ssse3()
+    }
 }
 
 impl fmt::Display for X64Backend {

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -2,9 +2,11 @@ test interpret
 test run
 target aarch64
 target s390x
+target x86_64 has_ssse3=false
 set enable_simd
-target x86_64 has_sse3 has_ssse3 has_sse41
-target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target x86_64
+target x86_64 sse41
+target x86_64 sse41 has_avx
 target riscv64 has_v
 
 function %sqmulrs_i16x8(i16x8, i16x8) -> i16x8 {

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -2288,7 +2288,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::I16x8RelaxedQ15mulrS => {
             let (a, b) = pop2_with_bitcast(state, I16X8, builder);
             state.push1(
-                if environ.relaxed_simd_deterministic() || !environ.is_x86() {
+                if environ.relaxed_simd_deterministic()
+                    || !environ.use_x86_pmulhrsw_for_relaxed_q15mul()
+                {
                     // Deterministic semantics are to match the
                     // `i16x8.q15mulr_sat_s` instruction.
                     builder.ins().sqmul_round_sat(a, b)

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -575,6 +575,12 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn use_x86_pshufb_for_relaxed_swizzle(&self) -> bool {
         false
     }
+
+    /// Returns whether the CLIF `x86_pmulhrsw` instruction should be used for
+    /// the `i8x16.relaxed_q15mulr_s` instruction.
+    fn use_x86_pmulhrsw_for_relaxed_q15mul(&self) -> bool {
+        false
+    }
 }
 
 /// An object satisfying the `ModuleEnvironment` trait can be passed as argument to the

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2207,4 +2207,8 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn use_x86_pshufb_for_relaxed_swizzle(&self) -> bool {
         self.isa.has_x86_pshufb_lowering()
     }
+
+    fn use_x86_pmulhrsw_for_relaxed_q15mul(&self) -> bool {
+        self.isa.has_x86_pmulhrsw_lowering()
+    }
 }


### PR DESCRIPTION
Additionally avoid the use of the `x86_pmulhrsw` instruction if SSSE3 isn't enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
