### PR TITLE
Fix a typo in an `unsafe impl Send/Sync`

### DIFF
--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -692,8 +692,8 @@ mod pre_patched_func_ref {
     }
 
     // Safety: This is upheld by `PrePatchedFuncRef::new` callers.
-    unsafe impl<T> Send for InstancePre<T> {}
-    unsafe impl<T> Sync for InstancePre<T> {}
+    unsafe impl Send for PrePatchedFuncRef {}
+    unsafe impl Sync for PrePatchedFuncRef {}
 }
 
 /// InstancePre's clone does not require T: Clone

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -666,34 +666,9 @@ pub struct InstancePre<T> {
     /// instantiation time.
     ///
     /// This is an `Arc<[T]>` for the same reason as `items`.
-    func_refs: Arc<[PrePatchedFuncRef]>,
+    func_refs: Arc<[VMFuncRef]>,
 
     _marker: std::marker::PhantomData<fn() -> T>,
-}
-
-pub(crate) use pre_patched_func_ref::PrePatchedFuncRef;
-mod pre_patched_func_ref {
-    use super::*;
-
-    pub struct PrePatchedFuncRef(VMFuncRef);
-
-    impl PrePatchedFuncRef {
-        /// Safety: callers must arrange for the given `func_ref` to be usable
-        /// in a `Send + Sync` manner (i.e. its associated `Module` is kept
-        /// alive or `Func` is alive and supports these things) and that the
-        /// `wasm_call` field is already patched in, if necessary.
-        pub unsafe fn new(func_ref: VMFuncRef) -> PrePatchedFuncRef {
-            PrePatchedFuncRef(func_ref)
-        }
-
-        pub fn func_ref(&self) -> &VMFuncRef {
-            &self.0
-        }
-    }
-
-    // Safety: This is upheld by `PrePatchedFuncRef::new` callers.
-    unsafe impl Send for PrePatchedFuncRef {}
-    unsafe impl Sync for PrePatchedFuncRef {}
 }
 
 /// InstancePre's clone does not require T: Clone
@@ -732,12 +707,12 @@ impl<T> InstancePre<T> {
                         // `f` needs its `VMFuncRef::wasm_call`
                         // patched with a Wasm-to-native trampoline.
                         debug_assert!(matches!(f.host_ctx(), crate::HostContext::Native(_)));
-                        func_refs.push(PrePatchedFuncRef::new(VMFuncRef {
+                        func_refs.push(VMFuncRef {
                             wasm_call: module
                                 .runtime_info()
                                 .wasm_to_native_trampoline(f.sig_index()),
                             ..*f.func_ref()
-                        }));
+                        });
                     }
                 }
             }
@@ -835,7 +810,7 @@ fn pre_instantiate_raw(
     module: &Module,
     items: &Arc<[Definition]>,
     host_funcs: usize,
-    func_refs: &Arc<[PrePatchedFuncRef]>,
+    func_refs: &Arc<[VMFuncRef]>,
 ) -> Result<OwnedImports> {
     if host_funcs > 0 {
         // Any linker-defined function of the `Definition::HostFunc` variant
@@ -852,7 +827,7 @@ fn pre_instantiate_raw(
         store.push_instance_pre_func_refs(func_refs.clone());
     }
 
-    let mut func_refs = func_refs.iter().map(|f| NonNull::from(f.func_ref()));
+    let mut func_refs = func_refs.iter().map(|f| NonNull::from(f));
     let mut imports = OwnedImports::new(module);
     for import in items.iter() {
         if !import.comes_from_same_store(store) {

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -76,7 +76,6 @@
 //! contents of `StoreOpaque`. This is an invariant that we, as the authors of
 //! `wasmtime`, must uphold for the public interface to be safe.
 
-use crate::instance::PrePatchedFuncRef;
 use crate::linker::Definition;
 use crate::module::BareModuleInfo;
 use crate::trampoline::VMHostGlobalContext;
@@ -97,7 +96,7 @@ use std::task::{Context, Poll};
 use wasmtime_runtime::{
     InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleInfo,
     OnDemandInstanceAllocator, SignalHandler, StoreBox, StorePtr, VMContext, VMExternRef,
-    VMExternRefActivationsTable, VMRuntimeLimits, WasmFault,
+    VMExternRefActivationsTable, VMFuncRef, VMRuntimeLimits, WasmFault,
 };
 
 mod context;
@@ -1215,7 +1214,7 @@ impl StoreOpaque {
         self.func_refs.fill(&mut self.modules);
     }
 
-    pub(crate) fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[PrePatchedFuncRef]>) {
+    pub(crate) fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[VMFuncRef]>) {
         self.func_refs.push_instance_pre_func_refs(func_refs);
     }
 

--- a/crates/wasmtime/src/store/func_refs.rs
+++ b/crates/wasmtime/src/store/func_refs.rs
@@ -1,4 +1,4 @@
-use crate::{instance::PrePatchedFuncRef, module::ModuleRegistry};
+use crate::module::ModuleRegistry;
 use std::{ptr::NonNull, sync::Arc};
 use wasmtime_runtime::{SendSyncPtr, VMFuncRef, VMNativeCallHostFuncContext};
 
@@ -20,7 +20,7 @@ pub struct FuncRefs {
     /// Pinned `VMFuncRef`s that had their `wasm_call` field
     /// pre-patched when constructing an `InstancePre`, and which we need to
     /// keep alive for our owning store's lifetime.
-    instance_pre_func_refs: Vec<Arc<[PrePatchedFuncRef]>>,
+    instance_pre_func_refs: Vec<Arc<[VMFuncRef]>>,
 }
 
 use send_sync_bump::SendSyncBump;
@@ -79,7 +79,7 @@ impl FuncRefs {
     }
 
     /// Push pre-patched `VMFuncRef`s from an `InstancePre`.
-    pub fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[PrePatchedFuncRef]>) {
+    pub fn push_instance_pre_func_refs(&mut self, func_refs: Arc<[VMFuncRef]>) {
         self.instance_pre_func_refs.push(func_refs);
     }
 }


### PR DESCRIPTION
This commit fixes a mistake in the `PrePatchedFuncRef` type where it has an `unsafe impl` to make it send/sync but the target of the impl was mistakenly `InstancePre<T>`

Note that this doesn't actually have any impact on the send/sync-ness of `InstancePre<T>` since it's not storing an instance of `T`, so it's always `Send`/`Sync` anyway. Nevertheless this reduces the scope of unsafety slightly as was originally intended.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
