### PR TITLE
Cranelift: CallSite constructors are infallible

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -159,7 +159,7 @@ fn emit_vm_call(
     }
 
     let mut abi =
-        X64CallSite::from_libcall(ctx.sigs(), &sig, &extname, dist, caller_conv, flags.clone())?;
+        X64CallSite::from_libcall(ctx.sigs(), &sig, &extname, dist, caller_conv, flags.clone());
 
     abi.emit_stack_pre_adjust(ctx);
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -102,8 +102,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             Opcode::ReturnCallIndirect,
             caller_conv,
             self.backend.flags().clone(),
-        )
-        .unwrap();
+        );
 
         // Allocate additional stack space for the new stack frame. We will
         // build it in the newly allocated space, but then copy it over our
@@ -181,8 +180,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             distance,
             caller_conv,
             self.backend.flags().clone(),
-        )
-        .unwrap();
+        );
 
         // Allocate additional stack space for the new stack frame. We will
         // build it in the newly allocated space, but then copy it over our

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2111,10 +2111,10 @@ impl<M: ABIMachineSpec> CallSite<M> {
         dist: RelocDistance,
         caller_conv: isa::CallConv,
         flags: settings::Flags,
-    ) -> CodegenResult<CallSite<M>> {
+    ) -> CallSite<M> {
         let sig = sigs.abi_sig_for_sig_ref(sig_ref);
         let clobbers = sigs.call_clobbers::<M>(sig);
-        Ok(CallSite {
+        CallSite {
             sig,
             uses: smallvec![],
             defs: smallvec![],
@@ -2124,7 +2124,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
             caller_conv,
             flags,
             _mach: PhantomData,
-        })
+        }
     }
 
     /// Create a callsite ABI object for a call directly to the specified
@@ -2136,10 +2136,10 @@ impl<M: ABIMachineSpec> CallSite<M> {
         dist: RelocDistance,
         caller_conv: isa::CallConv,
         flags: settings::Flags,
-    ) -> CodegenResult<CallSite<M>> {
+    ) -> CallSite<M> {
         let sig = sigs.abi_sig_for_signature(sig);
         let clobbers = sigs.call_clobbers::<M>(sig);
-        Ok(CallSite {
+        CallSite {
             sig,
             uses: smallvec![],
             defs: smallvec![],
@@ -2149,7 +2149,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
             caller_conv,
             flags,
             _mach: PhantomData,
-        })
+        }
     }
 
     /// Create a callsite ABI object for a call to a function pointer with the
@@ -2161,10 +2161,10 @@ impl<M: ABIMachineSpec> CallSite<M> {
         opcode: ir::Opcode,
         caller_conv: isa::CallConv,
         flags: settings::Flags,
-    ) -> CodegenResult<CallSite<M>> {
+    ) -> CallSite<M> {
         let sig = sigs.abi_sig_for_sig_ref(sig_ref);
         let clobbers = sigs.call_clobbers::<M>(sig);
-        Ok(CallSite {
+        CallSite {
             sig,
             uses: smallvec![],
             defs: smallvec![],
@@ -2174,7 +2174,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
             caller_conv,
             flags,
             _mach: PhantomData,
-        })
+        }
     }
 }
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -689,8 +689,7 @@ macro_rules! isle_prelude_caller_methods {
                 dist,
                 caller_conv,
                 self.backend.flags().clone(),
-            )
-            .unwrap();
+            );
 
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,
@@ -718,8 +717,7 @@ macro_rules! isle_prelude_caller_methods {
                 Opcode::CallIndirect,
                 caller_conv,
                 self.backend.flags().clone(),
-            )
-            .unwrap();
+            );
 
             assert_eq!(
                 inputs.len(&self.lower_ctx.dfg().value_lists) - off,


### PR DESCRIPTION
So no reason to return a result.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
