### PR TITLE
cranelift: Remove the `enable_simd` shared setting

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/settings.rs
+++ b/cranelift/codegen/meta/src/cdsl/settings.rs
@@ -142,17 +142,6 @@ impl SettingGroup {
         let num_predicates = self.num_bool_settings() + (self.predicates.len() as u8);
         self.bool_start_byte_offset + (num_predicates + 7) / 8
     }
-
-    pub fn get_bool(&self, name: &'static str) -> (BoolSettingIndex, &Self) {
-        for (i, s) in self.settings.iter().enumerate() {
-            if let SpecificSetting::Bool(_) = s.specific {
-                if s.name == name {
-                    return (BoolSettingIndex(i), self);
-                }
-            }
-        }
-        panic!("Should have found bool setting by name.");
-    }
 }
 
 /// This is the basic information needed to track the specific parts of a setting when building

--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -3,13 +3,13 @@ use crate::cdsl::settings::{PredicateNode, SettingGroup, SettingGroupBuilder};
 
 use crate::shared::Definitions as SharedDefinitions;
 
-pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
-    let settings = define_settings(&shared_defs.settings);
+pub(crate) fn define(_shared_defs: &mut SharedDefinitions) -> TargetIsa {
+    let settings = define_settings();
 
     TargetIsa::new("x86", settings)
 }
 
-fn define_settings(shared: &SettingGroup) -> SettingGroup {
+fn define_settings() -> SettingGroup {
     let mut settings = SettingGroupBuilder::new("x86");
 
     // CPUID.01H:ECX
@@ -114,51 +114,18 @@ fn define_settings(shared: &SettingGroup) -> SettingGroup {
         false,
     );
 
-    let shared_enable_simd = shared.get_bool("enable_simd");
-
     settings.add_predicate("use_ssse3", predicate!(has_ssse3));
     settings.add_predicate("use_sse41", predicate!(has_sse41));
     settings.add_predicate("use_sse42", predicate!(has_sse41 && has_sse42));
     settings.add_predicate("use_fma", predicate!(has_avx && has_fma));
 
-    settings.add_predicate(
-        "use_ssse3_simd",
-        predicate!(shared_enable_simd && has_ssse3),
-    );
-    settings.add_predicate(
-        "use_sse41_simd",
-        predicate!(shared_enable_simd && has_sse41),
-    );
-    settings.add_predicate(
-        "use_sse42_simd",
-        predicate!(shared_enable_simd && has_sse41 && has_sse42),
-    );
-
-    settings.add_predicate("use_avx_simd", predicate!(shared_enable_simd && has_avx));
-    settings.add_predicate(
-        "use_avx2_simd",
-        predicate!(shared_enable_simd && has_avx && has_avx2),
-    );
-    settings.add_predicate(
-        "use_avx512bitalg_simd",
-        predicate!(shared_enable_simd && has_avx512bitalg),
-    );
-    settings.add_predicate(
-        "use_avx512dq_simd",
-        predicate!(shared_enable_simd && has_avx512dq),
-    );
-    settings.add_predicate(
-        "use_avx512vl_simd",
-        predicate!(shared_enable_simd && has_avx512vl),
-    );
-    settings.add_predicate(
-        "use_avx512vbmi_simd",
-        predicate!(shared_enable_simd && has_avx512vbmi),
-    );
-    settings.add_predicate(
-        "use_avx512f_simd",
-        predicate!(shared_enable_simd && has_avx512f),
-    );
+    settings.add_predicate("use_avx", predicate!(has_avx));
+    settings.add_predicate("use_avx2", predicate!(has_avx && has_avx2));
+    settings.add_predicate("use_avx512bitalg", predicate!(has_avx512bitalg));
+    settings.add_predicate("use_avx512dq", predicate!(has_avx512dq));
+    settings.add_predicate("use_avx512vl", predicate!(has_avx512vl));
+    settings.add_predicate("use_avx512vbmi", predicate!(has_avx512vbmi));
+    settings.add_predicate("use_avx512f", predicate!(has_avx512f));
 
     settings.add_predicate("use_popcnt", predicate!(has_popcnt && has_sse42));
     settings.add_predicate("use_bmi1", predicate!(has_bmi1));

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -116,13 +116,6 @@ pub(crate) fn define() -> SettingGroup {
     );
 
     settings.add_bool(
-        "enable_simd",
-        "Enable the use of SIMD instructions.",
-        "",
-        false,
-    );
-
-    settings.add_bool(
         "enable_atomics",
         "Enable the use of atomic instructions",
         "",

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1636,20 +1636,20 @@
 
 ;;;; Helpers for Querying Enabled ISA Extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl pure use_avx512vl_simd () bool)
-(extern constructor use_avx512vl_simd use_avx512vl_simd)
+(decl pure use_avx512vl () bool)
+(extern constructor use_avx512vl use_avx512vl)
 
-(decl pure use_avx512dq_simd () bool)
-(extern constructor use_avx512dq_simd use_avx512dq_simd)
+(decl pure use_avx512dq () bool)
+(extern constructor use_avx512dq use_avx512dq)
 
-(decl pure use_avx512f_simd () bool)
-(extern constructor use_avx512f_simd use_avx512f_simd)
+(decl pure use_avx512f () bool)
+(extern constructor use_avx512f use_avx512f)
 
-(decl pure use_avx512bitalg_simd () bool)
-(extern constructor use_avx512bitalg_simd use_avx512bitalg_simd)
+(decl pure use_avx512bitalg () bool)
+(extern constructor use_avx512bitalg use_avx512bitalg)
 
-(decl pure use_avx512vbmi_simd () bool)
-(extern constructor use_avx512vbmi_simd use_avx512vbmi_simd)
+(decl pure use_avx512vbmi () bool)
+(extern constructor use_avx512vbmi use_avx512vbmi)
 
 (decl pure use_lzcnt () bool)
 (extern constructor use_lzcnt use_lzcnt)
@@ -1672,11 +1672,11 @@
 (decl pure use_sse42 () bool)
 (extern constructor use_sse42 use_sse42)
 
-(decl pure use_avx_simd () bool)
-(extern constructor use_avx_simd use_avx_simd)
+(decl pure use_avx () bool)
+(extern constructor use_avx use_avx)
 
-(decl pure use_avx2_simd () bool)
-(extern constructor use_avx2_simd use_avx2_simd)
+(decl pure use_avx2 () bool)
+(extern constructor use_avx2 use_avx2)
 
 ;;;; Helpers for Merging and Sinking Immediates/Loads  ;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2214,56 +2214,56 @@
 (rule (x64_movss_load from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movss) from))
 (rule 1 (x64_movss_load from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovss) from))
 
 (decl x64_movss_store (SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_movss_store addr data)
       (xmm_movrm (SseOpcode.Movss) addr data))
 (rule 1 (x64_movss_store addr data)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_vex (AvxOpcode.Vmovss) addr data))
 
 (decl x64_movsd_load (SyntheticAmode) Xmm)
 (rule (x64_movsd_load from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movsd) from))
 (rule 1 (x64_movsd_load from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovsd) from))
 
 (decl x64_movsd_store (SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_movsd_store addr data)
       (xmm_movrm (SseOpcode.Movsd) addr data))
 (rule 1 (x64_movsd_store addr data)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_vex (AvxOpcode.Vmovsd) addr data))
 
 (decl x64_movups_load (SyntheticAmode) Xmm)
 (rule (x64_movups_load from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movups) from))
 (rule 1 (x64_movups_load from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovups) from))
 
 (decl x64_movups_store (SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_movups_store addr data)
       (xmm_movrm (SseOpcode.Movups) addr data))
 (rule 1 (x64_movups_store addr data)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_vex (AvxOpcode.Vmovups) addr data))
 
 (decl x64_movupd_load (SyntheticAmode) Xmm)
 (rule (x64_movupd_load from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movupd) from))
 (rule 1 (x64_movupd_load from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovupd) from))
 
 (decl x64_movupd_store (SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_movupd_store addr data)
       (xmm_movrm (SseOpcode.Movupd) addr data))
 (rule 1 (x64_movupd_store addr data)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_vex (AvxOpcode.Vmovupd) addr data))
 
 ;; Helper for creating `movd` instructions.
@@ -2271,7 +2271,7 @@
 (rule (x64_movd_to_gpr from)
       (xmm_to_gpr (SseOpcode.Movd) from (OperandSize.Size32)))
 (rule 1 (x64_movd_to_gpr from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_vex (AvxOpcode.Vmovd) from (OperandSize.Size32)))
 
 ;; Helper for creating `movd` instructions.
@@ -2279,7 +2279,7 @@
 (rule (x64_movd_to_xmm from)
       (gpr_to_xmm (SseOpcode.Movd) from (OperandSize.Size32)))
 (rule 1 (x64_movd_to_xmm from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (gpr_to_xmm_vex (AvxOpcode.Vmovd) from (OperandSize.Size32)))
 
 ;; Helper for creating `movq` instructions.
@@ -2287,7 +2287,7 @@
 (rule (x64_movq_to_xmm src)
       (gpr_to_xmm (SseOpcode.Movq) src (OperandSize.Size64)))
 (rule 1 (x64_movq_to_xmm from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (gpr_to_xmm_vex (AvxOpcode.Vmovq) from (OperandSize.Size64)))
 
 ;; Helper for creating `movq` instructions.
@@ -2295,63 +2295,63 @@
 (rule (x64_movq_to_gpr src)
       (xmm_to_gpr (SseOpcode.Movq) src (OperandSize.Size64)))
 (rule 1 (x64_movq_to_gpr from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_vex (AvxOpcode.Vmovq) from (OperandSize.Size64)))
 
 (decl x64_movdqu_load (XmmMem) Xmm)
 (rule (x64_movdqu_load from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movdqu) from))
 (rule 1 (x64_movdqu_load from)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovdqu) from))
 
 (decl x64_movdqu_store (SyntheticAmode Xmm) SideEffectNoResult)
 (rule (x64_movdqu_store addr data)
       (xmm_movrm (SseOpcode.Movdqu) addr data))
 (rule 1 (x64_movdqu_store addr data)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_vex (AvxOpcode.Vmovdqu) addr data))
 
 (decl x64_pmovsxbw (XmmMem) Xmm)
 (rule (x64_pmovsxbw from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovsxbw) from))
 (rule 1 (x64_pmovsxbw from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovsxbw) from))
 
 (decl x64_pmovzxbw (XmmMem) Xmm)
 (rule (x64_pmovzxbw from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovzxbw) from))
 (rule 1 (x64_pmovzxbw from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovzxbw) from))
 
 (decl x64_pmovsxwd (XmmMem) Xmm)
 (rule (x64_pmovsxwd from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovsxwd) from))
 (rule 1 (x64_pmovsxwd from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovsxwd) from))
 
 (decl x64_pmovzxwd (XmmMem) Xmm)
 (rule (x64_pmovzxwd from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovzxwd) from))
 (rule 1 (x64_pmovzxwd from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovzxwd) from))
 
 (decl x64_pmovsxdq (XmmMem) Xmm)
 (rule (x64_pmovsxdq from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovsxdq) from))
 (rule 1 (x64_pmovsxdq from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovsxdq) from))
 
 (decl x64_pmovzxdq (XmmMem) Xmm)
 (rule (x64_pmovzxdq from)
       (xmm_unary_rm_r_unaligned (SseOpcode.Pmovzxdq) from))
 (rule 1 (x64_pmovzxdq from)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpmovzxdq) from))
 
 (decl x64_movrm (Type SyntheticAmode Gpr) SideEffectNoResult)
