### PR TITLE
handle interface functions correctly in `component::Linker::func_new`

### DIFF
--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -342,7 +342,8 @@ impl<T> LinkerInstance<'_, T> {
             .collect::<IndexMap<_, _>>();
 
         while let Some(name) = names.pop() {
-            if let Some(ty) = map.get(self.strings.strings[name].deref()) {
+            let name = self.strings.strings[name].deref();
+            if let Some(ty) = map.get(name) {
                 if let TypeDef::ComponentInstance(index) = ty {
                     map = &component.types()[*index].exports;
                 } else {

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -170,6 +170,111 @@ fn simple() -> Result<()> {
 }
 
 #[test]
+fn functions_in_instances() -> Result<()> {
+    let component = r#"
+        (component
+            (type $import-type (instance
+                (export "a" (func (param "a" string)))
+            ))
+            (import (interface "test:test/foo") (instance $import (type $import-type)))
+            (alias export $import "a" (func $log))
+
+            (core module $libc
+                (memory (export "memory") 1)
+
+                (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+                    unreachable)
+            )
+            (core instance $libc (instantiate $libc))
+            (core func $log_lower
+                (canon lower (func $log) (memory $libc "memory") (realloc (func $libc "realloc")))
+            )
+            (core module $m
+                (import "libc" "memory" (memory 1))
+                (import "host" "log" (func $log (param i32 i32)))
+
+                (func (export "call")
+                    i32.const 5
+                    i32.const 11
+                    call $log)
+
+                (data (i32.const 5) "hello world")
+            )
+            (core instance $i (instantiate $m
+                (with "libc" (instance $libc))
+                (with "host" (instance (export "log" (func $log_lower))))
+            ))
+            (func $call
+                (canon lift (core func $i "call"))
+            )
+            (component $c
+                (import "import-call" (func $f))
+                (export "call" (func $f))
+            )
+            (instance $export (instantiate $c
+                (with "import-call" (func $call))
+            ))
+            (export (interface "test:test/foo") (instance $export))
+        )
+    "#;
+
+    let engine = super::engine();
+    let component = Component::new(&engine, component)?;
+    let mut store = Store::new(&engine, None);
+    assert!(store.data().is_none());
+
+    // First, test the static API
+
+    let mut linker = Linker::new(&engine);
+    linker.instance("test:test/foo")?.func_wrap(
+        "a",
+        |mut store: StoreContextMut<'_, Option<String>>, (arg,): (WasmStr,)| -> Result<_> {
+            let s = arg.to_str(&store)?.to_string();
+            assert!(store.data().is_none());
+            *store.data_mut() = Some(s);
+            Ok(())
+        },
+    )?;
+    let instance = linker.instantiate(&mut store, &component)?;
+    let func = instance
+        .exports(&mut store)
+        .instance("test:test/foo")
+        .unwrap()
+        .typed_func::<(), ()>("call")?;
+    func.call(&mut store, ())?;
+    assert_eq!(store.data().as_ref().unwrap(), "hello world");
+
+    // Next, test the dynamic API
+
+    *store.data_mut() = None;
+    let mut linker = Linker::new(&engine);
+    linker.instance("test:test/foo")?.func_new(
+        &component,
+        "a",
+        |mut store: StoreContextMut<'_, Option<String>>, args, _results| {
+            if let Val::String(s) = &args[0] {
+                assert!(store.data().is_none());
+                *store.data_mut() = Some(s.to_string());
+                Ok(())
+            } else {
+                panic!()
+            }
+        },
+    )?;
+    let instance = linker.instantiate(&mut store, &component)?;
+    let func = instance
+        .exports(&mut store)
+        .instance("test:test/foo")
+        .unwrap()
+        .func("call")
+        .unwrap();
+    func.call(&mut store, &[], &mut [])?;
+    assert_eq!(store.data().as_ref().unwrap(), "hello world");
+
+    Ok(())
+}
+
+#[test]
 fn attempt_to_leave_during_malloc() -> Result<()> {
     let component = r#"
 (component


### PR DESCRIPTION
Many months ago, I implemented `func_new`, but only supporting top-level function imports.  If you tried to link a host function under an imported interface, it would mistakenly treat it as a top-level function and either error out if it couldn't find a corresponding type definition in the passed `&Component`; or, if it found a top-level function that happened to have the same name, it would use that type (which would coincidentally work if the type happens to match, but lead to a runtime error later on otherwise).

This fixes the issue by looking up the correct component instance when necessary and getting the type from there.

Note I've made no effort to optimize for performance here.  Happy to revisit that if there's a need.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
