### PR TITLE
aarch64: Fix `AuthenticatedRet` when stack bytes are popped

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3145,7 +3145,7 @@ impl MachInstEmit for Inst {
                     APIKey::B => 0b1,
                 };
 
-                if is_hint {
+                if is_hint || stack_bytes_to_pop > 0 {
                     sink.put4(0xd50323bf | key << 6); // autiasp / autibsp
                     Inst::Ret {
                         rets: vec![],

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -80,7 +80,7 @@ fn test_aarch64_binemit() {
             rets: vec![],
             stack_bytes_to_pop: 16,
         },
-        "FF0B5FD6",
+        "FF430091FF0B5FD6",
         "add sp, sp, #16 ; retaa",
     ));
     insns.push((Inst::Pacisp { key: APIKey::B }, "7F2303D5", "pacibsp"));


### PR DESCRIPTION
This commit fixes an accidental issue with #6478 where when pointer authentication was enabled and stack bytes are being popped during a return this didn't work. In this situation an authenticated return instruction was used, such as `retab`, and no extra stack bytes were popped. The fix here is to use the non-`retab` path which handles stack bytes being popped if there are stack bytes to pop.

Closes #6567

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
