### PR TITLE
winch(x64): Add support for return and unreachable

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -362,7 +362,9 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | Block { .. }
                         | Loop { .. }
                         | Br { .. }
-                        | BrIf { .. } => {}
+                        | BrIf { .. }
+                        | Unreachable { .. }
+                        | Return { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -351,7 +351,7 @@ impl ControlStackFrame {
     /// Returns the exit label of the current control stack frame. Note that
     /// this is similar to [`ControlStackFrame::label`], with the only difference that it
     /// returns `None` for `Loop` since its label doesn't represent an exit.
-    fn exit_label(&self) -> Option<&MachLabel> {
+    pub fn exit_label(&self) -> Option<&MachLabel> {
         use ControlStackFrame::*;
 
         match self {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -266,6 +266,10 @@ impl Masm for MacroAssembler {
     fn jmp(&mut self, _target: MachLabel) {
         todo!()
     }
+
+    fn unreachable(&mut self) {
+        todo!()
+    }
 }
 
 impl MacroAssembler {

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -842,4 +842,9 @@ impl Assembler {
     pub fn jmp(&mut self, target: MachLabel) {
         self.emit(Inst::JmpKnown { dst: target });
     }
+
+    /// Emit a trap instruction.
+    pub fn trap(&mut self, code: TrapCode) {
+        self.emit(Inst::Ud2 { trap_code: code })
+    }
 }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -14,7 +14,8 @@ use crate::{
 };
 use crate::{isa::reg::Reg, masm::CalleeKind};
 use cranelift_codegen::{
-    isa::x64::settings as x64_settings, settings, Final, MachBufferFinalized, MachLabel,
+    ir::TrapCode, isa::x64::settings as x64_settings, settings, Final, MachBufferFinalized,
+    MachLabel,
 };
 
 /// x64 MacroAssembler.
@@ -482,6 +483,10 @@ impl Masm for MacroAssembler {
             context.stack.push(Val::reg(dst));
             context.free_gpr(tmp);
         }
+    }
+
+    fn unreachable(&mut self) {
+        self.asm.trap(TrapCode::UnreachableCodeReached)
     }
 }
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -346,4 +346,7 @@ pub(crate) trait MacroAssembler {
 
     /// Emits and unconditional jump to the given label.
     fn jmp(&mut self, target: MachLabel);
+
+    /// Emit an unreachable code trap.
+    fn unreachable(&mut self);
 }

--- a/winch/filetests/filetests/x64/return/as_block_first.wat
+++ b/winch/filetests/filetests/x64/return/as_block_first.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-first")
+   (block (return) (call $dummy))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_block_last.wat
+++ b/winch/filetests/filetests/x64/return/as_block_last.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-last")
+   (block (nop) (call $dummy) (return))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883c408             	add	rsp, 8
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_block_mid.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-mid")
+   (block (call $dummy) (return) (call $dummy))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883c408             	add	rsp, 8
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_block_value.wat
+++ b/winch/filetests/filetests/x64/return/as_block_value.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-value") (result i32)
+   (block (result i32) (nop) (call $dummy) (return (i32.const 2)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_br_if_cond.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-br-if-cond")
+   (block (br_if 0 (return)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_br_value.wat
+++ b/winch/filetests/filetests/x64/return/as_br_value.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-br-value") (result i32)
+   (block (result i32) (br 0 (return (i32.const 9))))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c009000000       	mov	rax, 9
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_fist.wat
+++ b/winch/filetests/filetests/x64/return/as_call_fist.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-first") (result i32)
+    (call $f (return (i32.const 12)) (i32.const 2) (i32.const 3))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00c000000       	mov	rax, 0xc
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_last.wat
+++ b/winch/filetests/filetests/x64/return/as_call_last.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-last") (result i32)
+    (call $f (i32.const 1) (i32.const 2) (return (i32.const 14)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00e000000       	mov	rax, 0xe
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_call_mid.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+(module
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-mid") (result i32)
+    (call $f (i32.const 1) (return (i32.const 13)) (i32.const 3))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
+;;   20:	 4883c418             	add	rsp, 0x18
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c00d000000       	mov	rax, 0xd
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_first.wat
+++ b/winch/filetests/filetests/x64/return/as_func_first.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-func-first") (result i32)
+   (return (i32.const 1)) (i32.const 2)
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_last.wat
+++ b/winch/filetests/filetests/x64/return/as_func_last.wat
@@ -1,0 +1,12 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_func_mid.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-func-mid") (result i32)
+   (call $dummy) (return (i32.const 2)) (i32.const 3)
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c002000000       	mov	rax, 2
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_value.wat
+++ b/winch/filetests/filetests/x64/return/as_func_value.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+    (func (export "as-func-value") (result i32)
+        (nop) (call $dummy) (return (i32.const 3))
+    )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c003000000       	mov	rax, 3
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_if_cond.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-if-cond") (result i32)
+   (if (result i32)
+    (return (i32.const 2)) (then (i32.const 0)) (else (i32.const 1))
+   )
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_else.wat
+++ b/winch/filetests/filetests/x64/return/as_if_else.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+
+  (func (export "as-if-else") (param i32 i32) (result i32)
+   (if (result i32)
+    (local.get 0) (then (local.get 1)) (else (return (i32.const 4)))
+   )
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8409000000         	je	0x29
+;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   24:	 e907000000           	jmp	0x30
+;;   29:	 48c7c004000000       	mov	rax, 4
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_then.wat
+++ b/winch/filetests/filetests/x64/return/as_if_then.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+
+  (func (export "as-if-then") (param i32 i32) (result i32)
+   (if (result i32)
+    (local.get 0) (then (return (i32.const 3))) (else (local.get 1))
+   )
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f840c000000         	je	0x2c
+;;   20:	 48c7c003000000       	mov	rax, 3
+;;   27:	 e904000000           	jmp	0x30
+;;   2c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_first.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-loop-first") (result i32)
+   (loop (result i32) (return (i32.const 3)) (i32.const 2))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c003000000       	mov	rax, 3
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_last.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-loop-last") (result i32)
+   (loop (result i32) (nop) (call $dummy) (return (i32.const 5)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c005000000       	mov	rax, 5
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_mid.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-loop-mid") (result i32)
+   (loop (result i32) (call $dummy) (return (i32.const 4)) (i32.const 2))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c004000000       	mov	rax, 4
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_return_value.wat
+++ b/winch/filetests/filetests/x64/return/as_return_value.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-return-value") (result i64)
+    (return (return (i64.const 7)))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c007000000       	mov	rax, 7
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/nullary.wat
+++ b/winch/filetests/filetests/x64/return/nullary.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "nullary") (return))
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/type_i32.wat
+++ b/winch/filetests/filetests/x64/return/type_i32.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+
+  (func (export "type-i32-value") (result i32)
+   (block (result i32) (i32.ctz (return (i32.const 1))))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/type_i64_value.wat
+++ b/winch/filetests/filetests/x64/return/type_i64_value.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+
+  (func (export "type-i64-value") (result i64)
+   (block (result i64) (i64.ctz (return (i64.const 2))))
+  )
+)
+  
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c002000000       	mov	rax, 2
+;;   13:	 4883c408             	add	rsp, 8
+;;   17:	 5d                   	pop	rbp
+;;   18:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-block-broke") (result i32)
+    (block (result i32) (call $dummy) (br 0 (i32.const 1)) (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_first.wat
@@ -1,0 +1,14 @@
+;;! target = "x86_64"
+(module
+  (func (export "as-block-first") (result i32)
+    (block (result i32) (unreachable) (i32.const 2))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_last.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-last")
+    (block (nop) (call $dummy) (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module 
+  (func $dummy)
+  (func (export "as-block-mid") (result i32)
+    (block (result i32) (call $dummy) (unreachable) (i32.const 2))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_value.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-block-value") (result i32)
+    (block (result i32) (nop) (call $dummy) (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-br_if-cond")
+    (block (br_if 0 (unreachable)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_br_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_value.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (unreachable)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_call_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_first.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy3 (param i32 i32 i32))
+  (func (export "as-call-first")
+    (call $dummy3 (unreachable) (i32.const 2) (i32.const 3))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 4883c418             	add	rsp, 0x18
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_call_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_last.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+
+
+(module
+  (func $dummy3 (param i32 i32 i32))
+  (func (export "as-call-last")
+    (call $dummy3 (i32.const 1) (i32.const 2) (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 4883c418             	add	rsp, 0x18
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy3 (param i32 i32 i32))
+  (func (export "as-call-mid")
+    (call $dummy3 (i32.const 1) (unreachable) (i32.const 3))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec18             	sub	rsp, 0x18
+;;    8:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
+;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
+;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   19:	 4883c418             	add	rsp, 0x18
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_func_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_first.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-func-first") (result i32)
+    (unreachable) (i32.const -1)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_func_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_last.wat
@@ -1,0 +1,26 @@
+;;! target = "x86_64"
+(module
+  (func $dummy)
+  (func (export "as-func-last")
+    (call $dummy) (unreachable)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-func-mid") (result i32)
+    (call $dummy) (unreachable) (i32.const -1)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_func_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_value.wat
@@ -1,0 +1,27 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-func-value") (result i32)
+    (call $dummy) (unreachable)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-if-cond") (result i32)
+    (if (result i32) (unreachable) (then (i32.const 0)) (else (i32.const 1)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_if_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_else.wat
@@ -1,0 +1,23 @@
+;;! target = "x86_64"
+
+
+(module
+  (func (export "as-if-else") (param i32 i32) (result i32)
+    (if (result i32) (local.get 0) (then (local.get 1)) (else (unreachable)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8409000000         	je	0x29
+;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   24:	 e902000000           	jmp	0x2b
+;;   29:	 0f0b                 	ud2	
+;;   2b:	 4883c410             	add	rsp, 0x10
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_if_then.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-if-then") (param i32 i32) (result i32)
+    (if (result i32) (local.get 0) (then (unreachable)) (else (local.get 1)))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8402000000         	je	0x22
+;;   20:	 0f0b                 	ud2	
+;;   22:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   26:	 4883c410             	add	rsp, 0x10
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-if-then-no-else") (param i32 i32) (result i32)
+    (if (local.get 0) (then (unreachable))) (local.get 1)
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 89742408             	mov	dword ptr [rsp + 8], esi
+;;   10:	 4c893424             	mov	qword ptr [rsp], r14
+;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   18:	 85c0                 	test	eax, eax
+;;   1a:	 0f8402000000         	je	0x22
+;;   20:	 0f0b                 	ud2	
+;;   22:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   26:	 4883c410             	add	rsp, 0x10
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+
+(module
+  (func $dummy)
+  (func (export "as-loop-broke") (result i32)
+    (block (result i32)
+      (loop (result i32) (call $dummy) (br 1 (i32.const 1)) (unreachable))
+    )
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 48c7c001000000       	mov	rax, 1
+;;   20:	 4883c408             	add	rsp, 8
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
@@ -1,0 +1,16 @@
+;;! target = "x86_64"
+
+
+(module
+  (func (export "as-loop-first") (result i32)
+    (loop (result i32) (unreachable) (i32.const 2))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+
+
+(module
+  (func $dummy)
+  (func (export "as-loop-last")
+    (loop (nop) (call $dummy) (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
@@ -1,0 +1,28 @@
+;;! target = "x86_64"
+
+
+(module
+  (func $dummy)
+  (func (export "as-loop-mid") (result i32)
+    (loop (result i32) (call $dummy) (unreachable) (i32.const 2))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883c408             	add	rsp, 8
+;;   10:	 5d                   	pop	rbp
+;;   11:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 0f0b                 	ud2	
+;;   1b:	 4883c408             	add	rsp, 8
+;;   1f:	 5d                   	pop	rbp
+;;   20:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_return_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_return_value.wat
@@ -1,0 +1,15 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "as-return-value") (result i64)
+    (return (unreachable))
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/type_i32.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i32.wat
@@ -1,0 +1,13 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "type-i32") (result i32) (unreachable))
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/type_i64.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i64.wat
@@ -1,0 +1,13 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "type-i64") (result i32) (unreachable))
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 0f0b                 	ud2	
+;;    e:	 4883c408             	add	rsp, 8
+;;   12:	 5d                   	pop	rbp
+;;   13:	 c3                   	ret	


### PR DESCRIPTION

This change adds support for the `return` and `unreachable`
instructions. This change builds on top of the control flow building
blocks introduced in https://github.com/bytecodealliance/wasmtime/pull/6603

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
