### PR TITLE
x64: Lower SIMD requirement to SSE2

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -17,15 +17,13 @@ fn define_settings(shared: &SettingGroup) -> SettingGroup {
         "has_sse3",
         "Has support for SSE3.",
         "SSE3: CPUID.01H:ECX.SSE3[bit 0]",
-        // Needed for default `enable_simd` setting.
-        true,
+        false,
     );
     let has_ssse3 = settings.add_bool(
         "has_ssse3",
         "Has support for SSSE3.",
         "SSSE3: CPUID.01H:ECX.SSSE3[bit 9]",
-        // Needed for default `enable_simd` setting.
-        true,
+        false,
     );
     let has_sse41 = settings.add_bool(
         "has_sse41",

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -13,7 +13,7 @@ use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
     TextSectionBuilder, VCode,
 };
-use crate::result::{CodegenError, CodegenResult};
+use crate::result::CodegenResult;
 use crate::settings::{self as shared_settings, Flags};
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
@@ -221,39 +221,6 @@ fn isa_constructor(
     builder: &shared_settings::Builder,
 ) -> CodegenResult<OwnedTargetIsa> {
     let isa_flags = x64_settings::Flags::new(&shared_flags, builder);
-
-    // Check for compatibility between flags and ISA level
-    // requested. In particular, SIMD support requires SSSE3.
-    if !cfg!(miri) && shared_flags.enable_simd() {
-        if !isa_flags.has_sse3() || !isa_flags.has_ssse3() {
-            return Err(CodegenError::Unsupported(
-                "SIMD support requires SSE3 and SSSE3 on x86_64.".into(),
-            ));
-        }
-    }
-
     let backend = X64Backend::new_with_flags(triple, shared_flags, isa_flags);
     Ok(backend.wrapped())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::settings;
-    use crate::settings::Configurable;
-
-    // Check that feature tests for SIMD work correctly.
-    #[test]
-    fn simd_required_features() {
-        let mut shared_flags_builder = settings::builder();
-        shared_flags_builder.set("enable_simd", "true").unwrap();
-        let shared_flags = settings::Flags::new(shared_flags_builder);
-        let mut isa_builder = crate::isa::lookup_by_name("x86_64").unwrap();
-        isa_builder.set("has_sse3", "false").unwrap();
-        isa_builder.set("has_ssse3", "false").unwrap();
-        assert!(matches!(
-            isa_builder.finish(shared_flags),
-            Err(CodegenError::Unsupported(_)),
-        ));
-    }
 }

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx
+target x86_64 sse42 has_avx
 
 function %iadd_pairwise_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64
+target x86_64 ssse3
 
 function %iadd_pairwise_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set enable_simd
-target x86_64 has_avx has_avx2
+target x86_64 sse42 has_avx has_avx2
 
 function %splat_i8(i8) -> i8x16 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
