### PR TITLE
Cranelift: Provide better error messages when failing to parse hexadecimal `run` arguments

### DIFF
--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -49,7 +49,11 @@ macro_rules! match_imm {
                 let text = text.replace("_", "");
                 // Parse it in hexadecimal form.
                 <$unsigned>::from_str_radix(&text[2..], 16).map_err(|_| {
-                    $parser.error("unable to parse value as a hexadecimal immediate")
+                    $parser.error(&format!(
+                        "unable to parse '{}' value as a hexadecimal {} immediate",
+                        &text[2..],
+                        stringify!($unsigned),
+                    ))
                 })?
             } else {
                 // Parse it as a signed type to check for overflow and other issues.


### PR DESCRIPTION
Just something that helped when I was reducing a test case. Definitely more places we can do stuff like this, but this was all I needed for my purposes so for now I'd like to just get it landed and move along.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
