### PR TITLE
cranelift: Const Propagate `ireduce`

### DIFF
--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -70,6 +70,10 @@
                       (iconst _ k2)))
       (subsume (iconst ty (imm64_sshr ty k1 k2))))
 
+;; No need to check fits_in_64 since iconst is only implemented for <= 64 bits.
+(rule (simplify (ireduce narrow (iconst _ (u64_from_imm64 imm))))
+      (subsume (iconst narrow (imm64_masked narrow imm))))
+
 (rule (simplify (uextend (fits_in_64 wide) (iconst narrow imm)))
       (subsume (iconst wide (imm64 (u64_uextend_imm64 narrow imm)))))
 

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -230,3 +230,33 @@ block0:
 
 ; check: v3 = iconst.i8 0
 ; nextln: return v3
+
+function %ireduce_iconst() -> i8 {
+block0:
+    v1 = iconst.i16 -10
+    v2 = ireduce.i8 v1
+    return v2
+}
+
+; check: v3 = iconst.i8 246
+; nextln: return v3
+
+function %sextend_iconst() -> i32 {
+block0:
+    v1 = iconst.i16 -10
+    v2 = sextend.i32 v1
+    return v2
+}
+
+; check: v3 = iconst.i32 0xffff_fff6
+; nextln: return v3
+
+function %uextend_iconst() -> i32 {
+block0:
+    v1 = iconst.i16 0xfff6
+    v2 = uextend.i32 v1
+    return v2
+}
+
+; check: v3 = iconst.i32 0xfff6
+; nextln: return v3


### PR DESCRIPTION
👋 Hey,

I was playing around with cranelift over the weekend, and found that we currently don't have a cprop rule for `ireduce`, in my case this was preventing a bunch of the other optimizations from running.

I've also added some tests for the other extends which were missing.