### PR TITLE
x64: Fix ISA requirement for `pmaddubsw`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -219,6 +219,10 @@ impl TargetIsa for AArch64Backend {
     fn has_x86_pmulhrsw_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmaddubsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for AArch64Backend {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -352,6 +352,10 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Returns whether the CLIF `x86_pmulhrsw` instruction is implemented for
     /// this ISA.
     fn has_x86_pmulhrsw_lowering(&self) -> bool;
+
+    /// Returns whether the CLIF `x86_pmaddubsw` instruction is implemented for
+    /// this ISA.
+    fn has_x86_pmaddubsw_lowering(&self) -> bool;
 }
 
 /// Function alignment specifications as required by an ISA, returned by

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -194,6 +194,10 @@ impl TargetIsa for Riscv64Backend {
     fn has_x86_pmulhrsw_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmaddubsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for Riscv64Backend {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -194,6 +194,10 @@ impl TargetIsa for S390xBackend {
     fn has_x86_pmulhrsw_lowering(&self) -> bool {
         false
     }
+
+    fn has_x86_pmaddubsw_lowering(&self) -> bool {
+        false
+    }
 }
 
 impl fmt::Display for S390xBackend {

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1248,7 +1248,6 @@ impl SseOpcode {
             | SseOpcode::Pcmpgtd
             | SseOpcode::Pextrw
             | SseOpcode::Pinsrw
-            | SseOpcode::Pmaddubsw
             | SseOpcode::Pmaddwd
             | SseOpcode::Pmaxsw
             | SseOpcode::Pmaxub
@@ -1303,6 +1302,7 @@ impl SseOpcode {
             | SseOpcode::Pshufb
             | SseOpcode::Phaddw
             | SseOpcode::Phaddd
+            | SseOpcode::Pmaddubsw
             | SseOpcode::Movddup => SSSE3,
 
             SseOpcode::Blendvpd

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2413,6 +2413,7 @@
 ;; Rules for `x86_pmaddubsw` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I16X8 (x86_pmaddubsw x y)))
+      (if-let $true (use_ssse3))
       (x64_pmaddubsw y x))
 
 ;; Rules for `fadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3575,6 +3576,7 @@
         (has_type $I16X8 (iadd_pairwise
                            (swiden_low val @ (value_type $I8X16))
                            (swiden_high val))))
+      (if-let $true (use_ssse3))
       (let ((mul_const Xmm (x64_xmm_load_const $I8X16
               (emit_u128_le_const 0x01010101010101010101010101010101))))
         (x64_pmaddubsw mul_const val)))
@@ -3592,6 +3594,7 @@
         (has_type $I16X8 (iadd_pairwise
                            (uwiden_low val @ (value_type $I8X16))
                            (uwiden_high val))))
+      (if-let $true (use_ssse3))
       (let ((mul_const XmmMem (emit_u128_le_const 0x01010101010101010101010101010101)))
         (x64_pmaddubsw val mul_const)))
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -194,6 +194,10 @@ impl TargetIsa for X64Backend {
     fn has_x86_pmulhrsw_lowering(&self) -> bool {
         self.x64_flags.use_ssse3()
     }
+
+    fn has_x86_pmaddubsw_lowering(&self) -> bool {
+        self.x64_flags.use_ssse3()
+    }
 }
 
 impl fmt::Display for X64Backend {

--- a/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-pairwise-add.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target x86_64
+target x86_64 ssse3
 
 function %fn1(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -636,6 +636,10 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         self.config.target.contains("x86_64")
     }
 
+    fn use_x86_pmaddubsw_for_dot(&self) -> bool {
+        self.config.target.contains("x86_64")
+    }
+
     fn translate_call_ref(
         &mut self,
         _builder: &mut cranelift_frontend::FunctionBuilder<'_>,

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -581,6 +581,12 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn use_x86_pmulhrsw_for_relaxed_q15mul(&self) -> bool {
         false
     }
+
+    /// Returns whether the CLIF `x86_pmaddubsw` instruction should be used for
+    /// the relaxed-simd dot-product instructions instruction.
+    fn use_x86_pmaddubsw_for_dot(&self) -> bool {
+        false
+    }
 }
 
 /// An object satisfying the `ModuleEnvironment` trait can be passed as argument to the

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2211,4 +2211,8 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     fn use_x86_pmulhrsw_for_relaxed_q15mul(&self) -> bool {
         self.isa.has_x86_pmulhrsw_lowering()
     }
+
+    fn use_x86_pmaddubsw_for_dot(&self) -> bool {
+        self.isa.has_x86_pmaddubsw_lowering()
+    }
 }


### PR DESCRIPTION
This was erroneously listed as SSE2 but this is actually an SSSE3 instruction. This commit updates the ISA requirement as well as related lowerings to have everything work with an SSE2 baseline as well which is mostly plumbing to make sure the relaxed-simd dot product instructions use it when it's available but otherwise fall-back to the deterministic lowering.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
