### PR TITLE
winch(x64) Add support for local tee

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -354,6 +354,7 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | I64Popcnt { .. }
                         | LocalGet { .. }
                         | LocalSet { .. }
+                        | LocalTee { .. }
                         | Call { .. }
                         | Nop { .. }
                         | End { .. }

--- a/tests/misc_testsuite/winch/local_tee.wast
+++ b/tests/misc_testsuite/winch/local_tee.wast
@@ -1,0 +1,134 @@
+;; Test `local.tee` operator
+
+(module
+  ;; Typing
+
+  (func (export "type-local-i32") (result i32) (local i32) (local.tee 0 (i32.const 0)))
+  (func (export "type-local-i64") (result i64) (local i64) (local.tee 0 (i64.const 0)))
+
+  (func (export "type-param-i32") (param i32) (result i32) (local.tee 0 (i32.const 10)))
+  (func (export "type-param-i64") (param i64) (result i64) (local.tee 0 (i64.const 11)))
+
+  (func $dummy)
+
+  (func (export "as-block-first") (param i32) (result i32)
+    (block (result i32) (local.tee 0 (i32.const 1)) (call $dummy))
+  )
+  (func (export "as-block-mid") (param i32) (result i32)
+    (block (result i32) (call $dummy) (local.tee 0 (i32.const 1)) (call $dummy))
+  )
+  (func (export "as-block-last") (param i32) (result i32)
+    (block (result i32) (call $dummy) (call $dummy) (local.tee 0 (i32.const 1)))
+  )
+
+  (func (export "as-loop-first") (param i32) (result i32)
+    (loop (result i32) (local.tee 0 (i32.const 3)) (call $dummy))
+  )
+  (func (export "as-loop-mid") (param i32) (result i32)
+    (loop (result i32) (call $dummy) (local.tee 0 (i32.const 4)) (call $dummy))
+  )
+  (func (export "as-loop-last") (param i32) (result i32)
+    (loop (result i32) (call $dummy) (call $dummy) (local.tee 0 (i32.const 5)))
+  )
+
+  (func (export "as-br-value") (param i32) (result i32)
+    (block (result i32) (br 0 (local.tee 0 (i32.const 9))))
+  )
+
+  (func (export "as-br_if-cond") (param i32)
+    (block (br_if 0 (local.tee 0 (i32.const 1))))
+  )
+
+  (func (export "as-return-value") (param i32) (result i32)
+    (return (local.tee 0 (i32.const 7)))
+  )
+
+  (func (export "as-if-cond") (param i32) (result i32)
+    (if (result i32) (local.tee 0 (i32.const 2))
+      (then (i32.const 0)) (else (i32.const 1))
+    )
+  )
+  (func (export "as-if-then") (param i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then (local.tee 0 (i32.const 3))) (else (local.get 0))
+    )
+  )
+  (func (export "as-if-else") (param i32) (result i32)
+    (if (result i32) (local.get 0)
+      (then (local.get 0)) (else (local.tee 0 (i32.const 4)))
+    )
+  )
+
+  (func $f (param i32 i32 i32) (result i32) (i32.const -1))
+  (func (export "as-call-first") (param i32) (result i32)
+    (call $f (local.tee 0 (i32.const 12)) (i32.const 2) (i32.const 3))
+  )
+  (func (export "as-call-mid") (param i32) (result i32)
+    (call $f (i32.const 1) (local.tee 0 (i32.const 13)) (i32.const 3))
+  )
+  (func (export "as-call-last") (param i32) (result i32)
+    (call $f (i32.const 1) (i32.const 2) (local.tee 0 (i32.const 14)))
+  )
+
+  (func (export "as-local.set-value") (local i32)
+    (local.set 0 (local.tee 0 (i32.const 1)))
+  )
+  (func (export "as-local.tee-value") (param i32) (result i32)
+    (local.tee 0 (local.tee 0 (i32.const 1)))
+  )
+
+  (func (export "as-binary-left") (param i32) (result i32)
+    (i32.add (local.tee 0 (i32.const 3)) (i32.const 10))
+  )
+  (func (export "as-binary-right") (param i32) (result i32)
+    (i32.sub (i32.const 10) (local.tee 0 (i32.const 4)))
+  )
+
+  (func (export "as-test-operand") (param i32) (result i32)
+    (i32.eqz (local.tee 0 (i32.const 0)))
+  )
+
+  (func (export "as-compare-left") (param i32) (result i32)
+    (i32.le_s (local.tee 0 (i32.const 43)) (i32.const 10))
+  )
+  (func (export "as-compare-right") (param i32) (result i32)
+    (i32.ne (i32.const 10) (local.tee 0 (i32.const 42)))
+  )
+)
+
+(assert_return (invoke "type-local-i32") (i32.const 0))
+(assert_return (invoke "type-local-i64") (i64.const 0))
+
+(assert_return (invoke "type-param-i32" (i32.const 2)) (i32.const 10))
+(assert_return (invoke "type-param-i64" (i64.const 3)) (i64.const 11))
+
+(assert_return (invoke "as-block-first" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "as-block-mid" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "as-block-last" (i32.const 0)) (i32.const 1))
+
+(assert_return (invoke "as-loop-first" (i32.const 0)) (i32.const 3))
+(assert_return (invoke "as-loop-mid" (i32.const 0)) (i32.const 4))
+(assert_return (invoke "as-loop-last" (i32.const 0)) (i32.const 5))
+
+(assert_return (invoke "as-br-value" (i32.const 0)) (i32.const 9))
+
+(assert_return (invoke "as-br_if-cond" (i32.const 0)))
+
+(assert_return (invoke "as-return-value" (i32.const 0)) (i32.const 7))
+
+(assert_return (invoke "as-if-cond" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "as-if-then" (i32.const 1)) (i32.const 3))
+(assert_return (invoke "as-if-else" (i32.const 0)) (i32.const 4))
+
+(assert_return (invoke "as-call-first" (i32.const 0)) (i32.const -1))
+(assert_return (invoke "as-call-mid" (i32.const 0)) (i32.const -1))
+(assert_return (invoke "as-call-last" (i32.const 0)) (i32.const -1))
+
+(assert_return (invoke "as-local.set-value"))
+(assert_return (invoke "as-local.tee-value" (i32.const 0)) (i32.const 1))
+
+(assert_return (invoke "as-binary-left" (i32.const 0)) (i32.const 13))
+(assert_return (invoke "as-binary-right" (i32.const 0)) (i32.const 6))
+(assert_return (invoke "as-test-operand" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "as-compare-left" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "as-compare-right" (i32.const 0)) (i32.const 1))

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -320,6 +320,21 @@ impl<'a> CodeGenContext<'a> {
         }
     }
 
+    /// Pops the value at the stack top and assigns it to the local at the given
+    /// index, returning the register holding the source value.
+    pub fn set_local<M: MacroAssembler>(&mut self, masm: &mut M, index: u32) -> Reg {
+        let slot = self
+            .frame
+            .get_local(index)
+            .unwrap_or_else(|| panic!("valid local at slot = {}", index));
+        let size: OperandSize = slot.ty.into();
+        let src = self.pop_to_reg(masm, None, size);
+        let addr = masm.local_address(&slot);
+        masm.store(RegImm::reg(src), addr, size);
+
+        src
+    }
+
     /// Spill locals and registers to memory.
     // TODO optimize the spill range;
     //


### PR DESCRIPTION
This commit adds support for the `local.tee` instruction. This change also introduces a refactoring to the original implementation of `local.set` to be able to share most of the code for the implementation of `local.tee`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
