### PR TITLE
Cranelift: Log duration of timing passes

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -238,7 +238,7 @@ impl Profiler for DefaultProfiler {
 impl Drop for DefaultTimingToken {
     fn drop(&mut self) {
         let duration = self.start.elapsed();
-        log::debug!("timing: Ending {}", self.pass);
+        log::debug!("timing: Ending {}: {}ms", self.pass, duration.as_millis());
         let old_cur = CURRENT_PASS.with(|p| p.replace(self.prev));
         debug_assert_eq!(self.pass, old_cur, "Timing tokens dropped out of order");
         PASS_TIME.with(|rc| {


### PR DESCRIPTION
Might as well, have it right there. Weird seeing all these start/end logs without the duration itself, otherwise.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
