### PR TITLE
x64: Add a missing ssse3 condition to lowering rule

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -4395,6 +4395,7 @@
         (x64_vpbroadcastb (bitcast_gpr_to_xmm $I32 src)))
 (rule 3 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
         (if-let $true (use_sse41))
+        (if-let $true (use_ssse3))
         (x64_pshufb (x64_pinsrb (xmm_uninit_value) addr 0) (xmm_zero $I8X16)))
 (rule 4 (lower (has_type $I8X16 (splat (sinkable_load_exact addr))))
         (if-let $true (use_avx2))


### PR DESCRIPTION
This commit fixes a mistake from the SSE2-simd work where an SSSE3 guard was missing from a usage of `pshufb`. I assumed that the SSE4.1 guard was enough but a fuzz-generated test case shows that it's possible to enable SSE4.1 without SSSE3 so a second condition is added here (SSE4.1 remains for `pinsrb` and SSSE3 is for `pshufb`).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