@@ -2819,7 +2819,7 @@
 (rule 0 (x64_paddb src1 src2)
       (xmm_rm_r (SseOpcode.Paddb) src1 src2))
 (rule 1 (x64_paddb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddb) src1 src2))
 
 ;; Helper for creating `paddw` instructions.
@@ -2827,7 +2827,7 @@
 (rule 0 (x64_paddw src1 src2)
       (xmm_rm_r (SseOpcode.Paddw) src1 src2))
 (rule 1 (x64_paddw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddw) src1 src2))
 
 ;; Helper for creating `paddd` instructions.
@@ -2835,7 +2835,7 @@
 (rule 0 (x64_paddd src1 src2)
       (xmm_rm_r (SseOpcode.Paddd) src1 src2))
 (rule 1 (x64_paddd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddd) src1 src2))
 
 ;; Helper for creating `paddq` instructions.
@@ -2843,7 +2843,7 @@
 (rule 0 (x64_paddq src1 src2)
       (xmm_rm_r (SseOpcode.Paddq) src1 src2))
 (rule 1 (x64_paddq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddq) src1 src2))
 
 ;; Helper for creating `paddsb` instructions.
@@ -2851,7 +2851,7 @@
 (rule 0 (x64_paddsb src1 src2)
       (xmm_rm_r (SseOpcode.Paddsb) src1 src2))
 (rule 1 (x64_paddsb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddsb) src1 src2))
 
 ;; Helper for creating `paddsw` instructions.
@@ -2859,7 +2859,7 @@
 (rule 0 (x64_paddsw src1 src2)
       (xmm_rm_r (SseOpcode.Paddsw) src1 src2))
 (rule 1 (x64_paddsw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddsw) src1 src2))
 
 ;; Helper for creating `phaddw` instructions.
@@ -2867,7 +2867,7 @@
 (rule 0 (x64_phaddw src1 src2)
       (xmm_rm_r (SseOpcode.Phaddw) src1 src2))
 (rule 1 (x64_phaddw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vphaddw) src1 src2))
 
 ;; Helper for creating `phaddd` instructions.
@@ -2875,7 +2875,7 @@
 (rule 0 (x64_phaddd src1 src2)
       (xmm_rm_r (SseOpcode.Phaddd) src1 src2))
 (rule 1 (x64_phaddd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vphaddd) src1 src2))
 
 ;; Helper for creating `paddusb` instructions.
@@ -2883,7 +2883,7 @@
 (rule 0 (x64_paddusb src1 src2)
       (xmm_rm_r (SseOpcode.Paddusb) src1 src2))
 (rule 1 (x64_paddusb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddusb) src1 src2))
 
 ;; Helper for creating `paddusw` instructions.
@@ -2891,7 +2891,7 @@
 (rule 0 (x64_paddusw src1 src2)
       (xmm_rm_r (SseOpcode.Paddusw) src1 src2))
 (rule 1 (x64_paddusw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpaddusw) src1 src2))
 
 ;; Helper for creating `psubb` instructions.
@@ -2899,7 +2899,7 @@
 (rule 0 (x64_psubb src1 src2)
       (xmm_rm_r (SseOpcode.Psubb) src1 src2))
 (rule 1 (x64_psubb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubb) src1 src2))
 
 ;; Helper for creating `psubw` instructions.
@@ -2907,7 +2907,7 @@
 (rule 0 (x64_psubw src1 src2)
       (xmm_rm_r (SseOpcode.Psubw) src1 src2))
 (rule 1 (x64_psubw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubw) src1 src2))
 
 ;; Helper for creating `psubd` instructions.
@@ -2915,7 +2915,7 @@
 (rule 0 (x64_psubd src1 src2)
       (xmm_rm_r (SseOpcode.Psubd) src1 src2))
 (rule 1 (x64_psubd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubd) src1 src2))
 
 ;; Helper for creating `psubq` instructions.
@@ -2923,7 +2923,7 @@
 (rule 0 (x64_psubq src1 src2)
       (xmm_rm_r (SseOpcode.Psubq) src1 src2))
 (rule 1 (x64_psubq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubq) src1 src2))
 
 ;; Helper for creating `psubsb` instructions.
@@ -2931,7 +2931,7 @@
 (rule 0 (x64_psubsb src1 src2)
       (xmm_rm_r (SseOpcode.Psubsb) src1 src2))
 (rule 1 (x64_psubsb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubsb) src1 src2))
 
 ;; Helper for creating `psubsw` instructions.
@@ -2939,7 +2939,7 @@
 (rule 0 (x64_psubsw src1 src2)
       (xmm_rm_r (SseOpcode.Psubsw) src1 src2))
 (rule 1 (x64_psubsw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubsw) src1 src2))
 
 ;; Helper for creating `psubusb` instructions.
@@ -2947,7 +2947,7 @@
 (rule 0 (x64_psubusb src1 src2)
       (xmm_rm_r (SseOpcode.Psubusb) src1 src2))
 (rule 1 (x64_psubusb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubusb) src1 src2))
 
 ;; Helper for creating `psubusw` instructions.
@@ -2955,7 +2955,7 @@
 (rule 0 (x64_psubusw src1 src2)
       (xmm_rm_r (SseOpcode.Psubusw) src1 src2))
 (rule 1 (x64_psubusw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsubusw) src1 src2))
 
 ;; Helper for creating `pavgb` instructions.
@@ -2963,7 +2963,7 @@
 (rule 0 (x64_pavgb src1 src2)
       (xmm_rm_r (SseOpcode.Pavgb) src1 src2))
 (rule 1 (x64_pavgb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpavgb) src1 src2))
 
 ;; Helper for creating `pavgw` instructions.
@@ -2971,7 +2971,7 @@
 (rule 0 (x64_pavgw src1 src2)
       (xmm_rm_r (SseOpcode.Pavgw) src1 src2))
 (rule 1 (x64_pavgw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpavgw) src1 src2))
 
 ;; Helper for creating `pand` instructions.
@@ -2979,7 +2979,7 @@
 (rule 0 (x64_pand src1 src2)
       (xmm_rm_r (SseOpcode.Pand) src1 src2))
 (rule 1 (x64_pand src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpand) src1 src2))
 
 ;; Helper for creating `andps` instructions.
@@ -2987,7 +2987,7 @@
 (rule 0 (x64_andps src1 src2)
       (xmm_rm_r (SseOpcode.Andps) src1 src2))
 (rule 1 (x64_andps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vandps) src1 src2))
 
 ;; Helper for creating `andpd` instructions.
@@ -2995,7 +2995,7 @@
 (rule 0 (x64_andpd src1 src2)
       (xmm_rm_r (SseOpcode.Andpd) src1 src2))
 (rule 1 (x64_andpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vandpd) src1 src2))
 
 ;; Helper for creating `por` instructions.
@@ -3003,7 +3003,7 @@
 (rule 0 (x64_por src1 src2)
       (xmm_rm_r (SseOpcode.Por) src1 src2))
 (rule 1 (x64_por src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpor) src1 src2))
 
 ;; Helper for creating `orps` instructions.
@@ -3011,7 +3011,7 @@
 (rule 0 (x64_orps src1 src2)
       (xmm_rm_r (SseOpcode.Orps) src1 src2))
 (rule 1 (x64_orps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vorps) src1 src2))
 
 ;; Helper for creating `orpd` instructions.
@@ -3019,7 +3019,7 @@
 (rule 0 (x64_orpd src1 src2)
       (xmm_rm_r (SseOpcode.Orpd) src1 src2))
 (rule 1 (x64_orpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vorpd) src1 src2))
 
 ;; Helper fxor creating `pxor` instructions.
@@ -3027,7 +3027,7 @@
 (rule 0 (x64_pxor src1 src2)
       (xmm_rm_r (SseOpcode.Pxor) src1 src2))
 (rule 1 (x64_pxor src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpxor) src1 src2))
 
 ;; Helper fxor creating `xorps` instructions.
@@ -3035,7 +3035,7 @@
 (rule 0 (x64_xorps src1 src2)
       (xmm_rm_r (SseOpcode.Xorps) src1 src2))
 (rule 1 (x64_xorps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vxorps) src1 src2))
 
 ;; Helper fxor creating `xorpd` instructions.
@@ -3043,7 +3043,7 @@
 (rule 0 (x64_xorpd src1 src2)
       (xmm_rm_r (SseOpcode.Xorpd) src1 src2))
 (rule 1 (x64_xorpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vxorpd) src1 src2))
 
 ;; Helper for creating `pmullw` instructions.
