### PR TITLE
riscv64: Improve SIMD `icmp` codegen

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1269,6 +1269,10 @@
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) x (splat y))
   (rv_vmsltu_vx x y (unmasked) ty))
 
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) (splat x) y)
+  (rv_vmsgtu_vx y x (unmasked) ty))
+
+
 ;; IntCC.SignedLessThan
 
 (rule 0 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) x y)
@@ -1276,6 +1280,9 @@
 
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) x (splat y))
   (rv_vmslt_vx x y (unmasked) ty))
+
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) (splat x) y)
+  (rv_vmsgt_vx y x (unmasked) ty))
 
 ;; IntCC.UnsignedLessThanOrEqual
 
@@ -1307,6 +1314,9 @@
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) x (splat y))
   (rv_vmsgtu_vx x y (unmasked) ty))
 
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) (splat x) y)
+  (rv_vmsltu_vx y x (unmasked) ty))
+
 (rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) x (replicated_imm5 y))
   (rv_vmsgtu_vi x y (unmasked) ty))
 
@@ -1318,6 +1328,9 @@
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) x (splat y))
   (rv_vmsgt_vx x y (unmasked) ty))
 
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) (splat x) y)
+  (rv_vmslt_vx y x (unmasked) ty))
+
 (rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) x (replicated_imm5 y))
   (rv_vmsgt_vi x y (unmasked) ty))
 
@@ -1326,7 +1339,13 @@
 (rule 0 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) x y)
   (rv_vmsgeu_vv x y (unmasked) ty))
 
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) (splat x) y)
+  (rv_vmsleu_vx y x (unmasked) ty))
+
 ;; IntCC.SignedGreaterThanOrEqual
 
 (rule 0 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) x y)
   (rv_vmsge_vv x y (unmasked) ty))
+
+(rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) (splat x) y)
+  (rv_vmsle_vx y x (unmasked) ty))

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1225,6 +1225,7 @@
 
 
 ;; Builds a vector mask corresponding to the IntCC operation.
+;; TODO: We are still missing some rules here for immediates. See #6623
 (decl gen_icmp_mask (Type IntCC Value Value) VReg)
 
 ;; IntCC.Equal
@@ -1272,6 +1273,8 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) (splat x) y)
   (rv_vmsgtu_vx y x (unmasked) ty))
 
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) (replicated_imm5 x) y)
+  (rv_vmsgtu_vi y x (unmasked) ty))
 
 ;; IntCC.SignedLessThan
 
@@ -1283,6 +1286,9 @@
 
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) (splat x) y)
   (rv_vmsgt_vx y x (unmasked) ty))
+
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) (replicated_imm5 x) y)
+  (rv_vmsgt_vi y x (unmasked) ty))
 
 ;; IntCC.UnsignedLessThanOrEqual
 
@@ -1342,6 +1348,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) (splat x) y)
   (rv_vmsleu_vx y x (unmasked) ty))
 
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) (replicated_imm5 x) y)
+  (rv_vmsleu_vi y x (unmasked) ty))
+
 ;; IntCC.SignedGreaterThanOrEqual
 
 (rule 0 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) x y)
@@ -1349,3 +1358,6 @@
 
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) (splat x) y)
   (rv_vmsle_vx y x (unmasked) ty))
