### PR TITLE
Lean on wasmparser's type information when translating components

### DIFF
--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -62,11 +62,6 @@ pub struct Translator<'a, 'data> {
     /// As frames are popped from `lexical_scopes` their completed component
     /// will be pushed onto this list.
     static_components: PrimaryMap<StaticComponentIndex, Translation<'data>>,
-
-    /// Storage for type information used by `ComponentInstanceType::Synthetic`
-    /// which is thrown away after compilation is finished.
-    synthetic_instance_types:
-        PrimaryMap<SyntheticInstanceTypeIndex, HashMap<&'data str, ComponentItemType>>,
 }
 
 /// Representation of the syntactic scope of a component meaning where it is
@@ -153,12 +148,9 @@ struct Translation<'data> {
     /// index into an index space of what's being exported.
     exports: IndexMap<&'data str, ComponentItem>,
 
-    /// Type information (in Wasmtime's representation) for various
-    /// component-model index spaces.
-    funcs: PrimaryMap<FuncIndex, SignatureIndex>,
-    components: PrimaryMap<ComponentIndex, ComponentType>,
-    component_funcs: PrimaryMap<ComponentFuncIndex, TypeFuncIndex>,
-    component_instances: PrimaryMap<ComponentInstanceIndex, ComponentInstanceType>,
+    /// The next core function index that's going to be defined, used to lookup
+    /// type information when lowering.
+    core_func_index: u32,
 }
 
 #[allow(missing_docs)]
