### PR TITLE
Disable some icmp optimizations for vector types

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -125,11 +125,11 @@
        (eq bty x smax))
 
 ;; `band`/`bor` of 2 comparisons:
-(rule (simplify (band ty (icmp ty cc1 x y) (icmp ty cc2 x y)))
+(rule (simplify (band (fits_in_64 ty) (icmp ty cc1 x y) (icmp ty cc2 x y)))
   (if-let signed (intcc_comparable cc1 cc2))
   (compose_icmp ty (u64_and (decompose_intcc cc1) (decompose_intcc cc2)) signed x y))
 
-(rule (simplify (bor ty (icmp ty cc1 x y) (icmp ty cc2 x y)))
+(rule (simplify (bor (fits_in_64 ty) (icmp ty cc1 x y) (icmp ty cc2 x y)))
   (if-let signed (intcc_comparable cc1 cc2))
   (compose_icmp ty (u64_or (decompose_intcc cc1) (decompose_intcc cc2)) signed x y))
 

--- a/tests/misc_testsuite/simd/issue6725-no-egraph-panic.wast
+++ b/tests/misc_testsuite/simd/issue6725-no-egraph-panic.wast
@@ -9,7 +9,7 @@
 (module
   (func (result v128)
     (local v128)
-    (local.set 0 (v128.const i64 0 0))
+    (local.set 0 (v128.const i64x2 0 0))
     (i8x16.eq (local.get 0) (local.get 0))
     (i8x16.ne (local.get 0) (local.get 0))
     v128.or

--- a/tests/misc_testsuite/simd/issue6725-no-egraph-panic.wast
+++ b/tests/misc_testsuite/simd/issue6725-no-egraph-panic.wast
@@ -1,0 +1,17 @@
+(module
+  (func (param v128) (result v128)
+    (i8x16.eq (local.get 0) (local.get 0))
+    (i8x16.ne (local.get 0) (local.get 0))
+    v128.or
+  )
+)
+
+(module
+  (func (result v128)
+    (local v128)
+    (local.set 0 (v128.const i64 0 0))
+    (i8x16.eq (local.get 0) (local.get 0))
+    (i8x16.ne (local.get 0) (local.get 0))
+    v128.or
+  )
+)


### PR DESCRIPTION
This is a fix for #6725 where some icmp rules written for scalars were accidentally firing for vectors and generating invalid code, namely producing an `iconst` of a vector type.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