@@ -3051,7 +3051,7 @@
 (rule 0 (x64_pmullw src1 src2)
       (xmm_rm_r (SseOpcode.Pmullw) src1 src2))
 (rule 1 (x64_pmullw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmullw) src1 src2))
 
 ;; Helper for creating `pmulld` instructions.
@@ -3059,7 +3059,7 @@
 (rule 0 (x64_pmulld src1 src2)
       (xmm_rm_r (SseOpcode.Pmulld) src1 src2))
 (rule 1 (x64_pmulld src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmulld) src1 src2))
 
 ;; Helper for creating `pmulhw` instructions.
@@ -3067,7 +3067,7 @@
 (rule 0 (x64_pmulhw src1 src2)
       (xmm_rm_r (SseOpcode.Pmulhw) src1 src2))
 (rule 1 (x64_pmulhw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmulhw) src1 src2))
 
 ;; Helper for creating `pmulhrsw` instructions.
@@ -3075,7 +3075,7 @@
 (rule 0 (x64_pmulhrsw src1 src2)
       (xmm_rm_r (SseOpcode.Pmulhrsw) src1 src2))
 (rule 1 (x64_pmulhrsw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmulhrsw) src1 src2))
 
 ;; Helper for creating `pmulhuw` instructions.
@@ -3083,7 +3083,7 @@
 (rule 0 (x64_pmulhuw src1 src2)
       (xmm_rm_r (SseOpcode.Pmulhuw) src1 src2))
 (rule 1 (x64_pmulhuw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmulhuw) src1 src2))
 
 ;; Helper for creating `pmuldq` instructions.
@@ -3091,7 +3091,7 @@
 (rule 0 (x64_pmuldq src1 src2)
       (xmm_rm_r (SseOpcode.Pmuldq) src1 src2))
 (rule 1 (x64_pmuldq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmuldq) src1 src2))
 
 ;; Helper for creating `pmuludq` instructions.
@@ -3099,7 +3099,7 @@
 (rule 0 (x64_pmuludq src1 src2)
       (xmm_rm_r (SseOpcode.Pmuludq) src1 src2))
 (rule 1 (x64_pmuludq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmuludq) src1 src2))
 
 ;; Helper for creating `punpckhwd` instructions.
@@ -3107,7 +3107,7 @@
 (rule 0 (x64_punpckhwd src1 src2)
       (xmm_rm_r (SseOpcode.Punpckhwd) src1 src2))
 (rule 1 (x64_punpckhwd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpckhwd) src1 src2))
 
 ;; Helper for creating `punpcklwd` instructions.
@@ -3115,7 +3115,7 @@
 (rule 0 (x64_punpcklwd src1 src2)
       (xmm_rm_r (SseOpcode.Punpcklwd) src1 src2))
 (rule 1 (x64_punpcklwd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpcklwd) src1 src2))
 
 ;; Helper for creating `punpckldq` instructions.
@@ -3123,7 +3123,7 @@
 (rule 0 (x64_punpckldq src1 src2)
       (xmm_rm_r (SseOpcode.Punpckldq) src1 src2))
 (rule 1 (x64_punpckldq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpckldq) src1 src2))
 
 ;; Helper for creating `punpckhdq` instructions.
@@ -3131,7 +3131,7 @@
 (rule 0 (x64_punpckhdq src1 src2)
       (xmm_rm_r (SseOpcode.Punpckhdq) src1 src2))
 (rule 1 (x64_punpckhdq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpckhdq) src1 src2))
 
 ;; Helper for creating `punpcklqdq` instructions.
@@ -3139,7 +3139,7 @@
 (rule 0 (x64_punpcklqdq src1 src2)
       (xmm_rm_r (SseOpcode.Punpcklqdq) src1 src2))
 (rule 1 (x64_punpcklqdq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpcklqdq) src1 src2))
 
 ;; Helper for creating `punpckhqdq` instructions.
@@ -3147,7 +3147,7 @@
 (rule 0 (x64_punpckhqdq src1 src2)
       (xmm_rm_r (SseOpcode.Punpckhqdq) src1 src2))
 (rule 1 (x64_punpckhqdq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpunpckhqdq) src1 src2))
 
 ;; Helper for creating `unpcklps` instructions.
@@ -3155,7 +3155,7 @@
 (rule 0 (x64_unpcklps src1 src2)
       (xmm_rm_r (SseOpcode.Unpcklps) src1 src2))
 (rule 1 (x64_unpcklps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vunpcklps) src1 src2))
 
 ;; Helper for creating `unpckhps` instructions.
@@ -3163,7 +3163,7 @@
 (rule 0 (x64_unpckhps src1 src2)
       (xmm_rm_r (SseOpcode.Unpckhps) src1 src2))
 (rule 1 (x64_unpckhps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vunpckhps) src1 src2))
 
 ;; Helper for creating `andnps` instructions.
@@ -3171,7 +3171,7 @@
 (rule 0 (x64_andnps src1 src2)
       (xmm_rm_r (SseOpcode.Andnps) src1 src2))
 (rule 1 (x64_andnps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vandnps) src1 src2))
 
 ;; Helper for creating `andnpd` instructions.
@@ -3179,7 +3179,7 @@
 (rule 0 (x64_andnpd src1 src2)
       (xmm_rm_r (SseOpcode.Andnpd) src1 src2))
 (rule 1 (x64_andnpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vandnpd) src1 src2))
 
 ;; Helper for creating `pandn` instructions.
@@ -3187,7 +3187,7 @@
 (rule 0 (x64_pandn src1 src2)
       (xmm_rm_r (SseOpcode.Pandn) src1 src2))
 (rule 1 (x64_pandn src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpandn) src1 src2))
 
 ;; Helper for creating `addss` instructions.
@@ -3195,7 +3195,7 @@
 (rule (x64_addss src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Addss) src1 src2))
 (rule 1 (x64_addss src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vaddss) src1 src2))
 
 ;; Helper for creating `addsd` instructions.
@@ -3203,7 +3203,7 @@
 (rule (x64_addsd src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Addsd) src1 src2))
 (rule 1 (x64_addsd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vaddsd) src1 src2))
 
 ;; Helper for creating `addps` instructions.
@@ -3211,7 +3211,7 @@
 (rule 0 (x64_addps src1 src2)
       (xmm_rm_r (SseOpcode.Addps) src1 src2))
 (rule 1 (x64_addps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vaddps) src1 src2))
 
 ;; Helper for creating `addpd` instructions.
@@ -3219,7 +3219,7 @@
 (rule 0 (x64_addpd src1 src2)
       (xmm_rm_r (SseOpcode.Addpd) src1 src2))
 (rule 1 (x64_addpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vaddpd) src1 src2))
 
 ;; Helper for creating `subss` instructions.
@@ -3227,7 +3227,7 @@
 (rule (x64_subss src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Subss) src1 src2))
 (rule 1 (x64_subss src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vsubss) src1 src2))
 
 ;; Helper for creating `subsd` instructions.
@@ -3235,7 +3235,7 @@
 (rule (x64_subsd src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Subsd) src1 src2))
 (rule 1 (x64_subsd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vsubsd) src1 src2))
 
 ;; Helper for creating `subps` instructions.
@@ -3243,7 +3243,7 @@
 (rule 0 (x64_subps src1 src2)
       (xmm_rm_r (SseOpcode.Subps) src1 src2))
 (rule 1 (x64_subps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vsubps) src1 src2))
 
 ;; Helper for creating `subpd` instructions.
@@ -3251,7 +3251,7 @@
 (rule 0 (x64_subpd src1 src2)
       (xmm_rm_r (SseOpcode.Subpd) src1 src2))
 (rule 1 (x64_subpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vsubpd) src1 src2))
 
 ;; Helper for creating `mulss` instructions.
@@ -3259,7 +3259,7 @@
 (rule (x64_mulss src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Mulss) src1 src2))
 (rule 1 (x64_mulss src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmulss) src1 src2))
 
 ;; Helper for creating `mulsd` instructions.
@@ -3267,7 +3267,7 @@
 (rule (x64_mulsd src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Mulsd) src1 src2))
 (rule 1 (x64_mulsd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmulsd) src1 src2))
 
 ;; Helper for creating `mulps` instructions.
@@ -3275,7 +3275,7 @@
 (rule 0 (x64_mulps src1 src2)
       (xmm_rm_r (SseOpcode.Mulps) src1 src2))
 (rule 1 (x64_mulps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmulps) src1 src2))
 
 ;; Helper for creating `mulpd` instructions.
@@ -3283,7 +3283,7 @@
 (rule (x64_mulpd src1 src2)
       (xmm_rm_r (SseOpcode.Mulpd) src1 src2))
 (rule 1 (x64_mulpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmulpd) src1 src2))
 
 ;; Helper for creating `divss` instructions.
@@ -3291,7 +3291,7 @@
 (rule (x64_divss src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Divss) src1 src2))
 (rule 1 (x64_divss src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vdivss) src1 src2))
 
 ;; Helper for creating `divsd` instructions.
@@ -3299,7 +3299,7 @@
 (rule (x64_divsd src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Divsd) src1 src2))
 (rule 1 (x64_divsd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vdivsd) src1 src2))
 
 ;; Helper for creating `divps` instructions.
@@ -3307,7 +3307,7 @@
 (rule 0 (x64_divps src1 src2)
       (xmm_rm_r (SseOpcode.Divps) src1 src2))
 (rule 1 (x64_divps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vdivps) src1 src2))
 
 ;; Helper for creating `divpd` instructions.
@@ -3315,7 +3315,7 @@
 (rule 0 (x64_divpd src1 src2)
       (xmm_rm_r (SseOpcode.Divpd) src1 src2))
 (rule 1 (x64_divpd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vdivpd) src1 src2))
 
 ;; Helper for creating `blendvp{d,s}` and `pblendvb` instructions.
@@ -3329,7 +3329,7 @@
 (rule 0 (x64_blendvpd src1 src2 mask)
       (xmm_rm_r_blend (SseOpcode.Blendvpd) src1 src2 mask))
 (rule 1 (x64_blendvpd src1 src2 mask)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_blend_vex (AvxOpcode.Vblendvpd) src1 src2 mask))
 
 ;; Helper for creating `blendvps` instructions.
