### PR TITLE
Cranelift: upgrade to regalloc2 0.9.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12513beb38dd35aab3ac5f5b89fd0330159a0dc21d5309d75073011bbc8032b0"
+checksum = "5b4dcbd3a2ae7fb94b5813fa0e957c6ab51bf5d0a8ee1b69e0c2d0f1e6eb8485"
 dependencies = [
  "hashbrown 0.13.2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.9.1"
+regalloc2 = "0.9.2"
 
 # cap-std family:
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -163,7 +163,7 @@ notes = "I am an author of this crate"
 [[wildcard-audits.regalloc2]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
-user-id = 3726
+user-id = 3726 # Chris Fallin (cfallin)
 start = "2021-12-03"
 end = "2024-05-02"
 notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-develop it with Cranelift/Wasmtime, with the same code-review, testing/fuzzing, and security standards."

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -639,6 +639,13 @@ user-id = 187138
 user-login = "elliottt"
 user-name = "Trevor Elliott"
 
+[[publisher.regalloc2]]
+version = "0.9.2"
+when = "2023-07-14"
+user-id = 3726
+user-login = "cfallin"
+user-name = "Chris Fallin"
+
 [[publisher.ryu]]
 version = "1.0.9"
 when = "2021-12-12"


### PR DESCRIPTION
This pulls in bytecodealliance/regalloc2#152, which fixes a bug that is reachable on RISC-V: when two different register classes have the same stackslot size, the register allocation result might share a slot between two different classes, which can result in moves between classes that will cause a panic. The fix properly separates slots by class. There should be no impact on non-RISC-V architectures.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
