### PR TITLE
Trust crates published by dtolnay, epage, cuviper, Amanieu

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2657,6 +2657,132 @@ criteria = "safe-to-deploy"
 version = "0.6.4"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[trusted.async-trait]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-07-23"
+end = "2024-07-06"
+
+[[trusted.clap]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2024-07-06"
+
+[[trusted.clap_derive]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2021-12-08"
+end = "2024-07-06"
+
+[[trusted.clap_lex]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-04-15"
+end = "2024-07-06"
+
+[[trusted.indexmap]]
+criteria = "safe-to-deploy"
+user-id = 539 # Josh Stone (cuviper)
+start = "2020-01-15"
+end = "2024-07-06"
+
+[[trusted.itoa]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2024-07-06"
+
+[[trusted.libc]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2021-01-27"
+end = "2024-07-06"
+
+[[trusted.libm]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2022-02-06"
+end = "2024-07-06"
+
+[[trusted.lock_api]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-05-04"
+end = "2024-07-06"
+
+[[trusted.parking_lot]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-05-04"
+end = "2024-07-06"
+
+[[trusted.parking_lot_core]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2019-05-04"
+end = "2024-07-06"
+
+[[trusted.paste]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-19"
+end = "2024-07-06"
+
+[[trusted.ryu]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-05-02"
+end = "2024-07-06"
+
+[[trusted.scopeguard]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2020-02-16"
+end = "2024-07-06"
+
+[[trusted.serde]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-07-06"
+
+[[trusted.serde_derive]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-07-06"
+
+[[trusted.serde_json]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-02-28"
+end = "2024-07-06"
+
+[[trusted.syn]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-03-01"
+end = "2024-07-06"
+
+[[trusted.thiserror]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2024-07-06"
+
+[[trusted.thiserror-impl]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-09"
+end = "2024-07-06"
+
+[[trusted.toml]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-05-16"
+end = "2024-07-06"
+
 [[trusted.windows-sys]]
 criteria = "safe-to-deploy"
 user-id = 64539 # Kenny Kerr (kennykerr)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -218,10 +218,6 @@ criteria = "safe-to-deploy"
 version = "0.7.18"
 criteria = "safe-to-deploy"
 
-[[exemptions.async-trait]]
-version = "0.1.53"
-criteria = "safe-to-deploy"
-
 [[exemptions.autocfg]]
 version = "0.1.8"
 criteria = "safe-to-deploy"
@@ -272,18 +268,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.cipher]]
 version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap]]
-version = "3.2.8"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_derive]]
-version = "3.2.7"
-criteria = "safe-to-deploy"
-
-[[exemptions.clap_lex]]
-version = "0.2.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.console]]
@@ -508,10 +492,6 @@ version = "1.0.0-rc.3"
 criteria = "safe-to-deploy"
 notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
 
-[[exemptions.indexmap]]
-version = "1.9.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.indicatif]]
 version = "0.13.0"
 criteria = "safe-to-deploy"
@@ -528,10 +508,6 @@ criteria = "safe-to-deploy"
 version = "0.10.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.itoa]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.jobserver]]
 version = "0.1.24"
 criteria = "safe-to-deploy"
@@ -545,24 +521,12 @@ notes = "dependency of ring for wasm32 browser platform, which our project does 
 version = "0.9.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.libc]]
-version = "0.2.133"
-criteria = "safe-to-deploy"
-
 [[exemptions.libloading]]
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.libm]]
-version = "0.2.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.listenfd]]
 version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.lock_api]]
-version = "0.4.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.mach]]
@@ -636,18 +600,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.p256]]
 version = "0.9.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.parking_lot]]
-version = "0.11.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.parking_lot_core]]
-version = "0.8.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.paste]]
-version = "1.0.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.pem-rfc7468]]
@@ -807,28 +759,8 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.ryu]]
-version = "1.0.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.same-file]]
 version = "1.0.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.scopeguard]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde]]
-version = "1.0.137"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_derive]]
-version = "1.0.137"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_json]]
-version = "1.0.80"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
@@ -891,10 +823,6 @@ criteria = "safe-to-deploy"
 version = "5.0.3"
 criteria = "safe-to-run"
 
-[[exemptions.syn]]
-version = "1.0.92"
-criteria = "safe-to-deploy"
-
 [[exemptions.target-lexicon]]
 version = "0.12.3"
 criteria = "safe-to-deploy"
@@ -915,14 +843,6 @@ criteria = "safe-to-deploy"
 version = "0.15.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.thiserror]]
-version = "1.0.31"
-criteria = "safe-to-deploy"
-
-[[exemptions.thiserror-impl]]
-version = "1.0.31"
-criteria = "safe-to-deploy"
-
 [[exemptions.thread_local]]
 version = "1.1.4"
 criteria = "safe-to-run"
@@ -938,10 +858,6 @@ notes = "we are exempting tokio, hyper, and their tightly coupled dependencies b
 
 [[exemptions.tokio-macros]]
 version = "1.7.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.toml]]
-version = "0.5.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.tracing]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -404,12 +404,40 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.async-trait]]
+version = "0.1.53"
+when = "2022-03-25"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.bumpalo]]
 version = "3.12.0"
 when = "2023-01-17"
 user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
