### PR TITLE
allow perfmaps on any unix platform

### DIFF
--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -20,7 +20,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "linux")] {
+    if #[cfg(unix)] {
         mod perfmap;
         pub use perfmap::new as new_perfmap;
     } else {


### PR DESCRIPTION
# why? 

perfmaps are fairly simple files that are written to `/tmp/` and that are read by `perf`. It does kind of make sense to have them only work for linux, but with more modern profilers also adopting some of the `perf` standards like [samply](https://github.com/mstange/samply), which can run both on linux and on macos, it may make sense to be able to produce these artefacts also on macos. 

I know that samply does already support jitdumps, but currently the jitdump implementation here cannot run outside of linux as it uses `gettid`. Samply also supports perf maps, on both linux and macos, and the perf map implementation here is fairly simple and can run on both platforms.

This would be very beneficial for developers using macos to their code.

# how? 

change the `cfg!` statement to compile for all unix platforms.  