### PR TITLE
Store all instantiation arguments in a component

### DIFF
--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -303,7 +303,6 @@ impl ComponentDfg {
         let mut linearize = LinearizeDfg {
             dfg: &self,
             initializers: Vec::new(),
-            num_runtime_modules: 0,
             runtime_memories: Default::default(),
             runtime_post_return: Default::default(),
             runtime_reallocs: Default::default(),
@@ -336,7 +335,6 @@ impl ComponentDfg {
             exports,
             initializers: linearize.initializers,
 
-            num_runtime_modules: linearize.num_runtime_modules,
             num_runtime_memories: linearize.runtime_memories.len() as u32,
             num_runtime_post_returns: linearize.runtime_post_return.len() as u32,
             num_runtime_reallocs: linearize.runtime_reallocs.len() as u32,
@@ -355,7 +353,6 @@ impl ComponentDfg {
 struct LinearizeDfg<'a> {
     dfg: &'a ComponentDfg,
     initializers: Vec<GlobalInitializer>,
-    num_runtime_modules: u32,
     runtime_memories: HashMap<MemoryId, RuntimeMemoryIndex>,
     runtime_reallocs: HashMap<ReallocId, RuntimeReallocIndex>,
     runtime_post_return: HashMap<PostReturnId, RuntimePostReturnIndex>,
@@ -412,20 +409,8 @@ impl LinearizeDfg<'_> {
                     options,
                 }
             }
-            Export::ModuleStatic(i) => {
-                let index = RuntimeModuleIndex::from_u32(self.num_runtime_modules);
-                self.num_runtime_modules += 1;
-                self.initializers
-                    .push(GlobalInitializer::SaveStaticModule(*i));
-                info::Export::Module(index)
-            }
-            Export::ModuleImport(i) => {
-                let index = RuntimeModuleIndex::from_u32(self.num_runtime_modules);
-                self.num_runtime_modules += 1;
-                self.initializers
-                    .push(GlobalInitializer::SaveModuleImport(*i));
-                info::Export::Module(index)
-            }
+            Export::ModuleStatic(i) => info::Export::ModuleStatic(*i),
+            Export::ModuleImport(i) => info::Export::ModuleImport(*i),
             Export::Instance(map) => info::Export::Instance(
                 map.iter()
                     .map(|(name, export)| (name.clone(), self.export(export)))

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -140,10 +140,6 @@ pub struct Component {
     /// instantiate this component.
     pub num_lowerings: u32,
 
-    /// The number of modules that are required to be saved within an instance
-    /// at runtime, or effectively the number of exported modules.
-    pub num_runtime_modules: u32,
-
     /// The number of functions which "always trap" used to implement
     /// `canon.lower` of `canon.lift`'d functions within the same component.
     pub num_always_trap: u32,
@@ -220,13 +216,6 @@ pub enum GlobalInitializer {
     /// Same as `ExtractMemory`, except it's extracting a function pointer to be
     /// used as a `post-return` function.
     ExtractPostReturn(ExtractPostReturn),
-
-    /// The `module` specified is saved into the runtime state at the next
-    /// `RuntimeModuleIndex`, referred to later by `Export` definitions.
-    SaveStaticModule(StaticModuleIndex),
-
-    /// Same as `SaveModuleUpvar`, but for imports.
-    SaveModuleImport(RuntimeImportIndex),
 
     /// Similar to `ExtractMemory` and friends and indicates that a `VMFuncRef`
     /// needs to be initialized for a transcoder function and this will later be
@@ -434,10 +423,9 @@ pub enum Export {
         options: CanonicalOptions,
     },
     /// A module defined within this component is exported.
-    ///
-    /// The module index here indexes a module recorded with
-    /// `GlobalInitializer::SaveModule` above.
-    Module(RuntimeModuleIndex),
+    ModuleStatic(StaticModuleIndex),
+    /// A module imported into this component is exported.
+    ModuleImport(RuntimeImportIndex),
     /// A nested instance is being exported which has recursively defined
     /// `Export` items.
     Instance(IndexMap<String, Export>),

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -173,10 +173,6 @@ indices! {
     /// Same as `RuntimeMemoryIndex` except for the `post-return` function.
     pub struct RuntimePostReturnIndex(u32);
 
-    /// Index that represents an exported module from a component since that's
-    /// currently the only use for saving the entire module state at runtime.
-    pub struct RuntimeModuleIndex(u32);
-
     /// Index into the list of transcoders identified during compilation.
     ///
     /// This is used to index the `VMFuncRef` slots reserved for string encoders

--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -258,9 +258,7 @@ impl<'a> CompileInputs<'a> {
                 wasmtime_environ::component::GlobalInitializer::InstantiateModule(_)
                 | wasmtime_environ::component::GlobalInitializer::ExtractMemory(_)
                 | wasmtime_environ::component::GlobalInitializer::ExtractRealloc(_)
-                | wasmtime_environ::component::GlobalInitializer::ExtractPostReturn(_)
-                | wasmtime_environ::component::GlobalInitializer::SaveStaticModule(_)
-                | wasmtime_environ::component::GlobalInitializer::SaveModuleImport(_) => {
+                | wasmtime_environ::component::GlobalInitializer::ExtractPostReturn(_) => {
                     // Nothing to compile for these.
                 }
             }

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -47,9 +47,17 @@ pub(crate) struct InstanceData {
 
     /// Arguments that this instance used to be instantiated.
     ///
-    /// Strong references are stored to these argumentssince pointers are saved
+    /// Strong references are stored to these arguments since pointers are saved
     /// into the structures such as functions within the
     /// `OwnedComponentInstance` but it's our job to keep them alive.
+    ///
+    /// One purpose of this storage is to enable embedders to drop a `Linker`,
+    /// for example, after a component is instantiated. In that situation if the
+    /// arguments weren't held here then they might be dropped, and structures
+    /// such as `.lowering()` which point back into the original function would
+    /// become stale and use-after-free conditions when used. By preserving the
+    /// entire list here though we're guaranteed that nothing is lost for the
+    /// duration of the lifetime of this instance.
     imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
 }
 

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use wasmtime_environ::component::{
     AlwaysTrap, ComponentTypes, CoreDef, CoreExport, Export, ExportItem, ExtractMemory,
     ExtractPostReturn, ExtractRealloc, GlobalInitializer, InstantiateModule, LowerImport,
-    RuntimeImportIndex, RuntimeInstanceIndex, RuntimeModuleIndex, Transcoder,
+    RuntimeImportIndex, RuntimeInstanceIndex, Transcoder,
 };
 use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmType};
 use wasmtime_runtime::component::{ComponentInstance, OwnedComponentInstance};
@@ -30,20 +30,27 @@ pub struct Instance(pub(crate) Stored<Option<Box<InstanceData>>>);
 
 pub(crate) struct InstanceData {
     instances: PrimaryMap<RuntimeInstanceIndex, crate::Instance>,
-    // FIXME: shouldn't store the entire component here which keeps upvars
-    // alive and things like that, instead only the bare minimum necessary
-    // should be kept alive here (mostly just `wasmtime_environ::Component`).
+
+    // NB: in the future if necessary it would be possible to avoid storing an
+    // entire `Component` here and instead storing only information such as:
+    //
+    // * Some reference to `Arc<ComponentTypes>`
+    // * Necessary references to closed-over modules which are exported from the
+    //   component itself.
+    //
+    // Otherwise the full guts of this component should only ever be used during
+    // the instantiation of this instance, meaning that after instantiation much
+    // of the component can be thrown away (theoretically).
     component: Component,
-    exported_modules: PrimaryMap<RuntimeModuleIndex, Module>,
 
     state: OwnedComponentInstance,
 
-    /// Functions that this instance used during instantiation.
+    /// Arguments that this instance used to be instantiated.
     ///
-    /// Strong references are stored to these functions since pointers are saved
-    /// into the functions within the `OwnedComponentInstance` but it's our job
-    /// to keep them alive.
-    funcs: Vec<Arc<HostFunc>>,
+    /// Strong references are stored to these argumentssince pointers are saved
+    /// into the structures such as functions within the
+    /// `OwnedComponentInstance` but it's our job to keep them alive.
+    imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
 }
 
 impl Instance {
@@ -205,7 +212,7 @@ impl<'a> Instantiator<'a> {
     fn new(
         component: &'a Component,
         store: &mut StoreOpaque,
-        imports: &'a PrimaryMap<RuntimeImportIndex, RuntimeImport>,
+        imports: &'a Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
     ) -> Instantiator<'a> {
         let env_component = component.env_component();
         store.modules_mut().register_component(component);
@@ -216,11 +223,8 @@ impl<'a> Instantiator<'a> {
             data: InstanceData {
                 instances: PrimaryMap::with_capacity(env_component.num_runtime_instances as usize),
                 component: component.clone(),
-                exported_modules: PrimaryMap::with_capacity(
-                    env_component.num_runtime_modules as usize,
-                ),
                 state: OwnedComponentInstance::new(component.runtime_info(), store.traitobj()),
-                funcs: Vec::new(),
+                imports: imports.clone(),
             },
         }
     }
@@ -288,19 +292,6 @@ impl<'a> Instantiator<'a> {
                     self.extract_post_return(store.0, post_return)
                 }
 
-                GlobalInitializer::SaveStaticModule(idx) => {
-                    self.data
-                        .exported_modules
-                        .push(self.component.static_module(*idx).clone());
-                }
-
-                GlobalInitializer::SaveModuleImport(idx) => {
-                    self.data.exported_modules.push(match &self.imports[*idx] {
-                        RuntimeImport::Module(m) => m.clone(),
-                        _ => unreachable!(),
-                    });
-                }
-
                 GlobalInitializer::Transcoder(e) => self.transcoder(e),
             }
         }
@@ -330,15 +321,6 @@ impl<'a> Instantiator<'a> {
             array_call,
             type_index,
         );
-
-        // The `func` provided here must be retained within the `Store` itself
-        // after instantiation. Otherwise it might be possible to drop the
-        // `Arc<HostFunc>` and possibly result in a use-after-free. This comes
-        // about because the `.lowering()` method returns a structure that
-        // points to an interior pointer within the `func`. By saving the list
-        // of host functions used we can ensure that the function lives long
-        // enough for the whole duration of this instance.
-        self.data.funcs.push(func.clone());
     }
 
     fn always_trap(&mut self, trap: &AlwaysTrap) {
@@ -440,7 +422,7 @@ impl<'a> Instantiator<'a> {
     }
 
     fn assert_type_matches(
-        &mut self,
+        &self,
         store: &mut StoreOpaque,
         module: &Module,
         arg: &CoreDef,
@@ -485,7 +467,7 @@ impl<'a> Instantiator<'a> {
 /// method.
 pub struct InstancePre<T> {
     component: Component,
-    imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,
+    imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
     _marker: marker::PhantomData<fn() -> T>,
 }
 
@@ -513,7 +495,7 @@ impl<T> InstancePre<T> {
     ) -> InstancePre<T> {
         InstancePre {
             component,
-            imports,
+            imports: Arc::new(imports),
             _marker: marker::PhantomData,
         }
     }
@@ -649,7 +631,10 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
                 func,
                 options,
             )),
-            Export::Module(_) | Export::Instance(_) | Export::Type(_) => None,
+            Export::ModuleStatic(_)
+            | Export::ModuleImport(_)
+            | Export::Instance(_)
+            | Export::Type(_) => None,
         }
     }
 
@@ -670,7 +655,11 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
     /// Same as [`Instance::get_module`]
     pub fn module(&mut self, name: &str) -> Option<&'a Module> {
         match self.exports.get(name)? {
-            Export::Module(idx) => Some(&self.data.exported_modules[*idx]),
+            Export::ModuleStatic(idx) => Some(&self.data.component.static_module(*idx)),
+            Export::ModuleImport(idx) => Some(match &self.data.imports[*idx] {
+                RuntimeImport::Module(m) => m,
+                _ => unreachable!(),
+            }),
             _ => None,
         }
     }
@@ -688,12 +677,17 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
     // For now this is just quick-and-dirty to get wast support for iterating
     // over exported modules to work.
     pub fn modules(&self) -> impl Iterator<Item = (&'a str, &'a Module)> + '_ {
-        self.exports
-            .iter()
-            .filter_map(|(name, export)| match *export {
-                Export::Module(idx) => Some((name.as_str(), &self.data.exported_modules[idx])),
-                _ => None,
-            })
+        self.exports.iter().filter_map(|(name, export)| {
+            let module = match *export {
+                Export::ModuleStatic(idx) => self.data.component.static_module(idx),
+                Export::ModuleImport(idx) => match &self.data.imports[idx] {
+                    RuntimeImport::Module(m) => m,
+                    _ => unreachable!(),
+                },
+                _ => return None,
+            };
+            Some((name.as_str(), module))
+        })
     }
 
     fn as_mut(&mut self) -> ExportInstance<'a, '_> {


### PR DESCRIPTION
This commit updates how instantiation arguments are rooted within a component instance. Previously a list of import arguments was "unzipped" into a list of modules and a list of functions. This is becoming a bit more cumbersome in an upcoming change for resources where a third style of import is being added, so instead of this unzipping operation this commit instead replaces the list of imports with an `Arc`. This way instantiation is actually a bit cheaper since only one `Arc` needs to be retained instead of each individual argument imported into a module.

Additionally this refactors the way that exported modules are handled by avoiding translating everything into one list and instead continuing to store modules in two separate lists: those in the component and those imported.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