@@ -3337,7 +3337,7 @@
 (rule 0 (x64_blendvps src1 src2 mask)
       (xmm_rm_r_blend (SseOpcode.Blendvps) src1 src2 mask))
 (rule 1 (x64_blendvps src1 src2 mask)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_blend_vex (AvxOpcode.Vblendvps) src1 src2 mask))
 
 ;; Helper for creating `pblendvb` instructions.
@@ -3345,7 +3345,7 @@
 (rule 0 (x64_pblendvb src1 src2 mask)
       (xmm_rm_r_blend (SseOpcode.Pblendvb) src1 src2 mask))
 (rule 1 (x64_pblendvb src1 src2 mask)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_blend_vex (AvxOpcode.Vpblendvb) src1 src2 mask))
 
 ;; Helper for creating `pblendw` instructions.
@@ -3353,7 +3353,7 @@
 (rule 0 (x64_pblendw src1 src2 imm)
       (xmm_rm_r_imm (SseOpcode.Pblendw) src1 src2 imm (OperandSize.Size32)))
 (rule 1 (x64_pblendw src1 src2 imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vpblendw) src1 src2 imm))
 
 ;; Helper for creating `movsd`/`movss` instructions which create a new vector
@@ -3368,14 +3368,14 @@
 (rule (x64_movsd_regmove src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Movsd) src1 src2))
 (rule 1 (x64_movsd_regmove src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vmovsd) src1 src2))
 
 (decl x64_movss_regmove (Xmm Xmm) Xmm)
 (rule (x64_movss_regmove src1 src2)
       (xmm_rm_r_unaligned (SseOpcode.Movss) src1 src2))
 (rule 1 (x64_movss_regmove src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vmovss) src1 src2))
 
 ;; Helper for creating `movlhps` instructions.
@@ -3383,7 +3383,7 @@
 (rule 0 (x64_movlhps src1 src2)
       (xmm_rm_r (SseOpcode.Movlhps) src1 src2))
 (rule 1 (x64_movlhps src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmovlhps) src1 src2))
 
 ;; Helpers for creating `pmaxs*` instructions.
@@ -3395,17 +3395,17 @@
 (decl x64_pmaxsb (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxsb src1 src2) (xmm_rm_r (SseOpcode.Pmaxsb) src1 src2))
 (rule 1 (x64_pmaxsb src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxsb) src1 src2))
 (decl x64_pmaxsw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxsw src1 src2) (xmm_rm_r (SseOpcode.Pmaxsw) src1 src2))
 (rule 1 (x64_pmaxsw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxsw) src1 src2))
 (decl x64_pmaxsd (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxsd src1 src2) (xmm_rm_r (SseOpcode.Pmaxsd) src1 src2))
 (rule 1 (x64_pmaxsd src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxsd) src1 src2))
 
 ;; Helpers for creating `pmins*` instructions.
@@ -3417,17 +3417,17 @@
 (decl x64_pminsb (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminsb src1 src2) (xmm_rm_r (SseOpcode.Pminsb) src1 src2))
 (rule 1 (x64_pminsb src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminsb) src1 src2))
 (decl x64_pminsw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminsw src1 src2) (xmm_rm_r (SseOpcode.Pminsw) src1 src2))
 (rule 1 (x64_pminsw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminsw) src1 src2))
 (decl x64_pminsd (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminsd src1 src2) (xmm_rm_r (SseOpcode.Pminsd) src1 src2))
 (rule 1 (x64_pminsd src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminsd) src1 src2))
 
 ;; Helpers for creating `pmaxu*` instructions.
@@ -3439,17 +3439,17 @@
 (decl x64_pmaxub (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxub src1 src2) (xmm_rm_r (SseOpcode.Pmaxub) src1 src2))
 (rule 1 (x64_pmaxub src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxub) src1 src2))
 (decl x64_pmaxuw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxuw src1 src2) (xmm_rm_r (SseOpcode.Pmaxuw) src1 src2))
 (rule 1 (x64_pmaxuw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxuw) src1 src2))
 (decl x64_pmaxud (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaxud src1 src2) (xmm_rm_r (SseOpcode.Pmaxud) src1 src2))
 (rule 1 (x64_pmaxud src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpmaxud) src1 src2))
 
 ;; Helper for creating `pminu*` instructions.
@@ -3461,17 +3461,17 @@
 (decl x64_pminub (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminub src1 src2) (xmm_rm_r (SseOpcode.Pminub) src1 src2))
 (rule 1 (x64_pminub src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminub) src1 src2))
 (decl x64_pminuw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminuw src1 src2) (xmm_rm_r (SseOpcode.Pminuw) src1 src2))
 (rule 1 (x64_pminuw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminuw) src1 src2))
 (decl x64_pminud (Xmm XmmMem) Xmm)
 (rule 0 (x64_pminud src1 src2) (xmm_rm_r (SseOpcode.Pminud) src1 src2))
 (rule 1 (x64_pminud src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpminud) src1 src2))
 
 ;; Helper for creating `punpcklbw` instructions.
@@ -3479,7 +3479,7 @@
 (rule 0 (x64_punpcklbw src1 src2)
       (xmm_rm_r (SseOpcode.Punpcklbw) src1 src2))
 (rule 1 (x64_punpcklbw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpunpcklbw) src1 src2))
 
 ;; Helper for creating `punpckhbw` instructions.
@@ -3487,7 +3487,7 @@
 (rule 0 (x64_punpckhbw src1 src2)
       (xmm_rm_r (SseOpcode.Punpckhbw) src1 src2))
 (rule 1 (x64_punpckhbw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpunpckhbw) src1 src2))
 
 ;; Helper for creating `packsswb` instructions.
@@ -3495,7 +3495,7 @@
 (rule 0 (x64_packsswb src1 src2)
       (xmm_rm_r (SseOpcode.Packsswb) src1 src2))
 (rule 1 (x64_packsswb src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpacksswb) src1 src2))
 
 ;; Helper for creating `packssdw` instructions.
@@ -3503,7 +3503,7 @@
 (rule 0 (x64_packssdw src1 src2)
       (xmm_rm_r (SseOpcode.Packssdw) src1 src2))
 (rule 1 (x64_packssdw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpackssdw) src1 src2))
 
 ;; Helper for creating `packuswb` instructions.
@@ -3511,7 +3511,7 @@
 (rule 0 (x64_packuswb src1 src2)
       (xmm_rm_r (SseOpcode.Packuswb) src1 src2))
 (rule 1 (x64_packuswb src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpackuswb) src1 src2))
 
 ;; Helper for creating `packusdw` instructions.
@@ -3519,7 +3519,7 @@
 (rule 0 (x64_packusdw src1 src2)
       (xmm_rm_r (SseOpcode.Packusdw) src1 src2))
 (rule 1 (x64_packusdw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpackusdw) src1 src2))
 
 ;; Helper for creating `palignr` instructions.
@@ -3531,7 +3531,7 @@
                     imm
                     (OperandSize.Size32)))
 (rule 1 (x64_palignr src1 src2 imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vpalignr) src1 src2 imm))
 
 ;; Helpers for creating `cmpp*` instructions.
@@ -3547,7 +3547,7 @@
                     (encode_fcmp_imm imm)
                     (OperandSize.Size32)))
 (rule 1 (x64_cmpps src1 src2 imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vcmpps)
                        src1
                        src2
@@ -3564,7 +3564,7 @@
                     (encode_fcmp_imm imm)
                     (OperandSize.Size32)))
 (rule 1 (x64_cmppd src1 src2 imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vcmppd)
                        src1
                        src2
@@ -3579,7 +3579,7 @@
                     lane
                     (OperandSize.Size32)))
 (rule 1 (x64_pinsrb src1 src2 lane)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_vex_pinsr (AvxOpcode.Vpinsrb) src1 src2 lane))
 
 ;; Helper for creating `pinsrw` instructions.
@@ -3591,7 +3591,7 @@
                     lane
                     (OperandSize.Size32)))
 (rule 1 (x64_pinsrw src1 src2 lane)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_vex_pinsr (AvxOpcode.Vpinsrw) src1 src2 lane))
 
 ;; Helper for creating `pinsrd` instructions.
@@ -3603,7 +3603,7 @@
                     lane
                     (OperandSize.Size32)))
 (rule 1 (x64_pinsrd src1 src2 lane)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_vex_pinsr (AvxOpcode.Vpinsrd) src1 src2 lane))
 
 ;; Helper for creating `pinsrq` instructions.
@@ -3615,7 +3615,7 @@
                     lane
                     (OperandSize.Size64)))
 (rule 1 (x64_pinsrq src1 src2 lane)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_vex_pinsr (AvxOpcode.Vpinsrq) src1 src2 lane))
 
 ;; Helper for creating `roundss` instructions.
@@ -3623,7 +3623,7 @@
 (rule (x64_roundss src1 round)
       (xmm_unary_rm_r_imm (SseOpcode.Roundss) src1 (encode_round_imm round)))
 (rule 1 (x64_roundss src1 round)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundss) src1 (encode_round_imm round)))
 
 ;; Helper for creating `roundsd` instructions.
@@ -3631,7 +3631,7 @@
 (rule (x64_roundsd src1 round)
       (xmm_unary_rm_r_imm (SseOpcode.Roundsd) src1 (encode_round_imm round)))
 (rule 1 (x64_roundsd src1 round)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundsd) src1 (encode_round_imm round)))
 
 ;; Helper for creating `roundps` instructions.
@@ -3639,7 +3639,7 @@
 (rule (x64_roundps src1 round)
       (xmm_unary_rm_r_imm (SseOpcode.Roundps) src1 (encode_round_imm round)))
 (rule 1 (x64_roundps src1 round)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundps) src1 (encode_round_imm round)))
 
 ;; Helper for creating `roundpd` instructions.
@@ -3647,7 +3647,7 @@
 (rule (x64_roundpd src1 round)
       (xmm_unary_rm_r_imm (SseOpcode.Roundpd) src1 (encode_round_imm round)))
 (rule 1 (x64_roundpd src1 round)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundpd) src1 (encode_round_imm round)))
 
 ;; Helper for creating `pmaddwd` instructions.
