### PR TITLE
Add `WasiCtxBuilder` setters for the two clock types

### DIFF
--- a/crates/test-programs/tests/command.rs
+++ b/crates/test-programs/tests/command.rs
@@ -13,7 +13,7 @@ use wasmtime_wasi::preview2::{
     pipe::ReadPipe,
     wasi::command::add_to_linker,
     wasi::command::Command,
-    DirPerms, FilePerms, Table, WasiClocks, WasiCtx, WasiCtxBuilder, WasiView,
+    DirPerms, FilePerms, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 
 lazy_static::lazy_static! {
@@ -160,10 +160,8 @@ async fn time() -> Result<()> {
 
     let mut table = Table::new();
     let wasi = WasiCtxBuilder::new()
-        .set_clocks(WasiClocks {
-            wall: Box::new(FakeWallClock),
-            monotonic: Box::new(FakeMonotonicClock { now: Mutex::new(0) }),
-        })
+        .set_monotonic_clock(FakeMonotonicClock { now: Mutex::new(0) })
+        .set_wall_clock(FakeWallClock)
         .build(&mut table)?;
 
     let (mut store, command) =

--- a/crates/test-programs/tests/command.rs
+++ b/crates/test-programs/tests/command.rs
@@ -9,7 +9,7 @@ use wasmtime::{
     Config, Engine, Store,
 };
 use wasmtime_wasi::preview2::{
-    clocks::{WasiMonotonicClock, WasiWallClock},
+    clocks::{HostMonotonicClock, HostWallClock},
     pipe::ReadPipe,
     wasi::command::add_to_linker,
     wasi::command::Command,
@@ -131,7 +131,7 @@ async fn random() -> Result<()> {
 async fn time() -> Result<()> {
     struct FakeWallClock;
 
-    impl WasiWallClock for FakeWallClock {
+    impl HostWallClock for FakeWallClock {
         fn resolution(&self) -> Duration {
             Duration::from_secs(1)
         }
@@ -145,7 +145,7 @@ async fn time() -> Result<()> {
         now: Mutex<u64>,
     }
 
-    impl WasiMonotonicClock for FakeMonotonicClock {
+    impl HostMonotonicClock for FakeMonotonicClock {
         fn resolution(&self) -> u64 {
             1_000_000_000
         }

--- a/crates/wasi/src/preview2/clocks.rs
+++ b/crates/wasi/src/preview2/clocks.rs
@@ -10,8 +10,3 @@ pub trait WasiMonotonicClock: Send + Sync {
     fn resolution(&self) -> u64;
     fn now(&self) -> u64;
 }
-
-pub struct WasiClocks {
-    pub wall: Box<dyn WasiWallClock + Send + Sync>,
-    pub monotonic: Box<dyn WasiMonotonicClock + Send + Sync>,
-}

--- a/crates/wasi/src/preview2/clocks.rs
+++ b/crates/wasi/src/preview2/clocks.rs
@@ -1,12 +1,12 @@
 pub mod host;
 use cap_std::time::Duration;
 
-pub trait WasiWallClock: Send + Sync {
+pub trait HostWallClock: Send + Sync {
     fn resolution(&self) -> Duration;
     fn now(&self) -> Duration;
 }
 
-pub trait WasiMonotonicClock: Send + Sync {
+pub trait HostMonotonicClock: Send + Sync {
     fn resolution(&self) -> u64;
     fn now(&self) -> u64;
 }

--- a/crates/wasi/src/preview2/clocks/host.rs
+++ b/crates/wasi/src/preview2/clocks/host.rs
@@ -1,4 +1,4 @@
-use super::{WasiMonotonicClock, WasiWallClock};
+use super::{HostMonotonicClock, HostWallClock};
 use cap_std::time::{Duration, Instant, SystemClock};
 use cap_std::{ambient_authority, AmbientAuthority};
 use cap_time_ext::{MonotonicClockExt, SystemClockExt};
@@ -16,7 +16,7 @@ impl WallClock {
     }
 }
 
-impl WasiWallClock for WallClock {
+impl HostWallClock for WallClock {
     fn resolution(&self) -> Duration {
         self.clock.resolution()
     }
@@ -47,7 +47,7 @@ impl MonotonicClock {
     }
 }
 
-impl WasiMonotonicClock for MonotonicClock {
+impl HostMonotonicClock for MonotonicClock {
     fn resolution(&self) -> u64 {
         self.clock.resolution().as_nanos().try_into().unwrap()
     }
@@ -64,10 +64,10 @@ impl WasiMonotonicClock for MonotonicClock {
     }
 }
 
-pub fn monotonic_clock_ctx() -> Box<dyn WasiMonotonicClock + Send + Sync> {
+pub fn monotonic_clock() -> Box<dyn HostMonotonicClock + Send + Sync> {
     Box::new(MonotonicClock::new(ambient_authority()))
 }
 
-pub fn wall_clock_ctx() -> Box<dyn WasiWallClock + Send + Sync> {
+pub fn wall_clock() -> Box<dyn HostWallClock + Send + Sync> {
     Box::new(WallClock::new(ambient_authority()))
 }

--- a/crates/wasi/src/preview2/clocks/host.rs
+++ b/crates/wasi/src/preview2/clocks/host.rs
@@ -1,4 +1,4 @@
-use super::{WasiClocks, WasiMonotonicClock, WasiWallClock};
+use super::{WasiMonotonicClock, WasiWallClock};
 use cap_std::time::{Duration, Instant, SystemClock};
 use cap_std::{ambient_authority, AmbientAuthority};
 use cap_time_ext::{MonotonicClockExt, SystemClockExt};
@@ -64,10 +64,10 @@ impl WasiMonotonicClock for MonotonicClock {
     }
 }
 
-pub fn clocks_ctx() -> WasiClocks {
-    // Create the per-instance clock resources.
-    let monotonic = Box::new(MonotonicClock::new(ambient_authority()));
-    let wall = Box::new(WallClock::new(ambient_authority()));
+pub fn monotonic_clock_ctx() -> Box<dyn WasiMonotonicClock + Send + Sync> {
+    Box::new(MonotonicClock::new(ambient_authority()))
+}
 
-    WasiClocks { monotonic, wall }
+pub fn wall_clock_ctx() -> Box<dyn WasiWallClock + Send + Sync> {
+    Box::new(WallClock::new(ambient_authority()))
 }

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -1,5 +1,5 @@
 use crate::preview2::{
-    clocks::{self, WasiMonotonicClock, WasiWallClock},
+    clocks::{self, HostMonotonicClock, HostWallClock},
     filesystem::{Dir, TableFsExt},
     pipe, random, stdio,
     stream::{InputStream, OutputStream, TableStreamExt},
@@ -7,7 +7,7 @@ use crate::preview2::{
 };
 use cap_rand::{Rng, RngCore, SeedableRng};
 
-use super::clocks::host::{monotonic_clock_ctx, wall_clock_ctx};
+use super::clocks::host::{monotonic_clock, wall_clock};
 
 pub struct WasiCtxBuilder {
     stdin: Box<dyn InputStream>,
@@ -20,8 +20,8 @@ pub struct WasiCtxBuilder {
     random: Box<dyn RngCore + Send + Sync>,
     insecure_random: Box<dyn RngCore + Send + Sync>,
     insecure_random_seed: u128,
-    wall_clock: Box<dyn WasiWallClock + Send + Sync>,
-    monotonic_clock: Box<dyn WasiMonotonicClock + Send + Sync>,
+    wall_clock: Box<dyn HostWallClock + Send + Sync>,
+    monotonic_clock: Box<dyn HostMonotonicClock + Send + Sync>,
 }
 
 impl WasiCtxBuilder {
@@ -46,8 +46,8 @@ impl WasiCtxBuilder {
             random: random::thread_rng(),
             insecure_random,
             insecure_random_seed,
-            wall_clock: wall_clock_ctx(),
-            monotonic_clock: monotonic_clock_ctx(),
+            wall_clock: wall_clock(),
+            monotonic_clock: monotonic_clock(),
         }
     }
 
@@ -160,12 +160,12 @@ impl WasiCtxBuilder {
         self
     }
 
-    pub fn set_wall_clock(mut self, clock: impl clocks::WasiWallClock + 'static) -> Self {
+    pub fn set_wall_clock(mut self, clock: impl clocks::HostWallClock + 'static) -> Self {
         self.wall_clock = Box::new(clock);
         self
     }
 
-    pub fn set_monotonic_clock(mut self, clock: impl clocks::WasiMonotonicClock + 'static) -> Self {
+    pub fn set_monotonic_clock(mut self, clock: impl clocks::HostMonotonicClock + 'static) -> Self {
         self.monotonic_clock = Box::new(clock);
         self
     }
@@ -227,8 +227,8 @@ pub struct WasiCtx {
     pub(crate) random: Box<dyn RngCore + Send + Sync>,
     pub(crate) insecure_random: Box<dyn RngCore + Send + Sync>,
     pub(crate) insecure_random_seed: u128,
-    pub(crate) wall_clock: Box<dyn WasiWallClock + Send + Sync>,
-    pub(crate) monotonic_clock: Box<dyn WasiMonotonicClock + Send + Sync>,
+    pub(crate) wall_clock: Box<dyn HostWallClock + Send + Sync>,
+    pub(crate) monotonic_clock: Box<dyn HostMonotonicClock + Send + Sync>,
     pub(crate) env: Vec<(String, String)>,
     pub(crate) args: Vec<String>,
     pub(crate) preopens: Vec<(u32, String)>,

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -160,6 +160,16 @@ impl WasiCtxBuilder {
         self
     }
 
+    pub fn set_wall_clock(mut self, clock: impl clocks::WasiWallClock + 'static) -> Self {
+        self.clocks.wall = Box::new(clock);
+        self
+    }
+
+    pub fn set_monotonic_clock(mut self, clock: impl clocks::WasiMonotonicClock + 'static) -> Self {
+        self.clocks.monotonic = Box::new(clock);
+        self
+    }
+
     pub fn build(self, table: &mut Table) -> Result<WasiCtx, anyhow::Error> {
         use anyhow::Context;
         let Self {

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -36,7 +36,7 @@ pub mod wasi;
 
 pub use cap_fs_ext::SystemTimeSpec;
 pub use cap_rand::RngCore;
-pub use clocks::{WasiClocks, WasiMonotonicClock, WasiWallClock};
+pub use clocks::{WasiMonotonicClock, WasiWallClock};
 pub use ctx::{WasiCtx, WasiCtxBuilder, WasiView};
 pub use error::I32Exit;
 pub use filesystem::{DirPerms, FilePerms};

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -36,7 +36,7 @@ pub mod wasi;
 
 pub use cap_fs_ext::SystemTimeSpec;
 pub use cap_rand::RngCore;
-pub use clocks::{WasiMonotonicClock, WasiWallClock};
+pub use clocks::{HostMonotonicClock, HostWallClock};
 pub use ctx::{WasiCtx, WasiCtxBuilder, WasiView};
 pub use error::I32Exit;
 pub use filesystem::{DirPerms, FilePerms};

--- a/crates/wasi/src/preview2/preview2/clocks.rs
+++ b/crates/wasi/src/preview2/preview2/clocks.rs
@@ -27,7 +27,7 @@ impl TryFrom<SystemTime> for Datetime {
 #[async_trait::async_trait]
 impl<T: WasiView> wall_clock::Host for T {
     async fn now(&mut self) -> anyhow::Result<Datetime> {
-        let now = self.ctx().clocks.wall.now();
+        let now = self.ctx().wall_clock.now();
         Ok(Datetime {
             seconds: now.as_secs(),
             nanoseconds: now.subsec_nanos(),
@@ -35,7 +35,7 @@ impl<T: WasiView> wall_clock::Host for T {
     }
 
     async fn resolution(&mut self) -> anyhow::Result<Datetime> {
-        let res = self.ctx().clocks.wall.resolution();
+        let res = self.ctx().wall_clock.resolution();
         Ok(Datetime {
             seconds: res.as_secs(),
             nanoseconds: res.subsec_nanos(),
@@ -46,11 +46,11 @@ impl<T: WasiView> wall_clock::Host for T {
 #[async_trait::async_trait]
 impl<T: WasiView> monotonic_clock::Host for T {
     async fn now(&mut self) -> anyhow::Result<Instant> {
-        Ok(self.ctx().clocks.monotonic.now())
+        Ok(self.ctx().monotonic_clock.now())
     }
 
     async fn resolution(&mut self) -> anyhow::Result<Instant> {
-        Ok(self.ctx().clocks.monotonic.resolution())
+        Ok(self.ctx().monotonic_clock.resolution())
     }
 
     async fn subscribe(&mut self, when: Instant, absolute: bool) -> anyhow::Result<Pollable> {

--- a/crates/wasi/src/preview2/preview2/poll.rs
+++ b/crates/wasi/src/preview2/preview2/poll.rs
@@ -56,7 +56,7 @@ impl<T: WasiView> poll::Host for T {
                 }
                 PollableEntry::MonotonicClock(when, absolute) => {
                     poll.subscribe_monotonic_clock(
-                        &*self.ctx().clocks.monotonic,
+                        &*self.ctx().monotonic_clock,
                         when,
                         absolute,
                         userdata,

--- a/crates/wasi/src/preview2/sched.rs
+++ b/crates/wasi/src/preview2/sched.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use crate::preview2::{
-    clocks::WasiMonotonicClock,
+    clocks::HostMonotonicClock,
     stream::{InputStream, OutputStream},
 };
 use anyhow::Error;
@@ -43,7 +43,7 @@ impl<'a> Poll<'a> {
     }
     pub fn subscribe_monotonic_clock(
         &mut self,
-        clock: &'a dyn WasiMonotonicClock,
+        clock: &'a dyn HostMonotonicClock,
         deadline: u64,
         absolute: bool,
         ud: Userdata,

--- a/crates/wasi/src/preview2/sched/subscription.rs
+++ b/crates/wasi/src/preview2/sched/subscription.rs
@@ -1,5 +1,5 @@
 use crate::preview2::{
-    clocks::WasiMonotonicClock,
+    clocks::HostMonotonicClock,
     stream::{InputStream, OutputStream},
 };
 use anyhow::Error;
@@ -61,7 +61,7 @@ impl<'a> RwSubscription<'a> {
 }
 
 pub struct MonotonicClockSubscription<'a> {
-    pub clock: &'a dyn WasiMonotonicClock,
+    pub clock: &'a dyn HostMonotonicClock,
     pub absolute_deadline: u64,
 }
 


### PR DESCRIPTION
This allows users to set individual clock types on the `WasiCtxBuilder`.

## Before

```rust
let mut clocks = clocks_ctx();
clocks.wall = Box::new(MyWallClock);
builder.set_clocks(clocks)
```

## After 

```rust
builder.set_wall_clock(MyWallClock)
```

I didn't add any documentation because most of the other setters don't have any, and I was unsure what form the documentation should take. 