+
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) (replicated_imm5 x) y)
+  (rv_vmsle_vi y x (unmasked) ty))

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
@@ -244,11 +244,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsle.vv v0,v1,v8 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsle.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -265,12 +264,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x00, 0x14, 0x76
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x76
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -338,8 +336,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsle.vv v0,v1,v7 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmsle.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -358,9 +356,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x13, 0x76
+;   .byte 0x57, 0x40, 0x17, 0x76
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
@@ -336,11 +336,10 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a4,10
-;   vmsle.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsle.vi v0,v1,10 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v6,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v8,v6,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -356,13 +355,12 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x17, 0x76
-;   .byte 0xd7, 0x33, 0x00, 0x5e
-;   .byte 0xd7, 0xb4, 0x7f, 0x5c
+;   .byte 0x57, 0x30, 0x15, 0x76
+;   .byte 0x57, 0x33, 0x00, 0x5e
+;   .byte 0x57, 0xb4, 0x6f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x04, 0x05, 0x02
+;   .byte 0x27, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
@@ -242,11 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmslt.vv v0,v1,v8 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmslt.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -263,12 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x00, 0x14, 0x6e
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x6e
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -334,8 +332,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmslt.vv v0,v1,v7 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmslt.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -354,9 +352,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x13, 0x6e
+;   .byte 0x57, 0x40, 0x17, 0x6e
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
@@ -242,11 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmslt.vv v0,v8,v1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsgt.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -263,12 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x80, 0x6e
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x7e
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -336,8 +334,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmslt.vv v0,v7,v1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmsgt.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -356,9 +354,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x70, 0x6e
+;   .byte 0x57, 0x40, 0x17, 0x7e
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
@@ -334,11 +334,10 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a4,10
-;   vmsgt.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsgt.vi v0,v1,10 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v6,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v8,v6,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -354,13 +353,12 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x17, 0x7e
-;   .byte 0xd7, 0x33, 0x00, 0x5e
-;   .byte 0xd7, 0xb4, 0x7f, 0x5c
+;   .byte 0x57, 0x30, 0x15, 0x7e
+;   .byte 0x57, 0x33, 0x00, 0x5e
+;   .byte 0x57, 0xb4, 0x6f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x04, 0x05, 0x02
+;   .byte 0x27, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
@@ -336,11 +336,10 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a4,10
-;   vmsleu.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsleu.vi v0,v1,10 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v6,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v8,v6,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -356,13 +355,12 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x17, 0x72
-;   .byte 0xd7, 0x33, 0x00, 0x5e
-;   .byte 0xd7, 0xb4, 0x7f, 0x5c
+;   .byte 0x57, 0x30, 0x15, 0x72
+;   .byte 0x57, 0x33, 0x00, 0x5e
+;   .byte 0x57, 0xb4, 0x6f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x04, 0x05, 0x02
+;   .byte 0x27, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
@@ -244,11 +244,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsleu.vv v0,v1,v8 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsleu.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -265,12 +264,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x00, 0x14, 0x72
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x72
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -338,8 +336,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsleu.vv v0,v1,v7 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmsleu.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -358,9 +356,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x13, 0x72
+;   .byte 0x57, 0x40, 0x17, 0x72
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
@@ -242,11 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsltu.vv v0,v1,v8 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsltu.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -263,12 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x00, 0x14, 0x6a
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x6a
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -334,8 +332,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsltu.vv v0,v1,v7 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmsltu.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -354,9 +352,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x13, 0x6a
+;   .byte 0x57, 0x40, 0x17, 0x6a
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
@@ -242,11 +242,10 @@ block0(v0: i64x2, v1: i64):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.x v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsltu.vv v0,v8,v1 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v8,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v10,v8,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v10,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsgtu.vx v0,v1,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -263,12 +262,11 @@ block0(v0: i64x2, v1: i64):
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x44, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x80, 0x6a
-;   .byte 0x57, 0x34, 0x00, 0x5e
-;   .byte 0x57, 0xb5, 0x8f, 0x5c
+;   .byte 0x57, 0x40, 0x15, 0x7a
+;   .byte 0xd7, 0x33, 0x00, 0x5e
+;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x85, 0x05, 0x02
+;   .byte 0xa7, 0x84, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -336,8 +334,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vmv.v.i v7,10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmsltu.vv v0,v7,v1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   li a4,10
+;   vmsgtu.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -356,9 +354,9 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0x33, 0x05, 0x5e
-;   .byte 0x57, 0x80, 0x70, 0x6a
+;   .byte 0x57, 0x40, 0x17, 0x7a
 ;   .byte 0xd7, 0x33, 0x00, 0x5e
 ;   .byte 0xd7, 0xb4, 0x7f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
