### PR TITLE
riscv64: Enable `memory_multi` testsuite

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -224,7 +224,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         }
 
         "riscv64" => {
-            if testname.contains("memory_multi") || testsuite.contains("relaxed_simd") {
+            if testsuite.contains("relaxed_simd") {
                 return true;
             }
 


### PR DESCRIPTION
👋 Hey,

I don't know when this started working, but it seems to be working now. As far as I can tell this testsuite has been disabled since https://github.com/bytecodealliance/wasmtime/pull/4974, when it was introduced and was likely fixed in one of the bugfixes that we've had in the meantime.