+++ b/cranelift/filetests/filetests/isa/x64/sqmul_round_sat.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 ssse3
 
 function %f1(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-band-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band-splat.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 ssse3
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 function %band_splat_const_i8x16(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-band.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 

--- a/cranelift/filetests/filetests/runtests/simd-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bnot.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 ssse3
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 

--- a/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 function %bor_splat_const_i8x16(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-bor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 

--- a/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
@@ -2,10 +2,11 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse41
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 function %bxor_splat_const_i8x16(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-bxor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-fadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd.clif
@@ -1,9 +1,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fdiv.clif
@@ -1,9 +1,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-fmul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmul.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-fneg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fneg.clif
@@ -1,9 +1,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-fsub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fsub.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 function %iadd_splat_const_i8x16(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
@@ -2,10 +2,10 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_sse41=false
 set enable_simd
 target x86_64
-target x86_64 skylake
+target x86_64 sse42
+target x86_64 sse42 has_avx
 target riscv64 has_v
 
 

--- a/cranelift/filetests/filetests/runtests/simd-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/simd-min-max.clif
@@ -1,9 +1,9 @@
 test run
 test interpret
-target x86_64 has_sse41=false
 set enable_simd
 target aarch64
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx has_avx512vl has_avx512bitalg
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
@@ -2,9 +2,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -2,9 +2,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target x86_64 sse41 has_avx has_avx2

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqrt.clif
@@ -1,9 +1,9 @@
 test run
 target aarch64
 target s390x
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -1,9 +1,9 @@
 test run
-target x86_64 ssse3 has_sse41=false
 set enable_simd
 target aarch64
 target s390x
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 sse41 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 sse41 has_ssse3=false
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target riscv64gc has_v

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -2,9 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target x86_64 has_ssse3=false
 set enable_simd
 target x86_64
+target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target riscv64gc has_v

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -69,17 +69,6 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
             return Err("x86 support requires SSE2");
         }
 
-        // These are temporarily enabled by default (see #3810 for
-        // more) so that a default-constructed `Flags` can work with
-        // default Wasmtime features. Otherwise, the user must
-        // explicitly use native flags or turn these on when on x86-64
-        // platforms to avoid a configuration panic. In order for the
-        // "enable if detected" logic below to work, we must turn them
-        // *off* (differing from the default) and then re-enable below
-        // if present.
-        isa_builder.set("has_sse3", "false").unwrap();
-        isa_builder.set("has_ssse3", "false").unwrap();
-
         if std::is_x86_feature_detected!("sse3") {
             isa_builder.enable("has_sse3").unwrap();
         }

--- a/crates/fuzzing/src/generators/codegen_settings.rs
+++ b/crates/fuzzing/src/generators/codegen_settings.rs
@@ -1,8 +1,6 @@
 //! Generate Cranelift compiler settings.
 
-use crate::generators::ModuleConfig;
 use arbitrary::{Arbitrary, Unstructured};
-use std::collections::HashMap;
 
 /// Choose between matching the host architecture or a cross-compilation target.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -33,42 +31,6 @@ impl CodegenSettings {
                 }
             }
         }
-    }
-
-    /// Features such as sse3 are unconditionally enabled on the x86_64 target
-    /// because they are hard required for SIMD, but when SIMD is disabled, for
-    /// example, we support disabling these features.
-    ///
-    /// This method will take the wasm feature selection chosen, through
-    /// `module_config`, and possibly try to disable some more features by
-    /// reading more of the input.
-    pub fn maybe_disable_more_features(
-        &mut self,
-        module_config: &ModuleConfig,
-        u: &mut Unstructured<'_>,
-    ) -> arbitrary::Result<()> {
-        let flags = match self {
-            CodegenSettings::Target { flags, .. } => flags,
-            _ => return Ok(()),
-        };
-
-        if !module_config.config.simd_enabled {
-            // Note that regardless of architecture these booleans are generated
-            // to have test case failures unrelated to codegen setting input
-            // that fail on one architecture to fail on other architectures as
-            // well.
-            let new_flags = ["has_sse3", "has_ssse3"]
-                .into_iter()
-                .map(|name| Ok((name, u.arbitrary()?)))
-                .collect::<arbitrary::Result<HashMap<_, bool>>>()?;
-
-            for (name, val) in flags {
-                if let Some(new_value) = new_flags.get(name.as_str()) {
-                    *val = new_value.to_string();
-                }
-            }
-        }
-        Ok(())
     }
 }
 
@@ -136,17 +98,8 @@ impl<'a> Arbitrary<'a> for CodegenSettings {
                 "x86_64" => {
                     test: is_x86_feature_detected,
 
-                    // These features are considered to be baseline required by
-                    // Wasmtime. Currently some SIMD code generation will
-                    // fail if these features are disabled, so unconditionally
-                    // enable them as we're not interested in fuzzing without
-                    // them.
-                    //
-                    // Note that these may still be disabled above in
-                    // `maybe_disable_more_features`.
-                    std:"sse3" => clif:"has_sse3" ratio: 1 in 1,
-                    std:"ssse3" => clif:"has_ssse3" ratio: 1 in 1,
-
+                    std:"sse3" => clif:"has_sse3",
+                    std:"ssse3" => clif:"has_ssse3",
                     std:"sse4.1" => clif:"has_sse41",
                     std:"sse4.2" => clif:"has_sse42",
                     std:"popcnt" => clif:"has_popcnt",

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -332,11 +332,6 @@ impl<'a> Arbitrary<'a> for Config {
         // doesn't implement this yet, so forcibly always disable it.
         config.module_config.config.tail_call_enabled = false;
 
-        config
-            .wasmtime
-            .codegen
-            .maybe_disable_more_features(&config.module_config, u)?;
-
         // If using the pooling allocator, constrain the memory and module configurations
         // to the module limits.
         if let InstanceAllocationStrategy::Pooling(pooling) = &mut config.wasmtime.strategy {


### PR DESCRIPTION
All instructions in Cranelift now have lowerings for SSE2 as a baseline, even if they're not exactly the speediest things in the world. This enables lowering the baseline required for the SIMD proposal for WebAssembly to SSE2, the base features set of x86_64. Lots of tests were updated here to remove explicit `has_foo=false` annotations as they no longer have any effect.

Additionally fuzzing has been updated to enable disabling `sse3` and `ssse3` which will help stress-test all previously-added lowerings.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