@@ -334,11 +334,10 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a4,10
-;   vmsgtu.vx v0,v1,a4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmv.v.i v7,0 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vim v9,v7,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmsgtu.vi v0,v1,10 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmv.v.i v6,0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vim v8,v6,-1,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -354,13 +353,12 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   addi a4, zero, 0xa
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x40, 0x17, 0x7a
-;   .byte 0xd7, 0x33, 0x00, 0x5e
-;   .byte 0xd7, 0xb4, 0x7f, 0x5c
+;   .byte 0x57, 0x30, 0x15, 0x7a
+;   .byte 0x57, 0x33, 0x00, 0x5e
+;   .byte 0x57, 0xb4, 0x6f, 0x5c
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x04, 0x05, 0x02
+;   .byte 0x27, 0x04, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -57,3 +57,37 @@ block0:
     return v3
 }
 ; run: %icmp_eq_const_i64x2()  == 0
+
+function %simd_icmp_eq_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp eq v0, v2
+    return v3
+}
+; run: %simd_icmp_eq_splat_rhs_i32([1 0 -1 10], 10) == [0 0 0 -1]
+
+function %simd_icmp_eq_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp eq v0, v2
+    return v3
+}
+; run: %simd_icmp_eq_splat_const_rhs_i32([1 0 -1 10]) == [0 0 0 -1]
+
+function %simd_icmp_eq_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp eq v2, v1
+    return v3
+}
+; run: %simd_icmp_eq_splat_lhs_i32(10, [1 0 -1 10]) == [0 0 0 -1]
+
+function %simd_icmp_eq_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp eq v2, v0
+    return v3
+}
+; run: %simd_icmp_eq_splat_const_lhs_i32([1 0 -1 10]) == [0 0 0 -1]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -61,3 +61,38 @@ block0:
     return v5
 }
 ; run: %icmp_ne_const_i16x8() == 1
+
+
+function %simd_icmp_ne_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp ne v0, v2
+    return v3
+}
+; run: %simd_icmp_ne_splat_rhs_i32([1 0 -1 10], 10) == [-1 -1 -1 0]
+
+function %simd_icmp_ne_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ne v0, v2
+    return v3
+}
+; run: %simd_icmp_ne_splat_const_rhs_i32([1 0 -1 10]) == [-1 -1 -1 0]
+
+function %simd_icmp_ne_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp ne v2, v1
+    return v3
+}
+; run: %simd_icmp_ne_splat_lhs_i32(10, [1 0 -1 10]) == [-1 -1 -1 0]
+
+function %simd_icmp_ne_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+; run: %simd_icmp_ne_splat_const_lhs_i32([1 0 -1 10]) == [-1 -1 -1 0]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -51,3 +51,39 @@ block0:
     return v8
 }
 ; run: %icmp_sge_const_i16x8() == 1
+
+
+
+function %simd_icmp_sge_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp sge v0, v2
+    return v3
+}
+; run: %simd_icmp_sge_splat_rhs_i32([1 0 -1 10], 10) == [0 0 0 -1]
+
+function %simd_icmp_sge_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sge v0, v2
+    return v3
+}
+; run: %simd_icmp_sge_splat_const_rhs_i32([1 0 -1 10]) == [0 0 0 -1]
+
+function %simd_icmp_sge_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp sge v2, v1
+    return v3
+}
+; run: %simd_icmp_sge_splat_lhs_i32(10, [11 0 -1 10]) == [0 -1 -1 -1]
+
+function %simd_icmp_sge_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sge v2, v0
+    return v3
+}
+; run: %simd_icmp_sge_splat_const_lhs_i32([11 0 -1 10]) == [0 -1 -1 -1]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -67,3 +67,38 @@ block0:
     return v8
 }
 ; run: %icmp_sgt_const_i64x2() == 1
