### PR TITLE
preview2: refactor WasiCtxBuilder impl, and make WasiCtx fields private

### DIFF
--- a/crates/test-programs/tests/command.rs
+++ b/crates/test-programs/tests/command.rs
@@ -13,7 +13,7 @@ use wasmtime_wasi::preview2::{
     pipe::ReadPipe,
     wasi::command::add_to_linker,
     wasi::command::Command,
-    DirPerms, FilePerms, Table, WasiCtx, WasiCtxBuilder, WasiView,
+    DirPerms, FilePerms, Table, WasiClocks, WasiCtx, WasiCtxBuilder, WasiView,
 };
 
 lazy_static::lazy_static! {
@@ -159,9 +159,12 @@ async fn time() -> Result<()> {
     }
 
     let mut table = Table::new();
-    let mut wasi = WasiCtxBuilder::new().build(&mut table)?;
-    wasi.clocks.wall = Box::new(FakeWallClock);
-    wasi.clocks.monotonic = Box::new(FakeMonotonicClock { now: Mutex::new(0) });
+    let wasi = WasiCtxBuilder::new()
+        .set_clocks(WasiClocks {
+            wall: Box::new(FakeWallClock),
+            monotonic: Box::new(FakeMonotonicClock { now: Mutex::new(0) }),
+        })
+        .build(&mut table)?;
 
     let (mut store, command) =
         instantiate(get_component("time"), CommandCtx { table, wasi }).await?;

--- a/crates/test-programs/tests/reactor.rs
+++ b/crates/test-programs/tests/reactor.rs
@@ -85,38 +85,22 @@ async fn instantiate(
 #[test_log::test(tokio::test)]
 async fn reactor_tests() -> Result<()> {
     let mut table = Table::new();
-    let wasi = WasiCtxBuilder::new().build(&mut table)?;
+    let wasi = WasiCtxBuilder::new()
+        .push_env("GOOD_DOG", "gussie")
+        .build(&mut table)?;
 
     let (mut store, reactor) =
         instantiate(get_component("reactor_tests"), ReactorCtx { table, wasi }).await?;
 
-    store
-        .data_mut()
-        .wasi
-        .env
-        .push(("GOOD_DOG".to_owned(), "gussie".to_owned()));
-
+    // Show that integration with the WASI context is working - the guest will
+    // interpolate $GOOD_DOG to gussie here using the environment:
     let r = reactor
         .call_add_strings(&mut store, &["hello", "$GOOD_DOG"])
         .await?;
     assert_eq!(r, 2);
 
-    // Redefine the env, show that the adapter only fetches it once
-    // even if the libc ctors copy it in multiple times:
-    store.data_mut().wasi.env.clear();
-    store
-        .data_mut()
-        .wasi
-        .env
-        .push(("GOOD_DOG".to_owned(), "cody".to_owned()));
-    // Cody is indeed good but this should be "hello again" "gussie"
-    let r = reactor
-        .call_add_strings(&mut store, &["hello again", "$GOOD_DOG"])
-        .await?;
-    assert_eq!(r, 4);
-
     let contents = reactor.call_get_strings(&mut store).await?;
-    assert_eq!(contents, &["hello", "gussie", "hello again", "gussie"]);
+    assert_eq!(contents, &["hello", "gussie"]);
 
     // Show that we can pass in a resource type whose impls are defined in the
     // `host` and `wasi-common` crate.
@@ -129,7 +113,7 @@ async fn reactor_tests() -> Result<()> {
     let r = reactor.call_write_strings_to(&mut store, table_ix).await?;
     assert_eq!(r, Ok(()));
 
-    assert_eq!(*write_dest.read().unwrap(), b"hellogussiehello againgussie");
+    assert_eq!(*write_dest.read().unwrap(), b"hellogussie");
 
     // Show that the `with` invocation in the macro means we get to re-use the
     // type definitions from inside the `host` crate for these structures:

--- a/crates/wasi/src/preview2/pipe.rs
+++ b/crates/wasi/src/preview2/pipe.rs
@@ -26,9 +26,9 @@ use system_interface::io::ReadReady;
 /// easy to create. For example:
 ///
 /// ```
-/// use wasmtime_wasi::preview2::{pipe::ReadPipe, WasiCtx};
+/// use wasmtime_wasi::preview2::{pipe::ReadPipe, WasiCtxBuilder};
 /// let stdin = ReadPipe::from("hello from stdin!");
-/// let builder = WasiCtx::builder().set_stdin(stdin);
+/// let builder = WasiCtxBuilder::new().set_stdin(stdin);
 /// ```
 #[derive(Debug)]
 pub struct ReadPipe<R: Read + ReadReady> {
@@ -134,10 +134,10 @@ impl<R: Read + ReadReady + Any + Send + Sync> InputStream for ReadPipe<R> {
 /// A virtual pipe write end.
 ///
 /// ```no_run
-/// use wasmtime_wasi::preview2::{pipe::WritePipe, WasiCtx, Table};
+/// use wasmtime_wasi::preview2::{pipe::WritePipe, WasiCtxBuilder, Table};
 /// let mut table = Table::new();
 /// let stdout = WritePipe::new_in_memory();
-/// let mut ctx = WasiCtx::builder().set_stdout(stdout.clone()).build(&mut table).unwrap();
+/// let mut ctx = WasiCtxBuilder::new().set_stdout(stdout.clone()).build(&mut table).unwrap();
 /// // use ctx and table in an instance, then make sure it is dropped:
 /// drop(ctx);
 /// drop(table);


### PR DESCRIPTION
The optional-fields WasiCtxBuilder was an intermediate stepping stone which has outlived its usefulness - there is now only one sensible default value for each field, so we no longer need to expose the Default (empty) constructor.

There is no need for the WasiCtx::builder method being an alias for default, and it creates user confusion.

Finally, the WasiCtx itself is a private implementation detail for use in this crate only. The WasiCtxBuilder is the only way to customize its contents. We don't want to let users modify the fields of WasiCtx after it has been used by a wasm guest, because the guest may have made assumptions that fields won't change - e.g. the stderr field is fetched once by the adapter and assumed to always be the same, environment variables are copied into libc once and assumed to always be the same.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
