### PR TITLE
Fix signatures registered with modules-in-components

### DIFF
--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -27,9 +27,8 @@ use anyhow::Result;
 use std::collections::{btree_map, BTreeMap, BTreeSet};
 use std::{any::Any, collections::HashMap};
 use wasmtime_environ::{
-    Compiler, DefinedFuncIndex, FuncIndex, FunctionBodyData, FunctionLoc, ModuleTranslation,
-    ModuleType, ModuleTypes, PrimaryMap, SignatureIndex, StaticModuleIndex, Tunables,
-    WasmFunctionInfo,
+    Compiler, DefinedFuncIndex, FuncIndex, FunctionBodyData, ModuleTranslation, ModuleType,
+    ModuleTypes, PrimaryMap, SignatureIndex, StaticModuleIndex, Tunables, WasmFunctionInfo,
 };
 use wasmtime_jit::{CompiledFunctionInfo, CompiledModuleInfo};
 
@@ -691,17 +690,17 @@ pub struct Artifacts {
     #[cfg(feature = "component-model")]
     pub lowerings: PrimaryMap<
         wasmtime_environ::component::LoweredIndex,
-        wasmtime_environ::component::AllCallFunc<FunctionLoc>,
+        wasmtime_environ::component::AllCallFunc<wasmtime_environ::FunctionLoc>,
     >,
     #[cfg(feature = "component-model")]
     pub always_traps: PrimaryMap<
         wasmtime_environ::component::RuntimeAlwaysTrapIndex,
-        wasmtime_environ::component::AllCallFunc<FunctionLoc>,
+        wasmtime_environ::component::AllCallFunc<wasmtime_environ::FunctionLoc>,
     >,
     #[cfg(feature = "component-model")]
     pub transcoders: PrimaryMap<
         wasmtime_environ::component::RuntimeTranscoderIndex,
-        wasmtime_environ::component::AllCallFunc<FunctionLoc>,
+        wasmtime_environ::component::AllCallFunc<wasmtime_environ::FunctionLoc>,
     >,
 }
 

--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -24,7 +24,7 @@
 
 use crate::Engine;
 use anyhow::Result;
-use std::collections::{btree_map, BTreeMap};
+use std::collections::{btree_map, BTreeMap, BTreeSet};
 use std::{any::Any, collections::HashMap};
 use wasmtime_environ::{
     Compiler, DefinedFuncIndex, FuncIndex, FunctionBodyData, FunctionLoc, ModuleTranslation,
@@ -588,6 +588,13 @@ impl FunctionIndices {
             .remove(&CompileKey::NATIVE_TO_WASM_TRAMPOLINE_KIND)
             .unwrap_or_default();
 
+        // NB: unlike the above maps this is not emptied out during iteration
+        // since each module may reach into different portions of this map.
+        let wasm_to_native_trampolines = self
+            .indices
+            .remove(&CompileKey::WASM_TO_NATIVE_TRAMPOLINE_KIND)
+            .unwrap_or_default();
+
         artifacts.modules = translations
             .into_iter()
             .map(|(module, translation)| {
@@ -621,16 +628,20 @@ impl FunctionIndices {
                         })
                         .collect();
 
-                let wasm_to_native_trampolines: Vec<(SignatureIndex, FunctionLoc)> = self
-                    .indices
-                    .remove(&CompileKey::WASM_TO_NATIVE_TRAMPOLINE_KIND)
-                    .into_iter()
-                    .flat_map(|x| x)
-                    .map(|(key, i)| {
-                        (
-                            SignatureIndex::from_u32(key.index),
-                            symbol_ids_and_locs[i.unwrap_function()].1,
-                        )
+                let unique_and_sorted_sigs = translation
+                    .module
+                    .types
+                    .iter()
+                    .map(|(_, ty)| match ty {
+                        ModuleType::Function(ty) => *ty,
+                    })
+                    .collect::<BTreeSet<_>>();
+                let wasm_to_native_trampolines = unique_and_sorted_sigs
+                    .iter()
+                    .map(|idx| {
+                        let key = CompileKey::wasm_to_native_trampoline(*idx);
+                        let compiled = wasm_to_native_trampolines[&key];
+                        (*idx, symbol_ids_and_locs[compiled.unwrap_function()].1)
                     })
                     .collect();
 


### PR DESCRIPTION
This commit fixes a minor issue in
`FunctionIndices::link_and_append_code` which previously ended up only filling out the `wasm_to_native_trampolines` field for the first module rather than all the modules. Additionally the first module might have too many entries that encompass all modules instead of just its own entries. The fix in this commit is to refactor this logic to ensure that the necessary maps are present for all translations.

While technically a bug that can be surfaced through the embedder API it's pretty obscure. The given test here panics beforehand but succeeds afterwards, but this is moreso prep for some future resource-related work where this map will need persisting into the component metadata side of things.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