@@ -3655,14 +3655,14 @@
 (rule 0 (x64_pmaddwd src1 src2)
       (xmm_rm_r (SseOpcode.Pmaddwd) src1 src2))
 (rule 1 (x64_pmaddwd src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmaddwd) src1 src2))
 
 (decl x64_pmaddubsw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pmaddubsw src1 src2)
       (xmm_rm_r (SseOpcode.Pmaddubsw) src1 src2))
 (rule 1 (x64_pmaddubsw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpmaddubsw) src1 src2))
 
 ;; Helper for creating `insertps` instructions.
@@ -3674,7 +3674,7 @@
                     lane
                     (OperandSize.Size32)))
 (rule 1 (x64_insertps src1 src2 lane)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vinsertps) src1 src2 lane))
 
 ;; Helper for creating `pshufd` instructions.
@@ -3682,7 +3682,7 @@
 (rule (x64_pshufd src imm)
       (xmm_unary_rm_r_imm (SseOpcode.Pshufd) src imm))
 (rule 1 (x64_pshufd src imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshufd) src imm))
 
 ;; Helper for creating `pshufb` instructions.
@@ -3690,7 +3690,7 @@
 (rule 0 (x64_pshufb src1 src2)
       (xmm_rm_r (SseOpcode.Pshufb) src1 src2))
 (rule 1 (x64_pshufb src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpshufb) src1 src2))
 
 ;; Helper for creating `pshuflw` instructions.
@@ -3698,7 +3698,7 @@
 (rule (x64_pshuflw src imm)
       (xmm_unary_rm_r_imm (SseOpcode.Pshuflw) src imm))
 (rule 1 (x64_pshuflw src imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshuflw) src imm))
 
 ;; Helper for creating `pshufhw` instructions.
@@ -3706,7 +3706,7 @@
 (rule (x64_pshufhw src imm)
       (xmm_unary_rm_r_imm (SseOpcode.Pshufhw) src imm))
 (rule 1 (x64_pshufhw src imm)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_imm_vex (AvxOpcode.Vpshufhw) src imm))
 
 ;; Helper for creating `shufps` instructions.
@@ -3718,7 +3718,7 @@
                     byte
                     (OperandSize.Size32)))
 (rule 1 (x64_shufps src1 src2 byte)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmr_imm_vex (AvxOpcode.Vshufps) src1 src2 byte))
 
 ;; Helper for creating `pabsb` instructions.
@@ -3726,7 +3726,7 @@
 (rule (x64_pabsb src)
       (xmm_unary_rm_r (SseOpcode.Pabsb) src))
 (rule 1 (x64_pabsb src)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpabsb) src))
 
 ;; Helper for creating `pabsw` instructions.
@@ -3734,7 +3734,7 @@
 (rule (x64_pabsw src)
       (xmm_unary_rm_r (SseOpcode.Pabsw) src))
 (rule 1 (x64_pabsw src)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpabsw) src))
 
 ;; Helper for creating `pabsd` instructions.
@@ -3742,7 +3742,7 @@
 (rule (x64_pabsd src)
       (xmm_unary_rm_r (SseOpcode.Pabsd) src))
 (rule 1 (x64_pabsd src)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_unary_rm_r_vex (AvxOpcode.Vpabsd) src))
 
 ;; Helper for creating `vcvtudq2ps` instructions.
@@ -3793,7 +3793,7 @@
 (rule 0 (x64_psllw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psllw) src1 src2))
 (rule 1 (x64_psllw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpsllw) src1 src2))
 
 ;; Helper for creating `pslld` instructions.
@@ -3801,7 +3801,7 @@
 (rule 0 (x64_pslld src1 src2)
       (xmm_rmi_xmm (SseOpcode.Pslld) src1 src2))
 (rule 1 (x64_pslld src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpslld) src1 src2))
 
 ;; Helper for creating `psllq` instructions.
@@ -3809,7 +3809,7 @@
 (rule 0 (x64_psllq src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psllq) src1 src2))
 (rule 1 (x64_psllq src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpsllq) src1 src2))
 
 ;; Helper for creating `psrlw` instructions.
@@ -3817,7 +3817,7 @@
 (rule 0 (x64_psrlw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrlw) src1 src2))
 (rule 1 (x64_psrlw src1 src2)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpsrlw) src1 src2))
 
 ;; Helper for creating `psrld` instructions.
@@ -3825,7 +3825,7 @@
 (rule 0 (x64_psrld src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrld) src1 src2))
 (rule 1 (x64_psrld src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsrld) src1 src2))
 
 ;; Helper for creating `psrlq` instructions.
@@ -3833,7 +3833,7 @@
 (rule 0 (x64_psrlq src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrlq) src1 src2))
 (rule 1 (x64_psrlq src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsrlq) src1 src2))
 
 ;; Helper for creating `psraw` instructions.
@@ -3841,7 +3841,7 @@
 (rule 0 (x64_psraw src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psraw) src1 src2))
 (rule 1 (x64_psraw src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsraw) src1 src2))
 
 ;; Helper for creating `psrad` instructions.
@@ -3849,7 +3849,7 @@
 (rule 0 (x64_psrad src1 src2)
       (xmm_rmi_xmm (SseOpcode.Psrad) src1 src2))
 (rule 1 (x64_psrad src1 src2)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vpsrad) src1 src2))
 
 ;; Helper for creating `vpsraq` instructions.
@@ -3867,14 +3867,14 @@
 (rule (x64_pextrb src lane)
       (xmm_to_gpr_imm (SseOpcode.Pextrb) src lane))
 (rule 1 (x64_pextrb src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrb) src lane))
 
 (decl x64_pextrb_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrb_store addr src lane)
       (xmm_movrm_imm (SseOpcode.Pextrb) addr src lane))
 (rule 1 (x64_pextrb_store addr src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_imm_vex (AvxOpcode.Vpextrb) addr src lane))
 
 ;; Helper for creating `pextrw` instructions.
@@ -3882,14 +3882,14 @@
 (rule (x64_pextrw src lane)
       (xmm_to_gpr_imm (SseOpcode.Pextrw) src lane))
 (rule 1 (x64_pextrw src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrw) src lane))
 
 (decl x64_pextrw_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrw_store addr src lane)
       (xmm_movrm_imm (SseOpcode.Pextrw) addr src lane))
 (rule 1 (x64_pextrw_store addr src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_imm_vex (AvxOpcode.Vpextrw) addr src lane))
 
 ;; Helper for creating `pextrd` instructions.
@@ -3897,14 +3897,14 @@
 (rule (x64_pextrd src lane)
       (xmm_to_gpr_imm (SseOpcode.Pextrd) src lane))
 (rule 1 (x64_pextrd src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrd) src lane))
 
 (decl x64_pextrd_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrd_store addr src lane)
       (xmm_movrm_imm (SseOpcode.Pextrd) addr src lane))
 (rule 1 (x64_pextrd_store addr src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_imm_vex (AvxOpcode.Vpextrd) addr src lane))
 
 ;; Helper for creating `pextrq` instructions.
@@ -3912,14 +3912,14 @@
 (rule (x64_pextrq src lane)
       (xmm_to_gpr_imm (SseOpcode.Pextrq) src lane))
 (rule 1 (x64_pextrq src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrq) src lane))
 
 (decl x64_pextrq_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrq_store addr src lane)
       (xmm_movrm_imm (SseOpcode.Pextrq) addr src lane))
 (rule 1 (x64_pextrq_store addr src lane)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_movrm_imm_vex (AvxOpcode.Vpextrq) addr src lane))
 
 ;; Helper for creating `pmovmskb` instructions.
@@ -3927,7 +3927,7 @@
 (rule (x64_pmovmskb size src)
       (xmm_to_gpr (SseOpcode.Pmovmskb) src size))
 (rule 1 (x64_pmovmskb size src)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_vex (AvxOpcode.Vpmovmskb) src size))
 
 ;; Helper for creating `movmskps` instructions.
@@ -3935,7 +3935,7 @@
 (rule (x64_movmskps size src)
       (xmm_to_gpr (SseOpcode.Movmskps) src size))
 (rule 1 (x64_movmskps size src)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_vex (AvxOpcode.Vmovmskps) src size))
 
 ;; Helper for creating `movmskpd` instructions.
@@ -3943,7 +3943,7 @@
 (rule (x64_movmskpd size src)
       (xmm_to_gpr (SseOpcode.Movmskpd) src size))
 (rule 1 (x64_movmskpd size src)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_to_gpr_vex (AvxOpcode.Vmovmskpd) src size))
 
 ;; Helper for creating `not` instructions.
@@ -4061,7 +4061,7 @@
 (rule (x64_minss x y)
       (xmm_rm_r_unaligned (SseOpcode.Minss) x y))
 (rule 1 (x64_minss x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vminss) x y))
 
 ;; Helper for creating `minsd` instructions.
@@ -4069,7 +4069,7 @@
 (rule (x64_minsd x y)
       (xmm_rm_r_unaligned (SseOpcode.Minsd) x y))
 (rule 1 (x64_minsd x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vminsd) x y))
 
 ;; Helper for creating `minps` instructions.
@@ -4077,7 +4077,7 @@
 (rule 0 (x64_minps x y)
       (xmm_rm_r (SseOpcode.Minps) x y))
 (rule 1 (x64_minps x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vminps) x y))
 
 ;; Helper for creating `minpd` instructions.
@@ -4085,7 +4085,7 @@
 (rule 0 (x64_minpd x y)
       (xmm_rm_r (SseOpcode.Minpd) x y))
 (rule 1 (x64_minpd x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vminpd) x y))
 
 ;; Helper for creating `maxss` instructions.
@@ -4093,7 +4093,7 @@
 (rule (x64_maxss x y)
       (xmm_rm_r_unaligned (SseOpcode.Maxss) x y))
 (rule 1 (x64_maxss x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmaxss) x y))
 
 ;; Helper for creating `maxsd` instructions.
@@ -4101,7 +4101,7 @@
 (rule (x64_maxsd x y)
       (xmm_rm_r_unaligned (SseOpcode.Maxsd) x y))
 (rule 1 (x64_maxsd x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmaxsd) x y))
 
 ;; Helper for creating `maxps` instructions.