+
+
+function %simd_icmp_sgt_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp sgt v0, v2
+    return v3
+}
+; run: %simd_icmp_sgt_splat_rhs_i32([11 0 -1 10], 10) == [-1 0 0 0]
+
+function %simd_icmp_sgt_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sgt v0, v2
+    return v3
+}
+; run: %simd_icmp_sgt_splat_const_rhs_i32([11 0 -1 10]) == [-1 0 0 0]
+
+function %simd_icmp_sgt_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp sgt v2, v1
+    return v3
+}
+; run: %simd_icmp_sgt_splat_lhs_i32(10, [11 0 -1 10]) == [0 -1 -1 0]
+
+function %simd_icmp_sgt_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sgt v2, v0
+    return v3
+}
+; run: %simd_icmp_sgt_splat_const_lhs_i32([11 0 -1 10]) == [0 -1 -1 0]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -54,3 +54,38 @@ block0:
     return v8
 }
 ; run: %icmp_sle_const_i16x8() == 1
+
+
+function %simd_icmp_sle_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp sle v0, v2
+    return v3
+}
+; run: %simd_icmp_sle_splat_rhs_i32([11 0 -1 10], 10) == [0 -1 -1 -1]
+
+function %simd_icmp_sle_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sle v0, v2
+    return v3
+}
+; run: %simd_icmp_sle_splat_const_rhs_i32([11 0 -1 10]) == [0 -1 -1 -1]
+
+function %simd_icmp_sle_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp sle v2, v1
+    return v3
+}
+; run: %simd_icmp_sle_splat_lhs_i32(10, [11 0 -1 10]) == [-1 0 0 -1]
+
+function %simd_icmp_sle_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp sle v2, v0
+    return v3
+}
+; run: %simd_icmp_sle_splat_const_lhs_i32([11 0 -1 10]) == [-1 0 0 -1]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -51,3 +51,38 @@ block0:
     return v8
 }
 ; run: %icmp_slt_const_i32x4() == 1
+
+
+function %simd_icmp_slt_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp slt v0, v2
+    return v3
+}
+; run: %simd_icmp_slt_splat_rhs_i32([11 0 -1 10], 10) == [0 -1 -1 0]
+
+function %simd_icmp_slt_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp slt v0, v2
+    return v3
+}
+; run: %simd_icmp_slt_splat_const_rhs_i32([11 0 -1 10]) == [0 -1 -1 0]
+
+function %simd_icmp_slt_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp slt v2, v1
+    return v3
+}
+; run: %simd_icmp_slt_splat_lhs_i32(10, [11 0 -1 10]) == [-1 0 0 0]
+
+function %simd_icmp_slt_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp slt v2, v0
+    return v3
+}
+; run: %simd_icmp_slt_splat_const_lhs_i32([11 0 -1 10]) == [-1 0 0 0]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -52,3 +52,38 @@ block0(v0: i64x2, v1: i64x2):
 ; run: %simd_icmp_uge_i64([-1 0], [-1 1]) == [-1 0]
 ; run: %simd_icmp_uge_i64([-5 1], [-1 -1]) == [0 0]
 ; run: %simd_icmp_uge_i64([0 0], [0 0]) == [-1 -1]
+
+
+function %simd_icmp_uge_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %simd_icmp_uge_splat_rhs_i32([1 0 -1 10], 10) == [0 0 -1 -1]
+
+function %simd_icmp_uge_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %simd_icmp_uge_splat_const_rhs_i32([1 0 -1 10]) == [0 0 -1 -1]
+
+function %simd_icmp_uge_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp uge v2, v1
+    return v3
+}
+; run: %simd_icmp_uge_splat_lhs_i32(10, [11 0 -1 10]) == [0 -1 0 -1]
+
+function %simd_icmp_uge_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp uge v2, v0
+    return v3
+}
+; run: %simd_icmp_uge_splat_const_lhs_i32([11 0 -1 10]) == [0 -1 0 -1]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -51,3 +51,39 @@ block0(v0: i64x2, v1: i64x2):
 ; run: %simd_icmp_ugt_i64([-1 0], [-1 1]) == [0 0]
 ; run: %simd_icmp_ugt_i64([-5 1], [-1 -1]) == [0 0]
 ; run: %simd_icmp_ugt_i64([0 0], [0 0]) == [0 0]