+
+[[publisher.clap]]
+version = "3.2.8"
+when = "2022-06-30"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_derive]]
+version = "3.2.7"
+when = "2022-06-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_lex]]
+version = "0.2.4"
+when = "2022-06-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
 
 [[publisher.cranelift]]
 version = "0.97.1"
@@ -520,12 +548,138 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.indexmap]]
+version = "1.9.1"
+when = "2022-06-21"
+user-id = 539
+user-login = "cuviper"
+user-name = "Josh Stone"
+
+[[publisher.itoa]]
+version = "1.0.1"
+when = "2021-12-12"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.libc]]
+version = "0.2.132"
+when = "2022-08-16"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.libm]]
+version = "0.2.7"
+when = "2023-05-15"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.lock_api]]
+version = "0.4.7"
+when = "2022-03-30"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.parking_lot]]
+version = "0.11.2"
+when = "2021-08-27"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.parking_lot_core]]
+version = "0.8.5"
+when = "2021-08-28"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.paste]]
+version = "1.0.7"
+when = "2022-03-27"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.regalloc2]]
 version = "0.9.1"
 when = "2023-05-31"
 user-id = 187138
 user-login = "elliottt"
 user-name = "Trevor Elliott"
+
+[[publisher.ryu]]
+version = "1.0.9"
+when = "2021-12-12"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.scopeguard]]
+version = "1.1.0"
+when = "2020-02-16"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.serde]]
+version = "1.0.137"
+when = "2022-05-01"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_derive]]
+version = "1.0.137"
+when = "2022-05-01"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.serde_json]]
+version = "1.0.80"
+when = "2022-04-30"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.syn]]
+version = "1.0.92"
+when = "2022-04-29"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.syn]]
+version = "2.0.16"
+when = "2023-05-14"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror]]
+version = "1.0.31"
+when = "2022-04-30"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror-impl]]
+version = "1.0.31"
+when = "2022-04-30"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.toml]]
+version = "0.5.7"
+when = "2020-10-11"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.unicode-segmentation]]
 version = "1.10.1"
@@ -1073,6 +1227,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.9.0"
 
+[[audits.isrg.audits.libc]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-deploy"
+delta = "0.2.139 -> 0.2.141"
+
 [[audits.isrg.audits.once_cell]]
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
@@ -1307,6 +1466,18 @@ version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.libc]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.132 -> 0.2.138"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.libc]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.138 -> 0.2.139"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1505,6 +1676,12 @@ I am the primary author of the `synstructure` crate, and its current
 maintainer. The one use of `unsafe` is unnecessary, but documented and
 harmless. It will be removed in the next version.
 """
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.toml]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.7 -> 0.5.9"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.unicode-normalization]]


### PR DESCRIPTION
We discussed this in today's Wasmtime meeting and the consensus was that we trust each of these people to have a sufficient standard of care for anything they release.

This reduces our estimated audit backlog by about 184 kLOC.

For the most part, the trust records I'm adding here are identical to trust records that Mozilla is using. The fact that they've also decided these publishers are trustworthy is reassuring additional evidence for our decision. The exceptions and notable cases are as follows:

I've chosen to not trust three crates by these authors that Mozilla did not trust. I suspect Mozilla simply doesn't use these crates or has manually audited them, rather than there being any problem with the crates themselves. But I've chosen to be conservative about what we trust.

- autocfg: we only have an exception for an old version, and that version is only used transitively by wasi-crypto.
- env_logger: Mozilla has audited some versions; we should update, or add delta audits.
- thread_local: only used by tracing-subscriber which is only used in dev-dependencies.

I've trusted one crate that Mozilla did not: libm, when published by Amanieu. We're trusting libc when published by the same author, and libm is a small extension of the same trust.

Recent versions of the toml crate have been published by epage so I looked at in this process, but Mozilla only trusts the older versions which were published by alexcrichton. They've been delta-auditing the newer versions. I've chosen to follow their lead on this; Alex is a trusted contributor to Wasmtime anyway.

This PR is a step toward #6672, but I've run `cargo vet` myself rather than relying on anyone else's vetting.