### PR TITLE
Fix some warnings on nightly Rust

### DIFF
--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -90,7 +90,7 @@ impl TestFileCompiler {
     /// [TestFileCompiler::with_host_isa]).
     pub fn new(isa: OwnedTargetIsa) -> Self {
         let mut builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
-        drop(&mut builder); // require mutability on all architectures
+        let _ = &mut builder; // require mutability on all architectures
         #[cfg(target_arch = "x86_64")]
         {
             builder.symbol_lookup_fn(Box::new(|name| {

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -544,7 +544,7 @@ mod host {
                         $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
                     ];
                     let returns = vec![
-                        $( AbiParam::new(host_transcode!(@ty pointer_type $result)) ),*
+                        $( AbiParam::new(host_transcode!(@ty pointer_type $result)) )?
                     ];
                     let sig = func.import_signature(ir::Signature {
                         params,

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -544,7 +544,7 @@ mod host {
                         $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
                     ];
                     let returns = vec![
-                        $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
+                        $( AbiParam::new(host_transcode!(@ty pointer_type $result)) ),*
                     ];
                     let sig = func.import_signature(ir::Signature {
                         params,

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -525,7 +525,6 @@ impl Compiler {
 ///
 /// Note that a macro is used here to keep this in sync with the actual
 /// transcoder functions themselves which are also defined via a macro.
-#[allow(unused_mut)]
 mod host {
     use crate::compiler::Compiler;
     use cranelift_codegen::ir::{self, AbiParam};
@@ -541,11 +540,12 @@ mod host {
             $(
                 pub(super) fn $name(compiler: &Compiler, func: &mut ir::Function) -> (ir::SigRef, u32) {
                     let pointer_type = compiler.isa.pointer_type();
-                    let mut params = vec![
+                    let params = vec![
                         $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
                     ];
-                    let mut returns = Vec::new();
-                    $(host_transcode!(@push_return pointer_type params returns $result);)?
+                    let returns = vec![
+                        $( AbiParam::new(host_transcode!(@ty pointer_type $param)) ),*
+                    ];
                     let sig = func.import_signature(ir::Signature {
                         params,
                         returns,
@@ -560,12 +560,7 @@ mod host {
         (@ty $ptr:ident size) => ($ptr);
         (@ty $ptr:ident ptr_u8) => ($ptr);
         (@ty $ptr:ident ptr_u16) => ($ptr);
-
-        (@push_return $ptr:ident $params:ident $returns:ident size) => ($returns.push(AbiParam::new($ptr)););
-        (@push_return $ptr:ident $params:ident $returns:ident size_pair) => ({
-            $params.push(AbiParam::new($ptr));
-            $returns.push(AbiParam::new($ptr));
-        });
+        (@ty $ptr:ident ptr_size) => ($ptr);
     }
 
     wasmtime_environ::foreach_transcoder!(host_transcode);

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -60,11 +60,11 @@ macro_rules! foreach_transcoder {
             latin1_to_latin1(src: ptr_u8, len: size, dst: ptr_u8);
             latin1_to_utf16(src: ptr_u8, len: size, dst: ptr_u16);
             utf8_to_utf16(src: ptr_u8, len: size, dst: ptr_u16) -> size;
-            utf16_to_utf8(src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size) -> size_pair;
-            latin1_to_utf8(src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size) -> size_pair;
+            utf16_to_utf8(src: ptr_u16, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
+            latin1_to_utf8(src: ptr_u8, src_len: size, dst: ptr_u8, dst_len: size, ret2: ptr_size) -> size;
             utf16_to_compact_probably_utf16(src: ptr_u16, len: size, dst: ptr_u16) -> size;
-            utf8_to_latin1(src: ptr_u8, len: size, dst: ptr_u8) -> size_pair;
-            utf16_to_latin1(src: ptr_u16, len: size, dst: ptr_u8) -> size_pair;
+            utf8_to_latin1(src: ptr_u8, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
+            utf16_to_latin1(src: ptr_u16, len: size, dst: ptr_u8, ret2: ptr_size) -> size;
             utf8_to_compact_utf16(src: ptr_u8, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
             utf16_to_compact_utf16(src: ptr_u16, src_len: size, dst: ptr_u16, dst_len: size, bytes_so_far: size) -> size;
         }

--- a/crates/runtime/src/component/transcode.rs
+++ b/crates/runtime/src/component/transcode.rs
@@ -29,7 +29,6 @@ macro_rules! define_transcoders {
             $(
                 $name: unsafe extern "C" fn(
                     $(define_transcoders!(@ty $param),)*
-                    $(define_transcoders!(@retptr $result),)?
                 ) $( -> define_transcoders!(@ty $result))?,
             )*
         }
@@ -45,9 +44,7 @@ macro_rules! define_transcoders {
     (@ty size_pair) => (usize);
     (@ty ptr_u8) => (*mut u8);
     (@ty ptr_u16) => (*mut u16);
-
-    (@retptr size_pair) => (*mut usize);
-    (@retptr size) => (());
+    (@ty ptr_size) => (*mut usize);
 }
 
 wasmtime_environ::foreach_transcoder!(define_transcoders);
@@ -68,10 +65,6 @@ mod trampolines {
             $(
                 pub unsafe extern "C" fn $name(
                     $($pname : define_transcoders!(@ty $param),)*
-                    // If a result is given then a `size_pair` results gets its
-                    // second result value passed via a return pointer here, so
-                    // optionally indicate a return pointer.
-                    $(_retptr: define_transcoders!(@retptr $result))?
                 ) $( -> define_transcoders!(@ty $result))? {
                     $(transcoders!(@validate_param $pname $param);)*
 
@@ -82,10 +75,10 @@ mod trampolines {
                     // Additionally assume that every function below returns a
                     // `Result` where errors turn into traps.
                     let result = std::panic::catch_unwind(|| {
-                        super::$name($($pname),*)
+                        transcoders!(@invoke $name() $($pname)*)
                     });
                     match result {
-                        Ok(Ok(ret)) => transcoders!(@convert_ret ret _retptr $($result)?),
+                        Ok(Ok(ret)) => transcoders!(@convert_ret ret $($pname: $param)*),
                         Ok(Err(err)) => crate::traphandlers::raise_trap(
                             crate::traphandlers::TrapReason::User {
                                 error: err,
@@ -98,13 +91,17 @@ mod trampolines {
             )*
         );
 
-        (@convert_ret $ret:ident $retptr:ident) => ($ret);
-        (@convert_ret $ret:ident $retptr:ident size) => ($ret);
-        (@convert_ret $ret:ident $retptr:ident size_pair) => ({
+        // Helper macro to convert a 2-tuple automatically when the last
+        // parameter is a `ptr_size` argument.
+        (@convert_ret $ret:ident) => ($ret);
+        (@convert_ret $ret:ident $retptr:ident: ptr_size) => ({
             let (a, b) = $ret;
             *$retptr = b;
             a
         });
+        (@convert_ret $ret:ident $name:ident: $ty:ident $($rest:tt)*) => (
+            transcoders!(@convert_ret $ret $($rest)*)
+        );
 
         (@validate_param $arg:ident ptr_u16) => ({
             // This should already be guaranteed by the canonical ABI and our
@@ -113,6 +110,20 @@ mod trampolines {
             assert!(($arg as usize) % 2 == 0, "unaligned 16-bit pointer");
         });
         (@validate_param $arg:ident $ty:ident) => ();
+
+        // Helper macro to invoke `$m` with all of the tokens passed except for
+        // any argument named `ret2`
+        (@invoke $m:ident ($($args:tt)*)) => (super::$m($($args)*));
+
+        // ignore `ret2`-named arguments
+        (@invoke $m:ident ($($args:tt)*) ret2 $($rest:tt)*) => (
+            transcoders!(@invoke $m ($($args)*) $($rest)*)
+        );
+
+        // move all other arguments into the `$args` list
+        (@invoke $m:ident ($($args:tt)*) $param:ident $($rest:tt)*) => (
+            transcoders!(@invoke $m ($($args)* $param,) $($rest)*)
+        );
     }
 
     wasmtime_environ::foreach_transcoder!(transcoders);

--- a/crates/runtime/src/component/transcode.rs
+++ b/crates/runtime/src/component/transcode.rs
@@ -41,7 +41,6 @@ macro_rules! define_transcoders {
     };
 
     (@ty size) => (usize);
-    (@ty size_pair) => (usize);
     (@ty ptr_u8) => (*mut u8);
     (@ty ptr_u16) => (*mut u16);
     (@ty ptr_size) => (*mut usize);


### PR DESCRIPTION
* One is to avoid using `drop(&mut T)`
* Another is to avoid using `()` in FFI functions since apparently that's not recommended. Working around this in the macro was pretty tricky, however.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
