### PR TITLE
chore(wasmtime-cranelift): make builder public

### DIFF
--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -14,11 +14,42 @@ use std::sync::Arc;
 use wasmtime_cranelift_shared::isa_builder::IsaBuilder;
 use wasmtime_environ::{CacheStore, CompilerBuilder, Setting};
 
-struct Builder {
+/// A builder object for a Cranelift-based `Compiler`.
+pub struct Builder {
     inner: IsaBuilder<CodegenResult<OwnedTargetIsa>>,
     linkopts: LinkOptions,
     cache_store: Option<Arc<dyn CacheStore>>,
     clif_dir: Option<path::PathBuf>,
+}
+
+impl From<IsaBuilder> for Builder {
+    fn from(inner: IsaBuilder) -> Self {
+        Self {
+            inner,
+            linkopts: LinkOptions::default(),
+            cache_store: None,
+            clif_dir: None,
+        }
+    }
+}
+
+impl Builder {
+    /// Set the link options for the compiler.
+    pub fn linkopts(&mut self, linkopts: LinkOptions) -> &mut Self {
+        self.linkopts = linkopts;
+    }
+
+    /// Set the cache store for the compiler.
+    pub fn cache_store(&mut self, cache_store: Arc<dyn CacheStore>) -> &mut Self {
+        self.cache_store = Some(cache_store);
+        self
+    }
+
+    /// Set the directory where the compiler will emit clif files.
+    pub fn clif_dir(&mut self, path: &path::Path) -> &mut Self {
+        self.clif_dir = Some(path.to_path_buf());
+        self
+    }
 }
 
 #[derive(Clone, Default)]

--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -22,8 +22,8 @@ pub struct Builder {
     clif_dir: Option<path::PathBuf>,
 }
 
-impl From<IsaBuilder> for Builder {
-    fn from(inner: IsaBuilder) -> Self {
+impl From<IsaBuilder<CodegenResult<OwnedTargetIsa>>> for Builder {
+    fn from(inner: IsaBuilder<CodegenResult<OwnedTargetIsa>>) -> Self {
         Self {
             inner,
             linkopts: LinkOptions::default(),
@@ -37,6 +37,7 @@ impl Builder {
     /// Set the link options for the compiler.
     pub fn linkopts(&mut self, linkopts: LinkOptions) -> &mut Self {
         self.linkopts = linkopts;
+        self
     }
 
     /// Set the cache store for the compiler.

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -10,7 +10,7 @@ use cranelift_wasm::{DefinedFuncIndex, WasmFuncType, WasmType};
 use target_lexicon::CallingConvention;
 use wasmtime_cranelift_shared::CompiledFunctionMetadata;
 
-pub use builder::builder;
+pub use builder::{builder, Builder, LinkOptions};
 
 mod builder;
 mod compiler;


### PR DESCRIPTION

Resolves #6681 


- [x] implement build methods for `Builder`
- [x] make `Builder` public
- [x] make `LinkOptions` public
