### PR TITLE
Backport 6615 to the 10.x branch

### DIFF
--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -7,6 +7,7 @@
 //! Individual snapshots are available through
 //! `wasmtime_wasi::snapshots::preview_{0, 1}::Wasi::new(&Store, Rc<RefCell<WasiCtx>>)`.
 
+#[cfg(feature = "preview2")]
 pub mod preview2;
 
 pub use wasi_common::{Error, I32Exit, WasiCtx, WasiDir, WasiFile};


### PR DESCRIPTION
Backport #6615 to the release-10.0.0 branch. As `wasmtime-wasi-10.0.0` doesn't build with `--no-default-features` without this change, I'm going to follow up with a release of 10.0.1.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
