### PR TITLE
riscv64: Implement scalar `bswap` instruction

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1717,6 +1717,40 @@
   (rv_or (value_regs_get x 0) (value_regs_get y 0)))
 
 
+
+(decl gen_bswap (Type XReg) XReg)
+
+;; This is only here to make the rule below work. bswap.i8 isn't valid
+(rule 0 (gen_bswap $I8 x) x)
+
+(rule 1 (gen_bswap (ty_int_ref_16_to_64 ty) x)
+  (if-let half_ty (ty_half_width ty))
+  (if-let half_size (u64_to_imm12 (ty_bits half_ty)))
+  (let (;; This swaps the top bytes and zeroes the bottom bytes, so that
+        ;; we can or it with the bottom bytes later.
+        (swap_top XReg (gen_bswap half_ty x))
+        (top XReg (rv_slli swap_top half_size))
+
+        ;; Get the top half, swap it, and zero extend it so we can `or` it
+        ;; with the bottom half.
+        (shifted XReg (rv_srli x half_size))
+        (swap_bot XReg (gen_bswap half_ty shifted))
+        (bot XReg (zext swap_bot half_ty $I64)))
+    (rv_or top bot)))
+
+;; With `zbb` we can use `rev8` and shift the result
+(rule 2 (gen_bswap (int_fits_in_32 ty) x)
+  (if-let $true (has_zbb))
+  (if-let shift_amt (u64_to_imm12 (u64_sub 64 (ty_bits ty))))
+  (rv_srli (rv_rev8 x) shift_amt))
+
+;; With `zbb` we can use `rev8` that does this
+(rule 3 (gen_bswap $I64 x)
+  (if-let $true (has_zbb))
+  (rv_rev8 x))
+
+
+
 (decl lower_bit_reverse (Reg Type) Reg)
 
 (rule

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -679,6 +679,15 @@
     (hi_rev XReg (lower_bit_reverse (value_regs_get val 1) $I64)))
     (value_regs hi_rev lo_rev)))
 
+;;;; Rules for `bswap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule 1 (lower (has_type (fits_in_64 (ty_int ty)) (bswap x)))
+  (gen_bswap ty x))
+
+(rule 2 (lower (has_type $I128 (bswap x)))
+  (value_regs
+    (gen_bswap $I64 (value_regs_get x 1))
+    (gen_bswap $I64 (value_regs_get x 0))))
+
 
 ;;;; Rules for `ctz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule (lower (has_type (fits_in_64 ty) (ctz x)))