@@ -4109,7 +4109,7 @@
 (rule 0 (x64_maxps x y)
       (xmm_rm_r (SseOpcode.Maxps) x y))
 (rule 1 (x64_maxps x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmaxps) x y))
 
 ;; Helper for creating `maxpd` instructions.
@@ -4117,7 +4117,7 @@
 (rule 0 (x64_maxpd x y)
       (xmm_rm_r (SseOpcode.Maxpd) x y))
 (rule 1 (x64_maxpd x y)
-      (if-let $true (use_avx_simd))
+      (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vmaxpd) x y))
 
 ;; Helper for creating `vfmadd213*` instructions
@@ -4152,70 +4152,70 @@
 (decl x64_sqrtss (XmmMem) Xmm)
 (rule (x64_sqrtss x) (xmm_unary_rm_r_unaligned (SseOpcode.Sqrtss) x))
 (rule 1 (x64_sqrtss x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vsqrtss) x))
 
 ;; Helper for creating `sqrtsd` instructions.
 (decl x64_sqrtsd (XmmMem) Xmm)
 (rule (x64_sqrtsd x) (xmm_unary_rm_r_unaligned (SseOpcode.Sqrtsd) x))
 (rule 1 (x64_sqrtsd x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vsqrtsd) x))
 
 ;; Helper for creating `sqrtps` instructions.
 (decl x64_sqrtps (XmmMem) Xmm)
 (rule (x64_sqrtps x) (xmm_unary_rm_r (SseOpcode.Sqrtps) x))
 (rule 1 (x64_sqrtps x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vsqrtps) x))
 
 ;; Helper for creating `sqrtpd` instructions.
 (decl x64_sqrtpd (XmmMem) Xmm)
 (rule (x64_sqrtpd x) (xmm_unary_rm_r (SseOpcode.Sqrtpd) x))
 (rule 1 (x64_sqrtpd x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vsqrtpd) x))
 
 ;; Helper for creating `cvtss2sd` instructions.
 (decl x64_cvtss2sd (XmmMem) Xmm)
 (rule (x64_cvtss2sd x) (xmm_unary_rm_r_unaligned (SseOpcode.Cvtss2sd) x))
 (rule 1 (x64_cvtss2sd x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtss2sd) x))
 
 ;; Helper for creating `cvtsd2ss` instructions.
 (decl x64_cvtsd2ss (XmmMem) Xmm)
 (rule (x64_cvtsd2ss x) (xmm_unary_rm_r_unaligned (SseOpcode.Cvtsd2ss) x))
 (rule 1 (x64_cvtsd2ss x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtsd2ss) x))
 
 ;; Helper for creating `cvtdq2ps` instructions.
 (decl x64_cvtdq2ps (XmmMem) Xmm)
 (rule (x64_cvtdq2ps x) (xmm_unary_rm_r (SseOpcode.Cvtdq2ps) x))
 (rule 1 (x64_cvtdq2ps x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtdq2ps) x))
 
 ;; Helper for creating `cvtps2pd` instructions.
 (decl x64_cvtps2pd (XmmMem) Xmm)
 (rule (x64_cvtps2pd x) (xmm_unary_rm_r (SseOpcode.Cvtps2pd) x))
 (rule 1 (x64_cvtps2pd x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtps2pd) x))
 
 ;; Helper for creating `cvtpd2ps` instructions.
 (decl x64_cvtpd2ps (XmmMem) Xmm)
 (rule (x64_cvtpd2ps x) (xmm_unary_rm_r (SseOpcode.Cvtpd2ps) x))
 (rule 1 (x64_cvtpd2ps x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtpd2ps) x))
 
 ;; Helper for creating `cvtdq2pd` instructions.
 (decl x64_cvtdq2pd (XmmMem) Xmm)
 (rule (x64_cvtdq2pd x) (xmm_unary_rm_r (SseOpcode.Cvtdq2pd) x))
 (rule 1 (x64_cvtdq2pd x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvtdq2pd) x))
 
 ;; Helper for creating `cvtsi2ss` instructions.
@@ -4223,7 +4223,7 @@
 (rule (x64_cvtsi2ss ty x)
       (gpr_to_xmm (SseOpcode.Cvtsi2ss) x (raw_operand_size_of_type ty)))
 (rule 1 (x64_cvtsi2ss ty x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (gpr_to_xmm_vex (AvxOpcode.Vcvtsi2ss) x (raw_operand_size_of_type ty)))
 
 ;; Helper for creating `cvtsi2sd` instructions.
@@ -4231,7 +4231,7 @@
 (rule (x64_cvtsi2sd ty x)
       (gpr_to_xmm (SseOpcode.Cvtsi2sd) x (raw_operand_size_of_type ty)))
 (rule 1 (x64_cvtsi2sd ty x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (gpr_to_xmm_vex (AvxOpcode.Vcvtsi2sd) x (raw_operand_size_of_type ty)))
 
 ;; Helper for creating `cvttps2dq` instructions.
@@ -4239,7 +4239,7 @@
 (rule (x64_cvttps2dq x)
       (xmm_unary_rm_r (SseOpcode.Cvttps2dq) x))
 (rule 1 (x64_cvttps2dq x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvttps2dq) x))
 
 ;; Helper for creating `cvttpd2dq` instructions.
@@ -4247,7 +4247,7 @@
 (rule (x64_cvttpd2dq x)
       (xmm_unary_rm_r (SseOpcode.Cvttpd2dq) x))
 (rule 1 (x64_cvttpd2dq x)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vcvttpd2dq) x))
 
 ;; Helpers for creating `pcmpeq*` instructions.
@@ -4272,22 +4272,22 @@
 (decl x64_pcmpeqb (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpeqb x y) (xmm_rm_r (SseOpcode.Pcmpeqb) x y))
 (rule 1 (x64_pcmpeqb x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpeqb) x y))
 (decl x64_pcmpeqw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpeqw x y) (xmm_rm_r (SseOpcode.Pcmpeqw) x y))
 (rule 1 (x64_pcmpeqw x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpeqw) x y))
 (decl x64_pcmpeqd (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpeqd x y) (xmm_rm_r (SseOpcode.Pcmpeqd) x y))
 (rule 1 (x64_pcmpeqd x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpeqd) x y))
 (decl x64_pcmpeqq (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpeqq x y) (xmm_rm_r (SseOpcode.Pcmpeqq) x y))
 (rule 1 (x64_pcmpeqq x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpeqq) x y))
 
 ;; Helpers for creating `pcmpgt*` instructions.
@@ -4344,22 +4344,22 @@
 (decl x64_pcmpgtb (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpgtb x y) (xmm_rm_r (SseOpcode.Pcmpgtb) x y))
 (rule 1 (x64_pcmpgtb x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpgtb) x y))
 (decl x64_pcmpgtw (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpgtw x y) (xmm_rm_r (SseOpcode.Pcmpgtw) x y))
 (rule 1 (x64_pcmpgtw x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpgtw) x y))
 (decl x64_pcmpgtd (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpgtd x y) (xmm_rm_r (SseOpcode.Pcmpgtd) x y))
 (rule 1 (x64_pcmpgtd x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpgtd) x y))
 (decl x64_pcmpgtq (Xmm XmmMem) Xmm)
 (rule 0 (x64_pcmpgtq x y) (xmm_rm_r (SseOpcode.Pcmpgtq) x y))
 (rule 1 (x64_pcmpgtq x y)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_rmir_vex (AvxOpcode.Vpcmpgtq) x y))
 
 ;; Helpers for read-modify-write ALU form (AluRM).
@@ -4420,7 +4420,7 @@
 (rule (x64_movddup src)
       (xmm_unary_rm_r_unaligned (SseOpcode.Movddup) src))
 (rule 1 (x64_movddup src)
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (xmm_unary_rm_r_vex (AvxOpcode.Vmovddup) src))
 
 ;; Helper for creating `vpbroadcastb` instructions

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -784,13 +784,13 @@
 ;; feature sets. To remedy this, a small dance is done with an unsigned right
 ;; shift plus some extra ops.
 (rule 3 (lower (has_type ty @ $I64X2 (sshr src (iconst n))))
-        (if-let $true (use_avx512vl_simd))
-        (if-let $true (use_avx512f_simd))
+        (if-let $true (use_avx512vl))
+        (if-let $true (use_avx512f))
         (x64_vpsraq_imm src (shift_amount_masked ty n)))
 
 (rule 2 (lower (has_type ty @ $I64X2 (sshr src amt)))
-        (if-let $true (use_avx512vl_simd))
-        (if-let $true (use_avx512f_simd))
+        (if-let $true (use_avx512vl))
+        (if-let $true (use_avx512f))
         (let ((masked Gpr (x64_and $I64 amt (RegMemImm.Imm (shift_mask ty)))))
           (x64_vpsraq src (x64_movd_to_xmm masked))))
 
@@ -1018,8 +1018,8 @@
 ;; With AVX-512 we can implement `i64x2` multiplication with a single
 ;; instruction.
 (rule 3 (lower (has_type (multi_lane 64 2) (imul x y)))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512dq_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512dq))
       (x64_vpmullq x y))
 
 ;; Otherwise, for i64x2 multiplication we describe a lane A as being composed of
