### PR TITLE
`find_and_update` implements "path halving", not "path splitting"

### DIFF
--- a/cranelift/codegen/src/unionfind.rs
+++ b/cranelift/codegen/src/unionfind.rs
@@ -48,7 +48,7 @@ impl<Idx: EntityRef + Hash + std::fmt::Display + Ord + ReservedValue> UnionFind<
     /// (and others in its chain up to the root of the equivalence
     /// class) will be faster.
     pub fn find_and_update(&mut self, mut node: Idx) -> Idx {
-        // "Path splitting" mutating find (Tarjan and Van Leeuwen).
+        // "Path halving" mutating find (Tarjan and Van Leeuwen).
         debug_assert!(node != Idx::reserved_value());
         while node != self.parent[node].0 {
             let next = self.parent[self.parent[node].0].0;


### PR DESCRIPTION
Corrected the comment from "path splitting" to "path halving" to align with the implementation.

Path halving only updates every second node, whereas path splitting updates every node along the path. Regardless, their average performance tends to be negligible. Don't need to change the code to implement splitting instead.