### PR TITLE
wasmtime bench-api build error when using --feature wasi-crypto (#6670)

### DIFF
--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -518,7 +518,7 @@ impl BenchState {
             #[cfg(feature = "wasi-nn")]
             wasi_nn: wasmtime_wasi_nn::WasiNnCtx::new()?,
             #[cfg(feature = "wasi-crypto")]
-            wasi_crypto: wasmtime_wasi_nn::WasiCryptoCtx::new(),
+            wasi_crypto: wasmtime_wasi_crypto::WasiCryptoCtx::new(),
         };
 
         // NB: Start measuring instantiation time *after* we've created the WASI


### PR DESCRIPTION
Fixing build error reported in issue #6670.

Fixing typo of `wasmtime_wasi_nn` -> `wasmtime_wasi_crypto` that was causing a build error when building the bench-api with the wasi-crypto feature enabled. 
