### PR TITLE
Refactor compilation of component-related functions

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -261,7 +261,7 @@ impl Compiler {
                 vmctx,
                 i32::try_from(offsets.limits()).unwrap(),
             );
-            super::save_last_wasm_exit_fp_and_pc(builder, pointer_type, offsets.ptr, limits);
+            super::save_last_wasm_exit_fp_and_pc(builder, pointer_type, &offsets.ptr, limits);
         }
     }
 }


### PR DESCRIPTION
Extract some common functionality out to helper functions to reduce the boilerplate involved in compiling component-related functions. This is in preparation for upcoming resource-related work which adds more functions to compile.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