@@ -167,7 +159,12 @@ enum LocalInitializer<'data> {
     Import(ComponentExternName<'data>, TypeDef),
 
     // canonical function sections
-    Lower(ComponentFuncIndex, LocalCanonicalOptions),
+    Lower {
+        func: ComponentFuncIndex,
+        lower_ty: TypeFuncIndex,
+        canonical_abi: SignatureIndex,
+        options: LocalCanonicalOptions,
+    },
     Lift(TypeFuncIndex, FuncIndex, LocalCanonicalOptions),
 
     // core wasm modules
@@ -235,45 +232,6 @@ struct LocalCanonicalOptions {
     post_return: Option<FuncIndex>,
 }
 
-#[derive(Copy, Clone)]
-enum ComponentType {
-    /// A component was imported from so its type is listed by an index.
-    Index(TypeComponentIndex),
-    /// A component was defined statically inline so its type information can be
-    /// found in the `Translation` itself.
-    Static(StaticComponentIndex),
-}
-
-#[derive(Copy, Clone)]
-enum ComponentInstanceType {
-    /// An instance was imported so its type information is listed by index.
-    Index(TypeComponentInstanceIndex),
-    /// An instance was created through instantiating an imported component, so
-    /// the type of the index is inferred from the type of the component.
-    InstantiatedIndex(TypeComponentIndex),
-    /// An instance was created through instantiation of a statically defined
-    /// component, so the type information is inferred from a `Translation`.
-    InstantiatedStatic(StaticComponentIndex),
-    /// An instance was created from a list of other items, and the list can be
-    /// found in the `synthetic_instance_types` map.
-    Synthetic(SyntheticInstanceTypeIndex),
-}
-
-/// Only used as part of `synthetic_instance_types` which is used to infer type
-/// information for component-model items. This intentionally doesn't cover
-/// everything (e.g. modules are missing at this time since they aren't needed).
-#[derive(Copy, Clone)]
-enum ComponentItemType {
-    Func(TypeFuncIndex),
-    Component(ComponentType),
-    Instance(ComponentInstanceType),
-    Type(TypeDef),
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-struct SyntheticInstanceTypeIndex(u32);
-cranelift_entity::entity_impl!(SyntheticInstanceTypeIndex);
-
 enum Action {
     KeepGoing,
     Skip(usize),
@@ -297,7 +255,6 @@ impl<'a, 'data> Translator<'a, 'data> {
             lexical_scopes: Vec::new(),
             static_components: Default::default(),
             static_modules: Default::default(),
-            synthetic_instance_types: Default::default(),
             scope_vec,
         }
     }
@@ -395,39 +352,10 @@ impl<'a, 'data> Translator<'a, 'data> {
                         bail!("attempted to parse a wasm module with a component parser");
                     }
                 }
-
-                // Push a new scope for component types so outer aliases know
-                // that the 0th level is this new component.
-                self.types.push_type_scope();
             }
 
             Payload::End(offset) => {
-                let types = self.validator.end(offset)?;
-
-                // Record type information for this component now that we'll
-                // have it from wasmparser.
-                //
-                // Note that this uses type information from `wasmparser` to
-                // lookup signature of all core wasm functions in this
-                // component.  This avoids us having to reimplement the
-                // translate-interface-types-to-the-canonical-abi logic. The
-                // type of the function is then intern'd to get a
-                // `SignatureIndex` which is later used at runtime for a
-                // `VMSharedSignatureIndex`.
-                for idx in 0.. {
-                    let lowered_function_type = match types.function_at(idx) {
-                        Some(ty) => ty,
-                        None => break,
-                    };
-                    let ty = self.types.convert_func_type(lowered_function_type);
-                    let ty = self.types.module_types_builder().wasm_func_type(ty);
-                    self.result.funcs.push(ty);
-                }
-
-                // When leaving a module be sure to pop the types scope to
-                // ensure that when we go back to the previous module outer
-                // type alias indices work correctly again.
-                self.types.pop_type_scope();
+                self.validator.end(offset)?;
 
                 // Exit the current lexical scope. If there is no parent (no
                 // frame currently on the stack) then translation is finished.
@@ -447,9 +375,6 @@ impl<'a, 'data> Translator<'a, 'data> {
                 self.result
                     .initializers
                     .push(LocalInitializer::ComponentStatic(static_idx, closure_args));
-                self.result
-                    .components
-                    .push(ComponentType::Static(static_idx));
             }
 
             // When we see a type section the types are validated and then
@@ -462,17 +387,9 @@ impl<'a, 'data> Translator<'a, 'data> {
             // within a component.
             Payload::ComponentTypeSection(s) => {
                 self.validator.component_type_section(&s)?;
-                for ty in s {
-                    let ty = self.types.intern_component_type(&ty?)?;
-                    self.types.push_component_typedef(ty);
-                }
             }
             Payload::CoreTypeSection(s) => {
                 self.validator.core_type_section(&s)?;
-                for ty in s {
-                    let ty = self.types.intern_core_type(&ty?)?;
-                    self.types.push_core_typedef(ty);
-                }
             }
 
             // Processing the import section at this point is relatively simple
@@ -482,8 +399,11 @@ impl<'a, 'data> Translator<'a, 'data> {
                 self.validator.component_import_section(&s)?;
                 for import in s {
                     let import = import?;
-                    let ty = self.types.component_type_ref(&import.ty);
-                    self.push_typedef(ty);
+                    let types = self.validator.types(0).unwrap();
+                    let ty = types
+                        .component_entity_type_of_import(import.name.as_str())
+                        .unwrap();
+                    let ty = self.types.convert_component_entity_type(types, ty)?;
                     self.result
                         .initializers
                         .push(LocalInitializer::Import(import.name, ty));
@@ -494,6 +414,7 @@ impl<'a, 'data> Translator<'a, 'data> {
             // with the listed options for lifting/lowering.
             Payload::ComponentCanonicalSection(s) => {
                 self.validator.component_canonical_section(&s)?;
+                let types = self.validator.types(0).unwrap();
                 for func in s {
                     match func? {
                         wasmparser::CanonicalFunction::Lift {
@@ -501,28 +422,44 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index,
                             options,
                         } => {
-                            let ty = ComponentTypeIndex::from_u32(type_index);
-                            let ty = match self.types.component_outer_type(0, ty) {
-                                TypeDef::ComponentFunc(ty) => ty,
-                                // should not be possible after validation
-                                _ => unreachable!(),
-                            };
+                            let ty = types
+                                .type_at(type_index, false)
+                                .unwrap()
+                                .as_component_func_type()
+                                .unwrap();
+                            let ty = self.types.convert_component_func_type(types, ty)?;
                             let func = FuncIndex::from_u32(core_func_index);
                             let options = self.canonical_options(&options);
                             self.result
                                 .initializers
                                 .push(LocalInitializer::Lift(ty, func, options));
-                            self.result.component_funcs.push(ty);
                         }
                         wasmparser::CanonicalFunction::Lower {
                             func_index,
                             options,
                         } => {
+                            let lower_ty = types.component_function_at(func_index).unwrap();
+                            let lower_ty =
+                                self.types.convert_component_func_type(types, lower_ty)?;
+
                             let func = ComponentFuncIndex::from_u32(func_index);
                             let options = self.canonical_options(&options);
-                            self.result
-                                .initializers
-                                .push(LocalInitializer::Lower(func, options));
+
+                            let canonical_abi =
+                                types.function_at(self.result.core_func_index).unwrap();
+                            let canonical_abi = self.types.convert_func_type(canonical_abi);
+                            let canonical_abi = self
+                                .types
+                                .module_types_builder()
+                                .wasm_func_type(canonical_abi);
+
+                            self.result.initializers.push(LocalInitializer::Lower {
+                                func,
+                                options,
+                                canonical_abi,
+                                lower_ty,
+                            });
+                            self.result.core_func_index += 1;
                         }
 
                         wasmparser::CanonicalFunction::ResourceNew { .. }
@@ -602,10 +539,10 @@ impl<'a, 'data> Translator<'a, 'data> {
                             args,
                         } => {
                             let index = ComponentIndex::from_u32(component_index);
-                            self.instantiate_component(index, &args)
+                            self.instantiate_component(index, &args)?
                         }
                         wasmparser::ComponentInstance::FromExports(exports) => {
-                            self.instantiate_component_from_exports(&exports)
+                            self.instantiate_component_from_exports(&exports)?
                         }
                     };
                     self.result.initializers.push(init);
@@ -621,38 +558,12 @@ impl<'a, 'data> Translator<'a, 'data> {
                 self.validator.component_export_section(&s)?;
                 for export in s {
                     let export = export?;
-                    let item = self.kind_to_item(export.kind, export.index);
+                    let item = self.kind_to_item(export.kind, export.index)?;
                     let prev = self.result.exports.insert(export.name.as_str(), item);
                     assert!(prev.is_none());
                     self.result
                         .initializers
                         .push(LocalInitializer::Export(item));
-
-                    // Exports create a new index, so push the item onto the
-                    // appropriate list.
-                    match item {
-                        ComponentItem::Func(idx) => {
-                            self.result
-                                .component_funcs
-                                .push(self.result.component_funcs[idx]);
-                        }
-                        ComponentItem::Module(_idx) => {
-                            // We don't need to do anything here for modules as
-                            // the type information isn't tracked in the initial
-                            // translation pass.
-                        }
-                        ComponentItem::Component(idx) => {
-                            self.result.components.push(self.result.components[idx]);
-                        }
-                        ComponentItem::ComponentInstance(idx) => {
-                            self.result
-                                .component_instances
-                                .push(self.result.component_instances[idx]);
-                        }
-                        ComponentItem::Type(ty) => {
-                            self.types.push_component_typedef(ty);
-                        }
-                    }
                 }
             }
 
@@ -674,7 +585,6 @@ impl<'a, 'data> Translator<'a, 'data> {
                             name,
                         } => {
                             let instance = ComponentInstanceIndex::from_u32(instance_index);
-                            self.alias_component_instance_export(instance, name);
                             LocalInitializer::AliasComponentExport(instance, name)
                         }
                         wasmparser::ComponentAlias::Outer { kind, count, index } => {
@@ -712,28 +622,6 @@ impl<'a, 'data> Translator<'a, 'data> {
         }
 
         Ok(Action::KeepGoing)
-    }
-
-    fn push_typedef(&mut self, ty: TypeDef) {
-        match ty {
-            TypeDef::ComponentInstance(idx) => {
-                self.result
-                    .component_instances
-                    .push(ComponentInstanceType::Index(idx));
-            }
-            TypeDef::ComponentFunc(idx) => {
-                self.result.component_funcs.push(idx);
-            }
-            TypeDef::Component(idx) => {
-                self.result.components.push(ComponentType::Index(idx));
-            }
-            TypeDef::Interface(_) => {
-                self.types.push_component_typedef(ty);
-            }
-
-            // not processed here
-            TypeDef::CoreFunc(_) | TypeDef::Module(_) => {}
-        }
     }
 
     fn instantiate_module(
@@ -791,21 +679,14 @@ impl<'a, 'data> Translator<'a, 'data> {
         &mut self,
         component: ComponentIndex,
         raw_args: &[wasmparser::ComponentInstantiationArg<'data>],
-    ) -> LocalInitializer<'data> {
+    ) -> Result<LocalInitializer<'data>> {
         let mut args = HashMap::with_capacity(raw_args.len());
         for arg in raw_args {
-            let idx = self.kind_to_item(arg.kind, arg.index);
+            let idx = self.kind_to_item(arg.kind, arg.index)?;
             args.insert(arg.name, idx);
         }
 
-        self.result
-            .component_instances
-            .push(match self.result.components[component] {
-                ComponentType::Index(i) => ComponentInstanceType::InstantiatedIndex(i),
-                ComponentType::Static(i) => ComponentInstanceType::InstantiatedStatic(i),
-            });
-
-        LocalInitializer::ComponentInstantiate(component, args)
+        Ok(LocalInitializer::ComponentInstantiate(component, args))
     }
 
     /// Creates a synthetic module from the list of items currently in the
@@ -813,40 +694,22 @@ impl<'a, 'data> Translator<'a, 'data> {
     fn instantiate_component_from_exports(
         &mut self,
         exports: &[wasmparser::ComponentExport<'data>],
-    ) -> LocalInitializer<'data> {
+    ) -> Result<LocalInitializer<'data>> {
         let mut map = HashMap::with_capacity(exports.len());
-        let mut types = HashMap::with_capacity(exports.len());
         for export in exports {
-            let idx = self.kind_to_item(export.kind, export.index);
-            let ty = match idx {
-                ComponentItem::Func(i) => {
-                    Some(ComponentItemType::Func(self.result.component_funcs[i]))
-                }
-                ComponentItem::Component(i) => {
-                    Some(ComponentItemType::Component(self.result.components[i]))
-                }
-                ComponentItem::ComponentInstance(i) => Some(ComponentItemType::Instance(
-                    self.result.component_instances[i],
-                )),
-                ComponentItem::Type(ty) => Some(ComponentItemType::Type(ty)),
-                ComponentItem::Module(_) => None,
-            };
+            let idx = self.kind_to_item(export.kind, export.index)?;
             map.insert(export.name.as_str(), idx);
-            if let Some(ty) = ty {
-                types.insert(export.name.as_str(), ty);
-            }
         }
 
-        let index = self.synthetic_instance_types.push(types);
-        self.result
-            .component_instances
-            .push(ComponentInstanceType::Synthetic(index));
-
-        LocalInitializer::ComponentSynthetic(map)
+        Ok(LocalInitializer::ComponentSynthetic(map))
     }
 
-    fn kind_to_item(&self, kind: wasmparser::ComponentExternalKind, index: u32) -> ComponentItem {
-        match kind {
+    fn kind_to_item(
+        &mut self,
+        kind: wasmparser::ComponentExternalKind,
+        index: u32,
+    ) -> Result<ComponentItem> {
+        Ok(match kind {
             wasmparser::ComponentExternalKind::Func => {
                 let index = ComponentFuncIndex::from_u32(index);
                 ComponentItem::Func(index)
@@ -867,11 +730,12 @@ impl<'a, 'data> Translator<'a, 'data> {
                 unimplemented!("component values");
             }
             wasmparser::ComponentExternalKind::Type => {
-                let index = ComponentTypeIndex::from_u32(index);
-                let ty = self.types.component_outer_type(0, index);
+                let types = self.validator.types(0).unwrap();
+                let ty = types.id_from_type_index(index, false).unwrap();
+                let ty = self.types.convert_type(types, ty)?;
                 ComponentItem::Type(ty)
             }
-        }
+        })
     }
 
     fn alias_module_instance_export(
@@ -881,85 +745,15 @@ impl<'a, 'data> Translator<'a, 'data> {
         name: &'data str,
     ) -> LocalInitializer<'data> {
         match kind {
-            wasmparser::ExternalKind::Func => LocalInitializer::AliasExportFunc(instance, name),
+            wasmparser::ExternalKind::Func => {
+                self.result.core_func_index += 1;
+                LocalInitializer::AliasExportFunc(instance, name)
+            }
             wasmparser::ExternalKind::Memory => LocalInitializer::AliasExportMemory(instance, name),
             wasmparser::ExternalKind::Table => LocalInitializer::AliasExportTable(instance, name),
             wasmparser::ExternalKind::Global => LocalInitializer::AliasExportGlobal(instance, name),
             wasmparser::ExternalKind::Tag => {
                 unimplemented!("wasm exceptions");
-            }
-        }
-    }
-
-    fn alias_component_instance_export(
-        &mut self,
-        instance: ComponentInstanceIndex,
-        name: &'data str,
-    ) {
-        match self.result.component_instances[instance] {
-            // An imported component instance is being aliased, so the type of
-            // the aliased item is directly available from the instance type.
-            ComponentInstanceType::Index(ty) => {
-                let ty = self.types[ty].exports[name];
-                self.push_typedef(ty);
-            }
-
-            // An imported component was instantiated so the type of the aliased
-            // export is available through the type of the export on the
-            // original component.
-            ComponentInstanceType::InstantiatedIndex(ty) => {
-                let ty = self.types[ty].exports[name];
-                self.push_typedef(ty);
-            }
-
-            // A static nested component was instantiated which means that the
-            // type of the export can be looked up directly from the translation
-            // that was finished prior.
-            ComponentInstanceType::InstantiatedStatic(idx) => {
-                let translation = &self.static_components[idx];
-
-                match translation.exports[name] {
-                    ComponentItem::Func(idx) => {
-                        self.result
-                            .component_funcs
-                            .push(translation.component_funcs[idx]);
-                    }
-                    ComponentItem::Component(idx) => {
-                        self.result.components.push(translation.components[idx]);
-                    }
-                    ComponentItem::ComponentInstance(idx) => {
-                        self.result
-                            .component_instances
-                            .push(translation.component_instances[idx]);
-                    }
-                    ComponentItem::Type(ty) => {
-                        self.types.push_component_typedef(ty);
-                    }
-
-                    // ignored during this type pass
-                    ComponentItem::Module(_) => {}
-                }
-            }
-
-            // A synthetic instance is being aliased which means the global list
-            // of synthetic instance types can be consulted for the type
-            // information.
-            ComponentInstanceType::Synthetic(index) => {
-                let map = &self.synthetic_instance_types[index];
-                match map[name] {
-                    ComponentItemType::Func(ty) => {
-                        self.result.component_funcs.push(ty);
-                    }
-                    ComponentItemType::Component(ty) => {
-                        self.result.components.push(ty);
-                    }
-                    ComponentItemType::Instance(ty) => {
-                        self.result.component_instances.push(ty);
-                    }
-                    ComponentItemType::Type(ty) => {
-                        self.types.push_component_typedef(ty);
-                    }
-                }
             }
         }
     }
@@ -971,24 +765,8 @@ impl<'a, 'data> Translator<'a, 'data> {
         index: u32,
     ) {
         match kind {
-            // When aliasing a type the `ComponentTypesBuilder` is used to
-            // resolve the outer `count` plus the index, and then once it's
-            // resolved we push the type information into our local index
-            // space.
-            //
-            // Note that this is just copying indices around as all type
-            // information is basically a pointer back into the `TypesBuilder`
-            // structure (and the eventual `TypeTables` that it produces).
-            wasmparser::ComponentOuterAliasKind::CoreType => {
-                let index = TypeIndex::from_u32(index);
-                let ty = self.types.core_outer_type(count, index);
-                self.types.push_core_typedef(ty);
-            }
-            wasmparser::ComponentOuterAliasKind::Type => {
-                let index = ComponentTypeIndex::from_u32(index);
-                let ty = self.types.component_outer_type(count, index);
-                self.types.push_component_typedef(ty);
-            }
+            wasmparser::ComponentOuterAliasKind::CoreType => {}
+            wasmparser::ComponentOuterAliasKind::Type => {}
 
             // For more information about the implementation of outer aliases
             // see the documentation of `LexicalScope`. Otherwise though the
@@ -1020,20 +798,15 @@ impl<'a, 'data> Translator<'a, 'data> {
                     component =
                         ClosedOverComponent::Upvar(frame.closure_args.components.push(component));
                 }
-                let component_ty = match self.lexical_scopes.get(depth) {
-                    Some(frame) => frame.translation.components[index],
-                    None => self.result.components[index],
-                };
 
                 self.result
                     .initializers
                     .push(LocalInitializer::AliasComponent(component));
-                self.result.components.push(component_ty);
             }
         }
     }
 
-    fn canonical_options(&mut self, opts: &[wasmparser::CanonicalOption]) -> LocalCanonicalOptions {
+    fn canonical_options(&self, opts: &[wasmparser::CanonicalOption]) -> LocalCanonicalOptions {
         let mut ret = LocalCanonicalOptions {
             string_encoding: StringEncoding::Utf8,
             memory: None,

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -401,10 +401,12 @@ impl<'a> Inliner<'a> {
             // recording the lowering.
             //
             // NB: at this time only lowered imported functions are supported.
-            Lower(func, options) => {
-                let canonical_abi = frame.translation.funcs[frame.funcs.next_key()];
-                let lower_ty = frame.translation.component_funcs[*func];
-
+            Lower {
+                func,
+                options,
+                canonical_abi,
+                lower_ty,
+            } => {
                 let options_lower = self.adapter_options(frame, options);
                 let func = match &frame.component_funcs[*func] {
                     // If this component function was originally a host import
@@ -415,7 +417,7 @@ impl<'a> Inliner<'a> {
                         let import = self.runtime_import(path);
                         let options = self.canonical_options(options_lower);
                         let index = self.result.lowerings.push_uniq(dfg::LowerImport {
-                            canonical_abi,
+                            canonical_abi: *canonical_abi,
                             import,
                             options,
                         });
@@ -451,7 +453,7 @@ impl<'a> Inliner<'a> {
                         options: options_lift,
                         ..
                     } if options_lift.instance == options_lower.instance => {
-                        let index = self.result.always_trap.push_uniq(canonical_abi);
+                        let index = self.result.always_trap.push_uniq(*canonical_abi);
                         dfg::CoreDef::AlwaysTrap(index)
                     }
 
@@ -491,7 +493,7 @@ impl<'a> Inliner<'a> {
                         let adapter_idx = self.result.adapters.push_uniq(Adapter {
                             lift_ty: *lift_ty,
                             lift_options: options_lift.clone(),
-                            lower_ty,
+                            lower_ty: *lower_ty,
                             lower_options: options_lower,
                             func: func.clone(),
                         });

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -5,14 +5,13 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Index;
-use wasmparser::{
-    ComponentAlias, ComponentOuterAliasKind, ComponentTypeDeclaration, InstanceTypeDeclaration,
-};
+use wasmparser::names::KebabString;
+use wasmparser::types;
 use wasmtime_component_util::{DiscriminantSize, FlagsSize};
 
 pub use wasmtime_types::StaticModuleIndex;
@@ -307,7 +306,6 @@ where
 /// managing building up core wasm [`ModuleTypes`] as well.
 #[derive(Default)]
 pub struct ComponentTypesBuilder {
-    type_scopes: Vec<TypeScope>,
     functions: HashMap<TypeFunc, TypeFuncIndex>,
     lists: HashMap<TypeList, TypeListIndex>,
     records: HashMap<TypeRecord, TypeRecordIndex>,
@@ -326,13 +324,11 @@ pub struct ComponentTypesBuilder {
     // used at compile-time and not used at runtime, hence the location here
     // as opposed to `ComponentTypes`.
     type_info: TypeInformationCache,
-}
 
-#[derive(Default)]
-struct TypeScope {
-    core: PrimaryMap<TypeIndex, TypeDef>,
-    component: PrimaryMap<ComponentTypeIndex, TypeDef>,
-    instances: PrimaryMap<ComponentInstanceIndex, TypeComponentInstanceIndex>,
+    defined_types_cache: HashMap<types::TypeId, InterfaceType>,
+    module_types_cache: HashMap<types::TypeId, TypeModuleIndex>,
+    component_types_cache: HashMap<types::TypeId, TypeComponentIndex>,
+    instance_types_cache: HashMap<types::TypeId, TypeComponentInstanceIndex>,
 }
 
 macro_rules! intern_and_fill_flat_types {
@@ -371,419 +367,311 @@ impl ComponentTypesBuilder {
         &mut self.module_types
     }
 
-    /// Pushes a new scope when entering a new index space for types in the
-    /// component model.
-    ///
-    /// This happens when a component is recursed into or a module/instance
-    /// type is recursed into.
-    pub fn push_type_scope(&mut self) {
-        self.type_scopes.push(Default::default());
-    }
-
-    /// Adds a new `TypeDef` definition within the current component types
-    /// scope.
-    ///
-    /// Returns the `ComponentTypeIndex` associated with the type being pushed.
-    ///
-    /// # Panics
-    ///
-    /// Requires that `push_type_scope` was called previously.
-    pub fn push_component_typedef(&mut self, ty: TypeDef) -> ComponentTypeIndex {
-        debug_assert!(!matches!(ty, TypeDef::Module(_) | TypeDef::CoreFunc(_)));
-        self.type_scopes.last_mut().unwrap().component.push(ty)
-    }
-
-    /// Adds a new `TypeDef` definition within the current core types
-    /// scope.
-    ///
-    /// Returns the `TypeIndex` associated with the type being pushed. Note that
-    /// this should only be used with core-wasm-related `TypeDef` instances such
-    /// as `TypeDef::Module` and `TypeDef::CoreFunc`.
-    ///
-    /// # Panics
-    ///
-    /// Requires that `push_type_scope` was called previously.
-    pub fn push_core_typedef(&mut self, ty: TypeDef) -> TypeIndex {
-        debug_assert!(matches!(ty, TypeDef::Module(_) | TypeDef::CoreFunc(_)));
-        self.type_scopes.last_mut().unwrap().core.push(ty)
-    }
-
-    /// Looks up an "outer" type in this builder to handle outer aliases.
-    ///
-    /// The `count` parameter and `ty` are taken from the binary format itself,
-    /// and the `TypeDef` returned is what the outer type refers to.
-    ///
-    /// # Panics
-    ///
-    /// Assumes that `count` and `ty` are valid.
-    pub fn component_outer_type(&self, count: u32, ty: ComponentTypeIndex) -> TypeDef {
-        // Reverse the index and 0 means the "current scope"
-        let idx = self.type_scopes.len() - (count as usize) - 1;
-        self.type_scopes[idx].component[ty]
-    }
-
-    /// Same as `component_outer_type` but for core wasm types instead.
-    pub fn core_outer_type(&self, count: u32, ty: TypeIndex) -> TypeDef {
-        // Reverse the index and 0 means the "current scope"
-        let idx = self.type_scopes.len() - (count as usize) - 1;
-        self.type_scopes[idx].core[ty]
-    }
-
-    /// Pops a scope pushed by `push_type_scope`.
-    pub fn pop_type_scope(&mut self) {
-        self.type_scopes.pop().unwrap();
-    }
-
-    /// Translates a wasmparser `TypeComponent` into a Wasmtime `TypeDef`,
-    /// interning types along the way.
-    pub fn intern_component_type(&mut self, ty: &wasmparser::ComponentType<'_>) -> Result<TypeDef> {
-        Ok(match ty {
-            wasmparser::ComponentType::Defined(ty) => TypeDef::Interface(self.defined_type(ty)?),
-            wasmparser::ComponentType::Func(ty) => TypeDef::ComponentFunc(self.func_type(ty)),
-            wasmparser::ComponentType::Component(ty) => {
-                TypeDef::Component(self.component_type(ty)?)
-            }
-            wasmparser::ComponentType::Instance(ty) => {
-                TypeDef::ComponentInstance(self.component_instance_type(ty)?)
-            }
-            wasmparser::ComponentType::Resource { .. } => {
-                unimplemented!("resource types")
-            }
-        })
-    }
-
-    /// Translates a wasmparser `CoreType` into a Wasmtime `TypeDef`,
-    /// interning types along the way.
-    pub fn intern_core_type(&mut self, ty: &wasmparser::CoreType<'_>) -> Result<TypeDef> {
-        Ok(match ty {
-            wasmparser::CoreType::Func(ty) => {
-                let ty = self.convert_func_type(ty);
-                TypeDef::CoreFunc(self.module_types.wasm_func_type(ty))
-            }
-            wasmparser::CoreType::Module(ty) => TypeDef::Module(self.module_type(ty)?),
-        })
-    }
-
-    /// Translates a wasmparser `ComponentTypeRef` into a Wasmtime `TypeDef`.
-    pub fn component_type_ref(&self, ty: &wasmparser::ComponentTypeRef) -> TypeDef {
-        match ty {
-            wasmparser::ComponentTypeRef::Module(ty) => {
-                self.core_outer_type(0, TypeIndex::from_u32(*ty))
-            }
-            wasmparser::ComponentTypeRef::Func(ty)
-            | wasmparser::ComponentTypeRef::Type(wasmparser::TypeBounds::Eq(ty))
-            | wasmparser::ComponentTypeRef::Instance(ty)
-            | wasmparser::ComponentTypeRef::Component(ty) => {
-                self.component_outer_type(0, ComponentTypeIndex::from_u32(*ty))
-            }
-            wasmparser::ComponentTypeRef::Value(..) => {
-                unimplemented!("references to value types");
-            }
-            wasmparser::ComponentTypeRef::Type(wasmparser::TypeBounds::SubResource) => {
-                unimplemented!("resource types");
-            }
-        }
-    }
-
-    fn module_type(
+    /// Converts a wasmparser `ComponentFuncType` into Wasmtime's type
+    /// representation.
+    pub fn convert_component_func_type(
         &mut self,
-        ty: &[wasmparser::ModuleTypeDeclaration<'_>],
-    ) -> Result<TypeModuleIndex> {
-        let mut result = TypeModule::default();
-        self.push_type_scope();
-
-        for item in ty {
-            match item {
-                wasmparser::ModuleTypeDeclaration::Type(wasmparser::Type::Func(f)) => {
-                    let f = self.convert_func_type(f);
-                    let ty = TypeDef::CoreFunc(self.module_types.wasm_func_type(f));
-                    self.push_core_typedef(ty);
-                }
-                wasmparser::ModuleTypeDeclaration::Type(wasmparser::Type::Array(_)) => {
-                    unimplemented!("gc types");
-                }
-                wasmparser::ModuleTypeDeclaration::Export { name, ty } => {
-                    let prev = result
-                        .exports
-                        .insert(name.to_string(), self.entity_type(ty)?);
-                    assert!(prev.is_none());
-                }
-                wasmparser::ModuleTypeDeclaration::Import(import) => {
-                    let prev = result.imports.insert(
-                        (import.module.to_string(), import.name.to_string()),
-                        self.entity_type(&import.ty)?,
-                    );
-                    assert!(prev.is_none());
-                }
-                wasmparser::ModuleTypeDeclaration::OuterAlias {
-                    kind: wasmparser::OuterAliasKind::Type,
-                    count,
-                    index,
-                } => {
-                    let ty = self.core_outer_type(*count, TypeIndex::from_u32(*index));
-                    self.push_core_typedef(ty);
-                }
-            }
-        }
-
-        self.pop_type_scope();
-
-        Ok(self.component_types.modules.push(result))
-    }
-
-    fn entity_type(&self, ty: &wasmparser::TypeRef) -> Result<EntityType> {
-        Ok(match ty {
-            wasmparser::TypeRef::Func(idx) => {
-                let idx = TypeIndex::from_u32(*idx);
-                match self.core_outer_type(0, idx) {
-                    TypeDef::CoreFunc(idx) => EntityType::Function(idx),
-                    _ => unreachable!(), // not possible with valid components
-                }
-            }
-            wasmparser::TypeRef::Table(ty) => EntityType::Table(self.convert_table_type(ty)),
-            wasmparser::TypeRef::Memory(ty) => EntityType::Memory(ty.clone().into()),
-            wasmparser::TypeRef::Global(ty) => EntityType::Global(self.convert_global_type(ty)),
-            wasmparser::TypeRef::Tag(_) => bail!("exceptions proposal not implemented"),
-        })
-    }
-
-    fn component_type(
-        &mut self,
-        ty: &[ComponentTypeDeclaration<'_>],
-    ) -> Result<TypeComponentIndex> {
-        let mut result = TypeComponent::default();
-        self.push_type_scope();
-
-        for item in ty {
-            match item {
-                ComponentTypeDeclaration::Type(ty) => self.type_declaration_type(ty)?,
-                ComponentTypeDeclaration::CoreType(ty) => self.type_declaration_core_type(ty)?,
-                ComponentTypeDeclaration::Alias(alias) => self.type_declaration_alias(alias)?,
-                ComponentTypeDeclaration::Export { name, ty } => {
-                    let ty = self.type_declaration_define(ty);
-                    result.exports.insert(name.as_str().to_string(), ty);
-                }
-                ComponentTypeDeclaration::Import(import) => {
-                    let ty = self.type_declaration_define(&import.ty);
-                    result.imports.insert(import.name.as_str().to_string(), ty);
-                }
-            }
-        }
-
-        self.pop_type_scope();
-
-        Ok(self.component_types.components.push(result))
-    }
-
-    fn component_instance_type(
-        &mut self,
-        ty: &[InstanceTypeDeclaration<'_>],
-    ) -> Result<TypeComponentInstanceIndex> {
-        let mut result = TypeComponentInstance::default();
-        self.push_type_scope();
-
-        for item in ty {
-            match item {
-                InstanceTypeDeclaration::Type(ty) => self.type_declaration_type(ty)?,
-                InstanceTypeDeclaration::CoreType(ty) => self.type_declaration_core_type(ty)?,
-                InstanceTypeDeclaration::Alias(alias) => self.type_declaration_alias(alias)?,
-                InstanceTypeDeclaration::Export { name, ty } => {
-                    let ty = self.type_declaration_define(ty);
-                    result.exports.insert(name.as_str().to_string(), ty);
-                }
-            }
-        }
-
-        self.pop_type_scope();
-
-        Ok(self.component_types.component_instances.push(result))
-    }
-
-    fn type_declaration_type(&mut self, ty: &wasmparser::ComponentType<'_>) -> Result<()> {
-        let ty = self.intern_component_type(ty)?;
-        self.push_component_typedef(ty);
-        Ok(())
-    }
-
-    fn type_declaration_core_type(&mut self, ty: &wasmparser::CoreType<'_>) -> Result<()> {
-        let ty = self.intern_core_type(ty)?;
-        self.push_core_typedef(ty);
-        Ok(())
-    }
-
-    fn type_declaration_alias(&mut self, alias: &wasmparser::ComponentAlias<'_>) -> Result<()> {
-        match alias {
-            ComponentAlias::Outer {
-                kind: ComponentOuterAliasKind::CoreType,
-                count,
-                index,
-            } => {
-                let ty = self.core_outer_type(*count, TypeIndex::from_u32(*index));
-                self.push_core_typedef(ty);
-            }
-            ComponentAlias::Outer {
-                kind: ComponentOuterAliasKind::Type,
-                count,
-                index,
-            } => {
-                let ty = self.component_outer_type(*count, ComponentTypeIndex::from_u32(*index));
-                self.push_component_typedef(ty);
-            }
-            ComponentAlias::InstanceExport {
-                kind: _,
-                instance_index,
-                name,
-            } => {
-                let ty = self.type_scopes.last().unwrap().instances
-                    [ComponentInstanceIndex::from_u32(*instance_index)];
-                let ty = self.component_types[ty].exports[*name];
-                self.push_component_typedef(ty);
-            }
-            a => unreachable!("invalid alias {a:?}"),
-        }
-        Ok(())
-    }
-
-    fn type_declaration_define(&mut self, ty: &wasmparser::ComponentTypeRef) -> TypeDef {
-        let ty = self.component_type_ref(ty);
-        let scope = self.type_scopes.last_mut().unwrap();
-        match ty {
-            // If an import or an export within a component or instance type
-            // references an interface type itself then that creates a new type
-            // which is effectively an alias, so push the type information here.
-            TypeDef::Interface(_) => {
-                self.push_component_typedef(ty);
-            }
-
-            // When an import or an export references a component instance then
-            // that creates a "pseudo-instance" which type information is
-            // maintained about. This is later used during the `InstanceExport`
-            // alias within a type declaration.
-            TypeDef::ComponentInstance(ty) => {
-                scope.instances.push(ty);
-            }
-
-            // All other valid types are ignored since we don't need to maintain
-            // metadata about them here as index spaces are modified that we're
-            // not interested in.
-            _ => {}
-        }
-
-        ty
-    }
-
-    fn func_type(&mut self, ty: &wasmparser::ComponentFuncType<'_>) -> TypeFuncIndex {
+        types: types::TypesRef<'_>,
+        ty: &types::ComponentFuncType,
+    ) -> Result<TypeFuncIndex> {
         let ty = TypeFunc {
             params: ty
                 .params
                 .iter()
-                .map(|(_name, ty)| self.valtype(ty))
-                .collect(),
+                .map(|(_name, ty)| self.valtype(types, ty))
+                .collect::<Result<_>>()?,
             results: ty
                 .results
                 .iter()
-                .map(|(_name, ty)| self.valtype(ty))
-                .collect(),
+                .map(|(_name, ty)| self.valtype(types, ty))
+                .collect::<Result<_>>()?,
         };
-        self.add_func_type(ty)
+        Ok(self.add_func_type(ty))
     }
 
-    fn defined_type(&mut self, ty: &wasmparser::ComponentDefinedType<'_>) -> Result<InterfaceType> {
-        let result = match ty {
-            wasmparser::ComponentDefinedType::Primitive(ty) => ty.into(),
-            wasmparser::ComponentDefinedType::Record(e) => {
-                InterfaceType::Record(self.record_type(e))
+    /// Converts a wasmparser `ComponentEntityType` into Wasmtime's type
+    /// representation.
+    pub fn convert_component_entity_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: types::ComponentEntityType,
+    ) -> Result<TypeDef> {
+        Ok(match ty {
+            types::ComponentEntityType::Module(id) => {
+                TypeDef::Module(self.convert_module(types, id)?)
             }
-            wasmparser::ComponentDefinedType::Variant(e) => {
-                InterfaceType::Variant(self.variant_type(e))
+            types::ComponentEntityType::Component(id) => {
+                TypeDef::Component(self.convert_component(types, id)?)
             }
-            wasmparser::ComponentDefinedType::List(e) => InterfaceType::List(self.list_type(e)),
-            wasmparser::ComponentDefinedType::Tuple(e) => InterfaceType::Tuple(self.tuple_type(e)),
-            wasmparser::ComponentDefinedType::Flags(e) => InterfaceType::Flags(self.flags_type(e)),
-            wasmparser::ComponentDefinedType::Enum(e) => InterfaceType::Enum(self.enum_type(e)),
-            wasmparser::ComponentDefinedType::Union(e) => InterfaceType::Union(self.union_type(e)),
-            wasmparser::ComponentDefinedType::Option(e) => {
-                InterfaceType::Option(self.option_type(e))
+            types::ComponentEntityType::Instance(id) => {
+                TypeDef::ComponentInstance(self.convert_instance(types, id)?)
             }
-            wasmparser::ComponentDefinedType::Result { ok, err } => {
-                InterfaceType::Result(self.result_type(ok, err))
+            types::ComponentEntityType::Func(id) => {
+                let id = types
+                    .type_from_id(id)
+                    .unwrap()
+                    .as_component_func_type()
+                    .unwrap();
+                let idx = self.convert_component_func_type(types, id)?;
+                TypeDef::ComponentFunc(idx)
             }
-            wasmparser::ComponentDefinedType::Own(_)
-            | wasmparser::ComponentDefinedType::Borrow(_) => {
+            types::ComponentEntityType::Type { created, .. } => {
+                match types.type_from_id(created).unwrap() {
+                    types::Type::Defined(_) => {
+                        TypeDef::Interface(self.defined_type(types, created)?)
+                    }
+                    _ => bail!("unsupported type export"),
+                }
+            }
+            types::ComponentEntityType::Value(_) => bail!("values not supported"),
+        })
+    }
+
+    /// Converts a wasmparser `Type` into Wasmtime's type representation.
+    pub fn convert_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        id: types::TypeId,
+    ) -> Result<TypeDef> {
+        Ok(match types.type_from_id(id).unwrap() {
+            types::Type::Defined(_) => TypeDef::Interface(self.defined_type(types, id)?),
+            types::Type::Module(_) => TypeDef::Module(self.convert_module(types, id)?),
+            types::Type::Component(_) => TypeDef::Component(self.convert_component(types, id)?),
+            types::Type::ComponentInstance(_) => {
+                TypeDef::ComponentInstance(self.convert_instance(types, id)?)
+            }
+            types::Type::ComponentFunc(f) => {
+                TypeDef::ComponentFunc(self.convert_component_func_type(types, f)?)
+            }
+            types::Type::Instance(_) | types::Type::Func(_) | types::Type::Array(_) => {
+                unreachable!()
+            }
+            types::Type::Resource(_) => unimplemented!(),
+        })
+    }
+
+    fn convert_component(
+        &mut self,
+        types: types::TypesRef<'_>,
+        id: types::TypeId,
+    ) -> Result<TypeComponentIndex> {
+        if let Some(ret) = self.component_types_cache.get(&id) {
+            return Ok(*ret);
+        }
+        let ty = &types.type_from_id(id).unwrap().as_component_type().unwrap();
+        let mut result = TypeComponent::default();
+        for (name, ty) in ty.imports.iter() {
+            result.imports.insert(
+                name.clone(),
+                self.convert_component_entity_type(types, *ty)?,
+            );
+        }
+        for (name, ty) in ty.exports.iter() {
+            result.exports.insert(
+                name.clone(),
+                self.convert_component_entity_type(types, *ty)?,
+            );
+        }
+        let ret = self.component_types.components.push(result);
+        self.component_types_cache.insert(id, ret);
+        Ok(ret)
+    }
+
+    fn convert_instance(
+        &mut self,
+        types: types::TypesRef<'_>,
+        id: types::TypeId,
+    ) -> Result<TypeComponentInstanceIndex> {
+        if let Some(ret) = self.instance_types_cache.get(&id) {
+            return Ok(*ret);
+        }
+        let ty = &types
+            .type_from_id(id)
+            .unwrap()
+            .as_component_instance_type()
+            .unwrap();
+        let mut result = TypeComponentInstance::default();
+        for (name, ty) in ty.exports.iter() {
+            result.exports.insert(
+                name.clone(),
+                self.convert_component_entity_type(types, *ty)?,
+            );
+        }
+        let ret = self.component_types.component_instances.push(result);
+        self.instance_types_cache.insert(id, ret);
+        Ok(ret)
+    }
+
+    fn convert_module(
+        &mut self,
+        types: types::TypesRef<'_>,
+        id: types::TypeId,
+    ) -> Result<TypeModuleIndex> {
+        if let Some(ret) = self.module_types_cache.get(&id) {
+            return Ok(*ret);
+        }
+        let ty = &types.type_from_id(id).unwrap().as_module_type().unwrap();
+        let mut result = TypeModule::default();
+        for ((module, field), ty) in ty.imports.iter() {
+            result.imports.insert(
+                (module.clone(), field.clone()),
+                self.entity_type(types, ty)?,
+            );
+        }
+        for (name, ty) in ty.exports.iter() {
+            result
+                .exports
+                .insert(name.clone(), self.entity_type(types, ty)?);
+        }
+        let ret = self.component_types.modules.push(result);
+        self.module_types_cache.insert(id, ret);
+        Ok(ret)
+    }
+
+    fn entity_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::EntityType,
+    ) -> Result<EntityType> {
+        Ok(match ty {
+            types::EntityType::Func(idx) => {
+                let ty = types.type_from_id(*idx).unwrap().as_func_type().unwrap();
+                let ty = self.convert_func_type(ty);
+                EntityType::Function(self.module_types_builder().wasm_func_type(ty))
+            }
+            types::EntityType::Table(ty) => EntityType::Table(self.convert_table_type(ty)),
+            types::EntityType::Memory(ty) => EntityType::Memory(ty.clone().into()),
+            types::EntityType::Global(ty) => EntityType::Global(self.convert_global_type(ty)),
+            types::EntityType::Tag(_) => bail!("exceptions proposal not implemented"),
+        })
+    }
+
+    fn defined_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        id: types::TypeId,
+    ) -> Result<InterfaceType> {
+        if let Some(ty) = self.defined_types_cache.get(&id) {
+            return Ok(*ty);
+        }
+        let ret = match types.type_from_id(id).unwrap().as_defined_type().unwrap() {
+            types::ComponentDefinedType::Primitive(ty) => ty.into(),
+            types::ComponentDefinedType::Record(e) => {
+                InterfaceType::Record(self.record_type(types, e)?)
+            }
+            types::ComponentDefinedType::Variant(e) => {
+                InterfaceType::Variant(self.variant_type(types, e)?)
+            }
+            types::ComponentDefinedType::List(e) => InterfaceType::List(self.list_type(types, e)?),
+            types::ComponentDefinedType::Tuple(e) => {
+                InterfaceType::Tuple(self.tuple_type(types, e)?)
+            }
+            types::ComponentDefinedType::Flags(e) => InterfaceType::Flags(self.flags_type(e)),
+            types::ComponentDefinedType::Enum(e) => InterfaceType::Enum(self.enum_type(e)),
+            types::ComponentDefinedType::Union(e) => {
+                InterfaceType::Union(self.union_type(types, e)?)
+            }
+            types::ComponentDefinedType::Option(e) => {
+                InterfaceType::Option(self.option_type(types, e)?)
+            }
+            types::ComponentDefinedType::Result { ok, err } => {
+                InterfaceType::Result(self.result_type(types, ok, err)?)
+            }
+            types::ComponentDefinedType::Own(_) | types::ComponentDefinedType::Borrow(_) => {
                 unimplemented!("resource types")
             }
         };
-        let info = self.type_information(&result);
+        let info = self.type_information(&ret);
         if info.depth > MAX_TYPE_DEPTH {
             bail!("type nesting is too deep");
         }
-        Ok(result)
+        self.defined_types_cache.insert(id, ret);
+        Ok(ret)
     }
 
-    fn valtype(&mut self, ty: &wasmparser::ComponentValType) -> InterfaceType {
+    fn valtype(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::ComponentValType,
+    ) -> Result<InterfaceType> {
         match ty {
-            wasmparser::ComponentValType::Primitive(p) => p.into(),
-            wasmparser::ComponentValType::Type(idx) => {
-                let idx = ComponentTypeIndex::from_u32(*idx);
-                match self.component_outer_type(0, idx) {
-                    TypeDef::Interface(ty) => ty,
-                    // this should not be possible if the module validated
-                    _ => unreachable!(),
-                }
-            }
+            types::ComponentValType::Primitive(p) => Ok(p.into()),
+            types::ComponentValType::Type(id) => self.defined_type(types, *id),
         }
     }
 
-    fn record_type(&mut self, record: &[(&str, wasmparser::ComponentValType)]) -> TypeRecordIndex {
-        let fields = record
+    fn record_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::RecordType,
+    ) -> Result<TypeRecordIndex> {
+        let fields = ty
+            .fields
             .iter()
-            .map(|(name, ty)| RecordField {
-                name: name.to_string(),
-                ty: self.valtype(ty),
+            .map(|(name, ty)| {
+                Ok(RecordField {
+                    name: name.to_string(),
+                    ty: self.valtype(types, ty)?,
+                })
             })
-            .collect::<Box<[_]>>();
+            .collect::<Result<Box<[_]>>>()?;
         let abi = CanonicalAbiInfo::record(
             fields
                 .iter()
                 .map(|field| self.component_types.canonical_abi(&field.ty)),
         );
-        self.add_record_type(TypeRecord { fields, abi })
+        Ok(self.add_record_type(TypeRecord { fields, abi }))
     }
 
-    fn variant_type(&mut self, cases: &[wasmparser::VariantCase<'_>]) -> TypeVariantIndex {
-        let cases = cases
+    fn variant_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::VariantType,
+    ) -> Result<TypeVariantIndex> {
+        let cases = ty
+            .cases
             .iter()
-            .map(|case| {
+            .map(|(name, case)| {
                 // FIXME: need to implement `refines`, not sure what that
                 // is at this time.
-                assert!(case.refines.is_none());
-                VariantCase {
-                    name: case.name.to_string(),
-                    ty: case.ty.as_ref().map(|ty| self.valtype(ty)),
+                if case.refines.is_some() {
+                    bail!("refines is not supported at this time");
                 }
+                Ok(VariantCase {
+                    name: name.to_string(),
+                    ty: match &case.ty.as_ref() {
+                        Some(ty) => Some(self.valtype(types, ty)?),
+                        None => None,
+                    },
+                })
             })
-            .collect::<Box<[_]>>();
+            .collect::<Result<Box<[_]>>>()?;
         let (info, abi) = VariantInfo::new(cases.iter().map(|c| {
             c.ty.as_ref()
                 .map(|ty| self.component_types.canonical_abi(ty))
         }));
-        self.add_variant_type(TypeVariant { cases, abi, info })
+        Ok(self.add_variant_type(TypeVariant { cases, abi, info }))
     }
 
-    fn tuple_type(&mut self, types: &[wasmparser::ComponentValType]) -> TypeTupleIndex {
-        let types = types
+    fn tuple_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::TupleType,
+    ) -> Result<TypeTupleIndex> {
+        let types = ty
+            .types
             .iter()
-            .map(|ty| self.valtype(ty))
-            .collect::<Box<[_]>>();
+            .map(|ty| self.valtype(types, ty))
+            .collect::<Result<Box<[_]>>>()?;
         let abi = CanonicalAbiInfo::record(
             types
                 .iter()
                 .map(|ty| self.component_types.canonical_abi(ty)),
         );
-        self.add_tuple_type(TypeTuple { types, abi })
+        Ok(self.add_tuple_type(TypeTuple { types, abi }))
     }
 
-    fn flags_type(&mut self, flags: &[&str]) -> TypeFlagsIndex {
+    fn flags_type(&mut self, flags: &IndexSet<KebabString>) -> TypeFlagsIndex {
         let flags = TypeFlags {
             names: flags.iter().map(|s| s.to_string()).collect(),
             abi: CanonicalAbiInfo::flags(flags.len()),
@@ -791,48 +679,68 @@ impl ComponentTypesBuilder {
         self.add_flags_type(flags)
     }
 
-    fn enum_type(&mut self, variants: &[&str]) -> TypeEnumIndex {
+    fn enum_type(&mut self, variants: &IndexSet<KebabString>) -> TypeEnumIndex {
         let names = variants.iter().map(|s| s.to_string()).collect::<Box<[_]>>();
         let (info, abi) = VariantInfo::new(names.iter().map(|_| None));
         self.add_enum_type(TypeEnum { names, abi, info })
     }
 
-    fn union_type(&mut self, types: &[wasmparser::ComponentValType]) -> TypeUnionIndex {
-        let types = types
+    fn union_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::UnionType,
+    ) -> Result<TypeUnionIndex> {
+        let types = ty
+            .types
             .iter()
-            .map(|ty| self.valtype(ty))
-            .collect::<Box<[_]>>();
+            .map(|ty| self.valtype(types, ty))
+            .collect::<Result<Box<[_]>>>()?;
         let (info, abi) = VariantInfo::new(
             types
                 .iter()
                 .map(|t| Some(self.component_types.canonical_abi(t))),
         );
-        self.add_union_type(TypeUnion { types, abi, info })
+        Ok(self.add_union_type(TypeUnion { types, abi, info }))
     }
 
-    fn option_type(&mut self, ty: &wasmparser::ComponentValType) -> TypeOptionIndex {
-        let ty = self.valtype(ty);
+    fn option_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::ComponentValType,
+    ) -> Result<TypeOptionIndex> {
+        let ty = self.valtype(types, ty)?;
         let (info, abi) = VariantInfo::new([None, Some(self.component_types.canonical_abi(&ty))]);
-        self.add_option_type(TypeOption { ty, abi, info })
+        Ok(self.add_option_type(TypeOption { ty, abi, info }))
     }
 
     fn result_type(
         &mut self,
-        ok: &Option<wasmparser::ComponentValType>,
-        err: &Option<wasmparser::ComponentValType>,
-    ) -> TypeResultIndex {
-        let ok = ok.as_ref().map(|ty| self.valtype(ty));
-        let err = err.as_ref().map(|ty| self.valtype(ty));
+        types: types::TypesRef<'_>,
+        ok: &Option<types::ComponentValType>,
+        err: &Option<types::ComponentValType>,
+    ) -> Result<TypeResultIndex> {
+        let ok = match ok {
+            Some(ty) => Some(self.valtype(types, ty)?),
+            None => None,
+        };
+        let err = match err {
+            Some(ty) => Some(self.valtype(types, ty)?),
+            None => None,
+        };
         let (info, abi) = VariantInfo::new([
             ok.as_ref().map(|t| self.component_types.canonical_abi(t)),
             err.as_ref().map(|t| self.component_types.canonical_abi(t)),
         ]);
-        self.add_result_type(TypeResult { ok, err, abi, info })
+        Ok(self.add_result_type(TypeResult { ok, err, abi, info }))
     }
 
-    fn list_type(&mut self, ty: &wasmparser::ComponentValType) -> TypeListIndex {
-        let element = self.valtype(ty);
-        self.add_list_type(TypeList { element })
+    fn list_type(
+        &mut self,
+        types: types::TypesRef<'_>,
+        ty: &types::ComponentValType,
+    ) -> Result<TypeListIndex> {
+        let element = self.valtype(types, ty)?;
+        Ok(self.add_list_type(TypeList { element }))
     }
 
     /// Interns a new function type within this type information.
@@ -944,10 +852,7 @@ impl ComponentTypesBuilder {
 
 impl TypeConvert for ComponentTypesBuilder {
     fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType {
-        match self.type_scopes.last().unwrap().core[index] {
-            TypeDef::CoreFunc(i) => WasmHeapType::TypedFunc(i),
-            _ => unreachable!(),
-        }
+        panic!("heap types are not supported yet")
     }
 }
 

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -851,7 +851,7 @@ impl ComponentTypesBuilder {
 }
 
 impl TypeConvert for ComponentTypesBuilder {
-    fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType {
+    fn lookup_heap_type(&self, _index: TypeIndex) -> WasmHeapType {
         panic!("heap types are not supported yet")
     }
 }

--- a/tests/misc_testsuite/component-model/types.wast
+++ b/tests/misc_testsuite/component-model/types.wast
@@ -244,6 +244,7 @@
     (type $t99 (list $t98))
     (type $t100 (list $t99))
     (type $t101 (list $t100))
+    (export "t" (type $t101))
   )
   "type nesting is too deep")
 


### PR DESCRIPTION
Before this commit Wasmtime would build up its own representation of type information independently of wasmparser, effectively duplicating things such as type scopes and managing indices. This to some degree is required because Wasmtime's type information is serialized into compiled images and wasmparser's information isn't easily serialized. With the advent of resources in components, however, the task of doing this correctly has become much more difficult.

When component translation was first written it was more difficult to acquire type information from `wasmparser::Validator`. Nowadays there's helpful type information exposed every step of the way which makes it much easier to get at the types of items while we're translating rather than only at the very end (or not at all). This is one of the motivations for this commit where now it's possible to avoid duplicating the work `wasmparser` is doing whereas before it wasn't as easy.

Additionally with resources in the component model they perform namely a number of involved type substitutions during instantiation of arbitrary components which isn't implemented in Wasmtime today. Some of this will be required for Wasmtime to correctly implement resources so instead of doing all that again I've decided to replace Wasmtime's management of types with wasmparser's management of types.

The main difference in this commit is that Wasmtime no longer tracks type information during translation and that conversion into Wasmtime's type hierarchy now has a different entry point. Previously conversion would happen based on raw types read from the wasm file (think index-based things) whereas now translation happens on `wasmparser`'s parsed and validated hierarchy of types (think ID-based things rather than index-based things). This makes translation slightly more involved but overall it's largely performing the same work.

One gotcha with this PR is that core wasm modules using GC types and typed function references could theoretically have worked previously but they no longer work. It turns out that `wasmparser` is not correctly surfacing type information in components for core modules that use GC types, namely because `wasmparser`'s validated type hierarchy uses the same core wasm types as what's read raw from the type section. This in turn means that the index-based format can't be resolved. This is a bug in `wasmparser` which will need resolving but is a big chunk of work to take on, so for now the component model will panic on these sorts of modules (which are disabled by default anyway).

Overall the end-goal of this commit is to ease the implementation of resources a bit by heavily relying on `wasmparser`'s understanding of resources, chiefly the functionality of performing type substitutions on subcomponent instantiations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
