### PR TITLE
Bump cargo-vet to 0.8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     if: needs.determine.outputs.audit
     runs-on: ubuntu-latest
     env:
-      CARGO_VET_VERSION: 0.7.0
+      CARGO_VET_VERSION: 0.8.0
     steps:
     - uses: actions/checkout@v3
       with:

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -16,6 +16,142 @@ user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
 end = "2024-03-10"
 
+[[wildcard-audits.cranelift]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-bforest]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-codegen]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-codegen-meta]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-codegen-shared]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-control]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-05-22"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-entity]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-frontend]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-interpreter]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-isle]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-12-13"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-jit]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-module]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-native]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-object]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-reader]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-serde]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-wasm]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.derive_arbitrary]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -44,6 +180,30 @@ repository of which I'm one of the maintainers and publishers for. I am employed
 by a member of the Bytecode Alliance and plan to continue doing so and will
 actively maintain this crate over time.
 """
+
+[[wildcard-audits.wasi-cap-std-sync]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasi-common]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasi-tokio]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -137,6 +297,206 @@ I am employed by a member of the Bytecode Alliance and plan to continue doing
 so and will actively maintain this crate over time.
 """
 
+[[wildcard-audits.wasmtime]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-asm-macros]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-08-22"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cache]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cli]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cli-flags]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-05-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-component-macro]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-07-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-component-util]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-08-22"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cranelift]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cranelift-shared]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-04-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-environ]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-explorer]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-04-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-fiber]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-jit]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-jit-debug]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-03-07"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-jit-icache-coherence]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-11-21"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-runtime]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-types]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-crypto]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-http]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-05-22"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-nn]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-threads]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-03-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wast]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-winch]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-11-21"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wit-bindgen]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2023-01-20"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wast]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -162,6 +522,46 @@ repository of which I'm one of the primary maintainers and publishers for.
 I am employed by a member of the Bytecode Alliance and plan to continue doing
 so and will actively maintain this crate over time.
 """
+
+[[wildcard-audits.wiggle]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wiggle-generate]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wiggle-macro]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2021-10-29"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wiggle-test]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 18162 # Pat Hickey (pchickey)
+start = "2020-03-12"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.winch-codegen]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2022-11-21"
+end = "2024-06-26"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wit-bindgen]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.7"
+version = "0.8"
 
 [imports.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -23,109 +23,109 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
 [policy.cranelift]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-bforest]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-codegen]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-codegen-meta]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-codegen-shared]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-control]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-entity]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-frontend]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-interpreter]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-isle]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-jit]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-module]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-native]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-object]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-reader]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-serde]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.cranelift-wasm]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.isle-fuzz]
 criteria = "safe-to-run"
 
 [policy.wasi-cap-std-sync]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasi-common]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasi-crypto]
 audit-as-crates-io = false
 
 [policy.wasi-tokio]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-asm-macros]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-cache]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-cli]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-cli-flags]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-component-macro]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-component-util]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-cranelift]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-cranelift-shared]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-environ]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-environ-fuzz]
 criteria = "safe-to-run"
 
 [policy.wasmtime-explorer]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-fiber]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-fuzz]
 criteria = "safe-to-run"
@@ -134,58 +134,58 @@ criteria = "safe-to-run"
 criteria = "safe-to-run"
 
 [policy.wasmtime-jit]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-jit-debug]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-jit-icache-coherence]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-runtime]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-types]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wasi]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wasi-crypto]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wasi-http]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wasi-nn]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wasi-threads]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wast]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-winch]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wasmtime-wit-bindgen]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wiggle]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wiggle-generate]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wiggle-macro]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.wiggle-test]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.winch-codegen]
-audit-as-crates-io = false
+audit-as-crates-io = true
 
 [policy.witx]
 audit-as-crates-io = false

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -292,12 +292,6 @@ criteria = "safe-to-deploy"
 version = "0.2.2"
 notes = "Inspected it and is a tiny crate with just type definitions"
 
-[[audits.embark-studios.audits.epaint]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-violation = "<0.20.0"
-notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
-
 [[audits.embark-studios.audits.ittapi]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,206 @@
 
 # cargo-vet imports lock
 
+[[unpublished.cranelift]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-control]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-module]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-native]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-object]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-serde]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.cranelift-wasm]]
+version = "0.98.0"
+audited_as = "0.97.1"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasi-common]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasi-tokio]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-cache]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-component-util]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-cranelift-shared]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-explorer]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-jit]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-runtime]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-types]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wasi-crypto]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-winch]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wiggle]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wiggle-generate]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "11.0.0"
+audited_as = "10.0.1"
+
+[[unpublished.wiggle-test]]
+version = "0.0.0"
+audited_as = "0.1.0"
+
+[[unpublished.winch-codegen]]
+version = "0.9.0"
+audited_as = "0.8.1"
+
 [[publisher.arbitrary]]
 version = "1.3.0"
 when = "2023-03-13"
@@ -14,6 +214,108 @@ when = "2023-01-17"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
+
+[[publisher.cranelift]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-reader]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-serde]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.97.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.derive_arbitrary]]
 version = "1.3.0"
@@ -49,6 +351,24 @@ when = "2022-05-02"
 user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
+
+[[publisher.wasi-cap-std-sync]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-common]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasm-encoder]]
 version = "0.29.0"
@@ -92,6 +412,156 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasmtime]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cache]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli-flags]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-util]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift-shared]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-crypto]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wast]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wast]]
 version = "60.0.0"
 when = "2023-05-26"
@@ -105,6 +575,37 @@ when = "2023-05-26"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
+
+[[publisher.wiggle]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-generate]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "10.0.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-test]]
+version = "0.1.0"
+when = "2020-03-12"
+user-id = 18162
+user-login = "pchickey"
+user-name = "Pat Hickey"
+
+[[publisher.winch-codegen]]
+version = "0.8.1"
+when = "2023-06-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.windows-sys]]
 version = "0.45.0"


### PR DESCRIPTION
- Bump cargo-vet to 0.8.0.
- Use the new audited-as feature to enable audit-as-crates-io for not-yet-published versions of first-party crates, per discussion with @alexcrichton 