### PR TITLE
Release Wasmtime 11.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "11.0.0"
+version = "11.0.1"
 
 [[package]]
 name = "byteorder"
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -604,14 +604,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -638,25 +638,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.98.0"
+version = "0.98.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "serde",
 ]
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.13.2",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3441,7 +3441,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.92.0",
@@ -3497,7 +3497,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3840,14 +3840,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3989,11 +3989,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "11.0.0"
+version = "11.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -4179,7 +4179,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "openvino",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4326,7 +4326,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4480,7 +4480,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,63 +117,63 @@ exclude = [
 ]
 
 [workspace.package]
-version = "11.0.0"
+version = "11.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 rust-version = "1.66.0"
 
 [workspace.dependencies]
-wasmtime = { path = "crates/wasmtime", version = "11.0.0", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=11.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=11.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=11.0.0" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=11.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=11.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=11.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=11.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=11.0.0" }
-wasmtime-types = { path = "crates/types", version = "11.0.0" }
-wasmtime-jit = { path = "crates/jit", version = "=11.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=11.0.0" }
-wasmtime-runtime = { path = "crates/runtime", version = "=11.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=11.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "11.0.0" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "11.0.0" }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=11.0.0" }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "11.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "11.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=11.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=11.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=11.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "11.0.1", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=11.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=11.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=11.0.1" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=11.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=11.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=11.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=11.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=11.0.1" }
+wasmtime-types = { path = "crates/types", version = "11.0.1" }
+wasmtime-jit = { path = "crates/jit", version = "=11.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=11.0.1" }
+wasmtime-runtime = { path = "crates/runtime", version = "=11.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=11.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "11.0.1" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "11.0.1" }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=11.0.1" }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "11.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "11.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=11.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=11.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=11.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=11.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=11.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=11.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=11.0.0" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=11.0.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=11.0.0" }
+wiggle = { path = "crates/wiggle", version = "=11.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=11.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=11.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=11.0.1" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=11.0.1" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=11.0.1" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=11.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=11.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=11.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=11.0.1" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.98.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.98.0" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.98.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.98.0" }
-cranelift-native = { path = "cranelift/native", version = "0.98.0" }
-cranelift-module = { path = "cranelift/module", version = "0.98.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.98.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.98.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.98.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.98.1" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.98.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.98.1" }
+cranelift-native = { path = "cranelift/native", version = "0.98.1" }
+cranelift-module = { path = "cranelift/module", version = "0.98.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.98.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.98.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.98.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.98.0" }
+cranelift-object = { path = "cranelift/object", version = "0.98.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.98.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.98.0" }
-cranelift-control = { path = "cranelift/control", version = "0.98.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.98.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.98.1" }
+cranelift-control = { path = "cranelift/control", version = "0.98.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.98.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.9.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.9.1" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 11.0.0
 
-Unreleased.
+Released 2023-06-21.
 
 ### Added
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.98.0"
+version = "0.98.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.98.0"
+version = "0.98.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.98.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.98.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -40,8 +40,8 @@ criterion = { version = "0.4.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.98.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.98.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.98.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.98.1" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.98.0"
+version = "0.98.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -13,4 +13,4 @@ edition.workspace = true
 # rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.98.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.98.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.98.0"
+version = "0.98.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.98.0"
+version = "0.98.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.98.0"
+version = "0.98.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.98.0"
+version = "0.98.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.98.0"
+version = "0.98.1"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.98.0"
+version = "0.98.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.98.0"
+version = "0.98.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.98.0"
+version = "0.98.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -199,7 +199,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "11.0.0"
+#define WASMTIME_VERSION "11.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -211,7 +211,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 11.0.1, requested by @elliottt.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
