### PR TITLE
Update Rust in CI to 1.71.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -5,7 +5,7 @@ inputs:
   toolchain:
     description: 'Default toolchan to install'
     required: false
-    default: '1.69.0'
+    default: '1.71.0'
   lockfiles:
     description: 'Path glob for Cargo.lock files to use as cache keys'
     required: false


### PR DESCRIPTION
Released today this updates from 1.69.0 to 1.71.0. Note that 1.70.0 was skipped due to presumed codegen bugs for s390x and riscv64. These were previously tested to work with 1.71.0, so it's time to confirm.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
