### PR TITLE
Cranelift: Don't hard code stack-limit registers

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -431,7 +431,12 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
     }
 
-    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallInstVec<Inst> {
+    fn gen_add_imm(
+        _call_conv: isa::CallConv,
+        into_reg: Writable<Reg>,
+        from_reg: Reg,
+        imm: u32,
+    ) -> SmallInstVec<Inst> {
         let imm = imm as u64;
         let mut insts = SmallVec::new();
         if let Some(imm12) = Imm12::maybe_from_u64(imm) {
@@ -486,7 +491,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         Inst::LoadAddr { rd: into_reg, mem }
     }
 
-    fn get_stacklimit_reg() -> Reg {
+    fn get_stacklimit_reg(_call_conv: isa::CallConv) -> Reg {
         spilltmp_reg()
     }
 

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -286,11 +286,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         }
     }
 
-    fn get_stacklimit_reg() -> Reg {
+    fn get_stacklimit_reg(_call_conv: isa::CallConv) -> Reg {
         spilltmp_reg()
     }
 
-    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallInstVec<Inst> {
+    fn gen_add_imm(
+        _call_conv: isa::CallConv,
+        into_reg: Writable<Reg>,
+        from_reg: Reg,
+        imm: u32,
+    ) -> SmallInstVec<Inst> {
         let mut insts = SmallInstVec::new();
         if let Some(imm12) = Imm12::maybe_from_u64(imm as u64) {
             insts.push(Inst::AluRRImm12 {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -475,7 +475,12 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
     }
 
-    fn gen_add_imm(into_reg: Writable<Reg>, from_reg: Reg, imm: u32) -> SmallInstVec<Inst> {
+    fn gen_add_imm(
+        _call_conv: isa::CallConv,
+        into_reg: Writable<Reg>,
+        from_reg: Reg,
+        imm: u32,
+    ) -> SmallInstVec<Inst> {
         let mut insts = SmallVec::new();
         if let Some(imm) = UImm12::maybe_from_u64(imm as u64) {
             insts.push(Inst::LoadAddr {
@@ -528,7 +533,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         Inst::LoadAddr { rd: into_reg, mem }
     }
 
-    fn get_stacklimit_reg() -> Reg {
+    fn get_stacklimit_reg(_call_conv: isa::CallConv) -> Reg {
         spilltmp_reg()
     }
 

--- a/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
@@ -1,0 +1,51 @@
+test compile precise-output
+set enable_llvm_abi_extensions=true
+target x86_64
+
+;; The stack-limit checking code should not clobber the `i128`'s argument
+;; registers.
+
+function %a(i64 vmctx, i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail {
+    gv0 = vmctx
+    stack_limit = gv0
+
+    ;; Need a stack slot to actually emit the stack-limit checking code.
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128):
+    return v8
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   movq    %rax, %r14
+;   addq    %r14, $16, %r14
+;   cmpq    %rsp, %r14
+;   jnbe #trap=stk_ovf
+;   subq    %rsp, $16, %rsp
+; block0:
+;   movq    %r10, %rax
+;   movq    %r11, %rcx
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   movq %rax, %r14
+;   addq $0x10, %r14
+;   cmpq %rsp, %r14
+;   ja 0x27
+;   subq $0x10, %rsp
+; block1: ; offset 0x18
+;   movq %r10, %rax
+;   movq %r11, %rcx
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   ud2 ; trap: stk_ovf

--- a/cranelift/filetests/filetests/runtests/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/runtests/tail-stack-limit.clif
@@ -1,0 +1,38 @@
+test run
+test interpret
+
+set preserve_frame_pointers=true
+set enable_llvm_abi_extensions=true
+
+target x86_64
+;; target aarch64
+;; target riscv64
+;; target s390x
+
+function %a(i64 vmctx, i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail {
+    gv0 = vmctx
+    stack_limit = gv0
+
+    ;; Need a stack slot to actually emit the stack-limit checking code.
+    ss0 = explicit_slot 8
+
+block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128):
+    return v8
+}
+
+function %b(i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail {
+    fn0 = colocated %a(i64 vmctx, i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail
+    ;; This is our "vmctx" struct.
+    ss0 = explicit_slot 8
+
+block0(v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128):
+    ;; Store a 0 in the vmctx struct.
+    v9 = iconst.i64 0
+    stack_store.i64 v9, ss0
+
+    ;; Call %a with our vmctx.
+    v10 = stack_addr.i64 ss0
+    return_call fn0(v10, v1, v2, v3, v4, v5, v6, v7, v8)
+}
+
+; run: %b(1, 2, 3, 4, 5, 6, 7, 0x12345678123456781234567812345678) == 0x12345678123456781234567812345678


### PR DESCRIPTION
Pass in the calling convention so we can make an informed decision of which register to use as a stack-limit temporary register. We need to choose different registers on x64, for example, when using the `tail` calling convention vs system v calling convention.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