--- a/cranelift/filetests/filetests/isa/riscv64/bswap-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bswap-zbb.clif
@@ -1,0 +1,76 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_zbb
+
+function %bswap_i16(i16) -> i16 {
+block0(v0: i16):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   rev8 t2,a0
+;   srli a0,t2,48
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x93, 0x53, 0x85, 0x6b
+;   srli a0, t2, 0x30
+;   ret
+
+function %bswap_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   rev8 t2,a0
+;   srli a0,t2,32
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x93, 0x53, 0x85, 0x6b
+;   srli a0, t2, 0x20
+;   ret
+
+function %bswap_i64(i64) -> i64 {
+block0(v0: i64):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   rev8 a0,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x13, 0x55, 0x85, 0x6b
+;   ret
+
+function %bswap_i128(i128) -> i128 {
+block0(v0: i128):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   mv a3,a0
+;   rev8 a0,a1
+;   rev8 a1,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ori a3, a0, 0
+;   .byte 0x13, 0xd5, 0x85, 0x6b
+;   .byte 0x93, 0xd5, 0x86, 0x6b
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bswap.clif
@@ -1,0 +1,307 @@
+test compile precise-output
+set unwind_info=false
+target riscv64
+
+function %bswap_i16(i16) -> i16 {
+block0(v0: i16):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   slli t2,a0,8
+;   srli a1,a0,8
+;   andi a3,a1,255
+;   or a0,t2,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 8
+;   srli a1, a0, 8
+;   andi a3, a1, 0xff
+;   or a0, t2, a3
+;   ret
+
+function %bswap_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   slli t2,a0,8
+;   srli a1,a0,8
+;   andi a3,a1,255
+;   or a5,t2,a3
+;   slli a7,a5,16
+;   srli t4,a0,16
+;   slli t1,t4,8
+;   srli a0,t4,8
+;   andi a2,a0,255
+;   or a4,t1,a2
+;   slli a6,a4,48
+;   srli t3,a6,48
+;   or a0,a7,t3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 8
+;   srli a1, a0, 8
+;   andi a3, a1, 0xff
+;   or a5, t2, a3
+;   slli a7, a5, 0x10
+;   srli t4, a0, 0x10
+;   slli t1, t4, 8
+;   srli a0, t4, 8
+;   andi a2, a0, 0xff
+;   or a4, t1, a2
+;   slli a6, a4, 0x30
+;   srli t3, a6, 0x30
+;   or a0, a7, t3
+;   ret
+
+function %bswap_i64(i64) -> i64 {
+block0(v0: i64):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+; block0:
+;   slli t2,a0,8
+;   srli a1,a0,8
+;   andi a3,a1,255
+;   or a5,t2,a3
+;   slli a7,a5,16
+;   srli t4,a0,16
+;   slli t1,t4,8
+;   srli a1,t4,8
+;   andi a2,a1,255
+;   or a4,t1,a2
+;   slli a6,a4,48
+;   srli t3,a6,48
+;   or t0,a7,t3
+;   slli t2,t0,32
+;   srli a1,a0,32
+;   slli a3,a1,8
+;   srli a5,a1,8
+;   andi a7,a5,255
+;   or t4,a3,a7
+;   slli t1,t4,16
+;   srli a0,a1,16
+;   slli a2,a0,8
+;   srli a4,a0,8
+;   andi a6,a4,255
+;   or t3,a2,a6
+;   slli t0,t3,48
+;   srli a0,t0,48
+;   or a1,t1,a0
+;   slli a3,a1,32
+;   srli a5,a3,32
+;   or a0,t2,a5
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   slli t2, a0, 8
+;   srli a1, a0, 8
+;   andi a3, a1, 0xff
+;   or a5, t2, a3
+;   slli a7, a5, 0x10
+;   srli t4, a0, 0x10
+;   slli t1, t4, 8
+;   srli a1, t4, 8
+;   andi a2, a1, 0xff
+;   or a4, t1, a2
+;   slli a6, a4, 0x30
+;   srli t3, a6, 0x30
+;   or t0, a7, t3
+;   slli t2, t0, 0x20
+;   srli a1, a0, 0x20
+;   slli a3, a1, 8
+;   srli a5, a1, 8
+;   andi a7, a5, 0xff
+;   or t4, a3, a7
+;   slli t1, t4, 0x10
+;   srli a0, a1, 0x10
+;   slli a2, a0, 8
+;   srli a4, a0, 8
+;   andi a6, a4, 0xff
+;   or t3, a2, a6
+;   slli t0, t3, 0x30
+;   srli a0, t0, 0x30
+;   or a1, t1, a0
+;   slli a3, a1, 0x20
+;   srli a5, a3, 0x20
+;   or a0, t2, a5
+;   ret
+
+function %bswap_i128(i128) -> i128 {
+block0(v0: i128):
+    v1 = bswap v0
+    return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s11,-8(sp)
+;   add sp,-16
+; block0:
+;   slli a2,a1,8
+;   srli a3,a1,8
+;   andi a4,a3,255
+;   or a6,a2,a4
+;   slli t3,a6,16
+;   srli t0,a1,16
+;   slli t2,t0,8
+;   srli a2,t0,8
+;   andi a3,a2,255
+;   or a5,t2,a3
+;   slli a7,a5,48
+;   srli t4,a7,48
+;   or t1,t3,t4
+;   slli a2,t1,32
+;   srli a3,a1,32
+;   slli a4,a3,8
+;   srli a6,a3,8
+;   andi t3,a6,255
+;   or t0,a4,t3
+;   slli t2,t0,16
+;   srli a1,a3,16
+;   slli a3,a1,8
+;   srli a5,a1,8
+;   andi a7,a5,255
+;   or t4,a3,a7
+;   slli t1,t4,48
+;   srli a1,t1,48
+;   or a3,t2,a1
+;   slli a4,a3,32
+;   srli a6,a4,32
+;   or t3,a2,a6
+;   mv s11,t3
+;   slli t0,a0,8
+;   srli t2,a0,8
+;   andi a1,t2,255
+;   or a3,t0,a1
+;   slli a5,a3,16
+;   srli a7,a0,16
+;   slli t4,a7,8
+;   srli t1,a7,8
+;   andi a1,t1,255
+;   or a2,t4,a1
+;   slli a4,a2,48
+;   srli a6,a4,48
+;   or t3,a5,a6
+;   slli t0,t3,32
+;   srli t2,a0,32
+;   slli a1,t2,8
+;   srli a3,t2,8
+;   andi a5,a3,255
+;   or a7,a1,a5
+;   slli t4,a7,16
+;   srli t1,t2,16
+;   slli a0,t1,8
+;   srli a2,t1,8
+;   andi a4,a2,255
+;   or a6,a0,a4
+;   slli t3,a6,48
+;   srli t1,t3,48
+;   or t2,t4,t1
+;   slli a1,t2,32
+;   srli a3,a1,32
+;   or a1,t0,a3
+;   mv a0,s11
+;   add sp,+16
+;   ld s11,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+;   sd s11, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   slli a2, a1, 8
+;   srli a3, a1, 8
+;   andi a4, a3, 0xff
+;   or a6, a2, a4
+;   slli t3, a6, 0x10
+;   srli t0, a1, 0x10
+;   slli t2, t0, 8
+;   srli a2, t0, 8
+;   andi a3, a2, 0xff
+;   or a5, t2, a3
+;   slli a7, a5, 0x30
+;   srli t4, a7, 0x30
+;   or t1, t3, t4
+;   slli a2, t1, 0x20
+;   srli a3, a1, 0x20
+;   slli a4, a3, 8
+;   srli a6, a3, 8
+;   andi t3, a6, 0xff
+;   or t0, a4, t3
+;   slli t2, t0, 0x10
+;   srli a1, a3, 0x10
+;   slli a3, a1, 8
+;   srli a5, a1, 8
+;   andi a7, a5, 0xff
+;   or t4, a3, a7
+;   slli t1, t4, 0x30
+;   srli a1, t1, 0x30
+;   or a3, t2, a1
+;   slli a4, a3, 0x20
+;   srli a6, a4, 0x20
+;   or t3, a2, a6
+;   ori s11, t3, 0
+;   slli t0, a0, 8
+;   srli t2, a0, 8
+;   andi a1, t2, 0xff
+;   or a3, t0, a1
+;   slli a5, a3, 0x10
+;   srli a7, a0, 0x10
+;   slli t4, a7, 8
+;   srli t1, a7, 8
+;   andi a1, t1, 0xff
+;   or a2, t4, a1
+;   slli a4, a2, 0x30
+;   srli a6, a4, 0x30
+;   or t3, a5, a6
+;   slli t0, t3, 0x20
+;   srli t2, a0, 0x20
+;   slli a1, t2, 8
+;   srli a3, t2, 8
+;   andi a5, a3, 0xff
+;   or a7, a1, a5
+;   slli t4, a7, 0x10
+;   srli t1, t2, 0x10
+;   slli a0, t1, 8
+;   srli a2, t1, 8
+;   andi a4, a2, 0xff
+;   or a6, a0, a4
+;   slli t3, a6, 0x30
+;   srli t1, t3, 0x30
+;   or t2, t4, t1
+;   slli a1, t2, 0x20
+;   srli a3, a1, 0x20
+;   or a1, t0, a3
+;   ori a0, s11, 0
+;   addi sp, sp, 0x10
+;   ld s11, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/bswap.clif
+++ b/cranelift/filetests/filetests/runtests/bswap.clif
@@ -3,6 +3,8 @@ test run
 target x86_64
 target aarch64
 target s390x
+target riscv64
+target riscv64 has_zbb
 
 function %bswap_i16(i16) -> i16 {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/runtests/i128-bswap.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bswap.clif
@@ -4,6 +4,8 @@ set enable_llvm_abi_extensions
 target x86_64
 target aarch64
 target s390x
+target riscv64
+target riscv64 has_zbb
 
 function %bswap_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -714,8 +714,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Iabs, &[I128]),
                 // TODO
                 (Opcode::Bitselect, &[I128, I128, I128]),
-                // TODO
-                (Opcode::Bswap),
                 // https://github.com/bytecodealliance/wasmtime/issues/5528
                 (
                     Opcode::FcvtToUint | Opcode::FcvtToSint,


### PR DESCRIPTION
👋 Hey,

This PR Implements the `bswap` instruction on the RISC-V backend.

CC: #1092