+
+
+
+function %simd_icmp_ugt_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp ugt v0, v2
+    return v3
+}
+; run: %simd_icmp_ugt_splat_rhs_i32([11 0 -1 10], 10) == [-1 0 -1 0]
+
+function %simd_icmp_ugt_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ugt v0, v2
+    return v3
+}
+; run: %simd_icmp_ugt_splat_const_rhs_i32([11 0 -1 10]) == [-1 0 -1 0]
+
+function %simd_icmp_ugt_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp ugt v2, v1
+    return v3
+}
+; run: %simd_icmp_ugt_splat_lhs_i32(10, [11 0 -1 10]) == [0 -1 0 0]
+
+function %simd_icmp_ugt_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ugt v2, v0
+    return v3
+}
+; run: %simd_icmp_ugt_splat_const_lhs_i32([11 0 -1 10]) == [0 -1 0 0]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -53,3 +53,38 @@ block0(v0: i64x2, v1: i64x2):
 ; run: %simd_icmp_ule_i64([-1 0], [-1 1]) == [-1 -1]
 ; run: %simd_icmp_ule_i64([-5 1], [-1 -1]) == [-1 -1]
 ; run: %simd_icmp_ule_i64([0 0], [0 0]) == [-1 -1]
+
+
+function %simd_icmp_ule_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp ule v0, v2
+    return v3
+}
+; run: %simd_icmp_ule_splat_rhs_i32([11 0 -1 10], 10) == [0 -1 0 -1]
+
+function %simd_icmp_ule_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ule v0, v2
+    return v3
+}
+; run: %simd_icmp_ule_splat_const_rhs_i32([11 0 -1 10]) == [0 -1 0 -1]
+
+function %simd_icmp_ule_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp ule v2, v1
+    return v3
+}
+; run: %simd_icmp_ule_splat_lhs_i32(10, [11 0 -1 10]) == [-1 0 -1 -1]
+
+function %simd_icmp_ule_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ule v2, v0
+    return v3
+}
+; run: %simd_icmp_ule_splat_const_lhs_i32([11 0 -1 10]) == [-1 0 -1 -1]

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -66,3 +66,38 @@ block0(v0: i64x2, v1: i64x2):
 ; run: %simd_icmp_ult_i64([-1 0], [-1 1]) == [0 -1]
 ; run: %simd_icmp_ult_i64([-5 1], [-1 -1]) == [-1 -1]
 ; run: %simd_icmp_ult_i64([0 0], [0 0]) == [0 0]
+
+
+function %simd_icmp_ult_splat_rhs_i32(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = splat.i32x4 v1
+    v3 = icmp ult v0, v2
+    return v3
+}
+; run: %simd_icmp_ult_splat_rhs_i32([11 0 -1 10], 10) == [0 -1 0 0]
+
+function %simd_icmp_ult_splat_const_rhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ult v0, v2
+    return v3
+}
+; run: %simd_icmp_ult_splat_const_rhs_i32([11 0 -1 10]) == [0 -1 0 0]
+
+function %simd_icmp_ult_splat_lhs_i32(i32, i32x4) -> i32x4 {
+block0(v0: i32, v1: i32x4):
+    v2 = splat.i32x4 v0
+    v3 = icmp ult v2, v1
+    return v3
+}
+; run: %simd_icmp_ult_splat_lhs_i32(10, [11 0 -1 10]) == [-1 0 -1 0]
+
+function %simd_icmp_ult_splat_const_lhs_i32(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = iconst.i32 10
+    v2 = splat.i32x4 v1
+    v3 = icmp ult v2, v0
+    return v3
+}
+; run: %simd_icmp_ult_splat_const_lhs_i32([11 0 -1 10]) == [-1 0 -1 0]


### PR DESCRIPTION
👋 Hey,

This is a follow up PR to #6609. Here we implement some of the inverted rules. I've only implemented the cases where we can directly use another instruction. There are still a few more improvements to do, but I've filed those as a follow up in #6623 since I'm not planning on working on them right now.

I got these mostly by feeding in the equivalent IR to LLVM and checking which inverted instructions they produce. That being said, these cases all appear correct to me.