@@ -1200,8 +1200,8 @@
 
 ;; When AVX512 is available, we can use a single `vpabsq` instruction.
 (rule 2 (lower (has_type $I64X2 (iabs x)))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512f_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512f))
       (x64_vpabsq x))
 
 ;; Otherwise, we use a separate register, `neg`, to contain the results of `0 -
@@ -2193,8 +2193,8 @@
 
 
 (rule 2 (lower (has_type $I8X16 (popcnt src)))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512bitalg_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512bitalg))
       (x64_vpopcntb src))
 
 
@@ -3322,8 +3322,8 @@
 ;; When AVX512VL and AVX512F are available,
 ;; `fcvt_from_uint` can be lowered to a single instruction.
 (rule 2 (lower (has_type $F32X4 (fcvt_from_uint src)))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512f_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512f))
       (x64_vcvtudq2ps src))
 
 ;; Converting packed unsigned integers to packed floats
@@ -4230,15 +4230,15 @@
 ;; greater than 31) we must mask off those resulting values in the result of
 ;; `vpermi2b`.
 (rule 2 (lower (shuffle a b (vec_mask_from_immediate (perm_from_mask_with_zeros mask zeros))))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512vbmi_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512vbmi))
       (x64_andps (x64_vpermi2b (x64_xmm_load_const $I8X16 mask) a b) zeros))
 
 ;; However, if the shuffle mask contains no out-of-bounds values, we can use
 ;; `vpermi2b` without any masking.
 (rule 1 (lower (shuffle a b (vec_mask_from_immediate mask)))
-      (if-let $true (use_avx512vl_simd))
-      (if-let $true (use_avx512vbmi_simd))
+      (if-let $true (use_avx512vl))
+      (if-let $true (use_avx512vbmi))
       (x64_vpermi2b (x64_xmm_load_const $I8X16 (perm_from_mask mask)) a b))
 
 ;; If `lhs` and `rhs` are different, we must shuffle each separately and then OR
@@ -4379,13 +4379,13 @@
         (if-let $true (use_ssse3))
         (x64_pshufb (bitcast_gpr_to_xmm $I32 src) (xmm_zero $I8X16)))
 (rule 2 (lower (has_type $I8X16 (splat src)))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vpbroadcastb (bitcast_gpr_to_xmm $I32 src)))
 (rule 3 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
         (if-let $true (use_sse41))
         (x64_pshufb (x64_pinsrb (xmm_uninit_value) addr 0) (xmm_zero $I8X16)))
 (rule 4 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vpbroadcastb addr))
 
 ;; i16x8 splats: use `vpbroadcastw` on AVX2 and otherwise a 16-bit value is
@@ -4396,12 +4396,12 @@
 (rule 0 (lower (has_type $I16X8 (splat src)))
         (x64_pshufd (x64_pshuflw (bitcast_gpr_to_xmm $I32 src) 0) 0))
 (rule 1 (lower (has_type $I16X8 (splat src)))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vpbroadcastw (bitcast_gpr_to_xmm $I32 src)))
 (rule 2 (lower (has_type $I16X8 (splat (sinkable_load_exact addr))))
         (x64_pshufd (x64_pshuflw (x64_pinsrw (xmm_uninit_value) addr 0) 0) 0))
 (rule 3 (lower (has_type $I16X8 (splat (sinkable_load_exact addr))))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vpbroadcastw addr))
 
 ;; i32x4.splat - use `vpbroadcastd` on AVX2 and otherwise `pshufd` can be
@@ -4411,7 +4411,7 @@
 (rule 0 (lower (has_type $I32X4 (splat src)))
         (x64_pshufd (bitcast_gpr_to_xmm $I32 src) 0))
 (rule 1 (lower (has_type $I32X4 (splat src)))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vpbroadcastd (bitcast_gpr_to_xmm $I32 src)))
 
 ;; f32x4.splat - the source is already in an xmm register so `shufps` is all
@@ -4421,7 +4421,7 @@
         (let ((tmp Xmm src))
           (x64_shufps src src 0)))
 (rule 1 (lower (has_type $F32X4 (splat src)))
-        (if-let $true (use_avx2_simd))
+        (if-let $true (use_avx2))
         (x64_vbroadcastss src))
 
 ;; t32x4.splat of a load - use a `movss` to load into an xmm register and then
@@ -4432,12 +4432,12 @@
 ;; that the memory-operand encoding of `vbroadcastss` is usable with AVX, but
 ;; the register-based encoding is only available with AVX2. With the
 ;; `sinkable_load` extractor this should be guaranteed to use the memory-based
-;; encoding hence the `use_avx_simd` test.
+;; encoding hence the `use_avx` test.
 (rule 5 (lower (has_type (multi_lane 32 4) (splat (sinkable_load addr))))
         (let ((tmp Xmm (x64_movss_load addr)))
           (x64_shufps tmp tmp 0)))
 (rule 6 (lower (has_type (multi_lane 32 4) (splat (sinkable_load addr))))
-        (if-let $true (use_avx_simd))
+        (if-let $true (use_avx))
         (x64_vbroadcastss addr))
 
 ;; t64x2.splat - use `pshufd` to broadcast the lower 64-bit lane to the upper

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -170,38 +170,38 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn use_avx_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx_simd()
+    fn use_avx(&mut self) -> bool {
+        self.backend.x64_flags.use_avx()
     }
 
     #[inline]
-    fn use_avx2_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx2_simd()
+    fn use_avx2(&mut self) -> bool {
+        self.backend.x64_flags.use_avx2()
     }
 
     #[inline]
-    fn use_avx512vl_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx512vl_simd()
+    fn use_avx512vl(&mut self) -> bool {
+        self.backend.x64_flags.use_avx512vl()
     }
 
     #[inline]
-    fn use_avx512dq_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx512dq_simd()
+    fn use_avx512dq(&mut self) -> bool {
+        self.backend.x64_flags.use_avx512dq()
     }
 
     #[inline]
-    fn use_avx512f_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx512f_simd()
+    fn use_avx512f(&mut self) -> bool {
+        self.backend.x64_flags.use_avx512f()
     }
 
     #[inline]
-    fn use_avx512bitalg_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx512bitalg_simd()
+    fn use_avx512bitalg(&mut self) -> bool {
+        self.backend.x64_flags.use_avx512bitalg()
     }
 
     #[inline]
-    fn use_avx512vbmi_simd(&mut self) -> bool {
-        self.backend.x64_flags.use_avx512vbmi_simd()
+    fn use_avx512vbmi(&mut self) -> bool {
+        self.backend.x64_flags.use_avx512vbmi()
     }
 
     #[inline]

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -535,7 +535,6 @@ use_colocated_libcalls = false
 enable_float = true
 enable_nan_canonicalization = false
 enable_pinned_reg = false
-enable_simd = false
 enable_atomics = true
 enable_safepoints = false
 enable_llvm_abi_extensions = false
@@ -558,18 +557,17 @@ enable_incremental_compilation_cache_checks = false
             );
         }
         assert_eq!(f.opt_level(), super::OptLevel::None);
-        assert_eq!(f.enable_simd(), false);
     }
 
     #[test]
     fn modify_bool() {
         let mut b = builder();
         assert_eq!(b.enable("not_there"), Err(BadName("not_there".to_string())));
-        assert_eq!(b.enable("enable_simd"), Ok(()));
-        assert_eq!(b.set("enable_simd", "false"), Ok(()));
+        assert_eq!(b.enable("enable_atomics"), Ok(()));
+        assert_eq!(b.set("enable_atomics", "false"), Ok(()));
 
         let f = Flags::new(b);
-        assert_eq!(f.enable_simd(), false);
+        assert_eq!(f.enable_atomics(), false);
     }
 
     #[test]
@@ -579,9 +577,12 @@ enable_incremental_compilation_cache_checks = false
             b.set("not_there", "true"),
             Err(BadName("not_there".to_string()))
         );
-        assert_eq!(b.set("enable_simd", ""), Err(BadValue("bool".to_string())));
         assert_eq!(
-            b.set("enable_simd", "best"),
+            b.set("enable_atomics", ""),
+            Err(BadValue("bool".to_string()))
+        );
+        assert_eq!(
+            b.set("enable_atomics", "best"),
             Err(BadValue("bool".to_string()))
         );
         assert_eq!(
@@ -591,10 +592,10 @@ enable_incremental_compilation_cache_checks = false
             ))
         );
         assert_eq!(b.set("opt_level", "speed"), Ok(()));
-        assert_eq!(b.set("enable_simd", "0"), Ok(()));
+        assert_eq!(b.set("enable_atomics", "0"), Ok(()));
 
         let f = Flags::new(b);
-        assert_eq!(f.enable_simd(), false);
+        assert_eq!(f.enable_atomics(), false);
         assert_eq!(f.opt_level(), super::OptLevel::Speed);
     }
 }

--- a/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-bitwise-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target aarch64
 
 function %band_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-comparison-legalize.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target aarch64
 
 function %icmp_ne_32x4(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-lane-access-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target aarch64
 
 ;; shuffle

--- a/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-logical-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target aarch64
 
 function %bnot_i32x4(i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/ceil-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %f1(f32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %f1(i8x16) -> i8 {

--- a/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx
 
 function %f3(i32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-simd.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx512vl has_avx512f
 
 function %f1(i32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/x64/float-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %f32_add(f32, f32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/float-bitcast-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-bitcast-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx
 
 function %i32_to_f32(i32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/float-bitcast.clif
+++ b/cranelift/filetests/filetests/isa/x64/float-bitcast.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64
 
 function %i32_to_f32(i32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx
 
 function %fpromote(f32) -> f64 {

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64
 
 function %fpromote(f32) -> f64 {

--- a/cranelift/filetests/filetests/isa/x64/fsqrt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fsqrt-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx
 
 function %sqrt_f32(f32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/fsqrt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fsqrt.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64
 
 function %sqrt_f32(f32) -> f32 {

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %iadd_pairwise_i16x8(i16x8, i16x8) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
+++ b/cranelift/filetests/filetests/isa/x64/iadd-pairwise.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 ssse3
 
 function %iadd_pairwise_i16x8(i16x8, i16x8) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %insertlane_f64x2_zero(f64x2, f64) -> f64x2 {

--- a/cranelift/filetests/filetests/isa/x64/insertlane.clif
+++ b/cranelift/filetests/filetests/isa/x64/insertlane.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %insertlane_f64x2_zero(f64x2, f64) -> f64x2 {

--- a/cranelift/filetests/filetests/isa/x64/move-elision.clif
+++ b/cranelift/filetests/filetests/isa/x64/move-elision.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 skylake
 
 function %move_registers(i32x4) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %punpckldq(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle-avx512.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx512vl has_avx512vbmi
 
 function %shuffle_in_bounds(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %punpcklbw(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-abs-avx512.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 icelake-client
 
 function %f1(i64) -> i64x2 {

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %i8x16_add(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %mask_from_icmp(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %or_from_memory(f32x4, i64) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64
 
 function %band_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/isa/x64/simd-cmp-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-cmp-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %i8x16_eq(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-comparison-legalize.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %icmp_ne_32x4(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx has_avx2 has_avx512f has_avx512vl
 
 function %sshr(i64x2, i64) -> i64x2 {

--- a/cranelift/filetests/filetests/isa/x64/simd-issue-3951.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-issue-3951.clif
@@ -1,5 +1,4 @@
 test compile
-set enable_simd
 target x86_64 skylake
 
 ;; Compile a CLIF version of the register allocation issue identified in

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 
 ;; shuffle

--- a/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %sload8x8(i64) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-load-extend.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %uload8x8(i64) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %bnot_i32x4(i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx
 
 function %splat_i8(i8) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx2.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse42 has_avx has_avx2
 
 function %splat_i8(i8) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %splat_i8(i8) -> i8x16 {

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 sse41
 
 function %imul_swiden_hi_i8x16(i8x16, i8x16) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits-avx.clif
@@ -1,5 +1,4 @@
 test compile precise-output
-set enable_simd
 target x86_64 has_avx
 
 function %f1(i8x16) -> i8 {

--- a/cranelift/filetests/filetests/runtests/bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/ceil.clif
+++ b/cranelift/filetests/filetests/runtests/ceil.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/conversion.clif
+++ b/cranelift/filetests/filetests/runtests/conversion.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/fabs.clif
+++ b/cranelift/filetests/filetests/runtests/fabs.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/fadd.clif
+++ b/cranelift/filetests/filetests/runtests/fadd.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-eq.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-gt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-le.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-lt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ne.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-one.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ord.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ule.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ult.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uno.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fcopysign.clif
+++ b/cranelift/filetests/filetests/runtests/fcopysign.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/fdemote.clif
+++ b/cranelift/filetests/filetests/runtests/fdemote.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/fdiv.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/float-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitops.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 

--- a/cranelift/filetests/filetests/runtests/floor.clif
+++ b/cranelift/filetests/filetests/runtests/floor.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fmax.clif
+++ b/cranelift/filetests/filetests/runtests/fmax.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fmin-max-pseudo-vector.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-max-pseudo-vector.clif
@@ -1,5 +1,4 @@
 test run
-set enable_simd
 target aarch64
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug
 target x86_64

--- a/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fmin.clif
+++ b/cranelift/filetests/filetests/runtests/fmin.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fmul.clif
+++ b/cranelift/filetests/filetests/runtests/fmul.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/fneg.clif
+++ b/cranelift/filetests/filetests/runtests/fneg.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/fpromote.clif
+++ b/cranelift/filetests/filetests/runtests/fpromote.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target s390x

--- a/cranelift/filetests/filetests/runtests/fsub.clif
+++ b/cranelift/filetests/filetests/runtests/fsub.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/issue-5690.clif
+++ b/cranelift/filetests/filetests/runtests/issue-5690.clif
@@ -1,7 +1,6 @@
 test interpret
 test run
 set opt_level=speed
-set enable_simd=true
 set enable_safepoints=true
 set unwind_info=false
 set preserve_frame_pointers=true

--- a/cranelift/filetests/filetests/runtests/nearest.clif
+++ b/cranelift/filetests/filetests/runtests/nearest.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-avg-round.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-band-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band-splat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-band.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
@@ -2,7 +2,6 @@ test run
 target aarch64
 target s390x
 set opt_level=speed_and_size
-set enable_simd
 target x86_64
 target x86_64 skylake
 

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -1,5 +1,4 @@
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41

--- a/cranelift/filetests/filetests/runtests/simd-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bnot.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-bor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-bxor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-conversion.clif
+++ b/cranelift/filetests/filetests/runtests/simd-conversion.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-fadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-fcmp.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 

--- a/cranelift/filetests/filetests/runtests/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fdiv.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-fma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target aarch64

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-x86_64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-x86_64.clif
@@ -2,7 +2,6 @@
 ; If you change this file, you should most likely update
 ; simd-arithmetic-nondeterministic*.clif as well.
 test run
-set enable_simd
 target x86_64
 target x86_64 skylake
 

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 

--- a/cranelift/filetests/filetests/runtests/simd-fmul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmul.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-fneg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fneg.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-fsub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fsub.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-iadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 has_avx
 target aarch64

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-imul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-imul.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-ineg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ineg.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-ishl.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ishl.clif
@@ -1,5 +1,4 @@
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-isub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 skylake
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-lane-access.clif
+++ b/cranelift/filetests/filetests/runtests/simd-lane-access.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 

--- a/cranelift/filetests/filetests/runtests/simd-logical.clif
+++ b/cranelift/filetests/filetests/runtests/simd-logical.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 

--- a/cranelift/filetests/filetests/runtests/simd-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/simd-min-max.clif
@@ -1,6 +1,5 @@
 test run
 test interpret
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 ssse3

--- a/cranelift/filetests/filetests/runtests/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -2,7 +2,6 @@ test run
 test interpret
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-select.clif
+++ b/cranelift/filetests/filetests/runtests/simd-select.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
@@ -2,7 +2,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -2,7 +2,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqrt.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -1,5 +1,4 @@
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41 has_ssse3=false
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 ssse3
 target x86_64 sse41

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/simd-ushr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ushr.clif
@@ -1,5 +1,4 @@
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64 skylake

--- a/cranelift/filetests/filetests/runtests/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx

--- a/cranelift/filetests/filetests/runtests/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
@@ -1,7 +1,6 @@
 test run
 target s390x
 target aarch64
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-vconst.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst.clif
@@ -1,7 +1,6 @@
 test run
 target s390x
 target aarch64
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64gc has_v

--- a/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
+++ b/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
@@ -1,7 +1,6 @@
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -2,7 +2,6 @@ test interpret
 test run
 target aarch64
 target s390x
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64

--- a/cranelift/filetests/filetests/runtests/sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/sqrt.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target aarch64
 target x86_64
 target x86_64 has_avx

--- a/cranelift/filetests/filetests/runtests/trunc.clif
+++ b/cranelift/filetests/filetests/runtests/trunc.clif
@@ -1,6 +1,5 @@
 test interpret
 test run
-set enable_simd
 target x86_64
 target x86_64 sse41
 target x86_64 sse42

--- a/cranelift/filetests/filetests/runtests/umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/umulhi.clif
@@ -1,7 +1,6 @@
 test interpret
 test run
 target aarch64
-set enable_simd
 target x86_64 has_sse3 has_ssse3 has_sse41
 target s390x
 target riscv64

--- a/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
+++ b/cranelift/filetests/filetests/runtests/x64-xmm-mem-align-bug.clif
@@ -1,6 +1,5 @@
 test run
 set enable_llvm_abi_extensions
-set enable_simd
 target x86_64
 target x86_64 has_avx
 

--- a/cranelift/filetests/filetests/verifier/constant.clif
+++ b/cranelift/filetests/filetests/verifier/constant.clif
@@ -1,5 +1,4 @@
 test verifier
-set enable_simd
 
 function %incorrect_constant_size() {
 const13 = 0x0102030405  ; this constant has 5 bytes

--- a/cranelift/filetests/filetests/verifier/scalar-to-vector.clif
+++ b/cranelift/filetests/filetests/verifier/scalar-to-vector.clif
@@ -1,5 +1,4 @@
 test verifier
-set enable_simd=true
 target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 

--- a/cranelift/filetests/filetests/verifier/simd-lane-index.clif
+++ b/cranelift/filetests/filetests/verifier/simd-lane-index.clif
@@ -1,5 +1,4 @@
 test verifier
-set enable_simd
 target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 

--- a/cranelift/filetests/filetests/wasm/x64-relaxed-simd-deterministic.wat
+++ b/cranelift/filetests/filetests/wasm/x64-relaxed-simd-deterministic.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! compile = true
 ;;! relaxed_simd_deterministic = true
-;;! settings = ["enable_simd", "sse42", "has_avx"]
+;;! settings = ["sse42", "has_avx"]
 
 (module
   (func (param v128) (result v128)

--- a/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
+++ b/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! compile = true
-;;! settings = ["enable_simd", "sse41"]
+;;! settings = ["sse41"]
 
 (module
   (func (param v128) (result v128)

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -236,7 +236,6 @@ where
         // so they aren't very interesting to be automatically generated.
         builder.enable("enable_atomics")?;
         builder.enable("enable_float")?;
-        builder.enable("enable_simd")?;
 
         // `machine_code_cfg_info` generates additional metadata for the embedder but this doesn't feed back
         // into compilation anywhere, we leave it on unconditionally to make sure the generation doesn't panic.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1620,14 +1620,6 @@ impl Config {
                 bail!("compiler option 'enable_safepoints' must be enabled when 'reference types' is enabled");
             }
         }
-        if self.features.simd {
-            if !self
-                .compiler_config
-                .ensure_setting_unset_or_given("enable_simd", "true")
-            {
-                bail!("compiler option 'enable_simd' must be enabled when 'simd' is enabled");
-            }
-        }
 
         if self.features.relaxed_simd && !self.features.simd {
             bail!("cannot disable the simd proposal but enable the relaxed simd proposal");

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -415,7 +415,6 @@ impl Engine {
             | "enable_nan_canonicalization"
             | "enable_jump_tables"
             | "enable_float"
-            | "enable_simd"
             | "enable_verifier"
             | "regalloc_checker"
             | "regalloc_verbose_logs"


### PR DESCRIPTION
This commit removes a setting for Cranelift which I've found a bit confusing historically and I think is no longer necessary. The setting is currently documented as enabling SIMD instructions, but that only sort of works for the x64 backend and none of the other backends look at it. Historically this was used to flag to Cranelift that a higher x64 baseline feature set is required for codegen but as of #6625 that's no longer necessary.

Otherwise it seems more Cranelift-like nowadays to say that vector instructions generate SIMD instructions where non-vector instructions probably don't, but may still depending on activated CPU features. In that sense I'm not sure if a dedicated `enable_simd` setting is still motivated, so this PR removes it.

This renames some features in the x86 backend such as `use_avx_simd` to `use_avx` since the `_simd` part is no longer part of the computation now that `enable_simd` is gone.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
