### PR TITLE
[wit-bindgen] provide more control over type ownership

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{braced, token, Ident, Token};
-use wasmtime_wit_bindgen::{Opts, TrappableError};
+use wasmtime_wit_bindgen::{Opts, Ownership, TrappableError};
 use wit_parser::{PackageId, Resolve, UnresolvedPackage, WorldId};
 
 pub struct Config {
@@ -73,7 +73,7 @@ impl Parse for Config {
                     Opt::Tracing(val) => opts.tracing = val,
                     Opt::Async(val) => opts.async_ = val,
                     Opt::TrappableErrorType(val) => opts.trappable_error_type = val,
-                    Opt::DuplicateIfNecessary(val) => opts.duplicate_if_necessary = val,
+                    Opt::Ownership(val) => opts.ownership = val,
                     Opt::Interfaces(s) => {
                         if inline.is_some() {
                             return Err(Error::new(s.span(), "cannot specify a second source"));
@@ -168,7 +168,7 @@ mod kw {
     syn::custom_keyword!(tracing);
     syn::custom_keyword!(trappable_error_type);
     syn::custom_keyword!(world);
-    syn::custom_keyword!(duplicate_if_necessary);
+    syn::custom_keyword!(ownership);
     syn::custom_keyword!(interfaces);
     syn::custom_keyword!(with);
 }
@@ -180,7 +180,7 @@ enum Opt {
     Tracing(bool),
     Async(bool),
     TrappableErrorType(Vec<TrappableError>),
-    DuplicateIfNecessary(bool),
+    Ownership(Ownership),
     Interfaces(syn::LitStr),
     With(HashMap<String, String>),
 }
@@ -208,12 +208,44 @@ impl Parse for Opt {
             input.parse::<Token![async]>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::Async(input.parse::<syn::LitBool>()?.value))
-        } else if l.peek(kw::duplicate_if_necessary) {
-            input.parse::<kw::duplicate_if_necessary>()?;
+        } else if l.peek(kw::ownership) {
+            input.parse::<kw::ownership>()?;
             input.parse::<Token![:]>()?;
-            Ok(Opt::DuplicateIfNecessary(
-                input.parse::<syn::LitBool>()?.value,
-            ))
+            let ownership = input.parse::<syn::Ident>()?;
+            Ok(Opt::Ownership(match ownership.to_string().as_str() {
+                "Owning" => Ownership::Owning,
+                "Borrowing" => Ownership::Borrowing {
+                    duplicate_if_necessary: {
+                        let contents;
+                        braced!(contents in input);
+                        let field = contents.parse::<syn::Ident>()?;
+                        match field.to_string().as_str() {
+                            "duplicate_if_necessary" => {
+                                contents.parse::<Token![:]>()?;
+                                contents.parse::<syn::LitBool>()?.value
+                            }
+                            name => {
+                                return Err(Error::new(
+                                    field.span(),
+                                    format!(
+                                        "unrecognized `Ownership::Borrowing` field: `{name}`; \
+                                         expected `duplicate_if_necessary`"
+                                    ),
+                                ));
+                            }
+                        }
+                    },
+                },
+                name => {
+                    return Err(Error::new(
+                        ownership.span(),
+                        format!(
+                            "unrecognized ownership: `{name}`; \
+                             expected `Owning` or `Borrowing`"
+                        ),
+                    ));
+                }
+            }))
         } else if l.peek(kw::trappable_error_type) {
             input.parse::<kw::trappable_error_type>()?;
             input.parse::<Token![:]>()?;

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -14,7 +14,9 @@ macro_rules! gentest {
                 wasmtime::component::bindgen!({
                     path: $path,
                     tracing: true,
-                    duplicate_if_necessary: true,
+                    ownership: Borrowing {
+                        duplicate_if_necessary: true
+                    }
                 });
             }
         }

--- a/crates/test-programs/tests/reactor.rs
+++ b/crates/test-programs/tests/reactor.rs
@@ -37,6 +37,9 @@ wasmtime::component::bindgen!({
        "wasi:cli-base/stdout": preview2::wasi::cli_base::stdout,
        "wasi:cli-base/stderr": preview2::wasi::cli_base::stderr,
     },
+    ownership: Borrowing {
+        duplicate_if_necessary: false
+    }
 });
 
 struct ReactorCtx {

--- a/crates/wit-bindgen/src/types.rs
+++ b/crates/wit-bindgen/src/types.rs
@@ -69,11 +69,13 @@ impl Types {
             live.add_type(resolve, ty);
         }
         for id in live.iter() {
-            let info = self.type_info.get_mut(&id).unwrap();
-            if import {
-                info.owned = true;
-            } else {
-                info.borrowed = true;
+            if resolve.types[id].name.is_some() {
+                let info = self.type_info.get_mut(&id).unwrap();
+                if import {
+                    info.owned = true;
+                } else {
+                    info.borrowed = true;
+                }
             }
         }
         let mut live = LiveTypes::default();
@@ -82,7 +84,9 @@ impl Types {
             live.add_type(resolve, ty);
         }
         for id in live.iter() {
-            self.type_info.get_mut(&id).unwrap().owned = true;
+            if resolve.types[id].name.is_some() {
+                self.type_info.get_mut(&id).unwrap().owned = true;
+            }
         }
 
         for ty in func.results.iter_types() {

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -7,6 +7,7 @@ use wasmtime::{
     Store,
 };
 
+mod ownership;
 mod results;
 
 mod no_imports {

--- a/tests/all/component_model/bindgen/ownership.rs
+++ b/tests/all/component_model/bindgen/ownership.rs
@@ -1,0 +1,329 @@
+use super::{super::REALLOC_AND_FREE, engine};
+use anyhow::Result;
+use wasmtime::{
+    component::{Component, Linker},
+    Store,
+};
+
+fn component() -> String {
+    format!(
+        r#"
+        (component
+            (core module $libc
+                (memory (export "memory") 1)
+                {REALLOC_AND_FREE}
+            )
+            (core instance $libc (instantiate $libc))
+            (core module $m
+                (import "libc" "memory" (memory 0))
+                (import "libc" "realloc" (func $realloc (param i32 i32 i32 i32) (result i32)))
+                (func (export "core_foo_export") (param i32 i32) (result i32)
+                    (local $retptr i32)
+                    (local.set $retptr
+                        (call $realloc
+                            (i32.const 0)
+                            (i32.const 0)
+                            (i32.const 4)
+                            (i32.const 8)))
+                    (i32.store offset=0 (local.get $retptr) (local.get 0))
+                    (i32.store offset=4 (local.get $retptr) (local.get 1))
+                    (local.get $retptr)
+                )
+                (func (export "core_bar_export") (param i32 i32 i32 i32))
+                (func (export "core_baz_export") (param i32 i32 i32 i32) (result i32)
+                    (local $retptr i32)
+                    (local.set $retptr
+                        (call $realloc
+                            (i32.const 0)
+                            (i32.const 0)
+                            (i32.const 4)
+                            (i32.const 16)))
+                    (i32.store offset=0 (local.get $retptr) (local.get 0))
+                    (i32.store offset=4 (local.get $retptr) (local.get 1))
+                    (i32.store offset=8 (local.get $retptr) (local.get 2))
+                    (i32.store offset=12 (local.get $retptr) (local.get 3))
+                    (local.get $retptr)
+                )
+            )
+            (core instance $i (instantiate $m
+                (with "libc" (instance $libc))
+            ))
+
+            (func $f_foo
+                (param "a" (list (list string)))
+                (result (list (list string)))
+                (canon lift (core func $i "core_foo_export") (memory $libc "memory")
+                    (realloc (func $libc "realloc"))
+                )
+            )
+
+            (type $thing (record (field "name" string) (field "value" (list string))))
+
+            (func $f_bar
+                (param "a" $thing)
+                (canon lift (core func $i "core_bar_export") (memory $libc "memory")
+                    (realloc (func $libc "realloc"))
+                )
+            )
+
+            (func $f_baz
+                (param "a" $thing)
+                (result $thing)
+                (canon lift (core func $i "core_baz_export") (memory $libc "memory")
+                    (realloc (func $libc "realloc"))
+                )
+            )
+
+            (component $c_lists
+                (import "import-foo" (func $f
+                    (param "a" (list (list string)))
+                    (result (list (list string)))
+                ))
+                (export "foo" (func $f))
+            )
+            (instance $i_lists (instantiate $c_lists
+                (with "import-foo" (func $f_foo))
+            ))
+            (export "lists" (instance $i_lists))
+
+            (component $c_thing_in
+                (import "import-thing" (type $import-thing (eq $thing)))
+                (import "import-bar" (func $f (param "a" $import-thing)))
+                (export $export-thing "thing" (type $thing))
+                (export "bar" (func $f) (func (param "a" $export-thing)))
+            )
+            (instance $i_thing_in (instantiate $c_thing_in
+                (with "import-thing" (type $thing))
+                (with "import-bar" (func $f_bar))
+            ))
+            (export "thing-in" (instance $i_thing_in))
+
+            (component $c_thing_in_and_out
+                (import "import-thing" (type $import-thing (eq $thing)))
+                (import "import-baz" (func $f (param "a" $import-thing) (result $import-thing)))
+                (export $export-thing "thing" (type $thing))
+                (export "baz" (func $f) (func (param "a" $export-thing) (result $export-thing)))
+            )
+            (instance $i_thing_in_and_out (instantiate $c_thing_in_and_out
+                (with "import-thing" (type $thing))
+                (with "import-baz" (func $f_baz))
+            ))
+            (export "thing-in-and-out" (instance $i_thing_in_and_out))
+        )
+        "#
+    )
+}
+
+#[test]
+fn owning() -> Result<()> {
+    wasmtime::component::bindgen!({
+        inline: "
+        package inline:inline
+        world test {
+            export lists: interface {
+                foo: func(a: list<list<string>>) -> list<list<string>>
+            }
+
+            export thing-in: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                bar: func(a: thing)
+            }
+
+            export thing-in-and-out: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                baz: func(a: thing) -> thing
+            }
+        }",
+        ownership: Owning
+    });
+
+    impl PartialEq for exports::thing_in::Thing {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    impl PartialEq for exports::thing_in_and_out::Thing {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    let engine = engine();
+    let component = Component::new(&engine, component())?;
+
+    let linker = Linker::new(&engine);
+    let mut store = Store::new(&engine, ());
+    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+
+    let value = vec![vec!["a".to_owned(), "b".to_owned()]];
+    assert_eq!(value, test.lists().call_foo(&mut store, &value)?);
+
+    let value = exports::thing_in::Thing {
+        name: "thing 1".to_owned(),
+        value: vec!["some value".to_owned(), "another value".to_owned()],
+    };
+    test.thing_in().call_bar(&mut store, &value)?;
+
+    let value = exports::thing_in_and_out::Thing {
+        name: "thing 1".to_owned(),
+        value: vec!["some value".to_owned(), "another value".to_owned()],
+    };
+    assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
+
+    Ok(())
+}
+
+#[test]
+fn borrowing_no_duplication() -> Result<()> {
+    wasmtime::component::bindgen!({
+        inline: "
+        package inline:inline
+        world test {
+            export lists: interface {
+                foo: func(a: list<list<string>>) -> list<list<string>>
+            }
+
+            export thing-in: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                bar: func(a: thing)
+            }
+
+            export thing-in-and-out: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                baz: func(a: thing) -> thing
+            }
+        }",
+        ownership: Borrowing {
+            duplicate_if_necessary: false
+        }
+    });
+
+    impl PartialEq for exports::thing_in::Thing<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    impl PartialEq for exports::thing_in_and_out::Thing {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    let engine = engine();
+    let component = Component::new(&engine, component())?;
+
+    let linker = Linker::new(&engine);
+    let mut store = Store::new(&engine, ());
+    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+
+    let value = &[&["a", "b"] as &[_]] as &[_];
+    assert_eq!(value, test.lists().call_foo(&mut store, value)?);
+
+    let value = exports::thing_in::Thing {
+        name: "thing 1",
+        value: &["some value", "another value"],
+    };
+    test.thing_in().call_bar(&mut store, value)?;
+
+    let value = exports::thing_in_and_out::Thing {
+        name: "thing 1".to_owned(),
+        value: vec!["some value".to_owned(), "another value".to_owned()],
+    };
+    assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
+
+    Ok(())
+}
+
+#[test]
+fn borrowing_with_duplication() -> Result<()> {
+    wasmtime::component::bindgen!({
+        inline: "
+        package inline:inline
+        world test {
+            export lists: interface {
+                foo: func(a: list<list<string>>) -> list<list<string>>
+            }
+
+            export thing-in: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                bar: func(a: thing)
+            }
+
+            export thing-in-and-out: interface {
+                record thing {
+                    name: string,
+                    value: list<string>
+                }
+
+                baz: func(a: thing) -> thing
+            }
+        }",
+        ownership: Borrowing {
+            duplicate_if_necessary: true
+        }
+    });
+
+    impl PartialEq for exports::thing_in::Thing<'_> {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    impl PartialEq for exports::thing_in_and_out::ThingResult {
+        fn eq(&self, other: &Self) -> bool {
+            self.name == other.name && self.value == other.value
+        }
+    }
+
+    let engine = engine();
+    let component = Component::new(&engine, component())?;
+
+    let linker = Linker::new(&engine);
+    let mut store = Store::new(&engine, ());
+    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+
+    let value = &[&["a", "b"] as &[_]] as &[_];
+    assert_eq!(value, test.lists().call_foo(&mut store, value)?);
+
+    let value = exports::thing_in::Thing {
+        name: "thing 1",
+        value: &["some value", "another value"],
+    };
+    test.thing_in().call_bar(&mut store, value)?;
+
+    let value = exports::thing_in_and_out::ThingParam {
+        name: "thing 1",
+        value: &["some value", "another value"],
+    };
+    assert_eq!(
+        exports::thing_in_and_out::ThingResult {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        },
+        test.thing_in_and_out().call_baz(&mut store, value)?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This replaces the `duplicate_if_necessary` parameter to `wasmtime::component::bindgen` with a new `ownership` parameter which provides finer-grained control over whether and how generated types own their fields.

The default is `Ownership::Owning`, which means types own their fields regardless of how they are used in functions.  These types are passed by reference when used as parameters to guest-exported functions.  Note that this also affects how unnamed types (e.g. `list<list<string>>`) are passed: using a reference only at the top level (e.g. `&[Vec<String>]` instead of `&[&[&str]]`, which is more difficult to construct when using non-`'static` data).

The other option is `Ownership::Borrowing`, which includes a `duplicate_if_necessary` field, providing the same code generation strategy as was used prior to this change.

If we're happy with this approach, I'll open another PR in the `wit-bindgen` repo to match.

This also fixes a bug that caused named types to be considered owned and/or borrowed when they shouldn't have been due to having fields with unnamed types which were owned and/or borrowed in unrelated interfaces.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
