### PR TITLE
Run `cargo vet` on automated version bumps

### DIFF
--- a/.github/actions/install-cargo-vet/action.yml
+++ b/.github/actions/install-cargo-vet/action.yml
@@ -15,4 +15,6 @@ runs:
         path: ${{ runner.tool_cache }}/cargo-vet
         key: cargo-vet-bin-${{ inputs.version }}
     - run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+      shell: bash
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ inputs.version }} cargo-vet
+      shell: bash

--- a/.github/actions/install-cargo-vet/action.yml
+++ b/.github/actions/install-cargo-vet/action.yml
@@ -1,0 +1,18 @@
+name: 'Install the `cargo-vet` tool'
+description: 'Runs `cargo install cargo-vet`'
+
+inputs:
+  version:
+    description: 'Version to install'
+    required: false
+    default: '0.8.0'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v3
+      with:
+        path: ${{ runner.tool_cache }}/cargo-vet
+        key: cargo-vet-bin-${{ inputs.version }}
+    - run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
+    - run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ inputs.version }} cargo-vet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,19 +86,12 @@ jobs:
     needs: determine
     if: needs.determine.outputs.audit
     runs-on: ubuntu-latest
-    env:
-      CARGO_VET_VERSION: 0.8.0
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - uses: actions/cache@v3
-      with:
-        path: ${{ runner.tool_cache }}/cargo-vet
-        key: cargo-vet-bin-${{ env.CARGO_VET_VERSION }}
-    - run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
-    - run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
+    - uses: ./.github/actions/install-cargo-vet
     - run: cargo vet --locked
 
     # common logic to cancel the entire run if this job fails

--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -48,6 +48,9 @@ jobs:
           git config user.email 'wasmtime-publish@users.noreply.github.com'
           git remote set-url origin https://git:${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
+      - uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-cargo-vet
+
       - name: Bump major version number
         run: |
           set -ex
@@ -65,6 +68,9 @@ jobs:
           sed "s/VERSION/$num/" ci/RELEASES-template.md > RELEASES.md
           cat backup-releases >> RELEASES.md
           rm backup-releases
+
+          # Update `cargo vet` entries for all the new crate versions
+          cargo vet
 
           # Commit all of the above changes.
           git commit -am "Bump Wasmtime to $num"


### PR DESCRIPTION
As shown in the original CI of #6686 the recent changes for `cargo vet` 0.8.0 mean that the previous release process no longer works since it requires changes to the lock file for `cargo vet`. This updates the version bumping process to run `cargo vet` as part of the committed changes which hopefully will get everything to succeed. To ensure that the same version of `cargo vet` is used in both locations the installation procedure was extracted into its own separate little action.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
