### PR TITLE
Lock dependency on hyper to a single version

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -10,7 +10,7 @@ description = "Experimental HTTP library for WebAssembly in Wasmtime"
 [dependencies]
 anyhow = { workspace = true }
 bytes = "1.1.0"
-hyper = { version = "1.0.0-rc.3", features = ["full"] }
+hyper = { version = "=1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt-multi-thread", "time"] }
 http = { version = "0.2.9" }
 http-body = "1.0.0-rc.2"


### PR DESCRIPTION
Currently Cargo's interpretation of prerelease version doesn't quite match semver's, meaning that hyper, which is taking semver's interpretation, has broken Wasmtime builds without lock files. The rc.4 version of hyper released is no longer compatible with our usage which means that `cargo install wasmtime-cli` currently fails. It passes, however, with `--locked`.

To resolve this the dependency on hyper gets an `=` dependency for now to force it to be at this version.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
