### PR TITLE
Update calling conventions for wasm functions slightly

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -7,7 +7,7 @@ use cranelift_codegen::ir;
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_entity::PrimaryMap;
 use cranelift_wasm::{DefinedFuncIndex, WasmFuncType, WasmType};
-use target_lexicon::CallingConvention;
+use target_lexicon::Architecture;
 use wasmtime_cranelift_shared::CompiledFunctionMetadata;
 
 pub use builder::builder;

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -126,18 +126,27 @@ fn array_call_signature(isa: &dyn TargetIsa) -> ir::Signature {
 
 /// Get the internal Wasm calling convention signature for the given type.
 fn wasm_call_signature(isa: &dyn TargetIsa, wasm_func_ty: &WasmFuncType) -> ir::Signature {
-    let call_conv = if isa.triple().default_calling_convention().ok()
-        == Some(CallingConvention::AppleAarch64)
-    {
-        // FIXME: We need an Apple-specific calling convention, so that
-        // Cranelift's ABI implementation generates unwinding directives
-        // about pointer authentication usage, so we can't just use
-        // `CallConv::Fast`.
-        CallConv::AppleAarch64
-    } else {
-        CallConv::Fast
-    };
+    // NB: this calling convention in the near future is expected to be
+    // unconditionally switched to the "tail" calling convention once all
+    // platforms have support for tail calls.
+    //
+    // Also note that the calling convention for wasm functions is purely an
+    // internal implementation detail of cranelift and Wasmtime. Native Rust
+    // code does not interact with raw wasm functions and instead always
+    // operates through trampolines either using the `array_call_signature` or
+    // `native_call_signature` where the default platform ABI is used.
+    let call_conv = match isa.triple().architecture {
+        // On s390x the "wasmtime" calling convention is used to give vectors
+        // little-endian lane order at the ABI layer which should reduce the
+        // need for conversion when operating on vector function arguments. By
+        // default vectors on s390x are otherwise in big-endian lane order which
+        // would require conversions.
+        Architecture::S390x => CallConv::WasmtimeSystemV,
 
+        // All other platforms pick "fast" as the calling convention since it's
+        // presumably, well, the fastest.
+        _ => CallConv::Fast,
+    };
     let mut sig = blank_sig(isa, call_conv);
     let cvt = |ty: &WasmType| ir::AbiParam::new(value_type(isa, *ty));
     sig.params.extend(wasm_func_ty.params().iter().map(&cvt));


### PR DESCRIPTION
This resolves two issues from recent changes in #6649:

* First the s390x calling convention for wasm functions is changed back to `WasmtimeSystemV` from `Fast`. This was an accidental omission from #6649 where the conclusion was that s390x will continue using a calling convention with little-endian lane order for lane arguments. The only calling convention that supports this today is `WasmtimeSystemV`, although the `Tail` calling convention will likely use it in the future as well.

* Second the apple-aarch64 platform now uses the `Fast` calling convention instead of `AppleAarch64` calling convention. That convention was specified in #4195 but local testing shows that is not necessary in the sense that tests all pass with the `Fast` calling convention. This means that the prior comment why the `AppleAarch64` calling convention is required is no longer accurate and in the absence of a reason not to I went ahead and switched it to `Fast`.

In the near future all wasm functions will unconditionally use the `Tail` calling convention and at that time the lane order can be specified on s390x to be little-endian to satisfy all the constraints here. Additionally any unwinding directives, if necessary for aarch64, can be specified as needed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
